### PR TITLE
fix compiling errors in MSVC

### DIFF
--- a/MeshLib/Elements/TemplateHex-impl.h
+++ b/MeshLib/Elements/TemplateHex-impl.h
@@ -23,10 +23,10 @@
 namespace MeshLib {
 
 template <unsigned NNODES, CellType CELLHEXTYPE>
-const unsigned TemplateHex<NNODES, CELLHEXTYPE>::n_all_nodes = NNODES;
+const unsigned TemplateHex<NNODES, CELLHEXTYPE>::n_all_nodes;
 
 template <unsigned NNODES, CellType CELLHEXTYPE>
-const unsigned TemplateHex<NNODES, CELLHEXTYPE>::n_base_nodes = 8;
+const unsigned TemplateHex<NNODES, CELLHEXTYPE>::n_base_nodes;
 
 template <unsigned NNODES, CellType CELLHEXTYPE>
 const unsigned TemplateHex<NNODES,CELLHEXTYPE>::_face_nodes[6][4] =

--- a/MeshLib/Elements/TemplateHex.h
+++ b/MeshLib/Elements/TemplateHex.h
@@ -51,10 +51,10 @@ class TemplateHex : public Cell
 {
 public:
 	/// Constant: The number of all nodes for this element
-	static const unsigned n_all_nodes;
+	static const unsigned n_all_nodes = NNODES;
 
 	/// Constant: The number of base nodes for this element
-	static const unsigned n_base_nodes;
+	static const unsigned n_base_nodes = 8u;
 
 	/// Constructor with an array of mesh nodes.
 	TemplateHex(Node* nodes[NNODES], unsigned value = 0, std::size_t id = std::numeric_limits<std::size_t>::max());

--- a/MeshLib/Elements/TemplateLine-impl.h
+++ b/MeshLib/Elements/TemplateLine-impl.h
@@ -64,13 +64,13 @@ ElementErrorCode TemplateLine<NNODES,CELLLINETYPE>::validate() const
 }
 
 template <unsigned NNODES, CellType CELLLINETYPE>
-const unsigned TemplateLine<NNODES, CELLLINETYPE>::dimension = 1u;
+const unsigned TemplateLine<NNODES, CELLLINETYPE>::dimension;
 
 template <unsigned NNODES, CellType CELLLINETYPE>
-const unsigned TemplateLine<NNODES, CELLLINETYPE>::n_all_nodes = NNODES;
+const unsigned TemplateLine<NNODES, CELLLINETYPE>::n_all_nodes;
 
 template <unsigned NNODES, CellType CELLLINETYPE>
-const unsigned TemplateLine<NNODES, CELLLINETYPE>::n_base_nodes = 2u;
+const unsigned TemplateLine<NNODES, CELLLINETYPE>::n_base_nodes;
 
 } // namespace MeshLib
 

