### PR TITLE
Reorganize classes Properties and PropertyVector

### DIFF
--- a/MeshLib/Properties-impl.h
+++ b/MeshLib/Properties-impl.h
@@ -1,0 +1,121 @@
+/**
+ * \file
+ * \brief  Implemenatiom of the template part of the class Properties.
+ *
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+
+template <typename T>
+boost::optional<PropertyVector<T> &>
+Properties::createNewPropertyVector(std::string const& name,
+	MeshItemType mesh_item_type,
+	std::size_t tuple_size)
+{
+	std::map<std::string, PropertyVectorBase*>::const_iterator it(
+		_properties.find(name)
+	);
+	if (it != _properties.end()) {
+		ERR("A property of the name \"%s\" is already assigned to the mesh.",
+			name.c_str());
+		return boost::optional<PropertyVector<T> &>();
+	}
+	auto entry_info(
+		_properties.insert(
+			std::make_pair(
+				name, new PropertyVector<T>(name, mesh_item_type, tuple_size)
+			)
+		)
+	);
+	return boost::optional<PropertyVector<T> &>(*(
+			static_cast<PropertyVector<T>*>((entry_info.first)->second)
+		)
+	);
+}
+
+template <typename T>
+boost::optional<PropertyVector<T> &>
+Properties::createNewPropertyVector(std::string const& name,
+	std::size_t n_prop_groups,
+	std::vector<std::size_t> const& item2group_mapping,
+	MeshItemType mesh_item_type,
+	std::size_t tuple_size)
+{
+	// check if there is already a PropertyVector with the same name and
+	// mesh_item_type
+	std::map<std::string, PropertyVectorBase*>::const_iterator it(
+		_properties.find(name)
+	);
+	if (it != _properties.end()) {
+		ERR("A property of the name \"%s\" already assigned to the mesh.",
+			name.c_str());
+		return boost::optional<PropertyVector<T> &>();
+	}
+
+	// check entries of item2group_mapping of consistence
+	for (std::size_t k(0); k<item2group_mapping.size(); k++) {
+		std::size_t const group_id (item2group_mapping[k]);
+		if (group_id >= n_prop_groups) {
+			ERR("The mapping to property %d for item %d is not in the correct range [0,%d).", group_id, k, n_prop_groups);
+			return boost::optional<PropertyVector<T> &>();
+		}
+	}
+
+	auto entry_info(
+		_properties.insert(
+			std::pair<std::string, PropertyVectorBase*>(
+				name,
+				new PropertyVector<T>(n_prop_groups,
+					item2group_mapping, name, mesh_item_type)
+			)
+		)
+	);
+	return boost::optional<PropertyVector<T> &>
+		(*(static_cast<PropertyVector<T>*>((entry_info.first)->second)));
+}
+
+template <typename T>
+boost::optional<PropertyVector<T> const&>
+Properties::getPropertyVector(std::string const& name) const
+{
+	std::map<std::string, PropertyVectorBase*>::const_iterator it(
+		_properties.find(name)
+	);
+	if (it == _properties.end()) {
+		ERR("A property with the specified name is not available.");
+		return boost::optional<PropertyVector<T> const&>();
+	}
+
+	PropertyVector<T> const* t=dynamic_cast<PropertyVector<T>const*>(it->second);
+	if (!t) {
+		ERR("Could not downcast PropertyVectorBase.");
+		return boost::optional<PropertyVector<T> const&>();
+	}
+	return *t;
+}
+
+template <typename T>
+boost::optional<PropertyVector<T>&>
+Properties::getPropertyVector(std::string const& name)
+{
+	std::map<std::string, PropertyVectorBase*>::iterator it(
+		_properties.find(name)
+	);
+	if (it == _properties.end()) {
+		ERR("A property with the specified name is not available.");
+		return boost::optional<PropertyVector<T>&>();
+	}
+
+	PropertyVector<T> *t=dynamic_cast<PropertyVector<T>*>(it->second);
+	if (!t) {
+		ERR("Could not downcast PropertyVectorBase.");
+		return boost::optional<PropertyVector<T> &>();
+	}
+	return *t;
+}
+

--- a/MeshLib/Properties.cpp
+++ b/MeshLib/Properties.cpp
@@ -1,0 +1,82 @@
+/**
+ * \file
+ * \brief  Implementation of the class Properties that implements a container of
+ *         properties.
+ *
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "Properties.h"
+
+namespace MeshLib
+{
+
+void Properties::removePropertyVector(std::string const& name)
+{
+	std::map<std::string, PropertyVectorBase*>::const_iterator it(
+		_properties.find(name)
+	);
+	if (it == _properties.end()) {
+		WARN("A property of the name \"%s\" does not exist.",
+			name.c_str());
+		return;
+	}
+	delete it->second;
+	_properties.erase(it);
+}
+
+bool Properties::hasPropertyVector(std::string const& name)
+{
+	std::map<std::string, PropertyVectorBase*>::const_iterator it(
+		_properties.find(name)
+	);
+	if (it == _properties.end()) {
+		return false;
+	}
+	return true;
+}
+
+std::vector<std::string> Properties::getPropertyVectorNames() const
+{
+	std::vector<std::string> names;
+	for (auto p : _properties)
+		names.push_back(p.first);
+	return names;
+}
+
+Properties Properties::excludeCopyProperties(std::vector<std::size_t> const& exclude_ids) const
+{
+	Properties exclude_copy;
+	for (auto property_vector : _properties) {
+		exclude_copy._properties.insert(
+			std::make_pair(property_vector.first,
+			property_vector.second->clone(exclude_ids))
+		);
+	}
+	return exclude_copy;
+}
+
+Properties::Properties(Properties const& properties)
+	: _properties(properties._properties)
+{
+	std::vector<std::size_t> exclude_positions;
+	for (auto it(_properties.begin()); it != _properties.end(); ++it) {
+		PropertyVectorBase *t(it->second->clone(exclude_positions));
+		it->second = t;
+	}
+}
+
+Properties::~Properties()
+{
+	for (auto property_vector : _properties) {
+		delete property_vector.second;
+	}
+}
+
+} // end namespace MeshLib
+

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -69,7 +69,7 @@ public:
 		auto entry_info(
 			_properties.insert(
 				std::pair<std::string, boost::any>(
-					name, boost::any(PropertyVector<T>())
+					name, boost::any(PropertyVector<T>(name, mesh_item_type))
 				)
 			)
 		);
@@ -125,7 +125,8 @@ public:
 			_properties.insert(
 				std::pair<std::string, boost::any>(
 					name,
-					boost::any(PropertyVector<T>(n_prop_groups, item2group_mapping))
+					boost::any(PropertyVector<T>(n_prop_groups,
+						item2group_mapping, name, mesh_item_type))
 				)
 			)
 		);

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -169,6 +169,7 @@ public:
 				name.c_str());
 			return;
 		}
+		delete it->second;
 		_properties.erase(it);
 	}
 

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -154,13 +154,12 @@ public:
 				return boost::optional<PropertyVector<T> const&>();
 			}
 		} else {
-			ERR("A property with the specified name and MeshItemType is not available.");
+			ERR("A property with the specified name is not available.");
 			return boost::optional<PropertyVector<T> const&>();
 		}
 	}
 
-	void removeProperty(std::string const& name,
-		MeshItemType mesh_item_type)
+	void removeProperty(std::string const& name)
 	{
 		std::map<std::string, boost::any>::const_iterator it(
 			_properties.find(name)

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -139,7 +139,7 @@ public:
 	/// Method to get a vector of property values.
 	template <typename T>
 	boost::optional<PropertyVector<T> const&>
-	getProperty(std::string const& name) const
+	getPropertyVector(std::string const& name) const
 	{
 		std::map<std::string, boost::any>::const_iterator it(
 			_properties.find(name)
@@ -159,7 +159,7 @@ public:
 		}
 	}
 
-	void removeProperty(std::string const& name)
+	void removePropertyVector(std::string const& name)
 	{
 		std::map<std::string, boost::any>::const_iterator it(
 			_properties.find(name)
@@ -176,7 +176,7 @@ public:
 	/// Check if a PropertyVector accessible by the name is already
 	/// stored within the Properties object.
 	/// @param name the name of the property (for instance porosity)
-	bool hasProperty(std::string const& name)
+	bool hasPropertyVector(std::string const& name)
 	{
 		std::map<std::string, boost::any>::const_iterator it(
 			_properties.find(name)
@@ -187,7 +187,7 @@ public:
 		return true;
 	}
 
-	std::vector<std::string> getPropertyNames() const
+	std::vector<std::string> getPropertyVectorNames() const
 	{
 		std::vector<std::string> names;
 		for (auto it(_properties.cbegin()); it != _properties.cend(); it++)

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -58,9 +58,8 @@ public:
 	boost::optional<PropertyVector<T> &>
 	createNewPropertyVector(std::string const& name, MeshItemType mesh_item_type)
 	{
-		PropertyKeyType property_key(name, mesh_item_type);
-		std::map<PropertyKeyType, boost::any>::const_iterator it(
-			_properties.find(property_key)
+		std::map<std::string, boost::any>::const_iterator it(
+			_properties.find(name)
 		);
 		if (it != _properties.end()) {
 			ERR("A property of the name \"%s\" is already assigned to the mesh.",
@@ -69,8 +68,8 @@ public:
 		}
 		auto entry_info(
 			_properties.insert(
-				std::pair<PropertyKeyType, boost::any>(
-					property_key, boost::any(PropertyVector<T>())
+				std::pair<std::string, boost::any>(
+					name, boost::any(PropertyVector<T>())
 				)
 			)
 		);
@@ -104,9 +103,8 @@ public:
 	{
 		// check if there is already a PropertyVector with the same name and
 		// mesh_item_type
-		PropertyKeyType const property_key(name, mesh_item_type);
-		std::map<PropertyKeyType, boost::any>::const_iterator it(
-			_properties.find(property_key)
+		std::map<std::string, boost::any>::const_iterator it(
+			_properties.find(name)
 		);
 		if (it != _properties.end()) {
 			ERR("A property of the name \"%s\" already assigned to the mesh.",
@@ -125,8 +123,8 @@ public:
 
 		auto entry_info(
 			_properties.insert(
-				std::pair<PropertyKeyType, boost::any>(
-					property_key,
+				std::pair<std::string, boost::any>(
+					name,
 					boost::any(PropertyVector<T>(n_prop_groups, item2group_mapping))
 				)
 			)
@@ -140,12 +138,10 @@ public:
 	/// Method to get a vector of property values.
 	template <typename T>
 	boost::optional<PropertyVector<T> const&>
-	getProperty(std::string const& name,
-		MeshItemType mesh_item_type) const
+	getProperty(std::string const& name) const
 	{
-		PropertyKeyType const property_key(name, mesh_item_type);
-		std::map<PropertyKeyType, boost::any>::const_iterator it(
-			_properties.find(property_key)
+		std::map<std::string, boost::any>::const_iterator it(
+			_properties.find(name)
 		);
 		if (it != _properties.end()) {
 			try {
@@ -165,9 +161,8 @@ public:
 	void removeProperty(std::string const& name,
 		MeshItemType mesh_item_type)
 	{
-		PropertyKeyType const property_key(name, mesh_item_type);
-		std::map<PropertyKeyType, boost::any>::const_iterator it(
-			_properties.find(property_key)
+		std::map<std::string, boost::any>::const_iterator it(
+			_properties.find(name)
 		);
 		if (it == _properties.end()) {
 			WARN("A property of the name \"%s\" does not exist.",
@@ -177,16 +172,13 @@ public:
 		_properties.erase(it);
 	}
 
-	/// Check if a PropertyVector accessible by a combination of the
-	/// name and the type of the mesh item (Node or Element) is already
+	/// Check if a PropertyVector accessible by the name is already
 	/// stored within the Properties object.
 	/// @param name the name of the property (for instance porosity)
-	/// @param mesh_item_type to which item type the property is assigned to
-	bool hasProperty(std::string const& name, MeshItemType mesh_item_type)
+	bool hasProperty(std::string const& name)
 	{
-		PropertyKeyType const property_key(name, mesh_item_type);
-		std::map<PropertyKeyType, boost::any>::const_iterator it(
-			_properties.find(property_key)
+		std::map<std::string, boost::any>::const_iterator it(
+			_properties.find(name)
 		);
 		if (it == _properties.end()) {
 			return false;
@@ -195,28 +187,9 @@ public:
 	}
 
 private:
-	struct PropertyKeyType
-	{
-		PropertyKeyType(std::string const& n, MeshItemType t)
-			: name(n), mesh_item_type(t)
-		{}
-
-		std::string const name;
-		MeshItemType const mesh_item_type;
-
-		bool operator<(PropertyKeyType const& other) const
-		{
-			int res(name.compare(other.name));
-			if (res == 0) {
-				return mesh_item_type < other.mesh_item_type;
-			}
-			return res < 0;
-		}
-	};
-
 	/// A mapping from property's name to the stored object of any type.
 	/// See addProperty() and getProperty() documentation.
-	std::map<PropertyKeyType, boost::any> _properties;
+	std::map<std::string, boost::any> _properties;
 }; // end class
 
 } // end namespace MeshLib

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -146,19 +146,11 @@ public:
 		std::map<std::string, PropertyVectorBase*>::const_iterator it(
 			_properties.find(name)
 		);
-		if (it != _properties.end()) {
-			try {
-				return boost::optional<PropertyVector<T> const&>(
-						boost::any_cast<PropertyVector<T> const&>(it->second)
-					);
-			} catch (boost::bad_any_cast const&) {
-				ERR("A property with the specified data type is not available.");
-				return boost::optional<PropertyVector<T> const&>();
-			}
-		} else {
+		if (it == _properties.end()) {
 			ERR("A property with the specified name is not available.");
 			return boost::optional<PropertyVector<T> const&>();
 		}
+
 		PropertyVector<T> const* t=dynamic_cast<PropertyVector<T>const*>(it->second);
 		if (!t) {
 			ERR("Could not downcast PropertyVectorBase.");

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -56,7 +56,9 @@ public:
 	///   boost::optional else an empty boost::optional.
 	template <typename T>
 	boost::optional<PropertyVector<T> &>
-	createNewPropertyVector(std::string const& name, MeshItemType mesh_item_type)
+	createNewPropertyVector(std::string const& name,
+		MeshItemType mesh_item_type,
+		std::size_t tuple_size = 1)
 	{
 		std::map<std::string, boost::any>::const_iterator it(
 			_properties.find(name)
@@ -99,7 +101,8 @@ public:
 	createNewPropertyVector(std::string const& name,
 		std::size_t n_prop_groups,
 		std::vector<std::size_t> const& item2group_mapping,
-		MeshItemType mesh_item_type)
+		MeshItemType mesh_item_type,
+		std::size_t tuple_size = 1)
 	{
 		// check if there is already a PropertyVector with the same name and
 		// mesh_item_type

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -186,6 +186,14 @@ public:
 		return true;
 	}
 
+	std::vector<std::string> getPropertyNames() const
+	{
+		std::vector<std::string> names;
+		for (auto it(_properties.cbegin()); it != _properties.cend(); it++)
+			names.push_back(it->first);
+		return names;
+	}
+
 private:
 	/// A mapping from property's name to the stored object of any type.
 	/// See addProperty() and getProperty() documentation.

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -216,6 +216,41 @@ public:
 		return names;
 	}
 
+	/** copy all PropertyVector objects stored in the (internal) map but only
+	 * those values of a PropertyVector whose ids are not in the vector
+	 * exclude_ids.
+	 */
+	Properties excludeCopyProperties(std::vector<std::size_t> const& exclude_ids) const
+	{
+		Properties exclude_copy;
+		for (auto property_vector : _properties) {
+			exclude_copy._properties.insert(
+				std::make_pair(property_vector.first,
+				property_vector.second->clone(exclude_ids))
+			);
+		}
+		return exclude_copy;
+	}
+
+	Properties() {}
+
+	Properties(Properties const& properties)
+		: _properties(properties._properties)
+	{
+		std::vector<std::size_t> exclude_positions;
+		for (auto it(_properties.begin()); it != _properties.end(); ++it) {
+			PropertyVectorBase *t(it->second->clone(exclude_positions));
+			it->second = t;
+		}
+	}
+
+	~Properties()
+	{
+		for (auto property_vector : _properties) {
+			delete property_vector.second;
+		}
+	}
+
 private:
 	/// A mapping from property's name to the stored object of any type.
 	/// See addProperty() and getProperty() documentation.

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -28,13 +28,37 @@ class PropertyVector : public std::vector<PROP_VAL_TYPE>
 {
 friend class Properties;
 protected:
-	PropertyVector()
-		: std::vector<PROP_VAL_TYPE>()
+	/// @brief The constructor taking meta information for the data.
+	/// @param property_name a string describing the property
+	/// @param mesh_item_type the values of the property are either assigned to
+	/// nodes or cells (see enumeration @MeshItemType) (default:
+	/// MeshItemType::Cell)
+	/// @param tuple_size the number of elements of a tuple (default: 1)
+	explicit PropertyVector(std::string const& property_name,
+		MeshItemType mesh_item_type = MeshItemType::Cell,
+		std::size_t tuple_size = 1)
+		: std::vector<PROP_VAL_TYPE>(), _tuple_size(tuple_size),
+		_mesh_item_type(mesh_item_type), _property_name(property_name)
 	{}
 
-	explicit PropertyVector(std::size_t size)
-		: std::vector<PROP_VAL_TYPE>(size)
+	/// @brief The constructor taking meta information for the data.
+	/// @param n_property_values number of property values (value can be a tuple
+	/// with several entries)
+	/// @param property_name a string describing the property
+	/// @param mesh_item_type the values of the property are either assigned to
+	/// nodes or cells (see enumeration @MeshItemType) (default:
+	/// MeshItemType::Cell)
+	/// @param tuple_size the number of elements of a tuple (default: 1)
+	PropertyVector(std::size_t n_property_values,
+		std::string const& property_name,
+		MeshItemType mesh_item_type = MeshItemType::Cell,
+		std::size_t tuple_size = 1)
+		: std::vector<PROP_VAL_TYPE>(n_property_values*tuple_size)
 	{}
+
+	std::size_t const _tuple_size;
+	MeshItemType const _mesh_item_type;
+	std::string const _property_name;
 };
 
 /// Class template PropertyVector is a std::vector with template parameter
