### PR TITLE
GeoLib OctTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 6.0.3 (in preparation)
+
+### Features:
+
+- Implemented [OctTree](https://github.com/ufz/ogs/pull/714) for fast searching
+  points and nodes
+
 # 6.0.2
 
 | Released on 2015/06/15, [GitHub Release Link](https://github.com/ufz/ogs/releases/tag/6.0.2)

--- a/GeoLib/OctTree-impl.h
+++ b/GeoLib/OctTree-impl.h
@@ -1,0 +1,267 @@
+/**
+ * \date   2015-06-12
+ * \brief  Implementation of the OctTree class.
+ *
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+
+namespace GeoLib {
+
+template <typename POINT, std::size_t MAX_POINTS>
+template <typename T>
+OctTree<POINT, MAX_POINTS> OctTree<POINT, MAX_POINTS>::createOctTree(T ll, T ur,
+	double eps)
+{
+	// compute an axis aligned cube around the points ll and ur
+	const double dx(ur[0] - ll[0]);
+	const double dy(ur[1] - ll[1]);
+	const double dz(ur[2] - ll[2]);
+	if (dx >= dy && dx >= dz) {
+		ll[1] -= (dx-dy)/2.0;
+		ur[1] += (dx-dy)/2.0;
+		ll[2] -= (dx-dz)/2.0;
+		ur[2] += (dx-dz)/2.0;
+	} else {
+		if (dy >= dx && dy >= dz) {
+			ll[0] -= (dy-dx)/2.0;
+			ur[0] += (dy-dx)/2.0;
+			ll[2] -= (dy-dz)/2.0;
+			ur[2] += (dy-dz)/2.0;
+		} else {
+			ll[0] -= (dz-dx)/2.0;
+			ur[0] += (dz-dx)/2.0;
+			ll[1] -= (dz-dy)/2.0;
+			ur[1] += (dz-dy)/2.0;
+		}
+	}
+	return OctTree<POINT, MAX_POINTS>(ll, ur, eps);
+}
+
+template <typename POINT, std::size_t MAX_POINTS>
+OctTree<POINT, MAX_POINTS>::~OctTree()
+{
+	for (auto c : _children)
+		delete c;
+}
+
+template <typename POINT, std::size_t MAX_POINTS>
+bool OctTree<POINT, MAX_POINTS>::addPoint(POINT * pnt, POINT *& ret_pnt)
+{
+	// first do a range query using a epsilon box around the point pnt
+	std::vector<POINT*> query_pnts;
+	MathLib::Point3d min(
+		std::array<double,3>{{(*pnt)[0]-_eps, (*pnt)[1]-_eps, (*pnt)[2]-_eps}});
+	MathLib::Point3d max(
+		std::array<double,3>{{(*pnt)[0]+_eps, (*pnt)[1]+_eps, (*pnt)[2]+_eps}});
+	getPointsInRange(min, max, query_pnts);
+	if (! query_pnts.empty()) {
+		// check Euclidean norm
+		for (auto p : query_pnts) {
+			if (MathLib::sqrDist(*p, *pnt) < _eps*_eps) {
+				ret_pnt = p;
+				return false;
+			}
+		}
+	}
+
+	// the point pnt is not yet in the OctTree
+	if (isOutside(pnt)) {
+		ret_pnt = nullptr;
+		return false;
+	}
+
+	// at this place it holds true that the point is within [_ll, _ur]
+	if (!_is_leaf) {
+		for (auto c : _children) {
+			if (c->addPoint_(pnt, ret_pnt)) {
+				return true;
+			} else {
+				if (ret_pnt != nullptr)
+					return false;
+			}
+		}
+	}
+
+	ret_pnt = pnt;
+
+	if (_pnts.size () < MAX_POINTS) {
+		_pnts.push_back(pnt);
+	} else { // i.e. _pnts.size () == MAX_POINTS
+		splitNode(pnt);
+		_pnts.clear();
+	}
+	return true;
+}
+
+template <typename POINT, std::size_t MAX_POINTS>
+template <typename T>
+void OctTree<POINT, MAX_POINTS>::getPointsInRange(T const& min, T const& max,
+	std::vector<POINT*> &pnts) const
+{
+	if (_ur[0] < min[0] || _ur[1] < min[1] || _ur[2] < min[2])
+		return;
+
+	if (max[0] < _ll[0] || max[1] < _ll[1] || max[2] < _ll[2])
+		return;
+
+	if (_is_leaf) {
+		for (auto p : _pnts) {
+			if (min[0] <= (*p)[0] && (*p)[0] < max[0]
+				&& min[1] <= (*p)[1] && (*p)[1] < max[1]
+				&& min[2] <= (*p)[2] && (*p)[2] < max[2])
+				pnts.push_back(p);
+		}
+	} else {
+		for (std::size_t k(0); k<8; k++) {
+			_children[k]->getPointsInRange(min, max, pnts);
+		}
+	}
+}
+
+template <typename POINT, std::size_t MAX_POINTS>
+OctTree<POINT, MAX_POINTS>::OctTree(
+	MathLib::Point3d const& ll, MathLib::Point3d const& ur, double eps)
+	: _ll(ll), _ur(ur), _is_leaf(true), _eps(eps)
+{
+	_children.fill(nullptr);
+}
+
+template <typename POINT, std::size_t MAX_POINTS>
+bool OctTree<POINT, MAX_POINTS>::addPoint_(POINT * pnt, POINT *& ret_pnt)
+{
+	if (isOutside(pnt)) {
+		ret_pnt = nullptr;
+		return false;
+	}
+
+	// at this place it holds true that the point is within [_ll, _ur]
+	if (!_is_leaf) {
+		for (auto c : _children) {
+			if (c->addPoint_(pnt, ret_pnt)) {
+				return true;
+			} else {
+				if (ret_pnt != nullptr)
+					return false;
+			}
+		}
+	}
+
+	ret_pnt = pnt;
+	if (_pnts.size() < MAX_POINTS) {
+		_pnts.push_back(pnt);
+	} else { // i.e. _pnts.size () == MAX_POINTS
+		splitNode(pnt);
+		_pnts.clear();
+	}
+	return true;
+}
+
+template <typename POINT, std::size_t MAX_POINTS>
+bool OctTree<POINT, MAX_POINTS>::addPointToChild(POINT * pnt)
+{
+	if (isOutside(pnt))
+		return false;
+
+	if (_pnts.size() < MAX_POINTS) {
+		_pnts.push_back(pnt);
+	} else { // i.e. _pnts.size () == MAX_POINTS
+		splitNode(pnt);
+		_pnts.clear();
+	}
+	return true;
+}
+
+template <typename POINT, std::size_t MAX_POINTS>
+void OctTree<POINT, MAX_POINTS>::splitNode(POINT * pnt)
+{
+	const double x_mid((_ur[0] + _ll[0]) / 2.0);
+	const double y_mid((_ur[1] + _ll[1]) / 2.0);
+	const double z_mid((_ur[2] + _ll[2]) / 2.0);
+	MathLib::Point3d p0(std::array<double,3>{{x_mid, y_mid, _ll[2]}});
+	MathLib::Point3d p1(std::array<double,3>{{_ur[0], _ur[1], z_mid}});
+
+	// create child NEL
+	_children[static_cast<std::int8_t>(Quadrant::NEL)]
+		= new OctTree<POINT, MAX_POINTS> (p0, p1, _eps);
+
+	// create child NWL
+	p0[0] = _ll[0];
+	p1[0] = x_mid;
+	_children[static_cast<std::int8_t>(Quadrant::NWL)]
+		= new OctTree<POINT, MAX_POINTS> (p0, p1, _eps);
+
+	// create child SWL
+	p0[1] = _ll[1];
+	p1[1] = y_mid;
+	_children[static_cast<std::int8_t>(Quadrant::SWL)]
+		= new OctTree<POINT, MAX_POINTS> (_ll, p1, _eps);
+
+	// create child NEU
+	_children[static_cast<std::int8_t>(Quadrant::NEU)]
+		= new OctTree<POINT, MAX_POINTS> (p1, _ur, _eps);
+
+	// create child SEL
+	p0[0] = x_mid;
+	p1[0] = _ur[0];
+	_children[static_cast<std::int8_t>(Quadrant::SEL)]
+		= new OctTree<POINT, MAX_POINTS> (p0, p1, _eps);
+
+	// create child NWU
+	p0[0] = _ll[0];
+	p0[1] = y_mid;
+	p0[2] = z_mid;
+	p1[0] = x_mid;
+	p1[1] = _ur[1];
+	p1[2] = _ur[2];
+	_children[static_cast<std::int8_t>(Quadrant::NWU)]
+		= new OctTree<POINT, MAX_POINTS> (p0, p1, _eps);
+
+	// create child SWU
+	p0[1] = _ll[1];
+	p1[1] = y_mid;
+	_children[static_cast<std::int8_t>(Quadrant::SWU)]
+		= new OctTree<POINT, MAX_POINTS> (p0, p1, _eps);
+
+	// create child SEU
+	p0[0] = x_mid;
+	p1[0] = _ur[0];
+	p1[1] = y_mid;
+	p1[2] = _ur[2];
+	_children[static_cast<std::int8_t>(Quadrant::SEU)]
+		= new OctTree<POINT, MAX_POINTS> (p0, p1, _eps);
+
+	// add the passed point pnt to the childs at first
+	for (std::size_t k(0); k < 8; k++) {
+		if (_children[k]->addPointToChild(pnt))
+			break;
+	}
+
+	// distribute points to sub quadtrees
+	const std::size_t n_pnts(_pnts.size());
+	for (std::size_t j(0); j < n_pnts; j++) {
+		for (auto c : _children) {
+			if (c->addPointToChild(_pnts[j])) {
+				break;
+			}
+		}
+	}
+	_is_leaf = false;
+}
+
+template <typename POINT, std::size_t MAX_POINTS>
+bool OctTree<POINT, MAX_POINTS>::isOutside(POINT * pnt) const
+{
+	if ((*pnt)[0] < _ll[0] || (*pnt)[1] < _ll[1] || (*pnt)[2] < _ll[2])
+		return true;
+	if ((*pnt)[0] > _ur[0] || (*pnt)[1] > _ur[1] || (*pnt)[2] > _ur[2])
+		return true;
+	return false;
+}
+} // end namespace GeoLib
+

--- a/Tests/GeoLib/TestOctTree.cpp
+++ b/Tests/GeoLib/TestOctTree.cpp
@@ -1,0 +1,335 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include "gtest/gtest.h"
+#include <ctime>
+#include <random>
+
+#include "GeoLib/OctTree.h"
+#include "GeoLib/AABB.h"
+#include "GeoLib/Point.h"
+
+class GeoLibOctTree : public testing::Test
+{
+public:
+	typedef std::vector<GeoLib::Point*> VectorOfPoints;
+
+	GeoLibOctTree()
+	{}
+
+	~GeoLibOctTree()
+	{
+		for (auto p : ps_ptr) {
+			delete p;
+		}
+	}
+	template <std::size_t MAX_POINTS>
+	void
+	checkOctTreeChildsNonNullptr(
+		GeoLib::OctTree<GeoLib::Point, MAX_POINTS> const& oct_tree) const
+	{
+#ifndef NDEBUG
+		ASSERT_NE(nullptr, oct_tree.getChild(0));
+		ASSERT_NE(nullptr, oct_tree.getChild(1));
+		ASSERT_NE(nullptr, oct_tree.getChild(2));
+		ASSERT_NE(nullptr, oct_tree.getChild(3));
+		ASSERT_NE(nullptr, oct_tree.getChild(4));
+		ASSERT_NE(nullptr, oct_tree.getChild(5));
+		ASSERT_NE(nullptr, oct_tree.getChild(6));
+		ASSERT_NE(nullptr, oct_tree.getChild(7));
+#endif
+	}
+
+	template <std::size_t MAX_POINTS>
+	void
+	checkOctTreeChildsNullptr(GeoLib::OctTree<GeoLib::Point, MAX_POINTS> const& oct_tree) const
+	{
+#ifndef NDEBUG
+		ASSERT_EQ(nullptr, oct_tree.getChild(0));
+		ASSERT_EQ(nullptr, oct_tree.getChild(1));
+		ASSERT_EQ(nullptr, oct_tree.getChild(2));
+		ASSERT_EQ(nullptr, oct_tree.getChild(3));
+		ASSERT_EQ(nullptr, oct_tree.getChild(4));
+		ASSERT_EQ(nullptr, oct_tree.getChild(5));
+		ASSERT_EQ(nullptr, oct_tree.getChild(6));
+		ASSERT_EQ(nullptr, oct_tree.getChild(7));
+#endif
+	}
+
+protected:
+	void
+	generateEquidistantPoints3d(std::size_t const n = 11)
+	{
+		for (std::size_t k(0); k<n; ++k) {
+			double const z(k-(n-1)/2.0);
+			for (std::size_t j(0); j<n; ++j) {
+				double const y(j-(n-1)/2.0);
+				for (std::size_t i(0); i<n; ++i) {
+					ps_ptr.push_back(new GeoLib::Point(i-(n-1)/2.0, y, z));
+				}
+			}
+		}
+	}
+
+protected:
+	VectorOfPoints ps_ptr;
+};
+
+TEST_F(GeoLibOctTree, TestWithEquidistantPoints3d)
+{
+	generateEquidistantPoints3d();
+	double const eps(10*std::numeric_limits<double>::epsilon());
+	GeoLib::OctTree<GeoLib::Point, 2> oct_tree(
+		GeoLib::OctTree<GeoLib::Point, 2>::createOctTree(*ps_ptr.front(),
+		*ps_ptr.back(), eps));
+
+#ifndef NDEBUG
+	MathLib::Point3d const& ll(oct_tree.getLowerLeftCornerPoint());
+	MathLib::Point3d const& ur(oct_tree.getUpperRightCornerPoint());
+
+	EXPECT_EQ((*ps_ptr.front())[0], ll[0]);
+	EXPECT_EQ((*ps_ptr.front())[1], ll[1]);
+	EXPECT_EQ((*ps_ptr.front())[2], ll[2]);
+
+	EXPECT_EQ((*ps_ptr.back())[0], ur[0]);
+	EXPECT_EQ((*ps_ptr.back())[1], ur[1]);
+	EXPECT_EQ((*ps_ptr.back())[2], ur[2]);
+
+	checkOctTreeChildsNullptr<2>(oct_tree);
+
+	ASSERT_EQ(static_cast<std::size_t>(0), oct_tree.getPointVector().size());
+#endif
+
+	GeoLib::Point * ret_pnt(nullptr);
+	// insert the first point
+	ASSERT_TRUE(oct_tree.addPoint(ps_ptr[0], ret_pnt));
+
+	// make a range query
+	MathLib::Point3d const min(
+		std::array<double,3>{{(*(ps_ptr[0]))[0]-eps,
+		(*(ps_ptr[0]))[1]-eps, (*(ps_ptr[0]))[2]-eps}});
+	MathLib::Point3d const max(
+		std::array<double,3>{{(*(ps_ptr[0]))[0]+eps,
+		(*(ps_ptr[0]))[1]+eps, (*(ps_ptr[0]))[2]+eps}});
+	std::vector<GeoLib::Point*> query_pnts;
+	oct_tree.getPointsInRange(min, max, query_pnts);
+	ASSERT_EQ(1u, query_pnts.size());
+
+#ifndef NDEBUG
+	ASSERT_EQ(static_cast<std::size_t>(1), oct_tree.getPointVector().size());
+#endif
+
+	// try to insert the first point a second time
+	ASSERT_FALSE(oct_tree.addPoint(ps_ptr[0], ret_pnt));
+#ifndef NDEBUG
+	ASSERT_EQ(static_cast<std::size_t>(1), oct_tree.getPointVector().size());
+#endif
+
+	// insert the second point
+	ASSERT_TRUE(oct_tree.addPoint(ps_ptr[1], ret_pnt));
+#ifndef NDEBUG
+	ASSERT_EQ(static_cast<std::size_t>(2), oct_tree.getPointVector().size());
+	checkOctTreeChildsNullptr<2>(oct_tree);
+#endif
+
+	// insert a third point -> there should be subtrees
+	ASSERT_TRUE(oct_tree.addPoint(ps_ptr[2], ret_pnt));
+#ifndef NDEBUG
+	ASSERT_EQ(static_cast<std::size_t>(0), oct_tree.getPointVector().size());
+	checkOctTreeChildsNonNullptr<2>(oct_tree);
+
+	// all inserted points are in the SWL -> there should be another subtree
+	// level
+	checkOctTreeChildsNonNullptr<2>(*(oct_tree.getChild(2)));
+
+	// still all inserted points are in the SWL of the SWL
+	// -> there should be another subtree level
+	checkOctTreeChildsNonNullptr<2>(*(oct_tree.getChild(2)->getChild(2)));
+
+	checkOctTreeChildsNullptr<2>(*(oct_tree.getChild(2)->getChild(0)));
+	checkOctTreeChildsNullptr<2>(*(oct_tree.getChild(2)->getChild(1)));
+	checkOctTreeChildsNullptr<2>(*(oct_tree.getChild(2)->getChild(3)));
+	checkOctTreeChildsNullptr<2>(*(oct_tree.getChild(2)->getChild(4)));
+	checkOctTreeChildsNullptr<2>(*(oct_tree.getChild(2)->getChild(5)));
+	checkOctTreeChildsNullptr<2>(*(oct_tree.getChild(2)->getChild(6)));
+	checkOctTreeChildsNullptr<2>(*(oct_tree.getChild(2)->getChild(7)));
+
+	ASSERT_EQ(static_cast<std::size_t>(2),
+		oct_tree.getChild(2)->getChild(2)->getChild(2)->getPointVector().size());
+	ASSERT_EQ(static_cast<std::size_t>(1),
+		oct_tree.getChild(2)->getChild(2)->getChild(3)->getPointVector().size());
+#endif
+
+	ASSERT_TRUE(oct_tree.addPoint(ps_ptr[3], ret_pnt));
+#ifndef NDEBUG
+	ASSERT_EQ(static_cast<std::size_t>(1),
+		oct_tree.getChild(2)->getChild(3)->getPointVector().size());
+#endif
+
+	GeoLib::Point range_query_ll(*(ps_ptr.front()));
+	GeoLib::Point range_query_ur(*(ps_ptr[ps_ptr.size()/2]));
+	std::vector<GeoLib::Point*> result;
+	oct_tree.getPointsInRange(range_query_ll, range_query_ur, result);
+	ASSERT_EQ(static_cast<std::size_t>(4), result.size());
+
+	result.clear();
+	range_query_ur[0] = -2.5;
+	range_query_ur[1] = -2.5;
+	range_query_ur[2] = -2.5;
+	oct_tree.getPointsInRange(range_query_ll, range_query_ur, result);
+	ASSERT_EQ(static_cast<std::size_t>(3), result.size());
+
+	// insert some points not resulting in a further refinement of SWL
+	for (std::size_t k(4); k<11; ++k)
+		ASSERT_TRUE(oct_tree.addPoint(ps_ptr[k], ret_pnt));
+
+	result.clear();
+	oct_tree.getPointsInRange(range_query_ll, range_query_ur, result);
+	ASSERT_EQ(static_cast<std::size_t>(3), result.size());
+
+	// insert some points *resulting* in a further refinement of SWL
+	for (std::size_t k(11); k<25; ++k)
+		ASSERT_TRUE(oct_tree.addPoint(ps_ptr[k], ret_pnt));
+
+	result.clear();
+	oct_tree.getPointsInRange(range_query_ll, range_query_ur, result);
+	ASSERT_EQ(static_cast<std::size_t>(9), result.size());
+	
+	// insert all points with z = -5.0 - this does not result in a further
+	// refinement of SWL
+	for (std::size_t k(25); k<121; ++k)
+		ASSERT_TRUE(oct_tree.addPoint(ps_ptr[k], ret_pnt));
+
+	result.clear();
+	oct_tree.getPointsInRange(range_query_ll, range_query_ur, result);
+	ASSERT_EQ(static_cast<std::size_t>(9), result.size());
+
+	result.clear();
+	range_query_ur[0] = -3.75;
+	range_query_ur[1] = -3.75;
+	range_query_ur[2] = -3.75;
+	oct_tree.getPointsInRange(range_query_ll, range_query_ur, result);
+	ASSERT_EQ(static_cast<std::size_t>(4), result.size());
+
+	result.clear();
+	range_query_ur[0] = -4.25;
+	range_query_ur[1] = -4.25;
+	range_query_ur[2] = -4.25;
+	oct_tree.getPointsInRange(range_query_ll, range_query_ur, result);
+	ASSERT_EQ(static_cast<std::size_t>(1), result.size());
+
+	result.clear();
+	range_query_ll[0] = -4.75;
+	range_query_ll[1] = -4.75;
+	range_query_ll[2] = -4.75;
+	oct_tree.getPointsInRange(range_query_ll, range_query_ur, result);
+	for (auto p : result)
+		std::cout << *p << "\n";
+	ASSERT_EQ(static_cast<std::size_t>(0), result.size());
+
+	result.clear();
+	range_query_ll[0] = -5;
+	range_query_ll[1] = -5;
+	range_query_ll[2] = -5;
+	range_query_ur[0] = -0.25;
+	range_query_ur[1] = -4.75;
+	range_query_ur[2] = -4.75;
+	oct_tree.getPointsInRange(range_query_ll, range_query_ur, result);
+	ASSERT_EQ(static_cast<std::size_t>(5), result.size());
+}
+
+TEST_F(GeoLibOctTree, TestWithAlternatingPoints3d)
+{
+	// this case is not correctely handled by lexicographical sorting
+	double const eps(1e-1);
+	double const small_displacement(1e-2);
+	ps_ptr.push_back(new GeoLib::Point(0,0,0,0));
+	ps_ptr.push_back(new GeoLib::Point(2*small_displacement,0,0,1));
+	ps_ptr.push_back(new GeoLib::Point(small_displacement,1,0,2));
+	ps_ptr.push_back(new GeoLib::Point(4*small_displacement,0,0,3));
+	ps_ptr.push_back(new GeoLib::Point(3*small_displacement,1,0,4));
+	ps_ptr.push_back(new GeoLib::Point(6*small_displacement,0,0,5));
+	ps_ptr.push_back(new GeoLib::Point(5*small_displacement,1,0,6));
+
+	GeoLib::AABB<GeoLib::Point> const aabb(ps_ptr.cbegin(), ps_ptr.cend());
+	MathLib::Point3d min(aabb.getMinPoint());
+	MathLib::Point3d max(aabb.getMaxPoint());
+	GeoLib::OctTree<GeoLib::Point, 8> oct_tree(
+		GeoLib::OctTree<GeoLib::Point, 8>::createOctTree(min, max, eps));
+
+	// pt_ptr[0] should be inserted correctly
+	GeoLib::Point * ret_pnt(nullptr);
+	ASSERT_TRUE(oct_tree.addPoint(ps_ptr[0], ret_pnt));
+	ASSERT_EQ(ps_ptr[0], ret_pnt);
+	// ps_ptr[1] is in the eps-environment of ps_ptr[0]
+	ret_pnt = nullptr;
+	ASSERT_FALSE(oct_tree.addPoint(ps_ptr[1], ret_pnt));
+	ASSERT_EQ(ps_ptr[0], ret_pnt);
+	// pt_ptr[2] should be inserted correctly
+	ret_pnt = nullptr;
+	ASSERT_TRUE(oct_tree.addPoint(ps_ptr[2], ret_pnt));
+	ASSERT_EQ(ps_ptr[2], ret_pnt);
+	// ps_ptr[3] is in the eps-environment of ps_ptr[0]
+	ret_pnt = nullptr;
+	ASSERT_FALSE(oct_tree.addPoint(ps_ptr[3], ret_pnt));
+	ASSERT_EQ(ps_ptr[0], ret_pnt);
+	// ps_ptr[4] is in the eps-environment of ps_ptr[2]
+	ret_pnt = nullptr;
+	ASSERT_FALSE(oct_tree.addPoint(ps_ptr[4], ret_pnt));
+	ASSERT_EQ(ps_ptr[2], ret_pnt);
+	// ps_ptr[5] is in the eps-environment of ps_ptr[0]
+	ret_pnt = nullptr;
+	ASSERT_FALSE(oct_tree.addPoint(ps_ptr[5], ret_pnt));
+	ASSERT_EQ(ps_ptr[0], ret_pnt);
+	// ps_ptr[6] is in the eps-environment of ps_ptr[2]
+	ret_pnt = nullptr;
+	ASSERT_FALSE(oct_tree.addPoint(ps_ptr[6], ret_pnt));
+	ASSERT_EQ(ps_ptr[2], ret_pnt);
+}
+
+TEST_F(GeoLibOctTree, TestSmallDistanceDifferentLeafes)
+{
+	// case where two points with a small distance but different OctTree leafes
+	// are inserted
+	double const eps(0.5);
+	std::vector<GeoLib::Point*> ps_ptr;
+	for (int k(-10); k<11; ++k) {
+		for (int j(-10); j<11; ++j) {
+			std::size_t id((k+10)*21+(j+10));
+			for (int i(-10); i<11; ++i) {
+				ps_ptr.push_back(new GeoLib::Point(1.0*i, 1.0*j, 1.0*k, id+i+10));
+			}
+		}
+	}
+
+	// create OctTree
+	GeoLib::AABB<GeoLib::Point> const aabb(ps_ptr.cbegin(), ps_ptr.cend());
+	MathLib::Point3d min(aabb.getMinPoint());
+	MathLib::Point3d max(aabb.getMaxPoint());
+	GeoLib::OctTree<GeoLib::Point, 2> oct_tree(
+		GeoLib::OctTree<GeoLib::Point, 2>::createOctTree(min, max, eps));
+
+	// fill OctTree
+	for (auto p : ps_ptr) {
+		GeoLib::Point * ret_pnt(nullptr);
+		ASSERT_TRUE(oct_tree.addPoint(p, ret_pnt));
+		ASSERT_EQ(p, ret_pnt);
+	}
+
+	// point near the GeoLib::Point (0, -10, -10, 10) (with id 10)
+	GeoLib::Point *p0(new GeoLib::Point(0.1, -10.0, -10.0));
+	GeoLib::Point * ret_pnt(nullptr);
+	ASSERT_FALSE(oct_tree.addPoint(p0, ret_pnt));
+	ASSERT_EQ(10u, ret_pnt->getID());
+
+	(*p0)[0] = -0.1;
+	ret_pnt = nullptr;
+	ASSERT_FALSE(oct_tree.addPoint(p0, ret_pnt));
+	ASSERT_EQ(10u, ret_pnt->getID());
+}
+


### PR DESCRIPTION
This PR contains a rework of class `OctTree`, which will be used in another PR fixing some issues in `GeoLib::GEOObject` that is already in preparation (see branch [GeoLibReworkMergingGeometries](https://github.com/TomFischer/ogs/tree/GeoLibReworkMergingGeometries)). Also in this PR a tests for `OctTree` are added.

Maybe the `OctTree` can also be useful for other things like mesh node search?