### PR TITLE
Initialize with zeron in TemplatePoint default constructor

### DIFF
--- a/MathLib/Point3d.h
+++ b/MathLib/Point3d.h
@@ -53,7 +53,6 @@ inline MathLib::Point3d operator*(MATRIX const& mat, MathLib::Point3d const& p)
 {
     MathLib::Point3d new_p;
     for (std::size_t i(0); i<3; ++i) {
-        new_p[i] = 0.0;
         for (std::size_t j(0); j<3; ++j) {
             new_p[i] += mat(i,j)*p[j];
         }

--- a/MathLib/TemplatePoint.h
+++ b/MathLib/TemplatePoint.h
@@ -105,7 +105,7 @@ protected:
 
 template <typename T, std::size_t DIM>
 TemplatePoint<T,DIM>::TemplatePoint() :
-	_x()
+	_x({})
 {}
 
 template <typename T, std::size_t DIM>

--- a/MathLib/TemplatePoint.h
+++ b/MathLib/TemplatePoint.h
@@ -35,7 +35,7 @@ template <typename T, std::size_t DIM = 3> class TemplatePoint
 public:
 	typedef T FP_T;
 
-	/** default constructor */
+	/** default constructor with zero coordinates */
 	TemplatePoint();
 
 	/** constructor - constructs a TemplatePoint object


### PR DESCRIPTION
This PR is based on the comment by Tom (https://github.com/norihiro-w/ogs/commit/460d114a7241401719cf0b7c71162bd58cdea820#commitcomment-11468635), and changes the behaviour of a default constructor of MathLib::TemplatePoint to always initialize its coordinate with zero. 
