### PR TITLE
Fix memory leaks in tests

### DIFF
--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -190,19 +190,18 @@ void MeshSurfaceExtraction::get2DSurfaceElements(const std::vector<MeshLib::Elem
 				if ((*elem)->getNeighbor(j) != nullptr)
 					continue;
 
-				const MeshLib::Element* face = (*elem)->getFace(j);
+				auto const face = std::unique_ptr<MeshLib::Element const>{(*elem)->getFace(j)};
 				if (!complete_surface)
 				{
-					if (MathLib::scalarProduct(FaceRule::getSurfaceNormal(face).getNormalizedVector(), norm_dir) < cos_theta)
+					if (MathLib::scalarProduct(FaceRule::getSurfaceNormal(face.get()).getNormalizedVector(), norm_dir) < cos_theta)
 					{
-						delete face;
 						continue;
 					}
 				}
 				if (face->getGeomType() == MeshElemType::TRIANGLE)
-					sfc_elements.push_back(new MeshLib::Tri(*static_cast<const MeshLib::Tri*>(face)));
+					sfc_elements.push_back(new MeshLib::Tri(*static_cast<const MeshLib::Tri*>(face.get())));
 				else
-					sfc_elements.push_back(new MeshLib::Quad(*static_cast<const MeshLib::Quad*>(face)));
+					sfc_elements.push_back(new MeshLib::Quad(*static_cast<const MeshLib::Quad*>(face.get())));
 			}
 		}
 	}

--- a/Tests/FileIO/TestCsvReader.cpp
+++ b/Tests/FileIO/TestCsvReader.cpp
@@ -71,6 +71,10 @@ TEST_F(CsvInterfaceTest, SimpleReadPoints)
 		ASSERT_TRUE((*points[i])[1] == (*points2[i])[0]);
 		ASSERT_TRUE((*points[i])[2] == (*points2[i])[1]);
 	}
+	for (auto p : points)
+		delete p;
+	for (auto p : points2)
+		delete p;
 }
 
 /// Dealing with unconvertable data types
@@ -103,6 +107,8 @@ TEST_F(CsvInterfaceTest, MissingValues)
 	ASSERT_EQ(3, _result);
 	ASSERT_EQ(7, points.size());
 	ASSERT_NEAR(437.539, (*points[4])[2], std::numeric_limits<double>::epsilon());
+	for (auto p : points)
+		delete p;
 }
 
 /// Reading 2D points
@@ -114,6 +120,8 @@ TEST_F(CsvInterfaceTest, Points2D)
 	ASSERT_EQ(10, points.size());
 	for (std::size_t i=0; i<points.size(); ++i)
 		ASSERT_NEAR(0, (*points[i])[2], std::numeric_limits<double>::epsilon());
+	for (auto p : points)
+		delete p;
 }
 
 /// Dealing with non-sequential column order
@@ -140,6 +148,12 @@ TEST_F(CsvInterfaceTest, CoordinateOrder)
 		ASSERT_EQ((*points1[i])[0], (*points3[i])[1]);
 		ASSERT_EQ((*points1[i])[1], (*points3[i])[0]);
 	}
+	for (auto p : points1)
+		delete p;
+	for (auto p : points2)
+		delete p;
+	for (auto p : points3)
+		delete p;
 }
 
 /// Getting single columns

--- a/Tests/GeoLib/TestAABB.cpp
+++ b/Tests/GeoLib/TestAABB.cpp
@@ -200,6 +200,9 @@ TEST(GeoLib, AABBAllPointsWithNegativeCoordinatesI)
 	ASSERT_NEAR(-1.0, max_pnt[0], std::numeric_limits<double>::epsilon());
 	ASSERT_NEAR(-1.0, max_pnt[1], std::numeric_limits<double>::epsilon());
 	ASSERT_NEAR(-1.0, max_pnt[2], std::numeric_limits<double>::epsilon());
+
+	for (auto p : pnts)
+		delete p;
 }
 
 TEST(GeoLib, AABBAllPointsWithNegativeCoordinatesII)

--- a/Tests/GeoLib/TestBoundingSphere.cpp
+++ b/Tests/GeoLib/TestBoundingSphere.cpp
@@ -113,8 +113,11 @@ TEST(GeoLib, TestBoundingSphere)
     }
 
     /// Calculates the bounding sphere of points on a bounding sphere
-    std::vector<MathLib::Point3d*> *sphere_points (s.getRandomSpherePoints(1000));
+    auto sphere_points = std::unique_ptr<
+        std::vector<MathLib::Point3d*>>(s.getRandomSpherePoints(1000));
     GeoLib::MinimalBoundingSphere t(*sphere_points);
+    for (auto p : *sphere_points)
+        delete p;
     MathLib::Point3d center = s.getCenter();
     ASSERT_NEAR(0.5, center[0], std::numeric_limits<double>::epsilon());
     ASSERT_NEAR(0.5, center[1], std::numeric_limits<double>::epsilon());

--- a/Tests/GeoLib/TestComputeRotationMatrix.cpp
+++ b/Tests/GeoLib/TestComputeRotationMatrix.cpp
@@ -12,6 +12,15 @@
 #include "gtest/gtest.h"
 #include "AnalyticalGeometry.h"
 
