### PR TITLE
Using new mesh interface for Properties in class ElementValueModification 

### DIFF
--- a/MeshLib/MeshEditing/ElementValueModification.cpp
+++ b/MeshLib/MeshEditing/ElementValueModification.cpp
@@ -21,33 +21,7 @@
 #include "MeshLib/Mesh.h"
 #include "MeshLib/Elements/Element.h"
 
-
 namespace MeshLib {
-
-std::vector<unsigned> ElementValueModification::getMeshValues(const MeshLib::Mesh &mesh)
-{
-	const std::size_t nElements (mesh.getNElements());
-	std::vector<unsigned> value_mapping;
-	for (unsigned i=0; i<nElements; ++i)
-	{
-		bool exists(false);
-		unsigned value (mesh.getElement(i)->getValue());
-		const unsigned nValues (value_mapping.size());
-		for (unsigned j=0; j<nValues; ++j)
-		{
-			if (value == value_mapping[j])
-			{
-				exists = true;
-				break;
-			}
-		}
-		if (!exists)
-			value_mapping.push_back(value);
-	}
-
-	std::sort(value_mapping.begin(), value_mapping.end());
-	return value_mapping;
-}
 
 bool ElementValueModification::replace(MeshLib::Mesh &mesh,
 	std::string const& property_name, unsigned old_value, unsigned new_value,

--- a/MeshLib/MeshEditing/ElementValueModification.cpp
+++ b/MeshLib/MeshEditing/ElementValueModification.cpp
@@ -97,16 +97,29 @@ unsigned ElementValueModification::condense(MeshLib::Mesh &mesh)
 
 unsigned ElementValueModification::setByElementType(MeshLib::Mesh &mesh, MeshElemType ele_type, unsigned new_value)
 {
-	std::vector<MeshLib::Element*> &elements (const_cast<std::vector<MeshLib::Element*>&>(mesh.getElements()));
-	unsigned nValues = 0;
-	for (auto e : elements) {
-		if (e->getGeomType()!=ele_type)
-			continue;
-		e->setValue(new_value);
-		nValues++;
+	boost::optional<MeshLib::PropertyVector<unsigned> &>
+		optional_property_value_vec(
+			mesh.getProperties().getPropertyVector<unsigned>("MaterialIDs")
+		);
+
+	if (!optional_property_value_vec) {
+		return 0;
 	}
 
-	return nValues;
+	MeshLib::PropertyVector<unsigned> & property_value_vector(
+		optional_property_value_vec.get()
+	);
+
+	std::vector<MeshLib::Element*> const& elements(mesh.getElements());
+	std::size_t cnt(0);
+	for (std::size_t k(0); k<elements.size(); k++) {
+		if (elements[k]->getGeomType()!=ele_type)
+			continue;
+		property_value_vector[k] = new_value;
+		cnt++;
+	}
+
+	return cnt;
 }
 
 } // end namespace MeshLib

--- a/MeshLib/MeshEditing/ElementValueModification.h
+++ b/MeshLib/MeshEditing/ElementValueModification.h
@@ -41,6 +41,9 @@ public:
 	/// Returns true if successful or false if the value is already taken.
 	static bool replace(MeshLib::Mesh &mesh, unsigned old_value, unsigned new_value, bool replace_if_exists = false);
 
+	static bool replace(MeshLib::Mesh &mesh, std::string const& property_name,
+		unsigned old_value, unsigned new_value, bool replace_if_exists = false);
+
 	/// Sets new value for all elements having the given element type
 	/// Returns the number of elements having the given element type
 	static unsigned setByElementType(MeshLib::Mesh &mesh, MeshElemType ele_type, unsigned new_value);

--- a/MeshLib/MeshEditing/ElementValueModification.h
+++ b/MeshLib/MeshEditing/ElementValueModification.h
@@ -17,7 +17,11 @@
 
 #include <vector>
 
+#include <boost/optional.hpp>
+
 #include "MeshLib/MeshEnums.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/PropertyVector.h"
 
 namespace MeshLib {
 // forward declarations
@@ -42,6 +46,32 @@ public:
 	static unsigned setByElementType(MeshLib::Mesh &mesh, MeshElemType ele_type, unsigned new_value);
 
 private:
+	/// Returns sorted values of properties within the PropertyVector
+	/// These values are stored in a vector.
+	template <typename T>
+	static std::vector<T> getSortedPropertyValues(
+		MeshLib::PropertyVector<T> const& property_vector)
+	{
+		std::vector<T> value_mapping;
+		const std::size_t n_property_values(property_vector.size());
+		for (std::size_t i=0; i<n_property_values; ++i) {
+			bool exists(false);
+			T const& value (property_vector[i]);
+			std::size_t const size(value_mapping.size());
+			for (unsigned j=0; j<size; ++j) {
+				if (value == value_mapping[j]) {
+					exists = true;
+					break;
+				}
+			}
+			if (!exists)
+				value_mapping.push_back(value);
+		}
+
+		std::sort(value_mapping.begin(), value_mapping.end());
+		return value_mapping;
+	}
+
 	/// Returns the values of elements within the mesh
 	static std::vector<unsigned> getMeshValues(const MeshLib::Mesh &mesh);
 };

--- a/MeshLib/MeshEditing/ElementValueModification.h
+++ b/MeshLib/MeshEditing/ElementValueModification.h
@@ -75,8 +75,6 @@ private:
 		return value_mapping;
 	}
 
-	/// Returns the values of elements within the mesh
-	static std::vector<unsigned> getMeshValues(const MeshLib::Mesh &mesh);
 };
 
 } // end namespace MeshLib


### PR DESCRIPTION
This is another PR that changes the handling of materials. `Properties` and `PropertyVector` are used in `ElementValueModification`.