### PR TITLE
[Fix] Extraction of mesh elements based on bounding box

### DIFF
--- a/Applications/DataExplorer/DataView/MeshElementRemoval.ui
+++ b/Applications/DataExplorer/DataView/MeshElementRemoval.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>420</height>
+    <height>481</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -267,6 +267,23 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>meshNameComboBox</tabstop>
+  <tabstop>newMeshNameEdit</tabstop>
+  <tabstop>elementTypeCheckBox</tabstop>
+  <tabstop>elementTypeListWidget</tabstop>
+  <tabstop>materialIDCheckBox</tabstop>
+  <tabstop>materialListWidget</tabstop>
+  <tabstop>boundingBoxCheckBox</tabstop>
+  <tabstop>xMinEdit</tabstop>
+  <tabstop>xMaxEdit</tabstop>
+  <tabstop>yMinEdit</tabstop>
+  <tabstop>yMaxEdit</tabstop>
+  <tabstop>zMinEdit</tabstop>
+  <tabstop>zMaxEdit</tabstop>
+  <tabstop>zeroVolumeCheckBox</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>
@@ -276,8 +293,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
+     <x>388</x>
+     <y>469</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -292,8 +309,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
+     <x>388</x>
+     <y>469</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>

--- a/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
@@ -78,22 +78,21 @@ void MeshElementRemovalDialog::accept()
 	if (this->boundingBoxCheckBox->isChecked())
 	{
 		std::vector<MeshLib::Node*> const& nodes (_project.getMesh(this->meshNameComboBox->currentText().toStdString())->getNodes());
-		GeoLib::AABB<MeshLib::Node> aabb(nodes.begin(), nodes.end());
+		GeoLib::AABB<MeshLib::Node> const aabb(nodes.begin(), nodes.end());
 		MeshLib::Node minAABB = aabb.getMinPoint();
 		MeshLib::Node maxAABB = aabb.getMaxPoint();
-		double const eps (std::numeric_limits<double>::epsilon());
 
 		// only extract bounding box parameters that have been edited (otherwise there will be rounding errors!)
-		minAABB[0] = (aabb_edits[0]) ? this->xMinEdit->text().toDouble() : (minAABB[0] - eps);
-		maxAABB[0] = (aabb_edits[1]) ? this->xMaxEdit->text().toDouble() : (maxAABB[0] + eps);
-		minAABB[1] = (aabb_edits[2]) ? this->yMinEdit->text().toDouble() : (minAABB[1] - eps);
-		maxAABB[1] = (aabb_edits[3]) ? this->yMaxEdit->text().toDouble() : (maxAABB[1] + eps);
-		minAABB[2] = (aabb_edits[4]) ? this->zMinEdit->text().toDouble() : (minAABB[2] - eps);
-		maxAABB[2] = (aabb_edits[5]) ? this->zMaxEdit->text().toDouble() : (maxAABB[2] + eps);
-
+		minAABB[0] = (aabb_edits[0]) ? this->xMinEdit->text().toDouble() : (minAABB[0]);
+		maxAABB[0] = (aabb_edits[1]) ? this->xMaxEdit->text().toDouble() : (maxAABB[0]);
+		minAABB[1] = (aabb_edits[2]) ? this->yMinEdit->text().toDouble() : (minAABB[1]);
+		maxAABB[1] = (aabb_edits[3]) ? this->yMaxEdit->text().toDouble() : (maxAABB[1]);
+		minAABB[2] = (aabb_edits[4]) ? this->zMinEdit->text().toDouble() : (minAABB[2]);
+		maxAABB[2] = (aabb_edits[5]) ? this->zMaxEdit->text().toDouble() : (maxAABB[2]);
 		ex.searchByBoundingBox(minAABB, maxAABB);
 		anything_checked = true;
 	}
+
 	if (this->zeroVolumeCheckBox->isChecked())
 	{
 		ex.searchByContent();
@@ -149,7 +148,7 @@ void MeshElementRemovalDialog::on_boundingBoxCheckBox_toggled(bool is_checked)
 		this->yMaxEdit->setText(QString::number(maxAABB[1], 'f'));
 		this->zMinEdit->setText(QString::number(minAABB[2], 'f'));
 		this->zMaxEdit->setText(QString::number(maxAABB[2], 'f'));
-		std::fill(aabb_edits.begin(), aabb_edits.end(), false);
+		aabb_edits.fill(false);
 	}
 }
 
@@ -187,7 +186,3 @@ void MeshElementRemovalDialog::on_meshNameComboBox_currentIndexChanged(int idx)
 	if (this->boundingBoxCheckBox->isChecked()) this->on_boundingBoxCheckBox_toggled(true);
 	if (this->materialIDCheckBox->isChecked()) this->on_materialIDCheckBox_toggled(true);
 }
-
-
-
-

--- a/Applications/DataExplorer/DataView/MeshElementRemovalDialog.h
+++ b/Applications/DataExplorer/DataView/MeshElementRemovalDialog.h
@@ -40,12 +40,19 @@ private slots:
 	void on_elementTypeCheckBox_toggled(bool is_checked);
 	void on_materialIDCheckBox_toggled(bool is_checked);
 	void on_meshNameComboBox_currentIndexChanged(int idx);
+	void on_xMinEdit_textChanged() { aabb_edits[0] = true; }
+	void on_xMaxEdit_textChanged() { aabb_edits[1] = true; }
+	void on_yMinEdit_textChanged() { aabb_edits[2] = true; }
+	void on_yMaxEdit_textChanged() { aabb_edits[3] = true; }
+	void on_zMinEdit_textChanged() { aabb_edits[4] = true; }
+	void on_zMaxEdit_textChanged() { aabb_edits[5] = true; }
 	void accept();
 	void reject();
 
 private:
 	const ProjectData& _project;
 	unsigned _currentIndex, _aabbIndex, _matIDIndex;
+	std::array<bool, 6> aabb_edits;
 
 signals:
 	void meshAdded(MeshLib::Mesh* mesh);


### PR DESCRIPTION
we detected rounding error when string representations of double numbers are converted back to doubles (specifically in the bounding box specifications of the element extraction dialog)
this fix changes the dialog to only use text to double conversion for text fields that have been edited.