### PR TITLE
Optimization of AABB

### DIFF
--- a/Applications/DataExplorer/DataView/ElementTreeModel.cpp
+++ b/Applications/DataExplorer/DataView/ElementTreeModel.cpp
@@ -140,8 +140,8 @@ void ElementTreeModel::setMesh(MeshLib::Mesh const*const mesh)
 	_rootItem->appendChild(aabb_item);
 
 	const GeoLib::AABB<MeshLib::Node> aabb (MeshLib::MeshInformation::getBoundingBox(*mesh));
-	const MeshLib::Node& min = aabb.getMinPoint();
-	const MeshLib::Node& max = aabb.getMaxPoint();
+	auto const& min = aabb.getMinPoint();
+	auto const& max = aabb.getMaxPoint();
 
 	QList<QVariant> min_aabb;
 	min_aabb << "Min:" << QString::number(min[0], 'f') << QString::number(min[1], 'f') << QString::number(min[2], 'f');

--- a/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
@@ -79,8 +79,8 @@ void MeshElementRemovalDialog::accept()
 	{
 		std::vector<MeshLib::Node*> const& nodes (_project.getMesh(this->meshNameComboBox->currentText().toStdString())->getNodes());
 		GeoLib::AABB<MeshLib::Node> const aabb(nodes.begin(), nodes.end());
-		MeshLib::Node minAABB = aabb.getMinPoint();
-		MeshLib::Node maxAABB = aabb.getMaxPoint();
+		auto minAABB = aabb.getMinPoint();
+		auto maxAABB = aabb.getMaxPoint();
 
 		// only extract bounding box parameters that have been edited (otherwise there will be rounding errors!)
 		minAABB[0] = (aabb_edits[0]) ? this->xMinEdit->text().toDouble() : (minAABB[0]);
@@ -89,7 +89,11 @@ void MeshElementRemovalDialog::accept()
 		maxAABB[1] = (aabb_edits[3]) ? this->yMaxEdit->text().toDouble() : (maxAABB[1]);
 		minAABB[2] = (aabb_edits[4]) ? this->zMinEdit->text().toDouble() : (minAABB[2]);
 		maxAABB[2] = (aabb_edits[5]) ? this->zMaxEdit->text().toDouble() : (maxAABB[2]);
-		ex.searchByBoundingBox(minAABB, maxAABB);
+		std::vector<MathLib::Point3d> extent;
+		extent.push_back(minAABB);
+		extent.push_back(maxAABB);
+		const GeoLib::AABB<MathLib::Point3d> updated_aabb(extent.begin(), extent.end());
+		ex.searchByBoundingBox(updated_aabb);
 		anything_checked = true;
 	}
 
@@ -140,8 +144,8 @@ void MeshElementRemovalDialog::on_boundingBoxCheckBox_toggled(bool is_checked)
 		_aabbIndex = _currentIndex;
 		std::vector<MeshLib::Node*> const& nodes (_project.getMesh(this->meshNameComboBox->currentText().toStdString())->getNodes());
 		GeoLib::AABB<MeshLib::Node> aabb(nodes.begin(), nodes.end());
-		MeshLib::Node const minAABB = aabb.getMinPoint();
-		MeshLib::Node const maxAABB = aabb.getMaxPoint();
+		auto const& minAABB = aabb.getMinPoint();
+		auto const& maxAABB = aabb.getMaxPoint();
 		this->xMinEdit->setText(QString::number(minAABB[0], 'f'));
 		this->xMaxEdit->setText(QString::number(maxAABB[0], 'f'));
 		this->yMinEdit->setText(QString::number(minAABB[1], 'f'));

--- a/Applications/Utils/MeshEdit/moveMeshNodes.cpp
+++ b/Applications/Utils/MeshEdit/moveMeshNodes.cpp
@@ -37,7 +37,8 @@ int find_closest_point(MeshLib::Node const*const point, std::vector<MeshLib::Nod
 	return idx;
 }
 