@@ -50,19 +74,6 @@ template <typename T>
 class PropertyVector<T*> : public std::vector<T*>
 {
 friend class Properties;
-protected:
-	/// @param n_prop_groups number of different property values
-	/// @param item2group_mapping Class Mesh has a mapping from the mesh items
-	/// (Node or Element) to an index (position in the data structure).
-	/// The vector item2group_mapping must have the same number of entries as
-	/// the above mapping and the values have to be in the range
-	/// \f$[0, \text{n_prop_groups})\f$.
-	PropertyVector(std::size_t n_prop_groups,
-		std::vector<std::size_t> const& item2group_mapping)
-		: std::vector<T*>(n_prop_groups),
-		_item2group_mapping(item2group_mapping)
-	{}
-
 public:
 	/// Destructor ensures the deletion of the heap-constructed objects.
 	~PropertyVector()
@@ -78,6 +89,36 @@ public:
 	{
 		return (*static_cast<std::vector<T*> const*>(this))[_item2group_mapping[id]];
 	}
+
+protected:
+	/// @brief The constructor taking meta information for the data.
+	/// @param n_prop_groups number of different property values
+	/// @param item2group_mapping Class Mesh has a mapping from the mesh items
+	/// (Node or Element) to an index (position in the data structure).
+	/// The vector item2group_mapping must have the same number of entries as
+	/// the above mapping and the values have to be in the range
+	/// \f$[0, \text{n_prop_groups})\f$.
+	/// @param property_name a string describing the property
+	/// @param mesh_item_type the values of the property are either assigned to
+	/// nodes or cells (see enumeration @MeshItemType) (default:
+	/// MeshItemType::Cell)
+	/// @param tuple_size the number of elements of a tuple (default: 1)
+	PropertyVector(std::size_t n_prop_groups,
+		std::vector<std::size_t> const& item2group_mapping,
+		std::string const& property_name,
+		MeshItemType mesh_item_type = MeshItemType::Cell,
+		std::size_t tuple_size = 1)
+		: std::vector<T*>(n_prop_groups * tuple_size),
+		_tuple_size(tuple_size),
+		_mesh_item_type(mesh_item_type),
+		_property_name(property_name),
+		_item2group_mapping(item2group_mapping)
+	{}
+
+protected:
+	std::size_t const _tuple_size;
+	MeshItemType const _mesh_item_type;
+	std::string const _property_name;
 
 private:
 	std::vector<std::size_t> _item2group_mapping;

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -131,6 +131,7 @@ protected:
 	std::string const _property_name;
 
 private:
+	T* at(std::size_t);
 	std::vector<std::size_t> _item2group_mapping;
 };
 

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -27,6 +27,12 @@ template <typename PROP_VAL_TYPE>
 class PropertyVector : public std::vector<PROP_VAL_TYPE>
 {
 friend class Properties;
+
+public:
+	std::size_t getTupleSize() const { return _tuple_size; }
+	MeshItemType getMeshItemType() const { return _mesh_item_type; }
+	std::string const& getPropertyName() const { return _property_name; }
+
 protected:
 	/// @brief The constructor taking meta information for the data.
 	/// @param property_name a string describing the property
@@ -89,6 +95,10 @@ public:
 	{
 		return (*static_cast<std::vector<T*> const*>(this))[_item2group_mapping[id]];
 	}
+
+	std::size_t getTupleSize() const { return _tuple_size; }
+	MeshItemType getMeshItemType() const { return _mesh_item_type; }
+	std::string const& getPropertyName() const { return _property_name; }
 
 protected:
 	/// @brief The constructor taking meta information for the data.

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -39,6 +39,22 @@ public:
 };
 std::size_t const MeshLibMeshProperties::mesh_size;
 
