### PR TITLE
Mesh hole detection

### DIFF
--- a/Applications/DataExplorer/DataView/MeshAnalysis.ui
+++ b/Applications/DataExplorer/DataView/MeshAnalysis.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>483</width>
-    <height>650</height>
+    <height>787</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -345,6 +345,13 @@
         </property>
         <property name="alignment">
          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="4">
+       <widget class="QLabel" name="meshHoleOutputLabel">
+        <property name="text">
+         <string/>
         </property>
        </widget>
       </item>

--- a/Applications/DataExplorer/DataView/MeshAnalysisDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshAnalysisDialog.cpp
@@ -60,6 +60,10 @@ void MeshAnalysisDialog::on_startButton_pressed()
 		*mesh, this->zeroVolumeThreshold->text().toDouble() + std::numeric_limits<double>::epsilon()));
 	this->elementsGroupBox->setTitle("Elements (out of " + QString::number(mesh->getNElements()) + ")");
 	this->elementsMsgOutput(element_error_codes);
+	
+	unsigned const n_holes (MeshLib::MeshValidation::detectHoles(*mesh));
+	if (n_holes>0)
+		this->meshHoleOutputLabel->setText("<strong>" + QString::number(n_holes) + " hole(s) found within the mesh</strong>");
 }
 
 void MeshAnalysisDialog::nodesMsgOutput(std::vector<std::size_t> const& node_ids, std::vector<std::size_t> const& collapsibleNodeIds)

--- a/Applications/Utils/MeshEdit/checkMesh.cpp
+++ b/Applications/Utils/MeshEdit/checkMesh.cpp
@@ -91,8 +91,16 @@ int main(int argc, char *argv[])
 		// Validation
 		MeshLib::MeshValidation validation(*const_cast<MeshLib::Mesh*>(mesh)); // MeshValidation outputs error messages
 		/* Remark: MeshValidation can modify the original mesh */
-	}
 
+		unsigned const n_holes (MeshLib::MeshValidation::detectHoles(*mesh));
+		if (n_holes > 0)
+		{
+			INFO("%d hole(s) detected within the mesh", n_holes);
+		}
+		else
+			INFO ("No holes found within the mesh.");
+	}
+	
 	delete mesh;
 	delete custom_format;
 	delete logog_cout;

--- a/MeshLib/MeshQuality/MeshValidation.cpp
+++ b/MeshLib/MeshQuality/MeshValidation.cpp
@@ -176,9 +176,9 @@ unsigned MeshValidation::detectHoles(MeshLib::Mesh const& mesh)
 	return (--current_surface_id); 
 }
 