-bool containsPoint(MeshLib::Node const& pnt, MeshLib::Node const& min, MeshLib::Node const& max)
+bool containsPoint(MeshLib::Node const& pnt, MathLib::Point3d const& min,
+	MathLib::Point3d const& max)
 {
 	if (pnt[0] < min[0] || max[0] < pnt[0]) return false;
 	if (pnt[1] < min[1] || max[1] < pnt[1]) return false;
@@ -140,8 +141,8 @@ int main (int argc, char* argv[])
 		MeshLib::Mesh* ground_truth (FileIO::readMeshFromFile(value));
 		const std::vector<MeshLib::Node*> ground_truth_nodes (ground_truth->getNodes());
 		GeoLib::AABB<MeshLib::Node> bounding_box(ground_truth_nodes.begin(), ground_truth_nodes.end());
-		const MeshLib::Node min (bounding_box.getMinPoint());
-		const MeshLib::Node max (bounding_box.getMaxPoint());
+		MathLib::Point3d const& min(bounding_box.getMinPoint());
+		MathLib::Point3d const& max(bounding_box.getMaxPoint());
 
 		const size_t nNodes(mesh->getNNodes());
 		std::vector<MeshLib::Node*> nodes (mesh->getNodes());

--- a/Applications/Utils/MeshEdit/removeMeshElements.cpp
+++ b/Applications/Utils/MeshEdit/removeMeshElements.cpp
@@ -131,9 +131,13 @@ int main (int argc, char* argv[])
 		if (aabb_error)
 		    return 1;
 
-		MeshLib::Node ll (xSmallArg.getValue(), ySmallArg.getValue(), zSmallArg.getValue());
-		MeshLib::Node ur (xLargeArg.getValue(), yLargeArg.getValue(), zLargeArg.getValue());
-		const std::size_t n_removed_elements = ex.searchByBoundingBox(ll, ur);
+		std::array<MathLib::Point3d, 2> extent({{
+			MathLib::Point3d(std::array<double,3>{{xSmallArg.getValue(),
+				ySmallArg.getValue(), zSmallArg.getValue()}}),
+			MathLib::Point3d(std::array<double,3>{{xLargeArg.getValue(),
+				yLargeArg.getValue(), zLargeArg.getValue()}})}});
+		const std::size_t n_removed_elements = ex.searchByBoundingBox(
+			GeoLib::AABB<MathLib::Point3d>(extent.begin(), extent.end()));
 		INFO("%d elements found.", n_removed_elements);
 	}
 

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <vector>
 
+#include "MathLib/Point3d.h"
 #include "MathLib/MathTools.h"
 #include "Point.h"
 
@@ -41,8 +42,12 @@ public:
 	 * construction of object, initialization the axis aligned bounding box
 	 * */
 	AABB(std::vector<PNT_TYPE*> const& pnts, std::vector<std::size_t> const& ids) :
