### PR TITLE
[AL] Add LinearSolverType to GlobalSetup.

### DIFF
--- a/Applications/CLI/NumericsConfig.h
+++ b/Applications/CLI/NumericsConfig.h
@@ -78,7 +78,8 @@ using GlobalVectorMatrixBuilderType =
 using GlobalSetupType =
     AssemblerLib::GlobalSetup<
         detail::GlobalVectorMatrixBuilderType,
-        detail::GlobalExecutorType>;
+        detail::GlobalExecutorType,
+        detail::LinearSolverType>;
 
 
 //

--- a/AssemblerLib/GlobalSetup.h
+++ b/AssemblerLib/GlobalSetup.h
@@ -19,11 +19,13 @@ namespace AssemblerLib
 
 /// The GlobalSetup collects vector and matrix builder and corresponding global
 /// loop executor.
-template <typename VectorMatrixBuilder, typename Executor>
+template <typename VectorMatrixBuilder, typename Executor, typename LinearSolver_>
 struct GlobalSetup
 {
     typedef typename VectorMatrixBuilder::VectorType VectorType;
     typedef typename VectorMatrixBuilder::MatrixType MatrixType;
+
+    using LinearSolver = LinearSolver_;
 
     template <typename... Args>
     static

--- a/AssemblerLib/SerialDenseSetup.h
+++ b/AssemblerLib/SerialDenseSetup.h
@@ -15,6 +15,8 @@
 
 #include "AssemblerLib/SerialDenseVectorMatrixBuilder.h"
 #include "AssemblerLib/SerialExecutor.h"
+#include "AssemblerLib/SerialExecutor.h"
+#include "MathLib/LinAlg/Solvers/GaussAlgorithm.h"
 
 namespace AssemblerLib
 {
@@ -23,7 +25,11 @@ namespace AssemblerLib
 /// global assembly loop.
 typedef GlobalSetup<
         AssemblerLib::SerialDenseVectorMatrixBuilder,
-        AssemblerLib::SerialExecutor>
+        AssemblerLib::SerialExecutor,
+        MathLib::GaussAlgorithm<
+            typename AssemblerLib::SerialDenseVectorMatrixBuilder::MatrixType,
+            typename AssemblerLib::SerialDenseVectorMatrixBuilder::VectorType>
+        >
     SerialDenseSetup;
 
 }   // namespace AssemblerLib


### PR DESCRIPTION
It is used in NumericsConfig for coordination with global matrix/vector types, e.g.  a LIS solver goes together with LIS-matrix/vector.
