### PR TITLE
fixed issue von incorrect button deactivation after data set removal

### DIFF
--- a/Gui/DataView/StationTreeView.cpp
+++ b/Gui/DataView/StationTreeView.cpp
@@ -222,8 +222,12 @@ void StationTreeView::removeStationList()
 	{
 		TreeItem* item = static_cast<StationTreeModel*>(model())->getItem(index);
 		emit stationListRemoved((item->data(0).toString()).toStdString());
-		emit enableSaveButton(false);
-		emit enableRemoveButton(false);
+
+		if(this->selectionModel()->selectedIndexes().count() == 0)
+		{
+			emit enableSaveButton(false);
+			emit enableRemoveButton(false);
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes a bug where the "Remove"-Button in the StationTabWidget would be deactivated after removing a data set even if other data sets where still present.
