### PR TITLE
Added check for zero elements in mesh read method

### DIFF
--- a/FileIO/Legacy/MeshIO.cpp
+++ b/FileIO/Legacy/MeshIO.cpp
@@ -55,7 +55,7 @@ MeshLib::Mesh* MeshIO::loadMeshFromFile(const std::string& file_name)
 	if (!in.is_open())
 	{
 		WARN("MeshIO::loadMeshFromFile() - Could not open file %s.", file_name.c_str());
-		return NULL;
+		return nullptr;
 	}
 
 	std::string line_string ("");
@@ -121,6 +121,14 @@ MeshLib::Mesh* MeshIO::loadMeshFromFile(const std::string& file_name)
 			}
 		}
 
+		if (elements.empty())
+		{
+			ERR ("MeshIO::loadMeshFromFile() - File did not contain element information.");
+			for (auto it = nodes.begin(); it!=nodes.end(); ++it)
+				delete *it;
+			return nullptr;
+		}
+
 		MeshLib::Mesh* mesh (new MeshLib::Mesh(BaseLib::extractBaseNameWithoutExtension(
 		                                               file_name), nodes, elements));
 		mesh->setEdgeLengthRange(sqrt(edge_length[0]), sqrt(edge_length[1]));
@@ -135,7 +143,7 @@ MeshLib::Mesh* MeshIO::loadMeshFromFile(const std::string& file_name)
 	else
 	{
 		in.close();
-		return NULL;
+		return nullptr;
 	}
 }
 

--- a/FileIO/readMeshFromFile.cpp
+++ b/FileIO/readMeshFromFile.cpp
@@ -44,6 +44,6 @@ MeshLib::Mesh* readMeshFromFile(const std::string &file_name)
 		return FileIO::BoostVtuInterface::readVTUFile(file_name);
 
 	ERR("readMeshFromFile(): Unknown mesh file format in file %s.", file_name.c_str());
-	return 0;
+	return nullptr;
 }
 } // end namespace FileIO


### PR DESCRIPTION
Comment: For VTU meshes we already check for 0 elements (i.e. we check if the NumberOfCells-Attribute equals 0)

In both read-methods we don't test if the real number of elements in the file really equals the declared number of elements. We simply read an element for the declared number of times, i.e. if there are more elements we will miss some and if there are less some terrible things will probably happen.

Should we do something about that or do we have the view that input files should be syntactically correct?