+TEST_F(MeshLibMeshProperties, PropertyVectorTestMetaData)
+{
+	ASSERT_TRUE(mesh != nullptr);
+
+	std::string const prop_name("TestProperty");
+	boost::optional<MeshLib::PropertyVector<double> &> p(
+		mesh->getProperties().createNewPropertyVector<double>(prop_name,
+			MeshLib::MeshItemType::Cell)
+	);
+
+	ASSERT_EQ((*p).getPropertyName().compare(prop_name), 0u);
+	ASSERT_EQ((*p).getMeshItemType(), MeshLib::MeshItemType::Cell);
+	ASSERT_EQ((*p).getTupleSize(), 1u);
+}
+
+
 TEST_F(MeshLibMeshProperties, AddDoubleProperties)
 {
 	ASSERT_TRUE(mesh != nullptr);

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -61,7 +61,7 @@ TEST_F(MeshLibMeshProperties, AddDoubleProperties)
 		ASSERT_EQ((*double_properties)[k], (*double_properties_cpy)[k]);
 	}
 
-	mesh->getProperties().removeProperty(prop_name, MeshLib::MeshItemType::Cell);
+	mesh->getProperties().removeProperty(prop_name);
 	boost::optional<MeshLib::PropertyVector<double> const&>
 		removed_double_properties(
 			mesh->getProperties().getProperty<double>(prop_name)
@@ -124,7 +124,7 @@ TEST_F(MeshLibMeshProperties, AddDoublePointerProperties)
 		ASSERT_EQ((*group_properties)[k], (*group_properties_cpy)[k]);
 	}
 
