### PR TITLE
Changes the node numberung for creation of VTK_WEDGE objects

### DIFF
--- a/Gui/VtkVis/VtkMeshSource.cpp
+++ b/Gui/VtkVis/VtkMeshSource.cpp
@@ -145,7 +145,6 @@ int VtkMeshSource::RequestData( vtkInformation* request,
 		for (unsigned j = 0; j < nElemNodes; ++j)
 			point_ids->SetId(j, elem->getNode(j)->getID());
 
-		unsigned prism_swap_id;
 		switch (elem->getGeomType())
 		{
 		case MeshElemType::LINE:
@@ -167,7 +166,7 @@ int VtkMeshSource::RequestData( vtkInformation* request,
 			type = 13;
 			for (unsigned i=0; i<3; ++i)
 			{
-				prism_swap_id = point_ids->GetId(i);
+				const unsigned prism_swap_id = point_ids->GetId(i);
 				point_ids->SetId(i, point_ids->GetId(i+3));
 				point_ids->SetId(i+3, prism_swap_id);
 			}


### PR DESCRIPTION
VTK is inconsistent with numbering of 3D elements, especially when comparing HEXAHEDRON and WEDGE elements (i.e. hex node numbering starts at the bottom of the element, wedge node numbering starts at the top). As a result prism elements have been rendered incorrectly until now in GUI since this is the only element where our node numbering differs from vtk node numbering. This PR fixes this "problem" which will result in correct rendering of prism elements even if backfaces are not rendered.
