### PR TITLE
Speedup element coordinates mapping

### DIFF
--- a/GeoLib/AnalyticalGeometry-impl.h
+++ b/GeoLib/AnalyticalGeometry-impl.h
@@ -33,6 +33,28 @@ void getNewellPlane (const std::vector<T_POINT*>& pnts,
     d = MathLib::scalarProduct(centroid, plane_normal) / n_pnts;
 }
 
+template <class T_POINT>
+std::pair<MathLib::Vector3, double> getNewellPlane (const std::vector<T_POINT>& pnts)
+{
+    MathLib::Vector3 plane_normal;
+    MathLib::Vector3 centroid;
+    std::size_t n_pnts(pnts.size());
+    for (std::size_t i = n_pnts - 1, j = 0; j < n_pnts; i = j, j++) {
+        plane_normal[0] += (pnts[i][1] - pnts[j][1])
+                           * (pnts[i][2] + pnts[j][2]); // projection on yz
+        plane_normal[1] += (pnts[i][2] - pnts[j][2])
+                           * (pnts[i][0] + pnts[j][0]); // projection on xz
+        plane_normal[2] += (pnts[i][0] - pnts[j][0])
+                           * (pnts[i][1] + pnts[j][1]); // projection on xy
+
+        centroid += pnts[j];
+    }
+
+    plane_normal.normalize();
+    double d = MathLib::scalarProduct(centroid, plane_normal) / n_pnts;
+    return std::make_pair(plane_normal, d);
+}
+
 template<class T_MATRIX>
 void compute2DRotationMatrixToX(MathLib::Vector3 const& v,
         T_MATRIX & rot_mat)

--- a/GeoLib/AnalyticalGeometry.h
+++ b/GeoLib/AnalyticalGeometry.h
@@ -66,6 +66,11 @@ void getNewellPlane (const std::vector<T_POINT*>& pnts,
                      MathLib::Vector3 &plane_normal,
                      double& d);
 
