### PR TITLE
Cleanup mesh lib tests memory leaks

### DIFF
--- a/MeshGeoToolsLib/HeuristicSearchLength.cpp
+++ b/MeshGeoToolsLib/HeuristicSearchLength.cpp
@@ -34,8 +34,9 @@ HeuristicSearchLength::HeuristicSearchLength(MeshLib::Mesh const& mesh, LengthTy
 				it != elements.cend(); ++it) {
 			std::size_t const n_edges((*it)->getNEdges());
 			for (std::size_t k(0); k<n_edges; k++) {
-				double const len =
-					static_cast<MeshLib::Line const*>((*it)->getEdge(k))->getContent();
+				auto edge = (*it)->getEdge(k);	// allocation inside getEdge().
+				double const len = edge->getContent();
+				delete edge;
 				sum += len;
 				sum_of_sqr += len*len;
 			}

--- a/MeshLib/Node.cpp
+++ b/MeshLib/Node.cpp
@@ -22,6 +22,11 @@ Node::Node(const double coords[3], std::size_t id)
 {
 }
 
+Node::Node(std::array<double, 3> const& coords, std::size_t id)
+	: MathLib::Point3dWithID(coords, id)
+{
+}
+
 Node::Node(double x, double y, double z, std::size_t id)
 	: MathLib::Point3dWithID(std::array<double,3>({{x, y, z}}), id)
 {

--- a/MeshLib/Node.h
+++ b/MeshLib/Node.h
@@ -49,6 +49,9 @@ public:
 	/// Constructor using a coordinate array
 	Node(const double coords[3], std::size_t id = std::numeric_limits<std::size_t>::max());
 
+	/// Constructor using a coordinate array
+	Node(std::array<double, 3> const& coords, std::size_t id = std::numeric_limits<std::size_t>::max());
+
 	/// Constructor using single coordinates
 	Node(double x, double y, double z, std::size_t id = std::numeric_limits<std::size_t>::max());
 

--- a/Tests/MeshLib/MeshSubsets.cpp
+++ b/Tests/MeshLib/MeshSubsets.cpp
@@ -36,7 +36,7 @@ TEST(MeshLibMeshSubsets, UniqueMeshIds)
 
 TEST(MeshLibMeshSubsets, GetIntersectionByNodes)
 {
-	Mesh const* const mesh = MeshGenerator::generateLineMesh(1., 10);
+	auto mesh = std::unique_ptr<Mesh>{MeshGenerator::generateLineMesh(1., 10)};
 	MeshSubset all_nodes_mesh_subset(*mesh, &mesh->getNodes());
 
 	// Select nodes
@@ -46,8 +46,8 @@ TEST(MeshLibMeshSubsets, GetIntersectionByNodes)
 		const_cast<Node*>(mesh->getNode(2)),
 		const_cast<Node*>(mesh->getNode(5)),
 		const_cast<Node*>(mesh->getNode(7)) });
-	MeshSubset const* const some_nodes_mesh_subset =
-		all_nodes_mesh_subset.getIntersectionByNodes(some_nodes);
+	auto some_nodes_mesh_subset = std::unique_ptr<MeshSubset>
+		{all_nodes_mesh_subset.getIntersectionByNodes(some_nodes)};
 
 	// Check sizes.
 	ASSERT_EQ(some_nodes.size(), some_nodes_mesh_subset->getNNodes());

--- a/Tests/MeshLib/TestBoundaryElementSearch.cpp
+++ b/Tests/MeshLib/TestBoundaryElementSearch.cpp
@@ -29,15 +29,10 @@ public:
 		_quad_mesh(MeshGenerator::generateRegularQuadMesh(_geometric_size, _number_of_subdivisions_per_direction))
 	{}
 
-	~MeshLibBoundaryElementSearchInSimpleQuadMesh()
-	{
-		delete _quad_mesh;
-	}
-
 protected:
 	const double _geometric_size;
 	const std::size_t _number_of_subdivisions_per_direction;
-	Mesh* _quad_mesh;
+	std::unique_ptr<Mesh> _quad_mesh;
 };
 
 class MeshLibBoundaryElementSearchInSimpleHexMesh : public testing::Test
@@ -110,7 +105,8 @@ TEST_F(MeshLibBoundaryElementSearchInSimpleQuadMesh, PolylineSearch)
 		ASSERT_EQ(n_nodes_per_dir*(n_nodes_per_dir-1)-n_nodes_per_dir*(i+1), edge3->getNodeIndex(1));
 	}
 
