### PR TITLE
[GL] Fix bug in lineSegmentIntersect.

### DIFF
--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -136,6 +136,7 @@ bool lineSegmentIntersect(
 				return true;
 			return false;
 		}
+		return false;
 	}
 
 	MathLib::DenseMatrix<double> mat(2,2);

--- a/Tests/GeoLib/TestLineSegmentIntersect.cpp
+++ b/Tests/GeoLib/TestLineSegmentIntersect.cpp
@@ -19,7 +19,7 @@
 
 TEST(GeoLib, TestXAxisParallelLineSegmentIntersection2d)
 {
-	// two parallel line segments
+	// two intersecting parallel line segments
 	GeoLib::Point a(0.0, 0.0, 0.0);
 	GeoLib::Point b(1.0, 0.0, 0.0);
 	GeoLib::Point c(0.5, 0.0, 0.0);
@@ -31,7 +31,7 @@ TEST(GeoLib, TestXAxisParallelLineSegmentIntersection2d)
 
 TEST(GeoLib, TestParallelLineSegmentIntersection2d)
 {
-	// two parallel line segments
+	// two intersecting parallel line segments
 	GeoLib::Point a(0.0, 0.0, 0.0);
 	GeoLib::Point b(1.0, 1.0, 0.0);
 	GeoLib::Point c(0.5, 0.5, 0.0);
@@ -41,13 +41,25 @@ TEST(GeoLib, TestParallelLineSegmentIntersection2d)
 	EXPECT_TRUE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
 }
 
-TEST(GeoLib, TestNonIntersectingParallelLineSegments2d)
+TEST(GeoLib, TestNonIntersectingParallelLineSegments2dCaseI)
 {
 	// two non intersecting parallel line segments
 	GeoLib::Point a(0.0, 0.0, 0.0);
 	GeoLib::Point b(1.0, 1.0, 0.0);
 	GeoLib::Point c(1.5, 1.5, 0.0);
 	GeoLib::Point d(2.5, 2.5, 0.0);
+	GeoLib::Point s;
+
+	EXPECT_FALSE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+}
+
+TEST(GeoLib, TestNonIntersectingParallelLineSegments2dCaseII)
+{
+	// two non intersecting parallel line segments
+	GeoLib::Point a(0.0, 1.0, 0.0);
+	GeoLib::Point b(1.0, 0.0, 0.0);
+	GeoLib::Point c(0.0, -1.0, 0.0);
+	GeoLib::Point d(-1.0, 0.0, 0.0);
 	GeoLib::Point s;
 
 	EXPECT_FALSE(GeoLib::lineSegmentIntersect(a,b,c,d,s));


### PR DESCRIPTION
The special case where the line segments (a,b) and (c,d) are parallel but are not located at the same straight line was not handled properly. This led to a singular matrix and to a not a number solution. This commit fixes the handling of the special case.

This PR is related to issue https://github.com/ufz/ogs/issues/734.

fixes ufz/ogs#734