### PR TITLE
MeshLib add properties

### DIFF
--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -14,10 +14,6 @@
 
 #include "Mesh.h"
 
-#include <boost/optional.hpp>
-
-#include "logog/include/logog.hpp"
-
 #include "BaseLib/RunTime.h"
 
 #include "Elements/Tri.h"

--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -34,7 +34,8 @@ Mesh::Mesh(const std::string &name,
 	  _edge_length(std::numeric_limits<double>::max(), 0),
 	  _node_distance(std::numeric_limits<double>::max(), 0),
 	  _name(name), _nodes(nodes), _elements(elements),
-	  _n_base_nodes(n_base_nodes==0 ? nodes.size() : n_base_nodes)
+	  _n_base_nodes(n_base_nodes==0 ? nodes.size() : n_base_nodes),
+	  _properties(*this)
 {
 	assert(n_base_nodes <= nodes.size());
 	this->resetNodeIDs();
@@ -54,7 +55,8 @@ Mesh::Mesh(const Mesh &mesh)
 	  _edge_length(mesh._edge_length.first, mesh._edge_length.second),
 	  _node_distance(mesh._node_distance.first, mesh._node_distance.second),
 	  _name(mesh.getName()), _nodes(mesh.getNNodes()), _elements(mesh.getNElements()),
-	  _n_base_nodes(mesh.getNBaseNodes())
+	  _n_base_nodes(mesh.getNBaseNodes()),
+	  _properties(*this)
 {
 	const std::vector<Node*> nodes (mesh.getNodes());
 	const size_t nNodes (nodes.size());

--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -35,7 +35,7 @@ Mesh::Mesh(const std::string &name,
 	  _node_distance(std::numeric_limits<double>::max(), 0),
 	  _name(name), _nodes(nodes), _elements(elements),
 	  _n_base_nodes(n_base_nodes==0 ? nodes.size() : n_base_nodes),
-	  _properties(*this)
+	  _properties()
 {
 	assert(n_base_nodes <= nodes.size());
 	this->resetNodeIDs();
@@ -56,7 +56,7 @@ Mesh::Mesh(const Mesh &mesh)
 	  _node_distance(mesh._node_distance.first, mesh._node_distance.second),
 	  _name(mesh.getName()), _nodes(mesh.getNNodes()), _elements(mesh.getNElements()),
 	  _n_base_nodes(mesh.getNBaseNodes()),
-	  _properties(*this)
+	  _properties()
 {
 	const std::vector<Node*> nodes (mesh.getNodes());
 	const size_t nNodes (nodes.size());

--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -39,7 +39,7 @@ class Mesh : BaseLib::Counter<Mesh>
 public:
 	/// Constructor using a mesh name and an array of nodes and elements
 	/// @param name          Mesh name.
-	/// @param nodes         A vector of mesh nodes. In case nonlinear nodes are involved, one should 
+	/// @param nodes         A vector of mesh nodes. In case nonlinear nodes are involved, one should
 	///                      put them after line ones in the vector and set "n_base_nodes" argument.
 	/// @param elements      An array of mesh elements.
 	/// @param n_base_nodes  The number of base nodes. This is an optional parameter for nonlinear case.
@@ -131,7 +131,7 @@ protected:
 	 * calls setElementsConnectedToNodes to set the new information.
 	 * \attention This needs to be called if node neighbourhoods are reset.
 	 */
-	void resetElementsConnectedToNodes();	
+	void resetElementsConnectedToNodes();
 
 	/// Sets the dimension of the mesh.
 	void setDimension();

--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -18,12 +18,6 @@
 #include <cstdlib>
 #include <string>
 #include <vector>
-#include <map>
-
-#include <boost/any.hpp>
-#include <boost/optional.hpp>
-
-#include "logog/include/logog.hpp"
 
 #include "BaseLib/Counter.h"
 

--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -18,10 +18,14 @@
 #include <cstdlib>
 #include <string>
 #include <vector>
+#include <map>
+
+#include <boost/any.hpp>
 
 #include "BaseLib/Counter.h"
 
 #include "MeshEnums.h"
+#include "Location.h"
 
 namespace MeshLib
 {
@@ -159,6 +163,28 @@ protected:
 	std::vector<Node*> _nodes;
 	std::vector<Element*> _elements;
 	std::size_t _n_base_nodes;
+
+	struct PropertyKeyType
+	{
+		PropertyKeyType(std::string const& n, MeshItemType t)
+			: name(n), mesh_item_type(t)
+		{}
+
+		std::string name;
+		MeshItemType mesh_item_type;
+
+		bool operator<(PropertyKeyType const& other) const
+		{
+			if (name.compare(other.name) == 0) {
+				return mesh_item_type < other.mesh_item_type;
+			}
+			return name.compare(other.name) < 0 ? true : false;
+		}
+	};
+
+	/// A mapping from property's name to the stored object of any type.
+	/// See addProperty() and getProperty() documentation.
+	std::map<PropertyKeyType, boost::any> _properties;
 
 }; /* class */
 

--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -28,7 +28,7 @@
 #include "BaseLib/Counter.h"
 
 #include "MeshEnums.h"
-#include "Location.h"
+#include "Properties.h"
 
 namespace MeshLib
 {
@@ -127,49 +127,8 @@ public:
 	/// Return true if the mesh has any nonlinear nodes
 	bool isNonlinear() const { return (getNNodes() != getNBaseNodes()); }
 
-	/// Method to get a vector of property values.
-	template <typename T>
-	boost::optional<std::vector<T> const&>
-	getProperty(std::string const& name) const
-	{
-		PropertyKeyType property_key(name, MeshItemType::Cell);
-		std::map<PropertyKeyType, boost::any>::const_iterator it(
-			_properties.find(property_key)
-		);
-		if (it != _properties.end()) {
-			try {
-				boost::any_cast<std::vector<T> const&>(it->second);
-				return boost::any_cast<std::vector<T> const&>(it->second);
-			} catch (boost::bad_any_cast const&) {
-				ERR("A property with the desired data type is not available.");
-				return boost::optional<std::vector<T> const&>();
-			}
-		} else {
-			return boost::optional<std::vector<T> const&>();
-		}
-	}
-
-	/// Method to store a vector of property values assigned to a property name.
-	/// Since the implementation makes no assumption about the number of data
-	/// items stored within the vector, it is possible either to use a small
-	/// number of properties where each particular property can be assigned to
-	/// several mesh items. In contrast to this it is possible to have a
-	/// separate value for each mesh item.
-	/// The user has to ensure the correct usage of the vector later on.
-	template <typename T>
-	void addProperty(std::string const& name, std::vector<T> const& property)
-	{
-		PropertyKeyType property_key(name, MeshItemType::Cell);
-		std::map<PropertyKeyType, boost::any>::const_iterator it(
-			_properties.find(property_key)
-		);
-		if (it != _properties.end()) {
-			WARN("A property of the name \"%s\" already assigned to the mesh.",
-				name.c_str());
-			return;
-		}
-		_properties[property_key] = boost::any(property);
-	}
+	MeshLib::Properties & getProperties() { return _properties; }
+	MeshLib::Properties const& getProperties() const { return _properties; }
 
 protected:
 	/// Set the minimum and maximum length over the edges of the mesh.
@@ -210,29 +169,7 @@ protected:
 	std::vector<Node*> _nodes;
 	std::vector<Element*> _elements;
 	std::size_t _n_base_nodes;
-
-	struct PropertyKeyType
-	{
-		PropertyKeyType(std::string const& n, MeshItemType t)
-			: name(n), mesh_item_type(t)
-		{}
-
-		std::string name;
-		MeshItemType mesh_item_type;
-
-		bool operator<(PropertyKeyType const& other) const
-		{
-			if (name.compare(other.name) == 0) {
-				return mesh_item_type < other.mesh_item_type;
-			}
-			return name.compare(other.name) < 0 ? true : false;
-		}
-	};
-
-	/// A mapping from property's name to the stored object of any type.
-	/// See addProperty() and getProperty() documentation.
-	std::map<PropertyKeyType, boost::any> _properties;
-
+	Properties _properties;
 }; /* class */
 
 } /* namespace */

--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -127,6 +127,7 @@ public:
 	/// Return true if the mesh has any nonlinear nodes
 	bool isNonlinear() const { return (getNNodes() != getNBaseNodes()); }
 
+	/// Method to get a vector of property values.
 	template <typename T>
 	boost::optional<std::vector<T> const&>
 	getProperty(std::string const& name) const
@@ -148,6 +149,13 @@ public:
 		}
 	}
 
+	/// Method to store a vector of property values assigned to a property name.
+	/// Since the implementation makes no assumption about the number of data
+	/// items stored within the vector, it is possible either to use a small
+	/// number of properties where each particular property can be assigned to
+	/// several mesh items. In contrast to this it is possible to have a
+	/// separate value for each mesh item.
+	/// The user has to ensure the correct usage of the vector later on.
 	template <typename T>
 	void addProperty(std::string const& name, std::vector<T> const& property)
 	{

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -42,9 +42,10 @@ public:
 	/// Method to get a vector of property values.
 	template <typename T>
 	boost::optional<std::vector<T> const&>
-	getProperty(std::string const& name) const
+	getProperty(std::string const& name,
+		MeshItemType mesh_item_type = MeshItemType::Cell) const
 	{
-		PropertyKeyType property_key(name, MeshItemType::Cell);
+		PropertyKeyType property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(
 			_properties.find(property_key)
 		);
@@ -69,9 +70,10 @@ public:
 	/// separate value for each mesh item.
 	/// The user has to ensure the correct usage of the vector later on.
 	template <typename T>
-	void addProperty(std::string const& name, std::vector<T> const& property)
+	void addProperty(std::string const& name, std::vector<T> const& property,
+		MeshItemType mesh_item_type = MeshItemType::Cell)
 	{
-		PropertyKeyType property_key(name, MeshItemType::Cell);
+		PropertyKeyType property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(
 			_properties.find(property_key)
 		);

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -16,7 +16,6 @@
 
 #include <cstdlib>
 #include <string>
-#include <vector>
 #include <map>
 
 #include <boost/any.hpp>
@@ -25,6 +24,8 @@
 #include "logog/include/logog.hpp"
 
 #include "Location.h"
+
+#include "PropertyVector.h"
 
 namespace MeshLib
 {
@@ -41,7 +42,7 @@ public:
 
 	/// Method to get a vector of property values.
 	template <typename T>
-	boost::optional<std::vector<T> const&>
+	boost::optional<PropertyVector<T> *>
 	getProperty(std::string const& name,
 		MeshItemType mesh_item_type = MeshItemType::Cell) const
 	{
@@ -51,14 +52,13 @@ public:
 		);
 		if (it != _properties.end()) {
 			try {
-				boost::any_cast<std::vector<T> const&>(it->second);
-				return boost::any_cast<std::vector<T> const&>(it->second);
+				return boost::any_cast<PropertyVector<T> *>(it->second);
 			} catch (boost::bad_any_cast const&) {
 				ERR("A property with the desired data type is not available.");
-				return boost::optional<std::vector<T> const&>();
+				return boost::optional<PropertyVector<T> *>();
 			}
 		} else {
-			return boost::optional<std::vector<T> const&>();
+			return boost::optional<PropertyVector<T> *>();
 		}
 	}
 
@@ -70,7 +70,7 @@ public:
 	/// separate value for each mesh item.
 	/// The user has to ensure the correct usage of the vector later on.
 	template <typename T>
-	void addProperty(std::string const& name, std::vector<T> const& property,
+	void addProperty(std::string const& name, PropertyVector<T> * property,
 		MeshItemType mesh_item_type = MeshItemType::Cell)
 	{
 		PropertyKeyType property_key(name, mesh_item_type);

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -115,7 +115,7 @@ private:
 			if (name.compare(other.name) == 0) {
 				return mesh_item_type < other.mesh_item_type;
 			}
-			return name.compare(other.name) < 0 ? true : false;
+			return name.compare(other.name) < 0;
 		}
 	};
 

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -34,6 +34,16 @@ namespace MeshLib
 class Properties
 {
 public:
+	/// Method creates a PropertyVector if a PropertyVector with the same name
+	/// and the same type T was not already created before.
+	/// There are two versions of this method. This method is used
+	/// when every mesh item at hand has its own property value.
+	/// The user has to ensure the correct usage of the vector later on.
+	/// @tparam T type of the property value
+	/// @param name the name of the property
+	/// @param mesh_item_type for instance node or element assigned properties
+	/// @return On success a reference to a PropertyVector packed into a
+	///   boost::optional else an empty boost::optional.
 	template <typename T>
 	boost::optional<PropertyVector<T> &>
 	newProperty(std::string const& name, MeshItemType mesh_item_type)
@@ -59,6 +69,17 @@ public:
 			);
 	}
 
+	/// Method creates a PropertyVector if a PropertyVector with the same name
+	/// and the same type T was not already created before.
+	/// Since the implementation makes no assumption about the number of data
+	/// items stored within the vector, it is possible either to use a small
+	/// number of properties where each particular property can be assigned to
+	/// several mesh items.
+	/// @tparam T type of the property value
+	/// @param name the name of the property
+	/// @param mesh_item_type for instance node or element assigned properties
+	/// @return On success a reference to a PropertyVector packed into a
+	///   boost::optional else an empty boost::optional.
 	template <typename T>
 	boost::optional<PropertyVector<T> &>
 	newProperty(std::string const& name,

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -128,6 +128,18 @@ public:
 		_properties.erase(it);
 	}
 
+	bool hasProperty(std::string const& name, MeshItemType mesh_item_type)
+	{
+		PropertyKeyType property_key(name, mesh_item_type);
+		std::map<PropertyKeyType, boost::any>::const_iterator it(
+			_properties.find(property_key)
+		);
+		if (it == _properties.end()) {
+			return false;
+		}
+		return true;
+	}
+
 private:
 	struct PropertyKeyType
 	{

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -59,6 +59,35 @@ public:
 			);
 	}
 
+	template <typename T>
+	boost::optional<PropertyVector<T> &>
+	newProperty(std::string const& name,
+		std::size_t n_prop_groups,
+		std::vector<std::size_t> const& item2group_mapping,
+		MeshItemType mesh_item_type)
+	{
+		PropertyKeyType property_key(name, mesh_item_type);
+		std::map<PropertyKeyType, boost::any>::const_iterator it(
+			_properties.find(property_key)
+		);
+		if (it != _properties.end()) {
+			WARN("A property of the name \"%s\" already assigned to the mesh.",
+				name.c_str());
+			return boost::optional<PropertyVector<T> &>();
+		}
+		auto entry_info(
+			_properties.insert(
+				std::pair<PropertyKeyType, boost::any>(
+					property_key,
+					boost::any(PropertyVector<T>(n_prop_groups, item2group_mapping))
+				)
+			)
+		);
+		return boost::optional<PropertyVector<T> &>(
+			boost::any_cast<PropertyVector<T> &>(
+				(entry_info.first)->second)
+			);
+	}
 
 	/// Method to get a vector of property values.
 	template <typename T>

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -202,10 +202,11 @@ private:
 
 		bool operator<(PropertyKeyType const& other) const
 		{
-			if (name.compare(other.name) == 0) {
+			int res(name.compare(other.name));
+			if (res == 0) {
 				return mesh_item_type < other.mesh_item_type;
 			}
-			return name.compare(other.name) < 0;
+			return res < 0;
 		}
 	};
 

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -91,9 +91,9 @@ public:
 
 	/// Method to get a vector of property values.
 	template <typename T>
-	boost::optional<PropertyVector<T> *>
+	boost::optional<PropertyVector<T> const&>
 	getProperty(std::string const& name,
-		MeshItemType mesh_item_type) const
+		MeshItemType mesh_item_type)
 	{
 		PropertyKeyType property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(
@@ -101,13 +101,15 @@ public:
 		);
 		if (it != _properties.end()) {
 			try {
-				return boost::any_cast<PropertyVector<T> *>(it->second);
+				return boost::optional<PropertyVector<T> const&>(
+						boost::any_cast<PropertyVector<T> const&>(it->second)
+					);
 			} catch (boost::bad_any_cast const&) {
 				ERR("A property with the desired data type is not available.");
-				return boost::optional<PropertyVector<T> *>();
+				return boost::optional<PropertyVector<T> const&>();
 			}
 		} else {
-			return boost::optional<PropertyVector<T> *>();
+			return boost::optional<PropertyVector<T> const&>();
 		}
 	}
 

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -102,6 +102,14 @@ public:
 		std::vector<std::size_t> const& item2group_mapping,
 		MeshItemType mesh_item_type)
 	{
+		// check entries of item2group_mapping of consistence
+		for (std::size_t k(0); k<item2group_mapping.size(); k++) {
+			std::size_t const group_id (item2group_mapping[k]);
+			if (group_id >= n_prop_groups) {
+				ERR("The mapping to property %d for item %d is not in the correct range [0,%d).", group_id, k, n_prop_groups);
+				return boost::optional<PropertyVector<T> &>();
+			}
+		}
 		PropertyKeyType const property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(
 			_properties.find(property_key)

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -1,0 +1,130 @@
+/**
+ * \file
+ * \brief  Definition of the class Properties that implements a container of
+ *         properties.
+ *
+ * \copyright
+ * Copyright (c) 2012-2014, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROPERTIES_H_
+#define PROPERTIES_H_
+
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <map>
+
+#include <boost/any.hpp>
+#include <boost/optional.hpp>
+
+#include "logog/include/logog.hpp"
+
+#include "Location.h"
+
+namespace MeshLib
+{
+// forward declaration
+class Mesh;
+
+/// Properties associated to mesh items (nodes or elements).
+class Properties
+{
+public:
+	explicit Properties(MeshLib::Mesh const& mesh)
+		: _mesh(mesh)
+	{}
+
+	/// Method to get a vector of property values.
+	template <typename T>
+	boost::optional<std::vector<T> const&>
+	getProperty(std::string const& name) const
+	{
+		PropertyKeyType property_key(name, MeshItemType::Cell);
+		std::map<PropertyKeyType, boost::any>::const_iterator it(
+			_properties.find(property_key)
+		);
+		if (it != _properties.end()) {
+			try {
+				boost::any_cast<std::vector<T> const&>(it->second);
+				return boost::any_cast<std::vector<T> const&>(it->second);
+			} catch (boost::bad_any_cast const&) {
+				ERR("A property with the desired data type is not available.");
+				return boost::optional<std::vector<T> const&>();
+			}
+		} else {
+			return boost::optional<std::vector<T> const&>();
+		}
+	}
+
+	/// Method to store a vector of property values assigned to a property name.
+	/// Since the implementation makes no assumption about the number of data
+	/// items stored within the vector, it is possible either to use a small
+	/// number of properties where each particular property can be assigned to
+	/// several mesh items. In contrast to this it is possible to have a
+	/// separate value for each mesh item.
+	/// The user has to ensure the correct usage of the vector later on.
+	template <typename T>
+	void addProperty(std::string const& name, std::vector<T> const& property)
+	{
+		PropertyKeyType property_key(name, MeshItemType::Cell);
+		std::map<PropertyKeyType, boost::any>::const_iterator it(
+			_properties.find(property_key)
+		);
+		if (it != _properties.end()) {
+			WARN("A property of the name \"%s\" already assigned to the mesh.",
+				name.c_str());
+			return;
+		}
+		_properties[property_key] = boost::any(property);
+	}
+
+	void removeProperty(std::string const& name,
+		MeshItemType mesh_item_type = MeshItemType::Cell)
+	{
+		PropertyKeyType property_key(name, mesh_item_type);
+		std::map<PropertyKeyType, boost::any>::const_iterator it(
+			_properties.find(property_key)
+		);
+		if (it == _properties.end()) {
+			WARN("A property of the name \"%s\" does not exist.",
+				name.c_str());
+			return;
+		}
+		_properties.erase(it);
+	}
+
+private:
+	struct PropertyKeyType
+	{
+		PropertyKeyType(std::string const& n, MeshItemType t)
+			: name(n), mesh_item_type(t)
+		{}
+
+		std::string name;
+		MeshItemType mesh_item_type;
+
+		bool operator<(PropertyKeyType const& other) const
+		{
+			if (name.compare(other.name) == 0) {
+				return mesh_item_type < other.mesh_item_type;
+			}
+			return name.compare(other.name) < 0 ? true : false;
+		}
+	};
+
+	/// Mesh object the properties are assigned to.
+	MeshLib::Mesh const& _mesh;
+	/// A mapping from property's name to the stored object of any type.
+	/// See addProperty() and getProperty() documentation.
+	std::map<PropertyKeyType, boost::any> _properties;
+}; // end class
+
+} // end namespace MeshLib
+
+#endif
+

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -44,7 +44,7 @@ public:
 	template <typename T>
 	boost::optional<PropertyVector<T> *>
 	getProperty(std::string const& name,
-		MeshItemType mesh_item_type = MeshItemType::Cell) const
+		MeshItemType mesh_item_type) const
 	{
 		PropertyKeyType property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(
@@ -71,7 +71,7 @@ public:
 	/// The user has to ensure the correct usage of the vector later on.
 	template <typename T>
 	void addProperty(std::string const& name, PropertyVector<T> * property,
-		MeshItemType mesh_item_type = MeshItemType::Cell)
+		MeshItemType mesh_item_type)
 	{
 		PropertyKeyType property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(
@@ -86,7 +86,7 @@ public:
 	}
 
 	void removeProperty(std::string const& name,
-		MeshItemType mesh_item_type = MeshItemType::Cell)
+		MeshItemType mesh_item_type)
 	{
 		PropertyKeyType property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -113,29 +113,6 @@ public:
 		}
 	}
 
-	/// Method to store a vector of property values assigned to a property name.
-	/// Since the implementation makes no assumption about the number of data
-	/// items stored within the vector, it is possible either to use a small
-	/// number of properties where each particular property can be assigned to
-	/// several mesh items. In contrast to this it is possible to have a
-	/// separate value for each mesh item.
-	/// The user has to ensure the correct usage of the vector later on.
-	template <typename T>
-	void addProperty(std::string const& name, PropertyVector<T> * property,
-		MeshItemType mesh_item_type)
-	{
-		PropertyKeyType property_key(name, mesh_item_type);
-		std::map<PropertyKeyType, boost::any>::const_iterator it(
-			_properties.find(property_key)
-		);
-		if (it != _properties.end()) {
-			WARN("A property of the name \"%s\" already assigned to the mesh.",
-				name.c_str());
-			return;
-		}
-		_properties[property_key] = boost::any(property);
-	}
-
 	void removeProperty(std::string const& name,
 		MeshItemType mesh_item_type)
 	{

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -61,7 +61,7 @@ public:
 			_properties.find(property_key)
 		);
 		if (it != _properties.end()) {
-			WARN("A property of the name \"%s\" already assigned to the mesh.",
+			WARN("A property of the name \"%s\" is already assigned to the mesh.",
 				name.c_str());
 			return boost::optional<PropertyVector<T> &>();
 		}

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -95,7 +95,7 @@ public:
 		std::vector<std::size_t> const& item2group_mapping,
 		MeshItemType mesh_item_type)
 	{
-		PropertyKeyType property_key(name, mesh_item_type);
+		PropertyKeyType const property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(
 			_properties.find(property_key)
 		);
@@ -124,7 +124,7 @@ public:
 	getProperty(std::string const& name,
 		MeshItemType mesh_item_type)
 	{
-		PropertyKeyType property_key(name, mesh_item_type);
+		PropertyKeyType const property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(
 			_properties.find(property_key)
 		);
@@ -145,7 +145,7 @@ public:
 	void removeProperty(std::string const& name,
 		MeshItemType mesh_item_type)
 	{
-		PropertyKeyType property_key(name, mesh_item_type);
+		PropertyKeyType const property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(
 			_properties.find(property_key)
 		);
@@ -164,7 +164,7 @@ public:
 	/// @param mesh_item_type to which item type the property is assigned to
 	bool hasProperty(std::string const& name, MeshItemType mesh_item_type)
 	{
-		PropertyKeyType property_key(name, mesh_item_type);
+		PropertyKeyType const property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(
 			_properties.find(property_key)
 		);
@@ -181,8 +181,8 @@ private:
 			: name(n), mesh_item_type(t)
 		{}
 
-		std::string name;
-		MeshItemType mesh_item_type;
+		std::string const name;
+		MeshItemType const mesh_item_type;
 
 		bool operator<(PropertyKeyType const& other) const
 		{

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -102,14 +102,8 @@ public:
 		std::vector<std::size_t> const& item2group_mapping,
 		MeshItemType mesh_item_type)
 	{
-		// check entries of item2group_mapping of consistence
-		for (std::size_t k(0); k<item2group_mapping.size(); k++) {
-			std::size_t const group_id (item2group_mapping[k]);
-			if (group_id >= n_prop_groups) {
-				ERR("The mapping to property %d for item %d is not in the correct range [0,%d).", group_id, k, n_prop_groups);
-				return boost::optional<PropertyVector<T> &>();
-			}
-		}
+		// check if there is already a PropertyVector with the same name and
+		// mesh_item_type
 		PropertyKeyType const property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(
 			_properties.find(property_key)
@@ -119,6 +113,16 @@ public:
 				name.c_str());
 			return boost::optional<PropertyVector<T> &>();
 		}
+
+		// check entries of item2group_mapping of consistence
+		for (std::size_t k(0); k<item2group_mapping.size(); k++) {
+			std::size_t const group_id (item2group_mapping[k]);
+			if (group_id >= n_prop_groups) {
+				ERR("The mapping to property %d for item %d is not in the correct range [0,%d).", group_id, k, n_prop_groups);
+				return boost::optional<PropertyVector<T> &>();
+			}
+		}
+
 		auto entry_info(
 			_properties.insert(
 				std::pair<PropertyKeyType, boost::any>(

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -34,6 +34,31 @@ namespace MeshLib
 class Properties
 {
 public:
+	template <typename T>
+	boost::optional<PropertyVector<T> &>
+	newProperty(std::string const& name, MeshItemType mesh_item_type)
+	{
+		PropertyKeyType property_key(name, mesh_item_type);
+		std::map<PropertyKeyType, boost::any>::const_iterator it(
+			_properties.find(property_key)
+		);
+		if (it != _properties.end()) {
+			WARN("A property of the name \"%s\" already assigned to the mesh.",
+				name.c_str());
+			return boost::optional<PropertyVector<T> &>();
+		}
+		auto entry_info(
+			_properties.insert(
+				std::pair<PropertyKeyType, boost::any>(
+					property_key, boost::any(PropertyVector<T>())
+				)
+			)
+		);
+		return boost::optional<PropertyVector<T> &>(
+			boost::any_cast<PropertyVector<T> &>((entry_info.first)->second)
+			);
+	}
+
 
 	/// Method to get a vector of property values.
 	template <typename T>

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -137,7 +137,7 @@ public:
 	template <typename T>
 	boost::optional<PropertyVector<T> const&>
 	getProperty(std::string const& name,
-		MeshItemType mesh_item_type)
+		MeshItemType mesh_item_type) const
 	{
 		PropertyKeyType const property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -29,16 +29,11 @@
 
 namespace MeshLib
 {
-// forward declaration
-class Mesh;
 
 /// Properties associated to mesh items (nodes or elements).
 class Properties
 {
 public:
-	explicit Properties(MeshLib::Mesh const& mesh)
-		: _mesh(mesh)
-	{}
 
 	/// Method to get a vector of property values.
 	template <typename T>
@@ -119,8 +114,6 @@ private:
 		}
 	};
 
-	/// Mesh object the properties are assigned to.
-	MeshLib::Mesh const& _mesh;
 	/// A mapping from property's name to the stored object of any type.
 	/// See addProperty() and getProperty() documentation.
 	std::map<PropertyKeyType, boost::any> _properties;

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -32,7 +32,7 @@ namespace MeshLib
 
 /// @brief Material property manager on mesh items.
 /// Class Properties manages scalar, vector or matrix properties. For instance
-/// in groundwater flow porosity is scalar property and permeabilty can be
+/// in groundwater flow porosity is a scalar property and permeabilty can be
 /// stored as a tensor property. Properties are assigned to mesh items, i.e.
 /// Node or Element objects. The newProperty() method first creates a
 /// PropertyVector of template type T (scalar, vector or matrix).
@@ -79,8 +79,9 @@ public:
 
 	/// Method creates a PropertyVector if a PropertyVector with the same name
 	/// and the same type T was not already created before.
-	/// This method is used if only a small number of different properties
-	/// exists. In this case a mapping between mesh items and properties (stored
+	/// This method is used if only a small number of distinct property values
+	/// in a property exist (e.g. mapping material groups to elements).
+	/// In this case a mapping between mesh items and properties (stored
 	/// on the heap), see the parameter item2group_mapping, is required.
 	/// @tparam T type of the property value
 	/// @param name the name of the property

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -30,14 +30,22 @@
 namespace MeshLib
 {
 
-/// Properties associated to mesh items (nodes or elements).
+/// @brief Material property manager on mesh items.
+/// Class Properties manages scalar, vector or matrix properties. For instance
+/// in groundwater flow porosity is scalar property and permeabilty can be
+/// stored as a tensor property. Properties are assigned to mesh items, i.e.
+/// Node or Element objects. The newProperty() method first creates a
+/// PropertyVector of template type T (scalar, vector or matrix).
+/// This class stores the PropertyVector, accessible by a combination of the
+/// name and the type of the mesh item (Node or Element).
 class Properties
 {
 public:
 	/// Method creates a PropertyVector if a PropertyVector with the same name
 	/// and the same type T was not already created before.
 	/// There are two versions of this method. This method is used
-	/// when every mesh item at hand has its own property value.
+	/// when every mesh item at hand has its own property value, i.e. \f$n\f$
+	/// mesh item and \f$n\f$ different property values.
 	/// The user has to ensure the correct usage of the vector later on.
 	/// @tparam T type of the property value
 	/// @param name the name of the property
@@ -71,10 +79,9 @@ public:
 
 	/// Method creates a PropertyVector if a PropertyVector with the same name
 	/// and the same type T was not already created before.
-	/// Since the implementation makes no assumption about the number of data
-	/// items stored within the vector, it is possible either to use a small
-	/// number of properties where each particular property can be assigned to
-	/// several mesh items.
+	/// This method is used if only a small number of different properties
+	/// exists. In this case a mapping between mesh items and properties (stored
+	/// on the heap), see the parameter item2group_mapping, is required.
 	/// @tparam T type of the property value
 	/// @param name the name of the property
 	/// @param mesh_item_type for instance node or element assigned properties
@@ -149,6 +156,11 @@ public:
 		_properties.erase(it);
 	}
 
+	/// Check if a PropertyVector accessible by a combination of the
+	/// name and the type of the mesh item (Node or Element) is already
+	/// stored within the Properties object.
+	/// @param name the name of the property (for instance porosity)
+	/// @param mesh_item_type to which item type the property is assigned to
 	bool hasProperty(std::string const& name, MeshItemType mesh_item_type)
 	{
 		PropertyKeyType property_key(name, mesh_item_type);

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -54,7 +54,7 @@ public:
 	///   boost::optional else an empty boost::optional.
 	template <typename T>
 	boost::optional<PropertyVector<T> &>
-	newProperty(std::string const& name, MeshItemType mesh_item_type)
+	createNewPropertyVector(std::string const& name, MeshItemType mesh_item_type)
 	{
 		PropertyKeyType property_key(name, mesh_item_type);
 		std::map<PropertyKeyType, boost::any>::const_iterator it(
@@ -90,7 +90,7 @@ public:
 	///   boost::optional else an empty boost::optional.
 	template <typename T>
 	boost::optional<PropertyVector<T> &>
-	newProperty(std::string const& name,
+	createNewPropertyVector(std::string const& name,
 		std::size_t n_prop_groups,
 		std::vector<std::size_t> const& item2group_mapping,
 		MeshItemType mesh_item_type)

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -26,6 +26,7 @@ namespace MeshLib
 template <typename PROP_VAL_TYPE>
 class PropertyVector : public std::vector<PROP_VAL_TYPE>
 {
+friend class Properties;
 public:
 	PropertyVector()
 		: std::vector<PROP_VAL_TYPE>()
@@ -48,6 +49,7 @@ public:
 template <typename T>
 class PropertyVector<T*> : public std::vector<T*>
 {
+friend class Properties;
 public:
 	/// @param n_prop_groups number of different property values
 	/// @param item2group_mapping Class Mesh has a mapping from the mesh items

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -26,7 +26,11 @@ template <typename PROP_VAL_TYPE>
 class PropertyVector : public std::vector<PROP_VAL_TYPE>
 {
 public:
-	PropertyVector(std::size_t size)
+	PropertyVector()
+		: std::vector<PROP_VAL_TYPE>()
+	{}
+
+	explicit PropertyVector(std::size_t size)
 		: std::vector<PROP_VAL_TYPE>(size)
 	{}
 };

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -27,7 +27,7 @@ template <typename PROP_VAL_TYPE>
 class PropertyVector : public std::vector<PROP_VAL_TYPE>
 {
 friend class Properties;
-public:
+protected:
 	PropertyVector()
 		: std::vector<PROP_VAL_TYPE>()
 	{}
@@ -50,7 +50,7 @@ template <typename T>
 class PropertyVector<T*> : public std::vector<T*>
 {
 friend class Properties;
-public:
+protected:
 	/// @param n_prop_groups number of different property values
 	/// @param item2group_mapping Class Mesh has a mapping from the mesh items
 	/// (Node or Element) to an index (position in the data structure).
@@ -63,6 +63,7 @@ public:
 		_item2group_mapping(item2group_mapping)
 	{}
 
+public:
 	/// Destructor ensures the deletion of the heap-constructed objects.
 	~PropertyVector()
 	{

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -39,9 +39,10 @@ template <typename T>
 class PropertyVector<T*> : public std::vector<T*>
 {
 public:
-	PropertyVector(std::size_t n_mat_groups,
-		std::vector<std::size_t> const& mat_group_idx_map)
-		: std::vector<T*>(n_mat_groups), _mat_group_idx_map(mat_group_idx_map)
+	PropertyVector(std::size_t n_prop_groups,
+		std::vector<std::size_t> const& item2group_mapping)
+		: std::vector<T*>(n_prop_groups),
+		_item2group_mapping(item2group_mapping)
 	{}
 
 	~PropertyVector()
@@ -53,11 +54,11 @@ public:
 
 	T* const& operator[](std::size_t id) const
 	{
-		return (*static_cast<std::vector<T*> const *>(this))[_mat_group_idx_map[id]];
+		return (*static_cast<std::vector<T*> const*>(this))[_item2group_mapping[id]];
 	}
 
 private:
-	std::vector<std::size_t> _mat_group_idx_map;
+	std::vector<std::size_t> _item2group_mapping;
 };
 
 } // end namespace MeshLib

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -35,10 +35,6 @@ template <typename T>
 class PropertyVector<T*> : public std::vector<T*>
 {
 public:
-	PropertyVector(std::vector<T*> const& properties)
-		: std::vector<T*>(properties)
-	{}
-
 	PropertyVector(std::size_t n_mat_groups,
 		std::vector<std::size_t> const& mat_group_idx_map)
 		: std::vector<T*>(n_mat_groups), _mat_group_idx_map(mat_group_idx_map)

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -41,7 +41,7 @@ public:
 /// The behaviour has changed for the constructor, destructor and the operator[].
 /// The user has to provide the size and an item to group mapping for construction.
 /// The destructor takes care to delete the entries of the vector.
-/// The operator[] uses an item to group property map to access to the
+/// The operator[] uses an item-to-group property map to access the
 /// correct property.
 /// \tparam T pointer type, the type the type points to is typical a scalar,
 /// a vector or a matrix type

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -1,0 +1,65 @@
+/**
+ * \file
+ * \brief  Definition of the class Properties that implements a container of
+ *         properties.
+ *
+ * \copyright
+ * Copyright (c) 2012-2014, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROPERTYVECTOR_H_
+#define PROPERTYVECTOR_H_
+
+#include <algorithm>
+#include <vector>
+#include <type_traits>
+#include <memory>
+
+namespace MeshLib
+{
+
+template <typename PROP_VAL_TYPE>
+class PropertyVector : public std::vector<PROP_VAL_TYPE>
+{
+public:
+	PropertyVector(std::size_t size)
+		: std::vector<PROP_VAL_TYPE>(size)
+	{}
+};
+
+template <typename T>
+class PropertyVector<T*> : public std::vector<T*>
+{
+public:
+	PropertyVector(std::vector<T*> const& properties)
+		: std::vector<T*>(properties)
+	{}
+
+	PropertyVector(std::size_t n_mat_groups,
+		std::vector<std::size_t> const& mat_group_idx_map)
+		: std::vector<T*>(n_mat_groups), _mat_group_idx_map(mat_group_idx_map)
+	{}
+
+	~PropertyVector()
+	{
+		std::for_each(
+			this->begin(), this->end(), std::default_delete<T>()
+		);
+	}
+
+	T* const& operator[](std::size_t id) const
+	{
+		return (*static_cast<std::vector<T*> const *>(this))[_mat_group_idx_map[id]];
+	}
+
+private:
+	std::vector<std::size_t> _mat_group_idx_map;
+};
+
+} // end namespace MeshLib
+
+#endif

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -1,0 +1,53 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2014, OpenGeoSys Community (http://www.opengeosys.org)
+ *			Distributed under a Modified BSD License.
+ *			  See accompanying file LICENSE.txt or
+ *			  http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include <ctime>
+#include "gtest/gtest.h"
+
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/Elements/Line.h"
+
+class MeshLibMeshProperties : public ::testing::Test
+{
+	public:
+	MeshLibMeshProperties()
+		: mesh(nullptr)
+	{
+		mesh = MeshLib::MeshGenerator::generateRegularHexMesh(1.0, mesh_size);
+	}
+
+	~MeshLibMeshProperties()
+	{
+		delete mesh;
+	}
+
+	static std::size_t const mesh_size = 9;
+	MeshLib::Mesh * mesh;
+};
+std::size_t const MeshLibMeshProperties::mesh_size;
+
+TEST_F(MeshLibMeshProperties, AddDoubleProperties)
+{
+	ASSERT_TRUE(mesh != nullptr);
+	const std::size_t size(mesh_size*mesh_size*mesh_size);
+	std::vector<double> double_properties(size);
+	std::iota(double_properties.begin(), double_properties.end(), 1);
+
+	std::string const& prop_name("FirstTestProperty");
+	// add a vector with property values to the mesh
+	mesh->addProperty(prop_name, double_properties);
+
+	boost::optional<std::vector<double> const&>
+		double_properties_cpy(mesh->getProperty<double>(prop_name));
+
+	for (std::size_t k(0); k<size; k++) {
+		ASSERT_EQ(double_properties[k], (*double_properties_cpy)[k]);
+	}
+}
+

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -41,10 +41,10 @@ TEST_F(MeshLibMeshProperties, AddDoubleProperties)
 
 	std::string const& prop_name("FirstTestProperty");
 	// add a vector with property values to the mesh
-	mesh->addProperty(prop_name, double_properties);
+	mesh->getProperties().addProperty(prop_name, double_properties);
 
 	boost::optional<std::vector<double> const&>
-		double_properties_cpy(mesh->getProperty<double>(prop_name));
+		double_properties_cpy(mesh->getProperties().getProperty<double>(prop_name));
 
 	for (std::size_t k(0); k<size; k++) {
 		ASSERT_EQ(double_properties[k], (*double_properties_cpy)[k]);

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -61,7 +61,7 @@ public:
 		return group_props;
 	}
 
-	static std::size_t const mesh_size = 3;
+	static std::size_t const mesh_size = 5;
 	MeshLib::Mesh * mesh;
 };
 std::size_t const MeshLibMeshProperties::mesh_size;
@@ -175,9 +175,12 @@ TEST_F(MeshLibMeshProperties, AddArrayPointerProperties)
 	ASSERT_FALSE(!pointer_properties_cpy);
 
 	for (std::size_t k(0); k<n_elements; k++) {
-		ASSERT_EQ((*pointer_properties)[k][0], (*(*pointer_properties_cpy))[k][0]);
-		ASSERT_EQ((*pointer_properties)[k][1], (*(*pointer_properties_cpy))[k][1]);
-		ASSERT_EQ((*pointer_properties)[k][2], (*(*pointer_properties_cpy))[k][2]);
+		ASSERT_EQ((*((*pointer_properties)[k]))[0],
+			(*((*(*pointer_properties_cpy))[k]))[0]);
+		ASSERT_EQ((*((*pointer_properties)[k]))[1],
+			(*((*(*pointer_properties_cpy))[k]))[1]);
+		ASSERT_EQ((*((*pointer_properties)[k]))[2],
+			(*((*(*pointer_properties_cpy))[k]))[2]);
 	}
 
 	mesh->getProperties().removeProperty(prop_name);
@@ -210,9 +213,12 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 	// compare the content
 	const std::size_t n_elements(mesh_size*mesh_size*mesh_size);
 	for (std::size_t k(0); k<n_elements; k++) {
-		ASSERT_EQ((*pointer_properties)[k][0], (*(*pointer_properties_cpy))[k][0]);
-		ASSERT_EQ((*pointer_properties)[k][1], (*(*pointer_properties_cpy))[k][1]);
-		ASSERT_EQ((*pointer_properties)[k][2], (*(*pointer_properties_cpy))[k][2]);
+		ASSERT_EQ((*((*pointer_properties)[k]))[0],
+			(*((*(*pointer_properties_cpy))[k]))[0]);
+		ASSERT_EQ((*((*pointer_properties)[k]))[1],
+			(*((*(*pointer_properties_cpy))[k]))[1]);
+		ASSERT_EQ((*((*pointer_properties)[k]))[2],
+			(*((*(*pointer_properties_cpy))[k]))[2]);
 	}
 
 	// add a 2nd property

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -12,10 +12,15 @@
 #include "MeshLib/MeshGenerators/MeshGenerator.h"
 #include "MeshLib/Mesh.h"
 #include "MeshLib/Elements/Line.h"
+#include "PropertyVector.h"
+
+#ifdef OGS_USE_EIGEN
+#include <Eigen/Eigen>
+#endif
 
 class MeshLibMeshProperties : public ::testing::Test
 {
-	public:
+public:
 	MeshLibMeshProperties()
 		: mesh(nullptr)
 	{
@@ -27,7 +32,36 @@ class MeshLibMeshProperties : public ::testing::Test
 		delete mesh;
 	}
 
-	static std::size_t const mesh_size = 9;
+	template <typename T>
+	MeshLib::PropertyVector<T*>* createGroupPropertyValueVector(
+		std::size_t n_mat_groups)
+	{
+		const std::size_t n_elements(mesh_size*mesh_size*mesh_size);
+		std::vector<std::size_t> mat_group_idx_map(n_elements);
+		// create simple mat_group to index mapping
+		for (std::size_t j(0); j<n_mat_groups; j++) {
+			std::size_t const lower((double)(j)/(double)(n_mat_groups)*n_elements);
+			std::size_t const upper((double)(j+1)/(double)(n_mat_groups)*n_elements);
+			for (std::size_t k(lower); k<upper; k++) {
+				mat_group_idx_map[k] = j;
+			}
+		}
+		MeshLib::PropertyVector<T*> *group_props(
+			new MeshLib::PropertyVector<T*>(
+				n_mat_groups, mat_group_idx_map
+			)
+		);
+		for (auto it=group_props->begin(); it != group_props->end(); it++) {
+			(*it) = new T;
+			for (std::size_t idx(0); idx<(*it)->size(); idx++) {
+				(*(*it))[idx] = std::distance(group_props->begin(), it)+idx;
+			}
+		}
+
+		return group_props;
+	}
+
+	static std::size_t const mesh_size = 3;
 	MeshLib::Mesh * mesh;
 };
 std::size_t const MeshLibMeshProperties::mesh_size;
@@ -36,18 +70,218 @@ TEST_F(MeshLibMeshProperties, AddDoubleProperties)
 {
 	ASSERT_TRUE(mesh != nullptr);
 	const std::size_t size(mesh_size*mesh_size*mesh_size);
-	std::vector<double> double_properties(size);
-	std::iota(double_properties.begin(), double_properties.end(), 1);
+	MeshLib::PropertyVector<double> *double_properties(
+		new MeshLib::PropertyVector<double>(size)
+	);
+	// init property values
+	std::iota(double_properties->begin(), double_properties->end(), 1);
 
 	std::string const& prop_name("FirstTestProperty");
 	// add a vector with property values to the mesh
 	mesh->getProperties().addProperty(prop_name, double_properties);
 
-	boost::optional<std::vector<double> const&>
+	boost::optional<MeshLib::PropertyVector<double> *>
 		double_properties_cpy(mesh->getProperties().getProperty<double>(prop_name));
+	ASSERT_FALSE(!double_properties_cpy);
 
 	for (std::size_t k(0); k<size; k++) {
-		ASSERT_EQ(double_properties[k], (*double_properties_cpy)[k]);
+		ASSERT_EQ((*double_properties)[k], (*(*double_properties_cpy))[k]);
 	}
+
+	mesh->getProperties().removeProperty(prop_name);
+	boost::optional<MeshLib::PropertyVector<double> *>
+		removed_double_properties(mesh->getProperties().getProperty<double>(prop_name));
+
+	ASSERT_TRUE(!removed_double_properties);
+}
+
+TEST_F(MeshLibMeshProperties, AddDoublePointerProperties)
+{
+	ASSERT_TRUE(mesh != nullptr);
+	const std::size_t n_mat_groups(10);
+	const std::size_t n_elements(mesh_size*mesh_size*mesh_size);
+	std::vector<std::size_t> mat_group_idx_map(n_elements);
+	// create simple mat_group to index mapping
+	for (std::size_t j(0); j<n_mat_groups; j++) {
+		std::size_t const lower((double)(j)/(double)(n_mat_groups)*n_elements);
+		std::size_t const upper((double)(j+1)/(double)(n_mat_groups)*n_elements);
+		for (std::size_t k(lower); k<upper; k++) {
+			mat_group_idx_map[k] = j;
+		}
+	}
+	MeshLib::PropertyVector<double*> *pointer_properties(
+		new MeshLib::PropertyVector<double*>(n_mat_groups, mat_group_idx_map)
+	);
+	for (auto it=pointer_properties->begin(); it != pointer_properties->end(); it++)
+	{
+		(*it) = new double;
+		*(*it) = std::distance(pointer_properties->begin(), it);
+	}
+
+	std::string const& prop_name("TestMatGroupProperty");
+	// add a vector with property values to the mesh
+	mesh->getProperties().addProperty(prop_name, pointer_properties);
+
+	boost::optional<MeshLib::PropertyVector<double*> *>
+		pointer_properties_cpy(mesh->getProperties().getProperty<double*>(prop_name));
+	ASSERT_FALSE(!pointer_properties_cpy);
+
+	for (std::size_t k(0); k<n_elements; k++) {
+		ASSERT_EQ((*pointer_properties)[k], (*(*pointer_properties_cpy))[k]);
+	}
+
+	mesh->getProperties().removeProperty(prop_name);
+	boost::optional<MeshLib::PropertyVector<double*> *>
+		removed_double_properties(mesh->getProperties().getProperty<double*>(prop_name));
+
+	ASSERT_TRUE(!removed_double_properties);
+}
+
+TEST_F(MeshLibMeshProperties, AddArrayPointerProperties)
+{
+	ASSERT_TRUE(mesh != nullptr);
+	const std::size_t n_mat_groups(10);
+	const std::size_t n_elements(mesh_size*mesh_size*mesh_size);
+	std::vector<std::size_t> mat_group_idx_map(n_elements);
+	// create simple mat_group to index mapping
+	for (std::size_t j(0); j<n_mat_groups; j++) {
+		std::size_t const lower((double)(j)/(double)(n_mat_groups)*n_elements);
+		std::size_t const upper((double)(j+1)/(double)(n_mat_groups)*n_elements);
+		for (std::size_t k(lower); k<upper; k++) {
+			mat_group_idx_map[k] = j;
+		}
+	}
+	MeshLib::PropertyVector<std::array<double,3>*> *pointer_properties(
+		new MeshLib::PropertyVector<std::array<double,3>*>(
+			n_mat_groups, mat_group_idx_map
+		)
+	);
+	for (auto it=pointer_properties->begin(); it != pointer_properties->end(); it++)
+	{
+		(*it) = new std::array<double,3>;
+		(*(*it))[0] = std::distance(pointer_properties->begin(), it);
+		(*(*it))[1] = std::distance(pointer_properties->begin(), it)+1;
+		(*(*it))[2] = std::distance(pointer_properties->begin(), it)+2;
+	}
+
+	std::string const& prop_name("TestMatGroupProperty");
+	// add a vector with property values to the mesh
+	mesh->getProperties().addProperty(prop_name, pointer_properties);
+
+	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> *>
+		pointer_properties_cpy(
+			mesh->getProperties().getProperty<std::array<double,3>*>(prop_name)
+		);
+	ASSERT_FALSE(!pointer_properties_cpy);
+
+	for (std::size_t k(0); k<n_elements; k++) {
+		ASSERT_EQ((*pointer_properties)[k][0], (*(*pointer_properties_cpy))[k][0]);
+		ASSERT_EQ((*pointer_properties)[k][1], (*(*pointer_properties_cpy))[k][1]);
+		ASSERT_EQ((*pointer_properties)[k][2], (*(*pointer_properties_cpy))[k][2]);
+	}
+
+	mesh->getProperties().removeProperty(prop_name);
+	boost::optional<MeshLib::PropertyVector<std::array<double, 3>*> *>
+		removed_double_properties(
+			mesh->getProperties().getProperty<std::array<double,3>*>(prop_name)
+		);
+
+	ASSERT_TRUE(!removed_double_properties);
+}
+
+TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
+{
+	ASSERT_TRUE(mesh != nullptr);
+
+	const std::size_t n_mat_groups(10);
+	std::string const& prop_name("TestMatGroupVectorProperty");
+	// add a vector with property values to the mesh
+	MeshLib::PropertyVector<std::array<double,3>*> *pointer_properties(
+		createGroupPropertyValueVector<std::array<double,3>>(n_mat_groups));
+	mesh->getProperties().addProperty(prop_name, pointer_properties);
+
+	// fetch the vector filled with property values from mesh
+	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> *>
+		pointer_properties_cpy(
+			mesh->getProperties().getProperty<std::array<double,3>*>(prop_name)
+		);
+	ASSERT_FALSE(!pointer_properties_cpy);
+
+	// compare the content
+	const std::size_t n_elements(mesh_size*mesh_size*mesh_size);
+	for (std::size_t k(0); k<n_elements; k++) {
+		ASSERT_EQ((*pointer_properties)[k][0], (*(*pointer_properties_cpy))[k][0]);
+		ASSERT_EQ((*pointer_properties)[k][1], (*(*pointer_properties_cpy))[k][1]);
+		ASSERT_EQ((*pointer_properties)[k][2], (*(*pointer_properties_cpy))[k][2]);
+	}
+
+	// add a 2nd property
+	const std::size_t size(mesh_size*mesh_size*mesh_size);
+	MeshLib::PropertyVector<std::array<float,9>> *matrix_properties(
+		new MeshLib::PropertyVector<std::array<float,9>>(size)
+	);
+	// init property values
+	for (auto it=matrix_properties->begin(); it != matrix_properties->end(); it++)
+	{
+		for (std::size_t k(0); k<it->size(); k++) {
+			(*it)[k] = std::distance(matrix_properties->begin(), it)+k;
+		}
+	}
+
+	std::string const& prop_name_2("MatrixProperties");
+	// add a vector with property values to the mesh
+	mesh->getProperties().addProperty(prop_name_2, matrix_properties);
+
+	// fetch the vector in order to compare the content
+	boost::optional<MeshLib::PropertyVector<std::array<float,9>> *>
+		matrix_properties_cpy(mesh->getProperties().getProperty<std::array<float,9>>(prop_name_2));
+	ASSERT_FALSE(!matrix_properties_cpy);
+
+	// compare the values/matrices
+	for (std::size_t k(0); k<size; k++) {
+		ASSERT_EQ((*matrix_properties)[k], (*(*matrix_properties_cpy))[k]);
+	}
+
+	// add a 3rd property
+#ifdef OGS_USE_EIGEN
+	MeshLib::PropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>>
+		*properties_3(
+			new MeshLib::PropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>>(size)
+	);
+
+	// init property values
+	for (auto it=properties_3->begin(); it != properties_3->end(); it++)
+	{
+		for (int r(0); r<it->rows(); r++) {
+			for (int c(0); c<it->cols(); c++) {
+				(*it)(r,c) = std::distance(properties_3->begin(),it)
+					+ r*it->cols()+c+1;
+			}
+		}
+	}
+
+	std::string const& prop_name_3("Properties3");
+	// add a vector with property values to the mesh
+	mesh->getProperties().addProperty(prop_name_3, properties_3);
+
+	// fetch the vector in order to compare the content
+	boost::optional<
+		MeshLib::PropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>>*
+	> properties_3_cpy(
+		mesh->getProperties().getProperty<Eigen::Matrix<double,3,3,Eigen::RowMajor>>(prop_name_3)
+	);
+	ASSERT_FALSE(!properties_3_cpy);
+
+	// compare the values/matrices
+	auto it_cpy=(*properties_3_cpy)->begin();
+	for (auto it=properties_3->begin(); it != properties_3->end();
+		it++, it_cpy++) {
+		for (int r(0); r<it->rows(); r++) {
+			for (int c(0); c<it->cols(); c++) {
+				ASSERT_EQ((*it)(r,c), (*it_cpy)(r,c));
+			}
+		}
+	}
+#endif
 }
 

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -45,7 +45,7 @@ TEST_F(MeshLibMeshProperties, AddDoubleProperties)
 
 	std::string const prop_name("TestProperty");
 	boost::optional<MeshLib::PropertyVector<double> &> double_properties(
-		mesh->getProperties().newProperty<double>(prop_name,
+		mesh->getProperties().createNewPropertyVector<double>(prop_name,
 			MeshLib::MeshItemType::Cell)
 	);
 	(*double_properties).resize(size);
@@ -93,7 +93,7 @@ TEST_F(MeshLibMeshProperties, AddDoublePointerProperties)
 	}
 	// obtain PropertyVector data structure
 	boost::optional<MeshLib::PropertyVector<double*> &> group_properties(
-		mesh->getProperties().newProperty<double*>(
+		mesh->getProperties().createNewPropertyVector<double*>(
 			prop_name, n_prop_val_groups, prop_item2group_mapping,
 			MeshLib::MeshItemType::Cell
 		)
@@ -147,7 +147,7 @@ TEST_F(MeshLibMeshProperties, AddArrayPointerProperties)
 	}
 	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> &>
 		group_properties(
-			mesh->getProperties().newProperty<std::array<double,3>*>(
+			mesh->getProperties().createNewPropertyVector<std::array<double,3>*>(
 				prop_name, n_prop_val_groups, prop_item2group_mapping,
 				MeshLib::MeshItemType::Cell
 			)
@@ -211,7 +211,7 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 	// create data structure for the property
 	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> &>
 		group_properties(
-			mesh->getProperties().newProperty<std::array<double,3>*>(
+			mesh->getProperties().createNewPropertyVector<std::array<double,3>*>(
 				prop_name, n_prop_val_groups, prop_item2group_mapping,
 				MeshLib::MeshItemType::Cell
 			)
@@ -254,7 +254,7 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 		MeshLib::MeshItemType::Cell));
 	const std::size_t n_items_2(mesh_size*mesh_size*mesh_size);
 	boost::optional<MeshLib::PropertyVector<std::array<float,9>> &>
-		array_properties(mesh->getProperties().newProperty<
+		array_properties(mesh->getProperties().createNewPropertyVector<
 			std::array<float,9>
 		> (prop_name_2, MeshLib::MeshItemType::Cell)
 	);
@@ -293,7 +293,7 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 		MeshLib::MeshItemType::Cell));
 	boost::optional<
 		MeshLib::PropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>> &>
-	matrix_properties(mesh->getProperties().newProperty
+	matrix_properties(mesh->getProperties().createNewPropertyVector
 		<Eigen::Matrix<double,3,3,Eigen::RowMajor>> (
 			prop_name_3, MeshLib::MeshItemType::Cell)
 	);

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -12,6 +12,7 @@
 #include "MeshLib/MeshGenerators/MeshGenerator.h"
 #include "MeshLib/Mesh.h"
 #include "MeshLib/Elements/Line.h"
+#include "Location.h"
 #include "PropertyVector.h"
 
 #ifdef OGS_USE_EIGEN
@@ -78,19 +79,24 @@ TEST_F(MeshLibMeshProperties, AddDoubleProperties)
 
 	std::string const& prop_name("FirstTestProperty");
 	// add a vector with property values to the mesh
-	mesh->getProperties().addProperty(prop_name, double_properties);
+	mesh->getProperties().addProperty(prop_name, double_properties,
+		MeshLib::MeshItemType::Cell);
 
 	boost::optional<MeshLib::PropertyVector<double> *>
-		double_properties_cpy(mesh->getProperties().getProperty<double>(prop_name));
+		double_properties_cpy(mesh->getProperties().getProperty<double>(
+			prop_name, MeshLib::MeshItemType::Cell
+		));
 	ASSERT_FALSE(!double_properties_cpy);
 
 	for (std::size_t k(0); k<size; k++) {
 		ASSERT_EQ((*double_properties)[k], (*(*double_properties_cpy))[k]);
 	}
 
-	mesh->getProperties().removeProperty(prop_name);
+	mesh->getProperties().removeProperty(prop_name, MeshLib::MeshItemType::Cell);
 	boost::optional<MeshLib::PropertyVector<double> *>
-		removed_double_properties(mesh->getProperties().getProperty<double>(prop_name));
+		removed_double_properties(mesh->getProperties().getProperty<double>(prop_name,
+			MeshLib::MeshItemType::Cell)
+		);
 
 	ASSERT_TRUE(!removed_double_properties);
 }
@@ -120,19 +126,24 @@ TEST_F(MeshLibMeshProperties, AddDoublePointerProperties)
 
 	std::string const& prop_name("TestMatGroupProperty");
 	// add a vector with property values to the mesh
-	mesh->getProperties().addProperty(prop_name, pointer_properties);
+	mesh->getProperties().addProperty(prop_name, pointer_properties,
+		MeshLib::MeshItemType::Cell);
 
 	boost::optional<MeshLib::PropertyVector<double*> *>
-		pointer_properties_cpy(mesh->getProperties().getProperty<double*>(prop_name));
+		pointer_properties_cpy(mesh->getProperties().getProperty<double*>(
+			prop_name, MeshLib::MeshItemType::Cell
+		));
 	ASSERT_FALSE(!pointer_properties_cpy);
 
 	for (std::size_t k(0); k<n_elements; k++) {
 		ASSERT_EQ((*pointer_properties)[k], (*(*pointer_properties_cpy))[k]);
 	}
 
-	mesh->getProperties().removeProperty(prop_name);
+	mesh->getProperties().removeProperty(prop_name, MeshLib::MeshItemType::Cell);
 	boost::optional<MeshLib::PropertyVector<double*> *>
-		removed_double_properties(mesh->getProperties().getProperty<double*>(prop_name));
+		removed_double_properties(mesh->getProperties().getProperty<double*>(
+			prop_name, MeshLib::MeshItemType::Cell
+		));
 
 	ASSERT_TRUE(!removed_double_properties);
 }
@@ -166,11 +177,14 @@ TEST_F(MeshLibMeshProperties, AddArrayPointerProperties)
 
 	std::string const& prop_name("TestMatGroupProperty");
 	// add a vector with property values to the mesh
-	mesh->getProperties().addProperty(prop_name, pointer_properties);
+	mesh->getProperties().addProperty(prop_name, pointer_properties,
+		MeshLib::MeshItemType::Cell);
 
 	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> *>
 		pointer_properties_cpy(
-			mesh->getProperties().getProperty<std::array<double,3>*>(prop_name)
+			mesh->getProperties().getProperty<std::array<double,3>*>(
+				prop_name, MeshLib::MeshItemType::Cell
+			)
 		);
 	ASSERT_FALSE(!pointer_properties_cpy);
 
@@ -183,10 +197,12 @@ TEST_F(MeshLibMeshProperties, AddArrayPointerProperties)
 			(*((*(*pointer_properties_cpy))[k]))[2]);
 	}
 
-	mesh->getProperties().removeProperty(prop_name);
+	mesh->getProperties().removeProperty(prop_name, MeshLib::MeshItemType::Cell);
 	boost::optional<MeshLib::PropertyVector<std::array<double, 3>*> *>
 		removed_double_properties(
-			mesh->getProperties().getProperty<std::array<double,3>*>(prop_name)
+			mesh->getProperties().getProperty<std::array<double,3>*>(
+				prop_name, MeshLib::MeshItemType::Cell
+			)
 		);
 
 	ASSERT_TRUE(!removed_double_properties);
@@ -201,12 +217,15 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 	// add a vector with property values to the mesh
 	MeshLib::PropertyVector<std::array<double,3>*> *pointer_properties(
 		createGroupPropertyValueVector<std::array<double,3>>(n_mat_groups));
-	mesh->getProperties().addProperty(prop_name, pointer_properties);
+	mesh->getProperties().addProperty(prop_name, pointer_properties,
+		MeshLib::MeshItemType::Cell);
 
 	// fetch the vector filled with property values from mesh
 	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> *>
 		pointer_properties_cpy(
-			mesh->getProperties().getProperty<std::array<double,3>*>(prop_name)
+			mesh->getProperties().getProperty<std::array<double,3>*>(
+				prop_name, MeshLib::MeshItemType::Cell
+			)
 		);
 	ASSERT_FALSE(!pointer_properties_cpy);
 
@@ -236,11 +255,15 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 
 	std::string const& prop_name_2("MatrixProperties");
 	// add a vector with property values to the mesh
-	mesh->getProperties().addProperty(prop_name_2, matrix_properties);
+	mesh->getProperties().addProperty(prop_name_2, matrix_properties,
+		MeshLib::MeshItemType::Cell);
 
 	// fetch the vector in order to compare the content
 	boost::optional<MeshLib::PropertyVector<std::array<float,9>> *>
-		matrix_properties_cpy(mesh->getProperties().getProperty<std::array<float,9>>(prop_name_2));
+		matrix_properties_cpy(mesh->getProperties().getProperty<std::array<float,9>>(
+			prop_name_2, MeshLib::MeshItemType::Cell
+		)
+	);
 	ASSERT_FALSE(!matrix_properties_cpy);
 
 	// compare the values/matrices
@@ -268,13 +291,16 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 
 	std::string const& prop_name_3("Properties3");
 	// add a vector with property values to the mesh
-	mesh->getProperties().addProperty(prop_name_3, properties_3);
+	mesh->getProperties().addProperty(prop_name_3, properties_3,
+		MeshLib::MeshItemType::Cell);
 
 	// fetch the vector in order to compare the content
 	boost::optional<
 		MeshLib::PropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>>*
 	> properties_3_cpy(
-		mesh->getProperties().getProperty<Eigen::Matrix<double,3,3,Eigen::RowMajor>>(prop_name_3)
+		mesh->getProperties().getProperty<Eigen::Matrix<double,3,3,Eigen::RowMajor>>(
+			prop_name_3, MeshLib::MeshItemType::Cell
+		)
 	);
 	ASSERT_FALSE(!properties_3_cpy);
 

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -74,6 +74,12 @@ TEST_F(MeshLibMeshProperties, AddDoublePointerProperties)
 {
 	ASSERT_TRUE(mesh != nullptr);
 	std::string const& prop_name("GroupProperty");
+	// check if a property with the name is already assigned to the mesh
+	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name,
+			MeshLib::MeshItemType::Cell));
+	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name,
+			MeshLib::MeshItemType::Node));
+	// data needed for the property
 	const std::size_t n_prop_val_groups(10);
 	const std::size_t n_items(mesh_size*mesh_size*mesh_size);
 	std::vector<std::size_t> prop_item2group_mapping(n_items);
@@ -99,6 +105,11 @@ TEST_F(MeshLibMeshProperties, AddDoublePointerProperties)
 		*(*it) = std::distance((*group_properties).begin(), it);
 	}
 
+	// the mesh should have the property assigned to cells
+	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name,
+			MeshLib::MeshItemType::Cell));
+	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name,
+			MeshLib::MeshItemType::Node));
 	// fetch the properties from the container
 	boost::optional<MeshLib::PropertyVector<double*> const&>
 		group_properties_cpy(mesh->getProperties().getProperty<double*>(
@@ -122,7 +133,7 @@ TEST_F(MeshLibMeshProperties, AddDoublePointerProperties)
 TEST_F(MeshLibMeshProperties, AddArrayPointerProperties)
 {
 	ASSERT_TRUE(mesh != nullptr);
-	std::string const& prop_name("TestGroupPropertyWithArray");
+	std::string const& prop_name("GroupPropertyWithArray");
 	const std::size_t n_prop_val_groups(10);
 	const std::size_t n_items(mesh_size*mesh_size*mesh_size);
 	std::vector<std::size_t> prop_item2group_mapping(n_items);
@@ -182,7 +193,10 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 {
 	ASSERT_TRUE(mesh != nullptr);
 
-	std::string const& prop_name("TestMatGroupVectorProperty");
+	std::string const& prop_name("GroupVectorProperty");
+	// check if the property is already assigned to the mesh
+	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name,
+		MeshLib::MeshItemType::Cell));
 	const std::size_t n_prop_val_groups(10);
 	const std::size_t n_items(mesh_size*mesh_size*mesh_size);
 	std::vector<std::size_t> prop_item2group_mapping(n_items);
@@ -210,6 +224,10 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 		}
 	}
 
+	// the mesh should have the property assigned to cells
+	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name,
+		MeshLib::MeshItemType::Cell));
+
 	// fetch the vector filled with property values from mesh
 	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> const&>
 		group_properties_cpy(
@@ -231,6 +249,9 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 
 	// *** add a 2nd property ***
 	std::string const& prop_name_2("ItemwiseMatrixProperties");
+	// check if the property is already assigned to the mesh
+	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name_2,
+		MeshLib::MeshItemType::Cell));
 	const std::size_t n_items_2(mesh_size*mesh_size*mesh_size);
 	boost::optional<MeshLib::PropertyVector<std::array<float,9>> &>
 		array_properties(mesh->getProperties().newProperty<
@@ -244,6 +265,10 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 			(*it)[k] = std::distance(array_properties->begin(), it)+k;
 		}
 	}
+
+	// the mesh should have the property assigned to cells
+	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name_2,
+		MeshLib::MeshItemType::Cell));
 
 	// fetch the vector in order to compare the content
 	boost::optional<MeshLib::PropertyVector<std::array<float,9>> const&>
@@ -263,6 +288,9 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 	// *** add a 3rd property ***
 #ifdef OGS_USE_EIGEN
 	std::string const& prop_name_3("ItemwiseEigenMatrixProperties");
+	// check if the property is already assigned to the mesh
+	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name_3,
+		MeshLib::MeshItemType::Cell));
 	boost::optional<
 		MeshLib::PropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>> &>
 	matrix_properties(mesh->getProperties().newProperty
@@ -279,6 +307,10 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 			}
 		}
 	}
+
+	// the mesh should have the property assigned to cells
+	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name_3,
+		MeshLib::MeshItemType::Cell));
 
 	// fetch the vector in order to compare the content
 	boost::optional<


### PR DESCRIPTION
This PR is based on the discussion in PR #531:
- It adds an implemention to manage properties within the Mesh.
- The properties are associated to specific mesh items like mesh nodes or mesh
  elements via an enum class (see enum class MeshItemType).
- The properties are not restricted to a particular data type, you can use several types like double, vector or matrix
  types at run time together (see tests).
- There is not a possibility to get the value data type.