-	std::for_each(pnts.begin(), pnts.end(), [](GeoLib::Point* pnt) { delete pnt; });
+	for (auto p : pnts)
+		delete p;
 }
 
 TEST_F(MeshLibBoundaryElementSearchInSimpleHexMesh, SurfaceSearch)
@@ -170,6 +166,7 @@ TEST_F(MeshLibBoundaryElementSearchInSimpleHexMesh, SurfaceSearch)
 	for (auto nodeID : connected_nodeIDs_f)
 		ASSERT_EQ(0.0, (*_hex_mesh->getNode(nodeID))[1]); // check y coordinates
 
-	std::for_each(pnts.begin(), pnts.end(), [](GeoLib::Point* pnt) { delete pnt; });
+	for (auto p : pnts)
+		delete p;
 }
 

--- a/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
+++ b/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
@@ -38,37 +38,34 @@ public:
     typedef MeshLib::Line ElementType;
     static const unsigned e_nnodes = ElementType::n_all_nodes;
 
-    static MeshLib::Line* createY()
+    static std::unique_ptr<MeshLib::Line> createLine(
+        std::array<double, 3> const& a, std::array<double, 3> const& b)
     {
         MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
-        nodes[0] = new MeshLib::Node(0.0, -1.0, 0.0);
-        nodes[1] = new MeshLib::Node(0.0,  1.0, 0.0);
-        return new MeshLib::Line(nodes);
+        nodes[0] = new MeshLib::Node(a);
+        nodes[1] = new MeshLib::Node(b);
+        return std::unique_ptr<MeshLib::Line>{new MeshLib::Line(nodes)};
     }
 
-    static MeshLib::Line* createZ()
+    static std::unique_ptr<MeshLib::Line> createY()
     {
-        MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
-        nodes[0] = new MeshLib::Node(0.0, 0.0, -1.0);
-        nodes[1] = new MeshLib::Node(0.0, 0.0,  1.0);
-        return new MeshLib::Line(nodes);
+        return createLine({{0.0, -1.0, 0.0}}, {{0.0,  1.0, 0.0}});
     }
 
-    static MeshLib::Line* createXY()
+    static std::unique_ptr<MeshLib::Line> createZ()
+    {
+        return createLine({{0.0, 0.0, -1.0}}, {{0.0, 0.0,  1.0}});
+    }
+
+    static std::unique_ptr<MeshLib::Line> createXY()
     {
         // 45degree inclined
-        MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
-        nodes[0] = new MeshLib::Node(0.0, 0.0, 0.0);
-        nodes[1] = new MeshLib::Node(2./sqrt(2), 2./sqrt(2), 0.0);
-        return new MeshLib::Line(nodes);
+        return createLine({{0.0, 0.0, 0.0}}, {{2./sqrt(2), 2./sqrt(2), 0.0}});
     }
 
-    static MeshLib::Line* createXYZ()
+    static std::unique_ptr<MeshLib::Line> createXYZ()
     {
-        MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
-        nodes[0] = new MeshLib::Node(0.0, 0.0, 0.0);
-        nodes[1] = new MeshLib::Node(2./sqrt(3), 2./sqrt(3), 2./sqrt(3));
-        return new MeshLib::Line(nodes);
+        return createLine({{0.0, 0.0, 0.0}}, {{2./sqrt(3), 2./sqrt(3), 2./sqrt(3)}});
     }
 
 };
@@ -80,40 +77,48 @@ class TestQuad4
     typedef MeshLib::Quad ElementType;
     static const unsigned e_nnodes = ElementType::n_all_nodes;
 
