### PR TITLE
FEM condition GUI I/O update

### DIFF
--- a/Gui/DataView/ConditionWriter.ui
+++ b/Gui/DataView/ConditionWriter.ui
@@ -38,7 +38,7 @@
     <widget class="QComboBox" name="geoBox">
      <item>
       <property name="text">
-       <string>All (XML files only)</string>
+       <string>Save conditions on all geometries</string>
       </property>
      </item>
     </widget>
@@ -47,7 +47,7 @@
     <widget class="QComboBox" name="condTypeBox">
      <item>
       <property name="text">
-       <string>All (XML files only)</string>
+       <string>All Types of Conditions</string>
       </property>
      </item>
      <item>

--- a/Gui/mainwindow.cpp
+++ b/Gui/mainwindow.cpp
@@ -900,6 +900,8 @@ void MainWindow::addFEMConditions(std::vector<FEMCondition*> const& conditions)
 {
 	if (!conditions.empty())
 	{
+		this->_project.addConditions(conditions);
+
 		for (size_t i = 0; i < conditions.size(); i++)
 		{
 			bool condition_ok(true);
@@ -931,13 +933,10 @@ void MainWindow::addFEMConditions(std::vector<FEMCondition*> const& conditions)
 void MainWindow::writeFEMConditionsToFile(const QString &geoName, const FEMCondition::CondType type, const QString &fileName)
 {
 	QFileInfo fi(fileName);
-	if (fi.suffix().compare("cnd") == 0 )
-	{
-		XmlCndInterface xml(&_project);
-		xml.setNameForExport(geoName.toStdString());
-		xml.setConditionType(type);
-		xml.writeToFile(fileName.toStdString());
-	}
+	XmlCndInterface xml(&_project);
+	xml.setNameForExport(geoName.toStdString());
+	xml.setConditionType(type);
+	xml.writeToFile(fileName.toStdString());
 }
 
 void MainWindow::writeGeometryToFile(QString gliName, QString fileName)


### PR DESCRIPTION
Updates creating and writing FEM Conditions using GUI:
- when creating conds they are now explicitly written to ProjectData (this is also necessary to save them later)
- the dialog for saving conditions is updated for OGS6 (i.e. you can no longer save the old file formats)