-void MeshValidation::trackSurface(MeshLib::Element const*const element, std::vector<unsigned> &sfc_idx, unsigned const current_index)
+void MeshValidation::trackSurface(MeshLib::Element const* element, std::vector<unsigned> &sfc_idx, unsigned const current_index)
 {
-	std::stack<MeshLib::Element const*const> elem_stack;
+	std::stack<MeshLib::Element const*> elem_stack;
 	elem_stack.push(element);
 	while (!elem_stack.empty())
 	{
@@ -188,7 +188,7 @@ void MeshValidation::trackSurface(MeshLib::Element const*const element, std::vec
 		std::size_t const n_neighbors (elem->getNNeighbors());
 		for (std::size_t i=0; i<n_neighbors; ++i)
 		{
-			MeshLib::Element const*const neighbor (elem->getNeighbor(i));
+			MeshLib::Element const* neighbor (elem->getNeighbor(i));
 			if ( neighbor != nullptr && sfc_idx[neighbor->getID()] == std::numeric_limits<unsigned>::max())
 				elem_stack.push(neighbor);
 		}

--- a/MeshLib/MeshQuality/MeshValidation.cpp
+++ b/MeshLib/MeshQuality/MeshValidation.cpp
@@ -161,12 +161,7 @@ unsigned MeshValidation::detectHoles(MeshLib::Mesh const& mesh)
 
 	while (it != sfc_idx.cend())
 	{
-		int const idx = static_cast<int>(std::distance(sfc_idx.cbegin(), it));
-		if (idx<0 || idx>elements.size())
-		{
-			ERR ("Illegal element index found");
-			return std::numeric_limits<unsigned>::max();
-		}
+		std::size_t const idx = static_cast<std::size_t>(std::distance(sfc_idx.cbegin(), it));
 		trackSurface(elements[idx], sfc_idx, current_surface_id++);
 		it = std::find(sfc_idx.cbegin(), sfc_idx.cend(), std::numeric_limits<unsigned>::max());
 	}

--- a/MeshLib/MeshQuality/MeshValidation.cpp
+++ b/MeshLib/MeshQuality/MeshValidation.cpp
@@ -152,16 +152,8 @@ MeshValidation::ElementErrorCodeOutput(const std::vector<ElementErrorCode> &erro
 
 unsigned MeshValidation::detectHoles(MeshLib::Mesh const& mesh)
 {
-	MeshLib::Mesh* sfc_mesh (nullptr);
-	std::vector<MeshLib::Element*> elements;
-	if (mesh.getDimension() == 3)
-	{
-		MathLib::Vector3 const all_dir(0, 0, 0);
-		sfc_mesh = MeshSurfaceExtraction::getMeshSurface(mesh, all_dir, 90);
-		elements = sfc_mesh->getElements();
-	}
-	else
-		elements = mesh.getElements();
+	MeshLib::Mesh* boundary_mesh (MeshSurfaceExtraction::getMeshBoundary(mesh));
+	std::vector<MeshLib::Element*> const& elements (boundary_mesh->getElements());
 
 	std::vector<unsigned> sfc_idx (elements.size(), std::numeric_limits<unsigned>::max());
 	unsigned current_surface_id (0);
@@ -178,7 +170,7 @@ unsigned MeshValidation::detectHoles(MeshLib::Mesh const& mesh)
 		trackSurface(elements[idx], sfc_idx, current_surface_id++);
 		it = std::find(sfc_idx.cbegin(), sfc_idx.cend(), std::numeric_limits<unsigned>::max());
 	}
-	delete sfc_mesh;
+	delete boundary_mesh;
 
 	// Subtract "1" from the number of surfaces found to get the number of holes.
 	return (--current_surface_id); 

--- a/MeshLib/MeshQuality/MeshValidation.h
+++ b/MeshLib/MeshQuality/MeshValidation.h
@@ -23,6 +23,7 @@
 
 namespace MeshLib {
 	class Mesh;
+	class Element;
 
 /**
  * \brief A collection of methods for testing mesh quality and correctness
@@ -65,7 +66,26 @@ public:
 	static std::array<std::string, static_cast<std::size_t>(ElementErrorFlag::MaxValue)>
 		ElementErrorCodeOutput(const std::vector<ElementErrorCode> &error_codes);
 
+	/** 
+	 * Tests if holes are located within the mesh. 
+	 * In this context, a hole is a boundary of an element with no neighbor that cannot be reached from
+	 * the actual boundary of the mesh. Examples include a missing triangle in a 2D mesh or a missing 
+	 * Tetrahedron in a 3D mesh.
+	 * Note, that this method does not work when complex 3D structures are build from 2D mesh elements,
+	 * e.g. using the LayeredVolume-class.
+	 * @param mesh The mesh that is tested
+	 * @return The number of holes that have been found.
+	 */
+	static unsigned MeshValidation::detectHoles(MeshLib::Mesh const& mesh);
+
 private:
+	/** Finds all surface elements that can be reached from element. All elements that are found in this 
+	 * way are marked in the global sfc_idx vector using the current_index.
+	 * @param element The mesh element from which the search is started
+	 * @param sfc_idx The global index vector notifying to which surface elements belong
+	 * @param current_index The index that all elements reachable from element will be assigned in sfc_idx
+	 */
+	static void trackSurface(MeshLib::Element const*const element, std::vector<unsigned> &sfc_idx, unsigned const current_index);
 
 };
 

--- a/MeshLib/MeshQuality/MeshValidation.h
+++ b/MeshLib/MeshQuality/MeshValidation.h
@@ -72,11 +72,11 @@ public:
 	 * the actual boundary of the mesh. Examples include a missing triangle in a 2D mesh or a missing 
 	 * Tetrahedron in a 3D mesh.
 	 * Note, that this method does not work when complex 3D structures are build from 2D mesh elements,
-	 * e.g. using the LayeredVolume-class.
+	 * e.g. using the LayeredVolume-class, where more than two 2D elements may share an edge.
 	 * @param mesh The mesh that is tested
 	 * @return The number of holes that have been found.
 	 */
-	static unsigned MeshValidation::detectHoles(MeshLib::Mesh const& mesh);
+	static unsigned detectHoles(MeshLib::Mesh const& mesh);
 
 private:
 	/** Finds all surface elements that can be reached from element. All elements that are found in this 

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -54,6 +54,8 @@ public:
 
 	/**
 	 * Returns the boundary of mesh, i.e. lines for 2D meshes and surfaces for 3D meshes.
+	 * Note, that this method also returns inner boundaries and might give unexpected results
+	 * when the mesh geometry is not strict (e.g. more than two triangles sharing an edge).
 	 * \param mesh The original mesh of dimension d
 	 * \return     A mesh of dimension (d-1) representing the boundary of the mesh.
 	 */

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -39,11 +39,11 @@ public:
 	/// Returns a vector of the areas assigned to each node on a surface mesh.
 	static std::vector<double> getSurfaceAreaForNodes(const MeshLib::Mesh &mesh);
 
-	/// Returns the surface nodes of a layered mesh.
+	/// Returns the surface nodes of a mesh.
 	static std::vector<GeoLib::PointWithID*> getSurfaceNodes(const MeshLib::Mesh &mesh, const MathLib::Vector3 &dir, double angle);
 
 	/**
-	 * Returns the 2d-element mesh representing the surface of the given layered mesh.
+	 * Returns the 2d-element mesh representing the surface of the given mesh.
 	 * \param mesh                The original mesh
 	 * \param dir                 The direction in which face normals have to point to be considered surface elements
 	 * \param angle               The angle of the allowed deviation from the given direction (0 <= angle <= 90 degrees)
@@ -51,6 +51,8 @@ public:
 	 * \return                    A 2D mesh representing the surface in direction dir
 	 */
 	static MeshLib::Mesh* getMeshSurface(const MeshLib::Mesh &mesh, const MathLib::Vector3 &dir, double angle, bool keepOriginalNodeIds = false);
+
+	static MeshLib::Mesh* getMeshBoundary(const MeshLib::Mesh &mesh);
 
 private:
 	/// Functionality needed for getSurfaceNodes() and getMeshSurface()

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -52,6 +52,11 @@ public:
 	 */
 	static MeshLib::Mesh* getMeshSurface(const MeshLib::Mesh &mesh, const MathLib::Vector3 &dir, double angle, bool keepOriginalNodeIds = false);
 
+	/**
+	 * Returns the boundary of mesh, i.e. lines for 2D meshes and surfaces for 3D meshes.
+	 * \param mesh The original mesh of dimension d
+	 * \return     A mesh of dimension (d-1) representing the boundary of the mesh.
+	 */
 	static MeshLib::Mesh* getMeshBoundary(const MeshLib::Mesh &mesh);
 
 private:

--- a/Tests/MeshLib/TestMeshValidation.cpp
+++ b/Tests/MeshLib/TestMeshValidation.cpp
@@ -20,13 +20,6 @@
 #include "MeshLib/MeshGenerators/ConvertRasterToMesh.h"
 #include "MeshLib/MeshEditing/DuplicateMeshComponents.h"
 #include "MeshLib/Elements/Element.h"
-#include "MeshLib/Elements/Tri.h"
-#include "MeshLib/Elements/Quad.h"
-#include "MeshLib/Elements/Tet.h"
-#include "MeshLib/Elements/Hex.h"
-#include "MeshLib/Elements/Pyramid.h"
-#include "MeshLib/Elements/Prism.h"
-
 
 #include "GeoLib/Raster.h"
 

--- a/Tests/MeshLib/TestMeshValidation.cpp
+++ b/Tests/MeshLib/TestMeshValidation.cpp
@@ -1,0 +1,135 @@
+/**
+ * @file TestMeshValidation.cpp
+ * @author Karsten Rink
+ * @date 2015-01-29
+ * @brief Tests for MeshRevision class
+ *
+ * @copyright
+ * Copyright (c) 2012-2014, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include "gtest/gtest.h"
+
+#include "MeshLib/Mesh.h"
+#include "MeshLib/Node.h"
+#include "MeshLib/MeshQuality/MeshValidation.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
+#include "MeshLib/MeshGenerators/ConvertRasterToMesh.h"
+#include "MeshLib/MeshEditing/DuplicateMeshComponents.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Elements/Tri.h"
+#include "MeshLib/Elements/Quad.h"
+#include "MeshLib/Elements/Tet.h"
+#include "MeshLib/Elements/Hex.h"
+#include "MeshLib/Elements/Pyramid.h"
+#include "MeshLib/Elements/Prism.h"
+
+
+#include "GeoLib/Raster.h"
+
+TEST(MeshValidation, UnusedNodes)
+{
+	std::array<double, 12> pix = {0,0.1,0.2,0.1,0,0,0.1,0,0,0,-0.1,0};
+	GeoLib::Raster raster(4,3,0,0,1,pix.begin(), pix.end());
+	MeshLib::ConvertRasterToMesh conv(raster, MeshElemType::TRIANGLE, MeshLib::UseIntensityAs::ELEVATION);
+	MeshLib::Mesh* mesh = conv.execute();
+	std::vector<std::size_t> u_nodes = MeshLib::MeshValidation::findUnusedMeshNodes(*mesh);
+	ASSERT_EQ(0, u_nodes.size());
+
+	std::vector<MeshLib::Node*> nodes = MeshLib::copyNodeVector(mesh->getNodes());
+	nodes.push_back(new MeshLib::Node(-1,-1,-1));
+	std::vector<MeshLib::Element*> elems = MeshLib::copyElementVector(mesh->getElements(),nodes);
+	MeshLib::Mesh mesh2("mesh2", nodes, elems);
+	u_nodes = MeshLib::MeshValidation::findUnusedMeshNodes(mesh2);
+	ASSERT_EQ(1, u_nodes.size());
+	ASSERT_EQ(nodes.back()->getID(), u_nodes[0]);
+
+	delete mesh;
+}
+
+TEST(MeshValidation, DetectHolesTri)
+{
+	std::array<double, 12> pix = {0,0.1,0.2,0.1,0,0,0.1,0,0,0,-0.1,0};
+	GeoLib::Raster raster(4,3,0,0,1,pix.begin(), pix.end());
+	MeshLib::ConvertRasterToMesh conv(raster, MeshElemType::TRIANGLE, MeshLib::UseIntensityAs::ELEVATION);
+	MeshLib::Mesh* mesh = conv.execute();
+	unsigned n_holes = MeshLib::MeshValidation::detectHoles(*mesh);
+	ASSERT_EQ(0, n_holes);
+
+	{
+		std::vector<MeshLib::Node*> nodes = MeshLib::copyNodeVector(mesh->getNodes());
+		std::vector<MeshLib::Element*> elems = MeshLib::copyElementVector(mesh->getElements(),nodes);
+		elems.erase(elems.begin()+12);
+		MeshLib::Mesh mesh2("mesh2", nodes, elems);
+		n_holes = MeshLib::MeshValidation::detectHoles(mesh2);
+		ASSERT_EQ(1, n_holes);
+	}
+
+	{
+		std::vector<MeshLib::Node*> nodes = MeshLib::copyNodeVector(mesh->getNodes());
+		std::vector<MeshLib::Element*> elems = MeshLib::copyElementVector(mesh->getElements(),nodes);
+		elems.erase(elems.begin()+11);
+		elems.erase(elems.begin()+11);
+		MeshLib::Mesh mesh2("mesh2", nodes, elems);
+		n_holes = MeshLib::MeshValidation::detectHoles(mesh2);
+		ASSERT_EQ(1, n_holes);
+	}
+
+	{
+		std::vector<MeshLib::Node*> nodes = MeshLib::copyNodeVector(mesh->getNodes());
+		std::vector<MeshLib::Element*> elems = MeshLib::copyElementVector(mesh->getElements(),nodes);
+		elems.erase(elems.begin()+10);
+		elems.erase(elems.begin()+12);
+		MeshLib::Mesh mesh2("mesh2", nodes, elems);
+		n_holes = MeshLib::MeshValidation::detectHoles(mesh2);
+		ASSERT_EQ(2, n_holes);
+	}
+
+	delete mesh;
+}
+
+TEST(MeshValidation, DetectHolesHex)
+{
+	std::size_t xs=5, ys=4, zs=4;
+	GeoLib::Point origin(0,0,0);
+	MeshLib::Mesh* mesh = MeshLib::MeshGenerator::generateRegularHexMesh(5,4,4,1,1,1,origin, "mesh");
+	unsigned n_holes = MeshLib::MeshValidation::detectHoles(*mesh);
+	ASSERT_EQ(0, n_holes);
+
+	{
+		std::vector<MeshLib::Node*> nodes = MeshLib::copyNodeVector(mesh->getNodes());
+		std::vector<MeshLib::Element*> elems = MeshLib::copyElementVector(mesh->getElements(),nodes);
+		elems.erase(elems.begin()+27);
+		MeshLib::Mesh mesh2("mesh2", nodes, elems);
+		n_holes = MeshLib::MeshValidation::detectHoles(mesh2);
+		ASSERT_EQ(1, n_holes);
+	}
+
+	{
+		std::vector<MeshLib::Node*> nodes = MeshLib::copyNodeVector(mesh->getNodes());
+		std::vector<MeshLib::Element*> elems = MeshLib::copyElementVector(mesh->getElements(),nodes);
+		elems.erase(elems.begin()+28);
+		elems.erase(elems.begin()+27);
+		MeshLib::Mesh mesh2("mesh2", nodes, elems);
+		n_holes = MeshLib::MeshValidation::detectHoles(mesh2);
+		ASSERT_EQ(1, n_holes);
+	}
+
+	{
+		std::vector<MeshLib::Node*> nodes = MeshLib::copyNodeVector(mesh->getNodes());
+		std::vector<MeshLib::Element*> elems = MeshLib::copyElementVector(mesh->getElements(),nodes);
+		elems.erase(elems.begin()+29);
+		elems.erase(elems.begin()+27);
+		MeshLib::Mesh mesh2("mesh2", nodes, elems);
+		n_holes = MeshLib::MeshValidation::detectHoles(mesh2);
+		ASSERT_EQ(1, n_holes);
+	}
+	delete mesh;
+}
+
+
+
+


### PR DESCRIPTION
implements algorithm to detect "holes" within meshes (e.g. missing triangles in a 2D mesh) by using a kind of surface marching algorithm.
works for 2D and 3D meshes, as long as they don't have "weird" geometries, e.g. more than two 2D elements sharing an edge.
the test is included in gui and in nori's command line tool for mesh testing.

here's an example if you don't know what i am referring to by "holes in a mesh" (from inside Feng's Nankou study):
![mesh_hole2](https://cloud.githubusercontent.com/assets/798445/5959399/3c9cef62-a7ce-11e4-804d-8f6da2825f74.png)

currently i am only returning the number of holes found in the mesh. in theory i also know the boundaries of the holes at some point. i am not sure if it'd be useful to return those, too?!