### PR TITLE
add getGeoType() to GeoObject class and its child classes

### DIFF
--- a/GeoLib/GeoObject.h
+++ b/GeoLib/GeoObject.h
@@ -16,6 +16,8 @@
 #ifndef GEOOBJECT_H_
 #define GEOOBJECT_H_
 
+#include "GeoType.h"
+
 namespace GeoLib
 {
 class GeoObject
@@ -23,6 +25,9 @@ class GeoObject
 public:
 	GeoObject() {}
 	virtual ~GeoObject() {}
+
+	/// return a geometry type
+	virtual GEOTYPE getGeoType() const = 0;
 };
 } // end namespace GeoLib
 

--- a/GeoLib/Point.h
+++ b/GeoLib/Point.h
@@ -48,6 +48,9 @@ public:
 	GeoPoint (T const* x) :
 		MathLib::TemplatePoint<T>(x), GeoObject()
 	{}
+
+	/// return a geometry type
+	virtual GEOTYPE getGeoType() const {return GEOTYPE::POINT;}
 };
 
 typedef GeoLib::GeoPoint<double> Point;

--- a/GeoLib/Polyline.h
+++ b/GeoLib/Polyline.h
@@ -60,6 +60,9 @@ public:
 
 	virtual ~Polyline() {}
 
+	/// return a geometry type
+	virtual GEOTYPE getGeoType() const {return GEOTYPE::POLYLINE;}
+
 	/** write the points to the stream */
 	void write(std::ostream &os) const;
 

--- a/GeoLib/Surface.h
+++ b/GeoLib/Surface.h
@@ -38,6 +38,9 @@ public:
 	Surface	(const std::vector<Point*> &pnt_vec);
 	virtual ~Surface ();
 
+	/// return a geometry type
+	virtual GEOTYPE getGeoType() const {return GEOTYPE::SURFACE;}
+
 	/**
 	 * adds three indices describing a triangle and updates the bounding box
 	 * */


### PR DESCRIPTION
As discussed in #361, this PR adds `getGeoType()` to `GeoObject` class and its child classes
