### PR TITLE
Fix error in PointVec

### DIFF
--- a/GeoLib/PointVec.cpp
+++ b/GeoLib/PointVec.cpp
@@ -67,6 +67,13 @@ PointVec::PointVec (const std::string& name, std::vector<Point*>* points,
 	auto const data_vec_end = std::remove(_data_vec->begin(), _data_vec->end(), nullptr);
 	_data_vec->erase(data_vec_end, _data_vec->end());
 
+	// set value of the point id to the position of the point within _data_vec
+	for (std::size_t k(0); k<_data_vec->size(); ++k) {
+		if ((*_data_vec)[k]->getID() != k) {
+			(*_data_vec)[k]->setID(k);
+		}
+	}
+
 	if (number_of_all_input_pnts > _data_vec->size())
 		WARN("PointVec::PointVec(): there are %d double points.",
 			number_of_all_input_pnts - _data_vec->size());
@@ -117,6 +124,8 @@ std::size_t PointVec::uniqueInsert(Point* pnt)
 {
 	GeoLib::Point * ret_pnt(nullptr);
 	if (_oct_tree->addPoint(pnt, ret_pnt)) {
+		// set value of the point id to the position of the point within _data_vec
+		pnt->setID(_data_vec->size());
 		_data_vec->push_back(pnt);
 		return _data_vec->size()-1;
 	}
@@ -135,6 +144,7 @@ std::size_t PointVec::uniqueInsert(Point* pnt)
 		// add the new point
 		ret_pnt = nullptr;
 		_oct_tree->addPoint(pnt, ret_pnt);
+		// set value of the point id to the position of the point within _data_vec
 		pnt->setID(_data_vec->size());
 		_data_vec->push_back(pnt);
 		return _data_vec->size()-1;

--- a/Tests/GeoLib/TestPointVec.cpp
+++ b/Tests/GeoLib/TestPointVec.cpp
@@ -102,13 +102,83 @@ TEST_F(PointVecTest, TestPointVecPushBack)
 	ps_ptr->push_back(new GeoLib::Point(0,0,1,3));
 	GeoLib::PointVec point_vec(name, ps_ptr);
 
-	// Adding a new point with same coordinates changes nothing.
-	point_vec.push_back(new GeoLib::Point(0,0,0,4));
-	point_vec.push_back(new GeoLib::Point(1,0,0,5));
-	point_vec.push_back(new GeoLib::Point(0,1,0,6));
-	point_vec.push_back(new GeoLib::Point(0,0,1,7));
+	ASSERT_EQ(std::size_t(0), point_vec.getIDMap()[0]);
+	ASSERT_EQ(std::size_t(1), point_vec.getIDMap()[1]);
+	ASSERT_EQ(std::size_t(2), point_vec.getIDMap()[2]);
+	ASSERT_EQ(std::size_t(3), point_vec.getIDMap()[3]);
+
+	// Adding some points that are already existing.
+	ASSERT_EQ(std::size_t(0), point_vec.push_back(new GeoLib::Point(0,0,0,4)));
+	ASSERT_EQ(std::size_t(1), point_vec.push_back(new GeoLib::Point(1,0,0,5)));
+	ASSERT_EQ(std::size_t(2), point_vec.push_back(new GeoLib::Point(0,1,0,6)));
+	ASSERT_EQ(std::size_t(3), point_vec.push_back(new GeoLib::Point(0,0,1,7)));
 
 	ASSERT_EQ(std::size_t(4), point_vec.size());
+	ASSERT_EQ(std::size_t(8), point_vec.getIDMap().size());
+
+	ASSERT_EQ(std::size_t(0), point_vec.getIDMap()[4]);
+	ASSERT_EQ(std::size_t(1), point_vec.getIDMap()[5]);
+	ASSERT_EQ(std::size_t(2), point_vec.getIDMap()[6]);
+	ASSERT_EQ(std::size_t(3), point_vec.getIDMap()[7]);
+
+	// Adding again some already existing points.
+	ASSERT_EQ(std::size_t(0), point_vec.push_back(new GeoLib::Point(0,0,0,8)));
+	ASSERT_EQ(std::size_t(1), point_vec.push_back(new GeoLib::Point(1,0,0,9)));
+	ASSERT_EQ(std::size_t(2), point_vec.push_back(new GeoLib::Point(0,1,0,10)));
+	ASSERT_EQ(std::size_t(3), point_vec.push_back(new GeoLib::Point(0,0,1,11)));
+
+	ASSERT_EQ(std::size_t(4), point_vec.size());
+	ASSERT_EQ(std::size_t(12), point_vec.getIDMap().size());
+
+	ASSERT_EQ(std::size_t(0), point_vec.getIDMap()[8]);
+	ASSERT_EQ(std::size_t(1), point_vec.getIDMap()[9]);
+	ASSERT_EQ(std::size_t(2), point_vec.getIDMap()[10]);
+	ASSERT_EQ(std::size_t(3), point_vec.getIDMap()[11]);
+
+	// Adding some new points.
+	ASSERT_EQ(std::size_t(4), point_vec.push_back(new GeoLib::Point(0.1,0.1,0.1,12)));
+	ASSERT_EQ(std::size_t(5), point_vec.push_back(new GeoLib::Point(1.1,0.1,0.1,13)));
+	ASSERT_EQ(std::size_t(6), point_vec.push_back(new GeoLib::Point(0.1,1.1,0.1,14)));
+	ASSERT_EQ(std::size_t(7), point_vec.push_back(new GeoLib::Point(0.1,0.1,1.1,15)));
+
+	ASSERT_EQ(std::size_t(8), point_vec.size());
+	ASSERT_EQ(std::size_t(16), point_vec.getIDMap().size());
+
+	ASSERT_EQ(std::size_t(4), point_vec.getIDMap()[12]);
+	ASSERT_EQ(std::size_t(5), point_vec.getIDMap()[13]);
+	ASSERT_EQ(std::size_t(6), point_vec.getIDMap()[14]);
+	ASSERT_EQ(std::size_t(7), point_vec.getIDMap()[15]);
+
+	// Adding again some already existing points.
+	ASSERT_EQ(std::size_t(0), point_vec.push_back(new GeoLib::Point(0,0,0,16)));
+	ASSERT_EQ(std::size_t(1), point_vec.push_back(new GeoLib::Point(1,0,0,17)));
+	ASSERT_EQ(std::size_t(2), point_vec.push_back(new GeoLib::Point(0,1,0,18)));
+	ASSERT_EQ(std::size_t(3), point_vec.push_back(new GeoLib::Point(0,0,1,19)));
+
+	ASSERT_EQ(std::size_t(8), point_vec.size());
+	ASSERT_EQ(std::size_t(20), point_vec.getIDMap().size());
+
+	ASSERT_EQ(std::size_t(0), point_vec.getIDMap()[16]);
+	ASSERT_EQ(std::size_t(1), point_vec.getIDMap()[17]);
+	ASSERT_EQ(std::size_t(2), point_vec.getIDMap()[18]);
+	ASSERT_EQ(std::size_t(3), point_vec.getIDMap()[19]);
+
+	ASSERT_EQ(std::size_t(0), point_vec.getIDMap()[0]);
+	ASSERT_EQ(std::size_t(1), point_vec.getIDMap()[1]);
+	ASSERT_EQ(std::size_t(2), point_vec.getIDMap()[2]);
+	ASSERT_EQ(std::size_t(3), point_vec.getIDMap()[3]);
+	ASSERT_EQ(std::size_t(0), point_vec.getIDMap()[4]);
+	ASSERT_EQ(std::size_t(1), point_vec.getIDMap()[5]);
+	ASSERT_EQ(std::size_t(2), point_vec.getIDMap()[6]);
+	ASSERT_EQ(std::size_t(3), point_vec.getIDMap()[7]);
+	ASSERT_EQ(std::size_t(0), point_vec.getIDMap()[8]);
+	ASSERT_EQ(std::size_t(1), point_vec.getIDMap()[9]);
+	ASSERT_EQ(std::size_t(2), point_vec.getIDMap()[10]);
+	ASSERT_EQ(std::size_t(3), point_vec.getIDMap()[11]);
+	ASSERT_EQ(std::size_t(4), point_vec.getIDMap()[12]);
+	ASSERT_EQ(std::size_t(5), point_vec.getIDMap()[13]);
+	ASSERT_EQ(std::size_t(6), point_vec.getIDMap()[14]);
+	ASSERT_EQ(std::size_t(7), point_vec.getIDMap()[15]);
 }
 
 // Testing random input points.


### PR DESCRIPTION
After computing the entries of `_pnt_id_map` the ids of the point objects have to be set to the position within the `_data_vec`. Until now, this was not done correctly. This PR corrects the wrong behaviour. Additional there are some new tests.