### PR TITLE
Prism node ordering

### DIFF
--- a/Applications/Utils/MeshEdit/CMakeLists.txt
+++ b/Applications/Utils/MeshEdit/CMakeLists.txt
@@ -40,15 +40,15 @@ target_link_libraries(removeMeshElements
 ADD_CATALYST_DEPENDENCY(removeMeshElements)
 set_target_properties(removeMeshElements PROPERTIES FOLDER Utilities)
 
-add_executable(DataExplorer5NodeReordering DataExplorer5NodeReordering.cpp)
-target_link_libraries(DataExplorer5NodeReordering
+add_executable(NodeReordering NodeReordering.cpp)
+target_link_libraries(NodeReordering
 	FileIO
 	MeshLib
 	InSituLib
 	${CATALYST_LIBRARIES}
 )
-ADD_CATALYST_DEPENDENCY(DataExplorer5NodeReordering)
-set_target_properties(DataExplorer5NodeReordering PROPERTIES FOLDER Utilities)
+ADD_CATALYST_DEPENDENCY(NodeReordering)
+set_target_properties(NodeReordering PROPERTIES FOLDER Utilities)
 
 add_executable(MoveMesh MoveMesh.cpp)
 target_link_libraries(MoveMesh

--- a/MeshLib/MeshGenerators/VtkMeshConverter.cpp
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.cpp
@@ -345,8 +345,11 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(vtkUnstructuredGrid* gr
 		}
 		case VTK_WEDGE: {
 			MeshLib::Node** prism_nodes = new MeshLib::Node*[6];
-			for (unsigned k(0); k<6; k++)
-				prism_nodes[k] = nodes[node_ids[k]];
+			for (unsigned i=0; i<3; ++i)
+			{
+				prism_nodes[i] = nodes[node_ids[i+3]];
+				prism_nodes[i+3] = nodes[node_ids[i]];
+			}
 			elem = new MeshLib::Prism(prism_nodes, material);
 			break;
 		}


### PR DESCRIPTION
due to using InsituLib now (specifically, direct use of VTK methods for reading and writing meshes) we established in inconsistency for node ordering in prism-elements. this PR fixes that such that meshes are now again displayed correctly in OGS as well as in ParaView.

unfortunately, this also means that old ogs-meshes (created before including insitu-lib) need to have the prism nodes reordered. i adjusted the existing node-reordering tool to provide an easy way to do that (use parameter ```-m 2```).

note: the old meshes are not *per se* broken, it's just that the face-normals of prism elements point in the wrong direction. if this doesn't concern you, you need not re-order nodes.