+/** Same as getNewellPlane(pnts, plane_normal, d).
+ */
+template <class T_POINT>
+std::pair<MathLib::Vector3, double> getNewellPlane(const std::vector<T_POINT>& pnts);
+
 /**
  * Computes a rotation matrix that rotates the given 2D normal vector parallel to X-axis
  * @param v        a 2D normal vector to be rotated

--- a/MeshLib/ElementCoordinatesMappingLocal.cpp
+++ b/MeshLib/ElementCoordinatesMappingLocal.cpp
@@ -70,11 +70,6 @@ void getRotationMatrixToGlobal(
 namespace MeshLib
 {
 
-ElementCoordinatesMappingLocal::~ElementCoordinatesMappingLocal()
-{
-    for (auto p : _vec_nodes) delete p;
-}
-
 ElementCoordinatesMappingLocal::ElementCoordinatesMappingLocal(
     const Element& e,
     const CoordinateSystem &global_coords)

--- a/MeshLib/ElementCoordinatesMappingLocal.cpp
+++ b/MeshLib/ElementCoordinatesMappingLocal.cpp
@@ -16,48 +16,28 @@
 #include "MeshLib/Elements/Element.h"
 #include "MeshLib/Node.h"
 #include "MathLib/MathTools.h"
+#include "MathLib/Point3d.h"
 #include "MathLib/Vector3.h"
 
-namespace MeshLib
+namespace detail
 {
 
-ElementCoordinatesMappingLocal::ElementCoordinatesMappingLocal(
-    const Element& e,
-    const CoordinateSystem &global_coords)
-: _coords(global_coords), _matR2global(3,3)
+/// rotate points to local coordinates
+void rotateToLocal(
+    const MeshLib::RotationMatrix &matR2local,
+    std::vector<MathLib::Point3d*> &vec_nodes)
 {
-    assert(e.getDimension() <= global_coords.getDimension());
-    for(unsigned i = 0; i < e.getNNodes(); i++)
-        _vec_nodes.push_back(new MeshLib::Node(*(e.getNode(i))));
-
-    getRotationMatrixToGlobal(e, global_coords, _vec_nodes, _matR2global);
-#ifdef OGS_USE_EIGEN
-    rotateToLocal(_matR2global.transpose(), _vec_nodes);
-#else
-    RotationMatrix* m(_matR2global.transpose());
-    rotateToLocal(*m, _vec_nodes);
-    delete m;
-#endif
+    for (auto node : vec_nodes)
+        node->setCoords((matR2local*(*node)).getCoords());
 }
 
-ElementCoordinatesMappingLocal::~ElementCoordinatesMappingLocal()
-{
-    for (auto p : _vec_nodes) delete p;
-}
-
-void ElementCoordinatesMappingLocal::rotateToLocal(
-    const RotationMatrix &matR2local,
-    std::vector<MeshLib::Node*> &vec_nodes) const
-{
-    for (MeshLib::Node* node : vec_nodes)
-        node->setCoords((matR2local*static_cast<MathLib::Point3d>(*node)).getCoords());
-}
-
-void ElementCoordinatesMappingLocal::getRotationMatrixToGlobal(
-    const Element &e,
-    const CoordinateSystem &global_coords,
-    const std::vector<MeshLib::Node*> &vec_nodes,
-    RotationMatrix &matR) const
+/// get a rotation matrix to the global coordinates
+/// it computes R in x=R*x' where x is original coordinates and x' is local coordinates
+void getRotationMatrixToGlobal(
+    const MeshLib::Element &e,
+    const MeshLib::CoordinateSystem &global_coords,
+    const std::vector<MathLib::Point3d*> &vec_nodes,
+    MeshLib::RotationMatrix &matR)
 {
     const std::size_t global_dim = global_coords.getDimension();
 
@@ -76,13 +56,44 @@ void ElementCoordinatesMappingLocal::getRotationMatrixToGlobal(
         // get plane normal
         MathLib::Vector3 plane_normal;
         double d;
-        GeoLib::getNewellPlane (vec_nodes, plane_normal, d);
+        //std::tie(plane_normal, d) = GeoLib::getNewellPlane(vec_nodes);
+        GeoLib::getNewellPlane(vec_nodes, plane_normal, d);
+
         // compute a rotation matrix to XY
         GeoLib::computeRotationMatrixToXY(plane_normal, matR);
         // set a transposed matrix
         matR.transposeInPlace();
     }
 
+}
+}   // namespace detail
+
+namespace MeshLib
+{
+
+ElementCoordinatesMappingLocal::~ElementCoordinatesMappingLocal()
+{
+    for (auto p : _vec_nodes) delete p;
+}
+
+ElementCoordinatesMappingLocal::ElementCoordinatesMappingLocal(
+    const Element& e,
+    const CoordinateSystem &global_coords)
+: _coords(global_coords), _matR2global(3,3)
+{
+    assert(e.getDimension() <= global_coords.getDimension());
+    _vec_nodes.reserve(e.getNNodes());
+    for(unsigned i = 0; i < e.getNNodes(); i++)
+        _vec_nodes.push_back(new MathLib::Point3d(*static_cast<MathLib::Point3d const*>(e.getNode(i))));
+
+    detail::getRotationMatrixToGlobal(e, global_coords, _vec_nodes, _matR2global);
+#ifdef OGS_USE_EIGEN
+    detail::rotateToLocal(_matR2global.transpose(), _vec_nodes);
+#else
+    RotationMatrix* m(_matR2global.transpose());
+    detail::rotateToLocal(*m, _vec_nodes);
+    delete m;
+#endif
 }
 
 } // MeshLib

--- a/MeshLib/ElementCoordinatesMappingLocal.cpp
+++ b/MeshLib/ElementCoordinatesMappingLocal.cpp
@@ -35,16 +35,12 @@ void rotateToLocal(
 /// it computes R in x=R*x' where x is original coordinates and x' is local coordinates
 void getRotationMatrixToGlobal(
     const unsigned element_dimension,
-    const MeshLib::CoordinateSystem &global_coords,
+    const unsigned global_dim,
     const std::vector<MathLib::Point3d> &points,
     MeshLib::RotationMatrix &matR)
 {
-    const std::size_t global_dim = global_coords.getDimension();
-
     // compute R in x=R*x' where x are original coordinates and x' are local coordinates
-    if (global_dim == element_dimension) {
-        matR.setIdentity();
-    } else if (element_dimension == 1) {
+    if (element_dimension == 1) {
         MathLib::Vector3 xx(points[0], points[1]);
         xx.normalize();
         if (global_dim == 2)
@@ -80,7 +76,16 @@ ElementCoordinatesMappingLocal::ElementCoordinatesMappingLocal(
     for(unsigned i = 0; i < e.getNNodes(); i++)
         _points.emplace_back(e.getNode(i)->getCoords());
 
-    detail::getRotationMatrixToGlobal(e.getDimension(), global_coords, _points, _matR2global);
+    auto const element_dimension = e.getDimension();
+    auto const global_dimension = global_coords.getDimension();
+
+    if (global_dimension == element_dimension)
+    {
+        _matR2global.setIdentity();
+        return;
+    }
+
+    detail::getRotationMatrixToGlobal(element_dimension, global_dimension, _points, _matR2global);
 #ifdef OGS_USE_EIGEN
     detail::rotateToLocal(_matR2global.transpose(), _points);
 #else

--- a/MeshLib/ElementCoordinatesMappingLocal.cpp
+++ b/MeshLib/ElementCoordinatesMappingLocal.cpp
@@ -13,8 +13,10 @@
 
 #include "GeoLib/AnalyticalGeometry.h"
 
-#include "MathLib/MathTools.h"
+#include "MeshLib/Elements/Element.h"
 #include "MeshLib/Node.h"
+#include "MathLib/MathTools.h"
+#include "MathLib/Vector3.h"
 
 namespace MeshLib
 {

--- a/MeshLib/ElementCoordinatesMappingLocal.cpp
+++ b/MeshLib/ElementCoordinatesMappingLocal.cpp
@@ -34,7 +34,7 @@ void rotateToLocal(
 /// get a rotation matrix to the global coordinates
 /// it computes R in x=R*x' where x is original coordinates and x' is local coordinates
 void getRotationMatrixToGlobal(
-    const MeshLib::Element &e,
+    const unsigned element_dimension,
     const MeshLib::CoordinateSystem &global_coords,
     const std::vector<MathLib::Point3d> &points,
     MeshLib::RotationMatrix &matR)
@@ -42,9 +42,9 @@ void getRotationMatrixToGlobal(
     const std::size_t global_dim = global_coords.getDimension();
 
     // compute R in x=R*x' where x are original coordinates and x' are local coordinates
-    if (global_dim == e.getDimension()) {
+    if (global_dim == element_dimension) {
         matR.setIdentity();
-    } else if (e.getDimension() == 1) {
+    } else if (element_dimension == 1) {
         MathLib::Vector3 xx(points[0], points[1]);
         xx.normalize();
         if (global_dim == 2)
@@ -52,7 +52,7 @@ void getRotationMatrixToGlobal(
         else
             GeoLib::compute3DRotationMatrixToX(xx, matR);
         matR.transposeInPlace();
-    } else if (global_dim == 3 && e.getDimension() == 2) {
+    } else if (global_dim == 3 && element_dimension == 2) {
         // get plane normal
         MathLib::Vector3 plane_normal;
         double d;
@@ -80,7 +80,7 @@ ElementCoordinatesMappingLocal::ElementCoordinatesMappingLocal(
     for(unsigned i = 0; i < e.getNNodes(); i++)
         _points.emplace_back(e.getNode(i)->getCoords());
 
-    detail::getRotationMatrixToGlobal(e, global_coords, _points, _matR2global);
+    detail::getRotationMatrixToGlobal(e.getDimension(), global_coords, _points, _matR2global);
 #ifdef OGS_USE_EIGEN
     detail::rotateToLocal(_matR2global.transpose(), _points);
 #else

--- a/MeshLib/ElementCoordinatesMappingLocal.h
+++ b/MeshLib/ElementCoordinatesMappingLocal.h
@@ -13,17 +13,21 @@
 
 #ifdef OGS_USE_EIGEN
 #include <Eigen/Eigen>
+#else
+#include "MathLib/LinAlg/Dense/DenseMatrix.h"
 #endif
 
-#include "MathLib/Vector3.h"
-#include "MathLib/LinAlg/Dense/DenseMatrix.h"
+#include "MathLib/Point3d.h"
 
-#include "MeshLib/Elements/Element.h"
 #include "MeshLib/CoordinateSystem.h"
 
 namespace MeshLib
 {
+    class Element;
+}
 
+namespace MeshLib
+{
 #ifdef OGS_USE_EIGEN
 typedef Eigen::Matrix<double, 3u, 3u, Eigen::RowMajor> RotationMatrix;
 #else

--- a/MeshLib/ElementCoordinatesMappingLocal.h
+++ b/MeshLib/ElementCoordinatesMappingLocal.h
@@ -54,27 +54,17 @@ public:
     const CoordinateSystem getGlobalCoordinateSystem() const { return _coords; }
 
     /// return mapped coordinates of the node
-    const MeshLib::Node* getMappedCoordinates(size_t node_id) const
+    MathLib::Point3d const& getMappedCoordinates(std::size_t node_id) const
     {
-        return _vec_nodes[node_id];
+        return *_vec_nodes[node_id];
     }
 
     /// return a rotation matrix converting to global coordinates
     const RotationMatrix& getRotationMatrixToGlobal() const {return _matR2global;}
 
 private:
-    /// rotate points to local coordinates
-    void rotateToLocal(const RotationMatrix &matR2local, std::vector<MeshLib::Node*> &vec_pt) const;
-
-    /// get a rotation matrix to the global coordinates
-    /// it computes R in x=R*x' where x is original coordinates and x' is local coordinates
-    void getRotationMatrixToGlobal(
-            const Element &e, const CoordinateSystem &coordinate_system,
-            const std::vector<MeshLib::Node*> &vec_pt, RotationMatrix &matR2original) const;
-
-private:
     const CoordinateSystem _coords;
-    std::vector<MeshLib::Node*> _vec_nodes;
+    std::vector<MathLib::Point3d*> _vec_nodes;
     RotationMatrix _matR2global;
 };
 

--- a/MeshLib/ElementCoordinatesMappingLocal.h
+++ b/MeshLib/ElementCoordinatesMappingLocal.h
@@ -56,7 +56,7 @@ public:
     /// return mapped coordinates of the node
     MathLib::Point3d const& getMappedCoordinates(std::size_t node_id) const
     {
-        return *_vec_nodes[node_id];
+        return _points[node_id];
     }
 
     /// return a rotation matrix converting to global coordinates
@@ -64,7 +64,7 @@ public:
 
 private:
     const CoordinateSystem _coords;
-    std::vector<MathLib::Point3d*> _vec_nodes;
+    std::vector<MathLib::Point3d> _points;
     RotationMatrix _matR2global;
 };
 

--- a/MeshLib/ElementCoordinatesMappingLocal.h
+++ b/MeshLib/ElementCoordinatesMappingLocal.h
@@ -37,7 +37,7 @@ typedef MathLib::DenseMatrix<double> RotationMatrix;
 /**
  * This class maps node coordinates on intrinsic coordinates of the given element.
  */
