### PR TITLE
PropertyVector usage improvements.

### DIFF
--- a/InSituLib/VtkMappedPropertyVectorTemplate-impl.h
+++ b/InSituLib/VtkMappedPropertyVectorTemplate-impl.h
@@ -43,7 +43,7 @@ template <class Scalar> void VtkMappedPropertyVectorTemplate<Scalar>
 	this->Initialize();
 	_propertyVector = &propertyVector;
 	this->NumberOfComponents = _propertyVector->getTupleSize();
-	this->Size = this->NumberOfComponents *  _propertyVector->size();
+	this->Size = this->NumberOfComponents *  _propertyVector->getNumberOfTuples();
 	this->MaxId = this->Size - 1;
 	this->Modified();
 }

--- a/MeshLib/MeshEditing/ElementExtraction.cpp
+++ b/MeshLib/MeshEditing/ElementExtraction.cpp
@@ -81,7 +81,7 @@ std::size_t ElementExtraction::searchByMaterialID(int const matID)
 	MeshLib::PropertyVector<int> const& pv(opt_pv.get());
 
 	std::vector<std::size_t> matchedIDs;
-	for (std::size_t i(0); i<pv.size(); ++i) {
+	for (std::size_t i(0); i<pv.getNumberOfTuples(); ++i) {
 		if (pv[i]==matID)
 			matchedIDs.push_back(i);
 	}

--- a/MeshLib/MeshEditing/ElementValueModification.cpp
+++ b/MeshLib/MeshEditing/ElementValueModification.cpp
@@ -38,10 +38,10 @@ bool ElementValueModification::replace(MeshLib::Mesh &mesh,
 	MeshLib::PropertyVector<int> & property_value_vec(
 		optional_property_value_vec.get()
 	);
-	const std::size_t n_property_values(property_value_vec.size());
+	const std::size_t n_property_tuples(property_value_vec.getNumberOfTuples());
 
 	if (!replace_if_exists) {
-		for (std::size_t i=0; i<n_property_values; ++i) {
+		for (std::size_t i=0; i<n_property_tuples; ++i) {
 			if (property_value_vec[i] == new_value) {
 				WARN ("ElementValueModification::replaceElementValue() "
 					"- Replacement value \"%d\" is already taken, "
@@ -51,7 +51,7 @@ bool ElementValueModification::replace(MeshLib::Mesh &mesh,
 		}
 	}
 
-	for (std::size_t i=0; i<n_property_values; ++i) {
+	for (std::size_t i=0; i<n_property_tuples; ++i) {
 		if (property_value_vec[i] == old_value)
 			property_value_vec[i] = new_value;
 	}

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -63,9 +63,10 @@ public:
 		return t;
 	}
 
+	/// Method returns the number of tuples times the number of tuple components.
 	std::size_t size() const
 	{
-		return std::vector<PROP_VAL_TYPE>::size() / _tuple_size;
+		return std::vector<PROP_VAL_TYPE>::size();
 	}
 
 protected:
@@ -147,6 +148,11 @@ public:
 	std::size_t getNumberOfTuples() const
 	{
 		return std::vector<std::size_t>::size();
+	}
+	/// Method returns the number of tuples times the number of tuple components.
+	std::size_t size() const
+	{
+		return _tuple_size * std::vector<std::size_t>::size();
 	}
 	MeshItemType getMeshItemType() const { return _mesh_item_type; }
 	std::string const& getPropertyName() const { return _property_name; }

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -48,6 +48,10 @@ friend class Properties;
 
 public:
 	std::size_t getTupleSize() const { return _tuple_size; }
+	std::size_t getNumberOfTuples() const
+	{
+		return std::vector<PROP_VAL_TYPE>::size() / _tuple_size;
+	}
 	MeshItemType getMeshItemType() const { return _mesh_item_type; }
 	std::string const& getPropertyName() const { return _property_name; }
 
@@ -140,6 +144,10 @@ public:
 	}
 
 	std::size_t getTupleSize() const { return _tuple_size; }
+	std::size_t getNumberOfTuples() const
+	{
+		return std::vector<std::size_t>::size();
+	}
 	MeshItemType getMeshItemType() const { return _mesh_item_type; }
 	std::string const& getPropertyName() const { return _property_name; }
 

--- a/Tests/InSituLib/TestVtkMappedMeshSource.cpp
+++ b/Tests/InSituLib/TestVtkMappedMeshSource.cpp
@@ -263,18 +263,25 @@ TEST_F(InSituMesh, MappedMeshSourceRoundtrip)
 			// Check some properties on equality
 			auto doubleProps = meshProperties.getPropertyVector<double>("PointDoubleProperty");
 			auto newDoubleProps = newMeshProperties.getPropertyVector<double>("PointDoubleProperty");
+			ASSERT_EQ((*newDoubleProps).getTupleSize(), (*doubleProps).getTupleSize());
+			ASSERT_EQ((*newDoubleProps).getNumberOfTuples(), (*doubleProps).getNumberOfTuples());
 			ASSERT_EQ((*newDoubleProps).size(), (*doubleProps).size());
 			for(std::size_t i = 0; i < (*doubleProps).size(); i++)
 				ASSERT_EQ((*newDoubleProps)[i], (*doubleProps)[i]);
 
 			auto unsignedProps = meshProperties.getPropertyVector<unsigned>("CellUnsignedProperty");
 			auto newUnsignedIds = newMeshProperties.getPropertyVector<unsigned>("CellUnsignedProperty");
+
+			ASSERT_EQ((*newUnsignedIds).getTupleSize(), (*unsignedProps).getTupleSize());
+			ASSERT_EQ((*newUnsignedIds).getNumberOfTuples(), (*unsignedProps).getNumberOfTuples());
 			ASSERT_EQ((*newUnsignedIds).size(), (*unsignedProps).size());
 			for(std::size_t i = 0; i < (*unsignedProps).size(); i++)
 				ASSERT_EQ((*newUnsignedIds)[i], (*unsignedProps)[i]);
 
 			auto materialIds = meshProperties.getPropertyVector<int>("MaterialIDs");
 			auto newMaterialIds = newMeshProperties.getPropertyVector<int>("MaterialIDs");
+			ASSERT_EQ((*newMaterialIds).getTupleSize(), (*materialIds).getTupleSize());
+			ASSERT_EQ((*newMaterialIds).getNumberOfTuples(), (*materialIds).getNumberOfTuples());
 			ASSERT_EQ((*newMaterialIds).size(), (*materialIds).size());
 			for(std::size_t i = 0; i < (*materialIds).size(); i++)
 				ASSERT_EQ((*newMaterialIds)[i], (*materialIds)[i]);

--- a/Tests/InSituLib/TestVtkMappedPropertyVector.cpp
+++ b/Tests/InSituLib/TestVtkMappedPropertyVector.cpp
@@ -32,20 +32,20 @@ TEST(InSituLibMappedPropertyVector, Double)
 	MeshLib::Mesh* mesh = MeshLib::MeshGenerator::generateRegularHexMesh(length, mesh_size);
 
 	ASSERT_TRUE(mesh != nullptr);
-	const std::size_t size(mesh_size*mesh_size*mesh_size);
+	const std::size_t number_of_tuples(mesh_size*mesh_size*mesh_size);
 
 	std::string const prop_name("TestProperty");
 	boost::optional<MeshLib::PropertyVector<double> &> double_properties(
 		mesh->getProperties().createNewPropertyVector<double>(prop_name,
 			MeshLib::MeshItemType::Cell));
-	(*double_properties).resize(size);
+	(*double_properties).resize(number_of_tuples);
 	std::iota((*double_properties).begin(), (*double_properties).end(), 1);
 
 	vtkNew<InSituLib::VtkMappedPropertyVectorTemplate<double> > dataArray;
 	dataArray->SetPropertyVector(*double_properties);
 
 	ASSERT_EQ(dataArray->GetNumberOfComponents(), 1);
-	ASSERT_EQ(dataArray->GetNumberOfTuples(), size);
+	ASSERT_EQ(dataArray->GetNumberOfTuples(), number_of_tuples);
 
 	ASSERT_EQ(dataArray->GetValueReference(0), 1.0);
 	double* range = dataArray->GetRange(0);
@@ -64,20 +64,20 @@ TEST(InSituLibMappedPropertyVector, Int)
 	MeshLib::Mesh* mesh = MeshLib::MeshGenerator::generateRegularHexMesh(length, mesh_size);
 
 	ASSERT_TRUE(mesh != nullptr);
-	const std::size_t size(mesh_size*mesh_size*mesh_size);
+	const std::size_t number_of_tuples(mesh_size*mesh_size*mesh_size);
 
 	std::string const prop_name("TestProperty");
 	boost::optional<MeshLib::PropertyVector<int> &> properties(
 		mesh->getProperties().createNewPropertyVector<int>(prop_name,
 			MeshLib::MeshItemType::Cell));
-	(*properties).resize(size);
+	(*properties).resize(number_of_tuples);
 	std::iota((*properties).begin(), (*properties).end(), -5);
 
 	vtkNew<InSituLib::VtkMappedPropertyVectorTemplate<int> > dataArray;
 	dataArray->SetPropertyVector(*properties);
 
 	ASSERT_EQ(dataArray->GetNumberOfComponents(), 1);
-	ASSERT_EQ(dataArray->GetNumberOfTuples(), size);
+	ASSERT_EQ(dataArray->GetNumberOfTuples(), number_of_tuples);
 
 	ASSERT_EQ(dataArray->GetValueReference(0), -5);
 	double* range = dataArray->GetRange(0);
@@ -96,20 +96,20 @@ TEST(InSituLibMappedPropertyVector, Unsigned)
 	MeshLib::Mesh* mesh = MeshLib::MeshGenerator::generateRegularHexMesh(length, mesh_size);
 
 	ASSERT_TRUE(mesh != nullptr);
-	const std::size_t size(mesh_size*mesh_size*mesh_size);
+	const std::size_t number_of_tuples(mesh_size*mesh_size*mesh_size);
 
 	std::string const prop_name("TestProperty");
 	boost::optional<MeshLib::PropertyVector<unsigned> &> properties(
 		mesh->getProperties().createNewPropertyVector<unsigned>(prop_name,
 														   MeshLib::MeshItemType::Cell));
-	(*properties).resize(size);
+	(*properties).resize(number_of_tuples);
 	std::iota((*properties).begin(), (*properties).end(), 0);
 
 	vtkNew<InSituLib::VtkMappedPropertyVectorTemplate<unsigned> > dataArray;
 	dataArray->SetPropertyVector(*properties);
 
 	ASSERT_EQ(dataArray->GetNumberOfComponents(), 1);
-	ASSERT_EQ(dataArray->GetNumberOfTuples(), size);
+	ASSERT_EQ(dataArray->GetNumberOfTuples(), number_of_tuples);
 
 	ASSERT_EQ(dataArray->GetValueReference(0), 0);
 	double* range = dataArray->GetRange(0);

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -464,7 +464,7 @@ TEST_F(MeshLibProperties, CopyConstructor)
 TEST_F(MeshLibProperties, AddDoublePropertiesTupleSize2)
 {
 	ASSERT_TRUE(mesh != nullptr);
-	const std::size_t size(mesh_size*mesh_size*mesh_size);
+	const std::size_t number_of_tuples(mesh_size*mesh_size*mesh_size);
 
 	std::string const prop_name("TestProperty");
 	boost::optional<MeshLib::PropertyVector<double> &> opt_pv(
@@ -479,17 +479,18 @@ TEST_F(MeshLibProperties, AddDoublePropertiesTupleSize2)
 	ASSERT_EQ(0u, pv.getPropertyName().compare(prop_name));
 	ASSERT_EQ(MeshLib::MeshItemType::Cell, pv.getMeshItemType());
 	ASSERT_EQ(2u, pv.getTupleSize());
+	ASSERT_EQ(0u, pv.getNumberOfTuples());
 	ASSERT_EQ(0u, pv.size());
 
 	// push some values (2 tuples) into the vector
-	for (std::size_t k(0); k<size; k++) {
+	for (std::size_t k(0); k<number_of_tuples; k++) {
 		pv.push_back(static_cast<double>(k));
 		pv.push_back(static_cast<double>(k));
 	}
-	// check the size, i.e., the number of tuples
-	ASSERT_EQ(size, pv.size());
+	// check the number of tuples
+	ASSERT_EQ(number_of_tuples, pv.getNumberOfTuples());
 	// check the values
-	for (std::size_t k(0); k<size; k++) {
+	for (std::size_t k(0); k<number_of_tuples; k++) {
 		ASSERT_EQ(static_cast<double>(k), pv[2*k]);
 		ASSERT_EQ(static_cast<double>(k), pv[2*k+1]);
 	}

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -489,6 +489,7 @@ TEST_F(MeshLibProperties, AddDoublePropertiesTupleSize2)
 	}
 	// check the number of tuples
 	ASSERT_EQ(number_of_tuples, pv.getNumberOfTuples());
+	ASSERT_EQ(pv.getNumberOfTuples()*pv.getTupleSize(), pv.size());
 	// check the values
 	for (std::size_t k(0); k<number_of_tuples; k++) {
 		ASSERT_EQ(static_cast<double>(k), pv[2*k]);


### PR DESCRIPTION
For better usablility and readability of the `PropertyVector` this PR contains:
- Added `PropertyVector::getNumberOfTuples()` which returns the number of tuples.
- Changed the behaviour of `PropertyVector::size()`. The method now returns the number of tuples times the number of components per tuple.
