### PR TITLE
GeoLib fix line segment intersection algorithm

### DIFF
--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -128,9 +128,13 @@ bool lineSegmentIntersect(
 
 	if (parallel(v,w)) {
 		if (parallel(pq,v)) {
-			const double sqr_dist_pq(pq.getSqrLength());
-			if (sqr_dist_pq < sqr_len_v || sqr_dist_pq < sqr_len_w)
+			// check if c is located at v (c-a = t (b-a), t in [0,1])
+			if (qp[0] / v[0] <= 1.0)
 				return true;
+			// check if d is located at v (d-a = t (b-a), t in [0,1])
+			if (MathLib::Vector3(a,d)[0]/v[0] <= 1.0)
+				return true;
+			return false;
 		}
 	}
 

--- a/Tests/GeoLib/TestLineSegmentIntersect.cpp
+++ b/Tests/GeoLib/TestLineSegmentIntersect.cpp
@@ -108,7 +108,33 @@ TEST(GeoLib, TestNonIntersectingParallelLineSegments3d)
 	GeoLib::Point c(1.5, 1.5, 1.5);
 	GeoLib::Point d(2.5, 2.5, 2.5);
 	GeoLib::Point s;
+	EXPECT_FALSE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
 
+	// two axis parallel line segments that do not intersect
+	b[0] = 3.0;
+	b[1] = 0.0;
+	b[2] = 0.0;
+	c[0] = 4.0;
+	c[1] = 0.0;
+	c[2] = 0.0;
+	d[0] = 10.0;
+	d[1] = 0.0;
+	d[2] = 0.0;
+	EXPECT_FALSE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+
+	// two axis parallel line segments that do not intersect
+	a[0] = 1000.0;
+	a[1] = 0.0;
+	a[2] = 100.0;
+	b[0] = 400.0;
+	b[1] = 0.0;
+	b[2] = 100.0;
+	c[0] = 300.0;
+	c[1] = 0.0;
+	c[2] = 100.0;
+	d[0] = 0.0;
+	d[1] = 0.0;
+	d[2] = 100.0;
 	EXPECT_FALSE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
 }
 


### PR DESCRIPTION
@waltherm discovered a bug while reading a geometry. See issue #662. This bug is fixed with this PR. The previous failing cases are included as new tests.