### PR TITLE
[IO] BOOST_VERSION is defined only with version.hpp.

### DIFF
--- a/FileIO/XmlIO/Boost/BoostVtuInterface.cpp
+++ b/FileIO/XmlIO/Boost/BoostVtuInterface.cpp
@@ -20,6 +20,7 @@
 #include "zLibDataCompressor.h"
 #include <fstream>
 
+#include <boost/version.hpp>
 #include <boost/foreach.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 


### PR DESCRIPTION
Otherwise it is undefined and the BOOST_VERSION preprocessor
condition took the first branch because undefined = 0.

This is bugfix to my previous commit https://github.com/ufz/ogs/pull/459.