-	mesh->getProperties().removeProperty(prop_name, MeshLib::MeshItemType::Cell);
+	mesh->getProperties().removeProperty(prop_name);
 	boost::optional<MeshLib::PropertyVector<double*> const&>
 		removed_group_properties(mesh->getProperties().getProperty<double*>(
 			prop_name));
@@ -186,7 +186,7 @@ TEST_F(MeshLibMeshProperties, AddArrayPointerProperties)
 			(*((*group_properties_cpy)[k]))[2]);
 	}
 
-	mesh->getProperties().removeProperty(prop_name, MeshLib::MeshItemType::Cell);
+	mesh->getProperties().removeProperty(prop_name);
 	boost::optional<MeshLib::PropertyVector<std::array<double, 3>*> const&>
 		removed_group_properties(
 			mesh->getProperties().getProperty<std::array<double,3>*>(prop_name)

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -49,11 +49,11 @@ TEST_F(MeshLibProperties, PropertyVectorTestMetaData)
 			MeshLib::MeshItemType::Cell)
 	);
 
-	ASSERT_EQ((*p).getPropertyName().compare(prop_name), 0u);
-	ASSERT_EQ((*p).getMeshItemType(), MeshLib::MeshItemType::Cell);
-	ASSERT_EQ((*p).getTupleSize(), 1u);
+	ASSERT_EQ(0u, (*p).getPropertyName().compare(prop_name));
+	ASSERT_EQ(MeshLib::MeshItemType::Cell, (*p).getMeshItemType());
+	ASSERT_EQ(1u, (*p).getTupleSize());
+	ASSERT_EQ(0u, (*p).size());
 }
-
 
 TEST_F(MeshLibProperties, AddDoubleProperties)
 {
@@ -168,7 +168,7 @@ TEST_F(MeshLibProperties, AddArrayPointerProperties)
 		}
 	}
 	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> &>
