### PR TITLE
Using other Point constructors

### DIFF
--- a/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
+++ b/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
@@ -220,7 +220,7 @@ int main (int argc, char* argv[])
 	std::vector<GeoLib::Point> pnts_with_id;
 	const size_t n_merged_pnts(merged_pnts->size());
 	for(std::size_t k(0); k<n_merged_pnts; ++k) {
-		pnts_with_id.emplace_back((*merged_pnts)[k]->getCoords(), k);
+		pnts_with_id.emplace_back(*((*merged_pnts)[k]), k);
 	}
 
 	std::sort(pnts_with_id.begin(), pnts_with_id.end(),

--- a/FileIO/TINInterface.cpp
+++ b/FileIO/TINInterface.cpp
@@ -37,7 +37,7 @@ GeoLib::Surface* TINInterface::readTIN(std::string const& fname,
 
 	GeoLib::Surface* sfc = new GeoLib::Surface(*(pnt_vec.getVector()));
 	std::size_t id;
-	double p0[3], p1[3], p2[3];
+	MathLib::Point3d p0, p1, p2;
 	std::string line;
 	while (std::getline(in, line).good())
 	{

--- a/GeoLib/MinimalBoundingSphere.h
+++ b/GeoLib/MinimalBoundingSphere.h
@@ -46,7 +46,7 @@ public:
     MinimalBoundingSphere(std::vector<MathLib::Point3d*> const& points);
 
     /// Returns the center point of the sphere
-    MathLib::Point3d getCenter() const { return MathLib::Point3d(_center.getCoords()); }
+    MathLib::Point3d getCenter() const { return MathLib::Point3d(_center); }
 
     /// Returns the radius of the sphere
     double getRadius() const {return _radius; }

--- a/GeoLib/Point.h
+++ b/GeoLib/Point.h
@@ -48,8 +48,8 @@ public:
 		GeoLib::GeoObject()
 	{}
 
-	Point(Point const& p, std::size_t id) :
-		MathLib::Point3dWithID(p, id), GeoLib::GeoObject()
+	Point(MathLib::Point3d const& x, std::size_t id) :
+		MathLib::Point3dWithID(x, id), GeoLib::GeoObject()
 	{}
 
 	Point(std::array<double,3> const& x,

--- a/GeoLib/Raster.cpp
+++ b/GeoLib/Raster.cpp
@@ -81,7 +81,7 @@ Raster* Raster::getRasterFromSurface(Surface const& sfc, double cell_size, doubl
 
 	for (std::size_t r(0); r < n_cols; r++) {
 		for (std::size_t c(0); c < n_rows; c++) {
-			const double test_pnt[3] = { ll[0] + r*cell_size, ll[1] + c*cell_size, 0};
+			GeoLib::Point const test_pnt = { ll[0] + r*cell_size, ll[1] + c*cell_size, 0};
 			for (k=0; k<n_triangles; k++) {
 				if (sfc[k]->containsPoint2D(test_pnt)) {
 					GeoLib::Triangle const * const tri (sfc[k]);

--- a/MeshGeoToolsLib/GeoMapper.cpp
+++ b/MeshGeoToolsLib/GeoMapper.cpp
@@ -217,9 +217,10 @@ void GeoMapper::advancedMapOnMesh(const MeshLib::Mesh* mesh, const std::string &
 	std::vector<double> dist(nMeshNodes);  // distance between geo points and mesh nodes in (x,y)-plane
 	for (std::size_t i=0; i<nMeshNodes; ++i)
 	{
-		const double zero_coords[3] = {(* mesh->getNode(i))[0], (* mesh->getNode(i))[1], 0.0};
+		auto const zero_coords = GeoLib::Point((*mesh->getNode(i))[0],
+			(*mesh->getNode(i))[1], 0.0, mesh->getNode(i)->getID());
 		GeoLib::Point* pnt = grid.getNearestPoint(zero_coords);
-		dist[i] = MathLib::sqrDist(pnt->getCoords(), zero_coords);
+		dist[i] = MathLib::sqrDist(*pnt, zero_coords);
 		closest_geo_point[i] = (dist[i]<=max_segment_length) ? getIndexInPntVec(pnt, new_points) : -1;
 	}
 

--- a/MeshLib/ElementCoordinatesMappingLocal.cpp
+++ b/MeshLib/ElementCoordinatesMappingLocal.cpp
@@ -74,7 +74,7 @@ ElementCoordinatesMappingLocal::ElementCoordinatesMappingLocal(
     assert(e.getDimension() <= global_coords.getDimension());
     _points.reserve(e.getNNodes());
     for(unsigned i = 0; i < e.getNNodes(); i++)
-        _points.emplace_back(e.getNode(i)->getCoords());
+        _points.emplace_back(*(e.getNode(i)));
 
     auto const element_dimension = e.getDimension();
     auto const global_dimension = global_coords.getDimension();

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -248,7 +248,7 @@ std::vector<GeoLib::Point*> MeshSurfaceExtraction::getSurfaceNodes(const MeshLib
 	std::vector<GeoLib::Point*> surface_pnts(nNodes);
 	for (std::size_t i=0; i<nNodes; ++i)
 	{
-		surface_pnts[i] = new GeoLib::Point(sfc_nodes[i]->getCoords(), sfc_nodes[i]->getID());
+		surface_pnts[i] = new GeoLib::Point(*(sfc_nodes[i]), sfc_nodes[i]->getID());
 		delete sfc_nodes[i];
 	}
 	return surface_pnts;

--- a/MeshLib/Node.cpp
+++ b/MeshLib/Node.cpp
@@ -18,7 +18,8 @@
 namespace MeshLib {
 
 Node::Node(const double coords[3], std::size_t id)
-	: MathLib::Point3dWithID(coords, id)
+	: MathLib::Point3dWithID(
+		std::array<double,3>{{coords[0], coords[1], coords[2]}}, id)
 {
 }
 
@@ -33,7 +34,7 @@ Node::Node(double x, double y, double z, std::size_t id)
 }
 
 Node::Node(const Node &node)
-	: MathLib::Point3dWithID(node.getCoords(), node.getID())
+	: MathLib::Point3dWithID(node._x, node.getID())
 {
 }
 

--- a/Tests/GeoLib/TestGrid.cpp
+++ b/Tests/GeoLib/TestGrid.cpp
@@ -84,7 +84,7 @@ TEST(GeoLib, SearchNearestPointInGrid)
 	ASSERT_NO_THROW(grid = new GeoLib::Grid<GeoLib::Point>(pnts.begin(), pnts.end()));
 
 	GeoLib::Point p0(0,10,10);
-	GeoLib::Point* res(grid->getNearestPoint(p0.getCoords()));
+	GeoLib::Point* res(grid->getNearestPoint(p0));
 	ASSERT_EQ(sqrt(MathLib::sqrDist(*res, *pnts[0])), 0.0);
 
 	delete grid;
@@ -117,19 +117,19 @@ TEST(GeoLib, SearchNearestPointsInDenseGrid)
 
 	// search point (1,1,1) is outside of the point set
 	GeoLib::Point search_pnt(std::array<double,3>({{1,1,1}}), 0);
-	GeoLib::Point* res(grid->getNearestPoint(search_pnt.getCoords()));
+	GeoLib::Point* res(grid->getNearestPoint(search_pnt));
 	ASSERT_EQ(res->getID(), i_max*j_max*k_max-1);
 	ASSERT_NEAR(sqrt(MathLib::sqrDist(*res, search_pnt)), sqrt(3.0)/50.0, std::numeric_limits<double>::epsilon());
 
 	// search point (0,1,1) is outside of the point set
 	search_pnt[0] = 0;
-	res = grid->getNearestPoint(search_pnt.getCoords());
+	res = grid->getNearestPoint(search_pnt);
 	ASSERT_EQ(res->getID(), j_max*k_max - 1);
 	ASSERT_NEAR(sqrt(MathLib::sqrDist(*res, search_pnt)), sqrt(2.0)/50.0, std::numeric_limits<double>::epsilon());
 
 	// search point (0.5,1,1) is outside of the point set
 	search_pnt[0] = 0.5;
-	res = grid->getNearestPoint(search_pnt.getCoords());
+	res = grid->getNearestPoint(search_pnt);
 	ASSERT_EQ(res->getID(), j_max*k_max*(i_max/2 + 1) - 1);
 	ASSERT_NEAR(sqrt(MathLib::sqrDist(*res, search_pnt)), sqrt(2.0)/50.0, std::numeric_limits<double>::epsilon());
 
@@ -138,7 +138,7 @@ TEST(GeoLib, SearchNearestPointsInDenseGrid)
 		for (std::size_t j(0); j < j_max; j++) {
 			std::size_t offset1(j * k_max + offset0);
 			for (std::size_t k(0); k < k_max; k++) {
-				res = grid->getNearestPoint(pnts[offset1+k]->getCoords());
+				res = grid->getNearestPoint(*pnts[offset1+k]);
 				ASSERT_EQ(res->getID(), offset1+k);
 				ASSERT_NEAR(sqrt(MathLib::sqrDist(*res, *pnts[offset1+k])), 0.0, std::numeric_limits<double>::epsilon());
 			}


### PR DESCRIPTION
The reason for this PR is to make OGS more secure and to avoid the creation of unnecessary temporary objects.
Main changes:
- Generalized one constructor of class `GeoLib::Point` (commit f3f0b13).
- Avoid using potential insecure Point constructor (see https://github.com/TomFischer/ogs/blob/master/GeoLib/Point.h#L46-49). This constructor is potential insecure because there is not a check if the length of the given `x` is sufficient.
- Creating `Point3d` objects instead of `double [3]` fields at some places.

**Update**
Forgot to mention: Removing the insecure constructor is in preparation.