### PR TITLE
Provide default AssemblerLib::GlobalSetup ctor.

### DIFF
--- a/AssemblerLib/GlobalSetup.h
+++ b/AssemblerLib/GlobalSetup.h
@@ -45,6 +45,8 @@ struct GlobalSetup
     {
         return Executor::execute(std::forward<Args>(args)...);
     }
+
+	GlobalSetup() { }
 };
 
 }   // namespace AssemblerLib


### PR DESCRIPTION
Compilation fails otherwise with clang-3.3.0, and other compilers.
