### PR TITLE
Replaces all of std::endl with "\n".

### DIFF
--- a/BaseLib/StringTools.cpp
+++ b/BaseLib/StringTools.cpp
@@ -120,7 +120,7 @@ void correctScientificNotation(std::string filename, size_t precision)
 
 			outputStream << word << " ";
 		}
-		outputStream << std::endl;
+		outputStream << "\n";
 	}
 
 	stream.close();

--- a/FileIO/Legacy/MeshIO.cpp
+++ b/FileIO/Legacy/MeshIO.cpp
@@ -242,23 +242,25 @@ int MeshIO::write(std::ostream &out)
 
 	setPrecision(9);
 
-	out << "#FEM_MSH" << std::endl;
-
-	out << "$PCS_TYPE" << std::endl << "  NO_PCS" << std::endl;
-
-	out << "$NODES" << std::endl << "  ";
+	out << "#FEM_MSH\n"
+		<< "$PCS_TYPE\n"
+		<< "  NO_PCS\n"
+		<< "$NODES\n"
+		<< "  ";
 	const size_t n_nodes(_mesh->getNNodes());
-	out << n_nodes << std::endl;
+	out << n_nodes << "\n";
 	for (size_t i(0); i < n_nodes; ++i) {
-		out << i << " " << *(_mesh->getNode(i)) << std::endl;
+		out << i << " " << *(_mesh->getNode(i)) << "\n";
 	}
 
-	out << "$ELEMENTS" << std::endl << "  ";
+	out << "$ELEMENTS\n"
+		<< "  ";
+
 	writeElementsExceptLines(_mesh->getElements(), out);
 
-	out << " $LAYER" << std::endl;
-	out << "  0" << std::endl;
-	out << "#STOP" << std::endl;
+	out << " $LAYER\n"
+		<< "  0\n"
+		<< "#STOP\n";
 
 	return 1;
 }
@@ -289,14 +291,14 @@ void MeshIO::writeElementsExceptLines(std::vector<MeshLib::Element*> const& ele_
 			}
 		}
 	}
-	out << n_elements << std::endl;
+	out << n_elements << "\n";
 	for (size_t i(0), k(0); i < ele_vector_size; ++i) {
 		if (non_line_element[i] && non_null_element[i]) {
 			out << k << " " << ele_vec[i]->getValue() << " " << MshElemType2String(ele_vec[i]->getGeomType()) << " ";
 			unsigned nElemNodes (ele_vec[i]->getNNodes());
 			for(size_t j = 0; j < nElemNodes; ++j)
 				out << ele_vec[i]->getNode(nElemNodes - j - 1)->getID() << " ";
-			out << std::endl;
+			out << "\n";
 			++k;
 		}
 	}

--- a/FileIO/Legacy/OGSIOVer4.cpp
+++ b/FileIO/Legacy/OGSIOVer4.cpp
@@ -605,9 +605,9 @@ void writeGLIFileV4 (const std::string& fname,
 			if ((*plys)[k]->isClosed())
 			{
 				os << "#SURFACE" << "\n";
-				os << " $NAME " << "\n" << "  " << k << "\n"; //plys_vec->getNameOfElement ((*plys)[k]) << std::endl;
+				os << " $NAME " << "\n" << "  " << k << "\n"; //plys_vec->getNameOfElement ((*plys)[k]) << "\n";
 				os << " $TYPE " << "\n" << "  0" << "\n";
-				os << " $POLYLINES" << "\n" << "  " << k << "\n"; //plys_vec->getNameOfElement ((*plys)[k]) << std::endl;
+				os << " $POLYLINES" << "\n" << "  " << k << "\n"; //plys_vec->getNameOfElement ((*plys)[k]) << "\n";
 			}
 	}
 

--- a/FileIO/MeshIO/GMSHInterface.cpp
+++ b/FileIO/MeshIO/GMSHInterface.cpp
@@ -247,7 +247,7 @@ int GMSHInterface::write(std::ostream& out)
 #ifdef BUILD_TIMESTAMP
 	out << " built on " << BUILD_TIMESTAMP;
 #endif
-	out << std::endl << std::endl;
+	out << "\n\n";
 
 	writeGMSHInputFile(out);
 	return 1;
@@ -357,7 +357,7 @@ void GMSHInterface::writePoints(std::ostream& out) const
 	const size_t n_gmsh_pnts(_gmsh_pnts.size());
 	for (size_t k(0); k<n_gmsh_pnts; k++) {
 		if (_gmsh_pnts[k]) {
-			out << *(_gmsh_pnts[k]) << std::endl;
+			out << *(_gmsh_pnts[k]) << "\n";
 		}
 	}
 }

