### PR TITLE
Ignore XML comments in input files.

### DIFF
--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -64,7 +64,8 @@ int main(int argc, char *argv[])
 	// Project's configuration
 	ConfigTree project_config;
 
-	read_xml(project_arg.getValue(), project_config, false);
+	read_xml(project_arg.getValue(), project_config,
+			boost::property_tree::xml_parser::no_comments);
 	DBUG("Project configuration from file \'%s\' read.",
 		project_arg.getValue().c_str());
 

--- a/FileIO/XmlIO/Boost/BoostXmlGmlInterface.cpp
+++ b/FileIO/XmlIO/Boost/BoostXmlGmlInterface.cpp
@@ -53,7 +53,7 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
 	// build DOM tree
 	using boost::property_tree::ptree;
 	ptree doc;
-	read_xml(in, doc);
+	read_xml(in, doc, boost::property_tree::xml_parser::no_comments);
 
 	
 	if (!isGmlFile(doc))


### PR DESCRIPTION
... only those, which are read by the read_xml() function.

Otherwise the comments are stored in extra xmlcomment boost::property_tree, which is not parsed by any of the config readers.
With the new function the xmlcomments are ignored.