### PR TITLE
Refactoring point rotation functions 

### DIFF
--- a/GeoLib/AnalyticalGeometry.h
+++ b/GeoLib/AnalyticalGeometry.h
@@ -60,26 +60,6 @@ void getNewellPlane (const std::vector<GeoLib::Point*>& pnts,
                      double& d);
 
 /**
- * The vector plane_normal should be the surface normal of the plane surface described
- * by the points within the vector pnts. See function getNewellPlane() to get the
- * "plane normal" of a point set. The method rotates both the plane normal and
- * the points. The plane normal is rotated such that it is parallel to the \f$z\f$ axis.
- * @param plane_normal the normal of the plane
- * @param pnts pointers to points in a vector that should be rotated
- * @sa getNewellPlane()
- */
-void rotatePointsToXY(MathLib::Vector3 &plane_normal, std::vector<GeoLib::Point*> &pnts);
-
-/**
- * The vector plane_normal should be the surface normal of the plane surface described
- * by the points within the vector pnts. See function getNewellPlane() to get the
- * "plane normal" of a point set. The method rotates both the plane normal and
- * the points. The plane normal is rotated such that it is parallel to the \f$y\f$ axis.
- * @sa getNewellPlane()
- */
-void rotatePointsToXZ(MathLib::Vector3 &plane_normal, std::vector<GeoLib::Point*> &pnts);
-
-/**
  * Method computes the rotation matrix that rotates the given vector parallel to the \f$z\f$ axis.
  * @param plane_normal the (3d) vector that is rotated parallel to the \f$z\f$ axis
  * @param rot_mat 3x3 rotation matrix
@@ -88,11 +68,35 @@ void computeRotationMatrixToXY(MathLib::Vector3 const& plane_normal,
                                MathLib::DenseMatrix<double> & rot_mat);
 
 /**
+ * Method computes the rotation matrix that rotates the given vector parallel to the \f$y\f$ axis.
+ * @param plane_normal the (3d) vector that is rotated parallel to the \f$y\f$ axis
+ * @param rot_mat 3x3 rotation matrix
+ */
+void computeRotationMatrixToXZ(MathLib::Vector3 const& plane_normal,
+                               MathLib::DenseMatrix<double> & rot_mat);
+
+/**
  * rotate points according to the rotation matrix
  * @param rot_mat 3x3 dimensional rotation matrix
  * @param pnts vector of points
  */
 void rotatePoints(MathLib::DenseMatrix<double> const& rot_mat, std::vector<GeoLib::Point*> &pnts);
+
+/**
+ * rotate points to X-Y plane
+ * @param pnts a vector of points with a minimum length of three.
+ * Points are rotated using a rotation matrix computed from the first three points
+ * in the vector. Point coordinates are modified as a result of the rotation.
+ */
+void rotatePointsToXY(std::vector<GeoLib::Point*> &pnts);
+
+/**
+ * rotate points to X-Z plane
+ * @param pnts a vector of points with a minimum length of three.
+ * Points are rotated using a rotation matrix computed from the first three points
+ * in the vector. Point coordinates are modified as a result of the rotation.
+ */
+void rotatePointsToXZ(std::vector<GeoLib::Point*> &pnts);
 
 bool isPointInTriangle (const GeoLib::Point* p,
 		const GeoLib::Point* a, const GeoLib::Point* b, const GeoLib::Point* c);

--- a/GeoLib/EarClippingTriangulation.cpp
+++ b/GeoLib/EarClippingTriangulation.cpp
@@ -32,7 +32,7 @@ EarClippingTriangulation::EarClippingTriangulation(const GeoLib::Polygon* polygo
 	copyPolygonPoints (polygon);
 
 	if (rot) {
-		rotate ();
+		rotatePointsToXY (_pnts);
 		ensureCWOrientation ();
 	}
 
@@ -77,24 +77,6 @@ void EarClippingTriangulation::copyPolygonPoints (const GeoLib::Polygon* polygon
 	for (std::size_t k(0); k < n_pnts; k++) {
 		_pnts.push_back (new GeoLib::Point (*(polygon->getPoint(k))));
 	}
-}
-
-void EarClippingTriangulation::rotate ()
-{
-	// calculate supporting plane
-	MathLib::Vector3 plane_normal;
-	double d;
-	// compute the plane normal
-	getNewellPlane(_pnts, plane_normal, d);
-
-	double tol (std::numeric_limits<double>::epsilon());
-	if (fabs(plane_normal[0]) > tol || fabs(plane_normal[1]) > tol) {
-		// rotate copied points into x-y-plane
-		rotatePointsToXY(plane_normal, _pnts);
-	}
-
-	for (std::size_t k(0); k<_pnts.size(); k++)
-		(*(_pnts[k]))[2] = 0.0; // should be -= d but there are numerical errors
 }
 
 void EarClippingTriangulation::ensureCWOrientation ()

--- a/GeoLib/EarClippingTriangulation.h
+++ b/GeoLib/EarClippingTriangulation.h
@@ -39,7 +39,6 @@ private:
 	 * copies the points of the polygon to the vector _pnts
 	 */
 	inline void copyPolygonPoints (const GeoLib::Polygon* polygon);
-	inline void rotate ();
 	inline void ensureCWOrientation ();
 
 	inline bool isEar(std::size_t v0, std::size_t v1, std::size_t v2) const;

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -241,16 +241,8 @@ void Polygon::ensureCWOrientation ()
 	for (std::size_t k(0); k < n_pnts; k++)
 		tmp_polygon_pnts.push_back (new GeoLib::Point (*(this->getPoint(k))));
 
-	// *** calculate supporting plane (plane normal and
-	MathLib::Vector3 plane_normal;
-	double d;
-	GeoLib::getNewellPlane(tmp_polygon_pnts, plane_normal, d);
-
-	// *** rotate if necessary
-	double tol (std::numeric_limits<double>::epsilon());
-	if (fabs(plane_normal[0]) > tol || fabs(plane_normal[1]) > tol)
-		// rotate copied points into x-y-plane
-		GeoLib::rotatePointsToXY(plane_normal, tmp_polygon_pnts);
+	// rotate copied points into x-y-plane
+	GeoLib::rotatePointsToXY(tmp_polygon_pnts);
 
 	for (std::size_t k(0); k < tmp_polygon_pnts.size(); k++)
 		(*(tmp_polygon_pnts[k]))[2] = 0.0; // should be -= d but there are numerical errors


### PR DESCRIPTION
This PR reorganize point rotation functions in AnalyticalGeometry.h/.cpp (extracted from #369). Basically it substitutes `rotatePointsToXY(MathLib::Vector3 &plane_normal, std::vector<GeoLib::Point*> &pnts)` with `rotatePointsToXY(std::vector<GeoLib::Point*> &pnts)` which internally calls `computeRotationMatrixToXY()` and `rotatePoints()`. The same way was applied to `rotatePointsToXZ()`.
