### PR TITLE
Remove the range-based for-loops

### DIFF
--- a/MeshGeoToolsLib/MeshNodesAlongSurface.cpp
+++ b/MeshGeoToolsLib/MeshNodesAlongSurface.cpp
@@ -26,7 +26,8 @@ MeshNodesAlongSurface::MeshNodesAlongSurface(
 		GeoLib::Surface const& sfc) :
 	_sfc(sfc)
 {
-	for (auto* node : mesh_nodes) {
+	for (auto itr=mesh_nodes.cbegin(); itr!=mesh_nodes.cend(); ++itr) {
+		auto node = *itr;
 		if (!sfc.isPntInBoundingVolume(node->getCoords()))
 			continue;
 		if (sfc.isPntInSfc(node->getCoords())) {

--- a/MeshLib/MeshEditing/ElementExtraction.cpp
+++ b/MeshLib/MeshEditing/ElementExtraction.cpp
@@ -62,7 +62,8 @@ void ElementExtraction::searchByMaterialID(unsigned matID)
 	const std::vector<MeshLib::Element*> &ele_vec (this->_mesh.getElements());
 	std::vector<std::size_t> matchedIDs;
 	std::size_t i = 0;
-	for (MeshLib::Element* ele : ele_vec) {
+	for (auto itr=ele_vec.cbegin(); itr!=ele_vec.cend(); ++itr) {
+		const MeshLib::Element* ele = *itr;
 		if (ele->getValue()==matID)
 			matchedIDs.push_back(i);
 		i++;
@@ -75,7 +76,8 @@ void ElementExtraction::searchByElementType(MeshElemType eleType)
 	const std::vector<MeshLib::Element*> &ele_vec (this->_mesh.getElements());
 	std::vector<std::size_t> matchedIDs;
 	std::size_t i = 0;
-	for (MeshLib::Element* ele : ele_vec) {
+	for (auto itr=ele_vec.cbegin(); itr!=ele_vec.cend(); ++itr) {
+		const MeshLib::Element* ele = *itr;
 		if (ele->getGeomType()==eleType)
 			matchedIDs.push_back(i);
 		i++;
@@ -88,7 +90,8 @@ void ElementExtraction::searchByZeroContent()
 	const std::vector<MeshLib::Element*> &ele_vec (this->_mesh.getElements());
 	std::vector<std::size_t> matchedIDs;
 	std::size_t i = 0;
-	for (MeshLib::Element* ele : ele_vec) {
+	for (auto itr=ele_vec.cbegin(); itr!=ele_vec.cend(); ++itr) {
+		const MeshLib::Element* ele = *itr;
 		if (ele->getContent()<std::numeric_limits<double>::epsilon())
 			matchedIDs.push_back(i);
 		i++;

--- a/Tests/AssemblerLib/SteadyDiffusion2DExample1.h
+++ b/Tests/AssemblerLib/SteadyDiffusion2DExample1.h
@@ -64,8 +64,10 @@ struct SteadyDiffusion2DExample1
 	SteadyDiffusion2DExample1()
 	{
 		msh = MeshLib::MeshGenerator::generateRegularQuadMesh(2.0, mesh_subdivs);
-		for (auto* node : msh->getNodes())
+		for (auto itr=msh->getNodes().cbegin(); itr!=msh->getNodes().cend(); ++itr) {
+			auto* node = *itr;
 			vec_nodeIDs.push_back(node->getID());
+		}
 		vec_DirichletBC_id.resize(2 * mesh_stride);
 		for (std::size_t i = 0; i < mesh_stride; i++)
 		{

--- a/Tests/NumLib/TestCoordinatesMapping.cpp
+++ b/Tests/NumLib/TestCoordinatesMapping.cpp
@@ -60,9 +60,11 @@ class NumLibFemNaturalCoordinatesMappingQuad4Test : public ::testing::Test
         vec_eles.push_back(irregularQuad);
         vec_eles.push_back(clockwiseQuad);
         vec_eles.push_back(zeroAreaQuad);
-        for (auto e : vec_eles)
+        for (auto itr=vec_eles.cbegin(); itr!=vec_eles.cend(); ++itr) {
+            auto e = *itr;
             for (unsigned i=0; i<e->getNNodes(true); i++)
                 vec_nodes.push_back(e->getNode(i));
+        }
     }
 
     ~NumLibFemNaturalCoordinatesMappingQuad4Test()

--- a/Tests/NumLib/TestFeQuad4.cpp
+++ b/Tests/NumLib/TestFeQuad4.cpp
@@ -67,9 +67,11 @@ class NumLibFemIsoQuad4Test : public ::testing::Test
 
         // for destructor
         vec_eles.push_back(unitSquareQuad);
-        for (auto e : vec_eles)
+        for (auto itr=vec_eles.cbegin(); itr!=vec_eles.cend(); ++itr) {
+            auto e = *itr;
             for (unsigned i=0; i<e->getNNodes(true); i++)
                 vec_nodes.push_back(e->getNode(i));
+        }
     }
 
     ~NumLibFemIsoQuad4Test()

--- a/Utils/MeshEdit/removeMeshElements.cpp
+++ b/Utils/MeshEdit/removeMeshElements.cpp
@@ -34,7 +34,8 @@ std::vector<std::size_t> searchByMaterialID(const std::vector<MeshLib::Element*>
 {
 	std::vector<std::size_t> matchedIDs;
 	std::size_t i = 0;
-	for (MeshLib::Element* ele : ele_vec) {
+	for (auto itr=ele_vec.cbegin(); itr!=ele_vec.cend(); ++itr) {
+		const MeshLib::Element* ele = *itr;
 		if (ele->getValue()==matID)
 			matchedIDs.push_back(i);
 		i++;
@@ -46,7 +47,8 @@ std::vector<std::size_t> searchByElementType(const std::vector<MeshLib::Element*
 {
 	std::vector<std::size_t> matchedIDs;
 	std::size_t i = 0;
-	for (MeshLib::Element* ele : ele_vec) {
+	for (auto itr=ele_vec.cbegin(); itr!=ele_vec.cend(); ++itr) {
+		const MeshLib::Element* ele = *itr;
 		if (ele->getGeomType()==eleType)
 			matchedIDs.push_back(i);
 		i++;
@@ -58,7 +60,8 @@ std::vector<std::size_t> searchByZeroContent(const std::vector<MeshLib::Element*
 {
 	std::vector<std::size_t> matchedIDs;
 	std::size_t i = 0;
-	for (MeshLib::Element* ele : ele_vec) {
+	for (auto itr=ele_vec.cbegin(); itr!=ele_vec.cend(); ++itr) {
+		const MeshLib::Element* ele = *itr;
 		if (ele->getContent()==.0)
 			matchedIDs.push_back(i);
 		i++;
@@ -148,7 +151,8 @@ int main (int argc, char* argv[])
 	}
 	if (eleTypeArg.isSet()) {
 		std::vector<std::string> eleTypeNames = eleTypeArg.getValue();
-		for (auto typeName : eleTypeNames) {
+		for (auto itr=eleTypeNames.cbegin(); itr!=eleTypeNames.cend(); ++itr) {
+			auto typeName = *itr;
 			MeshElemType type = String2MeshElemType(typeName);
 			if (type == MeshElemType::INVALID) continue;
 			std::vector<std::size_t> vec_matched = searchByElementType(mesh->getElements(), type);
@@ -158,7 +162,8 @@ int main (int argc, char* argv[])
 	}
 	if (matIDArg.isSet()) {
 		std::vector<unsigned> vec_matID = matIDArg.getValue();
-		for (auto matID : vec_matID) {
+		for (auto itr=vec_matID.cbegin(); itr!=vec_matID.cend(); ++itr) {
+			auto matID = *itr;
 			std::vector<std::size_t> vec_matched = searchByMaterialID(mesh->getElements(), matID);
 			updateUnion(vec_matched, vec_elementIDs_removed);
 			INFO("%d elements with material ID %d found.", vec_matched.size(), matID);


### PR DESCRIPTION
This PR replaces the range-based for-loops with the iterator-based-for-loops. As Dima pointed out in #365, the range-based for-loops is not supported by IBM XLC.
