### PR TITLE
Correct MeshGeoTools references to MeshGeoToolsLib.

### DIFF
--- a/MeshGeoToolsLib/BoundaryElementsAlongPolyline.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsAlongPolyline.cpp
@@ -97,5 +97,5 @@ MeshLib::Element* BoundaryElementsAlongPolyline::modifyEdgeNodeOrdering(const Me
 	return new_edge;
 }
 
-} // end namespace MeshGeoTools
+} // end namespace MeshGeoToolsLib
 

--- a/MeshGeoToolsLib/BoundaryElementsAlongPolyline.h
+++ b/MeshGeoToolsLib/BoundaryElementsAlongPolyline.h
@@ -84,6 +84,6 @@ private:
 	std::vector<MeshLib::Element*> _boundary_elements;
 };
 
-} // end namespace MeshGeoTools
+} // end namespace MeshGeoToolsLib
 
 #endif /* BOUNDARYELEMENTSALONGPOLYLINE_H_ */

--- a/MeshGeoToolsLib/BoundaryElementsOnSurface.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsOnSurface.cpp
@@ -58,5 +58,5 @@ BoundaryElementsOnSurface::~BoundaryElementsOnSurface()
 		delete p;
 }
 
-} // end namespace MeshGeoTools
+} // end namespace MeshGeoToolsLib
 

--- a/MeshGeoToolsLib/BoundaryElementsOnSurface.h
+++ b/MeshGeoToolsLib/BoundaryElementsOnSurface.h
@@ -64,6 +64,6 @@ private:
 	std::vector<MeshLib::Element*> _boundary_elements;
 };
 
-} // end namespace MeshGeoTools
+} // end namespace MeshGeoToolsLib
 
 #endif /* BOUNDARYELEMENTSONSURFACE_H_ */

--- a/MeshGeoToolsLib/BoundaryElementsSearcher.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsSearcher.cpp
@@ -80,5 +80,5 @@ std::vector<MeshLib::Element*> const& BoundaryElementsSearcher::getBoundaryEleme
 	return _boundary_elements_along_surfaces.back()->getBoundaryElements();
 }
 
-} // end namespace MeshGeoTools
+} // end namespace MeshGeoToolsLib
 

--- a/MeshGeoToolsLib/BoundaryElementsSearcher.h
+++ b/MeshGeoToolsLib/BoundaryElementsSearcher.h
@@ -76,6 +76,6 @@ private:
 	std::vector<BoundaryElementsOnSurface*> _boundary_elements_along_surfaces;
 };
 
-} // end namespace MeshGeoTools
+} // end namespace MeshGeoToolsLib
 
 #endif /* BOUNDARYELEMENTSSEARCHER_H_ */

--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -139,4 +139,4 @@ MeshNodeSearcher::getMeshNodeSearcher(MeshLib::Mesh const& mesh)
 	return *_mesh_node_searchers[mesh_id];
 }
 
-} // end namespace MeshGeoTools
+} // end namespace MeshGeoToolsLib

--- a/MeshGeoToolsLib/MeshNodeSearcher.h
+++ b/MeshGeoToolsLib/MeshNodeSearcher.h
@@ -78,7 +78,7 @@ public:
 	 * Searches for the nearest mesh nodes along a GeoLib::Polyline.
 	 * The search for mesh nodes along a specific polyline will be performed
 	 * only once. The result ids will be stored inside an object
-	 * (@see class MeshGeoTools::MeshNodesAlongPolyline).
+	 * (@see class MeshGeoToolsLib::MeshNodesAlongPolyline).
 	 * @param ply the GeoLib::Polyline the nearest mesh nodes are searched for
 	 * @return a vector of mesh node ids
 	 */
@@ -88,7 +88,7 @@ public:
 	 * Searches for the nearest mesh nodes along a GeoLib::Surface.
 	 * The search for mesh nodes along a specific surface will be performed
 	 * only once. The result ids will be stored inside an object
-	 * (@see class MeshGeoTools::MeshNodesAlongSurface).
+	 * (@see class MeshGeoToolsLib::MeshNodesAlongSurface).
 	 * @param sfc the GeoLib::Surface the nearest mesh nodes are searched for
 	 * @return a vector of mesh node ids
 	 */
@@ -127,6 +127,6 @@ private:
 	static std::vector<std::unique_ptr<MeshNodeSearcher>> _mesh_node_searchers;
 };
 
-} // end namespace MeshGeoTools
+} // end namespace MeshGeoToolsLib
 
 #endif /* MESHNODESEARCHER_H_ */

--- a/MeshGeoToolsLib/MeshNodesAlongPolyline.cpp
+++ b/MeshGeoToolsLib/MeshNodesAlongPolyline.cpp
@@ -65,4 +65,4 @@ std::vector<double> const& MeshNodesAlongPolyline::getDistOfProjNodeFromPlyStart
 {
 	return _dist_of_proj_node_from_ply_start;
 }
-} // end namespace MeshGeoTools
+} // end namespace MeshGeoToolsLib

--- a/MeshGeoToolsLib/MeshNodesAlongSurface.cpp
+++ b/MeshGeoToolsLib/MeshNodesAlongSurface.cpp
@@ -55,4 +55,4 @@ GeoLib::Surface const& MeshNodesAlongSurface::getSurface () const
 	return _sfc;
 }
 
-} // end namespace MeshGeoTools
+} // end namespace MeshGeoToolsLib

--- a/NumLib/Function/LinearInterpolationAlongPolyline.h
+++ b/NumLib/Function/LinearInterpolationAlongPolyline.h
@@ -29,11 +29,6 @@ namespace MeshLib
 class Mesh;
 }
 
-namespace MeshGeoTools
-{
-class MeshNodesAlongPolyline;
-}
-
 namespace NumLib
 {
 /**

--- a/NumLib/Function/LinearInterpolationOnSurface.h
+++ b/NumLib/Function/LinearInterpolationOnSurface.h
@@ -29,11 +29,6 @@ namespace MeshLib
 class Mesh;
 }
 
-namespace MeshGeoTools
-{
-class MeshNodesAlongSurface;
-}
-
 namespace NumLib
 {
 /**


### PR DESCRIPTION
The namespace MeshGeoTools was renamed some time ago to MeshGeoToolsLib.
This removes or corrects the leftovers, mostly comments, but also some namespace declations.