+auto test3equal = [](double a, double b, double c, double const* result)
+{
+	EXPECT_EQ(a, result[0]);
+	EXPECT_EQ(b, result[1]);
+	EXPECT_EQ(c, result[2]);
+
+	delete[] result;
+};
+
 TEST(GeoLib, ComputeRotationMatrixToXYnegative)
 {
 	MathLib::Vector3 const n(0.0, -1.0, 0.0);
@@ -29,22 +38,13 @@ TEST(GeoLib, ComputeRotationMatrixToXYnegative)
 	EXPECT_EQ(0.0, rot_mat(2,2));
 
 	MathLib::Vector3 const x(0.0,1.0,0.0);
-	MathLib::Vector3 const result(rot_mat*x.getCoords());
-	EXPECT_EQ(0.0, result[0]);
-	EXPECT_EQ(0.0, result[1]);
-	EXPECT_EQ(-1.0, result[2]);
+	test3equal(0, 0, -1, rot_mat*x.getCoords());
 
 	MathLib::Vector3 const x0(10.0,1.0,0.0);
-	MathLib::Vector3 const r0(rot_mat*x0.getCoords());
-	EXPECT_EQ(10.0, r0[0]);
-	EXPECT_EQ(0.0, r0[1]);
-	EXPECT_EQ(-1.0, r0[2]);
+	test3equal(10, 0, -1, rot_mat*x0.getCoords());
 
 	MathLib::Vector3 const x1(10.0,0.0,10.0);
-	MathLib::Vector3 const r1(rot_mat*x1.getCoords());
-	EXPECT_EQ(10.0, r1[0]);
-	EXPECT_EQ(10.0, r1[1]);
-	EXPECT_EQ(0.0, r1[2]);
+	test3equal(10, 10, 0, rot_mat*x1.getCoords());
 }
 
 TEST(GeoLib, ComputeRotationMatrixToXYpositive)
@@ -64,21 +64,12 @@ TEST(GeoLib, ComputeRotationMatrixToXYpositive)
 	EXPECT_EQ(0.0, rot_mat(2,2));
 
 	MathLib::Vector3 const x(0.0,1.0,0.0);
-	MathLib::Vector3 const result(rot_mat*x.getCoords());
-	EXPECT_EQ(0.0, result[0]);
-	EXPECT_EQ(0.0, result[1]);
-	EXPECT_EQ(1.0, result[2]);
+	test3equal(0, 0, 1, rot_mat*x.getCoords());
 
 	MathLib::Vector3 const x0(10.0,1.0,0.0);
-	MathLib::Vector3 const r0(rot_mat*x0.getCoords());
-	EXPECT_EQ(10.0, r0[0]);
-	EXPECT_EQ(0.0, r0[1]);
-	EXPECT_EQ(1.0, r0[2]);
+	test3equal(10, 0, 1, rot_mat*x0.getCoords());
 
 	MathLib::Vector3 const x1(10.0,0.0,10.0);
-	MathLib::Vector3 const r1(rot_mat*x1.getCoords());
-	EXPECT_EQ(10.0, r1[0]);
-	EXPECT_EQ(-10.0, r1[1]);
-	EXPECT_EQ(0.0, r1[2]);
+	test3equal(10, -10, 0, rot_mat*x1.getCoords());
 }
 

--- a/Tests/InSituLib/TestVtkMappedMeshSource.cpp
+++ b/Tests/InSituLib/TestVtkMappedMeshSource.cpp
@@ -14,6 +14,7 @@
 
 #include "BaseLib/BuildInfo.h"
 
+#include <memory>
 #include <numeric>
 
 #include "FileIO/VtkIO/VtuInterface.h"
@@ -238,7 +239,7 @@ TEST_F(InSituMesh, MappedMeshSourceRoundtrip)
 					  cellUnsignedArray->GetNumberOfTuples());
 
 			// Both OGS meshes should be identical
-			MeshLib::Mesh *newMesh = MeshLib::VtkMeshConverter::convertUnstructuredGrid(vtkMesh);
+			auto newMesh = std::unique_ptr<MeshLib::Mesh>{MeshLib::VtkMeshConverter::convertUnstructuredGrid(vtkMesh)};
 			ASSERT_EQ(mesh->getNNodes(), newMesh->getNNodes());
 			ASSERT_EQ(mesh->getNElements(), newMesh->getNElements());
 

--- a/Tests/NumLib/TestCoordinatesMapping.cpp
+++ b/Tests/NumLib/TestCoordinatesMapping.cpp
@@ -311,5 +311,7 @@ TEST(NumLib, FemNaturalCoordinatesMappingLineY)
 	double exp_dNdx[2*e_nnodes] = {0, 0, -0.5, 0.5};
 	ASSERT_ARRAY_NEAR(exp_dNdx, shape.dNdx.data(), shape.dNdx.size(), eps);
 
+	for (auto n = 0; n < line->getNNodes(); ++n)
+		delete line->getNode(n);
 	delete line;
 }


### PR DESCRIPTION
Following ufz/ogs#745.

This removes all remaining memory leaks detected by clang's address-sanitizer in testrunner (caused by ogs).
There are few remaining but their traces lead to Qt.

One real memory leak (which would occur when using MeshSurfaceExtraction) is detected.
Other memory leaks are due to careless usage in the tests.