### PR TITLE
"scpr" was renamed

### DIFF
--- a/MathLib/LinAlg/VectorNorms.h
+++ b/MathLib/LinAlg/VectorNorms.h
@@ -23,7 +23,7 @@ namespace MathLib {
 
 double normEuklid (double const * const vec, std::size_t n)
 {
-	return sqrt (scpr (vec, vec, n));
+	return sqrt (scalarProduct (vec, vec, n));
 }
 
 } // end namespace MathLib


### PR DESCRIPTION
as titled. no compiling error occurred because the function is not used
