### PR TITLE
Use ssh for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = git://github.com/ufz/quickcheck.git
 [submodule "ThirdParty/VtkFbxConverter"]
 	path = ThirdParty/VtkFbxConverter
-	url = https://github.com/ufz-vislab/VtkFbxConverter.git
+	url = git://github.com/ufz-vislab/VtkFbxConverter.git
 [submodule "ThirdParty/VtkOsgConverter"]
 	path = ThirdParty/VtkOsgConverter
-	url = https://github.com/ufz-vislab/VtkOsgConverter.git
+	url = git://github.com/ufz-vislab/VtkOsgConverter.git


### PR DESCRIPTION
Is it ok to use ssh instead of https for submodules? Currently https doesn't work on Ubuntu for whatever reasons (https://bugs.launchpad.net/ubuntu/+source/gnutls26/+bug/1111882). 
