### PR TITLE
GeoLib: Rework PointVec

### DIFF
--- a/FileIO/Legacy/OGSIOVer4.cpp
+++ b/FileIO/Legacy/OGSIOVer4.cpp
@@ -469,7 +469,8 @@ bool readGLIFileV4(const std::string& fname,
 
 	unique_name = BaseLib::extractBaseName(fname);
 	if (!pnt_vec->empty())
-		geo->addPointVec(pnt_vec, unique_name, pnt_id_names_map);  // KR: insert into GEOObjects if not empty
+		// KR: insert into GEOObjects if not empty
+		geo->addPointVec(pnt_vec, unique_name, pnt_id_names_map, 1e-6);
 
 	// extract path for reading external files
 	const std::string path = BaseLib::extractPath(fname);

--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -511,9 +511,9 @@ void computeAndInsertAllIntersectionPoints(GeoLib::PointVec &pnt_vec,
 		auto it1(it0);
 		++it1;
 		for (; it1 != plys.end(); ++it1) {
-			GeoLib::Point s;
 			for (std::size_t i(0); i<(*it0)->getNumberOfPoints()-1; i++) {
 				for (std::size_t j(0); j<(*it1)->getNumberOfPoints()-1; j++) {
+					GeoLib::Point s(0.0, 0.0, 0.0, pnt_vec.size());
 					if (lineSegmentIntersect(*(*it0)->getPoint(i), *(*it0)->getPoint(i+1),
 						*(*it1)->getPoint(j), *(*it1)->getPoint(j+1), s)) {
 						std::size_t const id(pnt_vec.push_back(new GeoLib::Point(s)));

--- a/GeoLib/Point.h
+++ b/GeoLib/Point.h
@@ -27,6 +27,9 @@ namespace GeoLib
  * \ingroup GeoLib
  */
 
+// forward declaration
+class PointVec;
+
 class Point : public MathLib::Point3dWithID, public GeoLib::GeoObject
 {
 public:
@@ -56,6 +59,11 @@ public:
 
 	/// return a geometry type
 	virtual GEOTYPE getGeoType() const {return GEOTYPE::POINT;}
+
+protected:
+	friend GeoLib::PointVec;
+	/// Resets the id.
+	void setID(std::size_t id) { _id = id; }
 };
 
 static const Point ORIGIN(0, 0, 0);

--- a/GeoLib/PointVec.cpp
+++ b/GeoLib/PointVec.cpp
@@ -40,6 +40,13 @@ PointVec::PointVec (const std::string& name, std::vector<Point*>* points,
 	assert (_data_vec);
 	std::size_t const number_of_all_input_pnts(_data_vec->size());
 
+	// correct the ids if necessary
+	for (std::size_t k(0); k<_data_vec->size(); ++k) {
+		if ((*_data_vec)[k]->getID() == std::numeric_limits<std::size_t>::max()) {
+			(*_data_vec)[k]->setID(k);
+		}
+	}
+
 	// add all points in the oct tree in order to make them unique
 	_pnt_id_map.resize(number_of_all_input_pnts);
 	std::iota(_pnt_id_map.begin(), _pnt_id_map.end(), 0);

--- a/GeoLib/PointVec.h
+++ b/GeoLib/PointVec.h
@@ -18,6 +18,7 @@
 #include "Station.h"
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -25,6 +26,7 @@
 #define POINTVEC_H_
 
 #include "TemplateVec.h"
+#include "OctTree.h"
 
 namespace GeoLib
 {
@@ -104,16 +106,6 @@ public:
 
 private:
 	/**
-	 * Removes points out of the given point set that have the (nearly) same coordinates, i.e.
-	 * the distance of two points is smaller than eps measured in the maximum norm.
-	 * @param pnt_vec the given set of points stored in a vector
-	 * @param pnt_id_map the id mapping
-	 * @param eps if the distance (measured in maximum norm) between points \f$p_i\f$ and \f$p_j\f$
-	 * is smaller than eps the points \f$p_i\f$ and \f$p_j\f$ are considered as equal.
-	 */
-	void makePntsUnique (std::vector<GeoLib::Point*>* pnt_vec, std::vector<std::size_t> &pnt_id_map, double eps = std::numeric_limits<double>::epsilon());
-
-	/**
 	 * After the point set is modified (for example by makePntsUnique()) the mapping has to be corrected.
 	 */
 	void correctNameIDMapping();
@@ -146,6 +138,7 @@ private:
 
 	AABB<GeoLib::Point> _aabb;
 	double _rel_eps;
+	std::unique_ptr<GeoLib::OctTree<GeoLib::Point, 16>> _oct_tree;
 };
 } // end namespace
 

--- a/Tests/GeoLib/TestComputeAndInsertAllIntersectionPoints.cpp
+++ b/Tests/GeoLib/TestComputeAndInsertAllIntersectionPoints.cpp
@@ -23,21 +23,22 @@ TEST(GeoLib, TestComputeAndInsertAllIntersectionPoints)
 {
 	// *** insert points in vector
 	std::vector<GeoLib::Point*> *pnts(new std::vector<GeoLib::Point*>);
-	pnts->push_back(new GeoLib::Point(0.0,0.0,0.0));
-	pnts->push_back(new GeoLib::Point(11.0,0.0,0.0));
+	pnts->push_back(new GeoLib::Point(0.0,0.0,0.0,0));
+	pnts->push_back(new GeoLib::Point(11.0,0.0,0.0,1));
 
-	pnts->push_back(new GeoLib::Point(0.0,1.0,0.0));
-	pnts->push_back(new GeoLib::Point(1.0,-1.0,0.0));
-	pnts->push_back(new GeoLib::Point(2.0, 1.0,0.0));
-	pnts->push_back(new GeoLib::Point(3.0,-1.0,0.0));
-	pnts->push_back(new GeoLib::Point(4.0, 1.0,0.0));
-	pnts->push_back(new GeoLib::Point(5.0,-1.0,0.0));
-	pnts->push_back(new GeoLib::Point(6.0, 1.0,0.0));
-	pnts->push_back(new GeoLib::Point(7.0,-1.0,0.0));
-	pnts->push_back(new GeoLib::Point(8.0, 1.0,0.0));
-	pnts->push_back(new GeoLib::Point(9.0,-1.0,0.0));
-	pnts->push_back(new GeoLib::Point(10.0, 1.0,0.0));
-	pnts->push_back(new GeoLib::Point(11.0,-1.0,0.0));
+	pnts->push_back(new GeoLib::Point(0.0,1.0,0.0,2));
+	pnts->push_back(new GeoLib::Point(1.0,-1.0,0.0,3));
+	pnts->push_back(new GeoLib::Point(2.0, 1.0,0.0,4));
+	pnts->push_back(new GeoLib::Point(3.0,-1.0,0.0,5));
+	pnts->push_back(new GeoLib::Point(4.0, 1.0,0.0,6));
+	pnts->push_back(new GeoLib::Point(5.0,-1.0,0.0,7));
+	pnts->push_back(new GeoLib::Point(6.0, 1.0,0.0,8));
+	pnts->push_back(new GeoLib::Point(7.0,-1.0,0.0,9));
+	pnts->push_back(new GeoLib::Point(8.0, 1.0,0.0,10));
+	pnts->push_back(new GeoLib::Point(9.0,-1.0,0.0,11));
+	pnts->push_back(new GeoLib::Point(10.0, 1.0,0.0,12));
+	pnts->push_back(new GeoLib::Point(11.0,-1.0,0.0,13));
+
 
 	GeoLib::GEOObjects geo_objs;
 	std::string geo_name("TestGeometry");
@@ -48,7 +49,7 @@ TEST(GeoLib, TestComputeAndInsertAllIntersectionPoints)
 	ply0->addPoint(0);
 	ply0->addPoint(1);
 	GeoLib::Polyline* ply1(new GeoLib::Polyline(*pnts));
-	for (std::size_t k(2); k<14; k++)
+	for (std::size_t k(2); k<pnts->size(); ++k)
 		ply1->addPoint(k);
 	std::vector<GeoLib::Polyline*>* plys(new std::vector<GeoLib::Polyline*>);
 	plys->push_back(ply0);

--- a/Tests/GeoLib/TestGEOObjectsMerge.cpp
+++ b/Tests/GeoLib/TestGEOObjectsMerge.cpp
@@ -76,7 +76,7 @@ TEST(GeoLib, GEOObjectsMergePoints)
 	ASSERT_EQ(test_name, "PointSet0-7-7-7");
 
 	// *** insert "shifted" set of points
-	shift[0] += 8.0 * std::numeric_limits<double>::epsilon();
+	shift[0] += 1e-4;
 	names.push_back("ShiftedPointSet");
 	createSetOfTestPointsAndAssociatedNames(geo_objs, names[2], shift);
 

--- a/Tests/GeoLib/TestOctTree.cpp
+++ b/Tests/GeoLib/TestOctTree.cpp
@@ -29,12 +29,12 @@ public:
 			delete p;
 		}
 	}
+#ifndef NDEBUG
 	template <std::size_t MAX_POINTS>
 	void
 	checkOctTreeChildsNonNullptr(
 		GeoLib::OctTree<GeoLib::Point, MAX_POINTS> const& oct_tree) const
 	{
-#ifndef NDEBUG
 		ASSERT_NE(nullptr, oct_tree.getChild(0));
 		ASSERT_NE(nullptr, oct_tree.getChild(1));
 		ASSERT_NE(nullptr, oct_tree.getChild(2));
@@ -43,14 +43,14 @@ public:
 		ASSERT_NE(nullptr, oct_tree.getChild(5));
 		ASSERT_NE(nullptr, oct_tree.getChild(6));
 		ASSERT_NE(nullptr, oct_tree.getChild(7));
-#endif
 	}
+#endif
 
+#ifndef NDEBUG
 	template <std::size_t MAX_POINTS>
 	void
 	checkOctTreeChildsNullptr(GeoLib::OctTree<GeoLib::Point, MAX_POINTS> const& oct_tree) const
 	{
-#ifndef NDEBUG
 		ASSERT_EQ(nullptr, oct_tree.getChild(0));
 		ASSERT_EQ(nullptr, oct_tree.getChild(1));
 		ASSERT_EQ(nullptr, oct_tree.getChild(2));
@@ -59,8 +59,8 @@ public:
 		ASSERT_EQ(nullptr, oct_tree.getChild(5));
 		ASSERT_EQ(nullptr, oct_tree.getChild(6));
 		ASSERT_EQ(nullptr, oct_tree.getChild(7));
-#endif
 	}
+#endif
 
 protected:
 	void
@@ -298,11 +298,11 @@ TEST_F(GeoLibOctTree, TestSmallDistanceDifferentLeaves)
 	// case where two points with a small distance but different OctTree leaves
 	// are inserted
 	double const eps(0.5);
-	for (int k(-10); k<11; ++k) {
-		for (int j(-10); j<11; ++j) {
-			std::size_t id((k+10)*21+(j+10));
-			for (int i(-10); i<11; ++i) {
-				ps_ptr.push_back(new GeoLib::Point(1.0*i, 1.0*j, 1.0*k, id+i+10));
+	for (std::size_t k = 0; k < 21; ++k) {
+		for (std::size_t j = 0; j < 21; ++j) {
+			std::size_t id = k*21+j;
+			for (std::size_t i = 0; i < 21; ++i) {
+				ps_ptr.push_back(new GeoLib::Point(i-10., j-10., k-10., id+i));
 			}
 		}
 	}


### PR DESCRIPTION
The main change in this PR is the substitution of the method `GeoLib::PointVec::makePntsUnique()` with an `OctTree` based algorithm. This substitution fixes some mistakes that are nearly unavoidable using the old implementation. Furthermore it is much faster to use `GeoLib::PointVec::push_back()` methods. The PR is based on PR https://github.com/ufz/ogs/pull/720 and shall be merged after https://github.com/ufz/ogs/pull/720.