### PR TITLE
Data type change in Subdivision

### DIFF
--- a/BaseLib/Subdivision.h
+++ b/BaseLib/Subdivision.h
@@ -54,7 +54,7 @@ public:
 
 private:
 	const double _length;
-	const double _n_subdivision;
+	const std::size_t _n_subdivision;
 };
 
 /**


### PR DESCRIPTION
Changed data type for _n_subdivisions to avoid two implicit casts with potential loss of information.

@norihiro-w : can you pls check if this is okay for you?
