### PR TITLE
Restricted linking to the needed boost lib only.

### DIFF
--- a/BaseLib/CMakeLists.txt
+++ b/BaseLib/CMakeLists.txt
@@ -11,4 +11,7 @@ INCLUDE_DIRECTORIES(
 	.
 )
 
-TARGET_LINK_LIBRARIES( BaseLib ${Boost_LIBRARIES} )
+TARGET_LINK_LIBRARIES( BaseLib
+	boost_system
+	boost_filesystem 
+)

--- a/SimpleTests/MeshTests/CMakeLists.txt
+++ b/SimpleTests/MeshTests/CMakeLists.txt
@@ -27,7 +27,8 @@ TARGET_LINK_LIBRARIES ( MeshRead
 	logog
 	zlib
 	${ADDITIONAL_LIBS}
-	${Boost_LIBRARIES}
+	boost_system
+	boost_filesystem
 )
 
 # Create CollapseMeshNodes executable
@@ -44,7 +45,8 @@ TARGET_LINK_LIBRARIES ( CollapseMeshNodes
 	BaseLib
 	GeoLib
 	logog
-	${Boost_LIBRARIES}
+	boost_system
+	boost_filesystem
 )
 
 # Create MeshSearchTest executable
@@ -62,5 +64,6 @@ TARGET_LINK_LIBRARIES ( MeshSearchTest
 	GeoLib
 	logog
 	${ADDITIONAL_LIBS}
-	${Boost_LIBRARIES}
+	boost_system
+	boost_filesystem
 )

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -41,7 +41,8 @@ TARGET_LINK_LIBRARIES(testrunner
 	MeshLib
 	OgsLib
 	logog
-	${Boost_LIBRARIES}
+	boost_system
+	boost_filesystem
 	${CMAKE_THREAD_LIBS_INIT}
 )
 


### PR DESCRIPTION
This fixes a problem at least for linux users finding and linking with the dynamic linked version of boost libs.

In my case I have only dynamic linked version of the boost libs installed. As a consequence the static libs of boost are not found. The search of dynamic linked boost libs is successful on my computer. But some of the boost variables are not set in a correct way (maybe since the search for the static variant). Fortunatly it seems that variables for specific boost libs are set correct.
