### PR TITLE
Cleanup: Add point ids.

### DIFF
--- a/FileIO/TINInterface.cpp
+++ b/FileIO/TINInterface.cpp
@@ -99,11 +99,17 @@ GeoLib::Surface* TINInterface::readTIN(std::string const& fname,
 		}
 
 		// determine size pnt_vec to insert the correct ids
-		std::size_t const pnt_pos_0(pnt_vec.push_back(new GeoLib::Point(p0)));
-		std::size_t const pnt_pos_1(pnt_vec.push_back(new GeoLib::Point(p1)));
-		std::size_t const pnt_pos_2(pnt_vec.push_back(new GeoLib::Point(p2)));
+		std::size_t const s(pnt_vec.getVector()->size());
+
+		std::size_t const pnt_pos_0(pnt_vec.push_back(new GeoLib::Point(p0, s)));
+		std::size_t const pnt_pos_1(pnt_vec.push_back(new GeoLib::Point(p1, s+1)));
+		std::size_t const pnt_pos_2(pnt_vec.push_back(new GeoLib::Point(p2, s+2)));
 		// create new Triangle
-		sfc->addTriangle(pnt_pos_0, pnt_pos_1, pnt_pos_2);
+		if (pnt_pos_0 != std::numeric_limits<std::size_t>::max() &&
+			pnt_pos_1 != std::numeric_limits<std::size_t>::max() &&
+			pnt_pos_1 != std::numeric_limits<std::size_t>::max()) {
+			sfc->addTriangle(pnt_pos_0, pnt_pos_1, pnt_pos_2);
+		}
 	}
 
 	if (sfc->getNTriangles() == 0) {

--- a/GeoLib/GEOObjects.cpp
+++ b/GeoLib/GEOObjects.cpp
@@ -420,7 +420,8 @@ bool GEOObjects::mergePoints(std::vector<std::string> const & geo_names,
 
 		std::size_t const n_pnts(pnts->size());
 		for (std::size_t k(0); k < n_pnts; ++k) {
-			merged_points->push_back(new GeoLib::Point(*(*pnts)[k]));
+			merged_points->push_back(
+				new GeoLib::Point(*(*pnts)[k], pnt_offsets[j]+k));
 			std::string const& item_name(pnt_vec->getItemNameByID(k));
 			if (! item_name.empty()) {
 				merged_pnt_names->insert(

--- a/Tests/GeoLib/TestGEOObjectsMerge.cpp
+++ b/Tests/GeoLib/TestGEOObjectsMerge.cpp
@@ -33,11 +33,13 @@ void createSetOfTestPointsAndAssociatedNames(GeoLib::GEOObjects & geo_objs, std:
 		for (std::size_t j(0); j < pnts_per_edge; j++) {
 			const std::size_t offset(j * pnts_per_edge + k_offset);
 			for (std::size_t i(0); i < pnts_per_edge; i++) {
-				pnts->push_back(new GeoLib::Point(i+shift[0], j+shift[1], k+shift[2]));
+				std::size_t const id(i+offset);
+				pnts->push_back(
+					new GeoLib::Point(i+shift[0], j+shift[1], k+shift[2], id));
 				std::string pnt_name(
 						name + "-" + std::to_string(i) + "-" + std::to_string(j) + "-"
 								+ std::to_string(k));
-				pnt_name_map->insert(std::pair< std::string, std::size_t>(pnt_name, i + offset));
+				pnt_name_map->insert(std::make_pair(pnt_name, id));
 			}
 		}
 	}

--- a/Tests/GeoLib/TestPointVec.cpp
+++ b/Tests/GeoLib/TestPointVec.cpp
@@ -57,7 +57,7 @@ TEST_F(PointVecTest, TestPointVecCtorEmpty)
 // Testing input vector with single point.
 TEST_F(PointVecTest, TestPointVecCtorSinglePoint)
 {
-	ps_ptr->push_back(new GeoLib::Point(0,0,0));
+	ps_ptr->push_back(new GeoLib::Point(0,0,0,0));
 	GeoLib::PointVec* point_vec = nullptr;
 	ASSERT_NO_THROW(point_vec = new GeoLib::PointVec(name, ps_ptr));
 	ASSERT_EQ(std::size_t(1), point_vec->size());
@@ -68,8 +68,8 @@ TEST_F(PointVecTest, TestPointVecCtorSinglePoint)
 // Testing input vector with two different points.
 TEST_F(PointVecTest, TestPointVecCtorTwoDiffPoints)
 {
-	ps_ptr->push_back(new GeoLib::Point(0,0,0));
-	ps_ptr->push_back(new GeoLib::Point(1,0,0));
+	ps_ptr->push_back(new GeoLib::Point(0,0,0,0));
+	ps_ptr->push_back(new GeoLib::Point(1,0,0,1));
 
 	GeoLib::PointVec* point_vec = nullptr;
 	ASSERT_NO_THROW(point_vec = new GeoLib::PointVec(name, ps_ptr));
@@ -81,8 +81,8 @@ TEST_F(PointVecTest, TestPointVecCtorTwoDiffPoints)
 // Testing input vector with two equal points.
 TEST_F(PointVecTest, TestPointVecCtorTwoEqualPoints)
 {
-	ps_ptr->push_back(new GeoLib::Point(0,0,0));
-	ps_ptr->push_back(new GeoLib::Point(0,0,0));
+	ps_ptr->push_back(new GeoLib::Point(0,0,0,0));
+	ps_ptr->push_back(new GeoLib::Point(0,0,0,1));
 
 	GeoLib::PointVec* point_vec = nullptr;
 	ASSERT_NO_THROW(point_vec = new GeoLib::PointVec(name, ps_ptr));
@@ -94,17 +94,17 @@ TEST_F(PointVecTest, TestPointVecCtorTwoEqualPoints)
 // Testing input vector with single point.
 TEST_F(PointVecTest, TestPointVecPushBack)
 {
-	ps_ptr->push_back(new GeoLib::Point(0,0,0));
-	ps_ptr->push_back(new GeoLib::Point(1,0,0));
-	ps_ptr->push_back(new GeoLib::Point(0,1,0));
-	ps_ptr->push_back(new GeoLib::Point(0,0,1));
+	ps_ptr->push_back(new GeoLib::Point(0,0,0,0));
+	ps_ptr->push_back(new GeoLib::Point(1,0,0,1));
+	ps_ptr->push_back(new GeoLib::Point(0,1,0,2));
+	ps_ptr->push_back(new GeoLib::Point(0,0,1,3));
 	GeoLib::PointVec point_vec(name, ps_ptr);
 
 	// Adding a new point with same coordinates changes nothing.
-	point_vec.push_back(new GeoLib::Point(0,0,0));
-	point_vec.push_back(new GeoLib::Point(1,0,0));
-	point_vec.push_back(new GeoLib::Point(0,1,0));
-	point_vec.push_back(new GeoLib::Point(0,0,1));
+	point_vec.push_back(new GeoLib::Point(0,0,0,4));
+	point_vec.push_back(new GeoLib::Point(1,0,0,5));
+	point_vec.push_back(new GeoLib::Point(0,1,0,6));
+	point_vec.push_back(new GeoLib::Point(0,0,1,7));
 
 	ASSERT_EQ(std::size_t(4), point_vec.size());
 }

--- a/Tests/GeoLib/TestPointVec.cpp
+++ b/Tests/GeoLib/TestPointVec.cpp
@@ -31,7 +31,9 @@ protected:
 	{
 		std::uniform_real_distribution<double> rnd(-1, 1);
 		std::generate_n(std::back_inserter(*ps_ptr), n,
-			[&]() { return new GeoLib::Point(rnd(gen), rnd(gen), rnd(gen)); });
+			[&]() {
+				return new GeoLib::Point(rnd(gen), rnd(gen), rnd(gen), ps_ptr->size());
+			});
 	}
 
 protected:


### PR DESCRIPTION
In PR [673](https://github.com/ufz/ogs/pull/673) an id was introduced to the `GeoLib::Point`. At some places I missed to add this id when points are created. This PR is adding the ids to the points.