### PR TITLE
Fix compilation error w/o explicit default initialization of a const object.

### DIFF
--- a/MeshGeoToolsLib/BoundaryElementsSearcher.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsSearcher.cpp
@@ -45,7 +45,7 @@ std::vector<MeshLib::Element*> const& BoundaryElementsSearcher::getBoundaryEleme
 		return this->getBoundaryElementsOnSurface(*dynamic_cast<const GeoLib::Surface*>(&geoObj));
 		break;
 	default:
-		const static std::vector<MeshLib::Element*> dummy;
+		const static std::vector<MeshLib::Element*> dummy(0);
 		return dummy;
 	}
 }

--- a/Tests/MeshLib/MeshSubsets.cpp
+++ b/Tests/MeshLib/MeshSubsets.cpp
@@ -20,7 +20,7 @@ TEST(MeshLibMeshSubsets, UniqueMeshIds)
 	Mesh const m0("first", std::vector<Node*>(), std::vector<Element*>());
 	Mesh const m1("second", std::vector<Node*>(), std::vector<Element*>());
 
-	std::vector<Node*> const empty_node_ptr_vector;
+	std::vector<Node*> const empty_node_ptr_vector(0);
 
 	MeshSubset const ms0(m0, empty_node_ptr_vector);
 	MeshSubset const ms1(m1, empty_node_ptr_vector);


### PR DESCRIPTION
The compilation error:
```error: default initialization of an object of const type 'const std::vector<MeshLib::Element *>' without a user-provided default constructor```
is produced by clang-3.6.0, which is correct for the current standard, but will be corrected later as described in
http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#253

In gcc-5.1.0 this is only a warning.

See also [this SO thread](http://stackoverflow.com/questions/26077807/why-does-gcc-allow-a-const-object-without-a-user-declared-default-constructor-bu).