### PR TITLE
When giving a custom comparison in std::sort use < as operator (not <=).

### DIFF
--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -156,7 +156,7 @@ bool Polygon::containsSegment(GeoLib::Point const& a, GeoLib::Point const& b) co
 	// This induces a partition of the line segment into sub segments.
 	std::sort(s.begin(), s.end(),
 		[&a] (GeoLib::Point const& p0, GeoLib::Point const& p1) {
-			return MathLib::sqrDist(a, p0) <= MathLib::sqrDist(a, p1);
+			return MathLib::sqrDist(a, p0) < MathLib::sqrDist(a, p1);
 		}
 	);
 


### PR DESCRIPTION
`a <= b` is **not** equivalent with `b >= a` but `a < b` **is** equivalent to `b > a`.

This fixes crashes in debug mode (especially in some tests) in which case the
runtime checks this rule and quits execution on violation.

This gotcha was examined together with Dima and Tom.
