### PR TITLE
[A] Fix infinite recursion in findMeshByName.

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -87,7 +87,7 @@ void ProjectData::addMesh(MeshLib::Mesh* mesh)
 std::vector<MeshLib::Mesh*>::const_iterator ProjectData::findMeshByName(
 		std::string const& name) const
 {
-	return findMeshByName(name);
+	return const_cast<ProjectData&>(*this).findMeshByName(name);
 }
 
 std::vector<MeshLib::Mesh*>::iterator ProjectData::findMeshByName(


### PR DESCRIPTION
Calling a const version of the ProjectData::findMeshByName() would cause infinite recursion.
Instead of duplicating code (source and binary) a const_cast is applied: this is valid because the non-const version is not modifying the mesh container.