-    // 2.5D case: inclined
-    static MeshLib::Quad* createXYZ()
+    static std::unique_ptr<MeshLib::Quad> createQuad(
+        std::array<double, 3> const& a, std::array<double, 3> const& b,
+        std::array<double, 3> const& c, std::array<double, 3> const& d)
     {
         MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
+        nodes[0] = new MeshLib::Node(a);
+        nodes[1] = new MeshLib::Node(b);
+        nodes[2] = new MeshLib::Node(c);
+        nodes[3] = new MeshLib::Node(d);
+        return std::unique_ptr<MeshLib::Quad>{new MeshLib::Quad(nodes)};
+    }
+
+    // 2.5D case: inclined
+    static std::unique_ptr<MeshLib::Quad> createXYZ()
+    {
         // rotate 45 degree around x axis
-        nodes[0] = new MeshLib::Node( 1.0,  0.7071067811865475,  0.7071067811865475);
-        nodes[1] = new MeshLib::Node(-1.0,  0.7071067811865475,  0.7071067811865475);
-        nodes[2] = new MeshLib::Node(-1.0, -0.7071067811865475, -0.7071067811865475);
-        nodes[3] = new MeshLib::Node( 1.0, -0.7071067811865475, -0.7071067811865475);
-        return new MeshLib::Quad(nodes);
+        return createQuad(
+            {{ 1.0,  0.7071067811865475,  0.7071067811865475}},
+            {{-1.0,  0.7071067811865475,  0.7071067811865475}},
+            {{-1.0, -0.7071067811865475, -0.7071067811865475}},
+            {{ 1.0, -0.7071067811865475, -0.7071067811865475}});
     }
 
     // 2.5D case: inclined
-    static MeshLib::Quad* createXZ()
+    static std::unique_ptr<MeshLib::Quad> createXZ()
     {
-        MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
-        nodes[0] = new MeshLib::Node( 1.0, 0.0,  1.0);
-        nodes[1] = new MeshLib::Node(-1.0, 0.0,  1.0);
-        nodes[2] = new MeshLib::Node(-1.0, 0.0, -1.0);
-        nodes[3] = new MeshLib::Node( 1.0, 0.0, -1.0);
-        return new MeshLib::Quad(nodes);
+        return createQuad(
+            {{ 1.0, 0.0,  1.0}},
+            {{-1.0, 0.0,  1.0}},
+            {{-1.0, 0.0, -1.0}},
+            {{ 1.0, 0.0, -1.0}});
     }
 
     // 2.5D case: inclined
-    static MeshLib::Quad* createYZ()
+    static std::unique_ptr<MeshLib::Quad> createYZ()
     {
-        MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
-        nodes[0] = new MeshLib::Node(0.0,  1.0,  1.0);
-        nodes[1] = new MeshLib::Node(0.0, -1.0,  1.0);
-        nodes[2] = new MeshLib::Node(0.0, -1.0, -1.0);
-        nodes[3] = new MeshLib::Node(0.0,  1.0, -1.0);
-        return new MeshLib::Quad(nodes);
+        return createQuad(
+            {{0.0,  1.0,  1.0}},
+            {{0.0, -1.0,  1.0}},
+            {{0.0, -1.0, -1.0}},
+            {{0.0,  1.0, -1.0}});
     }
-
 };
 
 #if 0
@@ -161,6 +166,9 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimLineY)
     const double eps(std::numeric_limits<double>::epsilon());
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
+
+    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+        delete ele->getNode(n);
 }
 
 TEST(MeshLib, CoordinatesMappingLocalLowerDimLineZ)
@@ -175,6 +183,9 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimLineZ)
     const double eps(std::numeric_limits<double>::epsilon());
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
+
+    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+        delete ele->getNode(n);
 }
 
 TEST(MeshLib, CoordinatesMappingLocalLowerDimLineXY)
@@ -190,6 +201,9 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimLineXY)
     const double eps(std::numeric_limits<double>::epsilon());
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
+
+    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+        delete ele->getNode(n);
 }
 
 TEST(MeshLib, CoordinatesMappingLocalLowerDimLineXYZ)
@@ -205,6 +219,9 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimLineXYZ)
     const double eps(std::numeric_limits<double>::epsilon());
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
+
+    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+        delete ele->getNode(n);
 }
 
 TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadXZ)
@@ -222,6 +239,9 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadXZ)
     const double eps(std::numeric_limits<double>::epsilon());
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
+
+    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+        delete ele->getNode(n);
 }
 
 TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadYZ)
@@ -239,6 +259,9 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadYZ)
     const double eps(std::numeric_limits<double>::epsilon());
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
+
+    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+        delete ele->getNode(n);
 }
 
 TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadXYZ)
@@ -256,5 +279,8 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadXYZ)
     const double eps(std::numeric_limits<double>::epsilon());
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
+
+    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+        delete ele->getNode(n);
 }
 

