### PR TITLE
Extend global dense matrix

### DIFF
--- a/MathLib/LinAlg/Dense/GlobalDenseMatrix.h
+++ b/MathLib/LinAlg/Dense/GlobalDenseMatrix.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "DenseMatrix.h"
+#include "DenseVector.h"
 
 namespace MathLib
 {
@@ -64,6 +65,9 @@ public:
 	void addSubMatrix(std::vector<IDX_TYPE> const& row_pos,
 			std::vector<IDX_TYPE> const& col_pos, const T_DENSE_MATRIX &sub_matrix,
 			FP_TYPE fkt = static_cast<FP_TYPE>(1.0));
+
+    /// y = mat * x
+    void matvec ( const DenseVector<FP_TYPE> &x, DenseVector<FP_TYPE> &y) const;
 };
 
 } // end namespace MathLib

--- a/MathLib/LinAlg/Dense/GlobalDenseMatrix.tpp
+++ b/MathLib/LinAlg/Dense/GlobalDenseMatrix.tpp
@@ -78,6 +78,12 @@ GlobalDenseMatrix<FP_TYPE, IDX_TYPE>::addSubMatrix(std::vector<IDX_TYPE> const& 
 	}
 }
 
+template<typename FP_TYPE, typename IDX_TYPE>
+void
+GlobalDenseMatrix<FP_TYPE, IDX_TYPE>::matvec ( const DenseVector<FP_TYPE> &x, DenseVector<FP_TYPE> &y) const
+{
+	this->axpy (1.0, &x[0], 0.0, &y[0]);
+}
 
 } // end namespace MathLib
 


### PR DESCRIPTION
extend GlobalDenseMatrix class to provide the following interface
- `getRangeBegin()` and `getRangeEnd()`: needed for palletization, e.g. MPI 
- `matvec(x, y)`: y = M*x. Unfortunately axpy() is not supported in Lis. Or should this go to DenseMatrix class?
