### PR TITLE
[CMake] Made the invocation of the testrunner more consistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
   - cd build
   - cmake $CMAKE_ARGS ..
   - make
-  - if [[ "$CASE" != "CLI_PETSC" ]]; then ./bin/testrunner --gtest_filter=-MPITest* --gtest_shuffle --gtest_repeat=3; fi
+  - if [[ "$CASE" != "CLI_PETSC" ]]; then make tests; fi
   # PetSc
   - if [[ "$CASE" == "CLI_PETSC" ]]; then make tests_mpi; fi
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -79,18 +79,21 @@ ADD_CATALYST_DEPENDENCY(testrunner)
 
 # Add make-target test which runs the testrunner
 # This should override CTest's predefined test-target but it does not
+IF(DEFINED ENV{CI})
+	SET(TESTRUNNER_ADDITIONAL_ARGUMENTS ${TESTRUNNER_ADDITIONAL_ARGUMENTS} --gtest_shuffle --gtest_repeat=3)
+ENDIF()
 IF (OGS_USE_PETSC)
 	ADD_CUSTOM_TARGET(tests
-		mpirun -np 1 $<TARGET_FILE:testrunner> --gtest_filter=-MPITest*
+		mpirun -np 1 $<TARGET_FILE:testrunner> ${TESTRUNNER_ADDITIONAL_ARGUMENTS} --gtest_filter=-MPITest*
 		DEPENDS testrunner
 	)
 	ADD_CUSTOM_TARGET(tests_mpi
-		mpirun -np 3 $<TARGET_FILE:testrunner>  --gtest_filter=MPITest*
+		mpirun -np 3 $<TARGET_FILE:testrunner> ${TESTRUNNER_ADDITIONAL_ARGUMENTS}  --gtest_filter=MPITest*
 		DEPENDS testrunner
 	)
 ELSE ()
 	ADD_CUSTOM_TARGET(tests
-		$<TARGET_FILE:testrunner>
+		$<TARGET_FILE:testrunner> ${TESTRUNNER_ADDITIONAL_ARGUMENTS}
 		DEPENDS testrunner
 	)
 ENDIF ()

--- a/scripts/cmake/test/Test.cmake
+++ b/scripts/cmake/test/Test.cmake
@@ -50,12 +50,12 @@ ADD_CUSTOM_TARGET(
 	COMMAND ${CMAKE_CTEST_COMMAND}
 	--force-new-ctest-process --output-on-failure --exclude-regex LARGE
 	${CONFIG_PARAMETER} --parallel ${NUM_PROCESSORS} --test-action test
-	DEPENDS data
+	DEPENDS data ogs
 )
 ADD_CUSTOM_TARGET(
 	ctest-large
 	COMMAND ${CMAKE_CTEST_COMMAND}
 	--force-new-ctest-process --output-on-failure --tests-regex LARGE
 	${CONFIG_PARAMETER} --parallel ${NUM_PROCESSORS} --test-action test
-	DEPENDS data
+	DEPENDS data ogs
 )


### PR DESCRIPTION
As discussed with @endJunction in relation to #582.