--- a/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
+++ b/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
@@ -32,13 +32,12 @@
 namespace
 {
 
-class TestLine2
+namespace TestLine2
 {
-public:
     typedef MeshLib::Line ElementType;
-    static const unsigned e_nnodes = ElementType::n_all_nodes;
+    const unsigned e_nnodes = ElementType::n_all_nodes;
 
-    static std::unique_ptr<MeshLib::Line> createLine(
+    std::unique_ptr<MeshLib::Line> createLine(
         std::array<double, 3> const& a, std::array<double, 3> const& b)
     {
         MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
@@ -47,37 +46,36 @@ public:
         return std::unique_ptr<MeshLib::Line>{new MeshLib::Line(nodes)};
     }
 
-    static std::unique_ptr<MeshLib::Line> createY()
+    std::unique_ptr<MeshLib::Line> createY()
     {
         return createLine({{0.0, -1.0, 0.0}}, {{0.0,  1.0, 0.0}});
     }
 
-    static std::unique_ptr<MeshLib::Line> createZ()
+    std::unique_ptr<MeshLib::Line> createZ()
     {
         return createLine({{0.0, 0.0, -1.0}}, {{0.0, 0.0,  1.0}});
     }
 
-    static std::unique_ptr<MeshLib::Line> createXY()
+    std::unique_ptr<MeshLib::Line> createXY()
     {
         // 45degree inclined
         return createLine({{0.0, 0.0, 0.0}}, {{2./sqrt(2), 2./sqrt(2), 0.0}});
     }
 
-    static std::unique_ptr<MeshLib::Line> createXYZ()
+    std::unique_ptr<MeshLib::Line> createXYZ()
     {
         return createLine({{0.0, 0.0, 0.0}}, {{2./sqrt(3), 2./sqrt(3), 2./sqrt(3)}});
     }
 
 };
 
-class TestQuad4
+namespace TestQuad4
 {
- public:
     // Element information
     typedef MeshLib::Quad ElementType;
-    static const unsigned e_nnodes = ElementType::n_all_nodes;
+    const unsigned e_nnodes = ElementType::n_all_nodes;
 
-    static std::unique_ptr<MeshLib::Quad> createQuad(
+    std::unique_ptr<MeshLib::Quad> createQuad(
         std::array<double, 3> const& a, std::array<double, 3> const& b,
         std::array<double, 3> const& c, std::array<double, 3> const& d)
     {
@@ -90,7 +88,7 @@ class TestQuad4
     }
 
     // 2.5D case: inclined
-    static std::unique_ptr<MeshLib::Quad> createXYZ()
+    std::unique_ptr<MeshLib::Quad> createXYZ()
     {
         // rotate 45 degree around x axis
         return createQuad(
@@ -101,7 +99,7 @@ class TestQuad4
     }
 
     // 2.5D case: inclined
-    static std::unique_ptr<MeshLib::Quad> createXZ()
+    std::unique_ptr<MeshLib::Quad> createXZ()
     {
         return createQuad(
             {{ 1.0, 0.0,  1.0}},
@@ -111,7 +109,7 @@ class TestQuad4
     }
 
     // 2.5D case: inclined
-    static std::unique_ptr<MeshLib::Quad> createYZ()
+    std::unique_ptr<MeshLib::Quad> createYZ()
     {
         return createQuad(
             {{0.0,  1.0,  1.0}},

--- a/Tests/MeshLib/TestDuplicate.cpp
+++ b/Tests/MeshLib/TestDuplicate.cpp
@@ -23,7 +23,8 @@
 
 TEST(MeshLib, Duplicate)
 {
-	MeshLib::Mesh* mesh (MeshLib::MeshGenerator::generateRegularQuadMesh(10, 5, 1));
+	auto mesh = std::unique_ptr<MeshLib::Mesh>{
+		MeshLib::MeshGenerator::generateRegularQuadMesh(10, 5, 1)};
 
 	std::vector<MeshLib::Node*> new_nodes (MeshLib::copyNodeVector(mesh->getNodes()));
 	std::vector<MeshLib::Element*> new_elements (MeshLib::copyElementVector(mesh->getElements(), new_nodes));

--- a/Tests/MeshLib/TestElementConstants.cpp
+++ b/Tests/MeshLib/TestElementConstants.cpp
@@ -30,6 +30,9 @@ TEST(MeshLib, ElementConstantsQuad4)
 	ASSERT_EQ(2u, quad.getDimension());
 	ASSERT_EQ(4u, quad.getNNodes());
 	ASSERT_EQ(4u, quad.getNBaseNodes());
+
+	for (auto n : nodes)
+		delete n;
 }
 
 TEST(MeshLib, ElementConstantsQuad8)
@@ -54,6 +57,9 @@ TEST(MeshLib, ElementConstantsQuad8)
 	ASSERT_EQ(2u, quad8.getDimension());
 	ASSERT_EQ(8u, quad8.getNNodes());
 	ASSERT_EQ(4u, quad8.getNBaseNodes());
+
+	for (auto n : nodes)
+		delete n;
 }
 
 TEST(MeshLib, ElementConstantsQuad9)
@@ -79,6 +85,9 @@ TEST(MeshLib, ElementConstantsQuad9)
 	ASSERT_EQ(2u, quad9.getDimension());
 	ASSERT_EQ(9u, quad9.getNNodes());
 	ASSERT_EQ(4u, quad9.getNBaseNodes());
+
+	for (auto n : nodes)
+		delete n;
 }
 
 TEST(MeshLib, ElementConstantsHex8)
@@ -101,6 +110,9 @@ TEST(MeshLib, ElementConstantsHex8)
 	ASSERT_EQ(3u, ele.getDimension());
 	ASSERT_EQ(8u, ele.getNNodes());
 	ASSERT_EQ(8u, ele.getNBaseNodes());
+
+	for (auto n : nodes)
+		delete n;
 }
 
 TEST(MeshLib, ElementConstantsHex20)
@@ -135,6 +147,9 @@ TEST(MeshLib, ElementConstantsHex20)
 	ASSERT_EQ( 3u, ele.getDimension());
 	ASSERT_EQ(20u, ele.getNNodes());
 	ASSERT_EQ( 8u, ele.getNBaseNodes());
+
+	for (auto n : nodes)
+		delete n;
 }
 
 TEST(MeshLib, ElementConstantsTet4)
@@ -153,6 +168,9 @@ TEST(MeshLib, ElementConstantsTet4)
 	ASSERT_EQ(3u, ele.getDimension());
 	ASSERT_EQ(4u, ele.getNNodes());
 	ASSERT_EQ(4u, ele.getNBaseNodes());
+
+	for (auto n : nodes)
+		delete n;
 }
 
 TEST(MeshLib, ElementConstantsTet10)
@@ -178,5 +196,8 @@ TEST(MeshLib, ElementConstantsTet10)
 	ASSERT_EQ( 3u, ele.getDimension());
 	ASSERT_EQ(10u, ele.getNNodes());
 	ASSERT_EQ( 4u, ele.getNBaseNodes());
+
+	for (auto n : nodes)
+		delete n;
 }
 

--- a/Tests/MeshLib/TestElementStatus.cpp
+++ b/Tests/MeshLib/TestElementStatus.cpp
@@ -24,8 +24,10 @@ TEST(MeshLib, ElementStatus)
 {
 	const unsigned width (100);
 	const unsigned elements_per_side (20);
-	MeshLib::Mesh* mesh (MeshLib::MeshGenerator::generateRegularQuadMesh(width, elements_per_side));
-	MeshLib::ElementStatus status(mesh);
+	auto const mesh = std::unique_ptr<MeshLib::Mesh>{
+        MeshLib::MeshGenerator::generateRegularQuadMesh(width, elements_per_side)};
+
+	MeshLib::ElementStatus status(mesh.get());
 	const std::vector<MeshLib::Element*> elements (mesh->getElements());
 
 	for (unsigned i=0; i<elements_per_side; ++i)

--- a/Tests/MeshLib/TestMoveMeshNodes.cpp
+++ b/Tests/MeshLib/TestMoveMeshNodes.cpp
@@ -53,5 +53,10 @@ TEST(MeshLib, moveMeshNodes)
 		EXPECT_NEAR((*nodes_copy[0])[1], (*nodes[0])[1], eps);
 		EXPECT_NEAR((*nodes_copy[0])[2], (*nodes[0])[2], eps);
 	}
+
+	for (auto n : nodes)
+		delete n;
+	for (auto n : nodes_copy)
+		delete n;
 }
 

--- a/Tests/MeshLib/TestProjectMeshOnPlane.cpp
+++ b/Tests/MeshLib/TestProjectMeshOnPlane.cpp
@@ -11,6 +11,8 @@
  *              http://www.opengeosys.org/LICENSE.txt
  */
 
+#include <memory>
+
 #include "gtest/gtest.h"
 
 #include "Mesh.h"
@@ -34,11 +36,11 @@ public:
 		for (std::size_t i=0; i<n_nodes-1; i++)
 			elements.push_back(new MeshLib::Line(std::array<MeshLib::Node*,2>{{nodes[i], nodes[i+1]}}));
 
-		_mesh = new MeshLib::Mesh("TestMesh", nodes, elements);
+		_mesh = std::unique_ptr<MeshLib::Mesh>{new MeshLib::Mesh{"TestMesh", nodes, elements}};
 	}
 
 protected:
