### PR TITLE
[MGTL] Fix MeshNodeSearchers memoization due to changed mesh_id.

### DIFF
--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -128,7 +128,7 @@ MeshNodeSearcher&
 MeshNodeSearcher::getMeshNodeSearcher(MeshLib::Mesh const& mesh)
 {
 	std::size_t const mesh_id = mesh.getID();
-	if (_mesh_node_searchers.size() < mesh_id)
+	if (_mesh_node_searchers.size() < mesh_id+1)
 		_mesh_node_searchers.resize(mesh_id+1);
 
 	if (!_mesh_node_searchers[mesh_id])


### PR DESCRIPTION
This was overseen by me in ufz/ogs#738.