### PR TITLE
Proposal A: Derived mesh class for domain decomposition approach (Do not merge)

### DIFF
--- a/MeshLib/MeshDDC.h
+++ b/MeshLib/MeshDDC.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "Mesh"
 
 namespace MeshLib
 {


### PR DESCRIPTION
To  @norihiro-w  @rinkk @TomFischer :

This is a proposal to handle additional mesh data for  domain decomposition approach. This idea is to encapsulate all related data in a derived class of class mesh. By this way, `#ifdef`  is needed in local assembly for  MPI compilation. Of coarse, I can use template argument to avoid `#ifdef` if  the local assembly is finished.  Its usage would be

```
#ifdef USE_MPI
    MeshLib::MeshDDC* mesh = FileIO::readMeshFromFile(fname);
#endif
```

On the contrary, class Element can be also derived with additional data member for active node indices, this is demonstrated in another  PR (#421). With later local  `#ifdef` is avoid, but an index mapping to access element nodes is required.

Please give suggestion to me about Proposal A and B (#421), and any other idea about this issue. 