--- a/MeshLib/Elements/TemplateLine.h
+++ b/MeshLib/Elements/TemplateLine.h
@@ -39,13 +39,13 @@ class TemplateLine : public Element
 {
 public:
 	/// Constant: Dimension of this mesh element
-	static const unsigned dimension;
+	static const unsigned dimension = 1u;
 
 	/// Constant: The number of all nodes for this element
-	static const unsigned n_all_nodes;
+	static const unsigned n_all_nodes = NNODES;
 
 	/// Constant: The number of base nodes for this element
-	static const unsigned n_base_nodes;
+	static const unsigned n_base_nodes = 2u;
 
 	/// Constructor with an array of mesh nodes.
 	TemplateLine(Node* nodes[NNODES], unsigned value = 0, std::size_t id = std::numeric_limits<std::size_t>::max());

--- a/MeshLib/Elements/TemplatePrism-impl.h
+++ b/MeshLib/Elements/TemplatePrism-impl.h
@@ -25,10 +25,10 @@
 namespace MeshLib {
 
 template <unsigned NNODES, CellType CELLPRISMTYPE>
-const unsigned TemplatePrism<NNODES, CELLPRISMTYPE>::n_all_nodes = NNODES;
+const unsigned TemplatePrism<NNODES, CELLPRISMTYPE>::n_all_nodes;
 
 template <unsigned NNODES, CellType CELLPRISMTYPE>
-const unsigned TemplatePrism<NNODES, CELLPRISMTYPE>::n_base_nodes = 6;
+const unsigned TemplatePrism<NNODES, CELLPRISMTYPE>::n_base_nodes;
 
 template <unsigned NNODES, CellType CELLPRISMTYPE>
 const unsigned TemplatePrism<NNODES,CELLPRISMTYPE>::_face_nodes[5][4] =

--- a/MeshLib/Elements/TemplatePrism.h
+++ b/MeshLib/Elements/TemplatePrism.h
@@ -49,10 +49,10 @@ class TemplatePrism : public Cell
 {
 public:
 	/// Constant: The number of all nodes for this element
-	static const unsigned n_all_nodes;
+	static const unsigned n_all_nodes = NNODES;
 
 	/// Constant: The number of base nodes for this element
-	static const unsigned n_base_nodes;
+	static const unsigned n_base_nodes = 6u;
 
 	/// Constructor with an array of mesh nodes.
 	TemplatePrism(Node* nodes[NNODES], unsigned value = 0, std::size_t id = std::numeric_limits<std::size_t>::max());

--- a/MeshLib/Elements/TemplatePyramid-impl.h
+++ b/MeshLib/Elements/TemplatePyramid-impl.h
@@ -25,10 +25,10 @@
 namespace MeshLib {
 
 template <unsigned NNODES, CellType CELLPYRAMIDTYPE>
-const unsigned TemplatePyramid<NNODES, CELLPYRAMIDTYPE>::n_all_nodes = NNODES;
+const unsigned TemplatePyramid<NNODES, CELLPYRAMIDTYPE>::n_all_nodes;
 
 template <unsigned NNODES, CellType CELLPYRAMIDTYPE>
-const unsigned TemplatePyramid<NNODES, CELLPYRAMIDTYPE>::n_base_nodes = 5;
+const unsigned TemplatePyramid<NNODES, CELLPYRAMIDTYPE>::n_base_nodes;
 
 template <unsigned NNODES, CellType CELLPYRAMIDTYPE>
 const unsigned TemplatePyramid<NNODES,CELLPYRAMIDTYPE>::_face_nodes[5][4] =

--- a/MeshLib/Elements/TemplatePyramid.h
+++ b/MeshLib/Elements/TemplatePyramid.h
@@ -47,10 +47,10 @@ class TemplatePyramid : public Cell
 {
 public:
 	/// Constant: The number of all nodes for this element
-	static const unsigned n_all_nodes;
+	static const unsigned n_all_nodes = NNODES;
 
 	/// Constant: The number of base nodes for this element
-	static const unsigned n_base_nodes;
+	static const unsigned n_base_nodes = 5u;
 
 	/// Constructor with an array of mesh nodes.
 	TemplatePyramid(Node* nodes[NNODES], unsigned value = 0, std::size_t id = std::numeric_limits<std::size_t>::max());

--- a/MeshLib/Elements/TemplateQuad-impl.h
+++ b/MeshLib/Elements/TemplateQuad-impl.h
@@ -25,10 +25,10 @@ namespace MeshLib
 {
 
 template <unsigned NNODES, CellType CELLQUADTYPE>
-const unsigned TemplateQuad<NNODES, CELLQUADTYPE>::n_all_nodes = NNODES;
+const unsigned TemplateQuad<NNODES, CELLQUADTYPE>::n_all_nodes;
 
 template <unsigned NNODES, CellType CELLQUADTYPE>
-const unsigned TemplateQuad<NNODES, CELLQUADTYPE>::n_base_nodes = 4;
+const unsigned TemplateQuad<NNODES, CELLQUADTYPE>::n_base_nodes;
 
 template <unsigned NNODES, CellType CELLQUADTYPE>
 const unsigned TemplateQuad<NNODES, CELLQUADTYPE>::_edge_nodes[4][2] =

--- a/MeshLib/Elements/TemplateQuad.h
+++ b/MeshLib/Elements/TemplateQuad.h
@@ -41,10 +41,10 @@ class TemplateQuad : public Face
 {
 public:
 	/// Constant: The number of all nodes for this element
-	static const unsigned n_all_nodes;
+	static const unsigned n_all_nodes = NNODES;
 
 	/// Constant: The number of base nodes for this element
-	static const unsigned n_base_nodes;
+	static const unsigned n_base_nodes = 4u;
 
 	/// Constructor with an array of mesh nodes.
 	TemplateQuad(Node* nodes[NNODES], unsigned value = 0, std::size_t id = std::numeric_limits<std::size_t>::max());

--- a/MeshLib/Elements/TemplateTet-impl.h
+++ b/MeshLib/Elements/TemplateTet-impl.h
@@ -22,10 +22,10 @@
 namespace MeshLib {
 
 template <unsigned NNODES, CellType CELLTETTYPE>
-const unsigned TemplateTet<NNODES, CELLTETTYPE>::n_all_nodes = NNODES;
+const unsigned TemplateTet<NNODES, CELLTETTYPE>::n_all_nodes;
 
 template <unsigned NNODES, CellType CELLTETTYPE>
-const unsigned TemplateTet<NNODES, CELLTETTYPE>::n_base_nodes = 4;
+const unsigned TemplateTet<NNODES, CELLTETTYPE>::n_base_nodes;
 
 template <unsigned NNODES, CellType CELLTETTYPE>
 const unsigned TemplateTet<NNODES,CELLTETTYPE>::_face_nodes[4][3] =

--- a/MeshLib/Elements/TemplateTet.h
+++ b/MeshLib/Elements/TemplateTet.h
@@ -46,10 +46,10 @@ class TemplateTet : public Cell
 {
 public:
 	/// Constant: The number of all nodes for this element
-	static const unsigned n_all_nodes;
+	static const unsigned n_all_nodes = NNODES;
 
 	/// Constant: The number of base nodes for this element
-	static const unsigned n_base_nodes;
+	static const unsigned n_base_nodes = 4u;
 
 	/// Constructor with an array of mesh nodes.
 	TemplateTet(Node* nodes[NNODES], unsigned value = 0, std::size_t id = std::numeric_limits<std::size_t>::max());

--- a/MeshLib/Elements/TemplateTri-impl.h
+++ b/MeshLib/Elements/TemplateTri-impl.h
@@ -18,10 +18,10 @@
 namespace MeshLib {
 
 template <unsigned NNODES, CellType CELLTRITYPE>
-const unsigned TemplateTri<NNODES, CELLTRITYPE>::n_all_nodes = NNODES;
+const unsigned TemplateTri<NNODES, CELLTRITYPE>::n_all_nodes;
 
 template <unsigned NNODES, CellType CELLTRITYPE>
-const unsigned TemplateTri<NNODES, CELLTRITYPE>::n_base_nodes = 3;
+const unsigned TemplateTri<NNODES, CELLTRITYPE>::n_base_nodes;
 
 template <unsigned NNODES, CellType CELLTRITYPE>
 const unsigned TemplateTri<NNODES,CELLTRITYPE>::_edge_nodes[3][2] = {

--- a/MeshLib/Elements/TemplateTri.h
+++ b/MeshLib/Elements/TemplateTri.h
@@ -48,10 +48,10 @@ class TemplateTri : public Face
 {
 public:
 	/// Constant: The number of all nodes for this element
-	static const unsigned n_all_nodes;
+	static const unsigned n_all_nodes = NNODES;
 
 	/// Constant: The number of base nodes for this element
-	static const unsigned n_base_nodes;
+	static const unsigned n_base_nodes = 3u;
 
 	/// Constructor with an array of mesh nodes.
 	TemplateTri(Node* nodes[NNODES], unsigned value = 0, std::size_t id = std::numeric_limits<std::size_t>::max());


### PR DESCRIPTION
this fix works in my Windows environment. so hope it works well also in our Jenkins. It seems, in MSVC, constant values in template classes should be defined together with their declaration. Otherwise, the compiler cannot interpret it as const expression, which means we cannot write like `double x[Line::nnodes]`.
