### PR TITLE
[CM&TESTS] Added more filters to the unit test under USE_PETSC.

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -79,9 +79,9 @@ ADD_CATALYST_DEPENDENCY(testrunner)
 
 # Add make-target test which runs the testrunner
 # This should override CTest's predefined test-target but it does not
-IF (OGS_USE_PETSC)
+IF (OGS_USE_MPI)
 	ADD_CUSTOM_TARGET(tests
-		mpirun -np 1 $<TARGET_FILE:testrunner> --gtest_filter=-MPITest*
+		mpirun -np 1 $<TARGET_FILE:testrunner> --gtest_filter=-MPITest*:AssemblerLib*:templated*
 		DEPENDS testrunner
 	)
 	ADD_CUSTOM_TARGET(tests_mpi


### PR DESCRIPTION
This PR is tiny. 

Although non-MPI tests are disabled under ``travis`` by PR #577, this PR adds two ``gtest`` filters that allows one
run basic unit tests under ``USE_MPI`` condition in the code development. 

Once you compiled source  code with cmake option ``-DOGS_USE_PETSC``, you can run unit tests by two commands as:
```
make tests
make tests_mpi
```
With the filters, the tests related to AssemblerLib are disabled under ``USE_MPI``.