### PR TITLE
Supporting mixed dimensional elements in FE

### DIFF
--- a/AssemblerLib/LocalDataInitializer.h
+++ b/AssemblerLib/LocalDataInitializer.h
@@ -36,9 +36,10 @@ namespace AssemblerLib
 /// NumLib::ShapeLine2 is created.
 template <
     template <typename, typename> class LocalAssemblerDataInterface_,
-    template <typename, typename, typename, typename> class LocalAssemblerData_,
+    template <typename, typename, typename, typename, unsigned> class LocalAssemblerData_,
     typename GlobalMatrix_,
-    typename GlobalVector_>
+    typename GlobalVector_,
+    unsigned GlobalDim>
 class LocalDataInitializer
 {
     template <typename ShapeFunction_>
@@ -49,7 +50,7 @@ class LocalDataInitializer
         using LAData = LocalAssemblerData_<
                 ShapeFunction_,
                 IntegrationMethod<ShapeFunction_>,
-                GlobalMatrix_, GlobalVector_>;
+                GlobalMatrix_, GlobalVector_, GlobalDim>;
 
 
 public:

--- a/Documentation/bibliography.bib
+++ b/Documentation/bibliography.bib
@@ -1,8 +1,32 @@
-@book{Ericson:2004:RCD:1121584,
- author = {Ericson, Christer},
- title = {Real-Time Collision Detection (The Morgan Kaufmann Series in Interactive 3-D Technology) (The Morgan Kaufmann Series in Interactive 3D Technology)},
- year = {2004},
- isbn = {1558607323},
- publisher = {Morgan Kaufmann Publishers Inc.},
- address = {San Francisco, CA, USA},
+% This file was created with JabRef 2.10b2.
+% Encoding: UTF-8
+
+
+@Book{Ericson:2004:RCD:1121584,
+  Title                    = {Real-Time Collision Detection (The Morgan Kaufmann Series in Interactive 3-D Technology) (The Morgan Kaufmann Series in Interactive 3D Technology)},
+  Author                   = {Ericson, Christer},
+  Publisher                = {Morgan Kaufmann Publishers Inc.},
+  Year                     = {2004},
+
+  Address                  = {San Francisco, CA, USA},
+
+  ISBN                     = {1558607323}
 }
+
+@Article{Kolditz2001,
+  Title                    = {{Non-linear flow in fractured rock}},
+  Author                   = {Kolditz , Olaf},
+  Journal                  = {International Journal of Numerical Methods for Heat \& Fluid Flow},
+  Year                     = {2001},
+  Number                   = {6},
+  Pages                    = {547--575},
+  Volume                   = {11},
+
+  Doi                      = {10.1108/EUM0000000005668},
+  ISSN                     = {0961-5539},
+  Keywords                 = {abstract this paper deals,at the geothermal research,darcian flow behavior was,finite elements,fractured rock,non-,non-linear dynamics,observed in pumping tests,of fluid flow in,pumps,site at soultz-,with theory and computation},
+  Owner                    = {localadmin},
+  Timestamp                = {2015.06.10},
+  Url                      = {http://www.emeraldinsight.com/journals.htm?articleid=877229\&show=abstract}
+}
+

--- a/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping-impl.h
+++ b/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping-impl.h
@@ -68,7 +68,7 @@ inline void computeMappingMatrices(
     //jacobian: J=[dx/dr dy/dr // dx/ds dy/ds]
     for (std::size_t k=0; k<nnodes; k++) {
         const MeshLib::Node& mapped_pt = *ele_local_coord.getMappedCoordinates(k);
-        // outer product of dNdr and xyz for a particular node
+        // outer product of dNdr and mapped_pt for a particular node
         for (std::size_t i_r=0; i_r<dim; i_r++) {
             for (std::size_t j_x=0; j_x<dim; j_x++) {
                 shapemat.J(i_r,j_x) += shapemat.dNdr(i_r,k) * mapped_pt[j_x];

--- a/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping-impl.h
+++ b/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping-impl.h
@@ -116,7 +116,7 @@ inline void computeMappingMatrices(
         const unsigned ele_dim(shapemat.dNdr.rows());
         assert(shapemat.dNdr.rows()==ele.getDimension());
         const unsigned global_dim(ele_local_coord.getGlobalCoordinateSystem().getDimension());
-        if (ele_local_coord.getGlobalCoordinateSystem().getDimension()==ele.getDimension()) {
+        if (global_dim==ele_dim) {
             shapemat.dNdx.topLeftCorner(ele_dim, nnodes) = shapemat.invJ * shapemat.dNdr;
         } else {
             auto const& matR = ele_local_coord.getRotationMatrixToGlobal(); // 3 x 3

--- a/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.h
+++ b/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.h
@@ -25,8 +25,7 @@ namespace NumLib
  *
  * This class also supports coordinates mapping of mixed dimensional elements,
  * e.g. line elements in 2D space. Details of the mapping method can be found in
- * Kolditz O (2001) Non-linear flow in fractured rock. International Journal of
- * Numerical Methods for Heat & Fluid Flow 11:547–575.
+ * \cite Kolditz2001 .
  *
  * @tparam T_MESH_ELEMENT       Mesh element type
  * @tparam T_SHAPE_FUNC         Shape function class

--- a/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.h
+++ b/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.h
@@ -23,6 +23,11 @@ namespace NumLib
 /**
  * Coordinates mapping tools for natural coordinates
  *
+ * This class also supports coordinates mapping of mixed dimensional elements,
+ * e.g. line elements in 2D space. Details of the mapping method can be found in
+ * Kolditz O (2001) Non-linear flow in fractured rock. International Journal of
+ * Numerical Methods for Heat & Fluid Flow 11:547–575.
+ *
  * @tparam T_MESH_ELEMENT       Mesh element type
  * @tparam T_SHAPE_FUNC         Shape function class
  * @tparam T_SHAPE_MATRICES     Shape matrices class

--- a/NumLib/Fem/CoordinatesMapping/ShapeMatrices-impl.h
+++ b/NumLib/Fem/CoordinatesMapping/ShapeMatrices-impl.h
@@ -38,43 +38,43 @@ void setVectorZero(T &vec)
  */
 template <ShapeMatrixType FIELD_TYPE> struct ShapeDataFieldType {};
 
-template <class T_N, class T_DN, class T_J>
-inline void setZero(ShapeMatrices<T_N, T_DN, T_J> &shape, ShapeDataFieldType<ShapeMatrixType::N>)
+template <class T_N, class T_DNDR, class T_J, class T_DNDX>
+inline void setZero(ShapeMatrices<T_N, T_DNDR, T_J, T_DNDX> &shape, ShapeDataFieldType<ShapeMatrixType::N>)
 {
     setVectorZero(shape.N);
 }
 
-template <class T_N, class T_DN, class T_J>
-inline void setZero(ShapeMatrices<T_N, T_DN, T_J> &shape, ShapeDataFieldType<ShapeMatrixType::DNDR>)
+template <class T_N, class T_DNDR, class T_J, class T_DNDX>
+inline void setZero(ShapeMatrices<T_N, T_DNDR, T_J, T_DNDX> &shape, ShapeDataFieldType<ShapeMatrixType::DNDR>)
 {
     setMatrixZero(shape.dNdr);
 }
 
-template <class T_N, class T_DN, class T_J>
-inline void setZero(ShapeMatrices<T_N, T_DN, T_J> &shape, ShapeDataFieldType<ShapeMatrixType::DNDR_J>)
+template <class T_N, class T_DNDR, class T_J, class T_DNDX>
+inline void setZero(ShapeMatrices<T_N, T_DNDR, T_J, T_DNDX> &shape, ShapeDataFieldType<ShapeMatrixType::DNDR_J>)
 {
     setZero(shape, ShapeDataFieldType<ShapeMatrixType::DNDR>());
     setMatrixZero(shape.J);
     shape.detJ = .0;
 }
 
-template <class T_N, class T_DN, class T_J>
-inline void setZero(ShapeMatrices<T_N, T_DN, T_J> &shape, ShapeDataFieldType<ShapeMatrixType::N_J>)
+template <class T_N, class T_DNDR, class T_J, class T_DNDX>
+inline void setZero(ShapeMatrices<T_N, T_DNDR, T_J, T_DNDX> &shape, ShapeDataFieldType<ShapeMatrixType::N_J>)
 {
     setZero(shape, ShapeDataFieldType<ShapeMatrixType::N>());
     setZero(shape, ShapeDataFieldType<ShapeMatrixType::DNDR_J>());
 }
 
-template <class T_N, class T_DN, class T_J>
-inline void setZero(ShapeMatrices<T_N, T_DN, T_J> &shape, ShapeDataFieldType<ShapeMatrixType::DNDX>)
+template <class T_N, class T_DNDR, class T_J, class T_DNDX>
+inline void setZero(ShapeMatrices<T_N, T_DNDR, T_J, T_DNDX> &shape, ShapeDataFieldType<ShapeMatrixType::DNDX>)
 {
     setZero(shape, ShapeDataFieldType<ShapeMatrixType::DNDR_J>());
     setMatrixZero(shape.invJ);
     setMatrixZero(shape.dNdx);
 }
 
-template <class T_N, class T_DN, class T_J>
-inline void setZero(ShapeMatrices<T_N, T_DN, T_J> &shape, ShapeDataFieldType<ShapeMatrixType::ALL>)
+template <class T_N, class T_DNDR, class T_J, class T_DNDX>
+inline void setZero(ShapeMatrices<T_N, T_DNDR, T_J, T_DNDX> &shape, ShapeDataFieldType<ShapeMatrixType::ALL>)
 {
     setZero(shape, ShapeDataFieldType<ShapeMatrixType::N>());
     setZero(shape, ShapeDataFieldType<ShapeMatrixType::DNDX>());
@@ -82,21 +82,21 @@ inline void setZero(ShapeMatrices<T_N, T_DN, T_J> &shape, ShapeDataFieldType<Sha
 
 } //detail
 
-template <class T_N, class T_DN, class T_J>
-inline void ShapeMatrices<T_N, T_DN, T_J>::setZero()
+template <class T_N, class T_DNDR, class T_J, class T_DNDX>
+inline void ShapeMatrices<T_N, T_DNDR, T_J, T_DNDX>::setZero()
 {
     detail::setZero(*this, detail::ShapeDataFieldType<ShapeMatrixType::ALL>());
 }
 
-template <class T_N, class T_DN, class T_J>
+template <class T_N, class T_DNDR, class T_J, class T_DNDX>
 template <ShapeMatrixType T_SHAPE_MATRIX_TYPE>
-inline void ShapeMatrices<T_N, T_DN, T_J>::setZero()
+inline void ShapeMatrices<T_N, T_DNDR, T_J, T_DNDX>::setZero()
 {
     detail::setZero(*this, detail::ShapeDataFieldType<T_SHAPE_MATRIX_TYPE>());
 }
 
-template <class T_N, class T_DN, class T_J>
-void ShapeMatrices<T_N, T_DN, T_J>::resize(std::size_t const dim, std::size_t n_nodes)
+template <class T_N, class T_DNDR, class T_J, class T_DNDX>
+void ShapeMatrices<T_N, T_DNDR, T_J, T_DNDX>::resize(std::size_t const dim, std::size_t n_nodes)
 {
     N.resize(n_nodes);
     dNdr.resize(dim, n_nodes);
@@ -107,8 +107,8 @@ void ShapeMatrices<T_N, T_DN, T_J>::resize(std::size_t const dim, std::size_t n_
     setZero();
 }
 
-template <class T_N, class T_DN, class T_J>
-void ShapeMatrices<T_N, T_DN, T_J>::write(std::ostream& out) const
+template <class T_N, class T_DNDR, class T_J, class T_DNDX>
+void ShapeMatrices<T_N, T_DNDR, T_J, T_DNDX>::write(std::ostream& out) const
 {
     out << "N   :\n" << N << "\n";
     out << "dNdr:\n" << dNdr << "\n";
@@ -118,8 +118,8 @@ void ShapeMatrices<T_N, T_DN, T_J>::write(std::ostream& out) const
     out << "dNdx:\n" << dNdx << "\n";
 }
 
-template <class T_N, class T_DN, class T_J>
-std::ostream& operator<< (std::ostream &os, const ShapeMatrices<T_N, T_DN, T_J> &shape)
+template <class T_N, class T_DNDR, class T_J, class T_DNDX>
+std::ostream& operator<< (std::ostream &os, const ShapeMatrices<T_N, T_DNDR, T_J, T_DNDX> &shape)
 {
     shape.write (os);
     return os;

--- a/NumLib/Fem/CoordinatesMapping/ShapeMatrices.h
+++ b/NumLib/Fem/CoordinatesMapping/ShapeMatrices.h
@@ -27,7 +27,7 @@ enum class ShapeMatrixType
     N,      ///< calculates N
     DNDR,   ///< calculates dNdr
     N_J,    ///< calculates N, dNdr, J, and detJ
-    DNDR_J, ///< caluclates dNdr, J, and detJ
+    DNDR_J, ///< calculates dNdr, J, and detJ
     DNDX,   ///< calculates dNdr, J, detJ, invJ, and dNdx
     ALL     ///< calculates all
 };
@@ -36,22 +36,24 @@ enum class ShapeMatrixType
  * \brief Coordinates mapping matrices at particular location
  *
  * \tparam T_N      Vector type for shape functions
- * \tparam T_DN     Matrix type for gradient of shape functions
+ * \tparam T_DNDR   Matrix type for gradient of shape functions in natural coordinates
  * \tparam T_J      Jacobian matrix type
+ * \tparam T_DNDX   Matrix type for gradient of shape functions in physical coordinates
  */
-template <class T_N, class T_DN, class T_J>
+template <class T_N, class T_DNDR, class T_J, class T_DNDX>
 struct ShapeMatrices
 {
     typedef T_N ShapeType;
-    typedef T_DN DShapeType;
+    typedef T_DNDR DrShapeType;
     typedef T_J JacobianType;
+    typedef T_DNDX DxShapeType;
 
     ShapeType N;        ///< Vector of shape functions, N(r)
-    DShapeType dNdr;    ///< Matrix of gradient of shape functions in natural coordinates, dN(r)/dr
+    DrShapeType dNdr;   ///< Matrix of gradient of shape functions in natural coordinates, dN(r)/dr
     JacobianType J;     ///< Jacobian matrix, J=dx/dr
     double detJ;        ///< Determinant of the Jacobian
     JacobianType invJ;  ///< Inverse matrix of the Jacobian
-    DShapeType dNdx;    ///< Matrix of gradient of shape functions in physical coordinates, dN(r)/dx
+    DxShapeType dNdx;   ///< Matrix of gradient of shape functions in physical coordinates, dN(r)/dx
 
     /** The default constructor is used by fixed-size (at compile-time)
      * matrix/vector types where no resizing of the matrices/vectors is required
@@ -68,6 +70,19 @@ struct ShapeMatrices
     ShapeMatrices(std::size_t dim, std::size_t n_nodes)
     : N(n_nodes), dNdr(dim, n_nodes), J(dim, dim), detJ(.0),
       invJ(dim, dim), dNdx(dim, n_nodes)
+    {
+        this->setZero();
+    }
+
+    /**
+     * Initialize matrices and vectors
+     *
+     * @param dim       Spatial dimension
+     * @param n_nodes   The number of element nodes
+     */
+    ShapeMatrices(std::size_t local_dim, std::size_t global_dim, std::size_t n_nodes)
+    : N(n_nodes), dNdr(local_dim, n_nodes), J(local_dim, local_dim), detJ(.0),
+    invJ(local_dim, local_dim), dNdx(global_dim, n_nodes)
     {
         this->setZero();
     }

--- a/NumLib/Fem/ShapeMatrixPolicy.h
+++ b/NumLib/Fem/ShapeMatrixPolicy.h
@@ -17,7 +17,7 @@
 
 /// An implementation of ShapeMatrixPolicy using fixed size (compile-time) eigen
 /// matrices and vectors.
-template <typename ShapeFunction>
+template <typename ShapeFunction, unsigned GlobalDim>
 struct EigenFixedShapeMatrixPolicy
 {
     template <int N, int M>
@@ -29,17 +29,19 @@ struct EigenFixedShapeMatrixPolicy
     using NodalVectorType = _VectorType<ShapeFunction::NPOINTS>;
     using DimNodalMatrixType = _MatrixType<ShapeFunction::DIM, ShapeFunction::NPOINTS>;
     using DimMatrixType = _MatrixType<ShapeFunction::DIM, ShapeFunction::DIM>;
+    using GlobalDimNodalMatrixType = _MatrixType<GlobalDim, ShapeFunction::NPOINTS>;
 
     using ShapeMatrices =
         NumLib::ShapeMatrices<
             NodalVectorType,
             DimNodalMatrixType,
-            DimMatrixType>;
+            DimMatrixType,
+            GlobalDimNodalMatrixType>;
 };
 
 /// An implementation of ShapeMatrixPolicy using dynamic size eigen matrices and
 /// vectors.
-template <typename ShapeFunction>
+template <typename ShapeFunction, unsigned GlobalDim>
 struct EigenDynamicShapeMatrixPolicy
 {
     // Dynamic size local matrices are much slower in allocation than their
@@ -54,18 +56,20 @@ struct EigenDynamicShapeMatrixPolicy
     using NodalVectorType = _VectorType;
     using DimNodalMatrixType = _MatrixType;
     using DimMatrixType = _MatrixType;
+    using GlobalDimNodalMatrixType = _MatrixType;
 
     using ShapeMatrices =
         NumLib::ShapeMatrices<
             NodalVectorType,
             DimNodalMatrixType,
-            DimMatrixType>;
+            DimMatrixType,
+            GlobalDimNodalMatrixType>;
 };
 
 /// Default choice of the ShapeMatrixPolicy.
-template <typename ShapeFunction>
-using ShapeMatrixPolicyType = EigenFixedShapeMatrixPolicy<ShapeFunction>;
-//using ShapeMatrixPolicyType = EigenDynamicShapeMatrixPolicy<ShapeFunction>;
+template <typename ShapeFunction, unsigned GlobalDim>
+using ShapeMatrixPolicyType = EigenFixedShapeMatrixPolicy<ShapeFunction, GlobalDim>;
+//using ShapeMatrixPolicyType = EigenDynamicShapeMatrixPolicy<ShapeFunction, GlobalDim>;
 
 #endif  // OGS_USE_EIGEN
 

--- a/ProcessLib/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlowFEM.h
@@ -42,15 +42,16 @@ public:
 template <typename ShapeFunction_,
          typename IntegrationMethod_,
          typename GlobalMatrix,
-         typename GlobalVector>
+         typename GlobalVector,
+         unsigned GlobalDim>
 class LocalAssemblerData : public LocalAssemblerDataInterface<GlobalMatrix, GlobalVector>
 {
 public:
     using ShapeFunction = ShapeFunction_;
-    using NodalMatrixType = typename ShapeMatrixPolicyType<ShapeFunction>::NodalMatrixType;
-    using NodalVectorType = typename ShapeMatrixPolicyType<ShapeFunction>::NodalVectorType;
+    using NodalMatrixType = typename ShapeMatrixPolicyType<ShapeFunction, GlobalDim>::NodalMatrixType;
+    using NodalVectorType = typename ShapeMatrixPolicyType<ShapeFunction, GlobalDim>::NodalVectorType;
 
-    using ShapeMatricesType = ShapeMatrixPolicyType<ShapeFunction>;
+    using ShapeMatricesType = ShapeMatrixPolicyType<ShapeFunction, GlobalDim>;
     using ShapeMatrices = typename ShapeMatricesType::ShapeMatrices;
 
     /// The hydraulic_conductivity factor is directly integrated into the local

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -75,29 +75,9 @@ public:
 
     }
 
-    void initialize()
+    template <unsigned GlobalDim>
+    void createLocalAssemblers()
     {
-        DBUG("Initialize GroundwaterFlowProcess.");
-
-        DBUG("Construct dof mappings.");
-        // Create single component dof in every of the mesh's nodes.
-        _mesh_subset_all_nodes = new MeshLib::MeshSubset(_mesh, &_mesh.getNodes());
-
-        // Collect the mesh subsets in a vector.
-        _all_mesh_subsets.push_back(new MeshLib::MeshSubsets(_mesh_subset_all_nodes));
-
-        _local_to_global_index_map.reset(
-            new AssemblerLib::LocalToGlobalIndexMap(_all_mesh_subsets));
-
-        DBUG("Compute sparsity pattern");
-        _node_adjacency_table.createTable(_mesh.getNodes());
-
-        DBUG("Allocate global matrix, vectors, and linear solver.");
-        _A.reset(_global_setup.createMatrix(_local_to_global_index_map->dofSize()));
-        _x.reset(_global_setup.createVector(_local_to_global_index_map->dofSize()));
-        _rhs.reset(_global_setup.createVector(_local_to_global_index_map->dofSize()));
-        _linearSolver.reset(new typename GlobalSetup::LinearSolver(*_A));
-
         DBUG("Create local assemblers.");
         // Populate the vector of local assemblers.
         _local_assemblers.resize(_mesh.getNElements());
@@ -106,7 +86,8 @@ public:
             GroundwaterFlow::LocalAssemblerDataInterface,
             GroundwaterFlow::LocalAssemblerData,
             typename GlobalSetup::MatrixType,
-            typename GlobalSetup::VectorType>;
+            typename GlobalSetup::VectorType,
+            GlobalDim>;
 
         LocalDataInitializer initializer;
 
@@ -159,8 +140,39 @@ public:
         }
 
         for (auto bc : _neumann_bcs)
-            bc->initialize(_global_setup, *_A, *_rhs);
+            bc->initialize(_global_setup, *_A, *_rhs, _mesh.getDimension());
 
+    }
+
+    void initialize()
+    {
+        DBUG("Initialize GroundwaterFlowProcess.");
+
+        DBUG("Construct dof mappings.");
+        // Create single component dof in every of the mesh's nodes.
+        _mesh_subset_all_nodes = new MeshLib::MeshSubset(_mesh, &_mesh.getNodes());
+
+        // Collect the mesh subsets in a vector.
+        _all_mesh_subsets.push_back(new MeshLib::MeshSubsets(_mesh_subset_all_nodes));
+
+        _local_to_global_index_map.reset(
+            new AssemblerLib::LocalToGlobalIndexMap(_all_mesh_subsets));
+
+        DBUG("Compute sparsity pattern");
+        _node_adjacency_table.createTable(_mesh.getNodes());
+
+        DBUG("Allocate global matrix, vectors, and linear solver.");
+        _A.reset(_global_setup.createMatrix(_local_to_global_index_map->dofSize()));
+        _x.reset(_global_setup.createVector(_local_to_global_index_map->dofSize()));
+        _rhs.reset(_global_setup.createVector(_local_to_global_index_map->dofSize()));
+        _linearSolver.reset(new typename GlobalSetup::LinearSolver(*_A));
+
+        if (_mesh.getDimension()==1)
+            createLocalAssemblers<1>();
+        else if (_mesh.getDimension()==2)
+            createLocalAssemblers<2>();
+        else if (_mesh.getDimension()==3)
+            createLocalAssemblers<3>();
     }
 
     void solve()

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -10,6 +10,7 @@
 #ifndef PROCESS_LIB_GROUNDWATERFLOWPROCESS_H_
 #define PROCESS_LIB_GROUNDWATERFLOWPROCESS_H_
 
+#include <cassert>
 #include <memory>
 
 #include <boost/filesystem.hpp>
@@ -173,6 +174,8 @@ public:
             createLocalAssemblers<2>();
         else if (_mesh.getDimension()==3)
             createLocalAssemblers<3>();
+        else
+            assert(false);
     }
 
     void solve()

--- a/ProcessLib/NeumannBc.h
+++ b/ProcessLib/NeumannBc.h
@@ -89,9 +89,24 @@ public:
             delete p;
     }
 
+    template <typename GlobalSetup>
+    void
+    initialize(GlobalSetup const& global_setup,
+        typename GlobalSetup::MatrixType& A,
+        typename GlobalSetup::VectorType& rhs,
+        unsigned global_dim)
+    {
+        if (global_dim==1)
+            initialize<GlobalSetup, 1u>(global_setup, A, rhs);
+        else if (global_dim==2)
+            initialize<GlobalSetup, 2u>(global_setup, A, rhs);
+        else if (global_dim==3)
+            initialize<GlobalSetup, 3u>(global_setup, A, rhs);
+    }
+
     /// Allocates the local assemblers for each element and stores references to
     /// global matrix and the right-hand-side.
-    template <typename GlobalSetup>
+    template <typename GlobalSetup, unsigned GlobalDim>
     void
     initialize(GlobalSetup const& global_setup,
         typename GlobalSetup::MatrixType& A,
@@ -102,7 +117,8 @@ public:
             LocalNeumannBcAsmDataInterface,
             LocalNeumannBcAsmData,
             typename GlobalSetup::MatrixType,
-            typename GlobalSetup::VectorType>;
+            typename GlobalSetup::VectorType,
+            GlobalDim>;
 
         LocalDataInitializer initializer;
 

--- a/ProcessLib/NeumannBcAssembler.h
+++ b/ProcessLib/NeumannBcAssembler.h
@@ -39,15 +39,16 @@ public:
 template <typename ShapeFunction_,
          typename IntegrationMethod_,
          typename GlobalMatrix,
-         typename GlobalVector>
+         typename GlobalVector,
+         unsigned GlobalDim>
 class LocalNeumannBcAsmData : public LocalNeumannBcAsmDataInterface<GlobalMatrix, GlobalVector>
 {
 public:
     using ShapeFunction = ShapeFunction_;
-    using NodalMatrixType = typename ShapeMatrixPolicyType<ShapeFunction>::NodalMatrixType;
-    using NodalVectorType = typename ShapeMatrixPolicyType<ShapeFunction>::NodalVectorType;
+    using NodalMatrixType = typename ShapeMatrixPolicyType<ShapeFunction,GlobalDim>::NodalMatrixType;
+    using NodalVectorType = typename ShapeMatrixPolicyType<ShapeFunction,GlobalDim>::NodalVectorType;
 
-    using ShapeMatricesType = ShapeMatrixPolicyType<ShapeFunction>;
+    using ShapeMatricesType = ShapeMatrixPolicyType<ShapeFunction,GlobalDim>;
     using ShapeMatrices = typename ShapeMatricesType::ShapeMatrices;
 
     /// The neumann_bc_value factor is directly integrated into the local

--- a/Tests/NumLib/CoordinatesMappingTestData/TestHex8.h
+++ b/Tests/NumLib/CoordinatesMappingTestData/TestHex8.h
@@ -21,6 +21,7 @@ class TestHex8
     // Element information
     typedef MeshLib::Hex ElementType;
     typedef NumLib::ShapeHex8 ShapeFunctionType;
+    static const unsigned global_dim = ElementType::dimension;
     static const unsigned dim = 3; //ElementType::dimension;
     static const unsigned e_nnodes = ElementType::n_all_nodes;
     // Coordinates where shape functions are evaluated

--- a/Tests/NumLib/CoordinatesMappingTestData/TestLine2.h
+++ b/Tests/NumLib/CoordinatesMappingTestData/TestLine2.h
@@ -76,6 +76,15 @@ public:
         nodes[1] = new MeshLib::Node(0.0, 0.0, 0.0);
         return new MeshLib::Line(nodes);
     }
+
+    // 1.5d line
+    static MeshLib::Line* createY()
+    {
+        MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
+        nodes[0] = new MeshLib::Node(0.0, -1.0, 0.0);
+        nodes[1] = new MeshLib::Node(0.0,  1.0, 0.0);
+        return new MeshLib::Line(nodes);
+    }
 };
 
 const double TestLine2::r[dim] = {0.5};

--- a/Tests/NumLib/CoordinatesMappingTestData/TestLine2.h
+++ b/Tests/NumLib/CoordinatesMappingTestData/TestLine2.h
@@ -21,6 +21,7 @@ public:
     // Element information
     typedef MeshLib::Line ElementType;
     typedef NumLib::ShapeLine2 ShapeFunctionType;
+    static const unsigned global_dim = ElementType::dimension;
     static const unsigned dim = ElementType::dimension;
     static const unsigned e_nnodes = ElementType::n_all_nodes;
     // Coordinates where shape functions are evaluated

--- a/Tests/NumLib/CoordinatesMappingTestData/TestQuad4.h
+++ b/Tests/NumLib/CoordinatesMappingTestData/TestQuad4.h
@@ -21,6 +21,7 @@ class TestQuad4
     // Element information
     typedef MeshLib::Quad ElementType;
     typedef NumLib::ShapeQuad4 ShapeFunctionType;
+    static const unsigned global_dim = ElementType::dimension;
     static const unsigned dim = 2; //ElementType::dimension;
     static const unsigned e_nnodes = ElementType::n_all_nodes;
     // Coordinates where shape functions are evaluated

--- a/Tests/NumLib/CoordinatesMappingTestData/TestTri3.h
+++ b/Tests/NumLib/CoordinatesMappingTestData/TestTri3.h
@@ -21,6 +21,7 @@ class TestTri3
     // Element information
     typedef MeshLib::Tri ElementType;
     typedef NumLib::ShapeTri3 ShapeFunctionType;
+    static const unsigned global_dim = ElementType::dimension;
     static const unsigned dim = 2; //ElementType::dimension;
     static const unsigned e_nnodes = ElementType::n_all_nodes;
     // Coordinates where shape functions are evaluated

--- a/Tests/NumLib/FeTestData/TestFeHEX8.h
+++ b/Tests/NumLib/FeTestData/TestFeHEX8.h
@@ -33,6 +33,7 @@ public:
     static const unsigned e_nnodes = MeshElementType::n_all_nodes;
     static const unsigned n_sample_pt_order2 = 2*2*2;
     static const unsigned n_sample_pt_order3 = 3*3*3;
+    static const unsigned global_dim = MeshElementType::dimension;
 
     /// create a mesh element
     MeshLib::Hex* createMeshElement()

--- a/Tests/NumLib/FeTestData/TestFeLINE2.h
+++ b/Tests/NumLib/FeTestData/TestFeLINE2.h
@@ -33,6 +33,7 @@ public:
     static const unsigned e_nnodes = MeshElementType::n_all_nodes;
     static const unsigned n_sample_pt_order2 = 2;
     static const unsigned n_sample_pt_order3 = 3;
+    static const unsigned global_dim = MeshElementType::dimension;
 
     /// create a mesh element
     MeshLib::Line* createMeshElement()

--- a/Tests/NumLib/FeTestData/TestFeLINE3.h
+++ b/Tests/NumLib/FeTestData/TestFeLINE3.h
@@ -32,6 +32,7 @@ public:
     static const unsigned e_nnodes = MeshElementType::n_all_nodes;
     static const unsigned n_sample_pt_order2 = 2;
     static const unsigned n_sample_pt_order3 = 3;
+    static const unsigned global_dim = MeshElementType::dimension;
 
     /// create a mesh element
     MeshElementType* createMeshElement()

--- a/Tests/NumLib/FeTestData/TestFePRISM6.h
+++ b/Tests/NumLib/FeTestData/TestFePRISM6.h
@@ -32,6 +32,7 @@ public:
     static const unsigned e_nnodes = MeshElementType::n_all_nodes;
     static const unsigned n_sample_pt_order2 = 6;
     static const unsigned n_sample_pt_order3 = 6; //TODO no implementation yet
+    static const unsigned global_dim = MeshElementType::dimension;
 
     /// create a mesh element
     MeshElementType* createMeshElement()

--- a/Tests/NumLib/FeTestData/TestFePYRA5.h
+++ b/Tests/NumLib/FeTestData/TestFePYRA5.h
@@ -32,6 +32,7 @@ public:
     static const unsigned e_nnodes = MeshElementType::n_all_nodes;
     static const unsigned n_sample_pt_order2 = 5;
     static const unsigned n_sample_pt_order3 = 13;
+    static const unsigned global_dim = MeshElementType::dimension;
 
     /// create a mesh element
     MeshElementType* createMeshElement()

--- a/Tests/NumLib/FeTestData/TestFeQUAD4.h
+++ b/Tests/NumLib/FeTestData/TestFeQUAD4.h
@@ -33,6 +33,7 @@ public:
     static const unsigned e_nnodes = MeshElementType::n_all_nodes;
     static const unsigned n_sample_pt_order2 = 2*2;
     static const unsigned n_sample_pt_order3 = 3*3;
+    static const unsigned global_dim = MeshElementType::dimension;
 
     /// create a mesh element
     MeshLib::Quad* createMeshElement()

--- a/Tests/NumLib/FeTestData/TestFeTET4.h
+++ b/Tests/NumLib/FeTestData/TestFeTET4.h
@@ -32,6 +32,7 @@ public:
     static const unsigned e_nnodes = MeshElementType::n_all_nodes;
     static const unsigned n_sample_pt_order2 = 5;
     static const unsigned n_sample_pt_order3 = 15;
+    static const unsigned global_dim = MeshElementType::dimension;
 
     /// create a mesh element
     MeshElementType* createMeshElement()

--- a/Tests/NumLib/FeTestData/TestFeTRI3.h
+++ b/Tests/NumLib/FeTestData/TestFeTRI3.h
@@ -33,6 +33,7 @@ public:
     static const unsigned e_nnodes = MeshElementType::n_all_nodes;
     static const unsigned n_sample_pt_order2 = 3;
     static const unsigned n_sample_pt_order3 = 4;
+    static const unsigned global_dim = MeshElementType::dimension;
 
     /// create a mesh element
     MeshElementType* createMeshElement()

--- a/Tests/NumLib/TestCoordinatesMapping.cpp
+++ b/Tests/NumLib/TestCoordinatesMapping.cpp
@@ -83,7 +83,7 @@ public:
                 vec_nodes.push_back(e->getNode(i));
     }
 
-    ~NumLibFemNaturalCoordinatesMappingTest()
+    virtual ~NumLibFemNaturalCoordinatesMappingTest()
     {
         for (auto itr = vec_nodes.begin(); itr!=vec_nodes.end(); ++itr )
             delete *itr;
@@ -280,4 +280,36 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckZeroVolume)
     ASSERT_ARRAY_NEAR(exp_dNdx, shape.dNdx.data(), shape.dNdx.size(), this->eps);
 }
 
+TEST(NumLib, FemNaturalCoordinatesMappingLineY)
+{
+#ifdef OGS_USE_EIGEN
+	typedef Eigen::Matrix<double, 2, 1> NodalVector;
+	typedef Eigen::Matrix<double, 1, 2, Eigen::RowMajor> DimNodalMatrix;
+	typedef Eigen::Matrix<double, 1, 1, Eigen::RowMajor> DimMatrix;
+	typedef Eigen::Matrix<double, 2, 2, Eigen::RowMajor> GlobalDimNodalMatrix;
+#endif
+	// Shape data type
+	typedef ShapeMatrices<NodalVector,DimNodalMatrix,DimMatrix,GlobalDimNodalMatrix> ShapeMatricesType;
+	typedef NaturalCoordinatesMapping<MeshLib::Line, ShapeLine2, ShapeMatricesType> MappingType;
+	double r[] = {0.5};
+	auto line = TestLine2::createY();
+	static const unsigned dim = 1;
+	static const unsigned e_nnodes = 2;
+	ShapeMatricesType shape(dim, 2, e_nnodes);
+	MappingType::computeShapeMatrices(*line, r, shape);
 
+	double exp_J[dim*dim]= {0.0};
+	for (unsigned i=0; i<dim; i++)
+		exp_J[i+dim*i] = 1.0;
+
+	const double eps(std::numeric_limits<double>::epsilon());
+	ASSERT_ARRAY_NEAR(TestLine2::nat_exp_N, shape.N.data(), shape.N.size(), eps);
+	ASSERT_ARRAY_NEAR(TestLine2::nat_exp_dNdr, shape.dNdr.data(), shape.dNdr.size(), eps);
+	ASSERT_ARRAY_NEAR(exp_J, shape.J.data(), shape.J.size(), eps);
+	ASSERT_ARRAY_NEAR(exp_J, shape.invJ.data(), shape.invJ.size(), eps);
+	ASSERT_NEAR(1.0, shape.detJ, eps);
+	double exp_dNdx[2*e_nnodes] = {0, 0, -0.5, 0.5};
+	ASSERT_ARRAY_NEAR(exp_dNdx, shape.dNdx.data(), shape.dNdx.size(), eps);
+
+	delete line;
+}

--- a/Tests/NumLib/TestCoordinatesMapping.cpp
+++ b/Tests/NumLib/TestCoordinatesMapping.cpp
@@ -50,14 +50,16 @@ public:
     typedef typename T_TEST::ShapeFunctionType ShapeFunctionType;
     static const unsigned dim = T_TEST::dim;
     static const unsigned e_nnodes = T_TEST::e_nnodes;
+    static const unsigned global_dim = T_TEST::global_dim;
     // Matrix types
 #ifdef OGS_USE_EIGEN
     typedef Eigen::Matrix<double, e_nnodes, 1> NodalVector;
     typedef Eigen::Matrix<double, dim, e_nnodes, Eigen::RowMajor> DimNodalMatrix;
     typedef Eigen::Matrix<double, dim, dim, Eigen::RowMajor> DimMatrix;
+    typedef Eigen::Matrix<double, global_dim, e_nnodes, Eigen::RowMajor> GlobalDimNodalMatrix;
 #endif
     // Shape data type
-    typedef ShapeMatrices<NodalVector,DimNodalMatrix,DimMatrix> ShapeMatricesType;
+    typedef ShapeMatrices<NodalVector,DimNodalMatrix,DimMatrix,GlobalDimNodalMatrix> ShapeMatricesType;
     // Natural coordinates mapping type
     typedef NaturalCoordinatesMapping<ElementType, ShapeFunctionType, ShapeMatricesType> NaturalCoordsMappingType;
 

--- a/Tests/NumLib/TestFe.cpp
+++ b/Tests/NumLib/TestFe.cpp
@@ -38,13 +38,14 @@ namespace
 {
 
 // test cases
-template <class TestFeType_, template <typename> class ShapeMatrixPolicy_>
+template <class TestFeType_, template <typename, unsigned> class ShapeMatrixPolicy_>
 struct TestCase
 {
     typedef TestFeType_ TestFeType;
-    typedef ShapeMatrixPolicy_<typename TestFeType::ShapeFunction> ShapeMatrixTypes;
+    static const unsigned GlobalDim = TestFeType::global_dim;
+    using ShapeMatrixTypes = ShapeMatrixPolicy_<typename TestFeType::ShapeFunction, GlobalDim>;
     template <typename X>
-    using ShapeMatrixPolicy = ShapeMatrixPolicy_<X>;
+    using ShapeMatrixPolicy = ShapeMatrixPolicy_<X, GlobalDim>;
 };
 
 typedef ::testing::Types<

--- a/Tests/NumLib/TestShapeMatrices.cpp
+++ b/Tests/NumLib/TestShapeMatrices.cpp
@@ -34,7 +34,7 @@ TEST(NumLib, FemShapeMatricesWithEigen)
     typedef Eigen::Matrix<double, dim, dim, Eigen::RowMajor> DimMatrix;
 
     // Shape data type
-    typedef ShapeMatrices<NodalVector,DimNodalMatrix,DimMatrix> ShapeMatricesType;
+    typedef ShapeMatrices<NodalVector,DimNodalMatrix,DimMatrix,DimNodalMatrix> ShapeMatricesType;
 
     auto setShapeDataToOnes = [](ShapeMatricesType &shape)
             {


### PR DESCRIPTION
@endJunction sorry i forgot to upload implementations supporting mixed dimensional elements in FE part. your #698 can be merged at the moment, as it should be no problem with neumann BCs because it doesn't require dshape. To really support mixed dim ele in groundwaterflow, we need something like this PR.