-		group_properties(
+		group_prop_vec(
 			mesh->getProperties().createNewPropertyVector<std::array<double,3>*>(
 				prop_name, n_prop_val_groups, prop_item2group_mapping,
 				MeshLib::MeshItemType::Cell
@@ -191,11 +191,11 @@ TEST_F(MeshLibProperties, AddArrayPointerProperties)
 	ASSERT_FALSE(!group_properties_cpy);
 
 	for (std::size_t k(0); k<n_items; k++) {
-		ASSERT_EQ((*((*group_properties)[k]))[0],
+		ASSERT_EQ((*((*group_prop_vec)[k]))[0],
 			(*((*group_properties_cpy)[k]))[0]);
-		ASSERT_EQ((*((*group_properties)[k]))[1],
+		ASSERT_EQ((*((*group_prop_vec)[k]))[1],
 			(*((*group_properties_cpy)[k]))[1]);
-		ASSERT_EQ((*((*group_properties)[k]))[2],
+		ASSERT_EQ((*((*group_prop_vec)[k]))[2],
 			(*((*group_properties_cpy)[k]))[2]);
 	}
 
@@ -283,14 +283,17 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
 		> (prop_name_2, MeshLib::MeshItemType::Cell)
 	);
 
+	(*array_properties).resize(n_items_2);
+
 	// initialize the property values
-	for (std::size_t i(0); i<n_prop_val_groups; i++) {
+	for (std::size_t i(0); i<n_items_2; i++) {
 		// init property value
-		std::array<float,9> &matrix = (*array_properties)[i];
-		for (std::size_t k(0); k<matrix.size(); k++) {
-			matrix[k] = static_cast<float>(i+k);
+		for (std::size_t k(0); k<(*array_properties)[i].size(); k++) {
+			(*array_properties)[i][k] = static_cast<float>(i+k);
 		}
 	}
+
+	EXPECT_EQ(9, (*array_properties)[0].size());
 
 	// the mesh should have the property assigned to cells
 	ASSERT_TRUE(mesh->getProperties().hasPropertyVector(prop_name_2));
@@ -304,7 +307,7 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
 
 	// compare the values/matrices
 	for (std::size_t k(0); k<n_items_2; k++) {
-		for (std::size_t j(0); j<array_properties->size(); j++) {
+		for (std::size_t j(0); j<(*array_properties)[k].size(); j++) {
 			ASSERT_EQ((*array_properties)[k][j], (*array_properties_cpy)[k][j]);
 		}
 	}

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -54,8 +54,7 @@ TEST_F(MeshLibMeshProperties, AddDoubleProperties)
 
 	boost::optional<MeshLib::PropertyVector<double> const&>
 		double_properties_cpy(mesh->getProperties().getProperty<double>(
-			prop_name, MeshLib::MeshItemType::Cell
-		));
+			prop_name));
 	ASSERT_FALSE(!double_properties_cpy);
 
 	for (std::size_t k(0); k<size; k++) {
@@ -64,8 +63,8 @@ TEST_F(MeshLibMeshProperties, AddDoubleProperties)
 
 	mesh->getProperties().removeProperty(prop_name, MeshLib::MeshItemType::Cell);
 	boost::optional<MeshLib::PropertyVector<double> const&>
-		removed_double_properties(mesh->getProperties().getProperty<double>(prop_name,
-			MeshLib::MeshItemType::Cell)
+		removed_double_properties(
+			mesh->getProperties().getProperty<double>(prop_name)
 		);
 
 	ASSERT_TRUE(!removed_double_properties);
@@ -76,10 +75,7 @@ TEST_F(MeshLibMeshProperties, AddDoublePointerProperties)
 	ASSERT_TRUE(mesh != nullptr);
 	std::string const& prop_name("GroupProperty");
 	// check if a property with the name is already assigned to the mesh
-	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name,
-			MeshLib::MeshItemType::Cell));
-	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name,
-			MeshLib::MeshItemType::Node));
+	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name));
 	// data needed for the property
 	const std::size_t n_prop_val_groups(10);
 	const std::size_t n_items(mesh_size*mesh_size*mesh_size);
@@ -117,15 +113,11 @@ TEST_F(MeshLibMeshProperties, AddDoublePointerProperties)
 	}
 
 	// the mesh should have the property assigned to cells
-	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name,
-			MeshLib::MeshItemType::Cell));
-	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name,
-			MeshLib::MeshItemType::Node));
+	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name));
 	// fetch the properties from the container
 	boost::optional<MeshLib::PropertyVector<double*> const&>
 		group_properties_cpy(mesh->getProperties().getProperty<double*>(
-			prop_name, MeshLib::MeshItemType::Cell
-		));
+			prop_name));
 	ASSERT_FALSE(!group_properties_cpy);
 
 	for (std::size_t k(0); k<n_items; k++) {
@@ -135,8 +127,7 @@ TEST_F(MeshLibMeshProperties, AddDoublePointerProperties)
 	mesh->getProperties().removeProperty(prop_name, MeshLib::MeshItemType::Cell);
 	boost::optional<MeshLib::PropertyVector<double*> const&>
 		removed_group_properties(mesh->getProperties().getProperty<double*>(
-			prop_name, MeshLib::MeshItemType::Cell
-		));
+			prop_name));
 
 	ASSERT_TRUE(!removed_group_properties);
 }
@@ -182,9 +173,7 @@ TEST_F(MeshLibMeshProperties, AddArrayPointerProperties)
 
 	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> const&>
 		group_properties_cpy(
-			mesh->getProperties().getProperty<std::array<double,3>*>(
-				prop_name, MeshLib::MeshItemType::Cell
-			)
+			mesh->getProperties().getProperty<std::array<double,3>*>(prop_name)
 		);
 	ASSERT_FALSE(!group_properties_cpy);
 
@@ -200,9 +189,7 @@ TEST_F(MeshLibMeshProperties, AddArrayPointerProperties)
 	mesh->getProperties().removeProperty(prop_name, MeshLib::MeshItemType::Cell);
 	boost::optional<MeshLib::PropertyVector<std::array<double, 3>*> const&>
 		removed_group_properties(
-			mesh->getProperties().getProperty<std::array<double,3>*>(
-				prop_name, MeshLib::MeshItemType::Cell
-			)
+			mesh->getProperties().getProperty<std::array<double,3>*>(prop_name)
 		);
 
 	ASSERT_TRUE(!removed_group_properties);
