### PR TITLE
[A/U] GMSH2OGS: Add nullptr check.

### DIFF
--- a/Applications/Utils/FileConverter/GMSH2OGS.cpp
+++ b/Applications/Utils/FileConverter/GMSH2OGS.cpp
@@ -99,9 +99,13 @@ int main (int argc, char* argv[])
 		auto ex = MeshLib::ElementExtraction(*mesh);
 		ex.searchByElementType(MeshLib::MeshElemType::LINE);
 		auto m = ex.removeMeshElements(mesh->getName()+"-withoutLines");
-		INFO("Removed %d lines.", mesh->getNElements() - m->getNElements());
-		std::swap(m, mesh);
-		delete m;
+		if (m != nullptr) {
+			INFO("Removed %d lines.", mesh->getNElements() - m->getNElements());
+			std::swap(m, mesh);
+			delete m;
+		} else {
+			INFO("Mesh does not contain any lines.");
+		}
 	}
 
 	// *** write mesh in new format


### PR DESCRIPTION
@waltherm discovered a bug in the GMSH2OGS tool. Using a switch it is possible that line elements are not converted to the OGS mesh. In case the GMSH mesh does not contain line elements and the switch is activated the previous code crashed. The changes in this PR/commit will fix this.