### PR TITLE
Automatic activation of loaded data sets in VTK pipeline

### DIFF
--- a/Gui/VtkAct/VtkCustomInteractorStyle.cpp
+++ b/Gui/VtkAct/VtkCustomInteractorStyle.cpp
@@ -45,7 +45,7 @@
 vtkStandardNewMacro(VtkCustomInteractorStyle);
 
 VtkCustomInteractorStyle::VtkCustomInteractorStyle()
-	: _highlightActor(true), _alternateMouseActions(false)
+	: _highlightActor(false), _alternateMouseActions(false)
 {
 	selectedMapper = vtkDataSetMapper::New();
 	selectedActor = vtkActor::New();
@@ -197,7 +197,7 @@ void VtkCustomInteractorStyle::OnLeftButtonDown()
 
 			this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer()->
 			AddActor(selectedActor);
-			_highlightActor = true;
+			//_highlightActor = true;
 		}
 		else
 			this->Interactor->GetRenderWindow()->GetRenderers()->GetFirstRenderer()->

--- a/Gui/VtkVis/VtkVisPipeline.cpp
+++ b/Gui/VtkVis/VtkVisPipeline.cpp
@@ -314,12 +314,12 @@ QModelIndex VtkVisPipeline::addPipelineItem(VtkVisPipelineItem* item, const QMod
 
 	reset();
 	emit vtkVisPipelineChanged();
+	emit itemSelected(newIndex);
 
 	return newIndex;
 }
 
-QModelIndex VtkVisPipeline::addPipelineItem( vtkAlgorithm* source,
-                                      QModelIndex parent /* = QModelindex() */)
+QModelIndex VtkVisPipeline::addPipelineItem( vtkAlgorithm* source, QModelIndex parent /* = QModelindex() */)
 {
 	TreeItem* parentItem = getItem(parent);
 

--- a/Gui/VtkVis/VtkVisPipeline.h
+++ b/Gui/VtkVis/VtkVisPipeline.h
@@ -147,6 +147,7 @@ private:
 signals:
 	/// \brief Is emitted when a pipeline item was added or removed.
 	void vtkVisPipelineChanged() const;
+	void itemSelected(const QModelIndex&) const;
 };
 
 #endif // VTKVISPIPELINE_H

--- a/Gui/VtkVis/VtkVisPipelineView.cpp
+++ b/Gui/VtkVis/VtkVisPipelineView.cpp
@@ -49,7 +49,6 @@ VtkVisPipelineView::VtkVisPipelineView( QWidget* parent /*= 0*/ )
 	: QTreeView(parent)
 {
 	this->setItemsExpandable(false);
-	//setEditTriggers(QAbstractItemView::AllEditTriggers);
 	CheckboxDelegate* checkboxDelegate = new CheckboxDelegate(this);
 	this->setItemDelegateForColumn(1, checkboxDelegate);
 	this->header()->setStretchLastSection(false);
@@ -250,7 +249,7 @@ void VtkVisPipelineView::selectionChanged( const QItemSelection &selected,
 {
 	QTreeView::selectionChanged(selected, deselected);
 
-	QModelIndex index = this->selectionModel()->currentIndex();
+	QModelIndex index = *selected.indexes().begin();
 	if (index.isValid())
 	{
 		VtkVisPipelineItem* item = static_cast<VtkVisPipelineItem*>(index.internalPointer());
@@ -269,17 +268,19 @@ void VtkVisPipelineView::selectionChanged( const QItemSelection &selected,
 	}
 }
 
-void VtkVisPipelineView::selectItem( vtkProp3D* actor )
+void VtkVisPipelineView::selectItem(vtkProp3D* actor)
 {
-	QModelIndex index = ((VtkVisPipeline*)(this->model()))->getIndex(actor);
+	this->selectItem(static_cast<VtkVisPipeline*>(this->model())->getIndex(actor));	
+}
+
+void VtkVisPipelineView::selectItem(const QModelIndex &index)
+{
 	if (!index.isValid())
 		return;
 
-	blockSignals(true);
 	QItemSelectionModel* selectionModel = this->selectionModel();
 	selectionModel->clearSelection();
 	selectionModel->select(index, QItemSelectionModel::Select);
-	blockSignals(false);
 }
 
 void VtkVisPipelineView::addColorTable()

--- a/Gui/VtkVis/VtkVisPipelineView.h
+++ b/Gui/VtkVis/VtkVisPipelineView.h
@@ -47,6 +47,7 @@ protected slots:
 	/// Emits itemSelected() signals when an items was selected.
 	void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
 	void selectItem(vtkProp3D* actor);
+	void selectItem(const QModelIndex &index);
 
 private:
 	/// Creates a menu on right-clicking on an item.

--- a/Gui/mainwindow.cpp
+++ b/Gui/mainwindow.cpp
@@ -257,6 +257,9 @@ MainWindow::MainWindow(QWidget* parent /* = 0*/)
 	        visualizationWidget->vtkWidget, SLOT(update()));
 	connect(_vtkVisPipeline, SIGNAL(vtkVisPipelineChanged()),
 	        vtkVisTabWidget->vtkVisPipelineView, SLOT(expandAll()));
+	connect(_vtkVisPipeline, SIGNAL(itemSelected(const QModelIndex&)),
+	        vtkVisTabWidget->vtkVisPipelineView, SLOT(selectItem(const QModelIndex&)));
+
 
 	vtkVisTabWidget->vtkVisPipelineView->setModel(_vtkVisPipeline);
 	connect(vtkVisTabWidget->vtkVisPipelineView,


### PR DESCRIPTION
If a data set is loaded into the Data Explorer, the respective VtkVisPipelineItem is now automatically selected and activated. I.e. cells can instantly be picked and properties can be changed without selecting the item first.
If more than one item is added at the "same" time (e.g. with geometries), the last item is active (usually the surfaces).

Edit: Also set default highlighting option to false (i.e. bounding boxes are not shown if not explicitly switched on).
