### PR TITLE
[GeoLib] Speedup point name access.

### DIFF
--- a/Applications/Utils/FileConverter/TIN2VTK.cpp
+++ b/Applications/Utils/FileConverter/TIN2VTK.cpp
@@ -25,6 +25,7 @@
 // GeoLib
 #include "GeoLib/Point.h"
 #include "GeoLib/Surface.h"
+#include "GeoLib/PointVec.h"
 
 // FileIO
 #include "FileIO/VtkIO/VtuInterface.h"
@@ -55,11 +56,12 @@ int main (int argc, char* argv[])
 
 	INFO("reading the TIN file...");
 	const std::string tinFileName(inArg.getValue());
-	std::vector<GeoLib::Point*> pnt_vec;
-	std::unique_ptr<GeoLib::Surface> sfc(FileIO::TINInterface::readTIN(tinFileName, pnt_vec));
+	std::vector<GeoLib::Point*> *pnt_vec(new std::vector<GeoLib::Point*>);
+	GeoLib::PointVec point_vec("SurfacePoints", pnt_vec);
+	std::unique_ptr<GeoLib::Surface> sfc(FileIO::TINInterface::readTIN(tinFileName, point_vec));
 	if (!sfc)
 		return 1;
-	INFO("TIN read:  %d points, %d triangles", pnt_vec.size(), sfc->getNTriangles());
+	INFO("TIN read:  %d points, %d triangles", pnt_vec->size(), sfc->getNTriangles());
 
 	INFO("converting to mesh data");
 	std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::convertSurfaceToMesh(*sfc, BaseLib::extractBaseNameWithoutExtension(tinFileName), std::numeric_limits<double>::epsilon()));
@@ -69,7 +71,6 @@ int main (int argc, char* argv[])
 	FileIO::VtuInterface writer(mesh.get());
 	writer.writeToFile(outArg.getValue());
 
-	for (auto p : pnt_vec) delete p;
 	delete custom_format;
 	delete logog_cout;
 	LOGOG_SHUTDOWN();

--- a/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
+++ b/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
@@ -14,8 +14,6 @@
 #include <vector>
 #include <fstream>
 
-#include <boost/optional.hpp>
-
 // TCLAP
 #include "tclap/CmdLine.h"
 

