### PR TITLE
Cleanup in GeoLib

### DIFF
--- a/Applications/DataExplorer/DataView/GEOModels.cpp
+++ b/Applications/DataExplorer/DataView/GEOModels.cpp
@@ -89,14 +89,6 @@ void GEOModels::addPointVec( std::vector<GeoLib::Point*>* points,
 	emit geoDataAdded(_geoModel, name, GeoLib::GEOTYPE::POINT);
 }
 
-bool GEOModels::appendPointVec(const std::vector<GeoLib::Point*> &points,
-                               const std::string &name, std::vector<std::size_t>* ids)
-{
-	bool ret (GeoLib::GEOObjects::appendPointVec (points, name, ids));
-	// TODO import new points into geo-treeview
-	return ret;
-}
-
 bool GEOModels::removePointVec( const std::string &name )
 {
 	if (!isPntVecUsed(name))

--- a/Applications/DataExplorer/DataView/GEOModels.h
+++ b/Applications/DataExplorer/DataView/GEOModels.h
@@ -60,9 +60,7 @@ public slots:
 	                         std::string &name,
 	                         std::map<std::string, std::size_t>* name_pnt_id_map = NULL,
 	                         double eps = sqrt(std::numeric_limits<double>::epsilon()));
-	virtual bool appendPointVec(const std::vector<GeoLib::Point*> &points,
-	                            const std::string &name,
-	                            std::vector<std::size_t>* ids = NULL);
+
 	virtual bool removePointVec(const std::string &name);
 
 	virtual void addStationVec(std::vector<GeoLib::Point*>* stations,

--- a/FileIO/GmshIO/GMSHPolygonTree.cpp
+++ b/FileIO/GmshIO/GMSHPolygonTree.cpp
@@ -68,23 +68,23 @@ void GMSHPolygonTree::insertPolyline (GeoLib::PolylineWithSegmentMarker * ply)
 		// pay attention: loop bound is not fix!
 		size_t n_segments (ply->getNumberOfPoints()-1);
 		GeoLib::Point tmp_pnt;
+		GeoLib::PointVec & pnt_vec(*(_geo_objs.getPointVecObj(_geo_name)));
 		for (size_t k(0); k<n_segments; k++) {
 			if (! ply->isSegmentMarked(k)) {
 				size_t seg_num(0);
 				GeoLib::Point *intersection_pnt(new GeoLib::Point);
 				while (_node_polygon->getNextIntersectionPointPolygonLine(*(ply->getPoint(k)), *(ply->getPoint(k+1)), intersection_pnt, seg_num)) {
 					// insert the intersection point to point vector of GEOObjects instance
-					size_t pnt_id;
+					const std::size_t pnt_vec_size(pnt_vec.size());
 					// appendPoints deletes an already existing point
-					if (_geo_objs.appendPoint(intersection_pnt, _geo_name, pnt_id)) {
-						// case: new point
+					const std::size_t pnt_id(pnt_vec.push_back(intersection_pnt));
+					if (pnt_vec_size < pnt_vec.size()) { // case: new point
 						// modify the polygon
 						_node_polygon->insertPoint(seg_num+1, pnt_id);
 						// modify the polyline
 						ply->insertPoint(k+1, pnt_id);
 						n_segments++;
-					} else {
-						// case: existing point
+					} else { // case: existing point
 						// check if point id is within the polygon
 						if (! _node_polygon->isPointIDInPolyline(pnt_id)) {
 							_node_polygon->insertPoint(seg_num+1, pnt_id);

--- a/GeoLib/AnalyticalGeometry-impl.h
+++ b/GeoLib/AnalyticalGeometry-impl.h
@@ -18,7 +18,7 @@ void getNewellPlane (const std::vector<T_POINT*>& pnts,
     d = 0;
     MathLib::Vector3 centroid;
     std::size_t n_pnts(pnts.size());
-    for (size_t i(n_pnts - 1), j(0); j < n_pnts; i = j, j++) {
+    for (std::size_t i(n_pnts - 1), j(0); j < n_pnts; i = j, j++) {
         plane_normal[0] += ((*(pnts[i]))[1] - (*(pnts[j]))[1])
                            * ((*(pnts[i]))[2] + (*(pnts[j]))[2]); // projection on yz
         plane_normal[1] += ((*(pnts[i]))[2] - (*(pnts[j]))[2])

--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -175,11 +175,11 @@ bool lineSegmentIntersect(
 }
 
 bool lineSegmentsIntersect(const GeoLib::Polyline* ply,
-                           size_t &idx0,
-                           size_t &idx1,
+                           std::size_t &idx0,
+                           std::size_t &idx1,
                            GeoLib::Point& intersection_pnt)
 {
-	size_t n_segs(ply->getNumberOfPoints() - 1);
+	std::size_t n_segs(ply->getNumberOfPoints() - 1);
 	/**
 	 * computing the intersections of all possible pairs of line segments of the given polyline
 	 * as follows:
@@ -187,8 +187,8 @@ bool lineSegmentsIntersect(const GeoLib::Polyline* ply,
 	 * of the polyline and segment \f$s_2 = (C,B)\f$ defined by \f$j\f$-th and
 	 * \f$j+1\f$-st point of the polyline, \f$j>k+1\f$
 	 */
-	for (size_t k(0); k < n_segs - 2; k++) {
-		for (size_t j(k + 2); j < n_segs; j++) {
+	for (std::size_t k(0); k < n_segs - 2; k++) {
+		for (std::size_t j(k + 2); j < n_segs; j++) {
 			if (k != 0 || j < n_segs - 1) {
 				if (lineSegmentIntersect(*(ply->getPoint(k)), *(ply->getPoint(k + 1)),
 				                         *(ply->getPoint(j)), *(ply->getPoint(j + 1)),

--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -372,7 +372,7 @@ void computeRotationMatrixToXZ(MathLib::Vector3 const& plane_normal, MathLib::De
 
 void rotatePoints(MathLib::DenseMatrix<double> const& rot_mat, std::vector<GeoLib::Point*> &pnts)
 {
-	double* tmp (NULL);
+	double* tmp (nullptr);
 	const std::size_t n_pnts(pnts.size());
 	for (std::size_t k(0); k < n_pnts; k++) {
 		tmp = rot_mat * pnts[k]->getCoords();

--- a/GeoLib/AnalyticalGeometry.h
+++ b/GeoLib/AnalyticalGeometry.h
@@ -258,7 +258,7 @@ bool lineSegmentIntersect (const GeoLib::Point& a, const GeoLib::Point& b,
 /**
  * Calculates the intersection points of a line PQ and a triangle ABC.
  * This method requires ABC to be counterclockwise and PQ to point downward.
- * @return Intersection point or NULL if there is no intersection.
+ * @return Intersection point or nullptr if there is no intersection.
  */
 GeoLib::Point* triangleLineIntersection(MathLib::Point3d const& a, MathLib::Point3d const& b, MathLib::Point3d const& c, MathLib::Point3d const& p, MathLib::Point3d const& q);
 

--- a/GeoLib/GEOObjects.cpp
+++ b/GeoLib/GEOObjects.cpp
@@ -48,19 +48,6 @@ void GEOObjects::addPointVec(std::vector<Point*>* points,
 	_pnt_vecs.push_back(new PointVec(name, points, pnt_id_name_map, PointVec::PointType::POINT, eps));
 }
 
-bool GEOObjects::appendPoint(Point* point, std::string const &name, std::size_t& id)
-{
-	// search vector
-	std::size_t const idx = this->exists(name);
-	if (idx == std::numeric_limits<std::size_t>::max())
-		return false;
-
-	std::size_t const size_previous(_pnt_vecs[idx]->size());
-
-	id = _pnt_vecs[idx]->push_back(point);
-	return size_previous < _pnt_vecs[idx]->size();
-}
-
 const std::vector<Point*>* GEOObjects::getPointVec(const std::string &name) const
 {
 	std::size_t const idx = this->exists(name);

--- a/GeoLib/GEOObjects.cpp
+++ b/GeoLib/GEOObjects.cpp
@@ -48,27 +48,6 @@ void GEOObjects::addPointVec(std::vector<Point*>* points,
 	_pnt_vecs.push_back(new PointVec(name, points, pnt_id_name_map, PointVec::PointType::POINT, eps));
 }
 
-bool GEOObjects::appendPointVec(std::vector<Point*> const& new_points,
-                                std::string const &name, std::vector<std::size_t>* ids)
-{
-	// search vector
-	std::size_t const idx = this->exists(name);
-	if (idx == std::numeric_limits<std::size_t>::max())
-		return false;
-
-	std::size_t const n_new_pnts(new_points.size());
-
-	// append points
-	if (ids)
-		for (std::size_t k(0); k < n_new_pnts; k++)
-			ids->push_back (_pnt_vecs[idx]->push_back (new_points[k]));
-	else
-		for (std::size_t k(0); k < n_new_pnts; k++)
-			_pnt_vecs[idx]->push_back (new_points[k]);
-
-	return true;
-}
-
 bool GEOObjects::appendPoint(Point* point, std::string const &name, std::size_t& id)
 {
 	// search vector

--- a/GeoLib/GEOObjects.h
+++ b/GeoLib/GEOObjects.h
@@ -74,19 +74,6 @@ public:
 	                         std::map<std::string, std::size_t>* pnt_names = NULL,
 	                         double eps = sqrt(std::numeric_limits<double>::epsilon()));
 
-	/** copies the pointers to the points in the given vector to the PointVec of the provided name.
-	 * The pointers are managed by the GEOObjects, i.e. GEOObjects will delete the Points at the
-	 * end of its scope.
-	 * \param points the vector with points
-	 * \param name the name of the internal PointVec
-	 * \param ids On return the vector holds the ids of the inserted points within the internal vector.
-	 * In case the ids are not needed it is possible to give a NULL pointer (default value).
-	 * \return true if the points are appended, false if the a PointVec with the
-	 * corresponding name does not exist
-	 * */
-	virtual bool appendPointVec(const std::vector<Point*> &points,
-	                            std::string const &name, std::vector<std::size_t>* ids = NULL);
-
 	/**
 	 * Method appends the point the the PointVec object with the name name. The PointVec
 	 * object takes care about deleting the point. If the point already exists within the

--- a/GeoLib/GEOObjects.h
+++ b/GeoLib/GEOObjects.h
@@ -71,7 +71,7 @@ public:
 	 */
 	virtual void addPointVec(std::vector<Point*>* points,
 	                         std::string &name,
-	                         std::map<std::string, std::size_t>* pnt_names = NULL,
+	                         std::map<std::string, std::size_t>* pnt_names = nullptr,
 	                         double eps = sqrt(std::numeric_limits<double>::epsilon()));
 
 	/**
@@ -119,7 +119,7 @@ public:
 	 */
 	virtual void addPolylineVec(std::vector<Polyline*>* lines,
 	                            const std::string &name,
-	                            std::map<std::string,std::size_t>* ply_names = NULL);
+	                            std::map<std::string,std::size_t>* ply_names = nullptr);
 
 	/** copies the pointers to the polylines in the vector to the PolylineVec with provided name.
 	 * the pointers are managed by the GEOObjects, i.e. GEOObjects will delete the Polylines at the
@@ -161,7 +161,7 @@ public:
 	/** Adds a vector of surfaces with the given name to GEOObjects. */
 	virtual void addSurfaceVec(std::vector<Surface*>* surfaces,
 	                           const std::string &name,
-	                           std::map<std::string, std::size_t>* sfc_names = NULL);
+	                           std::map<std::string, std::size_t>* sfc_names = nullptr);
 
 	/**
 	 * Copies the surfaces in the vector to the SurfaceVec with the given name.

--- a/GeoLib/GEOObjects.h
+++ b/GeoLib/GEOObjects.h
@@ -75,18 +75,6 @@ public:
 	                         double eps = sqrt(std::numeric_limits<double>::epsilon()));
 
 	/**
-	 * Method appends the point the the PointVec object with the name name. The PointVec
-	 * object takes care about deleting the point. If the point already exists within the
-	 * PointVec object this method will delete it.
-	 * @param point (input) the point (exact the pointer to the point) that should be added
-	 * @param name (input) the name of the geometry the point should be added
-	 * @param id (output) the id of the point within the PointVec object will be set
-	 * @return true, if the point could be inserted (i.e. was not already contained in the vector)
-	 * else false (the user have to delete the point itself)
-	 */
-	bool appendPoint(Point* point, std::string const &name, std::size_t& id);
-
-	/**
 	 * Returns the point vector with the given name.
 	 */
 	const std::vector<Point*>* getPointVec(const std::string &name) const;

--- a/GeoLib/Grid.h
+++ b/GeoLib/Grid.h
@@ -125,11 +125,11 @@ public:
 	 * distance. A pointer to this object is returned.
 	 *
 	 * If there is not such a point, i.e., all the searched grid cells do not contain any
-	 * POINT object a NULL pointer is returned.
+	 * POINT object a nullptr pointer is returned.
 	 *
 	 * @param pnt a field that holds the coordinates of the point
 	 * @return a pointer to the point with the smallest distance within the grid cells that are
-	 * outlined above or NULL
+	 * outlined above or nullptr
 	 */
 	POINT* getNearestPoint(POINT const& pnt) const
 	{
@@ -137,7 +137,7 @@ public:
 		getGridCoords(pnt, coords);
 
 		double sqr_min_dist (MathLib::sqrDist(this->_min_pnt, this->_max_pnt));
-		POINT* nearest_pnt(NULL);
+		POINT* nearest_pnt(nullptr);
 
 		double dists[6];
 		getPointCellBorderDistances(pnt, dists, coords);
@@ -155,10 +155,10 @@ public:
 		} else {
 			// search in all border cells for at least one neighbor
 			double sqr_min_dist_tmp;
-			POINT * nearest_pnt_tmp(NULL);
+			POINT * nearest_pnt_tmp(nullptr);
 			std::size_t offset(1);
 
-			while (nearest_pnt == NULL) {
+			while (nearest_pnt == nullptr) {
 				std::size_t tmp_coords[3];
 				if (coords[0] < offset) {
 					tmp_coords[0] = 0;
@@ -478,7 +478,7 @@ void Grid<POINT>::createGridGeometry(GeoLib::GEOObjects* geo_obj) const
 				points->push_back(new GeoLib::Point(llf[0]+i*dx, llf[1]+(j+1)*dy, llf[2]+(k+1)*dz));
 				points->push_back(new GeoLib::Point(llf[0]+(i+1)*dx, llf[1]+(j+1)*dy, llf[2]+(k+1)*dz));
 				points->push_back(new GeoLib::Point(llf[0]+(i+1)*dx, llf[1]+j*dy, llf[2]+(k+1)*dz));
-				geo_obj->addPointVec(points, grid_names[grid_names.size()-1], NULL);
+				geo_obj->addPointVec(points, grid_names[grid_names.size()-1], nullptr);
 
 				std::vector<GeoLib::Polyline*>* plys (
 				        new std::vector<GeoLib::Polyline*>);
@@ -514,8 +514,8 @@ void Grid<POINT>::createGridGeometry(GeoLib::GEOObjects* geo_obj) const
 				ply5->addPoint(7);
 				plys->push_back(ply5);
 
-				geo_obj->addPolylineVec(plys,
-				                        grid_names[grid_names.size() - 1], NULL);
+				geo_obj->addPolylineVec(plys, grid_names[grid_names.size() - 1],
+					nullptr);
 			}
 		}
 	}

--- a/GeoLib/MinimalBoundingSphere.cpp
+++ b/GeoLib/MinimalBoundingSphere.cpp
@@ -188,7 +188,7 @@ std::vector<MathLib::Point3d*>* MinimalBoundingSphere::getRandomSpherePoints(std
 {
     std::vector<MathLib::Point3d*> *pnts = new std::vector<MathLib::Point3d*>;
     pnts->reserve(n_points);
-    srand ( static_cast<unsigned>(time(NULL)) );
+    srand ( static_cast<unsigned>(time(nullptr)) );
 
     for (std::size_t k(0); k<n_points; ++k)
     {

--- a/GeoLib/Polyline.cpp
+++ b/GeoLib/Polyline.cpp
@@ -403,7 +403,7 @@ double Polyline::getDistanceAlongPolyline(const MathLib::Point3d& pnt,
 	double dist, lambda;
 	bool found = false;
 	// loop over all line segments of the polyline
-	for (size_t k = 0; k < this->getNumberOfPoints() - 1; k++) {
+	for (std::size_t k = 0; k < this->getNumberOfPoints() - 1; k++) {
 		// is the orthogonal projection of the j-th node to the
 		// line g(lambda) = _ply->getPoint(k) + lambda * (_ply->getPoint(k+1) - _ply->getPoint(k))
 		// at the k-th line segment of the polyline, i.e. 0 <= lambda <= 1?

--- a/GeoLib/Polyline.cpp
+++ b/GeoLib/Polyline.cpp
@@ -332,7 +332,7 @@ Polyline* Polyline::constructPolylineFromSegments(const std::vector<Polyline*> &
 		if (!ply_found)
 		{
 			ERR("Error in Polyline::contructPolylineFromSegments() - Not all segments are connected.");
-			new_ply = NULL;
+			new_ply = nullptr;
 			break;
 		}
 	}

--- a/GeoLib/PolylineWithSegmentMarker.cpp
+++ b/GeoLib/PolylineWithSegmentMarker.cpp
@@ -19,9 +19,9 @@ namespace GeoLib {
 PolylineWithSegmentMarker::PolylineWithSegmentMarker(GeoLib::Polyline const& polyline)
 	: GeoLib::Polyline(polyline)
 {
-	const size_t n_pnts(getNumberOfPoints());
+	const std::size_t n_pnts(getNumberOfPoints());
 	_marker.resize(n_pnts);
-	for (size_t k(0); k<n_pnts; k++) {
+	for (std::size_t k(0); k<n_pnts; k++) {
 		_marker[k] = false;
 	}
 }
@@ -30,22 +30,22 @@ PolylineWithSegmentMarker::~PolylineWithSegmentMarker()
 {}
 
 
-void PolylineWithSegmentMarker::markSegment(size_t seg_num, bool mark_val)
+void PolylineWithSegmentMarker::markSegment(std::size_t seg_num, bool mark_val)
 {
 	_marker[seg_num] = mark_val;
 }
-bool PolylineWithSegmentMarker::isSegmentMarked(size_t seg_num) const
+bool PolylineWithSegmentMarker::isSegmentMarked(std::size_t seg_num) const
 {
 	return _marker[seg_num];
 }
 
-void PolylineWithSegmentMarker::addPoint(size_t pnt_id)
+void PolylineWithSegmentMarker::addPoint(std::size_t pnt_id)
 {
 	Polyline::addPoint(pnt_id);
 	_marker.push_back(false);
 }
 
-void PolylineWithSegmentMarker::insertPoint(size_t pos, size_t pnt_id)
+void PolylineWithSegmentMarker::insertPoint(std::size_t pos, std::size_t pnt_id)
 {
 	Polyline::insertPoint(pos, pnt_id);
 	_marker.insert(_marker.begin()+pos, _marker[pos]);

--- a/GeoLib/QuadTree.h
+++ b/GeoLib/QuadTree.h
@@ -49,14 +49,14 @@ public:
 	 * @param ur upper right point of the square
 	 */
 	QuadTree(POINT const& ll, POINT const& ur, std::size_t max_points_per_node) :
-		_father (NULL), _ll (ll), _ur (ur), _depth (0), _is_leaf (true),
+		_father (nullptr), _ll (ll), _ur (ur), _depth (0), _is_leaf (true),
 		_max_points_per_node (max_points_per_node)
 	{
 		assert (_max_points_per_node > 0);
 
 		// init childs
 		for (std::size_t k(0); k < 4; k++)
-			_childs[k] = NULL;
+			_childs[k] = nullptr;
 
 		if ((_ur[0] - _ll[0]) > (_ur[1] - _ll[1]))
 			_ur[1] = _ll[1] + _ur[0] - _ll[0];
@@ -141,28 +141,28 @@ public:
 
 					// check if north neighbor has to be refined
 					QuadTree<POINT>* north_neighbor (node->getNorthNeighbor());
-					if (north_neighbor != NULL)
+					if (north_neighbor != nullptr)
 						if (north_neighbor->getDepth() < node->getDepth ())
 							if (north_neighbor->isLeaf())
 								leaf_list.push_back (north_neighbor);
 
 					// check if west neighbor has to be refined
 					QuadTree<POINT>* west_neighbor (node->getWestNeighbor());
-					if (west_neighbor != NULL)
+					if (west_neighbor != nullptr)
 						if (west_neighbor->getDepth() < node->getDepth ())
 							if (west_neighbor->isLeaf())
 								leaf_list.push_back (west_neighbor);
 
 					// check if south neighbor has to be refined
 					QuadTree<POINT>* south_neighbor (node->getSouthNeighbor());
-					if (south_neighbor != NULL)
+					if (south_neighbor != nullptr)
 						if (south_neighbor->getDepth() < node->getDepth ())
 							if (south_neighbor->isLeaf())
 								leaf_list.push_back (south_neighbor);
 
 					// check if east neighbor has to be refined
 					QuadTree<POINT>* east_neighbor (node->getEastNeighbor());
-					if (east_neighbor != NULL)
+					if (east_neighbor != nullptr)
 						if (east_neighbor->getDepth() < node->getDepth ())
 							if (east_neighbor->isLeaf())
 								leaf_list.push_back (east_neighbor);
@@ -268,8 +268,8 @@ private:
 
 	QuadTree<POINT>* getNorthNeighbor () const
 	{
-		if (this->_father == NULL) // root of QuadTree
-			return NULL;
+		if (this->_father == nullptr) // root of QuadTree
+			return nullptr;
 
 		if (this->_father->isChild (this, Quadrant::SW))
 			return this->_father->getChild (Quadrant::NW);
@@ -277,8 +277,8 @@ private:
 			return this->_father->getChild (Quadrant::NE);
 
 		QuadTree<POINT>* north_neighbor (this->_father->getNorthNeighbor ());
-		if (north_neighbor == NULL)
-			return NULL;
+		if (north_neighbor == nullptr)
+			return nullptr;
 		if (north_neighbor->isLeaf())
 			return north_neighbor;
 
@@ -290,8 +290,8 @@ private:
 
 	QuadTree<POINT>* getSouthNeighbor () const
 	{
-		if (this->_father == NULL) // root of QuadTree
-			return NULL;
+		if (this->_father == nullptr) // root of QuadTree
+			return nullptr;
 
 		if (this->_father->isChild (this, Quadrant::NW))
 			return this->_father->getChild (Quadrant::SW);
@@ -299,8 +299,8 @@ private:
 			return this->_father->getChild (Quadrant::SE);
 
 		QuadTree<POINT>* south_neighbor (this->_father->getSouthNeighbor ());
-		if (south_neighbor == NULL)
-			return NULL;
+		if (south_neighbor == nullptr)
+			return nullptr;
 		if (south_neighbor->isLeaf())
 			return south_neighbor;
 
@@ -312,8 +312,8 @@ private:
 
 	QuadTree<POINT>* getEastNeighbor () const
 	{
-		if (this->_father == NULL) // root of QuadTree
-			return NULL;
+		if (this->_father == nullptr) // root of QuadTree
+			return nullptr;
 
 		if (this->_father->isChild (this, Quadrant::NW))
 			return this->_father->getChild (Quadrant::NE);
@@ -321,8 +321,8 @@ private:
 			return this->_father->getChild (Quadrant::SE);
 
 		QuadTree<POINT>* east_neighbor (this->_father->getEastNeighbor ());
-		if (east_neighbor == NULL)
-			return NULL;
+		if (east_neighbor == nullptr)
+			return nullptr;
 		if (east_neighbor->isLeaf())
 			return east_neighbor;
 
@@ -334,8 +334,8 @@ private:
 
 	QuadTree<POINT>* getWestNeighbor () const
 	{
-		if (this->_father == NULL) // root of QuadTree
-			return NULL;
+		if (this->_father == nullptr) // root of QuadTree
+			return nullptr;
 
 		if (this->_father->isChild (this, Quadrant::NE))
 			return this->_father->getChild (Quadrant::NW);
@@ -343,8 +343,8 @@ private:
 			return this->_father->getChild (Quadrant::SW);
 
 		QuadTree<POINT>* west_neighbor (this->_father->getWestNeighbor ());
-		if (west_neighbor == NULL)
-			return NULL;
+		if (west_neighbor == nullptr)
+			return nullptr;
 		if (west_neighbor->isLeaf())
 			return west_neighbor;
 
@@ -372,7 +372,7 @@ private:
 	{
 		// init childs
 		for (std::size_t k(0); k < 4; k++)
-			_childs[k] = NULL;
+			_childs[k] = nullptr;
 	}
 
 	void splitNode ()
@@ -407,7 +407,7 @@ private:
 	bool needToRefine (QuadTree<POINT>* node)
 	{
 		QuadTree<POINT>* north_neighbor (node->getNorthNeighbor ());
-		if (north_neighbor != NULL)
+		if (north_neighbor != nullptr)
 		{
 			if (north_neighbor->getDepth() == node->getDepth())
 				if (!north_neighbor->isLeaf ())
@@ -420,7 +420,7 @@ private:
 		}
 
 		QuadTree<POINT>* west_neighbor (node->getWestNeighbor ());
-		if (west_neighbor != NULL)
+		if (west_neighbor != nullptr)
 		{
 			if (west_neighbor->getDepth() == node->getDepth())
 				if (!west_neighbor->isLeaf ())
@@ -433,7 +433,7 @@ private:
 		}
 
 		QuadTree<POINT>* south_neighbor (node->getSouthNeighbor ());
-		if (south_neighbor != NULL)
+		if (south_neighbor != nullptr)
 		{
 			if (south_neighbor->getDepth() == node->getDepth())
 				if (!south_neighbor->isLeaf())
@@ -446,7 +446,7 @@ private:
 		}
 
 		QuadTree<POINT>* east_neighbor (node->getEastNeighbor ());
-		if (east_neighbor != NULL)
+		if (east_neighbor != nullptr)
 		{
 			if (east_neighbor->getDepth() == node->getDepth())
 				if (!east_neighbor->isLeaf ())

--- a/GeoLib/Raster.cpp
+++ b/GeoLib/Raster.cpp
@@ -30,9 +30,9 @@ void Raster::refineRaster(std::size_t scaling)
 
 	for (std::size_t row(0); row<_n_rows; row++) {
 		for (std::size_t col(0); col<_n_cols; col++) {
-			const size_t idx(row*_n_cols+col);
+			const std::size_t idx(row*_n_cols+col);
 			for (std::size_t new_row(row*scaling); new_row<(row+1)*scaling; new_row++) {
-				const size_t idx0(new_row*_n_cols*scaling);
+				const std::size_t idx0(new_row*_n_cols*scaling);
 				for (std::size_t new_col(col*scaling); new_col<(col+1)*scaling; new_col++) {
 					new_raster_data[idx0+new_col] = _raster_data[idx];
 				}
@@ -73,14 +73,14 @@ Raster* Raster::getRasterFromSurface(Surface const& sfc, double cell_size, doubl
 	MathLib::Point3d const& ll(sfc.getAABB().getMinPoint());
 	MathLib::Point3d const& ur(sfc.getAABB().getMaxPoint());
 
-	const std::size_t n_cols = static_cast<size_t>(std::fabs(ur[0]-ll[0]) / cell_size)+1;
-	const std::size_t n_rows = static_cast<size_t>(std::fabs(ur[1]-ll[1]) / cell_size)+1;
-	const size_t n_triangles (sfc.getNTriangles());
+	const std::size_t n_cols = static_cast<std::size_t>(std::fabs(ur[0]-ll[0]) / cell_size)+1;
+	const std::size_t n_rows = static_cast<std::size_t>(std::fabs(ur[1]-ll[1]) / cell_size)+1;
+	const std::size_t n_triangles (sfc.getNTriangles());
 	double *z_vals (new double[n_cols*n_rows]);
-	size_t k(0);
+	std::size_t k(0);
 
-	for (size_t r(0); r < n_cols; r++) {
-		for (size_t c(0); c < n_rows; c++) {
+	for (std::size_t r(0); r < n_cols; r++) {
+		for (std::size_t c(0); c < n_rows; c++) {
 			const double test_pnt[3] = { ll[0] + r*cell_size, ll[1] + c*cell_size, 0};
 			for (k=0; k<n_triangles; k++) {
 				if (sfc[k]->containsPoint2D(test_pnt)) {

--- a/GeoLib/SensorData.cpp
+++ b/GeoLib/SensorData.cpp
@@ -82,7 +82,7 @@ const std::vector<float>* SensorData::getTimeSeries(SensorDataType time_series_n
 			return _data_vecs[i];
 	}
 	ERR("Error in SensorData::getTimeSeries() - Time series \"%d\" not found.", time_series_name);
-	return NULL;
+	return nullptr;
 }
 
 std::string SensorData::getDataUnit(SensorDataType time_series_name) const

--- a/GeoLib/SensorData.cpp
+++ b/GeoLib/SensorData.cpp
@@ -30,17 +30,17 @@ SensorData::SensorData(const std::string &file_name)
 	this->readDataFromFile(file_name);
 }
 
-SensorData::SensorData(std::vector<size_t> time_steps)
+SensorData::SensorData(std::vector<std::size_t> time_steps)
 : _start(time_steps[0]), _end(time_steps[time_steps.size()-1]), _step_size(0), _time_unit(TimeStepType::NONE), _time_steps(time_steps)
 {
-	for (size_t i=1; i<time_steps.size(); i++)
+	for (std::size_t i=1; i<time_steps.size(); i++)
 	{
 		if (time_steps[i-1]>=time_steps[i])
 			ERR("Error in SensorData() - Time series has no order!");
 	}
 }
 
-SensorData::SensorData(size_t first_timestep, size_t last_timestep, size_t step_size)
+SensorData::SensorData(std::size_t first_timestep, std::size_t last_timestep, std::size_t step_size)
 : _start(first_timestep), _end(last_timestep), _step_size(step_size), _time_unit(TimeStepType::NONE)
 {
 }
@@ -76,7 +76,7 @@ void SensorData::addTimeSeries(SensorDataType data_name, std::vector<float> *dat
 
 const std::vector<float>* SensorData::getTimeSeries(SensorDataType time_series_name) const
 {
-	for (size_t i=0; i<_vec_names.size(); i++)
+	for (std::size_t i=0; i<_vec_names.size(); i++)
 	{
 		if (time_series_name == _vec_names[i])
 			return _data_vecs[i];
@@ -87,7 +87,7 @@ const std::vector<float>* SensorData::getTimeSeries(SensorDataType time_series_n
 
 std::string SensorData::getDataUnit(SensorDataType time_series_name) const
 {
-	for (size_t i=0; i<_vec_names.size(); i++)
+	for (std::size_t i=0; i<_vec_names.size(); i++)
 	{
 		if (time_series_name == _vec_names[i])
 			return _data_unit_string[i];
@@ -112,15 +112,15 @@ int SensorData::readDataFromFile(const std::string &file_name)
 	getline(in, line);
 	std::list<std::string> fields = BaseLib::splitString(line, '\t');
 	std::list<std::string>::const_iterator it (fields.begin());
-	size_t nFields = fields.size();
+	std::size_t nFields = fields.size();
 
 	if (nFields<2)
 		return 0;
 
-	size_t nDataArrays(nFields-1);
+	std::size_t nDataArrays(nFields-1);
 
 	//create vectors necessary to hold the data
-	for (size_t i=0; i<nDataArrays; i++)
+	for (std::size_t i=0; i<nDataArrays; i++)
 	{
 		this->_vec_names.push_back(SensorData::convertString2SensorDataType(*++it));
 		this->_data_unit_string.push_back("");
@@ -135,11 +135,11 @@ int SensorData::readDataFromFile(const std::string &file_name)
 		if (nFields == fields.size())
 		{
 			it = fields.begin();
-			size_t pos(it->rfind("."));
-			size_t current_time_step = (pos == std::string::npos) ? atoi((it++)->c_str()) : BaseLib::strDate2int(*it++);
+			std::size_t pos(it->rfind("."));
+			std::size_t current_time_step = (pos == std::string::npos) ? atoi((it++)->c_str()) : BaseLib::strDate2int(*it++);
 			this->_time_steps.push_back(current_time_step);
 
-			for (size_t i=0; i<nDataArrays; i++)
+			for (std::size_t i=0; i<nDataArrays; i++)
 				this->_data_vecs[i]->push_back(static_cast<float>(strtod((it++)->c_str(), 0)));
 		}
 		else

--- a/GeoLib/Station.cpp
+++ b/GeoLib/Station.cpp
@@ -30,16 +30,18 @@
 namespace GeoLib
 {
 Station::Station(double x, double y, double z, std::string name) :
-	Point (x,y,z), _name(name), _type(Station::StationType::STATION), _station_value(0.0), _sensor_data(NULL)
+	Point (x,y,z), _name(name), _type(Station::StationType::STATION),
+	_station_value(0.0), _sensor_data(nullptr)
 {}
 
 Station::Station(Point* coords, std::string name) :
-	Point (*coords), _name(name), _type(Station::StationType::STATION), _station_value(0.0), _sensor_data(NULL)
+	Point (*coords), _name(name), _type(Station::StationType::STATION),
+	_station_value(0.0), _sensor_data(nullptr)
 {}
 
 Station::Station(Station const& src) :
 	Point(src.getCoords()), _name(src._name), _type(src._type),
-	_station_value(src._station_value), _sensor_data(NULL)
+	_station_value(src._station_value), _sensor_data(nullptr)
 {}
 
 Station::~Station()
@@ -56,17 +58,17 @@ Station* Station::createStation(const std::string & line)
 	if (fields.size() >= 3)
 	{
 		it = fields.begin();
-		station->_name  = *it;
-		(*station)[0]     = strtod((BaseLib::replaceString(",", ".", *(++it))).c_str(), NULL);
-		(*station)[1]     = strtod((BaseLib::replaceString(",", ".", *(++it))).c_str(), NULL);
+		station->_name = *it;
+		(*station)[0] = strtod((BaseLib::replaceString(",", ".", *(++it))).c_str(), nullptr);
+		(*station)[1] = strtod((BaseLib::replaceString(",", ".", *(++it))).c_str(), nullptr);
 		if (++it != fields.end())
-			(*station)[2] = strtod((BaseLib::replaceString(",", ".", *it)).c_str(), NULL);
+			(*station)[2] = strtod((BaseLib::replaceString(",", ".", *it)).c_str(), nullptr);
 	}
 	else
 	{
 		INFO("Station::createStation() - Unexpected file format.");
 		delete station;
-		return NULL;
+		return nullptr;
 	}
 	return station;
 }

--- a/GeoLib/StationBorehole.cpp
+++ b/GeoLib/StationBorehole.cpp
@@ -207,17 +207,17 @@ StationBorehole* StationBorehole::createStation(const std::string &line)
 	StationBorehole* borehole = new StationBorehole();
 	std::list<std::string> fields = BaseLib::splitString(line, '\t');
 
-	if (fields.size()      >= 5)
+	if (fields.size() >= 5)
 	{
-		borehole->_name     = fields.front();
+		borehole->_name = fields.front();
 		fields.pop_front();
-		(*borehole)[0]      = strtod((BaseLib::replaceString(",", ".", fields.front())).c_str(), NULL);
+		(*borehole)[0] = strtod(BaseLib::replaceString(",", ".", fields.front()).c_str(), nullptr);
 		fields.pop_front();
-		(*borehole)[1]      = strtod((BaseLib::replaceString(",", ".", fields.front())).c_str(), NULL);
+		(*borehole)[1] = strtod(BaseLib::replaceString(",", ".", fields.front()).c_str(), nullptr);
 		fields.pop_front();
-		(*borehole)[2]      = strtod((BaseLib::replaceString(",", ".", fields.front())).c_str(), NULL);
+		(*borehole)[2] = strtod(BaseLib::replaceString(",", ".", fields.front()).c_str(), nullptr);
 		fields.pop_front();
-		borehole->_depth    = strtod((BaseLib::replaceString(",", ".", fields.front())).c_str(), NULL);
+		borehole->_depth = strtod(BaseLib::replaceString(",", ".", fields.front()).c_str(), nullptr);
 		fields.pop_front();
 		if (fields.empty())
 			borehole->_date = 0;
@@ -231,7 +231,7 @@ StationBorehole* StationBorehole::createStation(const std::string &line)
 	{
 		WARN("Station::createStation() - Unexpected file format.");
 		delete borehole;
-		return NULL;
+		return nullptr;
 	}
 	return borehole;
 }

--- a/GeoLib/StationBorehole.cpp
+++ b/GeoLib/StationBorehole.cpp
@@ -48,14 +48,14 @@ StationBorehole::~StationBorehole(void)
 {
 	// deletes profile vector of borehole, starting at layer 1
 	// the first point is NOT deleted as it points to the station object itself
-	for (size_t k(1); k < _profilePntVec.size(); k++)
+	for (std::size_t k(1); k < _profilePntVec.size(); k++)
 		delete _profilePntVec[k];
 }
 
 int StationBorehole::find(const std::string &str)
 {
-	size_t size = _soilName.size();
-	for (size_t i = 0; i < size; i++)
+	std::size_t size = _soilName.size();
+	for (std::size_t i = 0; i < size; i++)
 		if (_soilName[i].find(str) == 0)
 			return 1;
 	return 0;
@@ -89,14 +89,14 @@ int StationBorehole::addStratigraphy(const std::string &path, StationBorehole* b
 	std::vector<std::list<std::string> > data;
 	if (readStratigraphyFile(path, data))
 	{
-		size_t size = data.size();
-		for (size_t i = 0; i < size; i++)
+		std::size_t size = data.size();
+		for (std::size_t i = 0; i < size; i++)
 			addLayer(data[i], borehole);
 
 		// check if a layer is missing
 		size = borehole->_soilName.size();
 		INFO("StationBorehole::addStratigraphy ToDo");
-		//	for (size_t i=0; i<size; i++)
+		//	for (std::size_t i=0; i<size; i++)
 		//	{
 		//		if ((borehole->_soilLayerThickness[i] == -1) ||(borehole->_soilName[i].compare("") == 0))
 		//		{
@@ -145,8 +145,8 @@ int StationBorehole::addStratigraphy(const std::vector<Point*> &profile, const s
 	if (((profile.size()-1) == soil_names.size()) && (soil_names.size()>0))
 	{
 		this->_profilePntVec.push_back(profile[0]);
-		size_t nLayers = soil_names.size();
-		for (size_t i=0; i<nLayers; i++)
+		std::size_t nLayers = soil_names.size();
+		for (std::size_t i=0; i<nLayers; i++)
 		{
 			this->_profilePntVec.push_back(profile[i+1]);
 			this->_soilName.push_back(soil_names[i]);
@@ -166,9 +166,9 @@ int StationBorehole::addStratigraphies(const std::string &path, std::vector<Poin
 	{
 		std::string name;
 
-		size_t it = 0;
-		size_t nBoreholes = data.size();
-		for (size_t i = 0; i < nBoreholes; i++)
+		std::size_t it = 0;
+		std::size_t nBoreholes = data.size();
+		for (std::size_t i = 0; i < nBoreholes; i++)
 		{
 			std::list<std::string> fields = data[i];
 
@@ -256,8 +256,8 @@ StationBorehole* StationBorehole::createStation(const std::string &name,
 
 void StationBorehole::createSurrogateStratigraphies(std::vector<Point*>* boreholes)
 {
-	size_t nBoreholes = boreholes->size();
-	for (size_t i = 0; i < nBoreholes; i++)
+	std::size_t nBoreholes = boreholes->size();
+	for (std::size_t i = 0; i < nBoreholes; i++)
 	{
 		StationBorehole* bore = static_cast<StationBorehole*>((*boreholes)[i]);
 		bore->addSoilLayer(bore->getDepth(), "depth");
@@ -271,7 +271,7 @@ void StationBorehole::addSoilLayer ( double thickness, const std::string &soil_n
 	   if (_profilePntVec.empty())
 	    addSoilLayer ((*this)[0], (*this)[1], (*this)[2]-thickness, soil_name);
 	   else {
-	    size_t idx (_profilePntVec.size());
+	    std::size_t idx (_profilePntVec.size());
 	    // read coordinates from last above
 	    double x((*_profilePntVec[idx-1])[0]);
 	    double y((*_profilePntVec[idx-1])[1]);
@@ -284,7 +284,7 @@ void StationBorehole::addSoilLayer ( double thickness, const std::string &soil_n
 	if (_profilePntVec.empty())
 		addSoilLayer ((*this)[0], (*this)[1], (*this)[2], "");
 
-	size_t idx (_profilePntVec.size());
+	std::size_t idx (_profilePntVec.size());
 	double x((*_profilePntVec[idx - 1])[0]);
 	double y((*_profilePntVec[idx - 1])[1]);
 	double z((*_profilePntVec[0])[2] - thickness);

--- a/GeoLib/Surface.cpp
+++ b/GeoLib/Surface.cpp
@@ -65,7 +65,7 @@ Surface* Surface::createSurface(const Polyline &ply)
 {
 	if (!ply.isClosed()) {
 		WARN("Error in Surface::createSurface() - Polyline is not closed.");
-		return NULL;
+		return nullptr;
 	}
 
 	if (ply.getNumberOfPoints() > 2) {

--- a/GeoLib/Triangle.cpp
+++ b/GeoLib/Triangle.cpp
@@ -28,12 +28,13 @@ namespace GeoLib {
 Triangle::Triangle (std::vector<Point *> const &pnt_vec) :
 	_pnts(pnt_vec), _initialized (false), _longest_edge (0.0)
 {
-	_pnt_ids[0] = std::numeric_limits<size_t>::max();
-	_pnt_ids[1] = std::numeric_limits<size_t>::max();
-	_pnt_ids[2] = std::numeric_limits<size_t>::max();
+	_pnt_ids[0] = std::numeric_limits<std::size_t>::max();
+	_pnt_ids[1] = std::numeric_limits<std::size_t>::max();
+	_pnt_ids[2] = std::numeric_limits<std::size_t>::max();
 }
 
-Triangle::Triangle (std::vector<Point *> const &pnt_vec, size_t pnt_a, size_t pnt_b, size_t pnt_c) :
+Triangle::Triangle (std::vector<Point *> const &pnt_vec,
+	std::size_t pnt_a, std::size_t pnt_b, std::size_t pnt_c) :
 	_pnts(pnt_vec), _initialized (true), _longest_edge (0.0)
 {
 	_pnt_ids[0] = pnt_a;
@@ -47,7 +48,7 @@ Triangle::Triangle (std::vector<Point *> const &pnt_vec, size_t pnt_a, size_t pn
 	_longest_edge = sqrt (_longest_edge);
 }
 
-void Triangle::setTriangle (size_t pnt_a, size_t pnt_b, size_t pnt_c)
+void Triangle::setTriangle (std::size_t pnt_a, std::size_t pnt_b, std::size_t pnt_c)
 {
 	assert (pnt_a < _pnts.size() && pnt_b < _pnts.size() && pnt_c < _pnts.size());
 	_pnt_ids[0] = pnt_a;


### PR DESCRIPTION
PR contains:
- Removal of unused code.
- Change how intersection points are inserted in the GMSHPolygonTree (commit 6d3685e - the only commit with some "real" changes)
- Substitutions of `size_t` with `std::size_t` and `NULL` -> `nullptr`.