### PR TITLE
[MaL] Inline sqrDist(double*,...).

### DIFF
--- a/MathLib/MathTools.cpp
+++ b/MathLib/MathTools.cpp
@@ -42,12 +42,6 @@ double calcProjPntToLineAndDists(const double p[3], const double a[3],
 	return sqrt (sqrDist (p, proj_pnt));
 }
 
-double sqrDist(const double* p0, const double* p1)
-{
-	const double v[3] = {p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]};
-	return scalarProduct<double,3>(v,v);
-}
-
 double getAngle (const double p0[3], const double p1[3], const double p2[3])
 {
 	const double v0[3] = {p0[0]-p1[0], p0[1]-p1[1], p0[2]-p1[2]};

--- a/MathLib/MathTools.h
+++ b/MathLib/MathTools.h
@@ -122,7 +122,12 @@ bool operator==(TemplatePoint<T,DIM> const& a, TemplatePoint<T,DIM> const& b)
 }
 
 /** squared dist between double arrays p0 and p1 (size of arrays is 3) */
-double sqrDist(const double* p0, const double* p1);
+inline
+double sqrDist(const double* p0, const double* p1)
+{
+	const double v[3] = {p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]};
+	return scalarProduct<double,3>(v,v);
+}
 
 /** Distance between points p0 and p1 in the maximum norm. */
 template <typename T>


### PR DESCRIPTION
This reduces number of instructions executed in the `GeoLib::getNearestPoint()` from 1087e6 to 707e6 or around 34% (measured in SearchNearestPointsInDenseGrid test), which is not so bad for a single inline :)


The reason for this is that the `sqrDist` computation is around 20 instructions, but its call costs in order of 100 instructions. Use the assembly, Luke!