### PR TITLE
Enable caching of apt-get install on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ compiler:
   - gcc
   - clang
 
+cache:
+  - apt
+
 branches:
   only:
     - master


### PR DESCRIPTION
Just to try [this](http://about.travis-ci.org/docs/user/caching/#Caching-Ubuntu-packages) out.
