### PR TITLE
New developer guide available

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ numerical methods for the simulation of thermo-hydro-mechanical-chemical
 is object-oriented with an focus on the numerical solution of coupled multi-field
 problems (multi-physics). Parallel versions of OGS are available relying on
 both MPI and OpenMP concepts. Application areas of OGS are currently CO2
-sequestration, geothermal energy, water resources management, hydrology and 
+sequestration, geothermal energy, water resources management, hydrology and
 waste deposition. OGS is comprised of the THMC-simulator (simply referred to as
 *OGS*) and a visualization tool (*Data Explorer*). OGS is developed by the
 [OpenGeoSys Community][ogs].
@@ -20,7 +20,7 @@ beta release version, i.e. not all data structure and features are fixed yet. If
 you would like to have a peek into the current status of the code, we recommend to
 have a look at Norihiro's [draft branch](https://github.com/norihiro-w/ogs/tree/draft).
 Which is merely a proposed prototype. However, it should compile out of the box
-and supports many of the simulation processes in ogs5 already. The plan is to 
+and supports many of the simulation processes in ogs5 already. The plan is to
 refactor the code and to merge in functionality into the official ogs6-repository
 feature-by-feature.
 
@@ -39,7 +39,7 @@ attribute the work of the OpenGeoSys Community especially in scientific
 publications. See the [LICENSE.txt][license-source] for the license text.
 
 [ogs]: http://www.opengeosys.com
-[devguide]: http://devguide.opengeosys.org
+[devguide]: http://docs.opengeosys.org/docs/devguide
 [jenkins-ci]: https://svn.ufz.de/jenkins/job/OGS-6/
 [docs]: https://svn.ufz.de/jenkins/job/OGS-6/job/Docs/lastSuccessfulBuild/artifact/build/docs/index.html
 [license-source]: https://github.com/ufz/ogs/blob/master/LICENSE.txt


### PR DESCRIPTION
Dear all,

I have finished the [new developer guide](http://docs.opengeosys.org/docs/devguide). I like to ask to have a look at it before I will announce on mailing list. You don't need to read it from start to end but if you have some general remarks please let me know.

There is also short intro on [how to use the guide](http://docs.opengeosys.org/docs).

The [web system](http://buildwithcraft.com) I used is super flexible and it would be no problem to integrate other future guides (e.g. a user guide) into it. The documentation is written in the same Markdown as we use here on GitHub. If someone is interested in how it works I can also provide a login.
