### PR TITLE
[TR] Only run MPI related tests under condition PETSC.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,8 @@ script:
   - cd build
   - cmake $CMAKE_ARGS ..
   - make
-  - ./bin/testrunner --gtest_filter=-MPITest* --gtest_shuffle --gtest_repeat=3
+  - if [[ "$CASE" != "CLI_PETSC" ]]; then ./bin/testrunner --gtest_filter=-MPITest* --gtest_shuffle --gtest_repeat=3; fi
+  # PetSc
   - if [[ "$CASE" == "CLI_PETSC" ]]; then make tests_mpi; fi
 
 notifications:


### PR DESCRIPTION
For travis: if PETSc is used, only MPI related unit tests are performed.