-	MeshLib::Mesh* _mesh;
+	std::unique_ptr<MeshLib::Mesh> _mesh;
 };
 // Project to parallels of XY plane
 TEST_F(ProjectionTest, ProjectToXY)

--- a/Tests/MeshLib/TestVtkMeshConverter.cpp
+++ b/Tests/MeshLib/TestVtkMeshConverter.cpp
@@ -13,6 +13,7 @@
 #include <vtkDoubleArray.h>
 #include <vtkIntArray.h>
 #include <vtkPointData.h>
+#include <vtkSmartPointer.h>
 #include <vtkUnsignedIntArray.h>
 #include <vtkUnstructuredGrid.h>
 
@@ -27,7 +28,7 @@ public:
 		: vtu(nullptr)
 	{
 		// Points and cells
-		auto points = vtkPoints::New();
+		auto points = vtkSmartPointer<vtkPoints>::New();
 		points->InsertNextPoint(703.875, 758.75, 0.9971);
 		points->InsertNextPoint(767.625, 679.5, 6.2356);
 		points->InsertNextPoint(835.25, 602.50, 11.2227);
@@ -41,8 +42,8 @@ public:
 		points->InsertNextPoint(672, 549.375, 117.4165);
 		points->InsertNextPoint(739.75, 472.5, 120.92995);
 
-		auto cells = vtkCellArray::New();
-		auto cell1 = vtkIdList::New();
+		auto cells = vtkSmartPointer<vtkCellArray>::New();
+		auto cell1 = vtkSmartPointer<vtkIdList>::New();
 		cell1->InsertNextId(4);
 		cell1->InsertNextId(1);
 		cell1->InsertNextId(0);
@@ -51,7 +52,7 @@ public:
 		cell1->InsertNextId(7);
 		cell1->InsertNextId(6);
 		cell1->InsertNextId(9);
-		auto cell2 = vtkIdList::New();
+		auto cell2 = vtkSmartPointer<vtkIdList>::New();
 		cell2->InsertNextId(5);
 		cell2->InsertNextId(2);
 		cell2->InsertNextId(1);
@@ -63,19 +64,19 @@ public:
 		cells->InsertNextCell(cell1);
 		cells->InsertNextCell(cell2);
 
-		vtu = vtkUnstructuredGrid::New();
+		vtu = vtkSmartPointer<vtkUnstructuredGrid>::New();
 		vtu->SetPoints(points);
 		vtu->SetCells(12, cells);
 
 		// Data arrays
-		auto pointIds = vtkIntArray::New();
+		auto pointIds = vtkSmartPointer<vtkIntArray>::New();
 		pointIds->SetNumberOfComponents(1);
 		pointIds->SetName("PointIDs");
 		for (int i = 0; i < 12; ++i)
 			pointIds->InsertNextTuple1(i);
 		vtu->GetPointData()->AddArray(pointIds);
 
-		auto materialIds = vtkUnsignedIntArray::New();
+		auto materialIds = vtkSmartPointer<vtkUnsignedIntArray>::New();
 		materialIds->SetNumberOfComponents(1);
 		materialIds->SetName("MaterialIDs");
 		materialIds->InsertNextTuple1(0);
@@ -83,13 +84,8 @@ public:
 		vtu->GetCellData()->AddArray(materialIds);
 	}
 
-	~TestVtkMeshConverter()
-	{
-		vtu->Delete();
-	}
-
 	static std::size_t const mesh_size = 5;
-	vtkUnstructuredGrid * vtu;
+	vtkSmartPointer<vtkUnstructuredGrid> vtu;
 };
 
 TEST_F(TestVtkMeshConverter, Conversion)


### PR DESCRIPTION
 - The Node(array) ctor simplifies code in the tests.
 - One leak in HeuristicSearchLength is in production code.