### PR TITLE
Correct triangle Gauss integration

### DIFF
--- a/AssemblerLib/LocalDataInitializer.h
+++ b/AssemblerLib/LocalDataInitializer.h
@@ -19,6 +19,8 @@
 #include "MeshLib/Elements/Quad.h"
 #include "MeshLib/Elements/Hex.h"
 
+#include "NumLib/Fem/Integration/GaussIntegrationPolicy.h"
+
 #include "NumLib/Fem/ShapeFunction/ShapeLine2.h"
 #include "NumLib/Fem/ShapeFunction/ShapeTri3.h"
 #include "NumLib/Fem/ShapeFunction/ShapeQuad4.h"
@@ -35,14 +37,18 @@ namespace AssemblerLib
 template <
     template <typename, typename> class LocalAssemblerDataInterface_,
     template <typename, typename, typename, typename> class LocalAssemblerData_,
-    template <typename> class IntegrationPolicy_,
     typename GlobalMatrix_,
     typename GlobalVector_>
 class LocalDataInitializer
 {
     template <typename ShapeFunction_>
+    using IntegrationMethod = typename NumLib::GaussIntegrationPolicy<
+                typename ShapeFunction_::MeshElement>::IntegrationMethod;
+
+    template <typename ShapeFunction_>
         using LAData = LocalAssemblerData_<
-                ShapeFunction_, IntegrationPolicy_<ShapeFunction_>,
+                ShapeFunction_,
+                IntegrationMethod<ShapeFunction_>,
                 GlobalMatrix_, GlobalVector_>;
 
 

--- a/NumLib/Fem/Integration/GaussIntegrationPolicy.h
+++ b/NumLib/Fem/Integration/GaussIntegrationPolicy.h
@@ -13,6 +13,8 @@
 #include "NumLib/Fem/Integration/IntegrationGaussRegular.h"
 #include "NumLib/Fem/Integration/IntegrationGaussTri.h"
 
+#include "MeshLib/Elements/Tri.h"
+
 namespace NumLib
 {
 

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -30,8 +30,6 @@
 #include "MeshLib/NodeAdjacencyTable.h"
 #include "MeshGeoToolsLib/MeshNodeSearcher.h"
 
-#include "NumLib/Fem/Integration/IntegrationGaussRegular.h"
-
 #include "BoundaryCondition.h"
 #include "GroundwaterFlowFEM.h"
 #include "ProcessVariable.h"
@@ -44,8 +42,6 @@ class GroundwaterFlowProcess : public Process
 {
     using ConfigTree = boost::property_tree::ptree;
 
-    template <typename ShapeFunction_>
-    using IntegrationPolicy = NumLib::IntegrationGaussRegular<ShapeFunction_::DIM>;
     unsigned const _integration_order = 2;
 
 public:
@@ -104,7 +100,6 @@ public:
         using LocalDataInitializer = AssemblerLib::LocalDataInitializer<
             GroundwaterFlow::LocalAssemblerDataInterface,
             GroundwaterFlow::LocalAssemblerData,
-            IntegrationPolicy,
             typename GlobalSetup::MatrixType,
             typename GlobalSetup::VectorType>;
 


### PR DESCRIPTION
Currently in the `GroundwaterFlowProcess` the regular Gauss integration scheme was used. There is a special integration rule for triangle elements, which is different from the "regular" elements. This is used now.

Also move the choice of the integration scheme into the `LocalDataInitializer` from the processes.