### PR TITLE
fix compiler warnings C4800 with MSVC

### DIFF
--- a/MathLib/TemplatePoint.h
+++ b/MathLib/TemplatePoint.h
@@ -105,7 +105,7 @@ protected:
 
 template <typename T, std::size_t DIM>
 TemplatePoint<T,DIM>::TemplatePoint() :
-	_x({})
+	_x({0})
 {}
 
 template <typename T, std::size_t DIM>

--- a/MeshLib/CoordinateSystem.h
+++ b/MeshLib/CoordinateSystem.h
@@ -63,13 +63,13 @@ public:
     }
 
     /// has X dimension
-    bool hasX() const { return (_type & CoordinateSystemType::type::X); }
+    bool hasX() const { return (_type & CoordinateSystemType::type::X) != 0; }
 
     /// has Y dimension
-    bool hasY() const { return (_type & CoordinateSystemType::type::Y); }
+    bool hasY() const { return (_type & CoordinateSystemType::type::Y) != 0; }
 
     /// has z dimension
-    bool hasZ() const { return (_type & CoordinateSystemType::type::Z); }
+    bool hasZ() const { return (_type & CoordinateSystemType::type::Z) != 0; }
 
 private:
     template <class T>


### PR DESCRIPTION
following #687. This fix removes MSVC warnings C4800 "'type' : forcing value to bool 'true' or 'false' (performance warning)". 

In addition, warnings introduced by #686 