### PR TITLE
Revert "Replaced InsertNextXXX() with SetXXX() in VtkStationSource where...

### DIFF
--- a/Gui/VtkVis/VtkStationSource.cpp
+++ b/Gui/VtkVis/VtkStationSource.cpp
@@ -134,29 +134,23 @@ int VtkStationSource::RequestData( vtkInformation* request,
 	size_t site_count(0);
 
 	// Generate graphic objects
-	size_t nPoints = _stations->size();
-	newStations->SetNumberOfPoints(nPoints);
-	if(!isBorehole)
-		newVerts->Allocate(nPoints);
-	for(size_t i = 0; i < nPoints; ++i)
+	for (std::vector<GeoLib::Point*>::const_iterator it = _stations->begin();
+	     it != _stations->end(); ++it)
 	{
-		double coords[3] = { (*((*_stations)[i]))[0], (*((*_stations)[i]))[1], (*((*_stations)[i]))[2] };
-		newStations->SetPoint(i, coords);
+		double coords[3] = { (*(*it))[0], (*(*it))[1], (*(*it))[2] };
+		vtkIdType sid = newStations->InsertNextPoint(coords);
 		station_ids->InsertNextValue(site_count);
 		if (useStationValues)
-			station_values->InsertNextValue(static_cast<GeoLib::Station*>((*_stations)[i])->getStationValue());
+			station_values->InsertNextValue(static_cast<GeoLib::Station*>(*it)->getStationValue());
 
 		if (!isBorehole)
-		{
-			newVerts->InsertNextCell(1);
-			newVerts->InsertCellPoint(i);
-		}
+			newVerts->InsertNextCell(1, &sid);
 		else
 		{
 			std::vector<GeoLib::Point*> profile =
-			        static_cast<GeoLib::StationBorehole*>((*_stations)[i])->getProfile();
+			        static_cast<GeoLib::StationBorehole*>(*it)->getProfile();
 			std::vector<std::string> soilNames =
-			        static_cast<GeoLib::StationBorehole*>((*_stations)[i])->getSoilNames();
+			        static_cast<GeoLib::StationBorehole*>(*it)->getSoilNames();
 			const size_t nLayers = profile.size();
 
 			for (size_t i = 1; i < nLayers; i++)
@@ -170,7 +164,7 @@ int VtkStationSource::RequestData( vtkInformation* request,
 				newLines->InsertCellPoint(++lastMaxIndex); //end of boreholelayer
 				strat_ids->InsertNextValue(this->GetIndexByName(soilNames[i]));
 				if (useStationValues)
-					station_values->InsertNextValue(static_cast<GeoLib::Station*>((*_stations)[i])->getStationValue());
+					station_values->InsertNextValue(static_cast<GeoLib::Station*>(*it)->getStationValue());
 			}
 			lastMaxIndex++;
 		}


### PR DESCRIPTION
... possible."

This reverts commit a008957054b091cc5d4af2e31e0293a457c87c04 because of errors in borehole visualisation using the GUI.