@@ -214,8 +201,7 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 
 	std::string const& prop_name("GroupVectorProperty");
 	// check if the property is already assigned to the mesh
-	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name,
-		MeshLib::MeshItemType::Cell));
+	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name));
 	const std::size_t n_prop_val_groups(10);
 	const std::size_t n_items(mesh_size*mesh_size*mesh_size);
 	std::vector<std::size_t> prop_item2group_mapping(n_items);
@@ -254,15 +240,12 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 	}
 
 	// the mesh should have the property assigned to cells
-	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name,
-		MeshLib::MeshItemType::Cell));
+	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name));
 
 	// fetch the vector filled with property values from mesh
 	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> const&>
 		group_properties_cpy(
-			mesh->getProperties().getProperty<std::array<double,3>*>(
-				prop_name, MeshLib::MeshItemType::Cell
-			)
+			mesh->getProperties().getProperty<std::array<double,3>*>(prop_name)
 		);
 	ASSERT_FALSE(!group_properties_cpy);
 	// compare the content
@@ -279,8 +262,7 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 	// *** add a 2nd property ***
 	std::string const& prop_name_2("ItemwiseMatrixProperties");
 	// check if the property is already assigned to the mesh
-	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name_2,
-		MeshLib::MeshItemType::Cell));
+	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name_2));
 	const std::size_t n_items_2(mesh_size*mesh_size*mesh_size);
 	boost::optional<MeshLib::PropertyVector<std::array<float,9>> &>
 		array_properties(mesh->getProperties().createNewPropertyVector<
@@ -298,14 +280,12 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 	}
 
 	// the mesh should have the property assigned to cells
-	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name_2,
-		MeshLib::MeshItemType::Cell));
+	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name_2));
 
 	// fetch the vector in order to compare the content
 	boost::optional<MeshLib::PropertyVector<std::array<float,9>> const&>
 		array_properties_cpy(mesh->getProperties().getProperty<std::array<float,9>>(
-			prop_name_2, MeshLib::MeshItemType::Cell
-		)
+			prop_name_2)
 	);
 	ASSERT_FALSE(!array_properties_cpy);
 
@@ -320,8 +300,7 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 #ifdef OGS_USE_EIGEN
 	std::string const& prop_name_3("ItemwiseEigenMatrixProperties");
 	// check if the property is already assigned to the mesh
-	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name_3,
-		MeshLib::MeshItemType::Cell));
+	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name_3));
 	boost::optional<
 		MeshLib::PropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>> &>
 	matrix_properties(mesh->getProperties().createNewPropertyVector
@@ -340,16 +319,14 @@ TEST_F(MeshLibMeshProperties, AddVariousDifferentProperties)
 	}
 
 	// the mesh should have the property assigned to cells
-	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name_3,
-		MeshLib::MeshItemType::Cell));
+	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name_3));
 
 	// fetch the vector in order to compare the content
 	boost::optional<
 		MeshLib::PropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>> const&
 	> matrix_properties_cpy(
 		mesh->getProperties().getProperty<Eigen::Matrix<double,3,3,Eigen::RowMajor>>(
-			prop_name_3, MeshLib::MeshItemType::Cell
-		)
+			prop_name_3)
 	);
 	ASSERT_FALSE(!matrix_properties_cpy);
 

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -69,7 +69,7 @@ TEST_F(MeshLibProperties, AddDoubleProperties)
 	std::iota((*double_properties).begin(), (*double_properties).end(), 1);
 
 	boost::optional<MeshLib::PropertyVector<double> const&>
-		double_properties_cpy(mesh->getProperties().getProperty<double>(
+		double_properties_cpy(mesh->getProperties().getPropertyVector<double>(
 			prop_name));
 	ASSERT_FALSE(!double_properties_cpy);
 
@@ -77,10 +77,10 @@ TEST_F(MeshLibProperties, AddDoubleProperties)
 		ASSERT_EQ((*double_properties)[k], (*double_properties_cpy)[k]);
 	}
 
-	mesh->getProperties().removeProperty(prop_name);
+	mesh->getProperties().removePropertyVector(prop_name);
 	boost::optional<MeshLib::PropertyVector<double> const&>
 		removed_double_properties(
-			mesh->getProperties().getProperty<double>(prop_name)
+			mesh->getProperties().getPropertyVector<double>(prop_name)
 		);
 
 	ASSERT_TRUE(!removed_double_properties);
@@ -91,7 +91,7 @@ TEST_F(MeshLibProperties, AddDoublePointerProperties)
 	ASSERT_TRUE(mesh != nullptr);
 	std::string const& prop_name("GroupProperty");
 	// check if a property with the name is already assigned to the mesh
-	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name));
+	ASSERT_FALSE(mesh->getProperties().hasPropertyVector(prop_name));
 	// data needed for the property
 	const std::size_t n_prop_val_groups(10);
 	const std::size_t n_items(mesh_size*mesh_size*mesh_size);
@@ -125,10 +125,10 @@ TEST_F(MeshLibProperties, AddDoublePointerProperties)
 	}
 
 	// the mesh should have the property assigned to cells
-	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name));
+	ASSERT_TRUE(mesh->getProperties().hasPropertyVector(prop_name));
 	// fetch the properties from the container
 	boost::optional<MeshLib::PropertyVector<double*> const&>
