### PR TITLE
add a CLI tool "queryMesh" 

### DIFF
--- a/Applications/Utils/MeshEdit/CMakeLists.txt
+++ b/Applications/Utils/MeshEdit/CMakeLists.txt
@@ -154,3 +154,14 @@ ADD_CATALYST_DEPENDENCY(CreateBoundaryConditionsAlongPolylines)
 
 set_target_properties(CreateBoundaryConditionsAlongPolylines
 	PROPERTIES FOLDER Utilities)
+
+add_executable(queryMesh
+	queryMesh.cpp )
+target_link_libraries(queryMesh
+	FileIO
+	MeshLib
+	InSituLib
+	${CATALYST_LIBRARIES}
+)
+set_target_properties(queryMesh
+	PROPERTIES FOLDER Utilities)

--- a/Applications/Utils/MeshEdit/queryMesh.cpp
+++ b/Applications/Utils/MeshEdit/queryMesh.cpp
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ *
+ */
+
+#include <array>
+#include <string>
+
+#include "logog/include/logog.hpp"
+#include "tclap/CmdLine.h"
+
+#include "BaseLib/BuildInfo.h"
+#include "BaseLib/StringTools.h"
+#include "BaseLib/LogogSimpleFormatter.h"
+#include "BaseLib/FileTools.h"
+
+#include "MeshLib/Node.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Mesh.h"
+
+#include "FileIO/readMeshFromFile.h"
+
+int main(int argc, char *argv[])
+{
+	LOGOG_INITIALIZE();
+	logog::Cout* logog_cout (new logog::Cout);
+	BaseLib::LogogSimpleFormatter *custom_format (new BaseLib::LogogSimpleFormatter);
+	logog_cout->SetFormatter(*custom_format);
+
+	TCLAP::CmdLine cmd("Query mesh information", ' ', BaseLib::BuildInfo::git_describe);
+	TCLAP::UnlabeledValueArg<std::string> mesh_arg("mesh-file","input mesh file",true,"","string");
+	cmd.add( mesh_arg );
+	TCLAP::MultiArg<std::size_t> eleId_arg("e","element-id","element ID",false,"number");
+	cmd.add( eleId_arg );
+	TCLAP::MultiArg<std::size_t> nodeId_arg("n","node-id","node ID",false,"number");
+	cmd.add( nodeId_arg );
+
+	cmd.parse( argc, argv );
+
+	const std::string filename(mesh_arg.getValue());
+
+	// read the mesh file
+	const MeshLib::Mesh* mesh = FileIO::readMeshFromFile(filename);
+	if (!mesh)
+		return 1;
+
+	std::cout << std::scientific << std::setprecision(12);
+	for (auto ele_id : eleId_arg.getValue())
+	{
+		std::cout << "--------------------------------------------------------" << std::endl;
+		auto* ele = mesh->getElement(ele_id);
+		std::cout << "# Element " << ele->getID() << std::endl;
+		std::cout << "Type : " << CellType2String(ele->getCellType()) << std::endl;
+		std::cout << "Mat ID : " << ele->getValue() << std::endl;
+		std::cout << "Nodes: " << std::endl;
+		for (unsigned i=0; i<ele->getNNodes(); i++)
+			std::cout <<  ele->getNode(i)->getID() << " " << *ele->getNode(i) << std::endl;
+		std::cout << "Content: " << ele->getContent() << std::endl;
+		std::cout << "Neighbors: ";
+		for (unsigned i=0; i<ele->getNNeighbors(); i++)
+		{
+			if (ele->getNeighbor(i))
+				std::cout << ele->getNeighbor(i)->getID() << " ";
+			else
+				std::cout << "none ";
+		}
+		std::cout << std::endl;
+	}
+
+	for (auto node_id : nodeId_arg.getValue())
+	{
+		std::cout << "--------------------------------------------------------" << std::endl;
+		auto* node = mesh->getNode(node_id);
+		std::cout << "# Node" << node->getID() << std::endl;
+		std::cout << "Coordinates: " << *node << std::endl;
+		std::cout << "Connected elements: " ;
+		for (unsigned i=0; i<node->getNElements(); i++)
+			std::cout << node->getElement(i)->getID() << " ";
+		std::cout << std::endl;
+	}
+
+	delete mesh;
+	delete custom_format;
+	delete logog_cout;
+	LOGOG_SHUTDOWN();
+}