--- a/FileIO/MeshIO/GMSHLine.cpp
+++ b/FileIO/MeshIO/GMSHLine.cpp
@@ -25,7 +25,7 @@ GMSHLine::~GMSHLine()
 
 void GMSHLine::write(std::ostream &os, size_t id) const
 {
-	os << "Line(" << id << ") = {" << _start_pnt_id << "," << _end_pnt_id << "};" << std::endl;
+	os << "Line(" << id << ") = {" << _start_pnt_id << "," << _end_pnt_id << "};\n";
 }
 
 void GMSHLine::resetLineData(size_t start_point_id, size_t end_point_id)

--- a/FileIO/MeshIO/GMSHLineLoop.cpp
+++ b/FileIO/MeshIO/GMSHLineLoop.cpp
@@ -42,11 +42,11 @@ void GMSHLineLoop::write(std::ostream &os, size_t line_offset, size_t sfc_offset
 	os << "Line Loop(" << line_offset+n_lines << ") = {";
 	for (size_t k(0); k < n_lines - 1; k++)
 		os << line_offset + k << ",";
-	os << line_offset + n_lines - 1 << "};" << std::endl;
+	os << line_offset + n_lines - 1 << "};\n";
 
 	if (_is_sfc) {
 		// write plane surface
-		os << "Plane Surface (" << sfc_offset << ") = {" << line_offset+n_lines << "};" << std::endl;
+		os << "Plane Surface (" << sfc_offset << ") = {" << line_offset+n_lines << "};\n";
 	}
 
 }

--- a/FileIO/MeshIO/GMSHPolygonTree.cpp
+++ b/FileIO/MeshIO/GMSHPolygonTree.cpp
@@ -183,15 +183,15 @@ void GMSHPolygonTree::writeLineLoop(size_t &line_offset, size_t &sfc_offset, std
 	size_t first_pnt_id(_node_polygon->getPointID(0)), second_pnt_id;
 	for (size_t k(1); k<n_pnts; k++) {
 		second_pnt_id = _node_polygon->getPointID(k);
-		out << "Line(" << line_offset + k-1 << ") = {" << first_pnt_id << "," << second_pnt_id << "};" << std::endl;
+		out << "Line(" << line_offset + k-1 << ") = {" << first_pnt_id << "," << second_pnt_id << "};\n";
 		first_pnt_id = second_pnt_id;
 	}
 	out << "Line Loop(" << line_offset + n_pnts-1 << ") = {";
 	for (size_t k(0); k<n_pnts - 2; k++) {
 		out << line_offset+k << ",";
 	}
-	out << line_offset+n_pnts-2 << "};" << std::endl;
-	out << "Plane Surface(" << sfc_offset << ") = {" << line_offset+n_pnts-1 << "};" << std::endl;
+	out << line_offset+n_pnts-2 << "};\n";
+	out << "Plane Surface(" << sfc_offset << ") = {" << line_offset+n_pnts-1 << "};\n";
 	line_offset += n_pnts;
 	sfc_offset++;
 }
