### PR TITLE
Grouping source files by directories in CMakeLists.txt

### DIFF
--- a/Base/CMakeLists.txt
+++ b/Base/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Source files
-SET( HEADERS
+SET ( Base_Files
         binarySearch.h
         Configure.h.in
 	CPUTimeTimer.h
@@ -14,23 +14,21 @@ SET( HEADERS
 	TimeMeasurementBase.h
         uniqueListInsert.h
         wait.h
-)
-
-SET( SOURCES
 	binarySearch.cpp
 	DateTools.cpp
         CPUTimeTimer.cpp
 	RunTimeTimer.cpp
 	StringTools.cpp
 )
+SOURCE_GROUP( Base FILES ${Base_Files})
 
 # Create the library
-ADD_LIBRARY( Base STATIC ${HEADERS} ${SOURCES} )
+ADD_LIBRARY( Base STATIC ${Base_Files})
 
 SET_TARGET_PROPERTIES(Base PROPERTIES LINKER_LANGUAGE CXX)
 
 INCLUDE_DIRECTORIES(
-        ../GEOLib
+        ../GeoLib
         ../MathLib
         .
 )

--- a/GeoLib/CMakeLists.txt
+++ b/GeoLib/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Source files
-set( SOURCES
+SET ( GeoLib_Files
 	AxisAlignedBoundingBox.cpp
 	BruteForceClosestPair.cpp
 	Color.cpp
@@ -15,10 +15,6 @@ set( SOURCES
 	Surface.cpp
 	Triangle.cpp
 	Raster.cpp
-)
-
-# Header files
-set( HEADERS
 	AxisAlignedBoundingBox.h
 	BruteForceClosestPair.h
 	ClosestPair.h
@@ -44,28 +40,22 @@ set( HEADERS
 	Triangle.h
 	Raster.h
 )
+SOURCE_GROUP(GeoLib FILES ${GeoLib_Files})
 
 # Create the library
-add_library( GEO STATIC
-	${SOURCES}
-	${HEADERS}
-)
+ADD_LIBRARY(GeoLib STATIC ${GeoLib_Files})
 
 
 include_directories(
 	.
 	../Base
-	../FEM
-	../FileIO
 	../MathLib
-	../MSH
 )
 
 
 target_link_libraries (
-	GEO
+	GeoLib
 	Base
-	FEM
 	MathLib
 )
 

--- a/MathLib/CMakeLists.txt
+++ b/MathLib/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Source files
-SET( HEADERS
+#Source files grouped by a directory
+SET ( MathLib_Files
 	AnalyticalGeometry.h        
 	LinearInterpolation.h  
 	MathTools.h
@@ -8,10 +8,36 @@ SET( HEADERS
 	max.h
         sparse.h
 	vector_io.h
+	AnalyticalGeometry.cpp        
+	LinearInterpolation.cpp  
+	MathTools.cpp
+	EarClippingTriangulation.cpp  
+)
+SOURCE_GROUP( MathLib FILES ${MathLib_Files})
+
+SET ( MathLib_LinAlg_Files
 	LinAlg/MatrixBase.h
 	LinAlg/VectorNorms.h
+)
+SOURCE_GROUP( MathLib\\LinAlg FILES ${MathLib_LinAlg_Files})
+
+SET ( MathLib_LinAlg_Dense_Files
 	LinAlg/Dense/Matrix.h
-        LinAlg/Preconditioner/generateDiagPrecond.h
+)
+SOURCE_GROUP( MathLib\\LinAlg\\Dense FILES ${MathLib_LinAlg_Dense_Files})
+
+SET ( MathLib_LinAlg_Sparse_Files
+	LinAlg/Sparse/amuxCRS.h
+        LinAlg/Sparse/CRSMatrix.h
+        LinAlg/Sparse/CRSMatrixPThreads.h
+        LinAlg/Sparse/CRSMatrixOpenMP.h
+        LinAlg/Sparse/CRSSymMatrix.h
+        LinAlg/Sparse/SparseMatrixBase.h
+        LinAlg/Sparse/amuxCRS.cpp
+)
+SOURCE_GROUP( MathLib\\LinAlg\\Sparse FILES ${MathLib_LinAlg_Sparse_Files})
+
+SET ( MathLib_LinAlg_Solvers_Files
         LinAlg/Solvers/LinearSolver.h
         LinAlg/Solvers/DirectLinearSolver.h
         LinAlg/Solvers/DenseDirectLinearSolver.h
@@ -22,28 +48,21 @@ SET( HEADERS
         LinAlg/Solvers/BiCGStab.h
         LinAlg/Solvers/CG.h
         LinAlg/Solvers/GMRes.h
-	LinAlg/Sparse/amuxCRS.h
-        LinAlg/Sparse/CRSMatrix.h
-        LinAlg/Sparse/CRSMatrixPThreads.h
-        LinAlg/Sparse/CRSMatrixOpenMP.h
-        LinAlg/Sparse/CRSSymMatrix.h
-        LinAlg/Sparse/SparseMatrixBase.h
-)
-
-SET( SOURCES
-	AnalyticalGeometry.cpp        
-	LinearInterpolation.cpp  
-	MathTools.cpp
-	EarClippingTriangulation.cpp  
-        LinAlg/Sparse/amuxCRS.cpp
         LinAlg/Solvers/BiCGStab.cpp
         LinAlg/Solvers/CG.cpp
         LinAlg/Solvers/CGParallel.cpp
         LinAlg/Solvers/GMRes.cpp
 	LinAlg/Solvers/GaussAlgorithm.cpp
         LinAlg/Solvers/TriangularSolve.cpp
+)
+SOURCE_GROUP( MathLib\\LinAlg\\Solvers FILES ${MathLib_LinAlg_Solvers_Files})
+
+SET ( MathLib_LinAlg_Preconditioner_Files
+        LinAlg/Preconditioner/generateDiagPrecond.h
 	LinAlg/Preconditioner/generateDiagPrecond.cpp
 )
+SOURCE_GROUP( MathLib\\LinAlg\\Preconditioner FILES ${MathLib_LinAlg_Preconditioner_Files})
+
 
 INCLUDE_DIRECTORIES (
 	.
@@ -52,7 +71,14 @@ INCLUDE_DIRECTORIES (
 )
 
 # Create the library
-ADD_LIBRARY( MathLib STATIC ${HEADERS} ${SOURCES} )
+ADD_LIBRARY( MathLib STATIC 
+	${MathLib_Files} 
+	${MathLib_LinAlg_Files} 
+	${MathLib_LinAlg_Dense_Files}
+	${MathLib_LinAlg_Sparse_Files}
+	${MathLib_LinAlg_Solvers_Files}
+	${MathLib_LinAlg_Preconditioner_Files}
+)
 
 SET_TARGET_PROPERTIES(MathLib PROPERTIES LINKER_LANGUAGE CXX)
 


### PR DESCRIPTION
Hi all, 

I suggest to change our current way of grouping source files, i.e. header or source files, in CMakeLists.txt. Instead, I would like to group files by their directories. See changes in my commits. 

So far I know Visual Studio users can get an advantage from this changes. The IDE becomes able to show directories in project trees. Thus you can easily understand code structures and find files you wan to see. 

I don't really know if the changes cause any troubles on other environments. Please check it on your environment and merge into the main codes if there are no problems.

Best,
nori
