### PR TITLE
add VecNormType 

### DIFF
--- a/MathLib/LinAlg/VectorNorms.h
+++ b/MathLib/LinAlg/VectorNorms.h
@@ -1,7 +1,10 @@
 /**
  * \file
  * \author Thomas Fischer
- * \date   2011-06-06
+ * \author Wenqing Wang
+ *
+ * \date   2011-06-06 -- 2013-12-10
+ *
  * \brief  Definition of vector norm functions.
  *
  * \copyright
@@ -19,7 +22,16 @@
 
 #include "MathTools.h"
 
-namespace MathLib {
+namespace MathLib
+{
+
+/// Norm type. Not declared as class type in order to use the members as integers.
+enum class VecNormType
+{
+    NORM1,        ///< \f$\sum_i |x_i|\f$
+    NORM2,        ///< \f$\sqrt(\sum_i (x_i)^2)\f$
+    INFINITY_N    ///< \f$\mathrm{max}_i |x_i|\f$
+};
 
 inline
 double normEuklid (double const * const vec, std::size_t n)


### PR DESCRIPTION
I extracted commits from https://github.com/endJunction/ogs/commits/petsc_vector (#275), because I need them for implementing nonlinear solvers.