@@ -205,8 +205,8 @@ void GMSHPolygonTree::writeLineConstraints(size_t &line_offset, size_t sfc_numbe
 		for (size_t k(1); k<n_pnts; k++) {
 			second_pnt_id = _plys[j]->getPointID(k);
 			if (_plys[j]->isSegmentMarked(k-1) && _node_polygon->isPntInPolygon(*(_plys[j]->getPoint(k)))) {
-				out << "Line(" << line_offset + k-1 << ") = {" << first_pnt_id << "," << second_pnt_id << "};" << std::endl;
-				out << "Line { " << line_offset+k-1 << " } In Surface { " << sfc_number << " };" << std::endl;
+				out << "Line(" << line_offset + k-1 << ") = {" << first_pnt_id << "," << second_pnt_id << "};\n";
+				out << "Line { " << line_offset+k-1 << " } In Surface { " << sfc_number << " };\n";
 			}
 			first_pnt_id = second_pnt_id;
 		}
@@ -225,9 +225,9 @@ void GMSHPolygonTree::writeSubPolygonsAsLineConstraints(size_t &line_offset, siz
 		size_t first_pnt_id(_node_polygon->getPointID(0)), second_pnt_id;
 		for (size_t k(1); k<n_pnts; k++) {
 			second_pnt_id = _node_polygon->getPointID(k);
-			out << "Line(" << line_offset + k-1 << ") = {" << first_pnt_id << "," << second_pnt_id << "};" << std::endl;
+			out << "Line(" << line_offset + k-1 << ") = {" << first_pnt_id << "," << second_pnt_id << "};\n";
 			first_pnt_id = second_pnt_id;
-			out << "Line { " << line_offset+k-1 << " } In Surface { " << sfc_number << " };" << std::endl;
+			out << "Line { " << line_offset+k-1 << " } In Surface { " << sfc_number << " };\n";
 		}
 		line_offset += n_pnts;
 	}
@@ -239,8 +239,8 @@ void GMSHPolygonTree::writeStations(size_t & pnt_id_offset, size_t sfc_number, s
 	const size_t n_stations(_stations.size());
 	for (size_t k(0); k<n_stations; k++) {
 		out << "Point(" << pnt_id_offset + k << ") = {" << (*(_stations[k]))[0] << "," << (*(_stations[k]))[1] << ", 0.0, ";
-		out << _mesh_density_strategy->getMeshDensityAtPoint(_stations[k]) << "};" << std::endl;
-		out << "Point { " << pnt_id_offset + k << " } In Surface { " << sfc_number << " }; " << std::endl;
+		out << _mesh_density_strategy->getMeshDensityAtPoint(_stations[k]) << "};\n";
+		out << "Point { " << pnt_id_offset + k << " } In Surface { " << sfc_number << " };\n";
 	}
 	pnt_id_offset += n_stations;
 }
@@ -254,8 +254,8 @@ void GMSHPolygonTree::writeAdditionalPointData(size_t & pnt_id_offset, size_t sf
 		for (size_t k(0); k<n; k++) {
 			if (_node_polygon->isPntInPolygon(*(steiner_pnts[k]))) {
 				out << "Point(" << pnt_id_offset + k << ") = {" << (*(steiner_pnts[k]))[0] << "," << (*(steiner_pnts[k]))[1] << ", 0.0, ";
-				out << _mesh_density_strategy->getMeshDensityAtPoint(steiner_pnts[k]) << "};" << std::endl;
-				out << "Point { " << pnt_id_offset + k << " } In Surface { " << sfc_number << " }; " << std::endl;
+				out << _mesh_density_strategy->getMeshDensityAtPoint(steiner_pnts[k]) << "};\n";
+				out << "Point { " << pnt_id_offset + k << " } In Surface { " << sfc_number << " };\n";
 			}
 			delete steiner_pnts[k];
 		}

--- a/FileIO/RapidXmlIO/RapidVtuInterface.cpp
+++ b/FileIO/RapidXmlIO/RapidVtuInterface.cpp
@@ -345,7 +345,7 @@ int RapidVtuInterface::write(std::ostream& stream)
 	const std::string data_array_close("\t\t\t\t");
 	const std::string data_array_indent("\t\t\t\t  ");
 
-	stream << "<?xml version=\"1.0\"?>" << std::endl;
+	stream << "<?xml version=\"1.0\"?>\n";
 
 	xml_node<> *root_node (_doc->allocate_node(node_element, "VTKFile"));
 	_doc->append_node(root_node);

--- a/FileIO/Writer.cpp
+++ b/FileIO/Writer.cpp
@@ -47,7 +47,7 @@ int Writer::writeToFile(std::string const& filename)
 		// check file stream
 		if (!fileStream)
 		{
-			std::cerr << "Could not open file " << filename << " !" << std::endl;
+			std::cerr << "Could not open file " << filename << " !\n";
 			return 0;
 		}
 

--- a/GeoLib/Polyline.cpp
+++ b/GeoLib/Polyline.cpp
@@ -47,7 +47,7 @@ void Polyline::write(std::ostream &os) const
 {
 	std::size_t size(_ply_pnt_ids.size());
 	for (std::size_t k(0); k < size; k++)
-		os << *(_ply_pnts[_ply_pnt_ids[k]]) << std::endl;
+		os << *(_ply_pnts[_ply_pnt_ids[k]]) << "\n";
 }
 
 void Polyline::addPoint(std::size_t pnt_id)

--- a/GeoLib/Raster.cpp
+++ b/GeoLib/Raster.cpp
@@ -108,19 +108,19 @@ Raster* Raster::getRasterFromSurface(Surface const& sfc, double cell_size, doubl
 void Raster::writeRasterAsASC(std::ostream &os) const
 {
 	// write header
-	os << "ncols " << _n_cols << std::endl;
-	os << "nrows " << _n_rows << std::endl;
-	os << "xllcorner " << _ll_pnt[0] << std::endl;
-	os << "yllcorner " << _ll_pnt[1] << std::endl;
-	os << "cellsize " <<  _cell_size << std::endl;
-	os << "NODATA_value " << _no_data_val << std::endl;
+	os << "ncols " << _n_cols << "\n";
+	os << "nrows " << _n_rows << "\n";
+	os << "xllcorner " << _ll_pnt[0] << "\n";
+	os << "yllcorner " << _ll_pnt[1] << "\n";
+	os << "cellsize " <<  _cell_size << "\n";
+	os << "NODATA_value " << _no_data_val << "\n";
 
 	// write data
 	for (unsigned row(0); row<_n_rows; row++) {
 		for (unsigned col(0); col<_n_cols; col++) {
 			os << _raster_data[(_n_rows-row-1)*_n_cols+col] << " ";
 		}
-		os << std::endl;
+		os << "\n";
 	}
 }
 

--- a/Gui/DataView/DirectConditionGenerator.cpp
+++ b/Gui/DataView/DirectConditionGenerator.cpp
@@ -183,7 +183,7 @@ int DirectConditionGenerator::writeToFile(const std::string &name) const
 	if (out)
 	{
 		for (std::vector< std::pair<size_t,double> >::const_iterator it = _direct_values.begin(); it != _direct_values.end(); ++it)
-			out << it->first << "\t" << it->second << std::endl;
+			out << it->first << "\t" << it->second << "\n";
 
 		out.close();
 	}

--- a/Gui/VtkVis/VtkColorLookupTable.cpp
+++ b/Gui/VtkVis/VtkColorLookupTable.cpp
@@ -106,7 +106,7 @@ void VtkColorLookupTable::writeToFile(const std::string &filename)
 	{
 		unsigned char rgba[4];
 		this->GetTableValue(i, rgba);
-		out << i << "\t" << rgba[0] << "\t" << rgba[1] << "\t" << rgba[2] << std::endl;
+		out << i << "\t" << rgba[0] << "\t" << rgba[1] << "\t" << rgba[2] << "\n";
 	}
 
 	std::cout << " done." << std::endl;

--- a/Gui/VtkVis/VtkMeshSource.cpp
+++ b/Gui/VtkVis/VtkMeshSource.cpp
@@ -76,7 +76,7 @@ void VtkMeshSource::PrintSelf( ostream& os, vtkIndent indent )
 	int i = 0;
 	for (std::vector<MeshLib::Node*>::const_iterator it = nodes.begin(); it != nodes.end(); ++it)
 	{
-		os << indent << "Point " << i << " (" << (*it)[0] << ", " << (*it)[1] << ", " << (*it)[2] << ")" << std::endl;
+		os << indent << "Point " << i << " (" << (*it)[0] << ", " << (*it)[1] << ", " << (*it)[2] << ")\n";
 	}
 
 	i = 0;
@@ -85,7 +85,7 @@ void VtkMeshSource::PrintSelf( ostream& os, vtkIndent indent )
 		os << indent << "Element " << i << ": ";
 		for (unsigned t = 0; t < (*it)->getNNodes(); ++t)
 			os << (*it)->getNode(t)->getID() << " ";
-		os << std::endl;
+		os << "\n";
 	}
 }
 

--- a/Gui/VtkVis/VtkVisPipeline.cpp
+++ b/Gui/VtkVis/VtkVisPipeline.cpp
@@ -173,7 +173,7 @@ void VtkVisPipeline::loadFromFile(QString filename)
 	QTime myTimer;
 	myTimer.start();
 	std::cout << "VTK Read: " << filename.toStdString() <<
-	std::endl << std::flush;
+	std::endl;
 #endif
 
 	if (filename.size() > 0)
@@ -533,17 +533,17 @@ void VtkVisPipeline::checkMeshQuality(VtkMeshSource* source, MshQualityType::typ
 		std::ofstream out ("mesh_histogram.txt");
 		if (out) {
 			out << "# histogram depicts mesh quality criterion " << MshQualityType2String(t)
-				<< " for mesh " << source->GetMesh()->getName() << std::endl;
+				<< " for mesh " << source->GetMesh()->getName() << "\n";
 			nclasses = histogram.getNrBins();
 			std::vector<size_t> const& bin_cnts(histogram.getBinCounts());
 			const double min (histogram.getMinimum());
 			const double bin_width (histogram.getBinWidth());
 
 			for (size_t k(0); k < nclasses; k++)
-				out << min+k*bin_width << " " << bin_cnts[k] << std::endl;
+				out << min+k*bin_width << " " << bin_cnts[k] << "\n";
 			out.close ();
 		} else {
-			std::cerr << "could not open file mesh_histgram.txt" << std::endl;
+			std::cerr << "could not open file mesh_histgram.txt\n";
 		}
 
 //		size_t size (100);
@@ -552,8 +552,7 @@ void VtkVisPipeline::checkMeshQuality(VtkMeshSource* source, MshQualityType::typ
 //		std::ofstream out ("mesh_histogram.txt");
 //		const size_t histogram_size (histogram.size());
 //		for (size_t k(0); k < histogram_size; k++)
-//			out << k / static_cast<double>(histogram_size) << " " << histogram[k] <<
-//			std::endl;
+//			out << k / static_cast<double>(histogram_size) << " " << histogram[k] << "\n";
 //		out.close ();
 
 		delete checker;

--- a/MathLib/LinAlg/Dense/Matrix.h
+++ b/MathLib/LinAlg/Dense/Matrix.h
@@ -275,7 +275,7 @@ template <class T> void Matrix<T>::write (std::ostream &out) const
 		for (std::size_t j = 0; j < ncols; j++) {
 			out << data[address(i, j)] << "\t";
 		}
-		out << std::endl;
+		out << "\n";
 	}
 }
 

--- a/MathLib/sparse.h
+++ b/MathLib/sparse.h
@@ -51,15 +51,13 @@ template<class T> void CS_read(std::istream &is, unsigned &n, unsigned* &iA, uns
 
 #ifndef NDEBUG
 	// do simple checks
-	if (iA[0] != 0) std::cerr << std::endl << "CRS matrix: array iA doesn't start with 0"
-					<< std::endl;
+	if (iA[0] != 0) std::cerr << "\nCRS matrix: array iA doesn't start with 0\n";
 
 	unsigned i = 0;
 	while (i < iA[n] && jA[i] < n)
 		++i;
-	if (i < iA[n]) std::cerr << std::endl << "CRS matrix: the " << i
-					<< "th entry of jA has the value " << jA[i] << ", which is out of bounds."
-					<< std::endl;
+	if (i < iA[n]) std::cerr << "\nCRS matrix: the " << i
+					<< "th entry of jA has the value " << jA[i] << ", which is out of bounds.\n";
 #endif
 }
 

--- a/MeshLib/Mesh2MeshPropertyInterpolation.cpp
+++ b/MeshLib/Mesh2MeshPropertyInterpolation.cpp
@@ -135,7 +135,7 @@ void Mesh2MeshPropertyInterpolation::interpolatePropertiesForMesh(Mesh *dest_mes
 			}
 			out_src << "#STOP" << "\n";
 			out_src.close();
-			std::cerr << "no source nodes in dest element " << k << std::endl;
+			std::cerr << "no source nodes in dest element " << k << "\n";
 		}
 	}
 }

