### PR TITLE
Extract findGlobalIndices() method in LocalToGlobalIndexMap.

### DIFF
--- a/AssemblerLib/LocalToGlobalIndexMap.cpp
+++ b/AssemblerLib/LocalToGlobalIndexMap.cpp
@@ -30,34 +30,7 @@ LocalToGlobalIndexMap::LocalToGlobalIndexMap(
         {
             std::size_t const mesh_id = ms->getMeshID();
 
-            // For each element find the global indices for node/element
-            // components.
-            for (auto e = ms->elementsBegin();
-                    e != ms->elementsEnd(); ++e)
-            {
-                std::vector<MeshLib::Location> vec_items;
-                std::size_t const nnodes = (*e)->getNNodes();
-                vec_items.reserve(nnodes);
-
-                for (std::size_t n = 0; n < nnodes; n++)
-                {
-                    vec_items.emplace_back(
-                        mesh_id,
-                        MeshLib::MeshItemType::Node,
-                        (*e)->getNode(n)->getID());
-                }
-
-                // Save a line of indices for the current element.
-                switch (order)
-                {
-                    case AssemblerLib::ComponentOrder::BY_LOCATION:
-                        _rows.push_back(_mesh_component_map.getGlobalIndices<AssemblerLib::ComponentOrder::BY_LOCATION>(vec_items));
-                        break;
-                    case AssemblerLib::ComponentOrder::BY_COMPONENT:
-                        _rows.push_back(_mesh_component_map.getGlobalIndices<AssemblerLib::ComponentOrder::BY_COMPONENT>(vec_items));
-                        break;
-                }
-            }
+            findGlobalIndices(ms->elementsBegin(), ms->elementsEnd(), mesh_id, order);
         }
     }
 }

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -65,6 +65,41 @@ public:
     LineIndex columnIndices(std::size_t const mesh_item_id) const;
 
 private:
+    template <typename ElementIterator>
+    void
+    findGlobalIndices(ElementIterator first, ElementIterator last,
+        std::size_t const mesh_id, AssemblerLib::ComponentOrder const order)
+    {
+        // For each element find the global indices for node/element
+        // components.
+        for (ElementIterator e = first; e != last; ++e)
+        {
+            std::vector<MeshLib::Location> vec_items;
+            std::size_t const nnodes = (*e)->getNNodes();
+            vec_items.reserve(nnodes);
+
+            for (std::size_t n = 0; n < nnodes; n++)
+            {
+                vec_items.emplace_back(
+                    mesh_id,
+                    MeshLib::MeshItemType::Node,
+                    (*e)->getNode(n)->getID());
+            }
+
+            // Save a line of indices for the current element.
+            switch (order)
+            {
+                case AssemblerLib::ComponentOrder::BY_LOCATION:
+                    _rows.push_back(_mesh_component_map.getGlobalIndices<AssemblerLib::ComponentOrder::BY_LOCATION>(vec_items));
+                    break;
+                case AssemblerLib::ComponentOrder::BY_COMPONENT:
+                    _rows.push_back(_mesh_component_map.getGlobalIndices<AssemblerLib::ComponentOrder::BY_COMPONENT>(vec_items));
+                    break;
+            }
+        }
+    }
+
+private:
     std::vector<MeshLib::MeshSubsets*> const& _mesh_subsets;
     AssemblerLib::MeshComponentMap _mesh_component_map;
 


### PR DESCRIPTION
No logic change, just extracting a function. Merging this now would help with merging PETSc and NeumannBC stuff later.

This is used in the constructor and in another constructor added in #599.