### PR TITLE
Csv interface issues

### DIFF
--- a/FileIO/CsvInterface.cpp
+++ b/FileIO/CsvInterface.cpp
@@ -65,7 +65,7 @@ int CsvInterface::readPoints(std::string const& fname, char delim,
                              std::string const& z_column_name)
 {
 	std::ifstream in(fname.c_str());
-	std::array<std::string, 3> const column_names = { x_column_name, y_column_name, z_column_name };
+	std::array<std::string, 3> const column_names = {{x_column_name, y_column_name, z_column_name}};
 
 	if (!in.is_open()) {
 		ERR ("CsvInterface::readPoints(): Could not open file %s.", fname.c_str());
@@ -75,10 +75,10 @@ int CsvInterface::readPoints(std::string const& fname, char delim,
 	std::string line;
 	getline(in, line);
 	std::array<std::size_t, 3> const column_idx =
-		{ CsvInterface::findColumn(line, delim, x_column_name),
-		  CsvInterface::findColumn(line, delim, y_column_name),
-		  (z_column_name.empty()) ? CsvInterface::findColumn(line, delim, y_column_name) :
-		                            CsvInterface::findColumn(line, delim, z_column_name) };
+		{{ CsvInterface::findColumn(line, delim, x_column_name),
+		   CsvInterface::findColumn(line, delim, y_column_name),
+		   (z_column_name.empty()) ?  CsvInterface::findColumn(line, delim, y_column_name) :
+		                              CsvInterface::findColumn(line, delim, z_column_name) }};
 
 	for (std::size_t i=0; i<3; ++i)
 		if (column_idx[i] == std::numeric_limits<std::size_t>::max())
@@ -105,8 +105,8 @@ int CsvInterface::readPoints(std::string const& fname, char delim,
 
 	if (z_column_idx == std::numeric_limits<std::size_t>::max())
 		z_column_idx = y_column_idx;
-	std::array<std::size_t, 3> const column_idx = { x_column_idx, y_column_idx, z_column_idx };
-	
+	std::array<std::size_t, 3> const column_idx = {{ x_column_idx, y_column_idx, z_column_idx }};
+
 	return readPoints(in, delim, points, column_idx);
 }
 
@@ -114,13 +114,13 @@ int CsvInterface::readPoints(std::ifstream &in, char delim,
                              std::vector<GeoLib::Point*> &points,
                              std::array<std::size_t, 3> const& column_idx)
 {
-	std::array<std::size_t, 3> order = { 0, 1, 2 };
+	std::array<std::size_t, 3> order = {{ 0, 1, 2 }};
 	std::sort(order.begin(), order.end(),
 		[&column_idx](std::size_t idx1, std::size_t idx2) {return column_idx[idx1] < column_idx[idx2];});
 	std::array<std::size_t, 3> const column_advance =
-		{ column_idx[order[0]],
-		  column_idx[order[1]] - column_idx[order[0]],
-		  column_idx[order[2]] - column_idx[order[1]] };
+		{{ column_idx[order[0]],
+		   column_idx[order[1]] - column_idx[order[0]],
+		   column_idx[order[2]] - column_idx[order[1]] }};
 
 	std::string line;
 	std::size_t line_count(0);

--- a/FileIO/CsvInterface.cpp
+++ b/FileIO/CsvInterface.cpp
@@ -17,7 +17,7 @@
 
 namespace FileIO {
 
-int CsvInterface::readPoints(std::string const& fname, char delim, 
+int CsvInterface::readPoints(std::string const& fname, char delim,
                              std::vector<GeoLib::Point*> &points)
 {
 	std::ifstream in(fname.c_str());
@@ -74,12 +74,12 @@ int CsvInterface::readPoints(std::string const& fname, char delim,
 
 	std::string line;
 	getline(in, line);
-	std::array<std::size_t, 3> const column_idx = 
+	std::array<std::size_t, 3> const column_idx =
 		{ CsvInterface::findColumn(line, delim, x_column_name),
 		  CsvInterface::findColumn(line, delim, y_column_name),
-		  (z_column_name.empty()) ? CsvInterface::findColumn(line, delim, y_column_name) : 
+		  (z_column_name.empty()) ? CsvInterface::findColumn(line, delim, y_column_name) :
 		                            CsvInterface::findColumn(line, delim, z_column_name) };
-	
+
 	for (std::size_t i=0; i<3; ++i)
 		if (column_idx[i] == std::numeric_limits<std::size_t>::max())
 		{
@@ -115,17 +115,18 @@ int CsvInterface::readPoints(std::ifstream &in, char delim,
                              std::array<std::size_t, 3> const& column_idx)
 {
 	std::array<std::size_t, 3> order = { 0, 1, 2 };
-	std::sort(order.begin(), order.end(), 
+	std::sort(order.begin(), order.end(),
 		[&column_idx](std::size_t idx1, std::size_t idx2) {return column_idx[idx1] < column_idx[idx2];});
-	std::array<std::size_t, 3> const column_advance = 
-		{ column_idx[order[0]], 
-		  column_idx[order[1]] - column_idx[order[0]], 
+	std::array<std::size_t, 3> const column_advance =
+		{ column_idx[order[0]],
+		  column_idx[order[1]] - column_idx[order[0]],
 		  column_idx[order[2]] - column_idx[order[1]] };
 
 	std::string line;
 	std::size_t line_count(0);
 	std::size_t error_count(0);
 	std::list<std::string>::const_iterator it;
+
 	while ( getline(in, line) )
 	{
 		line_count++;

--- a/FileIO/CsvInterface.h
+++ b/FileIO/CsvInterface.h
@@ -38,7 +38,7 @@ namespace FileIO {
 class CsvInterface {
 
 public:
-	/** 
+	/**
 	 * Reads 3D points from a CSV file. It is assumed that the file has a header
 	 * specifying a name for each of the columns. The first three columns will be
 	 * interpreted as x-, y- and z-coordinate, respectively.
@@ -50,10 +50,10 @@ public:
 	static int readPoints(std::string const& fname, char delim,
 	                      std::vector<GeoLib::Point*> &points);
 
-	/** 
+	/**
 	 * Reads 3D points from a CSV file. It is assumed that the file has a header
 	 * specifying a name for each of the columns. The columns specified in the
-	 * function call will be used for reading x-, y- and z-coordinates, 
+	 * function call will be used for reading x-, y- and z-coordinates,
 	 * respectively If z_column_name is an empty string or not given at all, all
 	 * z-coordinates will be set to zero.
 	 * \param fname           Name of the file to be read
@@ -70,7 +70,7 @@ public:
 	                      std::string const& y_column_name,
 	                      std::string const& z_column_name = "");
 
-	/** 
+	/**
 	 * Reads 3D points from a headerless CSV file, so columns for x-, y- and
 	 * z-coordinates have to be specified using indices (starting with 0).
 	 * If z_column_idx is not given (or set to numeric_limits::max()), all
@@ -164,10 +164,10 @@ private:
 			std::istringstream stream(*it);
 			T value;
 			if (!(stream >> value))
-			{ 
-				ERR("Error reading value in line %d.", line_count); 
+			{
+				ERR("Error reading value in line %d.", line_count);
 				error_count++;
-				continue; 
+				continue;
 			}
 
 			data_array.push_back(value);

--- a/Tests/testrunner.cpp
+++ b/Tests/testrunner.cpp
@@ -13,6 +13,8 @@
  */
 
 // ** INCLUDES **
+#include <clocale>
+
 #include "gtest/gtest.h"
 #include "logog/include/logog.hpp"
 
@@ -37,6 +39,7 @@
 /// Implementation of the googletest testrunner
 int main(int argc, char* argv[])
 {
+    setlocale(LC_ALL, "C");
 #ifdef QT4_FOUND
     QApplication app(argc, argv, false);
 #endif


### PR DESCRIPTION
The locale at my environment was set to a comma instead of a period to separate the integer part from the non-integer part (for instance 1,2 instead of 1.2). Since some of the CsvInterface methods use locale dependend functions to read floating point numbers some of the CsvInterfaceTests failed. For this reason, I suggest to set the locale at start of the testrunner to the following: `setlocale(LC_NUMERIC,"C");`

Additional, there is one commit removing some warning in clang and one commit that remove some unnecessary whitespaces.