--- a/Utils/FileConverter/ConvertSHPToGLI.cpp
+++ b/Utils/FileConverter/ConvertSHPToGLI.cpp
@@ -48,7 +48,7 @@ void convertPoints (DBFHandle dbf_handle,
 	int n_records (DBFGetRecordCount (dbf_handle));
 	std::cout << "writing " << n_records << " records" << std::endl;
 
-//	out << "#POINTS" << std::endl;
+//	out << "#POINTS\n";
 //
 //	for (int k(0); k<n_records; k++) {
 //		double x (DBFReadDoubleAttribute( dbf_handle, k, x_id));
@@ -68,9 +68,9 @@ void convertPoints (DBFHandle dbf_handle,
 //				}
 //			}
 //		}
-//		out << std::endl;
+//		out << "\n";
 //	}
-//	out << "#STOP" << std::endl;
+//	out << "#STOP\n";
 
 	std::vector<GeoLib::Point*>* points (new std::vector<GeoLib::Point*>);
 	points->reserve (n_records);

--- a/Utils/FileConverter/GMSH2OGS.cpp
+++ b/Utils/FileConverter/GMSH2OGS.cpp
@@ -51,7 +51,7 @@ int main (int argc, char* argv[])
 	FEMRead(file_base_name, mesh_vec);
 	if (mesh_vec.empty())
 	{
-		std::cerr << "could not read mesh from file " << tmp << std::endl;
+		std::cerr << "could not read mesh from file " << tmp << "\n";
 		return -1;
 	}
 	MeshLib::CFEMesh* mesh (mesh_vec[mesh_vec.size() - 1]);


### PR DESCRIPTION
This is done for potential and obvious file streams.

This closes #87.

Please be aware that std::err is not buffered and after std::endl there is no need for std::flush.