--- a/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
+++ b/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
@@ -82,9 +82,9 @@ void writeBCsAndGML(GeoLib::GEOObjects & geometry_sets,
 	std::ofstream bc_out (geo_name+".bc");
 	for (std::size_t k(0); k<pnts.size(); k++) {
 		out << k << " " << *(pnts[k]);
-		boost::optional<std::string const&> pnt_name(pnt_vec_objs->getItemNameByID(k));
-		if (pnt_name) {
-			out << "$NAME " << pnt_name.get();
+		std::string const& pnt_name(pnt_vec_objs->getItemNameByID(k));
+		if (!pnt_name.empty()) {
+			out << "$NAME " << pnt_name;
 			bc_out << "#BOUNDARY_CONDITION\n";
 			bc_out << "  $PCS_TYPE\n";
 			bc_out << "    LIQUID_FLOW\n";

--- a/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
+++ b/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
@@ -14,6 +14,8 @@
 #include <vector>
 #include <fstream>
 
+#include <boost/optional.hpp>
+
 // TCLAP
 #include "tclap/CmdLine.h"
 
@@ -80,9 +82,9 @@ void writeBCsAndGML(GeoLib::GEOObjects & geometry_sets,
 	std::ofstream bc_out (geo_name+".bc");
 	for (std::size_t k(0); k<pnts.size(); k++) {
 		out << k << " " << *(pnts[k]);
-		std::string pnt_name;
-		if (pnt_vec_objs->getNameOfElementByID(k, pnt_name)) {
-			out << "$NAME " << pnt_name;
+		boost::optional<std::string const&> pnt_name(pnt_vec_objs->getItemNameByID(k));
+		if (pnt_name) {
+			out << "$NAME " << pnt_name.get();
 			bc_out << "#BOUNDARY_CONDITION\n";
 			bc_out << "  $PCS_TYPE\n";
 			bc_out << "    LIQUID_FLOW\n";

--- a/FileIO/Legacy/OGSIOVer4.cpp
+++ b/FileIO/Legacy/OGSIOVer4.cpp
@@ -16,8 +16,6 @@
 #include <limits>
 #include <sstream>
 
-#include <boost/optional.hpp>
-
 // ThirdParty/logog
 #include "logog/include/logog.hpp"
 
@@ -633,9 +631,9 @@ void writeAllDataToGLIFileV4 (const std::string& fname, const GeoLib::GEOObjects
 			const std::size_t n_pnts(pnts->size());
 			for (std::size_t k(0); k < n_pnts; k++) {
 				os << pnts_offset + k << " " << *((*pnts)[k]);
-				boost::optional<std::string const&> pnt_name(pnt_vec->getItemNameByID(k));
-				if (pnt_name) {
-					os << "$NAME " << pnt_name.get();
+				std::string const& pnt_name(pnt_vec->getItemNameByID(k));
+				if (! pnt_name.empty()) {
+					os << "$NAME " << pnt_name;
 				}
 				os << "\n";
 			}

--- a/FileIO/Legacy/OGSIOVer4.cpp
+++ b/FileIO/Legacy/OGSIOVer4.cpp
@@ -288,7 +288,7 @@ std::string readSurface(std::istream &in,
                         std::map<std::string,std::size_t>& sfc_names,
                         const std::vector<GeoLib::Polyline*> &ply_vec,
                         const std::map<std::string, std::size_t>& ply_vec_names,
-                        std::vector<Point*> &pnt_vec,
+                        GeoLib::PointVec &pnt_vec,
                         std::string const& path, std::vector<std::string>& errors)
 {
 	std::string line;
@@ -401,7 +401,7 @@ std::string readSurfaces(std::istream &in,
                          std::map<std::string, std::size_t>& sfc_names,
                          const std::vector<GeoLib::Polyline*> &ply_vec,
                          const std::map<std::string,std::size_t>& ply_vec_names,
-                         std::vector<Point*> &pnt_vec,
+                         GeoLib::PointVec & pnt_vec,
                          const std::string &path, std::vector<std::string>& errors)
 {
 	if (!in.good())
@@ -479,7 +479,10 @@ bool readGLIFileV4(const std::string& fname,
 	// read names of plys into temporary string-vec
 	std::map<std::string,std::size_t>* ply_names (new std::map<std::string,std::size_t>);
 	std::vector<GeoLib::Polyline*>* ply_vec(new std::vector<GeoLib::Polyline*>);
-	std::vector<Point*>* geo_pnt_vec(const_cast<std::vector<Point*>*>(geo->getPointVec(unique_name)));
+	GeoLib::PointVec & point_vec(
+		*const_cast<GeoLib::PointVec*>(geo->getPointVecObj(unique_name)));
+	std::vector<Point*>* geo_pnt_vec(const_cast<std::vector<GeoLib::Point*>*>(
+		point_vec.getVector()));
 	if (tag.find("#POLYLINE") != std::string::npos && in)
 	{
 		INFO("GeoLib::readGLIFile(): read polylines from stream.");
@@ -501,7 +504,7 @@ bool readGLIFileV4(const std::string& fname,
 		                   *sfc_names,
 		                   *ply_vec,
 		                   *ply_names,
-		                   *pnt_vec,
+		                   point_vec,
 		                   path,
 		                   errors);
 		INFO("GeoLib::readGLIFile(): \tok, %d surfaces read.", sfc_vec->size());

--- a/FileIO/Legacy/OGSIOVer4.cpp
+++ b/FileIO/Legacy/OGSIOVer4.cpp
@@ -16,6 +16,8 @@
 #include <limits>
 #include <sstream>
 
+#include <boost/optional.hpp>
+
 // ThirdParty/logog
 #include "logog/include/logog.hpp"
 
@@ -561,15 +563,15 @@ void writeGLIFileV4 (const std::string& fname,
 	std::vector<GeoLib::Point*> const* const pnts (pnt_vec->getVector());
 	std::ofstream os (fname.c_str());
 	if (pnts) {
-		std::string pnt_name;
 		const std::size_t n_pnts(pnts->size());
 		INFO("GeoLib::writeGLIFileV4(): writing %d points to file %s.", n_pnts, fname.c_str());
 		os << "#POINTS" << "\n";
 		os.precision(std::numeric_limits<double>::digits10);
 		for (std::size_t k(0); k < n_pnts; k++) {
 			os << k << " " << *((*pnts)[k]);
-			if (pnt_vec->getNameOfElementByID(k, pnt_name)) {
-				os << " $NAME " << pnt_name;
+			boost::optional<std::string const&> pnt_name(pnt_vec->getItemNameByID(k));
+			if (pnt_name) {
+				os << " $NAME " << pnt_name.get();
 			}
 			os << "\n";
 		}
@@ -628,8 +630,9 @@ void writeAllDataToGLIFileV4 (const std::string& fname, const GeoLib::GEOObjects
 			const std::size_t n_pnts(pnts->size());
 			for (std::size_t k(0); k < n_pnts; k++) {
 				os << pnts_offset + k << " " << *((*pnts)[k]);
-				if (pnt_vec->getNameOfElementByID(k, pnt_name)) {
-					os << " $NAME " << pnt_name;
+				boost::optional<std::string const&> pnt_name(pnt_vec->getItemNameByID(k));
+				if (pnt_name) {
+					os << "$NAME " << pnt_name.get();
 				}
 				os << "\n";
 			}

--- a/FileIO/Legacy/OGSIOVer4.cpp
+++ b/FileIO/Legacy/OGSIOVer4.cpp
@@ -572,9 +572,9 @@ void writeGLIFileV4 (const std::string& fname,
 		os.precision(std::numeric_limits<double>::digits10);
 		for (std::size_t k(0); k < n_pnts; k++) {
 			os << k << " " << *((*pnts)[k]);
-			boost::optional<std::string const&> pnt_name(pnt_vec->getItemNameByID(k));
-			if (pnt_name) {
-				os << " $NAME " << pnt_name.get();
+			std::string const& pnt_name(pnt_vec->getItemNameByID(k));
+			if (!pnt_name.empty()) {
+				os << " $NAME " << pnt_name;
 			}
 			os << "\n";
 		}

--- a/FileIO/TINInterface.cpp
+++ b/FileIO/TINInterface.cpp
@@ -23,7 +23,7 @@ namespace FileIO
 {
 
 GeoLib::Surface* TINInterface::readTIN(std::string const& fname,
-	std::vector<GeoLib::Point*> &pnt_vec,
+	GeoLib::PointVec &pnt_vec,
 	std::vector<std::string>* errors)
 {
 	// open file
@@ -35,7 +35,7 @@ GeoLib::Surface* TINInterface::readTIN(std::string const& fname,
 		return nullptr;
 	}
 
-	GeoLib::Surface* sfc = new GeoLib::Surface(pnt_vec);
+	GeoLib::Surface* sfc = new GeoLib::Surface(*(pnt_vec.getVector()));
 	std::size_t id;
 	double p0[3], p1[3], p2[3];
 	std::string line;
@@ -99,12 +99,11 @@ GeoLib::Surface* TINInterface::readTIN(std::string const& fname,
 		}
 
 		// determine size pnt_vec to insert the correct ids
-		std::size_t const pnt_pos(pnt_vec.size());
-		pnt_vec.push_back(new GeoLib::Point(p0));
-		pnt_vec.push_back(new GeoLib::Point(p1));
-		pnt_vec.push_back(new GeoLib::Point(p2));
+		std::size_t const pnt_pos_0(pnt_vec.push_back(new GeoLib::Point(p0)));
+		std::size_t const pnt_pos_1(pnt_vec.push_back(new GeoLib::Point(p1)));
+		std::size_t const pnt_pos_2(pnt_vec.push_back(new GeoLib::Point(p2)));
 		// create new Triangle
-		sfc->addTriangle(pnt_pos, pnt_pos + 1, pnt_pos + 2);
+		sfc->addTriangle(pnt_pos_0, pnt_pos_1, pnt_pos_2);
 	}
 
 	if (sfc->getNTriangles() == 0) {

--- a/FileIO/TINInterface.h
+++ b/FileIO/TINInterface.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "GeoLib/Point.h"
+#include "GeoLib/PointVec.h"
 
 namespace GeoLib
 {
@@ -36,7 +37,7 @@ public:
 	 * @return a pointer to a GeoLib::Surface object created from TIN data. nullptr is returned if it fails to read the file.
 	 */
 	static GeoLib::Surface* readTIN(std::string const& fname,
-	                                std::vector<GeoLib::Point*> &pnt_vec,
+	                                GeoLib::PointVec &pnt_vec,
 	                                std::vector<std::string>* errors = nullptr);
 
 	/**

--- a/FileIO/XmlIO/Boost/BoostXmlGmlInterface.cpp
+++ b/FileIO/XmlIO/Boost/BoostXmlGmlInterface.cpp
@@ -305,9 +305,9 @@ bool BoostXmlGmlInterface::write()
 		pnt_tag.put("<xmlattr>.x", (*((*pnts)[k]))[0]);
 		pnt_tag.put("<xmlattr>.y", (*((*pnts)[k]))[1]);
 		pnt_tag.put("<xmlattr>.z", (*((*pnts)[k]))[2]);
-		std::string point_name;
-		if (pnt_vec->getNameOfElementByID(k, point_name))
-			pnt_tag.put("<xmlattr>.name", point_name);
+		boost::optional<std::string const&> point_name(pnt_vec->getItemNameByID(k));
+		if (point_name)
+			pnt_tag.put("<xmlattr>.name", point_name.get());
 	}
 
 #if BOOST_VERSION <= 105500

--- a/FileIO/XmlIO/Boost/BoostXmlGmlInterface.cpp
+++ b/FileIO/XmlIO/Boost/BoostXmlGmlInterface.cpp
@@ -305,9 +305,9 @@ bool BoostXmlGmlInterface::write()
 		pnt_tag.put("<xmlattr>.x", (*((*pnts)[k]))[0]);
 		pnt_tag.put("<xmlattr>.y", (*((*pnts)[k]))[1]);
 		pnt_tag.put("<xmlattr>.z", (*((*pnts)[k]))[2]);
-		boost::optional<std::string const&> point_name(pnt_vec->getItemNameByID(k));
-		if (point_name)
-			pnt_tag.put("<xmlattr>.name", point_name.get());
+		std::string const& point_name(pnt_vec->getItemNameByID(k));
+		if (!point_name.empty())
+			pnt_tag.put("<xmlattr>.name", point_name);
 	}
 
 #if BOOST_VERSION <= 105500

--- a/FileIO/XmlIO/Qt/XmlGmlInterface.cpp
+++ b/FileIO/XmlIO/Qt/XmlGmlInterface.cpp
@@ -12,8 +12,6 @@
  *
  */
 
-#include <boost/optional.hpp>
-
 // ThirdParty/logog
 #include "logog/include/logog.hpp"
 

--- a/FileIO/XmlIO/Qt/XmlGmlInterface.cpp
+++ b/FileIO/XmlIO/Qt/XmlGmlInterface.cpp
@@ -246,10 +246,10 @@ bool XmlGmlInterface::write()
 				pointTag.setAttribute("y", QString::number((*(*points)[i])[1], 'f'));
 				pointTag.setAttribute("z", QString::number((*(*points)[i])[2], 'f'));
 
-				boost::optional<std::string const&> point_name(pnt_vec->getItemNameByID(i));
-				if (point_name)
+				std::string const& point_name(pnt_vec->getItemNameByID(i));
+				if (!point_name.empty())
 					pointTag.setAttribute("name",
-					                      QString::fromStdString(point_name.get()));
+					                      QString::fromStdString(point_name));
 
 				pointsListTag.appendChild(pointTag);
 			}

--- a/FileIO/XmlIO/Qt/XmlGmlInterface.cpp
+++ b/FileIO/XmlIO/Qt/XmlGmlInterface.cpp
@@ -12,6 +12,8 @@
  *
  */
 
+#include <boost/optional.hpp>
+
 // ThirdParty/logog
 #include "logog/include/logog.hpp"
 
@@ -244,10 +246,10 @@ bool XmlGmlInterface::write()
 				pointTag.setAttribute("y", QString::number((*(*points)[i])[1], 'f'));
 				pointTag.setAttribute("z", QString::number((*(*points)[i])[2], 'f'));
 
-				std::string point_name;
-				if (pnt_vec->getNameOfElementByID(i, point_name))
+				boost::optional<std::string const&> point_name(pnt_vec->getItemNameByID(i));
+				if (point_name)
 					pointTag.setAttribute("name",
-					                      QString::fromStdString(point_name));
+					                      QString::fromStdString(point_name.get()));
 
 				pointsListTag.appendChild(pointTag);
 			}

--- a/GeoLib/PointVec.cpp
+++ b/GeoLib/PointVec.cpp
@@ -45,6 +45,12 @@ PointVec::PointVec (const std::string& name, std::vector<Point*>* points,
 		     number_of_all_input_pnts - _data_vec->size());
 
 	correctNameIDMapping();
+	// create the inverse mapping
+	_id_to_name_map.resize(_data_vec->size());
+	// fetch the names from the name id map
+	for (auto p : *_name_id_map) {
+		_id_to_name_map[p.second] = p.first;
+	}
 }
 
 PointVec::~PointVec ()
@@ -52,7 +58,8 @@ PointVec::~PointVec ()
 
 std::size_t PointVec::push_back (Point* pnt)
 {
-	_pnt_id_map.push_back (uniqueInsert(pnt));
+	_pnt_id_map.push_back(uniqueInsert(pnt));
+	_id_to_name_map.push_back("");
 	return _pnt_id_map[_pnt_id_map.size() - 1];
 }
 
@@ -60,11 +67,13 @@ void PointVec::push_back (Point* pnt, std::string const*const name)
 {
 	if (name == nullptr) {
 		_pnt_id_map.push_back (uniqueInsert(pnt));
+		_id_to_name_map.push_back("");
 		return;
 	}
 
 	std::map<std::string,std::size_t>::const_iterator it (_name_id_map->find (*name));
 	if (it != _name_id_map->end()) {
+		_id_to_name_map.push_back("");
 		WARN("PointVec::push_back(): two points share the name %s.", name->c_str());
 		return;
 	}
@@ -72,6 +81,7 @@ void PointVec::push_back (Point* pnt, std::string const*const name)
 	std::size_t id (uniqueInsert (pnt));
 	_pnt_id_map.push_back (id);
 	(*_name_id_map)[*name] = id;
+	_id_to_name_map.push_back(*name);
 }
 
 std::size_t PointVec::uniqueInsert (Point* pnt)
@@ -205,6 +215,14 @@ void PointVec::correctNameIDMapping()
 			++it;
 		}
 	}
+}
+
+boost::optional<std::string const&> PointVec::getItemNameByID(std::size_t id) const
+{
+	if (_id_to_name_map[id].empty())
+		return boost::optional<std::string const&>();
+	else
+		return boost::optional<std::string const&>(_id_to_name_map[id]);
 }
 
 } // end namespace

--- a/GeoLib/PointVec.cpp
+++ b/GeoLib/PointVec.cpp
@@ -217,12 +217,9 @@ void PointVec::correctNameIDMapping()
 	}
 }
 
-boost::optional<std::string const&> PointVec::getItemNameByID(std::size_t id) const
+std::string const& PointVec::getItemNameByID(std::size_t id) const
 {
-	if (_id_to_name_map[id].empty())
-		return boost::optional<std::string const&>();
-	else
-		return boost::optional<std::string const&>(_id_to_name_map[id]);
+    return _id_to_name_map[id];
 }
 
 } // end namespace

--- a/GeoLib/PointVec.h
+++ b/GeoLib/PointVec.h
@@ -21,8 +21,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/optional.hpp>
-
 #ifndef POINTVEC_H_
 #define POINTVEC_H_
 

--- a/GeoLib/PointVec.h
+++ b/GeoLib/PointVec.h
@@ -21,6 +21,8 @@
 #include <string>
 #include <vector>
 
+#include <boost/optional.hpp>
+
 #ifndef POINTVEC_H_
 #define POINTVEC_H_
 
@@ -100,6 +102,8 @@ public:
 
 	const GeoLib::AABB<GeoLib::Point>& getAABB () const;
 
+	boost::optional<std::string const&> getItemNameByID(std::size_t id) const;
+
 private:
 	/**
 	 * Removes points out of the given point set that have the (nearly) same coordinates, i.e.
@@ -137,6 +141,10 @@ private:
 	 * to their lexicographical order
 	 */
 	std::vector<std::size_t> _pnt_id_map;
+
+	/// The reverse map to the name to id map, for fast lookup of the name to a
+	/// given point id.
+	std::vector<std::string> _id_to_name_map;
 
 	AABB<GeoLib::Point> _aabb;
 };

--- a/GeoLib/PointVec.h
+++ b/GeoLib/PointVec.h
@@ -102,7 +102,7 @@ public:
 
 	const GeoLib::AABB<GeoLib::Point>& getAABB () const;
 
-	boost::optional<std::string const&> getItemNameByID(std::size_t id) const;
+	std::string const& getItemNameByID(std::size_t id) const;
 
 private:
 	/**


### PR DESCRIPTION
The suggested implementation uses a vector of strings to speed up the access the point name. Thus, more memory is used but the access, especially for point sets with more than 100.000 points is faster (_hours vs. seconds_).