### PR TITLE
Fix MeshLayerMapper compilation

### DIFF
--- a/Applications/DataExplorer/DataView/MeshLayerEditDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshLayerEditDialog.cpp
@@ -258,8 +258,7 @@ MeshLib::Mesh* MeshLayerEditDialog::createTetMesh()
 		std::vector<float> layer_thickness;
 		for (unsigned i=0; i<nLayers; ++i)
 			layer_thickness.push_back(this->_edits[i]->text().toFloat());
-		MeshLayerMapper const mapper;
-		tg_mesh = mapper.createStaticLayers(*_msh, layer_thickness);
+		tg_mesh = MeshLayerMapper::createStaticLayers(*_msh, layer_thickness);
 		std::vector<MeshLib::Node> tg_attr;
 		FileIO::TetGenInterface tetgen_interface;
 		tetgen_interface.writeTetGenSmesh(filename.toStdString(), *tg_mesh, tg_attr);
@@ -305,8 +304,7 @@ void MeshLayerEditDialog::accept()
 		new_mesh = new MeshLib::Mesh(*_msh);
 		const std::string imgPath ( this->_edits[0]->text().toStdString() );
 		const double noDataReplacementValue = this->_noDataReplacementEdit->text().toDouble();
-		MeshLayerMapper const mapper;
-		if (!mapper.layerMapping(*new_mesh, imgPath, noDataReplacementValue))
+		if (!MeshLayerMapper::layerMapping(*new_mesh, imgPath, noDataReplacementValue))
 		{
 			delete new_mesh;
 			return;

--- a/MeshLib/MeshGenerators/MeshLayerMapper.cpp
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.cpp
@@ -37,7 +37,7 @@ const unsigned MeshLayerMapper::_pyramid_base[3][4] =
 	{0, 3, 4, 1}, // Point 6 missing
 };
 
-MeshLib::Mesh* MeshLayerMapper::createStaticLayers(MeshLib::Mesh const& mesh, std::vector<float> const& layer_thickness_vector, std::string const& mesh_name) const
+MeshLib::Mesh* MeshLayerMapper::createStaticLayers(MeshLib::Mesh const& mesh, std::vector<float> const& layer_thickness_vector, std::string const& mesh_name)
 {
 	std::vector<float> thickness;
 	for (std::size_t i=0; i<layer_thickness_vector.size(); ++i)

--- a/MeshLib/MeshGenerators/MeshLayerMapper.cpp
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.cpp
@@ -30,13 +30,6 @@
 #include "MeshLib/Elements/Prism.h"
 #include "MeshLib/MeshSurfaceExtraction.h"
 
-const unsigned MeshLayerMapper::_pyramid_base[3][4] =
-{
-	{1, 3, 4, 2}, // Point 4 missing
-	{2, 4, 3, 0}, // Point 5 missing
-	{0, 3, 4, 1}, // Point 6 missing
-};
-
 MeshLib::Mesh* MeshLayerMapper::createStaticLayers(MeshLib::Mesh const& mesh, std::vector<float> const& layer_thickness_vector, std::string const& mesh_name)
 {
 	std::vector<float> thickness;
@@ -155,6 +148,13 @@ bool MeshLayerMapper::createRasterLayers(
 
 void MeshLayerMapper::addLayerToMesh(const MeshLib::Mesh &dem_mesh, unsigned layer_id, GeoLib::Raster const& raster)
 {
+    const unsigned pyramid_base[3][4] =
+    {
+        {1, 3, 4, 2}, // Point 4 missing
+        {2, 4, 3, 0}, // Point 5 missing
+        {0, 3, 4, 1}, // Point 6 missing
+    };
+
     std::size_t const nNodes = dem_mesh.getNNodes();
     std::vector<MeshLib::Node*> const& nodes = dem_mesh.getNodes();
     int const last_layer_node_offset = (layer_id-1) * nNodes;
@@ -190,10 +190,10 @@ void MeshLayerMapper::addLayerToMesh(const MeshLib::Mesh &dem_mesh, unsigned lay
             break;
         case 5:
             std::array<MeshLib::Node*, 5> pyramid_nodes;
-            pyramid_nodes[0] = new_elem_nodes[_pyramid_base[missing_idx][0]];
-            pyramid_nodes[1] = new_elem_nodes[_pyramid_base[missing_idx][1]];
-            pyramid_nodes[2] = new_elem_nodes[_pyramid_base[missing_idx][2]];
-            pyramid_nodes[3] = new_elem_nodes[_pyramid_base[missing_idx][3]];
+            pyramid_nodes[0] = new_elem_nodes[pyramid_base[missing_idx][0]];
+            pyramid_nodes[1] = new_elem_nodes[pyramid_base[missing_idx][1]];
+            pyramid_nodes[2] = new_elem_nodes[pyramid_base[missing_idx][2]];
+            pyramid_nodes[3] = new_elem_nodes[pyramid_base[missing_idx][3]];
             pyramid_nodes[4] = new_elem_nodes[missing_idx];
             _elements.push_back(new MeshLib::Pyramid(pyramid_nodes, layer_id));
             break;

--- a/MeshLib/MeshGenerators/MeshLayerMapper.h
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.h
@@ -35,7 +35,7 @@ public:
 	* \param mesh_name The name of the newly created mesh
 	* \return A mesh with the requested number of layers of prism/hex elements
 	*/
-	MeshLib::Mesh* createStaticLayers(MeshLib::Mesh const& mesh, std::vector<float> const& layer_thickness_vector, std::string const& mesh_name = "SubsurfaceMesh") const;
+	static MeshLib::Mesh* createStaticLayers(MeshLib::Mesh const& mesh, std::vector<float> const& layer_thickness_vector, std::string const& mesh_name = "SubsurfaceMesh");
 
 	/**
 	* Based on a 2D triangle mesh this method creates a 3D mesh with a given number of prism-layers.

--- a/MeshLib/MeshGenerators/MeshLayerMapper.h
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.h
@@ -67,8 +67,6 @@ public:
 private:
 	/// Adds another layer to a subsurface mesh
 	void addLayerToMesh(const MeshLib::Mesh &mesh_layer, unsigned layer_id, GeoLib::Raster const& raster);
-
-	static const unsigned _pyramid_base[3][4];
 };
 
 #endif //MESHLAYERMAPPER_H


### PR DESCRIPTION
This fixes compilation error introduced by removing the empty constructor in the `MeshLayeredMapper`.

This happens with the mac's compiler, which is more strict and produces the following error:
```
<.../ogs/Applications/DataExplorer/DataView/MeshLayerEditDialog.cpp>:261:25: error: default initialization of an object of const type 'const MeshLayerMapper' requires a user-provided default constructor
                MeshLayerMapper const mapper;
                                      ^
<..../ogs/Applications/DataExplorer/DataView/MeshLayerEditDialog.cpp>:308:25: error: default initialization of an object of const type 'const MeshLayerMapper' requires a user-provided default constructor
                MeshLayerMapper const mapper;
                                      ^
```

... but the referred objects are not required at all: removing them.