### PR TITLE
Made the invocation of the testrunner more consistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
   - cd build
   - cmake $CMAKE_ARGS ..
   - make
-  - if [[ "$CASE" != "CLI_PETSC" ]]; then ./bin/testrunner --gtest_filter=-MPITest* --gtest_shuffle --gtest_repeat=3; fi
+  - if [[ "$CASE" != "CLI_PETSC" ]]; then make tests; fi
   # PetSc
   - if [[ "$CASE" == "CLI_PETSC" ]]; then make tests_mpi; fi
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -90,7 +90,7 @@ if(DEFINED ENV{CI})
 endif()
 if(OGS_USE_PETSC)
 	add_custom_target(tests
-		mpirun -np 1 $<TARGET_FILE:testrunner> ${TESTRUNNER_ADDITIONAL_ARGUMENTS} --gtest_filter=-MPITest*
+		mpirun -np 1 $<TARGET_FILE:testrunner> ${TESTRUNNER_ADDITIONAL_ARGUMENTS} --gtest_filter=-MPITest*:*AssemblerLib*
 		DEPENDS testrunner
 	)
 	add_custom_target(tests_mpi

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -85,18 +85,21 @@ ADD_CATALYST_DEPENDENCY(testrunner)
 
 # Add make-target test which runs the testrunner
 # This should override CTest's predefined test-target but it does not
+if(DEFINED ENV{CI})
+	set(TESTRUNNER_ADDITIONAL_ARGUMENTS ${TESTRUNNER_ADDITIONAL_ARGUMENTS} --gtest_shuffle --gtest_repeat=3)
+endif()
 if(OGS_USE_PETSC)
 	add_custom_target(tests
-		mpirun -np 1 $<TARGET_FILE:testrunner> --gtest_filter=-MPITest*
+		mpirun -np 1 $<TARGET_FILE:testrunner> ${TESTRUNNER_ADDITIONAL_ARGUMENTS} --gtest_filter=-MPITest*
 		DEPENDS testrunner
 	)
 	add_custom_target(tests_mpi
-		mpirun -np 3 $<TARGET_FILE:testrunner>  --gtest_filter=MPITest*
+		mpirun -np 3 $<TARGET_FILE:testrunner> ${TESTRUNNER_ADDITIONAL_ARGUMENTS}  --gtest_filter=MPITest*
 		DEPENDS testrunner
 	)
 else()
 	add_custom_target(tests
-		$<TARGET_FILE:testrunner>
+		$<TARGET_FILE:testrunner> ${TESTRUNNER_ADDITIONAL_ARGUMENTS}
 		DEPENDS testrunner
 	)
 endif()

--- a/scripts/cmake/test/Test.cmake
+++ b/scripts/cmake/test/Test.cmake
@@ -50,12 +50,12 @@ add_custom_target(
 	COMMAND ${CMAKE_CTEST_COMMAND}
 	--force-new-ctest-process --output-on-failure --exclude-regex LARGE
 	${CONFIG_PARAMETER} --parallel ${NUM_PROCESSORS} --test-action test
-	DEPENDS data
+	DEPENDS data ogs
 )
 add_custom_target(
 	ctest-large
 	COMMAND ${CMAKE_CTEST_COMMAND}
 	--force-new-ctest-process --output-on-failure --tests-regex LARGE
 	${CONFIG_PARAMETER} --parallel ${NUM_PROCESSORS} --test-action test
-	DEPENDS data
+	DEPENDS data ogs
 )


### PR DESCRIPTION
This replaces https://github.com/ufz/ogs/pull/591.

Additionally it removes the AssemblerLib tests from the 'tests' target when building with OGS_USE_PETSC, as requested in https://github.com/ufz/ogs/pull/582.

[Technical note: there is no second '-' required for gtest_filter.]