--- a/MeshLib/MeshEnums.cpp
+++ b/MeshLib/MeshEnums.cpp
@@ -92,6 +92,33 @@ std::vector<std::string> getMeshElemTypeStringsShort()
 	return vec;
 }
 
+const std::string CellType2String(const CellType t)
+{
+#define RETURN_CELL_TYPE_STR(t, type)\
+	if (t == CellType::type)\
+		return #type;
+
+	RETURN_CELL_TYPE_STR(t, LINE2);
+	RETURN_CELL_TYPE_STR(t, LINE3);
+	RETURN_CELL_TYPE_STR(t, QUAD4);
+	RETURN_CELL_TYPE_STR(t, QUAD8);
+	RETURN_CELL_TYPE_STR(t, QUAD9);
+	RETURN_CELL_TYPE_STR(t, HEX8);
+	RETURN_CELL_TYPE_STR(t, HEX20);
+	RETURN_CELL_TYPE_STR(t, HEX27);
+	RETURN_CELL_TYPE_STR(t, TRI3);
+	RETURN_CELL_TYPE_STR(t, TRI6);
+	RETURN_CELL_TYPE_STR(t, TET4);
+	RETURN_CELL_TYPE_STR(t, TET10);
+	RETURN_CELL_TYPE_STR(t, PRISM6);
+	RETURN_CELL_TYPE_STR(t, PRISM15);
+	RETURN_CELL_TYPE_STR(t, PYRAMID5);
+
+	return "none";
+
+#undef RETURN_CELL_TYPE_STR
+}
+
 const std::string MeshQualityType2String(const MeshQualityType t)
 {
     if (t == MeshQualityType::ELEMENTSIZE)

--- a/MeshLib/MeshEnums.h
+++ b/MeshLib/MeshEnums.h
@@ -86,6 +86,9 @@ std::vector<MeshElemType> getMeshElemTypes();
 /// Returns a vector of strings of mesh element types
 std::vector<std::string> getMeshElemTypeStringsShort();
 
+/// Given a MeshElemType this returns the appropriate string.
+const std::string CellType2String(const CellType t);
+
 const std::string MeshQualityType2String(const MeshQualityType t);
 
 #endif //MESHENUMS_H


### PR DESCRIPTION
Add the new CLI tool "queryMesh" with which one easily get information of specific elements and nodes.
This PR includes #664 

Example: `queryMesh 1d_tet.msh -e 0 -e 1 -n 0 -n 1`
Output
```
info: Reading OGS legacy mesh ... 
info:   ... finished.
info: Nr. Nodes: 804.
info: Nr. Elements: 1200.
--------------------------------------------------------
# Element 0
Type : TET4
Mat ID : 0
Nodes: 
44 2.200000000000e+01 0.000000000000e+00 0.000000000000e+00 
648 2.250000000000e+01 5.000000000000e-01 5.000000000000e-01 
447 2.250000000000e+01 0.000000000000e+00 5.000000000000e-01 
649 2.300000000000e+01 5.000000000000e-01 5.000000000000e-01 
Content: 2.083333333333e-02
Neighbors: 615 413 none 950 
--------------------------------------------------------
# Element 1
Type : TET4
Mat ID : 0
Nodes: 
200 1.000000000000e+02 0.000000000000e+00 0.000000000000e+00 
401 1.000000000000e+02 5.000000000000e-01 0.000000000000e+00 
199 9.950000000000e+01 0.000000000000e+00 0.000000000000e+00 
803 1.000000000000e+02 5.000000000000e-01 5.000000000000e-01 
Content: 2.083333333333e-02
Neighbors: none none 1196 2 
--------------------------------------------------------
# Node0
Coordinates: 0.000000000000e+00 0.000000000000e+00 0.000000000000e+00 
Connected elements: 42 52 78 993 1001 1002 
--------------------------------------------------------
# Node1
Coordinates: 5.000000000000e-01 0.000000000000e+00 0.000000000000e+00 
Connected elements: 42 78 92 104 210 981 995 1023 
```
