### PR TITLE
Add quadratic mesh element types

### DIFF
--- a/Applications/DataExplorer/VtkVis/VtkMeshSource.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkMeshSource.cpp
@@ -45,7 +45,7 @@
 #include <vtkTriangle.h>
 #include <vtkWedge.h> // == Prism
 
-#include "InSituLib/VtkOGSEnum.h"
+#include "MeshLib/VtkOGSEnum.h"
 
 vtkStandardNewMacro(VtkMeshSource);
 
@@ -146,7 +146,7 @@ int VtkMeshSource::RequestData( vtkInformation* request,
 		for (unsigned j = 0; j < nElemNodes; ++j)
 			point_ids->SetId(j, elem->getNode(j)->getID());
 
-		type = InSituLib::OGSToVtkCellType(elem->getCellType());
+		type = OGSToVtkCellType(elem->getCellType());
 		if (type==0) {
 			ERR("VtkMeshSource::RequestData(): Unknown element type \"%s\".",
 					CellType2String(elem->getCellType()).c_str());

--- a/Applications/DataExplorer/VtkVis/VtkMeshSource.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkMeshSource.cpp
@@ -135,7 +135,6 @@ int VtkMeshSource::RequestData( vtkInformation* request,
 	// Generate mesh elements
 	for (unsigned i = 0; i < nElems; ++i)
 	{
-		int type(0);
 		const MeshLib::Element* elem (elems[i]);
 
 		materialIDs->InsertValue(i, elem->getValue());
@@ -145,8 +144,8 @@ int VtkMeshSource::RequestData( vtkInformation* request,
 		for (unsigned j = 0; j < nElemNodes; ++j)
 			point_ids->SetId(j, elem->getNode(j)->getID());
 
-		type = OGSToVtkCellType(elem->getCellType());
-		if (type==0)
+		const int type = OGSToVtkCellType(elem->getCellType());
+		if (type == -1)
 		{
 			ERR("VtkMeshSource::RequestData(): Unknown element type \"%s\".",
 					CellType2String(elem->getCellType()).c_str());

--- a/InSituLib/CMakeLists.txt
+++ b/InSituLib/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(InSituLib
 	VtkMappedMesh.cpp
 	VtkMappedMeshSource.h
 	VtkMappedMeshSource.cpp
+	VtkOGSEnum.h
+	VtkOGSEnum.cpp
 )
 
 include(AddCatalystDependency)

--- a/InSituLib/CMakeLists.txt
+++ b/InSituLib/CMakeLists.txt
@@ -10,8 +10,12 @@ add_library(InSituLib
 	VtkMappedMesh.cpp
 	VtkMappedMeshSource.h
 	VtkMappedMeshSource.cpp
-	VtkOGSEnum.h
-	VtkOGSEnum.cpp
+)
+
+target_link_libraries(InSituLib
+	BaseLib
+	MeshLib
+	logog
 )
 
 include(AddCatalystDependency)

--- a/InSituLib/VtkMappedMesh.cpp
+++ b/InSituLib/VtkMappedMesh.cpp
@@ -28,7 +28,6 @@
 #include "Element.h"
 #include "MeshLib/Node.h"
 #include "MeshEnums.h"
-
 #include "VtkOGSEnum.h"
 
 namespace InSituLib {

--- a/InSituLib/VtkMappedMesh.cpp
+++ b/InSituLib/VtkMappedMesh.cpp
@@ -82,6 +82,24 @@ void VtkMappedMeshImpl::GetCellPoints(vtkIdType cellId, vtkIdList *ptIds)
 			ptIds->SetId(i+3, prism_swap_id);
 		}
 	}
+	else if(GetCellType(cellId) == VTK_QUADRATIC_WEDGE)
+	{
+		std::array<vtkIdType, 15> ogs_nodeIds;
+		for (unsigned i=0; i<15; ++i)
+			ogs_nodeIds[i] = ptIds->GetId(i);
+		for (unsigned i=0; i<3; ++i)
+		{
+			ptIds->SetId(i, ogs_nodeIds[i+3]);
+			ptIds->SetId(i+3, ogs_nodeIds[i]);
+		}
+		for (unsigned i=0; i<3; ++i)
+			ptIds->SetId(6+i, ogs_nodeIds[8-i]);
+		for (unsigned i=0; i<3; ++i)
+			ptIds->SetId(9+i, ogs_nodeIds[14-i]);
+		ptIds->SetId(12, ogs_nodeIds[9]);
+		ptIds->SetId(13, ogs_nodeIds[11]);
+		ptIds->SetId(14, ogs_nodeIds[10]);
+	}
 }
 
 void VtkMappedMeshImpl::GetPointCells(vtkIdType ptId, vtkIdList *cellIds)

--- a/InSituLib/VtkMappedMesh.cpp
+++ b/InSituLib/VtkMappedMesh.cpp
@@ -60,30 +60,60 @@ vtkIdType VtkMappedMeshImpl::GetNumberOfCells()
 int VtkMappedMeshImpl::GetCellType(vtkIdType cellId)
 {
 	int type = 0;
-	switch ((*_elements)[cellId]->getGeomType())
+	switch ((*_elements)[cellId]->getCellType())
 	{
-		case MeshElemType::INVALID:
+		case CellType::INVALID:
 			break;
-		case MeshElemType::LINE:
+		case CellType::LINE2:
 			type = VTK_LINE;
 			break;
-		case MeshElemType::TRIANGLE:
+		case CellType::LINE3:
+			type = VTK_QUADRATIC_EDGE;
+			break;
+		case CellType::TRI3:
 			type = VTK_TRIANGLE;
 			break;
-		case MeshElemType::QUAD:
+		case CellType::TRI6:
+			type = VTK_QUADRATIC_TRIANGLE;
+			break;
+		case CellType::QUAD4:
 			type = VTK_QUAD;
 			break;
-		case MeshElemType::HEXAHEDRON:
+		case CellType::QUAD8:
+			type = VTK_QUADRATIC_QUAD;
+			break;
+		case CellType::QUAD9:
+			type = VTK_BIQUADRATIC_QUAD;
+			break;
+		case CellType::HEX8:
 			type = VTK_HEXAHEDRON;
 			break;
-		case MeshElemType::TETRAHEDRON:
+		case CellType::HEX20:
+			type = VTK_QUADRATIC_HEXAHEDRON;
+			break;
+		case CellType::HEX27:
+			type = VTK_TRIQUADRATIC_HEXAHEDRON;
+			break;
+		case CellType::TET4:
 			type = VTK_TETRA;
 			break;
-		case MeshElemType::PRISM:
+		case CellType::TET10:
+			type = VTK_QUADRATIC_TETRA;
+			break;
+		case CellType::PRISM6:
 			type = VTK_WEDGE;
 			break;
-		case MeshElemType::PYRAMID:
+		case CellType::PRISM15:
+			type = VTK_QUADRATIC_WEDGE;
+			break;
+		case CellType::PRISM18:
+			type = VTK_BIQUADRATIC_QUADRATIC_WEDGE;
+			break;
+		case CellType::PYRAMID5:
 			type = VTK_PYRAMID;
+			break;
+		case CellType::PYRAMID13:
+			type = VTK_QUADRATIC_PYRAMID;
 			break;
 	}
 	return type;
@@ -133,16 +163,16 @@ void VtkMappedMeshImpl::GetIdsOfCellsOfType(int type, vtkIdTypeArray *array)
 
 	for (auto elem(_elements->begin()); elem != _elements->end(); ++elem)
 	{
-		if ((*elem)->getGeomType() == VtkCellTypeToOGS(type))
+		if ((*elem)->getCellType() == VtkCellTypeToOGS(type))
 			array->InsertNextValue((*elem)->getID());
 	}
 }
 
 int VtkMappedMeshImpl::IsHomogeneous()
 {
-	MeshElemType type = (*(_elements->begin()))->getGeomType();
+	CellType type = (*(_elements->begin()))->getCellType();
 	for (auto elem(_elements->begin()); elem != _elements->end(); ++elem)
-		if((*elem)->getGeomType() != type)
+		if((*elem)->getCellType() != type)
 			return 0;
 	return 1;
 }

--- a/InSituLib/VtkMappedMesh.cpp
+++ b/InSituLib/VtkMappedMesh.cpp
@@ -29,6 +29,8 @@
 #include "MeshLib/Node.h"
 #include "MeshEnums.h"
 
+#include "VtkOGSEnum.h"
+
 namespace InSituLib {
 
 vtkStandardNewMacro(VtkMappedMesh)
@@ -59,64 +61,7 @@ vtkIdType VtkMappedMeshImpl::GetNumberOfCells()
 
 int VtkMappedMeshImpl::GetCellType(vtkIdType cellId)
 {
-	int type = 0;
-	switch ((*_elements)[cellId]->getCellType())
-	{
-		case CellType::INVALID:
-			break;
-		case CellType::LINE2:
-			type = VTK_LINE;
-			break;
-		case CellType::LINE3:
-			type = VTK_QUADRATIC_EDGE;
-			break;
-		case CellType::TRI3:
-			type = VTK_TRIANGLE;
-			break;
-		case CellType::TRI6:
-			type = VTK_QUADRATIC_TRIANGLE;
-			break;
-		case CellType::QUAD4:
-			type = VTK_QUAD;
-			break;
-		case CellType::QUAD8:
-			type = VTK_QUADRATIC_QUAD;
-			break;
-		case CellType::QUAD9:
-			type = VTK_BIQUADRATIC_QUAD;
-			break;
-		case CellType::HEX8:
-			type = VTK_HEXAHEDRON;
-			break;
-		case CellType::HEX20:
-			type = VTK_QUADRATIC_HEXAHEDRON;
-			break;
-		case CellType::HEX27:
-			type = VTK_TRIQUADRATIC_HEXAHEDRON;
-			break;
-		case CellType::TET4:
-			type = VTK_TETRA;
-			break;
-		case CellType::TET10:
-			type = VTK_QUADRATIC_TETRA;
-			break;
-		case CellType::PRISM6:
-			type = VTK_WEDGE;
-			break;
-		case CellType::PRISM15:
-			type = VTK_QUADRATIC_WEDGE;
-			break;
-		case CellType::PRISM18:
-			type = VTK_BIQUADRATIC_QUADRATIC_WEDGE;
-			break;
-		case CellType::PYRAMID5:
-			type = VTK_PYRAMID;
-			break;
-		case CellType::PYRAMID13:
-			type = VTK_QUADRATIC_PYRAMID;
-			break;
-	}
-	return type;
+	return OGSToVtkCellType((*_elements)[cellId]->getCellType());
 }
 
 void VtkMappedMeshImpl::GetCellPoints(vtkIdType cellId, vtkIdList *ptIds)

--- a/InSituLib/VtkMappedMesh.h
+++ b/InSituLib/VtkMappedMesh.h
@@ -70,69 +70,6 @@ private:
 	const std::vector<MeshLib::Node*>* _nodes;
 	const std::vector<MeshLib::Element*>* _elements;
 	vtkIdType NumberOfCells;
-
-	static CellType VtkCellTypeToOGS(int type)
-	{
-		CellType ogs;
-		switch (type)
-		{
-			case VTK_LINE:
-				ogs = CellType::LINE2;
-				break;
-			case VTK_QUADRATIC_EDGE:
-				ogs = CellType::LINE3;
-				break;
-			case VTK_TRIANGLE:
-				ogs = CellType::TRI3;
-				break;
-			case VTK_QUADRATIC_TRIANGLE:
-				ogs = CellType::TRI6;
-				break;
-			case VTK_QUAD:
-				ogs = CellType::QUAD4;
-				break;
-			case VTK_QUADRATIC_QUAD:
-				ogs = CellType::QUAD8;
-				break;
-			case VTK_BIQUADRATIC_QUAD:
-				ogs = CellType::QUAD9;
-				break;
-			case VTK_HEXAHEDRON:
-				ogs = CellType::HEX8;
-				break;
-			case VTK_QUADRATIC_HEXAHEDRON:
-				ogs = CellType::HEX20;
-				break;
-			case VTK_TRIQUADRATIC_HEXAHEDRON:
-				ogs = CellType::HEX27;
-				break;
-			case VTK_TETRA:
-				ogs = CellType::TET4;
-				break;
-			case VTK_QUADRATIC_TETRA:
-				ogs = CellType::TET10;
-				break;
-			case VTK_WEDGE:
-				ogs = CellType::PRISM6;
-				break;
-			case VTK_QUADRATIC_WEDGE:
-				ogs = CellType::PRISM15;
-				break;
-			case VTK_BIQUADRATIC_QUADRATIC_WEDGE:
-				ogs = CellType::PRISM18;
-				break;
-			case VTK_PYRAMID:
-				ogs = CellType::PYRAMID5;
-				break;
-			case VTK_QUADRATIC_PYRAMID:
-				ogs = CellType::PYRAMID13;
-				break;
-			default:
-				ogs = CellType::INVALID;
-				break;
-		}
-		return ogs;
-	}
 };
 
 vtkMakeMappedUnstructuredGrid(VtkMappedMesh, VtkMappedMeshImpl)

--- a/InSituLib/VtkMappedMesh.h
+++ b/InSituLib/VtkMappedMesh.h
@@ -71,34 +71,64 @@ private:
 	const std::vector<MeshLib::Element*>* _elements;
 	vtkIdType NumberOfCells;
 
-	static MeshElemType VtkCellTypeToOGS(int type)
+	static CellType VtkCellTypeToOGS(int type)
 	{
-		MeshElemType ogs;
+		CellType ogs;
 		switch (type)
 		{
 			case VTK_LINE:
-				ogs = MeshElemType::LINE;
+				ogs = CellType::LINE2;
+				break;
+			case VTK_QUADRATIC_EDGE:
+				ogs = CellType::LINE3;
 				break;
 			case VTK_TRIANGLE:
-				ogs = MeshElemType::TRIANGLE;
+				ogs = CellType::TRI3;
+				break;
+			case VTK_QUADRATIC_TRIANGLE:
+				ogs = CellType::TRI6;
 				break;
 			case VTK_QUAD:
-				ogs = MeshElemType::QUAD;
+				ogs = CellType::QUAD4;
+				break;
+			case VTK_QUADRATIC_QUAD:
+				ogs = CellType::QUAD8;
+				break;
+			case VTK_BIQUADRATIC_QUAD:
+				ogs = CellType::QUAD9;
 				break;
 			case VTK_HEXAHEDRON:
-				ogs = MeshElemType::HEXAHEDRON;
+				ogs = CellType::HEX8;
+				break;
+			case VTK_QUADRATIC_HEXAHEDRON:
+				ogs = CellType::HEX20;
+				break;
+			case VTK_TRIQUADRATIC_HEXAHEDRON:
+				ogs = CellType::HEX27;
 				break;
 			case VTK_TETRA:
-				ogs = MeshElemType::TETRAHEDRON;
+				ogs = CellType::TET4;
+				break;
+			case VTK_QUADRATIC_TETRA:
+				ogs = CellType::TET10;
 				break;
 			case VTK_WEDGE:
-				ogs = MeshElemType::PRISM;
+				ogs = CellType::PRISM6;
+				break;
+			case VTK_QUADRATIC_WEDGE:
+				ogs = CellType::PRISM15;
+				break;
+			case VTK_BIQUADRATIC_QUADRATIC_WEDGE:
+				ogs = CellType::PRISM18;
 				break;
 			case VTK_PYRAMID:
-				ogs = MeshElemType::PYRAMID;
+				ogs = CellType::PYRAMID5;
+				break;
+			case VTK_QUADRATIC_PYRAMID:
+				ogs = CellType::PYRAMID13;
 				break;
 			default:
-				ogs = MeshElemType::INVALID;
+				ogs = CellType::INVALID;
 				break;
 		}
 		return ogs;

--- a/InSituLib/VtkOGSEnum.cpp
+++ b/InSituLib/VtkOGSEnum.cpp
@@ -1,0 +1,143 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "VtkOGSEnum.h"
+
+#include <vtkCellType.h>
+
+namespace InSituLib
+{
+
+CellType VtkCellTypeToOGS(int type)
+{
+	CellType ogs;
+	switch (type)
+	{
+		case VTK_LINE:
+			ogs = CellType::LINE2;
+			break;
+		case VTK_QUADRATIC_EDGE:
+			ogs = CellType::LINE3;
+			break;
+		case VTK_TRIANGLE:
+			ogs = CellType::TRI3;
+			break;
+		case VTK_QUADRATIC_TRIANGLE:
+			ogs = CellType::TRI6;
+			break;
+		case VTK_QUAD:
+			ogs = CellType::QUAD4;
+			break;
+		case VTK_QUADRATIC_QUAD:
+			ogs = CellType::QUAD8;
+			break;
+		case VTK_BIQUADRATIC_QUAD:
+			ogs = CellType::QUAD9;
+			break;
+		case VTK_HEXAHEDRON:
+			ogs = CellType::HEX8;
+			break;
+		case VTK_QUADRATIC_HEXAHEDRON:
+			ogs = CellType::HEX20;
+			break;
+		case VTK_TRIQUADRATIC_HEXAHEDRON:
+			ogs = CellType::HEX27;
+			break;
+		case VTK_TETRA:
+			ogs = CellType::TET4;
+			break;
+		case VTK_QUADRATIC_TETRA:
+			ogs = CellType::TET10;
+			break;
+		case VTK_WEDGE:
+			ogs = CellType::PRISM6;
+			break;
+		case VTK_QUADRATIC_WEDGE:
+			ogs = CellType::PRISM15;
+			break;
+		case VTK_BIQUADRATIC_QUADRATIC_WEDGE:
+			ogs = CellType::PRISM18;
+			break;
+		case VTK_PYRAMID:
+			ogs = CellType::PYRAMID5;
+			break;
+		case VTK_QUADRATIC_PYRAMID:
+			ogs = CellType::PYRAMID13;
+			break;
+		default:
+			ogs = CellType::INVALID;
+			break;
+	}
+	return ogs;
+}
+
+int OGSToVtkCellType(CellType ogs)
+{
+	int type = 0;
+	switch (ogs)
+	{
+		case CellType::INVALID:
+			break;
+		case CellType::LINE2:
+			type = VTK_LINE;
+			break;
+		case CellType::LINE3:
+			type = VTK_QUADRATIC_EDGE;
+			break;
+		case CellType::TRI3:
+			type = VTK_TRIANGLE;
+			break;
+		case CellType::TRI6:
+			type = VTK_QUADRATIC_TRIANGLE;
+			break;
+		case CellType::QUAD4:
+			type = VTK_QUAD;
+			break;
+		case CellType::QUAD8:
+			type = VTK_QUADRATIC_QUAD;
+			break;
+		case CellType::QUAD9:
+			type = VTK_BIQUADRATIC_QUAD;
+			break;
+		case CellType::HEX8:
+			type = VTK_HEXAHEDRON;
+			break;
+		case CellType::HEX20:
+			type = VTK_QUADRATIC_HEXAHEDRON;
+			break;
+		case CellType::HEX27:
+			type = VTK_TRIQUADRATIC_HEXAHEDRON;
+			break;
+		case CellType::TET4:
+			type = VTK_TETRA;
+			break;
+		case CellType::TET10:
+			type = VTK_QUADRATIC_TETRA;
+			break;
+		case CellType::PRISM6:
+			type = VTK_WEDGE;
+			break;
+		case CellType::PRISM15:
+			type = VTK_QUADRATIC_WEDGE;
+			break;
+		case CellType::PRISM18:
+			type = VTK_BIQUADRATIC_QUADRATIC_WEDGE;
+			break;
+		case CellType::PYRAMID5:
+			type = VTK_PYRAMID;
+			break;
+		case CellType::PYRAMID13:
+			type = VTK_QUADRATIC_PYRAMID;
+			break;
+	}
+	return type;
+}
+
+} // end namespace
+

--- a/InSituLib/VtkOGSEnum.h
+++ b/InSituLib/VtkOGSEnum.h
@@ -1,0 +1,24 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef VTKOGSENUM_H_
+#define VTKOGSENUM_H_
+
+#include "MeshEnums.h"
+
+namespace InSituLib
+{
+
+CellType VtkCellTypeToOGS(int type);
+
+int OGSToVtkCellType(CellType ogs);
+
+} // end namespace
+
+#endif // VTKOGSENUM_H_

--- a/MeshLib/Elements/Element.cpp
+++ b/MeshLib/Elements/Element.cpp
@@ -121,10 +121,14 @@ void Element::computeSqrNodeDistanceRange(double &min, double &max, bool check_a
 
 const Element* Element::getNeighbor(unsigned i) const
 {
+#ifndef NDEBUG
 	if (i < getNNeighbors())
+#endif
 		return _neighbors[i];
+#ifndef NDEBUG
 	ERR("Error in MeshLib::Element::getNeighbor() - Index does not exist.");
 	return nullptr;
+#endif
 }
 
 unsigned Element::getNodeIDinElement(const MeshLib::Node* node) const
@@ -138,24 +142,34 @@ unsigned Element::getNodeIDinElement(const MeshLib::Node* node) const
 
 const Node* Element::getNode(unsigned i) const
 {
-	if (i < getNBaseNodes())
+#ifndef NDEBUG
+	if (i < getNNodes())
+#endif
 		return _nodes[i];
+#ifndef NDEBUG
 	ERR("Error in MeshLib::Element::getNode() - Index %d in %s", i, MeshElemType2String(getGeomType()).c_str());
 	return nullptr;
+#endif
 }
 
 void Element::setNode(unsigned idx, Node* node)
 {
-	if (idx < getNBaseNodes())
+#ifndef NDEBUG
+	if (idx < getNNodes())
+#endif
 		_nodes[idx] = node;
 }
 
 unsigned Element::getNodeIndex(unsigned i) const
 {
-	if (i<getNBaseNodes())
+#ifndef NDEBUG
+	if (i<getNNodes())
+#endif
 		return _nodes[i]->getID();
+#ifndef NDEBUG
 	ERR("Error in MeshLib::Element::getNodeIndex() - Index does not exist.");
 	return std::numeric_limits<unsigned>::max();
+#endif
 }
 
 bool Element::hasNeighbor(Element* elem) const

--- a/MeshLib/Elements/Hex.h
+++ b/MeshLib/Elements/Hex.h
@@ -17,9 +17,11 @@
 
 #include "TemplateElement.h"
 #include "HexRule8.h"
+#include "HexRule20.h"
 
 namespace MeshLib {
 typedef TemplateElement<HexRule8> Hex;
+typedef TemplateElement<HexRule20> Hex20;
 }
 
 #endif /* HEX_H_ */

--- a/MeshLib/Elements/HexRule20.cpp
+++ b/MeshLib/Elements/HexRule20.cpp
@@ -1,0 +1,63 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "HexRule20.h"
+
+#include <array>
+
+#include "logog/include/logog.hpp"
+
+#include "GeoLib/AnalyticalGeometry.h"
+
+#include "MeshLib/Node.h"
+#include "Quad.h"
+#include "Line.h"
+
+namespace MeshLib {
+
+const unsigned HexRule20::face_nodes[6][8] =
+{
+	{0, 3, 2, 1, 11, 10,  9,  8}, // Face 0
+	{0, 1, 5, 4,  8, 17, 12, 11}, // Face 1
+	{1, 2, 6, 5,  9, 18, 13, 17}, // Face 2
+	{2, 3, 7, 6, 10, 19, 14, 18}, // Face 3
+	{3, 0, 4, 7, 11, 16, 15, 19}, // Face 4
+	{4, 5, 6, 7, 12, 13, 14, 15}  // Face 5
+};
+
+const unsigned HexRule20::edge_nodes[12][3] =
+{
+	{0, 1, 8}, // Edge 0
+	{1, 2, 9}, // Edge 1
+	{2, 3, 10}, // Edge 2
+	{0, 3, 11}, // Edge 3
+	{4, 5, 12}, // Edge 4
+	{5, 6, 13}, // Edge 5
+	{6, 7, 14}, // Edge 6
+	{4, 7, 15}, // Edge 7
+	{0, 4, 16}, // Edge 8
+	{1, 5, 17}, // Edge 9
+	{2, 6, 18}, // Edge 10
+	{3, 7, 19}  // Edge 11
+};
+
+const Element* HexRule20::getFace(const Element* e, unsigned i)
+{
+	if (i < n_faces)
+	{
+		std::array<Node*, 8> nodes;
+		for (unsigned j=0; j<8; j++)
+			nodes[j] = const_cast<Node*>(e->getNode(face_nodes[i][j]));
+		return new Quad8(nodes);
+	}
+	ERR("Error in MeshLib::Element::getFace() - Index %d does not exist.", i);
+	return nullptr;
+}
+
+} // end namespace MeshLib

--- a/MeshLib/Elements/HexRule20.h
+++ b/MeshLib/Elements/HexRule20.h
@@ -1,0 +1,75 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef HEXRULE20_H_
+#define HEXRULE20_H_
+
+#include "MeshLib/MeshEnums.h"
+#include "Element.h"
+#include "EdgeReturn.h"
+#include "HexRule8.h"
+
+namespace MeshLib
+{
+
+/**
+ * A 20-nodes Hexahedron Element.
+ * @code
+ *
+ *  Hex:
+ *                14
+ *          7-----------6
+ *         /:          /|
+ *        / :         / |
+ *     15/  :        /13|
+ *      / 19:       /   | 18
+ *     /    : 12   /    |
+ *    4-----------5     |
+ *    |     :     | 10  |
+ *    |     3.....|.....2
+ *    |    .      |    /
+ * 16 |   .       |17 /
+ *    |11.        |  / 9
+ *    | .         | /
+ *    |.          |/
+ *    0-----------1
+ *          8
+ *
+ * @endcode
+ */
+class HexRule20 : public HexRule8
+{
+public:
+	/// Constant: The number of all nodes for this element
+	static const unsigned n_all_nodes = 20u;
+
+	/// Constant: The FEM type of the element
+	static const CellType cell_type = CellType::HEX20;
+
+	/// Constant: Local node index table for faces
+	static const unsigned face_nodes[6][8];
+
+	/// Constant: Local node index table for edge
+	static const unsigned edge_nodes[12][3];
+
+	/// Returns the i-th edge of the element.
+	typedef QuadraticEdgeReturn EdgeReturn;
+
+	/// Get the number of nodes for face i.
+	static unsigned getNFaceNodes(unsigned /*i*/) { return 8; }
+
+	/// Returns the i-th face of the element.
+	static const Element* getFace(const Element* e, unsigned i);
+
+}; /* class */
+
+} /* namespace */
+
+#endif /* HEXRULE20_H_ */
+

--- a/MeshLib/Elements/Prism.h
+++ b/MeshLib/Elements/Prism.h
@@ -17,10 +17,12 @@
 
 #include "TemplateElement.h"
 #include "PrismRule6.h"
+#include "PrismRule15.h"
 
 namespace MeshLib {
 
 typedef TemplateElement<PrismRule6> Prism;
+typedef TemplateElement<PrismRule15> Prism15;
 
 }
 

--- a/MeshLib/Elements/PrismRule15.cpp
+++ b/MeshLib/Elements/PrismRule15.cpp
@@ -1,0 +1,72 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "PrismRule15.h"
+
+#include "logog/include/logog.hpp"
+
+#include "GeoLib/AnalyticalGeometry.h"
+
+#include "MeshLib/Node.h"
+#include "Quad.h"
+#include "Tri.h"
+
+namespace MeshLib {
+
+const unsigned PrismRule15::face_nodes[5][8] =
+{
+	{0, 2, 1,  8,  7,  6, 99, 99}, // Face 0
+	{0, 1, 4,  3,  6, 10, 12,  9}, // Face 1
+	{1, 2, 5,  4,  7, 11, 13, 10}, // Face 2
+	{2, 0, 3,  5,  8,  9, 14, 11}, // Face 3
+	{3, 4, 5, 12, 13, 14, 99, 99}  // Face 4
+};
+
+const unsigned PrismRule15::edge_nodes[9][3] =
+{
+	{0, 1, 6}, // Edge 0
+	{1, 2, 7}, // Edge 1
+	{0, 2, 8}, // Edge 2
+	{0, 3, 9}, // Edge 3
+	{1, 4, 10}, // Edge 4
+	{2, 5, 11}, // Edge 5
+	{3, 4, 12}, // Edge 6
+	{4, 5, 13}, // Edge 7
+	{3, 5, 14}  // Edge 8
+};
+
+const unsigned PrismRule15::n_face_nodes[5] = { 6, 8, 8, 8, 6 };
+
+unsigned PrismRule15::getNFaceNodes(unsigned i)
+{
+	if (i<5)
+		return n_face_nodes[i];
+	ERR("Error in MeshLib::Element::getNFaceNodes() - Index %d does not exist.", i);
+	return 0;
+}
+
+const Element* PrismRule15::getFace(const Element* e, unsigned i)
+{
+	if (i < n_faces)
+	{
+		unsigned nFaceNodes (e->getNFaceNodes(i));
+		Node** nodes = new Node*[nFaceNodes];
+		for (unsigned j=0; j<nFaceNodes; j++)
+			nodes[j] = const_cast<Node*>(e->getNode(face_nodes[i][j]));
+
+		if (i==0 || i==4)
+			return new Tri6(nodes);
+		else
+			return new Quad8(nodes);
+	}
+	ERR("Error in MeshLib::Element::getFace() - Index %d does not exist.", i);
+	return nullptr;
+}
+
+} // end namespace MeshLib

--- a/MeshLib/Elements/PrismRule15.h
+++ b/MeshLib/Elements/PrismRule15.h
@@ -1,0 +1,76 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PRISMRULE15_H_
+#define PRISMRULE15_H_
+
+#include "MeshLib/MeshEnums.h"
+#include "Element.h"
+#include "EdgeReturn.h"
+#include "PrismRule6.h"
+
+namespace MeshLib
+{
+
+/**
+ * This class represents a 3d prism element with 15 nodes. The following sketch shows the node and edge numbering.
+ * @anchor PrismNodeAndEdgeNumbering
+ * @code
+ *            5
+ *           / \
+ *          / : \
+ *       14/  :  \13
+ *        /   :11 \
+ *       /    : 12 \
+ *      3-----------4
+ *      |     :     |
+ *      |     2     |
+ *      |    . .    |
+ *     9|   .   .   |10
+ *      | 8.     .7 |
+ *      | .       . |
+ *      |.         .|
+ *      0-----------1
+ *            6
+ *
+ * @endcode
+ */
+class PrismRule15 : public PrismRule6
+{
+public:
+	/// Constant: The number of all nodes for this element
+	static const unsigned n_all_nodes = 15u;
+
+	/// Constant: The FEM type of the element
+	static const CellType cell_type = CellType::PRISM15;
+
+	/// Constant: Local node index table for faces
+	static const unsigned face_nodes[5][8];
+
+	/// Constant: Local node index table for edge
+	static const unsigned edge_nodes[9][3];
+
+	/// Constant: Table for the number of nodes for each face
+	static const unsigned n_face_nodes[5];
+
+	/// Returns the i-th edge of the element.
+	typedef QuadraticEdgeReturn EdgeReturn;
+
+	/// Get the number of nodes for face i.
+	static unsigned getNFaceNodes(unsigned i);
+
+	/// Returns the i-th face of the element.
+	static const Element* getFace(const Element* e, unsigned i);
+
+}; /* class */
+
+} /* namespace */
+
+#endif /* PRISMRULE15_H_ */
+

--- a/MeshLib/Elements/Pyramid.h
+++ b/MeshLib/Elements/Pyramid.h
@@ -17,10 +17,12 @@
 
 #include "TemplateElement.h"
 #include "PyramidRule5.h"
+#include "PyramidRule13.h"
 
 namespace MeshLib {
 
 typedef TemplateElement<PyramidRule5> Pyramid;
+typedef TemplateElement<PyramidRule13> Pyramid13;
 
 }
 

--- a/MeshLib/Elements/PyramidRule13.cpp
+++ b/MeshLib/Elements/PyramidRule13.cpp
@@ -1,0 +1,71 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "PyramidRule13.h"
+
+#include "logog/include/logog.hpp"
+
+#include "GeoLib/AnalyticalGeometry.h"
+
+#include "MeshLib/Node.h"
+#include "Quad.h"
+#include "Tri.h"
+
+namespace MeshLib {
+
+const unsigned PyramidRule13::face_nodes[5][8] =
+{
+	{0, 1, 4, 5, 10, 9, 99, 99}, // Face 0
+	{1, 2, 4, 6, 11, 10, 99, 99}, // Face 1
+	{2, 3, 4, 7, 12, 11, 99, 99}, // Face 2
+	{3, 0, 4, 8, 9, 12, 99, 99}, // Face 3
+	{0, 3, 2, 1, 8, 7, 6, 5}  // Face 4
+};
+
+const unsigned PyramidRule13::edge_nodes[8][3] =
+{
+	{0, 1, 5}, // Edge 0
+	{1, 2, 6}, // Edge 1
+	{2, 3, 7}, // Edge 2
+	{0, 3, 8}, // Edge 3
+	{0, 4, 9}, // Edge 4
+	{1, 4, 10}, // Edge 5
+	{2, 4, 11}, // Edge 6
+	{3, 4, 12}  // Edge 7
+};
+
+const unsigned PyramidRule13::n_face_nodes[5] = { 6, 6, 6, 6, 8 };
+
+unsigned PyramidRule13::getNFaceNodes(unsigned i)
+{
+	if (i<5)
+		return n_face_nodes[i];
+	ERR("Error in MeshLib::Element::getNFaceNodes() - Index %d does not exist.", i);
+	return 0;
+}
+
+const Element* PyramidRule13::getFace(const Element* e, unsigned i)
+{
+	if (i<e->getNFaces())
+	{
+		unsigned nFaceNodes (e->getNFaceNodes(i));
+		Node** nodes = new Node*[nFaceNodes];
+		for (unsigned j=0; j<nFaceNodes; j++)
+			nodes[j] = const_cast<Node*>(e->getNode(face_nodes[i][j]));
+
+		if (i<4)
+			return new Tri6(nodes);
+		else
+			return new Quad8(nodes);
+	}
+	ERR("Error in MeshLib::Element::getFace() - Index %d does not exist.", i);
+	return nullptr;
+}
+
+} // end namespace MeshLib

--- a/MeshLib/Elements/PyramidRule13.h
+++ b/MeshLib/Elements/PyramidRule13.h
@@ -1,0 +1,75 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PYRAMIDRULE13_H_
+#define PYRAMIDRULE13_H_
+
+#include "MeshLib/MeshEnums.h"
+#include "Element.h"
+#include "EdgeReturn.h"
+#include "PyramidRule5.h"
+
+namespace MeshLib
+{
+
+/**
+ * This class represents a 3d pyramid element. The following sketch shows the node and edge numbering.
+ * @anchor PyramidNodeAndEdgeNumbering
+ * @code
+ *
+ *               4
+ *             //|\
+ *            // | \
+ *         12//  |  \11
+ *          //   |10 \
+ *         //    |    \
+ *        3/.... |.....2
+ *       ./      |  7 /
+ *      ./9      |   /
+ *    8./        |  /6
+ *    ./         | /
+ *   ./          |/
+ *  0------------1
+ *        5
+ * @endcode
+
+ */
+class PyramidRule13 : public PyramidRule5
+{
+public:
+	/// Constant: The number of all nodes for this element
+	static const unsigned n_all_nodes = 13u;
+
+	/// Constant: The FEM type of the element
+	static const CellType cell_type = CellType::PYRAMID13;
+
+	/// Constant: Local node index table for faces
+	static const unsigned face_nodes[5][8];
+
+	/// Constant: Local node index table for edge
+	static const unsigned edge_nodes[8][3];
+
+	/// Constant: Table for the number of nodes for each face
+	static const unsigned n_face_nodes[5];
+
+	/// Returns the i-th edge of the element.
+	typedef QuadraticEdgeReturn EdgeReturn;
+
+	/// Get the number of nodes for face i.
+	static unsigned getNFaceNodes(unsigned i);
+
+	/// Returns the i-th face of the element.
+	static const Element* getFace(const Element* e, unsigned i);
+
+}; /* class */
+
+} /* namespace */
+
+#endif /* PYRAMIDRULE13_H_ */
+

--- a/MeshLib/Elements/Tet.h
+++ b/MeshLib/Elements/Tet.h
@@ -17,10 +17,12 @@
 
 #include "TemplateElement.h"
 #include "TetRule4.h"
+#include "TetRule10.h"
 
 namespace MeshLib {
 
 typedef TemplateElement<TetRule4> Tet;
+typedef TemplateElement<TetRule10> Tet10;
 
 }
 

--- a/MeshLib/Elements/TetRule10.cpp
+++ b/MeshLib/Elements/TetRule10.cpp
@@ -1,0 +1,53 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "TetRule10.h"
+
+#include <array>
+
+#include "logog/include/logog.hpp"
+
+#include "MeshLib/Node.h"
+#include "Tri.h"
+
+namespace MeshLib
+{
+
+const unsigned TetRule10::face_nodes[4][6] =
+{
+	{0, 2, 1, 6, 5, 4}, // Face 0
+	{0, 1, 3, 4, 8, 7}, // Face 1
+	{1, 2, 3, 5, 9, 8}, // Face 2
+	{2, 0, 3, 6, 7, 9}  // Face 3
+};
+
+const unsigned TetRule10::edge_nodes[6][3] =
+{
+	{0, 1, 4}, // Edge 0
+	{1, 2, 5}, // Edge 1
+	{0, 2, 6}, // Edge 2
+	{0, 3, 7}, // Edge 3
+	{1, 3, 8}, // Edge 4
+	{2, 3, 9}  // Edge 5
+};
+
+const Element* TetRule10::getFace(const Element* e, unsigned i)
+{
+	if (i<n_faces)
+	{
+		std::array<Node*,6> nodes;
+		for (unsigned j=0; j<6; j++)
+			nodes[j] = const_cast<Node*>(e->getNode(face_nodes[i][j]));
+		return new Tri6(nodes);
+	}
+	ERR("Error in MeshLib::Element::getFace() - Index %d does not exist.", i);
+	return nullptr;
+}
+
+} // end namespace MeshLib

--- a/MeshLib/Elements/TetRule10.h
+++ b/MeshLib/Elements/TetRule10.h
@@ -1,0 +1,70 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef TETRULE10_H_
+#define TETRULE10_H_
+
+#include "MeshLib/MeshEnums.h"
+#include "Element.h"
+#include "EdgeReturn.h"
+#include "TetRule4.h"
+
+namespace MeshLib
+{
+
+/**
+ * This class represents a 3d tetrahedron element with 10 nodes. The following sketch shows the node and edge numbering.
+ * @anchor TetrahedronNodeAndEdgeNumbering
+ * @code
+ *          3
+ *         /|\
+ *        / | \
+ *      7/  |  \9
+ *      /   |8  \
+ *     /    |    \
+ *    0.....|.....2
+ *     \    |  2 /
+ *      \   |   /
+ *      4\  |  /5
+ *        \ | /
+ *         \|/
+ *          1
+ *
+ * @endcode
+ */
+class TetRule10 : public TetRule4
+{
+public:
+	/// Constant: The number of all nodes for this element
+	static const unsigned n_all_nodes = 10u;
+
+	/// Constant: The FEM type of the element
+	static const CellType cell_type = CellType::TET10;
+
+	/// Constant: Local node index table for faces
+	static const unsigned face_nodes[4][6];
+
+	/// Constant: Local node index table for edge
+	static const unsigned edge_nodes[6][3];
+
+	/// Returns the i-th edge of the element.
+	typedef QuadraticEdgeReturn EdgeReturn;
+
+	/// Get the number of nodes for face i.
+	static unsigned getNFaceNodes(unsigned /*i*/) { return 6; }
+
+	/// Returns the i-th face of the element.
+	static const Element* getFace(const Element* e, unsigned i);
+
+}; /* class */
+
+} /* namespace */
+
+#endif /* TETRULE10_H_ */
+

--- a/MeshLib/Elements/TriRule6.cpp
+++ b/MeshLib/Elements/TriRule6.cpp
@@ -1,9 +1,4 @@
 /**
- * \file
- * \author Thomas Fischer
- * \date   Sep 27, 2012
- * \brief  Definition of the Tri class.
- *
  * \copyright
  * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
  *            Distributed under a Modified BSD License.
@@ -12,18 +7,15 @@
  *
  */
 
-#ifndef TRI_H_
-#define TRI_H_
-
-#include "TemplateElement.h"
-#include "TriRule3.h"
 #include "TriRule6.h"
 
 namespace MeshLib {
 
-typedef TemplateElement<TriRule3> Tri;
-typedef TemplateElement<TriRule6> Tri6;
+const unsigned TriRule6::edge_nodes[3][3] =
+{
+		{0, 1, 3}, // Edge 0
+		{1, 2, 4}, // Edge 1
+		{2, 0, 5}, // Edge 2
+};
 
-}
-
-#endif /* TRI_H_ */
+} // end namespace MeshLib

--- a/MeshLib/Elements/TriRule6.h
+++ b/MeshLib/Elements/TriRule6.h
@@ -1,0 +1,59 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef TRIRULE6_H_
+#define TRIRULE6_H_
+
+#include "MeshLib/MeshEnums.h"
+#include "TriRule3.h"
+#include "EdgeReturn.h"
+
+namespace MeshLib
+{
+
+/**
+ * This class represents a 2d triangle element with 6 nodes.
+ *
+ * The following sketch shows the node and edge numbering.
+ * @anchor TriNodeAndEdgeNumbering
+ * @code
+ *
+ *          2
+ *          o
+ *         / \
+ *        /   \
+ *      5/     \4
+ *      /       \
+ *     /         \
+ *    0-----------1
+ *          3
+ *
+ * @endcode
+ */
+class TriRule6 : public TriRule3
+{
+public:
+	/// Constant: The number of all nodes for this element
+	static const unsigned n_all_nodes = 6u;
+
+	/// Constant: The FEM type of the element
+	static const CellType cell_type = CellType::TRI6;
+
+	/// Constant: Local node index table for edge
+	static const unsigned edge_nodes[3][3];
+
+	/// Returns the i-th edge of the element.
+	typedef QuadraticEdgeReturn EdgeReturn;
+
+}; /* class */
+
+} /* namespace */
+
+#endif /* TRIRULE6_H_ */
+

--- a/MeshLib/MeshEnums.cpp
+++ b/MeshLib/MeshEnums.cpp
@@ -113,6 +113,7 @@ const std::string CellType2String(const CellType t)
 	RETURN_CELL_TYPE_STR(t, PRISM6);
 	RETURN_CELL_TYPE_STR(t, PRISM15);
 	RETURN_CELL_TYPE_STR(t, PYRAMID5);
+	RETURN_CELL_TYPE_STR(t, PYRAMID13);
 
 	return "none";
 

--- a/MeshLib/MeshEnums.h
+++ b/MeshLib/MeshEnums.h
@@ -55,7 +55,8 @@ enum class CellType
 	PRISM6,
 	PRISM15,
 	PRISM18,
-	PYRAMID5
+	PYRAMID5,
+	PYRAMID13
 };
 
 /**

--- a/MeshLib/VtkOGSEnum.cpp
+++ b/MeshLib/VtkOGSEnum.cpp
@@ -11,9 +11,6 @@
 
 #include <vtkCellType.h>
 
-namespace InSituLib
-{
-
 CellType VtkCellTypeToOGS(int type)
 {
 	CellType ogs;
@@ -139,5 +136,4 @@ int OGSToVtkCellType(CellType ogs)
 	return type;
 }
 
-} // end namespace
 

--- a/MeshLib/VtkOGSEnum.cpp
+++ b/MeshLib/VtkOGSEnum.cpp
@@ -13,127 +13,88 @@
 
 CellType VtkCellTypeToOGS(int type)
 {
-	CellType ogs;
 	switch (type)
 	{
 		case VTK_LINE:
-			ogs = CellType::LINE2;
-			break;
+			return CellType::LINE2;
 		case VTK_QUADRATIC_EDGE:
-			ogs = CellType::LINE3;
-			break;
+			return CellType::LINE3;
 		case VTK_TRIANGLE:
-			ogs = CellType::TRI3;
-			break;
+			return CellType::TRI3;
 		case VTK_QUADRATIC_TRIANGLE:
-			ogs = CellType::TRI6;
-			break;
+			return CellType::TRI6;
 		case VTK_QUAD:
-			ogs = CellType::QUAD4;
-			break;
+			return CellType::QUAD4;
 		case VTK_QUADRATIC_QUAD:
-			ogs = CellType::QUAD8;
-			break;
+			return CellType::QUAD8;
 		case VTK_BIQUADRATIC_QUAD:
-			ogs = CellType::QUAD9;
-			break;
+			return CellType::QUAD9;
 		case VTK_HEXAHEDRON:
-			ogs = CellType::HEX8;
-			break;
+			return CellType::HEX8;
 		case VTK_QUADRATIC_HEXAHEDRON:
-			ogs = CellType::HEX20;
-			break;
+			return CellType::HEX20;
 		case VTK_TRIQUADRATIC_HEXAHEDRON:
-			ogs = CellType::HEX27;
-			break;
+			return CellType::HEX27;
 		case VTK_TETRA:
-			ogs = CellType::TET4;
-			break;
+			return CellType::TET4;
 		case VTK_QUADRATIC_TETRA:
-			ogs = CellType::TET10;
-			break;
+			return CellType::TET10;
 		case VTK_WEDGE:
-			ogs = CellType::PRISM6;
-			break;
+			return CellType::PRISM6;
 		case VTK_QUADRATIC_WEDGE:
-			ogs = CellType::PRISM15;
-			break;
+			return CellType::PRISM15;
 		case VTK_BIQUADRATIC_QUADRATIC_WEDGE:
-			ogs = CellType::PRISM18;
-			break;
+			return CellType::PRISM18;
 		case VTK_PYRAMID:
-			ogs = CellType::PYRAMID5;
-			break;
+			return CellType::PYRAMID5;
 		case VTK_QUADRATIC_PYRAMID:
-			ogs = CellType::PYRAMID13;
-			break;
+			return CellType::PYRAMID13;
 		default:
-			ogs = CellType::INVALID;
-			break;
+			return CellType::INVALID;
 	}
-	return ogs;
 }
 
 int OGSToVtkCellType(CellType ogs)
 {
-	int type = 0;
 	switch (ogs)
 	{
-		case CellType::INVALID:
-			break;
 		case CellType::LINE2:
-			type = VTK_LINE;
-			break;
+			return VTK_LINE;
 		case CellType::LINE3:
-			type = VTK_QUADRATIC_EDGE;
-			break;
+			return VTK_QUADRATIC_EDGE;
 		case CellType::TRI3:
-			type = VTK_TRIANGLE;
-			break;
+			return VTK_TRIANGLE;
 		case CellType::TRI6:
-			type = VTK_QUADRATIC_TRIANGLE;
-			break;
+			return VTK_QUADRATIC_TRIANGLE;
 		case CellType::QUAD4:
-			type = VTK_QUAD;
-			break;
+			return VTK_QUAD;
 		case CellType::QUAD8:
-			type = VTK_QUADRATIC_QUAD;
-			break;
+			return VTK_QUADRATIC_QUAD;
 		case CellType::QUAD9:
-			type = VTK_BIQUADRATIC_QUAD;
-			break;
+			return VTK_BIQUADRATIC_QUAD;
 		case CellType::HEX8:
-			type = VTK_HEXAHEDRON;
-			break;
+			return VTK_HEXAHEDRON;
 		case CellType::HEX20:
-			type = VTK_QUADRATIC_HEXAHEDRON;
-			break;
+			return VTK_QUADRATIC_HEXAHEDRON;
 		case CellType::HEX27:
-			type = VTK_TRIQUADRATIC_HEXAHEDRON;
-			break;
+			return VTK_TRIQUADRATIC_HEXAHEDRON;
 		case CellType::TET4:
-			type = VTK_TETRA;
-			break;
+			return VTK_TETRA;
 		case CellType::TET10:
-			type = VTK_QUADRATIC_TETRA;
-			break;
+			return VTK_QUADRATIC_TETRA;
 		case CellType::PRISM6:
-			type = VTK_WEDGE;
-			break;
+			return VTK_WEDGE;
 		case CellType::PRISM15:
-			type = VTK_QUADRATIC_WEDGE;
-			break;
+			return VTK_QUADRATIC_WEDGE;
 		case CellType::PRISM18:
-			type = VTK_BIQUADRATIC_QUADRATIC_WEDGE;
-			break;
+			return VTK_BIQUADRATIC_QUADRATIC_WEDGE;
 		case CellType::PYRAMID5:
-			type = VTK_PYRAMID;
-			break;
+			return VTK_PYRAMID;
 		case CellType::PYRAMID13:
-			type = VTK_QUADRATIC_PYRAMID;
-			break;
+			return VTK_QUADRATIC_PYRAMID;
+		default:
+			return -1;
 	}
-	return type;
 }
 
 

--- a/MeshLib/VtkOGSEnum.h
+++ b/MeshLib/VtkOGSEnum.h
@@ -12,13 +12,8 @@
 
 #include "MeshEnums.h"
 
-namespace InSituLib
-{
-
 CellType VtkCellTypeToOGS(int type);
 
 int OGSToVtkCellType(CellType ogs);
-
-} // end namespace
 
 #endif // VTKOGSENUM_H_

--- a/Tests/MeshLib/TestElementConstants.cpp
+++ b/Tests/MeshLib/TestElementConstants.cpp
@@ -9,10 +9,12 @@
 #include "gtest/gtest.h"
 
 #include "Elements/Quad.h"
+#include "Elements/Hex.h"
+#include "Elements/Tet.h"
 
 using namespace MeshLib;
 
-TEST(MeshLib, Quad4ElementConstants)
+TEST(MeshLib, ElementConstantsQuad4)
 {
 	ASSERT_EQ(2u, Quad::dimension);
 	ASSERT_EQ(4u, Quad::n_all_nodes);
@@ -30,7 +32,7 @@ TEST(MeshLib, Quad4ElementConstants)
 	ASSERT_EQ(4u, quad.getNBaseNodes());
 }
 
-TEST(MeshLib, Quad8ElementConstants)
+TEST(MeshLib, ElementConstantsQuad8)
 {
 	ASSERT_EQ(2u, Quad8::dimension);
 	ASSERT_EQ(8u, Quad8::n_all_nodes);
@@ -54,7 +56,7 @@ TEST(MeshLib, Quad8ElementConstants)
 	ASSERT_EQ(4u, quad8.getNBaseNodes());
 }
 
-TEST(MeshLib, Quad9ElementConstants)
+TEST(MeshLib, ElementConstantsQuad9)
 {
 	ASSERT_EQ(2u, Quad9::dimension);
 	ASSERT_EQ(9u, Quad9::n_all_nodes);
@@ -77,5 +79,104 @@ TEST(MeshLib, Quad9ElementConstants)
 	ASSERT_EQ(2u, quad9.getDimension());
 	ASSERT_EQ(9u, quad9.getNNodes());
 	ASSERT_EQ(4u, quad9.getNBaseNodes());
+}
+
+TEST(MeshLib, ElementConstantsHex8)
+{
+	ASSERT_EQ(3u, Hex::dimension);
+	ASSERT_EQ(8u, Hex::n_all_nodes);
+	ASSERT_EQ(8u, Hex::n_base_nodes);
+
+	std::array<Node*, 8> nodes;
+	nodes[0] = new Node(0.0, 0.0, 0.0);
+	nodes[1] = new Node(0.0, 1.0, 0.0);
+	nodes[2] = new Node(1.0, 1.0, 0.0);
+	nodes[3] = new Node(1.0, 0.0, 0.0);
+	nodes[4] = new Node(0.0, 0.0, 1.0);
+	nodes[5] = new Node(0.0, 1.0, 1.0);
+	nodes[6] = new Node(1.0, 1.0, 1.0);
+	nodes[7] = new Node(1.0, 0.0, 1.0);
+	Hex ele(nodes);
+
+	ASSERT_EQ(3u, ele.getDimension());
+	ASSERT_EQ(8u, ele.getNNodes());
+	ASSERT_EQ(8u, ele.getNBaseNodes());
+}
+
+TEST(MeshLib, ElementConstantsHex20)
+{
+	ASSERT_EQ( 3u, Hex20::dimension);
+	ASSERT_EQ(20u, Hex20::n_all_nodes);
+	ASSERT_EQ( 8u, Hex20::n_base_nodes);
+
+	std::array<Node*, 20> nodes;
+	nodes[0] = new Node(0.0, 0.0, 0.0);
+	nodes[1] = new Node(1.0, 0.0, 0.0);
+	nodes[2] = new Node(1.0, 1.0, 0.0);
+	nodes[3] = new Node(0.0, 1.0, 0.0);
+	nodes[4] = new Node(0.0, 0.0, 1.0);
+	nodes[5] = new Node(1.0, 0.0, 1.0);
+	nodes[6] = new Node(1.0, 1.0, 1.0);
+	nodes[7] = new Node(0.0, 1.0, 1.0);
+	nodes[8] = new Node(0.5, 0.0, 0.0);
+	nodes[9] = new Node(1.0, 0.5, 0.0);
+	nodes[10] = new Node(0.5, 1.0, 0.0);
+	nodes[11] = new Node(0.0, 0.5, 0.0);
+	nodes[12] = new Node(0.5, 0.0, 1.0);
+	nodes[13] = new Node(1.0, 0.5, 1.0);
+	nodes[14] = new Node(0.5, 1.0, 1.0);
+	nodes[15] = new Node(0.0, 0.5, 1.0);
+	nodes[16] = new Node(0.0, 0.0, 0.5);
+	nodes[17] = new Node(1.0, 0.0, 0.5);
+	nodes[18] = new Node(1.0, 1.0, 0.5);
+	nodes[19] = new Node(0.0, 1.0, 0.5);
+	Hex20 ele(nodes);
+
+	ASSERT_EQ( 3u, ele.getDimension());
+	ASSERT_EQ(20u, ele.getNNodes());
+	ASSERT_EQ( 8u, ele.getNBaseNodes());
+}
+
+TEST(MeshLib, ElementConstantsTet4)
+{
+	ASSERT_EQ(3u, Tet::dimension);
+	ASSERT_EQ(4u, Tet::n_all_nodes);
+	ASSERT_EQ(4u, Tet::n_base_nodes);
+
+	std::array<Node*, 4> nodes;
+	nodes[0] = new Node(0.0, 0.0, 0.0);
+	nodes[1] = new Node(1.0, 0.0, 0.0);
+	nodes[2] = new Node(0.0, 1.0, 0.0);
+	nodes[3] = new Node(0.0, 0.0, 1.0);
+	Tet ele(nodes);
+
+	ASSERT_EQ(3u, ele.getDimension());
+	ASSERT_EQ(4u, ele.getNNodes());
+	ASSERT_EQ(4u, ele.getNBaseNodes());
+}
+
+TEST(MeshLib, ElementConstantsTet10)
+{
+	ASSERT_EQ( 3u, Tet10::dimension);
+	ASSERT_EQ(10u, Tet10::n_all_nodes);
+	ASSERT_EQ( 4u, Tet10::n_base_nodes);
+
+	std::array<Node*, 10> nodes;
+	nodes[0] = new Node(0.0, 0.0, 0.0);
+	nodes[1] = new Node(1.0, 0.0, 0.0);
+	nodes[2] = new Node(0.0, 1.0, 0.0);
+	nodes[3] = new Node(0.0, 0.0, 1.0);
+
+	nodes[4] = new Node(0.5, 0.0, 0.0);
+	nodes[5] = new Node(0.5, 0.5, 0.0);
+	nodes[6] = new Node(0.0, 0.5, 0.0);
+	nodes[7] = new Node(0.0, 0.0, 0.5);
+	nodes[8] = new Node(0.5, 0.0, 0.5);
+	nodes[9] = new Node(0.0, 0.5, 0.5);
+	Tet10 ele(nodes);
+
+	ASSERT_EQ( 3u, ele.getDimension());
+	ASSERT_EQ(10u, ele.getNNodes());
+	ASSERT_EQ( 4u, ele.getNBaseNodes());
 }
 


### PR DESCRIPTION
This PR implements quadratic version of Tri, Tet, Hex, Prism and Pyramid elements in MeshLib. I also tried to involve them in InSituLib.  