### PR TITLE
Added build target archive-data on Linux / Mac.

### DIFF
--- a/scripts/cmake/packaging/ArchiveTestdata.cmake
+++ b/scripts/cmake/packaging/ArchiveTestdata.cmake
@@ -5,7 +5,8 @@ elseif(UNIX)
 else()
 	return()
 endif()
-if(NOT REALPATH_TOOL_PATH)
+find_program(ZIP_TOOL_PATH zip)
+if(NOT REALPATH_TOOL_PATH OR NOT ZIP_TOOL_PATH)
 	return()
 endif()
 
@@ -13,5 +14,5 @@ add_custom_target(archive-data
 	bash ${CMAKE_SOURCE_DIR}/scripts/packaging/archive-testdata.sh
 	DEPENDS data
 	WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-	COMMENT "Packaging testdata to ogs6-data.tar.gz" VERBATIM
+	COMMENT "Packaging testdata to ogs6-data.tar.gz and ogs6-data.zip" VERBATIM
 )

--- a/scripts/cmake/packaging/ArchiveTestdata.cmake
+++ b/scripts/cmake/packaging/ArchiveTestdata.cmake
@@ -1,0 +1,17 @@
+if(APPLE)
+	find_program(REALPATH_TOOL_PATH grealpath)
+elseif(UNIX)
+	find_program(REALPATH_TOOL_PATH realpath)
+else()
+	return()
+endif()
+if(NOT REALPATH_TOOL_PATH)
+	return()
+endif()
+
+add_custom_target(archive-data
+	bash ${CMAKE_SOURCE_DIR}/scripts/packaging/archive-testdata.sh
+	DEPENDS data
+	WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+	COMMENT "Packaging testdata to ogs6-data.tar.gz" VERBATIM
+)

--- a/scripts/cmake/packaging/Pack.cmake
+++ b/scripts/cmake/packaging/Pack.cmake
@@ -1,4 +1,5 @@
 include(packaging/PackagingMacros)
+include(packaging/ArchiveTestdata)
 
 #### Packaging setup ####
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "OGS-6 THM/C Simulator")

--- a/scripts/packaging/archive-testdata.sh
+++ b/scripts/packaging/archive-testdata.sh
@@ -8,5 +8,7 @@ pushd . > /dev/null
 cd ./tmp/Tests/Data
 tar zcf ogs6-data.tar.gz ./*
 mv ogs6-data.tar.gz ../../../
+zip -r -q ogs6-data .
+mv ogs6-data.zip ../../../
 popd > /dev/null
 rm -rf tmp/

--- a/scripts/packaging/archive-testdata.sh
+++ b/scripts/packaging/archive-testdata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+if [[ $OSTYPE == darwin* ]]; then
+	find ./Tests/Data -not -name "*.md5-stamp" -not -name "*expected*" -not -type d -exec mkdir -p ./tmp/{} \; -exec cp `grealpath {}` ./tmp/{} \;
+else
+	find ./Tests/Data -not -name "*.md5-stamp" -not -name "*expected*" -not -type d -exec mkdir -p ./tmp/{} \; -exec cp `realpath {}` ./tmp/{} \;
+fi
+pushd . > /dev/null
+cd ./tmp/Tests/Data
+tar zcf ogs6-data.tar.gz ./*
+mv ogs6-data.tar.gz ../../../
+popd > /dev/null
+rm -rf tmp/


### PR DESCRIPTION
This target creates a gzipped tar and a zip-file of all files in `Tests/Data`. Symlinks are resolved and files are stored with their correct name.

Requirements:

- `zip`
- `realpath`