-		group_properties_cpy(mesh->getProperties().getProperty<double*>(
+		group_properties_cpy(mesh->getProperties().getPropertyVector<double*>(
 			prop_name));
 	ASSERT_FALSE(!group_properties_cpy);
 
@@ -136,9 +136,9 @@ TEST_F(MeshLibProperties, AddDoublePointerProperties)
 		ASSERT_EQ((*group_properties)[k], (*group_properties_cpy)[k]);
 	}
 
-	mesh->getProperties().removeProperty(prop_name);
+	mesh->getProperties().removePropertyVector(prop_name);
 	boost::optional<MeshLib::PropertyVector<double*> const&>
-		removed_group_properties(mesh->getProperties().getProperty<double*>(
+		removed_group_properties(mesh->getProperties().getPropertyVector<double*>(
 			prop_name));
 
 	ASSERT_TRUE(!removed_group_properties);
@@ -186,7 +186,7 @@ TEST_F(MeshLibProperties, AddArrayPointerProperties)
 
 	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> const&>
 		group_properties_cpy(
-			mesh->getProperties().getProperty<std::array<double,3>*>(prop_name)
+			mesh->getProperties().getPropertyVector<std::array<double,3>*>(prop_name)
 		);
 	ASSERT_FALSE(!group_properties_cpy);
 
@@ -199,10 +199,10 @@ TEST_F(MeshLibProperties, AddArrayPointerProperties)
 			(*((*group_properties_cpy)[k]))[2]);
 	}
 
-	mesh->getProperties().removeProperty(prop_name);
+	mesh->getProperties().removePropertyVector(prop_name);
 	boost::optional<MeshLib::PropertyVector<std::array<double, 3>*> const&>
 		removed_group_properties(
-			mesh->getProperties().getProperty<std::array<double,3>*>(prop_name)
+			mesh->getProperties().getPropertyVector<std::array<double,3>*>(prop_name)
 		);
 
 	ASSERT_TRUE(!removed_group_properties);
@@ -214,7 +214,7 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
 
 	std::string const& prop_name("GroupVectorProperty");
 	// check if the property is already assigned to the mesh
-	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name));
+	ASSERT_FALSE(mesh->getProperties().hasPropertyVector(prop_name));
 	const std::size_t n_prop_val_groups(10);
 	const std::size_t n_items(mesh_size*mesh_size*mesh_size);
 	std::vector<std::size_t> prop_item2group_mapping(n_items);
@@ -253,12 +253,12 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
 	}
 
 	// the mesh should have the property assigned to cells
-	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name));
+	ASSERT_TRUE(mesh->getProperties().hasPropertyVector(prop_name));
 
 	// fetch the vector filled with property values from mesh
 	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> const&>
 		group_properties_cpy(
-			mesh->getProperties().getProperty<std::array<double,3>*>(prop_name)
+			mesh->getProperties().getPropertyVector<std::array<double,3>*>(prop_name)
 		);
 	ASSERT_FALSE(!group_properties_cpy);
 	// compare the content
@@ -275,7 +275,7 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
 	// *** add a 2nd property ***
 	std::string const& prop_name_2("ItemwiseMatrixProperties");
 	// check if the property is already assigned to the mesh
-	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name_2));
+	ASSERT_FALSE(mesh->getProperties().hasPropertyVector(prop_name_2));
 	const std::size_t n_items_2(mesh_size*mesh_size*mesh_size);
 	boost::optional<MeshLib::PropertyVector<std::array<float,9>> &>
 		array_properties(mesh->getProperties().createNewPropertyVector<
@@ -293,11 +293,11 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
 	}
 
 	// the mesh should have the property assigned to cells
-	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name_2));
+	ASSERT_TRUE(mesh->getProperties().hasPropertyVector(prop_name_2));
 
 	// fetch the vector in order to compare the content
 	boost::optional<MeshLib::PropertyVector<std::array<float,9>> const&>
-		array_properties_cpy(mesh->getProperties().getProperty<std::array<float,9>>(
+		array_properties_cpy(mesh->getProperties().getPropertyVector<std::array<float,9>>(
 			prop_name_2)
 	);
 	ASSERT_FALSE(!array_properties_cpy);
@@ -313,7 +313,7 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
 #ifdef OGS_USE_EIGEN
 	std::string const& prop_name_3("ItemwiseEigenMatrixProperties");
 	// check if the property is already assigned to the mesh
-	ASSERT_FALSE(mesh->getProperties().hasProperty(prop_name_3));
+	ASSERT_FALSE(mesh->getProperties().hasPropertyVector(prop_name_3));
 	boost::optional<
 		MeshLib::PropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>> &>
 	matrix_properties(mesh->getProperties().createNewPropertyVector
@@ -332,13 +332,13 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
 	}
 
 	// the mesh should have the property assigned to cells
-	ASSERT_TRUE(mesh->getProperties().hasProperty(prop_name_3));
+	ASSERT_TRUE(mesh->getProperties().hasPropertyVector(prop_name_3));
 
 	// fetch the vector in order to compare the content
 	boost::optional<
 		MeshLib::PropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>> const&
 	> matrix_properties_cpy(
-		mesh->getProperties().getProperty<Eigen::Matrix<double,3,3,Eigen::RowMajor>>(
+		mesh->getProperties().getPropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>>(
 			prop_name_3)
 	);
 	ASSERT_FALSE(!matrix_properties_cpy);

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -120,12 +120,8 @@ TEST_F(MeshLibProperties, AddDoublePointerProperties)
 		)
 	);
 	// initialize the property values
-	for (auto it=group_properties->begin(); it != group_properties->end(); it++)
-	{
-		(*it) = new double;
-		*(*it) = static_cast<double>(
-			std::distance(group_properties->begin(), it)
-		);
+	for (std::size_t i(0); i<n_prop_val_groups; i++) {
+		(*group_properties).initPropertyValue(i, i+1);
 	}
 
 	// the mesh should have the property assigned to cells
@@ -179,12 +175,13 @@ TEST_F(MeshLibProperties, AddArrayPointerProperties)
 			)
 		);
 	// initialize the property values
-	for (auto it=(*group_properties).begin(); it != (*group_properties).end(); it++)
-	{
-		(*it) = new std::array<double,3>;
-		(*(*it))[0] = std::distance((*group_properties).begin(), it);
-		(*(*it))[1] = std::distance((*group_properties).begin(), it)+1;
-		(*(*it))[2] = std::distance((*group_properties).begin(), it)+2;
+	for (std::size_t i(0); i<n_prop_val_groups; i++) {
+		(*group_prop_vec).initPropertyValue(i,
+			std::array<double,3>({{static_cast<double>(i),
+				static_cast<double>(i+1),
+				static_cast<double>(i+2)}}
+			)
+		);
 	}
 
 	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> const&>
@@ -246,13 +243,13 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
 			)
 		);
 	// initialize the property values
-	for (auto it=group_properties->begin(); it != group_properties->end(); it++) {
-		(*it) = new std::array<double,3>;
-		for (std::size_t idx(0); idx<(*it)->size(); idx++) {
-			(*(*it))[idx] = static_cast<double>(
-				static_cast<std::size_t>(
-					std::distance(group_properties->begin(),it)) + idx);
-		}
+	for (std::size_t i(0); i<n_prop_val_groups; i++) {
+		(*group_properties).initPropertyValue(i,
+			std::array<double,3>({{static_cast<double>(i),
+				static_cast<double>(i+1),
+				static_cast<double>(i+2)}}
+			)
+		);
 	}
 
 	// the mesh should have the property assigned to cells
@@ -285,13 +282,13 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
 			std::array<float,9>
 		> (prop_name_2, MeshLib::MeshItemType::Cell)
 	);