-		_min_pnt(std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max()),
-		_max_pnt(std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest())
+		_min_pnt(std::array<double,3>{{std::numeric_limits<double>::max(),
+			std::numeric_limits<double>::max(),
+			std::numeric_limits<double>::max()}}),
+		_max_pnt(std::array<double,3>{{std::numeric_limits<double>::lowest(),
+			std::numeric_limits<double>::lowest(),
+			std::numeric_limits<double>::lowest()}})
 	{
 		assert(! ids.empty());
 		init(pnts[ids[0]]);
@@ -70,8 +75,12 @@ public:
 	 */
 	template <typename InputIterator>
 	AABB(InputIterator first, InputIterator last) :
-		_min_pnt(std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max()),
-		_max_pnt(std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest())
+		_min_pnt(std::array<double,3>{{std::numeric_limits<double>::max(),
+			std::numeric_limits<double>::max(),
+			std::numeric_limits<double>::max()}}),
+		_max_pnt(std::array<double,3>{{std::numeric_limits<double>::lowest(),
+			std::numeric_limits<double>::lowest(),
+			std::numeric_limits<double>::lowest()}})
 	{
 		if (! (std::distance(first,last) > 0)) {
 			throw std::invalid_argument("AABB::AABB(InputIterator first, InputIterator last): first == last");
@@ -111,14 +120,14 @@ public:
 	 * for the given point set
 	 * @return a point
 	 */
-	PNT_TYPE const& getMinPoint() const { return _min_pnt; }
+	MathLib::Point3d const& getMinPoint() const { return _min_pnt; }
 
 	/**
 	 * returns a point that coordinates are maximal for each dimension
 	 * within the given point set
 	 * @return a point
 	 */
-	PNT_TYPE const& getMaxPoint() const { return _max_pnt; }
+	MathLib::Point3d const& getMaxPoint() const { return _max_pnt; }
 
 	/**
 	 * Method checks if the given AABB object is contained within the
@@ -133,8 +142,8 @@ public:
 	}
 
 protected:
-	PNT_TYPE _min_pnt;
-	PNT_TYPE _max_pnt;
+	MathLib::Point3d _min_pnt;
+	MathLib::Point3d _max_pnt;
 private:
 	void init(PNT_TYPE const & pnt)
 	{

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -41,13 +41,7 @@ public:
 	/**
 	 * construction of object, initialization the axis aligned bounding box
 	 * */
-	AABB(std::vector<PNT_TYPE*> const& pnts, std::vector<std::size_t> const& ids) :
-		_min_pnt(std::array<double,3>{{std::numeric_limits<double>::max(),
-			std::numeric_limits<double>::max(),
-			std::numeric_limits<double>::max()}}),
-		_max_pnt(std::array<double,3>{{std::numeric_limits<double>::lowest(),
-			std::numeric_limits<double>::lowest(),
-			std::numeric_limits<double>::lowest()}})
+	AABB(std::vector<PNT_TYPE*> const& pnts, std::vector<std::size_t> const& ids)
 	{
 		assert(! ids.empty());
 		init(pnts[ids[0]]);
@@ -74,13 +68,7 @@ public:
 	 * @attention{The iterator last must be reachable from first.}
 	 */
 	template <typename InputIterator>
-	AABB(InputIterator first, InputIterator last) :
-		_min_pnt(std::array<double,3>{{std::numeric_limits<double>::max(),
-			std::numeric_limits<double>::max(),
-			std::numeric_limits<double>::max()}}),
-		_max_pnt(std::array<double,3>{{std::numeric_limits<double>::lowest(),
-			std::numeric_limits<double>::lowest(),
-			std::numeric_limits<double>::lowest()}})
+	AABB(InputIterator first, InputIterator last)
 	{
 		if (! (std::distance(first,last) > 0)) {
 			throw std::invalid_argument("AABB::AABB(InputIterator first, InputIterator last): first == last");
@@ -142,8 +130,14 @@ public:
 	}
 
 protected:
-	MathLib::Point3d _min_pnt;
-	MathLib::Point3d _max_pnt;
+	MathLib::Point3d _min_pnt = std::array<double,3>{{
+		std::numeric_limits<double>::max(),
+		std::numeric_limits<double>::max(),
+		std::numeric_limits<double>::max()}};
+	MathLib::Point3d _max_pnt = std::array<double,3>{{
+		std::numeric_limits<double>::lowest(),
+		std::numeric_limits<double>::lowest(),
+		std::numeric_limits<double>::lowest()}};
 private:
 	void init(PNT_TYPE const & pnt)
 	{

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -98,7 +98,8 @@ public:
 	/**
 	 * check if point is in the axis aligned bounding box
 	 */
-	bool containsPoint(PNT_TYPE const & pnt) const
+	template <typename T>
+	bool containsPoint(T const & pnt) const
 	{
 		if (pnt[0] < _min_pnt[0] || _max_pnt[0] < pnt[0]) return false;
 		if (pnt[1] < _min_pnt[1] || _max_pnt[1] < pnt[1]) return false;

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -20,7 +20,6 @@
 #include <iterator>
 #include <cassert>
 #include <vector>
-#include <stdexcept>
 
 #include "MathLib/MathTools.h"
 #include "Point.h"

--- a/GeoLib/Grid.h
+++ b/GeoLib/Grid.h
@@ -25,6 +25,7 @@
 #include "GEOObjects.h"
 
 // MathLib
+#include "MathLib/Point3d.h"
 #include "MathLib/MathTools.h"
 
 namespace GeoLib
@@ -233,8 +234,10 @@ public:
 	 */
 	void getPntVecsOfGridCellsIntersectingCube(POINT const& center, double half_len, std::vector<std::vector<POINT*> const*>& pnts) const;
 
-	void getPntVecsOfGridCellsIntersectingCuboid(POINT const& min_pnt, POINT const& max_pnt, std::vector<std::vector<POINT*> const*>& pnts) const;
-
+	void getPntVecsOfGridCellsIntersectingCuboid(
+		MathLib::Point3d const& min_pnt,
+		MathLib::Point3d const& max_pnt,
+		std::vector<std::vector<POINT*> const*>& pnts) const;
 
 #ifndef NDEBUG
 	/**
@@ -318,7 +321,8 @@ private:
 	 * @param pnt (input) the coordinates of the point
 	 * @param coords (output) the coordinates of the grid cell
 	 */
-	inline void getGridCoords(POINT const& pnt, std::size_t* coords) const;
+	template <typename T>
+	inline void getGridCoords(T const& pnt, std::size_t* coords) const;
 
 	/**
 	 *
@@ -416,9 +420,10 @@ void Grid<POINT>::getPntVecsOfGridCellsIntersectingCube(POINT const& center,
 }
 
 template<typename POINT>
-void Grid<POINT>::getPntVecsOfGridCellsIntersectingCuboid(POINT const& min_pnt,
-                                                          POINT const& max_pnt,
-                                                          std::vector<std::vector<POINT*> const*>& pnts) const
+void Grid<POINT>::getPntVecsOfGridCellsIntersectingCuboid(
+	MathLib::Point3d const& min_pnt,
+	MathLib::Point3d const& max_pnt,
+	std::vector<std::vector<POINT*> const*>& pnts) const
 {
 	std::size_t min_coords[3];
 	getGridCoords(min_pnt, min_coords);
@@ -521,7 +526,8 @@ void Grid<POINT>::createGridGeometry(GeoLib::GEOObjects* geo_obj) const
 #endif
 
 template <typename POINT>
-void Grid<POINT>::getGridCoords(POINT const& pnt, std::size_t* coords) const
+template <typename T>
+void Grid<POINT>::getGridCoords(T const& pnt, std::size_t* coords) const
 {
 	for (std::size_t k(0); k<3; k++) {
 		if (pnt[k] < this->_min_pnt[k]) {

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -64,8 +64,8 @@ bool Polygon::initialise ()
 
 bool Polygon::isPntInPolygon (GeoLib::Point const & pnt) const
 {
-	GeoLib::Point const& min_aabb_pnt (_aabb.getMinPoint());
-	GeoLib::Point const& max_aabb_pnt (_aabb.getMaxPoint());
+	MathLib::Point3d const& min_aabb_pnt(_aabb.getMinPoint());
+	MathLib::Point3d const& max_aabb_pnt(_aabb.getMaxPoint());
 
 	if (pnt[0] < min_aabb_pnt[0] || max_aabb_pnt[0] < pnt[0] || pnt[1] < min_aabb_pnt[1] ||
 	    max_aabb_pnt[1] < pnt[1])

--- a/GeoLib/Raster.cpp
+++ b/GeoLib/Raster.cpp
@@ -70,8 +70,8 @@ GeoLib::Point const& Raster::getOrigin() const
 
 Raster* Raster::getRasterFromSurface(Surface const& sfc, double cell_size, double no_data_val)
 {
-	Point const& ll (sfc.getAABB().getMinPoint());
-	Point const& ur (sfc.getAABB().getMaxPoint());
+	MathLib::Point3d const& ll(sfc.getAABB().getMinPoint());
+	MathLib::Point3d const& ur(sfc.getAABB().getMaxPoint());
 
 	const std::size_t n_cols = static_cast<size_t>(std::fabs(ur[0]-ll[0]) / cell_size)+1;
 	const std::size_t n_rows = static_cast<size_t>(std::fabs(ur[1]-ll[1]) / cell_size)+1;

--- a/MeshLib/CoordinateSystem.h
+++ b/MeshLib/CoordinateSystem.h
@@ -12,6 +12,7 @@
 #include <cmath>
 
 #include "GeoLib/AABB.h"
+#include "MathLib/Vector3.h"
 
 namespace MeshLib
 {
@@ -83,7 +84,7 @@ unsigned char CoordinateSystem::getCoordinateSystem(const GeoLib::AABB<T> &bbox)
 {
     unsigned char coords = 0;
 
-    const T pt_diff = bbox.getMaxPoint() - bbox.getMinPoint();
+    const MathLib::Vector3 pt_diff(bbox.getMinPoint(), bbox.getMaxPoint());
 
     if (std::abs(pt_diff[0]) > .0)
         coords |= CoordinateSystemType::X;

--- a/MeshLib/MeshEditing/ElementExtraction.cpp
+++ b/MeshLib/MeshEditing/ElementExtraction.cpp
@@ -118,13 +118,10 @@ std::size_t ElementExtraction::searchByContent(double eps)
 	return matchedIDs.size();
 }
 
-std::size_t ElementExtraction::searchByBoundingBox(const MeshLib::Node &x1, const MeshLib::Node &x2)
+std::size_t ElementExtraction::searchByBoundingBox(
+	GeoLib::AABB<MathLib::Point3d> const& aabb)
 {
 	const std::vector<MeshLib::Element*> &ele_vec (this->_mesh.getElements());
-	std::vector<MeshLib::Node> extent;
-	extent.push_back(x1);
-	extent.push_back(x2);
-	const GeoLib::AABB<MeshLib::Node> aabb(extent.begin(), extent.end());
 
 	std::vector<std::size_t> matchedIDs;
 	const std::size_t n_elems(ele_vec.size());

--- a/MeshLib/MeshEditing/ElementExtraction.h
+++ b/MeshLib/MeshEditing/ElementExtraction.h
@@ -17,6 +17,9 @@
 
 #include <string>
 #include <vector>
+
+#include "GeoLib/AABB.h"
+
 #include "MeshLib/MeshEnums.h"
 #include "MeshLib/Node.h"
 
@@ -50,7 +53,7 @@ public:
 	std::size_t searchByContent(double eps = std::numeric_limits<double>::epsilon());
 
 	/// Marks all elements with at least one node outside the bounding box spanned by x1 and x2;
-	std::size_t searchByBoundingBox(const MeshLib::Node &x1, const MeshLib::Node &x2);
+	std::size_t searchByBoundingBox(GeoLib::AABB<MathLib::Point3d> const& aabb);
 
 
 private:

--- a/Tests/GeoLib/TestAABB.cpp
+++ b/Tests/GeoLib/TestAABB.cpp
@@ -21,6 +21,7 @@
 #include <list>
 #include <iostream>
 
+#include "MathLib/Point3d.h"
 #include "Point.h"
 #include "AABB.h"
 
@@ -42,8 +43,8 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPoints)
 	 // construct from list points a axis algined bounding box
 	 GeoLib::AABB<GeoLib::Point> aabb(pnts_list.begin(), pnts_list.end());
 
-	 GeoLib::Point const& min_pnt(aabb.getMinPoint());
-	 GeoLib::Point const& max_pnt(aabb.getMaxPoint());
+	 MathLib::Point3d const& min_pnt(aabb.getMinPoint());
+	 MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
 
 	 ASSERT_LE(minus_half_box_size, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size;
@@ -75,8 +76,8 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAList)
 	 // construct from list points a axis algined bounding box
 	 GeoLib::AABB<GeoLib::Point> aabb(pnts_list.begin(), pnts_list.end());
 
-	 GeoLib::Point const& min_pnt(aabb.getMinPoint());
-	 GeoLib::Point const& max_pnt(aabb.getMaxPoint());
+	 MathLib::Point3d const& min_pnt(aabb.getMinPoint());
+	 MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
 
 	 ASSERT_LE(minus_half_box_size, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size;
@@ -104,8 +105,8 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPointsInAVector)
 	 // construct from list points a axis algined bounding box
 	 GeoLib::AABB<GeoLib::Point> aabb(pnts.begin(), pnts.end());
 
-	 GeoLib::Point const& min_pnt(aabb.getMinPoint());
-	 GeoLib::Point const& max_pnt(aabb.getMaxPoint());
+	 MathLib::Point3d const& min_pnt(aabb.getMinPoint());
+	 MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
 
 	 ASSERT_LE(minus_half_box_size, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size;
@@ -137,8 +138,8 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAVector)
 	 // construct from list points a axis algined bounding box
 	 GeoLib::AABB<GeoLib::Point> aabb(pnts.begin(), pnts.end());
 
-	 GeoLib::Point const& min_pnt(aabb.getMinPoint());
-	 GeoLib::Point const& max_pnt(aabb.getMaxPoint());
+	 MathLib::Point3d const& min_pnt(aabb.getMinPoint());
+	 MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
 
 	 ASSERT_LE(minus_half_box_size, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size;
@@ -172,8 +173,8 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomBox)
 	 // construct from list points a axis aligned bounding box
 	 GeoLib::AABB<GeoLib::Point> aabb(pnts.begin(), pnts.end());
 
-	 GeoLib::Point const& min_pnt(aabb.getMinPoint());
-	 GeoLib::Point const& max_pnt(aabb.getMaxPoint());
+	 MathLib::Point3d const& min_pnt(aabb.getMinPoint());
+	 MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
 
 	 ASSERT_LE(minus_half_box_size_x, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size_x;
 	 ASSERT_LE(minus_half_box_size_y, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size_y;
@@ -194,7 +195,7 @@ TEST(GeoLib, AABBAllPointsWithNegativeCoordinatesI)
 	ids.push_back(1);
 	GeoLib::AABB<GeoLib::Point> aabb(pnts, ids);
 
-	GeoLib::Point const& max_pnt(aabb.getMaxPoint());
+	MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
 
 	ASSERT_NEAR(-1.0, max_pnt[0], std::numeric_limits<double>::epsilon());
 	ASSERT_NEAR(-1.0, max_pnt[1], std::numeric_limits<double>::epsilon());
@@ -211,7 +212,7 @@ TEST(GeoLib, AABBAllPointsWithNegativeCoordinatesII)
 	// construct from points of the vector a axis aligned bounding box
 	GeoLib::AABB<GeoLib::Point> aabb(pnts.begin(), pnts.end());
 
-	GeoLib::Point const& max_pnt(aabb.getMaxPoint());
+	MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
 
 	ASSERT_NEAR(-1.0, max_pnt[0], std::numeric_limits<double>::epsilon());
 	ASSERT_NEAR(-1.0, max_pnt[1], std::numeric_limits<double>::epsilon());


### PR DESCRIPTION
This PR is a result of https://github.com/ufz/ogs/issues/710. @endJunction discovered, that creating AABB objects is relative expensive. So in this PR the size of management overhead of the class `AABB<Node>` is reduced  from 304 byte to 64 byte. I am curious on the new callgraph and run time comparisons.