### PR TITLE
Mesh properties; small addons.

### DIFF
--- a/Applications/Utils/MeshEdit/checkMesh.cpp
+++ b/Applications/Utils/MeshEdit/checkMesh.cpp
@@ -42,6 +42,8 @@ int main(int argc, char *argv[])
 	cmd.add( mesh_arg );
 	TCLAP::SwitchArg valid_arg("v","validation","validate the mesh");
 	cmd.add( valid_arg );
+	TCLAP::SwitchArg print_properties_arg("p","print_properties","print properties stored in the mesh");
+	cmd.add( print_properties_arg );
 
 	cmd.parse( argc, argv );
 
@@ -86,6 +88,14 @@ int main(int argc, char *argv[])
 
 	const std::pair<unsigned, unsigned> minmax_values(MeshLib::MeshInformation::getValueBounds(*mesh));
 	INFO("Material IDs: [%d, %d]", minmax_values.first, minmax_values.second);
+
+	if (print_properties_arg.isSet()) {
+		MeshLib::Properties const& properties = mesh->getProperties();
+		std::vector<std::string> const& names = properties.getPropertyVectorNames();
+		INFO("There are %d properties in the mesh", names.size());
+		for (std::size_t i = 0; i < names.size(); ++i)
+			INFO("\t%d: %s", i, names[i].c_str());
+	}
 
 	if (valid_arg.isSet()) {
 		// Validation

--- a/MeshLib/Properties.cpp
+++ b/MeshLib/Properties.cpp
@@ -30,7 +30,7 @@ void Properties::removePropertyVector(std::string const& name)
 	_properties.erase(it);
 }
 
-bool Properties::hasPropertyVector(std::string const& name)
+bool Properties::hasPropertyVector(std::string const& name) const
 {
 	std::map<std::string, PropertyVectorBase*>::const_iterator it(
 		_properties.find(name)

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -98,7 +98,7 @@ public:
 	/// Check if a PropertyVector accessible by the name is already
 	/// stored within the Properties object.
 	/// @param name the name of the property (for instance porosity)
-	bool hasPropertyVector(std::string const& name);
+	bool hasPropertyVector(std::string const& name) const;
 
 	std::vector<std::string> getPropertyVectorNames() const;
 


### PR DESCRIPTION
 - Add `--print_properties` flag to `checkMesh` utility which is then printing the names of all available properties in the mesh file.
 - Mark `Properties::hasPropertyVector()` const.