### PR TITLE
[T] Remove memory leaks in AssemblerLib tests.

### DIFF
--- a/Tests/AssemblerLib/LocalToGlobalIndexMap.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMap.cpp
@@ -103,4 +103,9 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapTest, SubsetByComponent)
     // components.
     ASSERT_EQ(selected_nodes.size() * selected_components.size(),
             dof_map_subset->dofSize());
+
+    delete dof_map_subset;
+    for (auto p : selected_components)
+        delete p;
+    delete selected_subset;
 }

--- a/Tests/AssemblerLib/TestMeshComponentMap.cpp
+++ b/Tests/AssemblerLib/TestMeshComponentMap.cpp
@@ -161,7 +161,11 @@ TEST_F(AssemblerLibMeshComponentMapTest, SubsetOfNodesByComponent)
         EXPECT_EQ(cmap->getGlobalIndex(l, comp1_id),
             cmap_subset.getGlobalIndex(l, comp1_id));
     }
+
+    for (auto p : selected_components)
+        delete p;
 }
+
 TEST_F(AssemblerLibMeshComponentMapTest, SubsetOfNodesByLocation)
 {
     cmap = new MeshComponentMap(components,
@@ -192,4 +196,7 @@ TEST_F(AssemblerLibMeshComponentMapTest, SubsetOfNodesByLocation)
         EXPECT_EQ(cmap->getGlobalIndex(l, comp1_id),
             cmap_subset.getGlobalIndex(l, comp1_id));
     }
+
+    for (auto p : selected_components)
+        delete p;
 }

--- a/Tests/AssemblerLib/TestSerialLinearSolver.cpp
+++ b/Tests/AssemblerLib/TestSerialLinearSolver.cpp
@@ -137,4 +137,7 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
 
     std::remove_if(vec_comp_dis.begin(), vec_comp_dis.end(),
         [](MeshLib::MeshSubsets * p) { delete p; return true; });
+
+    for (auto p : local_assembler_data)
+        delete p;
 }


### PR DESCRIPTION
... based on output of the clang's address sanitizer tool.