### PR TITLE
Load DIRECT conditions in GUI

### DIFF
--- a/Gui/DataView/MshView.cpp
+++ b/Gui/DataView/MshView.cpp
@@ -268,10 +268,8 @@ void MshView::addDIRECTSourceTerms()
 
 void MshView::loadDIRECTSourceTerms()
 {
-	// TODO6 QModelIndex index = this->selectionModel()->currentIndex();
-	// TODO6 const MeshLib::Mesh* grid = static_cast<MshModel*>(this->model())->getMesh(index);
-	// TODO6 const std::vector<MeshLib::Node*>* nodes = grid->getNodes();
-	// TODO6 emit requestDIRECTSourceTerms(grid->getName(), nodes);
+	QModelIndex index = this->selectionModel()->currentIndex();
+	emit loadFEMCondFileRequested(index.data(0).toString().toStdString());
 }
 
 void MshView::checkMeshQuality ()

--- a/Gui/DataView/MshView.h
+++ b/Gui/DataView/MshView.h
@@ -101,7 +101,7 @@ signals:
 	void requestCondSetupDialog(const std::string&, const GeoLib::GEOTYPE, const std::size_t, bool on_points);
 	void requestMeshRemoval(const QModelIndex&);
 	void requestMeshToGeometryConversion(const MeshLib::Mesh*);
-	void requestDIRECTSourceTerms(const std::string, const std::vector<GeoLib::Point*>*);
+	void loadFEMCondFileRequested(const std::string);
 	void saveMeshAction();
 
 /*

--- a/Gui/mainwindow.h
+++ b/Gui/mainwindow.h
@@ -49,6 +49,7 @@ public:
 
 protected:
 	void closeEvent( QCloseEvent* event );
+	void addFEMConditions(std::vector<FEMCondition*> const& conditions);
 
 protected slots:
 	void showGeoDockWidget( bool show );
@@ -101,7 +102,7 @@ protected slots:
 	void showVisalizationPrefsDialog();
 	void showTrackingSettingsDialog();
 	void updateDataViews();
-	void addFEMConditions(std::vector<FEMCondition*> const& conditions);
+	void createFEMConditions(std::vector<FEMCondition*> const& conditions);
 	void writeFEMConditionsToFile(const QString &geoName, const FEMCondition::CondType type, const QString &fileName);
 	void writeGeometryToFile(QString listName, QString fileName);
 	void writeStationListToFile(QString listName, QString fileName);


### PR DESCRIPTION
Switched functionality for loading DIRECT conditions on meshes back on. This was already included in OGS-5 and we commented out some calls when we transferred the GUI to OGS-6.
I made the necessary modifications to the make it work again and updated it based on the changes to the QtXmlInterface made by @TomFischer.
