### PR TITLE
Calling the OGS File Converter as an external application

### DIFF
--- a/Gui/mainwindow.cpp
+++ b/Gui/mainwindow.cpp
@@ -1022,6 +1022,18 @@ void MainWindow::exportBoreholesToGMS(std::string listName,
 	GMSInterface::writeBoreholesToGMS(stations, fileName);
 }
 
+
+void MainWindow::callFileConverter() const
+{
+	if (system(NULL) != 0) // command processor available
+	{
+		std::string call_command("OGSFileConverter");
+		system(call_command.c_str());
+	}
+	else
+		OGSError::box("Error executing OGS File Converter", "Error");
+}
+
 void MainWindow::callGMSH(std::vector<std::string> & selectedGeometries,
                           unsigned param1, double param2, double param3, double param4,
                           bool delete_geo_file)

--- a/Gui/mainwindow.h
+++ b/Gui/mainwindow.h
@@ -61,6 +61,8 @@ protected slots:
 	void open(int i = 0);
 	/// Function calls for saving files.
 	void save();
+	/// Calls the OGSFileConverter as an external tool
+	void callFileConverter() const;
 	/// Function calls for generating GMSH files from the GUI
 	void callGMSH(std::vector<std::string> & selectedGeometries,
 	              unsigned param1,

--- a/Gui/mainwindow.ui
+++ b/Gui/mainwindow.ui
@@ -652,6 +652,22 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>actionFile_Converter</sender>
+   <signal>triggered()</signal>
+   <receiver>MainWindowClass</receiver>
+   <slot>callFileConverter()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>400</x>
+     <y>372</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>open()</slot>
@@ -666,5 +682,6 @@
   <slot>showLicense()</slot>
   <slot>showMergeGeometriesDialog()</slot>
   <slot>showMeshElementRemovalDialog()</slot>
+  <slot>callFileConverter()</slot>
  </slots>
 </ui>


### PR DESCRIPTION
This adds a system call to open the OGS File Converter (FC) from the tools menu.
The FC is build as an OGS-5 tool to allow batch conversion between old and new OGS files. For the Windows version of the Data Explorer the FC is deployed with the downloadable zip and will be available in the working dir (so calling it will not be a problem).

If I am doing something wrong here, pls let me know.
Also, I don't know if this works via Linux.
An up-to-date version of the FC-utility is available from the OGS-5 trunk.
