### PR TITLE
Fix for always adding OGS files to Recent Files menu

### DIFF
--- a/Gui/mainwindow.cpp
+++ b/Gui/mainwindow.cpp
@@ -580,6 +580,8 @@ void MainWindow::loadFile(ImportFileType::type t, const QString &fileName)
 		{
 			this->loadFEMConditionsFromFile(fileName);
 		}
+
+		emit fileUsed(fileName);
 	}
 	else if (t == ImportFileType::FEFLOW)
 	{
@@ -702,8 +704,6 @@ void MainWindow::loadFile(ImportFileType::type t, const QString &fileName)
 		//settings.setValue("lastOpenedVtkFileDirectory", dir.absolutePath());
 	}
 	updateDataViews();
-
-	if (t == ImportFileType::OGS) emit fileUsed(fileName);
 }
 
 void MainWindow::updateDataViews()


### PR DESCRIPTION
Fixes an error where OGS files were not added to -=Recent Files= menu when they where opened from a tree view.
