### PR TITLE
fix reading of matgroups from gmsh msh

### DIFF
--- a/FileIO/GMSHInterface.cpp
+++ b/FileIO/GMSHInterface.cpp
@@ -274,7 +274,7 @@ GMSHInterface::readElement(std::ifstream &in,
 	int mat_id;
 	std::vector<unsigned> node_ids;
 	std::vector<MeshLib::Node*> elem_nodes;
-	in >> idx >> type >> n_tags >> dummy >> mat_id;
+	in >> idx >> type >> n_tags >> mat_id >> dummy;
 
 	// skip tags
 	for (std::size_t j = 2; j < n_tags; j++)


### PR DESCRIPTION
now reads "physical entity" as the MaterialIDs, before was reading "elementary geometrical entity" as MaterialIDs

from the gmsh manual:
http://www.geuz.org/gmsh/doc/texinfo/gmsh.html#MSH-ASCII-file-format
number-of-tags
 gives the number of integer tags that follow for the n-th element. By default, the first tag is the number of the physical entity to which the element belongs; the second is the number of the elementary geometrical entity to which the element belongs; the third is the number of mesh partitions to which the element belongs, followed by the partition ids (negative partition ids indicate ghost cells). A zero tag is equivalent to no tag. Gmsh and most codes using the MSH 2 format require at least the first two tags (physical and elementary tags).