### PR TITLE
Fix a bug that precision given in Writer() is unused  in VTU output

### DIFF
--- a/FileIO/RapidXmlIO/BoostVtuInterface.cpp
+++ b/FileIO/RapidXmlIO/BoostVtuInterface.cpp
@@ -442,6 +442,7 @@ int BoostVtuInterface::write(std::ostream& stream)
 	celldata_node.put("<xmlattr>.Scalars", "MaterialIDs");
 
 	std::stringstream oss(std::stringstream::out);
+	oss.precision(stream.precision());
 	oss << std::endl << data_array_indent;
 	for (unsigned i = 0; i < nElems; i++)
 		oss << elements[i]->getValue() << " ";

--- a/FileIO/RapidXmlIO/RapidVtuInterface.cpp
+++ b/FileIO/RapidXmlIO/RapidVtuInterface.cpp
@@ -373,6 +373,7 @@ int RapidVtuInterface::write(std::ostream& stream)
 	celldata_node->append_attribute(_doc->allocate_attribute("Scalars", "MaterialIDs"));
 
 	std::stringstream oss(std::stringstream::out);
+	oss.precision(stream.precision());
 	oss << std::endl << data_array_indent;
 	for (unsigned i=0; i<nElems; i++)
 		oss << elements[i]->getValue() << " ";


### PR DESCRIPTION
This bug was reported by Guido, who tried to use OGS2VTK with his mesh file. If one use `stringstream` during file outputs, one should be careful about precision specified in `stream` variable which is configured in `Writer` class.
