### PR TITLE
ExternalData is stored on Amazon S3

### DIFF
--- a/scripts/cmake/Find.cmake
+++ b/scripts/cmake/Find.cmake
@@ -60,6 +60,8 @@ endif()
 
 find_program(CURL_TOOL_PATH curl DOC "The curl-tool")
 
+find_program(S3CMD_TOOL_PATH s3cmd DOC "S3cmd tool for uploading to Amazon S3")
+
 ######################
 ### Find libraries ###
 ######################


### PR DESCRIPTION
All external data files are now also stored on [Amazon S3](http://aws.amazon.com/s3/) which is a cheap (3.5 cent per GByte per month) cloud storage provider. The first year is free, afterwards it will be paid by the OpenGeoSys e.V.

This PR adds the S3 download URL and a new target `upload-data` which uploads new files to S3 (requires [s3cmd](http://s3tools.org/s3cmd) and credentials, you can still use the `sync-data`-target on envinf1 to let Jenkins do this for you, see the [developer guide](http://docs.opengeosys.org/docs/devguide/testing/test-data)).