### PR TITLE
MessageBox Extension for GUI Error messages

### DIFF
--- a/Gui/Base/OGSError.cpp
+++ b/Gui/Base/OGSError.cpp
@@ -47,3 +47,4 @@ bool OGSError::question(const QString &e, const QString &t)
 		return true;
 	return false;
 }
+

--- a/Gui/Base/OGSError.h
+++ b/Gui/Base/OGSError.h
@@ -39,8 +39,11 @@ public:
 
 	/**
 	 * Displays a question in a QMessageBox (offering Ok | Cancel options)
+	 * Default value is 'Cancel' so that no bad things happen if the user
+	 * presses enter without reading the text (e.g. when overwriting files)
 	 * \param e The error message.
 	 * \param t The title of the message box
+	 * \return 'true' if 'Ok' has been pressed, 'false' otherwise
 	 * \sa QMessageBox
 	 */
 	static bool question(const QString &e, const QString &t);


### PR DESCRIPTION
Gives a message and allows to click "ok" or "cancel" (returning true or false).
I needed this for the conversion tool but it's a useful thing to have in the GUI in general.
