### PR TITLE
Fix a bug in FEFLOW import

### DIFF
--- a/Applications/Utils/FileConverter/FEFLOW2OGS.cpp
+++ b/Applications/Utils/FileConverter/FEFLOW2OGS.cpp
@@ -17,20 +17,20 @@
 #include "logog/include/logog.hpp"
 
 // BaseLib
-#include "FileTools.h"
-#include "RunTime.h"
+#include "BaseLib/FileTools.h"
+#include "BaseLib/RunTime.h"
 #ifndef WIN32
-#include "MemWatch.h"
+#include "BaseLib/MemWatch.h"
 #endif
-#include "LogogSimpleFormatter.h"
+#include "BaseLib/LogogSimpleFormatter.h"
 
 // FileIO
-#include "Legacy/MeshIO.h"
-#include "FEFLOWInterface.h"
+#include "FileIO/Legacy/MeshIO.h"
+#include "FileIO/FEFLOWInterface.h"
 #include "FileIO/VtkIO/VtuInterface.h"
 
 // MeshLib
-#include "Mesh.h"
+#include "MeshLib/Mesh.h"
 
 int main (int argc, char* argv[])
 {

--- a/Applications/Utils/FileConverter/FEFLOW2OGS.cpp
+++ b/Applications/Utils/FileConverter/FEFLOW2OGS.cpp
@@ -25,6 +25,7 @@
 #include "BaseLib/LogogSimpleFormatter.h"
 
 // FileIO
+#include "FileIO/writeMeshToFile.h"
 #include "FileIO/Legacy/MeshIO.h"
 #include "FileIO/FEFLOWInterface.h"
 #include "FileIO/VtkIO/VtuInterface.h"
@@ -85,20 +86,9 @@ int main (int argc, char* argv[])
 
 	// *** write mesh in new format
 	std::string ogs_mesh_fname(ogs_mesh_arg.getValue());
+	INFO("Writing %s.", ogs_mesh_fname.c_str());
+	FileIO::writeMeshToFile(*mesh, ogs_mesh_fname);
 
-	if (BaseLib::getFileExtension(ogs_mesh_fname).compare("msh") == 0) {
-		INFO("Writing %s.", ogs_mesh_fname.c_str());
-		FileIO::Legacy::MeshIO mesh_io;
-		mesh_io.setMesh(mesh);
-		mesh_io.writeToFile(ogs_mesh_fname);
-	} else {
-		if (BaseLib::getFileExtension(ogs_mesh_fname).compare("vtu") != 0) {
-			ogs_mesh_fname += ".vtu";
-		}
-		INFO("Writing %s.", ogs_mesh_fname.c_str());
-		FileIO::VtuInterface mesh_io(mesh);
-		mesh_io.writeToFile(ogs_mesh_fname);
-	}
 	INFO("\tDone.");
 
 	delete mesh;

--- a/FileIO/FEFLOWInterface.cpp
+++ b/FileIO/FEFLOWInterface.cpp
@@ -362,15 +362,20 @@ void FEFLOWInterface::readPoints(QDomElement &nodesEle, const std::string &tag, 
 	QDomElement xmlEle = nodesEle.firstChildElement(QString::fromStdString(tag));
 	if (xmlEle.isNull())
 		return;
-	QString str_pt_list1 = xmlEle.text().simplified();
+	QString str_pt_list1 = xmlEle.text();
 	std::istringstream ss(str_pt_list1.toStdString());
+	std::string line_str;
 	while (!ss.eof())
 	{
+		std::getline(ss, line_str);
+		BaseLib::trim(line_str, ' ');
+		if (line_str.empty()) continue;
+		std::istringstream line_ss(line_str);
 		size_t pt_id = 0;
 		double pt_xyz[3] = { };
-		ss >> pt_id;
+		line_ss >> pt_id;
 		for (int i = 0; i < dim; i++)
-			ss >> pt_xyz[i];
+			line_ss >> pt_xyz[i];
 		points[pt_id - 1] = new GeoLib::PointWithID(pt_xyz, pt_id);
 	}
 }


### PR DESCRIPTION
This PR includes
- fix a bug in importing a FEFLOW file reported by Sophie. Dimension of node coords given under "supermesh" section may not be equal to the dimension of the problem (e.g. only x,y coords are given while a problem is 3d).
- minor refactoring in FEFLOW2OGS.cpp