-class ElementCoordinatesMappingLocal
+class ElementCoordinatesMappingLocal final
 {
 public:
     /**
@@ -46,9 +46,6 @@ public:
      * \param global_coord_system   Global coordinate system
      */
     ElementCoordinatesMappingLocal(const Element &e, const CoordinateSystem &global_coord_system);
-
-    /// Destructor
-    virtual ~ElementCoordinatesMappingLocal();
 
     /// return the global coordinate system
     const CoordinateSystem getGlobalCoordinateSystem() const { return _coords; }

--- a/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping-impl.h
+++ b/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping-impl.h
@@ -67,7 +67,7 @@ inline void computeMappingMatrices(
 
     //jacobian: J=[dx/dr dy/dr // dx/ds dy/ds]
     for (std::size_t k=0; k<nnodes; k++) {
-        const MeshLib::Node& mapped_pt = *ele_local_coord.getMappedCoordinates(k);
+        const MathLib::Point3d& mapped_pt = ele_local_coord.getMappedCoordinates(k);
         // outer product of dNdr and mapped_pt for a particular node
         for (std::size_t i_r=0; i_r<dim; i_r++) {
             for (std::size_t j_x=0; j_x<dim; j_x++) {

--- a/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
+++ b/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
@@ -141,7 +141,7 @@ void debugOutput(MeshLib::Element *ele, MeshLib::ElementCoordinatesMappingLocal 
 // check if using the rotation matrix results in the original coordinates
 #define CHECK_COORDS(ele, mapping)\
     for (unsigned ii=0; ii<ele->getNNodes(); ii++) {\
-    	MathLib::Point3d global(matR*static_cast<MathLib::Point3d>(*mapping.getMappedCoordinates(ii)));\
+        MathLib::Point3d global(matR*mapping.getMappedCoordinates(ii));\
         const double eps(std::numeric_limits<double>::epsilon());\
         ASSERT_ARRAY_NEAR(&(*ele->getNode(ii))[0], global.getCoords(), 3u, eps);\
     }


### PR DESCRIPTION
__Merge after__ ufz/ogs#706.

Based on measurements in ufz/ogs#702 following is achieved:
old measurements:

          | dirichlet 1e4 | neumann 1e4   | neumann 1e5
----------|-----------|-------------|-----------
master    |848,454,453|1,118,595,144|21,346,872,940
lower_dim |941,440,774|1,200,626,996|22,149,452,336
diff      |92,986,321 |82,031,852   | 802,579,396

current measurements:

          | dirichlet 1e4 | neumann 1e4   | neumann 1e5
----------|-----------|-------------|-----------
lower_dim |941,440,774|1,200,626,996|22,149,452,336
speedupECM |884,765,064|1,143,814,590|21,577,168,825
diff      |-56,675,710 |-56,812,406   | -572,283,511
