### PR TITLE
Optimizations

### DIFF
--- a/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
@@ -65,7 +65,7 @@ void MeshElementRemovalDialog::accept()
 	{
 		QList<QListWidgetItem*> items = this->elementTypeListWidget->selectedItems();
 		for (int i=0; i<items.size(); ++i)
-			ex.searchByElementType(String2MeshElemType(items[i]->text().toStdString()));
+			ex.searchByElementType(MeshLib::String2MeshElemType(items[i]->text().toStdString()));
 		anything_checked = true;
 	}
 	if (this->materialIDCheckBox->isChecked())

--- a/Applications/DataExplorer/DataView/MeshQualitySelectionDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshQualitySelectionDialog.cpp
@@ -21,7 +21,7 @@
 
 /// Constructor
 MeshQualitySelectionDialog::MeshQualitySelectionDialog(QDialog* parent)
-: QDialog(parent), _metric (MeshQualityType::EDGERATIO), _histogram_path("")
+: QDialog(parent), _metric (MeshLib::MeshQualityType::EDGERATIO), _histogram_path("")
 {
 	setupUi(this);
 	this->choiceEdges->toggle();
@@ -33,7 +33,7 @@ MeshQualitySelectionDialog::~MeshQualitySelectionDialog()
 
 void MeshQualitySelectionDialog::on_histogramCheckBox_toggled(bool is_checked) const
 {
-	histogramPathEdit->setEnabled(is_checked); 
+	histogramPathEdit->setEnabled(is_checked);
 	histogramPathButton->setEnabled(is_checked);
 }
 
@@ -51,17 +51,17 @@ void MeshQualitySelectionDialog::on_histogramPathButton_pressed()
 void MeshQualitySelectionDialog::accept()
 {
 	if (this->choiceEdges->isChecked())
-		_metric = MeshQualityType::EDGERATIO;
+		_metric = MeshLib::MeshQualityType::EDGERATIO;
 	else if (this->choiceArea->isChecked())
-		_metric = MeshQualityType::ELEMENTSIZE;
+		_metric = MeshLib::MeshQualityType::ELEMENTSIZE;
 	else if (this->choiceVolume->isChecked())
-		_metric = MeshQualityType::SIZEDIFFERENCE;
+		_metric = MeshLib::MeshQualityType::SIZEDIFFERENCE;
 	else if (this->choiceAngles->isChecked())
-		_metric = MeshQualityType::EQUIANGLESKEW;
+		_metric = MeshLib::MeshQualityType::EQUIANGLESKEW;
 	else if (this->choiceRadius->isChecked())
-		_metric = MeshQualityType::RADIUSEDGERATIO;
+		_metric = MeshLib::MeshQualityType::RADIUSEDGERATIO;
 	else
-		_metric = MeshQualityType::INVALID;
+		_metric = MeshLib::MeshQualityType::INVALID;
 
 	if (this->histogramCheckBox->isChecked())
 	{

--- a/Applications/DataExplorer/DataView/MeshQualitySelectionDialog.h
+++ b/Applications/DataExplorer/DataView/MeshQualitySelectionDialog.h
@@ -33,7 +33,7 @@ public:
 	~MeshQualitySelectionDialog(void);
 
 	/// Returns selected metric
-	MeshQualityType getSelectedMetric() const { return _metric; }
+	MeshLib::MeshQualityType getSelectedMetric() const { return _metric; }
 
 	/// Returns true if a histogram needs to be calculated
 	bool getHistogram() const { return this->histogramCheckBox->isChecked(); }
@@ -42,7 +42,7 @@ public:
 	std::string getHistogramPath() const { return _histogram_path; }
 
 private:
-	MeshQualityType _metric;
+	MeshLib::MeshQualityType _metric;
 	std::string _histogram_path;
 
 private slots:

--- a/Applications/DataExplorer/DataView/MshModel.cpp
+++ b/Applications/DataExplorer/DataView/MshModel.cpp
@@ -71,12 +71,12 @@ void MshModel::addMeshObject(const MeshLib::Mesh* mesh)
 	const std::vector<MeshLib::Element*> &elems = mesh->getElements();
 	const size_t nElems (elems.size());
 	QString elem_type_string("");
-	MeshElemType elem_type(MeshElemType::INVALID);
+	MeshLib::MeshElemType elem_type(MeshLib::MeshElemType::INVALID);
 
 	for (size_t i = 0; i < nElems; i++)
 	{
 		const MeshLib::Element* current_element (elems[i]);
-		MeshElemType t (current_element->getGeomType());
+		MeshLib::MeshElemType t (current_element->getGeomType());
 		QList<QVariant> elemData;
 		elemData.reserve(3);
 		if (t != elem_type)

--- a/Applications/DataExplorer/DataView/NetCdfConfigureDialog.cpp
+++ b/Applications/DataExplorer/DataView/NetCdfConfigureDialog.cpp
@@ -4,6 +4,7 @@
 #include "NetCdfConfigureDialog.h"
 
 #include "MeshGenerators/VtkMeshConverter.h"
+#include "MeshLib/MeshEnums.h"
 #include "VtkGeoImageSource.h"
 #include "VtkRaster.h"
 
@@ -360,13 +361,13 @@ void NetCdfConfigureDialog::createDataObject()
 
 	if (this->radioMesh->isChecked())
 	{
-		MeshElemType meshElemType = MeshElemType::QUAD;
+		MeshLib::MeshElemType meshElemType = MeshLib::MeshElemType::QUAD;
 		MeshLib::UseIntensityAs useIntensity = MeshLib::UseIntensityAs::MATERIAL;
 		if (comboBoxMeshElemType->currentIndex() == 1)
 		{
-			meshElemType = MeshElemType::TRIANGLE;
+			meshElemType = MeshLib::MeshElemType::TRIANGLE;
 		}else{
-			meshElemType = MeshElemType::QUAD;
+			meshElemType = MeshLib::MeshElemType::QUAD;
 		}
 		if ((comboBoxUseIntensity->currentIndex()) == 1)
 		{

--- a/Applications/DataExplorer/VtkVis/MeshFromRasterDialog.cpp
+++ b/Applications/DataExplorer/VtkVis/MeshFromRasterDialog.cpp
@@ -38,9 +38,9 @@ void MeshFromRasterDialog::accept()
 	if (this->materialButton->isChecked()) i_type = MeshLib::UseIntensityAs::MATERIAL;
 	else if (this->ignoreButton->isChecked()) i_type = MeshLib::UseIntensityAs::NONE;
 
-	MeshElemType e_type(MeshElemType::TRIANGLE);
-	if (this->quadButton->isChecked()) e_type = MeshElemType::QUAD;
-	else if (this->hexButton->isChecked()) e_type = MeshElemType::HEXAHEDRON;
+	MeshLib::MeshElemType e_type(MeshLib::MeshElemType::TRIANGLE);
+	if (this->quadButton->isChecked()) e_type = MeshLib::MeshElemType::QUAD;
+	else if (this->hexButton->isChecked()) e_type = MeshLib::MeshElemType::HEXAHEDRON;
 
 	emit setMeshParameters(this->mshNameEdit->text(), e_type, i_type);
 	this->done(QDialog::Accepted);

--- a/Applications/DataExplorer/VtkVis/MeshFromRasterDialog.h
+++ b/Applications/DataExplorer/VtkVis/MeshFromRasterDialog.h
@@ -19,9 +19,8 @@
 
 #include <QtGui/QDialog>
 
-enum class MeshElemType;
-
 namespace MeshLib {
+	enum class MeshElemType;
 	enum class UseIntensityAs;
 }
 
@@ -47,7 +46,7 @@ private slots:
 	void reject();
 
 signals:
-	void setMeshParameters(QString, MeshElemType, MeshLib::UseIntensityAs);
+	void setMeshParameters(QString, MeshLib::MeshElemType, MeshLib::UseIntensityAs);
 
 };
 

--- a/Applications/DataExplorer/VtkVis/VtkMeshSource.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkMeshSource.cpp
@@ -152,7 +152,7 @@ int VtkMeshSource::RequestData( vtkInformation* request,
 			return 0;
 		}
 
-		if (elem->getCellType() == CellType::PRISM6)
+		if (elem->getCellType() == MeshLib::CellType::PRISM6)
 		{
 			for (unsigned i=0; i<3; ++i)
 			{
@@ -161,7 +161,7 @@ int VtkMeshSource::RequestData( vtkInformation* request,
 				point_ids->SetId(i+3, prism_swap_id);
 			}
 		}
-		else if (elem->getCellType() == CellType::PRISM15)
+		else if (elem->getCellType() == MeshLib::CellType::PRISM15)
 		{
 			std::array<vtkIdType, 15> ogs_nodeIds;
 			for (unsigned i=0; i<15; ++i)

--- a/Applications/DataExplorer/VtkVis/VtkTextureOnSurfaceFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkTextureOnSurfaceFilter.cpp
@@ -107,13 +107,18 @@ int VtkTextureOnSurfaceFilter::RequestData( vtkInformation* request,
 		textureCoordinates->InsertNextTuple(newcoords);
 	}
 */
-	for (size_t i = 0; i < nPoints; i++)
+
+	int const range[2] = { max.first - min.first, max.second - min.second };
+	// Scale values relative to the range.
+
+	double coords[3];
+	for (std::size_t i = 0; i < nPoints; i++)
 	{
-		double coords[3];
 		points->GetPoint(i, coords);
-		float newcoords[2] = { MathLib::normalize(min.first, max.first, coords[0]),
-		                       MathLib::normalize(min.second,max.second, coords[1])};
-		textureCoordinates->SetTuple(i, newcoords);
+
+		textureCoordinates->SetTuple2(i,
+			(coords[0] - min.first) / range[0],
+			(coords[1] - min.second) / range[1]);
 	}
 
 	// put it all together

--- a/Applications/DataExplorer/VtkVis/VtkVisPipeline.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkVisPipeline.cpp
@@ -431,7 +431,7 @@ void VtkVisPipeline::listArrays(vtkDataSet* dataSet)
 		ERR("VtkVisPipeline::listArrays(): not a valid vtkDataSet.");
 }
 
-void VtkVisPipeline::showMeshElementQuality(VtkMeshSource* source, MeshQualityType t, std::vector<double> const& quality)
+void VtkVisPipeline::showMeshElementQuality(VtkMeshSource* source, MeshLib::MeshQualityType t, std::vector<double> const& quality)
 {
 	if (!source || quality.empty())
 		return;
@@ -451,7 +451,7 @@ void VtkVisPipeline::showMeshElementQuality(VtkMeshSource* source, MeshQualityTy
 		VtkCompositeFilter* filter =
 			VtkFilterFactory::CreateCompositeFilter("VtkCompositeElementSelectionFilter",
 			                                        parentItem->transformFilter());
-		if (t == MeshQualityType::ELEMENTSIZE)
+		if (t == MeshLib::MeshQualityType::ELEMENTSIZE)
 		{
 			auto const range (std::minmax_element(quality.cbegin(), quality.cend()));
 			static_cast<VtkCompositeElementSelectionFilter*>(filter)->setRange(*range.first, *range.second);

--- a/Applications/DataExplorer/VtkVis/VtkVisPipeline.h
+++ b/Applications/DataExplorer/VtkVis/VtkVisPipeline.h
@@ -97,7 +97,7 @@ public:
 	void setGlobalBackfaceCulling(bool enable) const;
 
 	/// Checks the quality of mesh elements and adds a filter to highlight deformed elements.
-	void showMeshElementQuality(VtkMeshSource* mesh, MeshQualityType t, std::vector<double> const& quality);
+	void showMeshElementQuality(VtkMeshSource* mesh, MeshLib::MeshQualityType t, std::vector<double> const& quality);
 
 public slots:
 	/// \brief Adds the given Model to the pipeline.

--- a/Applications/DataExplorer/VtkVis/VtkVisPipelineView.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkVisPipelineView.cpp
@@ -202,7 +202,7 @@ void VtkVisPipelineView::showImageToMeshConversionDialog()
 	dlg->exec();
 }
 
-void VtkVisPipelineView::constructMeshFromImage(QString msh_name, MeshElemType element_type, MeshLib::UseIntensityAs intensity_type)
+void VtkVisPipelineView::constructMeshFromImage(QString msh_name, MeshLib::MeshElemType element_type, MeshLib::UseIntensityAs intensity_type)
 {
 	vtkSmartPointer<vtkAlgorithm> algorithm =
 		static_cast<VtkVisPipelineItem*>(static_cast<VtkVisPipeline*>(this->model())->

--- a/Applications/DataExplorer/VtkVis/VtkVisPipelineView.h
+++ b/Applications/DataExplorer/VtkVis/VtkVisPipelineView.h
@@ -29,6 +29,7 @@ enum class MeshElemType;
 namespace MeshLib {
 	class Mesh;
 	enum class UseIntensityAs;
+	enum class MeshElemType;
 }
 
 /**
@@ -76,7 +77,7 @@ private slots:
 	void addPipelineFilterItem();
 
 	/// Calls the conversion method for creating an OGS Mesh from a vtkImageData object.
-	void constructMeshFromImage(QString msh_name, MeshElemType element_type, MeshLib::UseIntensityAs intensity_type);
+	void constructMeshFromImage(QString msh_name, MeshLib::MeshElemType element_type, MeshLib::UseIntensityAs intensity_type);
 
 	/// Calls the dialog to
 	void showImageToMeshConversionDialog();

--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -436,7 +436,7 @@ void MainWindow::save()
 	}
 	else if (fi.suffix().toLower() == "geo")
 	{
-		int const return_val = 
+		int const return_val =
 			FileIO::GMSHInterface::writeGeoFile(*_project.getGEOObjects(), fileName.toStdString());
 
 		if (return_val == 1)
@@ -1048,7 +1048,7 @@ void MainWindow::showMshQualitySelectionDialog(VtkMeshSource* mshSource)
 	MeshQualitySelectionDialog dlg;
 	if (dlg.exec() != QDialog::Accepted)
 		return;
-	MeshQualityType const type (dlg.getSelectedMetric());
+	MeshLib::MeshQualityType const type (dlg.getSelectedMetric());
 	MeshLib::ElementQualityInterface quality_interface(*mshSource->GetMesh(), type);
 	_vtkVisPipeline->showMeshElementQuality(mshSource, type, quality_interface.getQualityVector());
 

--- a/Applications/Utils/FileConverter/GMSH2OGS.cpp
+++ b/Applications/Utils/FileConverter/GMSH2OGS.cpp
@@ -97,7 +97,7 @@ int main (int argc, char* argv[])
 	// *** remove line elements on request
 	if (exclude_lines_arg.getValue()) {
 		auto ex = MeshLib::ElementExtraction(*mesh);
-		ex.searchByElementType(MeshElemType::LINE);
+		ex.searchByElementType(MeshLib::MeshElemType::LINE);
 		auto m = ex.removeMeshElements(mesh->getName()+"-withoutLines");
 		INFO("Removed %d lines.", mesh->getNElements() - m->getNElements());
 		std::swap(m, mesh);

--- a/Applications/Utils/MeshEdit/AddTopLayer.cpp
+++ b/Applications/Utils/MeshEdit/AddTopLayer.cpp
@@ -157,19 +157,19 @@ int main (int argc, char* argv[])
 	std::size_t const n_sfc_elements(sfc_elements.size());
 	for (std::size_t k(0); k<n_sfc_elements; ++k) {
 		MeshLib::Element const*const sfc_elem(sfc_elements[k]);
-		if (sfc_elem->getGeomType() == MeshElemType::TRIANGLE) {
+		if (sfc_elem->getGeomType() == MeshLib::MeshElemType::TRIANGLE) {
 			// add a prism
 			subsfc_elements.push_back(extrudeElement(subsfc_nodes,
 				static_cast<MeshLib::Tri const*const>(sfc_elem),
 				subsfc_sfc_id_map));
 		} else {
-			if (sfc_elements[k]->getGeomType() == MeshElemType::QUAD) {
+			if (sfc_elements[k]->getGeomType() == MeshLib::MeshElemType::QUAD) {
 				// add a hexahedron
 				subsfc_elements.push_back(extrudeElement(subsfc_nodes,
 					static_cast<MeshLib::Quad const*const>(sfc_elem),
 					subsfc_sfc_id_map));
 			} else {
-				if (sfc_elements[k]->getGeomType() == MeshElemType::LINE) {
+				if (sfc_elements[k]->getGeomType() == MeshLib::MeshElemType::LINE) {
 					// add a quad
 					subsfc_elements.push_back(extrudeElement(subsfc_nodes,
 						static_cast<MeshLib::Line const*const>(sfc_elem),

--- a/Applications/Utils/MeshEdit/NodeReordering.cpp
+++ b/Applications/Utils/MeshEdit/NodeReordering.cpp
@@ -38,22 +38,22 @@ void reorderNodes(std::vector<MeshLib::Element*> &elements)
 
 		switch (elements[i]->getGeomType())
 		{
-			case MeshElemType::TETRAHEDRON:
+			case MeshLib::MeshElemType::TETRAHEDRON:
 				for(size_t j = 0; j < 4; ++j)
 					elements[i]->setNode(j, nodes[(j+1)%4]);
 				break;
-			case MeshElemType::PYRAMID:
+			case MeshLib::MeshElemType::PYRAMID:
 				for(size_t j = 0; j < 5; ++j)
 					elements[i]->setNode(j, nodes[(j+1)%5]);
 				break;
-			case MeshElemType::PRISM:
+			case MeshLib::MeshElemType::PRISM:
 				for(size_t j = 0; j < 3; ++j)
 				{
 					elements[i]->setNode(j, nodes[j+3]);
 					elements[i]->setNode(j+3, nodes[j]);
 				}
 				break;
-			case MeshElemType::HEXAHEDRON:
+			case MeshLib::MeshElemType::HEXAHEDRON:
 				for(size_t j = 0; j < 4; ++j)
 				{
 					elements[i]->setNode(j, nodes[j+4]);
@@ -77,7 +77,7 @@ void reorderNodes2(std::vector<MeshLib::Element*> &elements)
 		std::vector<MeshLib::Node*> nodes(elements[i]->getNodes(), elements[i]->getNodes() + nElemNodes);
 
 		for(size_t j = 0; j < nElemNodes; ++j)
-			if (elements[i]->getGeomType() == MeshElemType::PRISM)
+			if (elements[i]->getGeomType() == MeshLib::MeshElemType::PRISM)
 			{
 				for(size_t j = 0; j < 3; ++j)
 				{

--- a/Applications/Utils/MeshEdit/editMaterialID.cpp
+++ b/Applications/Utils/MeshEdit/editMaterialID.cpp
@@ -55,7 +55,7 @@ int main (int argc, char* argv[])
 	TCLAP::ValueArg<unsigned> newIDArg("n", "new-material-id",
 	                                      "new material id", false, 0, "number");
 	cmd.add(newIDArg);
-	std::vector<std::string> eleList(getMeshElemTypeStringsShort());
+	std::vector<std::string> eleList(MeshLib::getMeshElemTypeStringsShort());
 	TCLAP::ValuesConstraint<std::string> allowedVals(eleList);
 	TCLAP::ValueArg<std::string> eleTypeArg("e", "element-type",
 	                                      "element type", false, "", &allowedVals);
@@ -98,7 +98,7 @@ int main (int argc, char* argv[])
 	} else if (specifyArg.isSet()) {
 		INFO("Specifying material ID...");
 		const std::string eleTypeName(eleTypeArg.getValue());
-		const MeshElemType eleType = String2MeshElemType(eleTypeName);
+		const MeshLib::MeshElemType eleType = MeshLib::String2MeshElemType(eleTypeName);
 		const unsigned newID = newIDArg.getValue();
 		unsigned cnt = MeshLib::ElementValueModification::setByElementType(*mesh, eleType, newID);
 		INFO("updated %d elements", cnt);

--- a/Applications/Utils/MeshEdit/removeMeshElements.cpp
+++ b/Applications/Utils/MeshEdit/removeMeshElements.cpp
@@ -94,8 +94,8 @@ int main (int argc, char* argv[])
 	if (eleTypeArg.isSet()) {
 		const std::vector<std::string> eleTypeNames = eleTypeArg.getValue();
 		for (auto typeName : eleTypeNames) {
-			const MeshElemType type = String2MeshElemType(typeName);
-			if (type == MeshElemType::INVALID) continue;
+			const MeshLib::MeshElemType type = MeshLib::String2MeshElemType(typeName);
+			if (type == MeshLib::MeshElemType::INVALID) continue;
 			const std::size_t n_removed_elements = ex.searchByElementType(type);
 			INFO("%d %s elements found.", n_removed_elements, typeName.c_str());
 		}

--- a/Applications/Utils/SimpleMeshCreation/CMakeLists.txt
+++ b/Applications/Utils/SimpleMeshCreation/CMakeLists.txt
@@ -31,6 +31,7 @@ if(OGS_BUILD_GUI)
 		MeshLib
 		FileIO
 		VtkVis
+		InSituLib
 		zlib
 		${CATALYST_LIBRARIES}
 		${QT_LIBRARIES}

--- a/Applications/Utils/SimpleMeshCreation/CMakeLists.txt
+++ b/Applications/Utils/SimpleMeshCreation/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories(
 	${CMAKE_SOURCE_DIR}/Gui/VtkVis
 )
 
-if(TARGET VtkVis)
+if(OGS_BUILD_GUI)
 
 	add_executable(generateStructuredQuadMesh generateStructuredQuadMesh.cpp)
 	set_target_properties(generateStructuredQuadMesh PROPERTIES FOLDER Utils)
@@ -37,7 +37,7 @@ if(TARGET VtkVis)
 	)
 	ADD_CATALYST_DEPENDENCY(createMeshElemPropertiesFromASCRaster)
 
-endif() # VtkVis-target is existing
+endif() # OGS_BUILD_GUI (VtkVis-target is existing)
 
 
 add_executable(generateStructuredMesh generateStructuredMesh.cpp)

--- a/Applications/Utils/SimpleMeshCreation/createMeshElemPropertiesFromASCRaster.cpp
+++ b/Applications/Utils/SimpleMeshCreation/createMeshElemPropertiesFromASCRaster.cpp
@@ -50,25 +50,25 @@
 // http://en.wikipedia.org/wiki/Algorithms_for_calculating_variance. The
 // original is citing D.E. Knuth. TAOCP, vol 2.
 template <typename InputIterator>
-std::pair<decltype(*first), decltype(*first)>
-computeMeanAndVariance(InputIterator first, InputIterator last)
+auto computeMeanAndVariance(InputIterator first, InputIterator last) ->
+	std::pair<typename InputIterator::value_type, typename InputIterator::value_type>
 {
-	using T = decltype(*first);
+	using T = typename InputIterator::value_type;
 	std::size_t n = 0;
-	T mu = 0;
-	T M2 = 0;
+	auto mu = T{0};
+	auto M2 = T{0};
 
 	while (first != last)
 	{
 		T const x = *first++;
 		n++;
-		delta = x - mu;
+		auto delta = x - mu;
 		mu += delta/n;
 		M2 += delta * (x - mu);
 	}
 
 	if (n < 2)
-		return std::make_pair(mu, 0);
+		return std::make_pair(mu, T{0});
 
 	return std::make_pair(mu, M2/(n - 1));
 }

--- a/Applications/Utils/SimpleMeshCreation/createMeshElemPropertiesFromASCRaster.cpp
+++ b/Applications/Utils/SimpleMeshCreation/createMeshElemPropertiesFromASCRaster.cpp
@@ -35,13 +35,11 @@
 // GeoLib
 #include "Raster.h"
 
-// Gui/VtkVis
-#include "VtkMeshConverter.h"
-
 // MathLib
 #include "MathTools.h"
 
 // MeshLib
+#include "MeshGenerators/VtkMeshConverter.h"
 #include "MeshGenerators/ConvertRasterToMesh.h"
 #include "Elements/Element.h"
 #include "Mesh.h"
@@ -142,7 +140,8 @@ int main (int argc, char* argv[])
 	MeshLib::Mesh* dest_mesh(FileIO::readMeshFromFile(mesh_arg.getValue()));
 
 	// read raster and if required manipulate it
-	GeoLib::Raster* raster(GeoLib::Raster::getRasterFromASCFile(raster_arg.getValue()));
+	GeoLib::Raster* raster(FileIO::AsciiRasterInterface::getRasterFromASCFile(
+		raster_arg.getValue()));
 	if (refinement_arg.getValue() > 1) {
 		raster->refineRaster(refinement_arg.getValue());
 		if (refinement_raster_output_arg.getValue()) {
@@ -151,7 +150,7 @@ int main (int argc, char* argv[])
 			                                      raster_arg.getValue()));
 			new_raster_fname += "-" + std::to_string(raster->getNRows()) + "x" +
 			                    std::to_string(raster->getNCols()) + ".asc";
-			FileIO::AsciiRasterInterface::writeRasterAsASC(raster, new_raster_fname);
+			FileIO::AsciiRasterInterface::writeRasterAsASC(*raster, new_raster_fname);
 		}
 	}
 
@@ -174,7 +173,7 @@ int main (int argc, char* argv[])
 		INFO("Variance of source: %f.", var);
 	}
 
-	MeshLib::Mesh* src_mesh(MeshLib::ConvertRasterToMesh(*raster, MeshElemType::QUAD,
+	MeshLib::Mesh* src_mesh(MeshLib::ConvertRasterToMesh(*raster, MeshLib::MeshElemType::QUAD,
 					MeshLib::UseIntensityAs::MATERIAL).execute());
 
 	std::vector<std::size_t> src_perm(size);

--- a/Applications/Utils/SimpleMeshCreation/generateStructuredMesh.cpp
+++ b/Applications/Utils/SimpleMeshCreation/generateStructuredMesh.cpp
@@ -38,21 +38,21 @@ namespace
 
 /// Get dimension of the mesh element type.
 /// @param eleType element type
-unsigned getDimension(MeshElemType eleType)
+unsigned getDimension(MeshLib::MeshElemType eleType)
 {
 	switch (eleType)
 	{
-		case MeshElemType::LINE:
+		case MeshLib::MeshElemType::LINE:
 			return 1;
-		case MeshElemType::QUAD:
-		case MeshElemType::TRIANGLE:
+		case MeshLib::MeshElemType::QUAD:
+		case MeshLib::MeshElemType::TRIANGLE:
 			return 2;
-		case MeshElemType::HEXAHEDRON:
-		case MeshElemType::PRISM:
-		case MeshElemType::PYRAMID:
-		case MeshElemType::TETRAHEDRON:
+		case MeshLib::MeshElemType::HEXAHEDRON:
+		case MeshLib::MeshElemType::PRISM:
+		case MeshLib::MeshElemType::PYRAMID:
+		case MeshLib::MeshElemType::TETRAHEDRON:
 			return 3;
-		case MeshElemType::INVALID:
+		case MeshLib::MeshElemType::INVALID:
 			return 0;
 	}
 	return 0;
@@ -144,7 +144,7 @@ int main (int argc, char* argv[])
 	// parse arguments
 	cmd.parse(argc, argv);
 	const std::string eleTypeName(eleTypeArg.getValue());
-	const MeshElemType eleType = String2MeshElemType(eleTypeName);
+	const MeshLib::MeshElemType eleType = MeshLib::String2MeshElemType(eleTypeName);
 	const unsigned dim = getDimension(eleType);
 
 	bool dim_used[3] = {false};
@@ -195,16 +195,16 @@ int main (int argc, char* argv[])
 	MeshLib::Mesh* mesh = nullptr;
 	switch (eleType)
 	{
-	case MeshElemType::LINE:
+	case MeshLib::MeshElemType::LINE:
 		mesh = MeshLib::MeshGenerator::generateLineMesh(*vec_div[0]);
 		break;
-	case MeshElemType::TRIANGLE:
+	case MeshLib::MeshElemType::TRIANGLE:
 		mesh = MeshLib::MeshGenerator::generateRegularTriMesh(*vec_div[0], *vec_div[1]);
 		break;
-	case MeshElemType::QUAD:
+	case MeshLib::MeshElemType::QUAD:
 		mesh = MeshLib::MeshGenerator::generateRegularQuadMesh(*vec_div[0], *vec_div[1]);
 		break;
-	case MeshElemType::HEXAHEDRON:
+	case MeshLib::MeshElemType::HEXAHEDRON:
 		mesh = MeshLib::MeshGenerator::generateRegularHexMesh(*vec_div[0], *vec_div[1], *vec_div[2]);
 		break;
 	default:

--- a/Applications/Utils/SimpleMeshCreation/generateStructuredQuadMesh.cpp
+++ b/Applications/Utils/SimpleMeshCreation/generateStructuredQuadMesh.cpp
@@ -18,11 +18,9 @@
 // FileIO/Legacy
 #include "MeshIO.h"
 
-// Gui/VtkVis
-#include "VtkMeshConverter.h"
-
 // MeshLib
 #include "Mesh.h"
+#include "MeshGenerators/VtkMeshConverter.h"
 
 int main (int argc, char* argv[])
 {
@@ -51,7 +49,8 @@ int main (int argc, char* argv[])
 	double* values (new double[size]);
 	const double origin[3] = {origin_x_arg.getValue() + edge_length/2, origin_y_arg.getValue() + edge_length/2, origin_z_arg.getValue()};
 	for (unsigned i=0; i<size; ++i) values[i]=0;
-	MeshLib::Mesh* mesh(VtkMeshConverter::convertImgToMesh(values, origin, height, width, edge_length, MeshElemType::QUAD, UseIntensityAs::MATERIAL));
+	MeshLib::Mesh* mesh(MeshLib::VtkMeshConverter::convertImgToMesh(values, origin, height, width,
+		edge_length, MeshLib::MeshElemType::QUAD, MeshLib::UseIntensityAs::MATERIAL));
 
 	delete [] values;
 

--- a/FileIO/FEFLOWInterface.cpp
+++ b/FileIO/FEFLOWInterface.cpp
@@ -87,21 +87,21 @@ MeshLib::Mesh* FEFLOWInterface::readFEFLOWFile(const std::string &filename)
 		{
 			assert(!vec_nodes.empty());
 
-			MeshElemType eleType = MeshElemType::INVALID;
+			MeshLib::MeshElemType eleType = MeshLib::MeshElemType::INVALID;
 			if (fem_dim.n_nodes_of_element == 2)
-				eleType = MeshElemType::LINE;
+				eleType = MeshLib::MeshElemType::LINE;
 			else if (fem_dim.n_nodes_of_element == 3)
-				eleType = MeshElemType::TRIANGLE;
+				eleType = MeshLib::MeshElemType::TRIANGLE;
 			else if (fem_dim.n_nodes_of_element == 4 && fem_class.dimension == 2)
-				eleType = MeshElemType::TRIANGLE;
+				eleType = MeshLib::MeshElemType::TRIANGLE;
 			else if (fem_dim.n_nodes_of_element == 4 && fem_class.dimension == 3)
-				eleType = MeshElemType::TETRAHEDRON;
+				eleType = MeshLib::MeshElemType::TETRAHEDRON;
 			else if (fem_dim.n_nodes_of_element == 6 && fem_class.dimension == 3)
-				eleType = MeshElemType::PRISM;
+				eleType = MeshLib::MeshElemType::PRISM;
 			else if (fem_dim.n_nodes_of_element == 8 && fem_class.dimension == 3)
-				eleType = MeshElemType::HEXAHEDRON;
+				eleType = MeshLib::MeshElemType::HEXAHEDRON;
 
-			if (eleType == MeshElemType::INVALID) {
+			if (eleType == MeshLib::MeshElemType::INVALID) {
 				ERR("FEFLOWInterface::readFEFLOWFile(): Unsupported element type with the number of node = %d and dim = %d", fem_dim.n_nodes_of_element, fem_class.dimension);
 				std::for_each(vec_nodes.begin(), vec_nodes.end(), [](MeshLib::Node* nod) { delete nod;});
 				vec_nodes.clear();
@@ -312,7 +312,9 @@ void FEFLOWInterface::readElevation(std::ifstream &in, const FEM_CLASS &fem_clas
 		in.seekg(pos_prev_line);
 }
 
-MeshLib::Element* FEFLOWInterface::readElement(const FEM_DIM &fem_dim, const MeshElemType elem_type, const std::string& line, const std::vector<MeshLib::Node*> &nodes)
+MeshLib::Element* FEFLOWInterface::readElement(const FEM_DIM &fem_dim,
+	const MeshLib::MeshElemType elem_type, const std::string& line,
+	const std::vector<MeshLib::Node*> &nodes)
 {
 	std::stringstream ss(line);
 
@@ -327,8 +329,8 @@ MeshLib::Element* FEFLOWInterface::readElement(const FEM_DIM &fem_dim, const Mes
 			for (unsigned k(0); k < fem_dim.n_nodes_of_element; ++k)
 				ele_nodes[k] = nodes[idx[k]-1];
 			break;
-		case MeshElemType::HEXAHEDRON:
-		case MeshElemType::PRISM:
+		case MeshLib::MeshElemType::HEXAHEDRON:
+		case MeshLib::MeshElemType::PRISM:
 			const unsigned n_half_nodes = fem_dim.n_nodes_of_element/2;
 			for (unsigned k(0); k < n_half_nodes; ++k) {
 				ele_nodes[k] = nodes[idx[k+n_half_nodes]-1];
@@ -339,17 +341,17 @@ MeshLib::Element* FEFLOWInterface::readElement(const FEM_DIM &fem_dim, const Mes
 
 	switch (elem_type)
 	{
-		case MeshElemType::LINE:
+		case MeshLib::MeshElemType::LINE:
 			return new MeshLib::Line(ele_nodes);
-		case MeshElemType::TRIANGLE:
+		case MeshLib::MeshElemType::TRIANGLE:
 			return new MeshLib::Tri(ele_nodes);
-		case MeshElemType::QUAD:
+		case MeshLib::MeshElemType::QUAD:
 			return new MeshLib::Quad(ele_nodes);
-		case MeshElemType::TETRAHEDRON:
+		case MeshLib::MeshElemType::TETRAHEDRON:
 			return new MeshLib::Tet(ele_nodes);
-		case MeshElemType::HEXAHEDRON:
+		case MeshLib::MeshElemType::HEXAHEDRON:
 			return new MeshLib::Hex(ele_nodes);
-		case MeshElemType::PRISM:
+		case MeshLib::MeshElemType::PRISM:
 			return new MeshLib::Prism(ele_nodes);
 		default:
 			assert(false);

--- a/FileIO/FEFLOWInterface.h
+++ b/FileIO/FEFLOWInterface.h
@@ -25,6 +25,7 @@ namespace MeshLib
 class Mesh;
 class Element;
 class Node;
+enum class MeshElemType;
 }
 
 namespace FileIO
@@ -121,7 +122,7 @@ private:
 	};
 
 	/// read node indices and create a mesh element
-	MeshLib::Element* readElement(const FEM_DIM &fem_dim, const MeshElemType elem_type, const std::string& line, const std::vector<MeshLib::Node*> &nodes);
+	MeshLib::Element* readElement(const FEM_DIM &fem_dim, const MeshLib::MeshElemType elem_type, const std::string& line, const std::vector<MeshLib::Node*> &nodes);
 
 	/// read node coordinates
 	void readNodeCoordinates(std::ifstream &in, const FEM_CLASS &fem_class, const FEM_DIM &fem_dim, std::vector<MeshLib::Node*> &nodes);

--- a/FileIO/GmshIO/GMSHAdaptiveMeshDensity.cpp
+++ b/FileIO/GmshIO/GMSHAdaptiveMeshDensity.cpp
@@ -120,7 +120,7 @@ void GMSHAdaptiveMeshDensity::getSteinerPoints (std::vector<GeoLib::Point*> & pn
 			if ((*it)->getDepth() + additional_levels > max_depth) {
 				additional_levels = max_depth - (*it)->getDepth();
 			}
-			const std::size_t n_pnts_per_quad_dim (MathLib::fastpow(2, additional_levels));
+			const std::size_t n_pnts_per_quad_dim = 1 << additional_levels;
 			const double delta ((ur[0] - ll[0]) / (2 * n_pnts_per_quad_dim));
 			for (std::size_t i(0); i<n_pnts_per_quad_dim; i++) {
 				for (std::size_t j(0); j<n_pnts_per_quad_dim; j++) {

--- a/FileIO/Legacy/MeshIO.cpp
+++ b/FileIO/Legacy/MeshIO.cpp
@@ -172,20 +172,20 @@ MeshLib::Element* MeshIO::readElement(std::istream& in,
 	const std::vector<MeshLib::Node*> &nodes) const
 {
 	std::string elem_type_str("");
-	MeshElemType elem_type (MeshElemType::INVALID);
+	MeshLib::MeshElemType elem_type (MeshLib::MeshElemType::INVALID);
 
 	do {
 		if (!(in >> elem_type_str))
 			return nullptr;
-		elem_type = String2MeshElemType(elem_type_str);
-	} while (elem_type == MeshElemType::INVALID);
+		elem_type = MeshLib::String2MeshElemType(elem_type_str);
+	} while (elem_type == MeshLib::MeshElemType::INVALID);
 
 	unsigned* idx = new unsigned[8];
 	MeshLib::Element* elem;
 
 	switch(elem_type)
 	{
-	case MeshElemType::LINE: {
+	case MeshLib::MeshElemType::LINE: {
 		for (int i = 0; i < 2; ++i)
 			if (!(in >> idx[i]))
 				return nullptr;
@@ -196,7 +196,7 @@ MeshLib::Element* MeshIO::readElement(std::istream& in,
 		elem = new MeshLib::Line(edge_nodes);
 		break;
 	}
-	case MeshElemType::TRIANGLE: {
+	case MeshLib::MeshElemType::TRIANGLE: {
 		for (int i = 0; i < 3; ++i)
 			if (!(in >> idx[i]))
 				return nullptr;
@@ -206,7 +206,7 @@ MeshLib::Element* MeshIO::readElement(std::istream& in,
 		elem = new MeshLib::Tri(tri_nodes);
 		break;
 	}
-	case MeshElemType::QUAD: {
+	case MeshLib::MeshElemType::QUAD: {
 		for (int i = 0; i < 4; ++i)
 			if (!(in >> idx[i]))
 				return nullptr;
@@ -216,7 +216,7 @@ MeshLib::Element* MeshIO::readElement(std::istream& in,
 		elem = new MeshLib::Quad(quad_nodes);
 		break;
 	}
-	case MeshElemType::TETRAHEDRON: {
+	case MeshLib::MeshElemType::TETRAHEDRON: {
 		for (int i = 0; i < 4; ++i)
 			if (!(in >> idx[i]))
 				return nullptr;
@@ -226,7 +226,7 @@ MeshLib::Element* MeshIO::readElement(std::istream& in,
 		elem = new MeshLib::Tet(tet_nodes);
 		break;
 	}
-	case MeshElemType::HEXAHEDRON: {
+	case MeshLib::MeshElemType::HEXAHEDRON: {
 		for (int i = 0; i < 8; ++i)
 			if (!(in >> idx[i]))
 				return nullptr;
@@ -236,7 +236,7 @@ MeshLib::Element* MeshIO::readElement(std::istream& in,
 		elem = new MeshLib::Hex(hex_nodes);
 		break;
 	}
-	case MeshElemType::PYRAMID: {
+	case MeshLib::MeshElemType::PYRAMID: {
 		for (int i = 0; i < 5; ++i)
 			if (!(in >> idx[i]))
 				return nullptr;
@@ -246,7 +246,7 @@ MeshLib::Element* MeshIO::readElement(std::istream& in,
 		elem = new MeshLib::Pyramid(pyramid_nodes);
 		break;
 	}
-	case MeshElemType::PRISM: {
+	case MeshLib::MeshElemType::PRISM: {
 		for (int i = 0; i < 6; ++i)
 			if (!(in >> idx[i]))
 				return nullptr;
@@ -322,21 +322,21 @@ void MeshIO::writeElements(std::vector<MeshLib::Element*> const& ele_vec,
 	}
 }
 
-std::string MeshIO::ElemType2StringOutput(const MeshElemType t) const
+std::string MeshIO::ElemType2StringOutput(const MeshLib::MeshElemType t) const
 {
-	if (t == MeshElemType::LINE)
+	if (t == MeshLib::MeshElemType::LINE)
 		return "line";
-	if (t == MeshElemType::QUAD)
+	if (t == MeshLib::MeshElemType::QUAD)
 		return "quad";
-	if (t == MeshElemType::HEXAHEDRON)
+	if (t == MeshLib::MeshElemType::HEXAHEDRON)
 		return "hex";
-	if (t == MeshElemType::TRIANGLE)
+	if (t == MeshLib::MeshElemType::TRIANGLE)
 		return "tri";
-	if (t == MeshElemType::TETRAHEDRON)
+	if (t == MeshLib::MeshElemType::TETRAHEDRON)
 		return "tet";
-	if (t == MeshElemType::PRISM)
+	if (t == MeshLib::MeshElemType::PRISM)
 		return "pris";
-	if (t == MeshElemType::PYRAMID)
+	if (t == MeshLib::MeshElemType::PYRAMID)
 		return "pyra";
 	return "none";
 }

--- a/FileIO/Legacy/MeshIO.h
+++ b/FileIO/Legacy/MeshIO.h
@@ -30,6 +30,7 @@ namespace MeshLib
 	class Mesh;
 	class Node;
 	class Element;
+	enum class MeshElemType;
 }
 
 
@@ -62,7 +63,7 @@ private:
 		std::ostream &out) const;
 	std::size_t readMaterialID(std::istream & in) const;
 	MeshLib::Element* readElement(std::istream& line, const std::vector<MeshLib::Node*> &nodes) const;
-	std::string ElemType2StringOutput(const MeshElemType t) const;
+	std::string ElemType2StringOutput(const MeshLib::MeshElemType t) const;
 
 	const MeshLib::Mesh* _mesh;
 

--- a/FileIO/SHPInterface.cpp
+++ b/FileIO/SHPInterface.cpp
@@ -236,7 +236,8 @@ bool SHPInterface::write2dMeshToSHP(const std::string &file_name, const MeshLib:
 		const MeshLib::Element* e (mesh.getElement(i));
 
 		// ignore all elements except triangles and quads
-		if ((e->getGeomType() == MeshElemType::TRIANGLE) || (e->getGeomType() == MeshElemType::QUAD))
+		if ((e->getGeomType() == MeshLib::MeshElemType::TRIANGLE) ||
+			(e->getGeomType() == MeshLib::MeshElemType::QUAD))
 		{
 			// write element ID and material group to DBF-file
 			DBFWriteIntegerAttribute(hDBF, polygon_id, elem_id_field, i);

--- a/FileIO/TetGenInterface.cpp
+++ b/FileIO/TetGenInterface.cpp
@@ -660,9 +660,9 @@ void TetGenInterface::write3dElements(std::ofstream &out,
 void TetGenInterface::writeElementToFacets(std::ofstream &out, const MeshLib::Element &element, unsigned &element_count) const
 {
 	element_count++;
-	if (element.getGeomType() == MeshElemType::TRIANGLE)
+	if (element.getGeomType() == MeshLib::MeshElemType::TRIANGLE)
 		out << "3  " << element.getNodeIndex(0) << " " << element.getNodeIndex(1) << " " << element.getNodeIndex(2) << " " << element.getValue() << " # " << element_count << "\n";
-	else if (element.getGeomType() == MeshElemType::QUAD)
+	else if (element.getGeomType() == MeshLib::MeshElemType::QUAD)
 	{
 		out << "3  " << element.getNodeIndex(0) << " " << element.getNodeIndex(1) << " " << element.getNodeIndex(2) << " " << element.getValue() << " # " << element_count << "\n";
 		element_count++;

--- a/InSituLib/VtkMappedMesh.cpp
+++ b/InSituLib/VtkMappedMesh.cpp
@@ -132,7 +132,7 @@ void VtkMappedMeshImpl::GetIdsOfCellsOfType(int type, vtkIdTypeArray *array)
 
 int VtkMappedMeshImpl::IsHomogeneous()
 {
-	CellType type = (*(_elements->begin()))->getCellType();
+	MeshLib::CellType type = (*(_elements->begin()))->getCellType();
 	for (auto elem(_elements->begin()); elem != _elements->end(); ++elem)
 		if((*elem)->getCellType() != type)
 			return 0;

--- a/MathLib/MathTools.cpp
+++ b/MathLib/MathTools.cpp
@@ -48,11 +48,6 @@ double sqrDist(const double* p0, const double* p1)
 	return scalarProduct<double,3>(v,v);
 }
 
-float normalize(float min, float max, float val)
-{
-	return (val - min) / static_cast<float>(max - min);
-}
-
 double getAngle (const double p0[3], const double p1[3], const double p2[3])
 {
 	const double v0[3] = {p0[0]-p1[0], p0[1]-p1[1], p0[2]-p1[2]};

--- a/MathLib/MathTools.h
+++ b/MathLib/MathTools.h
@@ -135,9 +135,6 @@ T maxNormDist(const MathLib::TemplatePoint<T>* p0, const MathLib::TemplatePoint<
 	return std::max(x, std::max(y, z));
 }
 
-/** linear normalisation of val from [min, max] into [0,1] */
-float normalize(float min, float max, float val);
-
 /**
  * Let \f$p_0, p_1, p_2 \in R^3\f$. The function getAngle
  * computes the angle between the edges \f$(p_0,p_1)\f$ and \f$(p_1,p_2)\f$

--- a/MathLib/MathTools.h
+++ b/MathLib/MathTools.h
@@ -145,24 +145,6 @@ T maxNormDist(const MathLib::TemplatePoint<T>* p0, const MathLib::TemplatePoint<
  */
 double getAngle (const double p0[3], const double p1[3], const double p2[3]);
 
-
-/**
- * simple power function that takes as a second argument an integer instead of a float
- * @param base basis of the expression
- * @param exp exponent of the expression
- * @return base^exp
- */
-template <typename T> inline
-T fastpow (T base, std::size_t exp)
-{
-	T result (base);
-	if (exp == 0)
-		result = static_cast<T>(1);
-	for (std::size_t k(1); k < exp; k++)
-		result *= base;
-	return result;
-}
-
 /**
  * Template metaprogramming, compile-time version of pow() for integral
  * exponents.

--- a/MeshGeoToolsLib/GeoMapper.cpp
+++ b/MeshGeoToolsLib/GeoMapper.cpp
@@ -160,9 +160,9 @@ double GeoMapper::getMeshElevation(double x, double y, double min_val, double ma
 
 	for (std::size_t i=0; i<elements.size(); ++i)
 	{
-		if (intersection==nullptr && elements[i]->getGeomType() != MeshElemType::LINE)
+		if (intersection==nullptr && elements[i]->getGeomType() != MeshLib::MeshElemType::LINE)
 			intersection=GeoLib::triangleLineIntersection(*elements[i]->getNode(0), *elements[i]->getNode(1), *elements[i]->getNode(2), GeoLib::Point(x,y,max_val), GeoLib::Point(x,y,min_val));
-		if (intersection==nullptr && elements[i]->getGeomType() == MeshElemType::QUAD)
+		if (intersection==nullptr && elements[i]->getGeomType() == MeshLib::MeshElemType::QUAD)
 			intersection=GeoLib::triangleLineIntersection(*elements[i]->getNode(0), *elements[i]->getNode(2), *elements[i]->getNode(3), GeoLib::Point(x,y,max_val), GeoLib::Point(x,y,min_val));
 	}
 	if (intersection)

--- a/MeshLib/Location.cpp
+++ b/MeshLib/Location.cpp
@@ -24,13 +24,6 @@ std::ostream& operator<<(std::ostream& os, MeshItemType const& t)
     return os;
 }
 
-bool operator<(const Location& left, const Location& right)
-{
-    if (left.mesh_id != right.mesh_id) return left.mesh_id < right.mesh_id;
-    if (left.item_type != right.item_type) return left.item_type < right.item_type;
-    return left.item_id < right.item_id;
-}
-
 std::ostream& operator<<(std::ostream& os, Location const& l)
 {
     return os << "(" << l.mesh_id

--- a/MeshLib/Location.h
+++ b/MeshLib/Location.h
@@ -37,7 +37,14 @@ struct Location
 };
 
 /// Lexicographic order of Location.
-bool operator<(const Location& left, const Location& right);
+inline
+bool operator<(const Location& left, const Location& right)
+{
+    if (left.mesh_id != right.mesh_id) return left.mesh_id < right.mesh_id;
+    if (left.item_type != right.item_type) return left.item_type < right.item_type;
+    return left.item_id < right.item_id;
+}
+
 
 std::ostream& operator<<(std::ostream& os, Location const& l);
 

--- a/MeshLib/MeshEnums.cpp
+++ b/MeshLib/MeshEnums.cpp
@@ -14,6 +14,8 @@
 
 #include "MeshEnums.h"
 
+namespace MeshLib {
+
 const std::string MeshElemType2String(const MeshElemType t)
 {
 	if (t == MeshElemType::LINE)
@@ -135,3 +137,4 @@ const std::string MeshQualityType2String(const MeshQualityType t)
     return "none";
 }
 
+}

--- a/MeshLib/MeshEnums.h
+++ b/MeshLib/MeshEnums.h
@@ -18,6 +18,8 @@
 #include <string>
 #include <vector>
 
+namespace MeshLib {
+
 /**
  * \brief Types of mesh elements supported by OpenGeoSys.
  * Values are from VTKCellType enum
@@ -72,6 +74,16 @@ enum class MeshQualityType
 	RADIUSEDGERATIO
 };
 
+/**
+ * \brief Selection of possible interpretations for intensities.
+ */
+enum class UseIntensityAs
+{
+	ELEVATION,
+	MATERIAL,
+	NONE
+};
+
 /// Given a MeshElemType this returns the appropriate string.
 const std::string MeshElemType2String(const MeshElemType t);
 
@@ -91,5 +103,7 @@ std::vector<std::string> getMeshElemTypeStringsShort();
 const std::string CellType2String(const CellType t);
 
 const std::string MeshQualityType2String(const MeshQualityType t);
+
+}
 
 #endif //MESHENUMS_H

--- a/MeshLib/MeshGenerators/ConvertRasterToMesh.h
+++ b/MeshLib/MeshGenerators/ConvertRasterToMesh.h
@@ -23,15 +23,6 @@ namespace MeshLib {
 // forward declaration
 class Mesh;
 
-/**
- * Struct gives a selection of possible interpretations for intensities
- */
-enum class UseIntensityAs
-{
-	ELEVATION,
-	MATERIAL,
-	NONE
-};
 
 /**
  * Class to convert raster data into meshes. Based on Karsten Rinks algorithm.

--- a/MeshLib/MeshGenerators/LayeredVolume.cpp
+++ b/MeshLib/MeshGenerators/LayeredVolume.cpp
@@ -25,9 +25,9 @@
 #include "MeshLib/MeshGenerators/MeshLayerMapper.h"
 
 
-bool LayeredVolume::createRasterLayers(const MeshLib::Mesh &mesh, 
-                                       const std::vector<GeoLib::Raster const*> &rasters, 
-                                       double minimum_thickness, 
+bool LayeredVolume::createRasterLayers(const MeshLib::Mesh &mesh,
+                                       const std::vector<GeoLib::Raster const*> &rasters,
+                                       double minimum_thickness,
                                        double noDataReplacementValue)
 {
 	if (mesh.getDimension() != 2)
@@ -36,10 +36,10 @@ bool LayeredVolume::createRasterLayers(const MeshLib::Mesh &mesh,
 	_elevation_epsilon = calcEpsilon(*rasters[0], *rasters.back());
 	if (_elevation_epsilon <= 0)
 		return false;
-	
+
 	// remove line elements, only tri + quad remain
 	MeshLib::ElementExtraction ex(mesh);
-	ex.searchByElementType(MeshElemType::LINE);
+	ex.searchByElementType(MeshLib::MeshElemType::LINE);
 	MeshLib::Mesh* top (ex.removeMeshElements("MeshLayer"));
 	if (top==nullptr)
 		top = new MeshLib::Mesh(mesh);
@@ -84,14 +84,14 @@ void LayeredVolume::addLayerToMesh(const MeshLib::Mesh &dem_mesh, unsigned layer
 	const std::vector<MeshLib::Element*> &layer_elements (dem_mesh.getElements());
 	for (MeshLib::Element* elem : layer_elements)
 	{
-		if (elem->getGeomType() == MeshElemType::TRIANGLE)
+		if (elem->getGeomType() == MeshLib::MeshElemType::TRIANGLE)
 		{
 			std::array<MeshLib::Node*,3> tri_nodes = {{ _nodes[node_id_offset+elem->getNodeIndex(0)],
 			                                            _nodes[node_id_offset+elem->getNodeIndex(1)],
 			                                            _nodes[node_id_offset+elem->getNodeIndex(2)] }};
 			_elements.push_back(new MeshLib::Tri(tri_nodes, layer_id));
 		}
-		else if (elem->getGeomType() == MeshElemType::QUAD)
+		else if (elem->getGeomType() == MeshLib::MeshElemType::QUAD)
 		{
 			std::array<MeshLib::Node*,4> quad_nodes = {{ _nodes[node_id_offset+elem->getNodeIndex(0)],
 			                                             _nodes[node_id_offset+elem->getNodeIndex(1)],

--- a/MeshLib/MeshGenerators/MeshLayerMapper.cpp
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.cpp
@@ -80,7 +80,7 @@ MeshLib::Mesh* MeshLayerMapper::createStaticLayers(MeshLib::Mesh const& mesh, st
 			const MeshLib::Element* sfc_elem( elems[i] );
 			if (sfc_elem->getDimension() < 2) // ignore line-elements
 				continue;
-				
+
 			const unsigned nElemNodes(sfc_elem->getNBaseNodes());
 			MeshLib::Node** e_nodes = new MeshLib::Node*[2*nElemNodes];
 
@@ -90,9 +90,11 @@ MeshLib::Mesh* MeshLayerMapper::createStaticLayers(MeshLib::Mesh const& mesh, st
 				e_nodes[j] = new_nodes[node_id+nNodes];
 				e_nodes[j+nElemNodes] = new_nodes[node_id];
 			}
-			if (sfc_elem->getGeomType() == MeshElemType::TRIANGLE)	// extrude triangles to prism
+			// extrude triangles to prism
+			if (sfc_elem->getGeomType() == MeshLib::MeshElemType::TRIANGLE)
 				new_elems.push_back (new MeshLib::Prism(e_nodes, mat_id));
-			else if (sfc_elem->getGeomType() == MeshElemType::QUAD)	// extrude quads to hexes
+			// extrude quads to hexes
+			else if (sfc_elem->getGeomType() == MeshLib::MeshElemType::QUAD)
 				new_elems.push_back (new MeshLib::Hex(e_nodes, mat_id));
 		}
 	}
@@ -129,7 +131,8 @@ bool MeshLayerMapper::createRasterLayers(
 
 	// number of triangles in the original mesh
 	std::size_t const nElems (std::count_if(mesh.getElements().begin(), mesh.getElements().end(),
-		[](MeshLib::Element const* elem) { return (elem->getGeomType() == MeshElemType::TRIANGLE);}));
+		[](MeshLib::Element const* elem)
+			{ return (elem->getGeomType() == MeshLib::MeshElemType::TRIANGLE);}));
 	_elements.reserve(nElems * (nLayers-1));
 
 	// add bottom layer
@@ -137,7 +140,7 @@ bool MeshLayerMapper::createRasterLayers(
 	for (MeshLib::Node* node : nodes)
 		_nodes.push_back(new MeshLib::Node(*node));
 	delete bottom;
-	
+
 	// add the other layers
 	for (std::size_t i=1; i<nLayers; ++i)
 		addLayerToMesh(*top, i, *rasters[i]);
@@ -169,7 +172,7 @@ void MeshLayerMapper::addLayerToMesh(const MeshLib::Mesh &dem_mesh, unsigned lay
     for (std::size_t i=0; i<nElems; ++i)
     {
         MeshLib::Element* elem (elems[i]);
-        if (elem->getGeomType() != MeshElemType::TRIANGLE)
+        if (elem->getGeomType() != MeshLib::MeshElemType::TRIANGLE)
             continue;
         unsigned node_counter(3), missing_idx(0);
         std::array<MeshLib::Node*, 6> new_elem_nodes;
@@ -248,7 +251,7 @@ bool MeshLayerMapper::layerMapping(MeshLib::Mesh &new_mesh, GeoLib::Raster const
 		}
 
 		double elevation (raster.interpolateValueAtPoint(*nodes[i]));
-		if (std::abs(elevation - no_data) < std::numeric_limits<double>::epsilon()) 
+		if (std::abs(elevation - no_data) < std::numeric_limits<double>::epsilon())
 			elevation = noDataReplacementValue;
 		nodes[i]->updateCoordinates((*nodes[i])[0], (*nodes[i])[1], elevation);
 	}

--- a/MeshLib/MeshGenerators/VtkMeshConverter.cpp
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.cpp
@@ -47,11 +47,12 @@ namespace MeshLib
 namespace detail
 {
 template <class T_ELEMENT>
-MeshLib::Element* createElementWithSameNodeOrder(const std::vector<MeshLib::Node*> &nodes, const std::vector<unsigned> &node_ids, unsigned material)
+MeshLib::Element* createElementWithSameNodeOrder(const std::vector<MeshLib::Node*> &nodes,
+		vtkIdList* const node_ids, unsigned material)
 {
 	MeshLib::Node** ele_nodes = new MeshLib::Node*[T_ELEMENT::n_all_nodes];
 	for (unsigned k(0); k<T_ELEMENT::n_all_nodes; k++)
-		ele_nodes[k] = nodes[node_ids[k]];
+		ele_nodes[k] = nodes[node_ids->GetId(k)];
 	return new T_ELEMENT(ele_nodes, material);
 }
 }
@@ -280,15 +281,11 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(vtkUnstructuredGrid* gr
 	const size_t nElems = grid->GetNumberOfCells();
 	std::vector<MeshLib::Element*> elements(nElems);
 	vtkDataArray* scalars = grid->GetCellData()->GetScalars("MaterialIDs");
-	auto point_id_list = vtkSmartPointer<vtkIdList>::New();
+	auto node_ids = vtkSmartPointer<vtkIdList>::New();
 	for (size_t i = 0; i < nElems; i++)
 	{
 		MeshLib::Element* elem;
-		grid->GetCellPoints(i, point_id_list);
-		std::vector<unsigned> node_ids;
-		node_ids.reserve(point_id_list->GetNumberOfIds());
-		for (auto j = 0; j < point_id_list->GetNumberOfIds(); j++)
-			node_ids.push_back(point_id_list->GetId(j));
+		grid->GetCellPoints(i, node_ids);
 
 		const unsigned material = (scalars) ? static_cast<int>(scalars->GetComponent(i,0)) : 0;
 
@@ -309,10 +306,10 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(vtkUnstructuredGrid* gr
 		}
 		case VTK_PIXEL: {
 			MeshLib::Node** quad_nodes = new MeshLib::Node*[4];
-			quad_nodes[0] = nodes[node_ids[0]];
-			quad_nodes[1] = nodes[node_ids[1]];
-			quad_nodes[2] = nodes[node_ids[3]];
-			quad_nodes[3] = nodes[node_ids[2]];
+			quad_nodes[0] = nodes[node_ids->GetId(0)];
+			quad_nodes[1] = nodes[node_ids->GetId(1)];
+			quad_nodes[2] = nodes[node_ids->GetId(3)];
+			quad_nodes[3] = nodes[node_ids->GetId(2)];
 			elem = new MeshLib::Quad(quad_nodes, material);
 			break;
 		}
@@ -326,14 +323,14 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(vtkUnstructuredGrid* gr
 		}
 		case VTK_VOXEL: {
 			MeshLib::Node** voxel_nodes = new MeshLib::Node*[8];
-			voxel_nodes[0] = nodes[node_ids[0]];
-			voxel_nodes[1] = nodes[node_ids[1]];
-			voxel_nodes[2] = nodes[node_ids[3]];
-			voxel_nodes[3] = nodes[node_ids[2]];
-			voxel_nodes[4] = nodes[node_ids[4]];
-			voxel_nodes[5] = nodes[node_ids[5]];
-			voxel_nodes[6] = nodes[node_ids[7]];
-			voxel_nodes[7] = nodes[node_ids[6]];
+			voxel_nodes[0] = nodes[node_ids->GetId(0)];
+			voxel_nodes[1] = nodes[node_ids->GetId(1)];
+			voxel_nodes[2] = nodes[node_ids->GetId(3)];
+			voxel_nodes[3] = nodes[node_ids->GetId(2)];
+			voxel_nodes[4] = nodes[node_ids->GetId(4)];
+			voxel_nodes[5] = nodes[node_ids->GetId(5)];
+			voxel_nodes[6] = nodes[node_ids->GetId(7)];
+			voxel_nodes[7] = nodes[node_ids->GetId(6)];
 			elem = new MeshLib::Hex(voxel_nodes, material);
 			break;
 		}
@@ -345,8 +342,8 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(vtkUnstructuredGrid* gr
 			MeshLib::Node** prism_nodes = new MeshLib::Node*[6];
 			for (unsigned i=0; i<3; ++i)
 			{
-				prism_nodes[i] = nodes[node_ids[i+3]];
-				prism_nodes[i+3] = nodes[node_ids[i]];
+				prism_nodes[i] = nodes[node_ids->GetId(i+3)];
+				prism_nodes[i+3] = nodes[node_ids->GetId(i)];
 			}
 			elem = new MeshLib::Prism(prism_nodes, material);
 			break;
@@ -383,16 +380,16 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(vtkUnstructuredGrid* gr
 			MeshLib::Node** prism_nodes = new MeshLib::Node*[15];
 			for (unsigned i=0; i<3; ++i)
 			{
-				prism_nodes[i] = nodes[node_ids[i+3]];
-				prism_nodes[i+3] = nodes[node_ids[i]];
+				prism_nodes[i] = nodes[node_ids->GetId(i+3)];
+				prism_nodes[i+3] = nodes[node_ids->GetId(i)];
 			}
 			for (unsigned i=0; i<3; ++i)
-				prism_nodes[6+i] = nodes[node_ids[8-i]];
-			prism_nodes[9] = nodes[node_ids[12]];
-			prism_nodes[10] = nodes[node_ids[14]];
-			prism_nodes[11] = nodes[node_ids[13]];
+				prism_nodes[6+i] = nodes[node_ids->GetId(8-i)];
+			prism_nodes[9] = nodes[node_ids->GetId(12)];
+			prism_nodes[10] = nodes[node_ids->GetId(14)];
+			prism_nodes[11] = nodes[node_ids->GetId(13)];
 			for (unsigned i=0; i<3; ++i)
-				prism_nodes[12+i] = nodes[node_ids[11-i]];
+				prism_nodes[12+i] = nodes[node_ids->GetId(11-i)];
 			elem = new MeshLib::Prism15(prism_nodes, material);
 			break;
 		}

--- a/MeshLib/MeshGenerators/VtkMeshConverter.cpp
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.cpp
@@ -280,13 +280,16 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(vtkUnstructuredGrid* gr
 	const size_t nElems = grid->GetNumberOfCells();
 	std::vector<MeshLib::Element*> elements(nElems);
 	vtkDataArray* scalars = grid->GetCellData()->GetScalars("MaterialIDs");
+	auto point_id_list = vtkSmartPointer<vtkIdList>::New();
 	for (size_t i = 0; i < nElems; i++)
 	{
 		MeshLib::Element* elem;
-		const size_t nElemNodes (grid->GetCell(i)->GetNumberOfPoints());
-		std::vector<unsigned> node_ids(nElemNodes);
-		for (size_t j=0; j<nElemNodes; j++)
-			node_ids[j] = grid->GetCell(i)->GetPointId(j);
+		grid->GetCellPoints(i, point_id_list);
+		std::vector<unsigned> node_ids;
+		node_ids.reserve(point_id_list->GetNumberOfIds());
+		for (auto j = 0; j < point_id_list->GetNumberOfIds(); j++)
+			node_ids.push_back(point_id_list->GetId(j));
+
 		const unsigned material = (scalars) ? static_cast<int>(scalars->GetComponent(i,0)) : 0;
 
 		int cell_type = grid->GetCellType(i);

--- a/MeshLib/MeshGenerators/VtkMeshConverter.h
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.h
@@ -28,14 +28,6 @@ namespace MeshLib {
 class Mesh;
 class Properties;
 
-/// Selection of possible interpretations for intensities
-enum class UseIntensityAs
-{
-	ELEVATION,
-	MATERIAL,
-	NONE
-};
-
 
 /**
  * \brief Adapter class to convert FEM Mesh to a representation more suited for visualisation purposes

--- a/MeshLib/VtkOGSEnum.cpp
+++ b/MeshLib/VtkOGSEnum.cpp
@@ -11,88 +11,88 @@
 
 #include <vtkCellType.h>
 
-CellType VtkCellTypeToOGS(int type)
+MeshLib::CellType VtkCellTypeToOGS(int type)
 {
 	switch (type)
 	{
 		case VTK_LINE:
-			return CellType::LINE2;
+			return MeshLib::CellType::LINE2;
 		case VTK_QUADRATIC_EDGE:
-			return CellType::LINE3;
+			return MeshLib::CellType::LINE3;
 		case VTK_TRIANGLE:
-			return CellType::TRI3;
+			return MeshLib::CellType::TRI3;
 		case VTK_QUADRATIC_TRIANGLE:
-			return CellType::TRI6;
+			return MeshLib::CellType::TRI6;
 		case VTK_QUAD:
-			return CellType::QUAD4;
+			return MeshLib::CellType::QUAD4;
 		case VTK_QUADRATIC_QUAD:
-			return CellType::QUAD8;
+			return MeshLib::CellType::QUAD8;
 		case VTK_BIQUADRATIC_QUAD:
-			return CellType::QUAD9;
+			return MeshLib::CellType::QUAD9;
 		case VTK_HEXAHEDRON:
-			return CellType::HEX8;
+			return MeshLib::CellType::HEX8;
 		case VTK_QUADRATIC_HEXAHEDRON:
-			return CellType::HEX20;
+			return MeshLib::CellType::HEX20;
 		case VTK_TRIQUADRATIC_HEXAHEDRON:
-			return CellType::HEX27;
+			return MeshLib::CellType::HEX27;
 		case VTK_TETRA:
-			return CellType::TET4;
+			return MeshLib::CellType::TET4;
 		case VTK_QUADRATIC_TETRA:
-			return CellType::TET10;
+			return MeshLib::CellType::TET10;
 		case VTK_WEDGE:
-			return CellType::PRISM6;
+			return MeshLib::CellType::PRISM6;
 		case VTK_QUADRATIC_WEDGE:
-			return CellType::PRISM15;
+			return MeshLib::CellType::PRISM15;
 		case VTK_BIQUADRATIC_QUADRATIC_WEDGE:
-			return CellType::PRISM18;
+			return MeshLib::CellType::PRISM18;
 		case VTK_PYRAMID:
-			return CellType::PYRAMID5;
+			return MeshLib::CellType::PYRAMID5;
 		case VTK_QUADRATIC_PYRAMID:
-			return CellType::PYRAMID13;
+			return MeshLib::CellType::PYRAMID13;
 		default:
-			return CellType::INVALID;
+			return MeshLib::CellType::INVALID;
 	}
 }
 
-int OGSToVtkCellType(CellType ogs)
+int OGSToVtkCellType(MeshLib::CellType ogs)
 {
 	switch (ogs)
 	{
-		case CellType::LINE2:
+		case MeshLib::CellType::LINE2:
 			return VTK_LINE;
-		case CellType::LINE3:
+		case MeshLib::CellType::LINE3:
 			return VTK_QUADRATIC_EDGE;
-		case CellType::TRI3:
+		case MeshLib::CellType::TRI3:
 			return VTK_TRIANGLE;
-		case CellType::TRI6:
+		case MeshLib::CellType::TRI6:
 			return VTK_QUADRATIC_TRIANGLE;
-		case CellType::QUAD4:
+		case MeshLib::CellType::QUAD4:
 			return VTK_QUAD;
-		case CellType::QUAD8:
+		case MeshLib::CellType::QUAD8:
 			return VTK_QUADRATIC_QUAD;
-		case CellType::QUAD9:
+		case MeshLib::CellType::QUAD9:
 			return VTK_BIQUADRATIC_QUAD;
-		case CellType::HEX8:
+		case MeshLib::CellType::HEX8:
 			return VTK_HEXAHEDRON;
-		case CellType::HEX20:
+		case MeshLib::CellType::HEX20:
 			return VTK_QUADRATIC_HEXAHEDRON;
-		case CellType::HEX27:
+		case MeshLib::CellType::HEX27:
 			return VTK_TRIQUADRATIC_HEXAHEDRON;
-		case CellType::TET4:
+		case MeshLib::CellType::TET4:
 			return VTK_TETRA;
-		case CellType::TET10:
+		case MeshLib::CellType::TET10:
 			return VTK_QUADRATIC_TETRA;
-		case CellType::PRISM6:
+		case MeshLib::CellType::PRISM6:
 			return VTK_WEDGE;
-		case CellType::PRISM15:
+		case MeshLib::CellType::PRISM15:
 			return VTK_QUADRATIC_WEDGE;
-		case CellType::PRISM18:
+		case MeshLib::CellType::PRISM18:
 			return VTK_BIQUADRATIC_QUADRATIC_WEDGE;
-		case CellType::PYRAMID5:
+		case MeshLib::CellType::PYRAMID5:
 			return VTK_PYRAMID;
-		case CellType::PYRAMID13:
+		case MeshLib::CellType::PYRAMID13:
 			return VTK_QUADRATIC_PYRAMID;
-		case CellType::INVALID:
+		case MeshLib::CellType::INVALID:
 			return -1;
 		default:
 			return -1;

--- a/MeshLib/VtkOGSEnum.h
+++ b/MeshLib/VtkOGSEnum.h
@@ -12,8 +12,8 @@
 
 #include "MeshEnums.h"
 
-CellType VtkCellTypeToOGS(int type);
+MeshLib::CellType VtkCellTypeToOGS(int type);
 
-int OGSToVtkCellType(CellType ogs);
+int OGSToVtkCellType(MeshLib::CellType ogs);
 
 #endif // VTKOGSENUM_H_

--- a/Tests/MeshLib/TestMeshRevision.cpp
+++ b/Tests/MeshLib/TestMeshRevision.cpp
@@ -41,13 +41,13 @@ TEST(MeshEditing, Tri)
 	MeshLib::MeshRevision rev(mesh);
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-	ASSERT_EQ(MeshElemType::LINE, result->getElement(0)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::LINE, result->getElement(0)->getGeomType());
 	ASSERT_EQ(1, result->getElement(0)->getContent());
 	ASSERT_EQ(2u, result->getNNodes());
 	delete result;
 
 	result = rev.simplifyMesh("new_mesh", 0.0999);
-	ASSERT_EQ(MeshElemType::TRIANGLE, result->getElement(0)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, result->getElement(0)->getGeomType());
 	ASSERT_EQ(0.05, result->getElement(0)->getContent());
 	ASSERT_EQ(3u, result->getNNodes());
 	delete result;
@@ -70,7 +70,7 @@ TEST(MeshEditing, NonPlanarQuad)
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
 	ASSERT_EQ(2u, result->getNElements());
-	ASSERT_EQ(MeshElemType::TRIANGLE, result->getElement(1)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, result->getElement(1)->getGeomType());
 
 	delete result;
 }
@@ -92,7 +92,7 @@ TEST(MeshEditing, Quad2Line)
 	MeshLib::MeshRevision rev(mesh);
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-	ASSERT_EQ(MeshElemType::LINE, result->getElement(0)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::LINE, result->getElement(0)->getGeomType());
 	ASSERT_NEAR(1.414213562373095, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 	ASSERT_EQ(2u, result->getNNodes());
 
@@ -116,7 +116,7 @@ TEST(MeshEditing, Quad2Tri)
 	MeshLib::MeshRevision rev(mesh);
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-	ASSERT_EQ(MeshElemType::TRIANGLE, result->getElement(0)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, result->getElement(0)->getGeomType());
 	ASSERT_NEAR(0.5049752469181039, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 	ASSERT_EQ(3u, result->getNNodes());
 
@@ -145,7 +145,7 @@ TEST(MeshEditing, NonPlanarHex)
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
 	ASSERT_EQ(6u, result->getNElements());
-	ASSERT_EQ(MeshElemType::TETRAHEDRON, result->getElement(4)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(4)->getGeomType());
 	ASSERT_NEAR(0.25, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 	ASSERT_NEAR(0.1666666666666667, result->getElement(5)->getContent(), std::numeric_limits<double>::epsilon());
 
@@ -174,8 +174,8 @@ TEST(MeshEditing, Hex2PyramidPrism)
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
 	ASSERT_EQ(2u, result->getNElements());
-	ASSERT_EQ(MeshElemType::PYRAMID, result->getElement(0)->getGeomType());
-	ASSERT_EQ(MeshElemType::PRISM, result->getElement(1)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::PYRAMID, result->getElement(0)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::PRISM, result->getElement(1)->getGeomType());
 	ASSERT_NEAR(0.3333333333333333, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 	ASSERT_NEAR(0.5, result->getElement(1)->getContent(), std::numeric_limits<double>::epsilon());
 
@@ -204,7 +204,7 @@ TEST(MeshEditing, Hex2FourTets)
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
 	ASSERT_EQ(4u, result->getNElements());
-	ASSERT_EQ(MeshElemType::TETRAHEDRON, result->getElement(1)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(1)->getGeomType());
 	ASSERT_NEAR(0.1666666666666667, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 	ASSERT_NEAR(0.1666666666666667, result->getElement(1)->getContent(), std::numeric_limits<double>::epsilon());
 	ASSERT_NEAR(0.1666666666666667, result->getElement(2)->getContent(), std::numeric_limits<double>::epsilon());
@@ -235,7 +235,7 @@ TEST(MeshEditing, Hex2TwoTets)
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
 	ASSERT_EQ(2u, result->getNElements());
-	ASSERT_EQ(MeshElemType::TETRAHEDRON, result->getElement(1)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(1)->getGeomType());
 	ASSERT_NEAR(0.1666666666666667, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 	ASSERT_NEAR(0.1666666666666667, result->getElement(1)->getContent(), std::numeric_limits<double>::epsilon());
 
@@ -261,7 +261,7 @@ TEST(MeshEditing, NonPlanarPyramid)
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
 	ASSERT_EQ(2u, result->getNElements());
-	ASSERT_EQ(MeshElemType::TETRAHEDRON, result->getElement(1)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(1)->getGeomType());
 	ASSERT_NEAR(0.25, result->getElement(0)->getContent(),  std::numeric_limits<double>::epsilon());
 	ASSERT_NEAR(0.1666666666666667, result->getElement(1)->getContent(), std::numeric_limits<double>::epsilon());
 
@@ -287,7 +287,7 @@ TEST(MeshEditing, Pyramid2Tet)
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
 	ASSERT_EQ(1u, result->getNElements());
-	ASSERT_EQ(MeshElemType::TETRAHEDRON, result->getElement(0)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(0)->getGeomType());
 	ASSERT_NEAR(0.16666666666666666, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 
 	delete result;
@@ -312,7 +312,7 @@ TEST(MeshEditing, Pyramid2Quad)
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
 	ASSERT_EQ(1u, result->getNElements());
-	ASSERT_EQ(MeshElemType::QUAD, result->getElement(0)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::QUAD, result->getElement(0)->getGeomType());
 	ASSERT_NEAR(1, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 
 	delete result;
@@ -338,7 +338,7 @@ TEST(MeshEditing, Pyramid2Tri)
 
 	ASSERT_EQ(3u, result->getNNodes());
 	ASSERT_EQ(1u, result->getNElements());
-	ASSERT_EQ(MeshElemType::TRIANGLE, result->getElement(0)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, result->getElement(0)->getGeomType());
 	ASSERT_NEAR(0.5, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 
 	delete result;
@@ -364,7 +364,7 @@ TEST(MeshEditing, NonPlanarPrism)
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
 	ASSERT_EQ(3u, result->getNElements());
-	ASSERT_EQ(MeshElemType::TETRAHEDRON, result->getElement(2)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(2)->getGeomType());
 	ASSERT_NEAR(0.1666666666666667, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 
 	delete result;
@@ -391,7 +391,7 @@ TEST(MeshEditing, Prism2TwoTets)
 
 	ASSERT_EQ(5u, result->getNNodes());
 	ASSERT_EQ(2u, result->getNElements());
-	ASSERT_EQ(MeshElemType::TETRAHEDRON, result->getElement(1)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(1)->getGeomType());
 	ASSERT_NEAR(0.1666666666666667, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 	ASSERT_NEAR(0.15, result->getElement(1)->getContent(), std::numeric_limits<double>::epsilon());
 
@@ -418,7 +418,7 @@ TEST(MeshEditing, Prism2Quad)
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
 	ASSERT_EQ(1u, result->getNElements());
-	ASSERT_EQ(MeshElemType::QUAD, result->getElement(0)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::QUAD, result->getElement(0)->getGeomType());
 	ASSERT_NEAR(1.345362404707371, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 
 	delete result;
@@ -444,7 +444,7 @@ TEST(MeshEditing, Prism2Tet)
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
 	ASSERT_EQ(1u, result->getNElements());
-	ASSERT_EQ(MeshElemType::TETRAHEDRON, result->getElement(0)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(0)->getGeomType());
 	ASSERT_NEAR(0.1666666666666667, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 
 	delete result;
@@ -470,7 +470,7 @@ TEST(MeshEditing, Prism2Tri)
 	MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
 	ASSERT_EQ(1u, result->getNElements());
-	ASSERT_EQ(MeshElemType::TRIANGLE, result->getElement(0)->getGeomType());
+	ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, result->getElement(0)->getGeomType());
 	ASSERT_NEAR(0.5, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 
 	delete result;

--- a/Tests/MeshLib/TestMeshValidation.cpp
+++ b/Tests/MeshLib/TestMeshValidation.cpp
@@ -27,7 +27,7 @@ TEST(MeshValidation, UnusedNodes)
 {
 	std::array<double, 12> pix = {{0,0.1,0.2,0.1,0,0,0.1,0,0,0,-0.1,0}};
 	GeoLib::Raster raster(4,3,0,0,1,pix.begin(), pix.end());
-	MeshLib::ConvertRasterToMesh conv(raster, MeshElemType::TRIANGLE, MeshLib::UseIntensityAs::ELEVATION);
+	MeshLib::ConvertRasterToMesh conv(raster, MeshLib::MeshElemType::TRIANGLE, MeshLib::UseIntensityAs::ELEVATION);
 	MeshLib::Mesh* mesh = conv.execute();
 	std::vector<std::size_t> u_nodes = MeshLib::MeshValidation::findUnusedMeshNodes(*mesh);
 	ASSERT_EQ(0, u_nodes.size());
@@ -47,7 +47,7 @@ TEST(MeshValidation, DetectHolesTri)
 {
 	std::array<double, 12> pix = {{0,0.1,0.2,0.1,0,0,0.1,0,0,0,-0.1,0}};
 	GeoLib::Raster raster(4,3,0,0,1,pix.begin(), pix.end());
-	MeshLib::ConvertRasterToMesh conv(raster, MeshElemType::TRIANGLE, MeshLib::UseIntensityAs::ELEVATION);
+	MeshLib::ConvertRasterToMesh conv(raster, MeshLib::MeshElemType::TRIANGLE, MeshLib::UseIntensityAs::ELEVATION);
 	MeshLib::Mesh* mesh = conv.execute();
 	unsigned n_holes = MeshLib::MeshValidation::detectHoles(*mesh);
 	ASSERT_EQ(0, n_holes);

--- a/Tests/MeshLib/TestTriLineMesh.cpp
+++ b/Tests/MeshLib/TestTriLineMesh.cpp
@@ -79,9 +79,9 @@ TEST_F(MeshLibTriLineMesh, Construction)
 {
     ASSERT_TRUE(mesh != nullptr);
     ASSERT_EQ(3u, mesh->getNElements());
-    ASSERT_EQ(MeshElemType::TRIANGLE, elements[0]->getGeomType());
-    ASSERT_EQ(MeshElemType::TRIANGLE, elements[1]->getGeomType());
-    ASSERT_EQ(MeshElemType::LINE, elements[2]->getGeomType());
+    ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, elements[0]->getGeomType());
+    ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, elements[1]->getGeomType());
+    ASSERT_EQ(MeshLib::MeshElemType::LINE, elements[2]->getGeomType());
     ASSERT_EQ(4u, mesh->getNNodes());
 }
 


### PR DESCRIPTION
 - One very big optimization in vtk mesh conversion routine. See commit msg for details; in summary the `ctest -E diff` command needs around 10% less time.
 - Smaller optimization for boost::multi_index table: making comparison operator available for inlining indeed inlines the code. (around 1% overall improvement).
 - Replace MathLib::nomalize and fastpow with faster implementations.

The latter changes are touching a createMeshPropertiesFromASCRaster, ~~which I could not test. It seems the code is not compiling at all. Probably I miss some special flags for cmake.~~ (Thanks to Lars for fixing compilation)
Please test this.

Also the performance of VtkTextureOnSurfaceFilter should increase significantly. How can one check this? (and more important, that my changes do not break anything?) (:white_check_mark: Thanks Lars!)