### PR TITLE
introduce GeoDomain class

### DIFF
--- a/GeoLib/GEOObjects.cpp
+++ b/GeoLib/GEOObjects.cpp
@@ -522,6 +522,10 @@ const GeoLib::GeoObject* GEOObjects::getGeoObject(const std::string &geo_name,
 							sfc_vec->getElementByName(geo_obj_name)));
 		break;
 	}
+	case GeoLib::GEOTYPE::GEODOMAIN: {
+		geo_obj = const_cast<GeoLib::GeoDomain*>(&_geo_domain);
+		break;
+	}
 	default:
 		ERR("GEOObjects::getGeoObject(): geometric type not handled.")
 		return nullptr;
@@ -547,6 +551,9 @@ GeoLib::GeoObject const* GEOObjects::getGeoObject(
 
 	if(!geo_obj)
 		geo_obj = getGeoObject(geo_name, GeoLib::GEOTYPE::SURFACE, geo_obj_name);
+
+	if(!geo_obj)
+		geo_obj = getGeoObject(geo_name, GeoLib::GEOTYPE::GEODOMAIN, geo_obj_name);
 
 	if (!geo_obj) {
 		ERR("GEOObjects::getGeoObject(): Could not find \"%s\" in geometry %s.",

--- a/GeoLib/GEOObjects.h
+++ b/GeoLib/GEOObjects.h
@@ -24,6 +24,7 @@
 #include "PolylineVec.h"
 #include "Surface.h"
 #include "SurfaceVec.h"
+#include "GeoDomain.h"
 
 #include "Station.h"
 
@@ -258,6 +259,8 @@ protected:
 	std::vector<PolylineVec*> _ply_vecs;
 	/** vector manages pointers to SurfaceVec objects */
 	std::vector<SurfaceVec*> _sfc_vecs;
+
+	GeoDomain _geo_domain;
 private:
 	/**
 	 * Method merges points from different geometries into one geometry. This

--- a/GeoLib/GeoDomain.h
+++ b/GeoLib/GeoDomain.h
@@ -1,0 +1,27 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef GEODOMAIN_H_
+#define GEODOMAIN_H_
+
+#include "GeoType.h"
+#include "GeoObject.h"
+
+namespace GeoLib
+{
+class GeoDomain : public GeoObject
+{
+public:
+	virtual ~GeoDomain() = default;
+	/// return a geometry type
+	virtual GEOTYPE getGeoType() const {return GEOTYPE::GEODOMAIN; }
+};
+} // end namespace GeoLib
+
+#endif /* GEODOMAIN_H_ */

--- a/GeoLib/GeoType.cpp
+++ b/GeoLib/GeoType.cpp
@@ -23,6 +23,7 @@ GEOTYPE convertGeoType (const std::string& geo_type_str)
 	if (geo_type_str.compare ("SURFACE") == 0) return GEOTYPE::SURFACE;
 	if (geo_type_str.compare ("VOLUME") == 0) return GEOTYPE::VOLUME;
 	if (geo_type_str.compare ("GEODOMAIN") == 0) return GEOTYPE::GEODOMAIN;
+	if (geo_type_str.compare ("DOMAIN") == 0) return GEOTYPE::GEODOMAIN;
 	return GEOTYPE::INVALID;
 }
 

--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -69,6 +69,11 @@ std::vector<std::size_t> MeshNodeSearcher::getMeshNodeIDs(GeoLib::GeoObject cons
 	case GeoLib::GEOTYPE::SURFACE:
 		vec_nodes = this->getMeshNodeIDsAlongSurface(*static_cast<const GeoLib::Surface*>(&geoObj));
 		break;
+	case GeoLib::GEOTYPE::GEODOMAIN:
+		vec_nodes.resize(_mesh.getNNodes());
+		for (std::size_t i=0; i<_mesh.getNNodes(); i++)
+			vec_nodes[i] = i;
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
I would like to propose adding `GeoDomain` class as a member of `GeoObject`. With the class, we can provide consistent interface for any geometric definition in some functions such as `MeshNodeSearcher::getMeshNodeIDs()`.