-	// init property values
-	for (auto it=array_properties->begin(); it != array_properties->end(); it++)
-	{
-		for (std::size_t k(0); k<it->size(); k++) {
-			(*it)[k] = static_cast<float>(
-				static_cast<std::size_t>(
-					std::distance(array_properties->begin(), it)) + k);
+
+	// initialize the property values
+	for (std::size_t i(0); i<n_prop_val_groups; i++) {
+		// init property value
+		std::array<float,9> &matrix = (*array_properties)[i];
+		for (std::size_t k(0); k<matrix.size(); k++) {
+			matrix[k] = static_cast<float>(i+k);
 		}
 	}
 
@@ -391,11 +388,8 @@ TEST_F(MeshLibProperties, CopyConstructor)
 		)
 	);
 	// initialize the property values
-	for (auto it=group_properties->begin(); it != group_properties->end(); it++) {
-		(*it) = new double;
-		*(*it) = static_cast<double>(
-			std::distance(group_properties->begin(), it)
-		);
+	for (std::size_t i(0); i<n_prop_val_groups; i++) {
+		(*group_properties).initPropertyValue(i, i+1);
 	}
 
 	// create a copy from the original Properties object
@@ -411,21 +405,7 @@ TEST_F(MeshLibProperties, CopyConstructor)
 	// check if the values in the PropertyVector of the copy of the Properties
 	// are the same
 	for (std::size_t k(0); k<n_items; k++) {
-		ASSERT_EQ((*group_properties)[k], (*group_properties_cpy)[k]);
+		EXPECT_EQ(*(*group_properties)[k], *(*group_properties_cpy)[k]);
 	}
-
-/*
-	mesh->getProperties().removePropertyVector(prop_name);
-	boost::optional<MeshLib::PropertyVector<double*> const&>
-		removed_group_properties(mesh->getProperties().getPropertyVector<double*>(
-			prop_name));
-	ASSERT_TRUE(!removed_group_properties);
-
-	properties_copy.removePropertyVector(prop_name);
-	boost::optional<MeshLib::PropertyVector<double*> const&>
-		removed_group_properties_copy(mesh->getProperties().getPropertyVector<double*>(
-			prop_name));
-	ASSERT_TRUE(!removed_group_properties_copy);
-*/
 }
 

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -65,8 +65,15 @@ TEST_F(MeshLibProperties, AddDoubleProperties)
 		mesh->getProperties().createNewPropertyVector<double>(prop_name,
 			MeshLib::MeshItemType::Cell)
 	);
+	ASSERT_EQ(0u, (*double_properties).size());
+
 	(*double_properties).resize(size);
+	ASSERT_EQ(size, (*double_properties).size());
+
 	std::iota((*double_properties).begin(), (*double_properties).end(), 1);
+	for (std::size_t k(0); k<size; k++) {
+		ASSERT_EQ(static_cast<double>(k+1), (*double_properties)[k]);
+	}
 
 	boost::optional<MeshLib::PropertyVector<double> const&>
 		double_properties_cpy(mesh->getProperties().getPropertyVector<double>(
@@ -119,9 +126,28 @@ TEST_F(MeshLibProperties, AddDoublePointerProperties)
 			MeshLib::MeshItemType::Cell
 		)
 	);
+	ASSERT_EQ(prop_item2group_mapping.size(), (*group_properties).size());
+
 	// initialize the property values
 	for (std::size_t i(0); i<n_prop_val_groups; i++) {
 		(*group_properties).initPropertyValue(i, i+1);
+	}
+	// check mapping to values
+	for (std::size_t i(0); i<n_prop_val_groups; i++) {
+		std::size_t const lower(
+			static_cast<std::size_t>(
+				(static_cast<double>(i)/n_prop_val_groups)*n_items
+			)
+		);
+		std::size_t const upper(
+			static_cast<std::size_t>(
+				(static_cast<double>(i+1)/n_prop_val_groups)*n_items
+			)
+		);
+		for (std::size_t k(lower); k<upper; k++) {
+			ASSERT_NEAR(static_cast<double>(i+1), *(*group_properties)[k],
+				std::numeric_limits<double>::epsilon());
+		}
 	}
 
 	// the mesh should have the property assigned to cells
@@ -174,6 +200,8 @@ TEST_F(MeshLibProperties, AddArrayPointerProperties)
 				MeshLib::MeshItemType::Cell
 			)
 		);
+	ASSERT_EQ(prop_item2group_mapping.size(), group_prop_vec->size());
+
 	// initialize the property values
 	for (std::size_t i(0); i<n_prop_val_groups; i++) {
 		(*group_prop_vec).initPropertyValue(i,
@@ -182,6 +210,27 @@ TEST_F(MeshLibProperties, AddArrayPointerProperties)
 				static_cast<double>(i+2)}}
 			)
 		);
+	}
+	// check the mapping to values
+	for (std::size_t i(0); i<n_prop_val_groups; i++) {
+		std::size_t const lower(
+			static_cast<std::size_t>(
+				(static_cast<double>(i)/n_prop_val_groups)*n_items
+			)
+		);
+		std::size_t const upper(
+			static_cast<std::size_t>(
+				(static_cast<double>(i+1)/n_prop_val_groups)*n_items
+			)
+		);
+		for (std::size_t k(lower); k<upper; k++) {
+			ASSERT_NEAR(static_cast<double>(i), (*(*group_prop_vec)[k])[0],
+				std::numeric_limits<double>::epsilon());
+			ASSERT_NEAR(static_cast<double>(i+1), (*(*group_prop_vec)[k])[1],
+				std::numeric_limits<double>::epsilon());
+			ASSERT_NEAR(static_cast<double>(i+2), (*(*group_prop_vec)[k])[2],
+				std::numeric_limits<double>::epsilon());
+		}
 	}
 
 	boost::optional<MeshLib::PropertyVector<std::array<double,3>*> const&>


### PR DESCRIPTION
This PR improves the usability of the classes `Properties`and `PropertyVector` due to
- Renaming some methods in Properties.
- Adding some methods that are needed for the use.
- Using base class and derived classes instead of `boost::any` in `Properties`.
- Changed the implementation of class template `PropertyVector` in case of pointer types.
- Add more tests.

Many of the commits of this PR are broken off the PR https://github.com/ufz/ogs/pull/607 to make review easier. It will follow further PRs based on this PR. If possible I would appreciated I quick review :smile: 