### PR TITLE
Improve point type constructors

### DIFF
--- a/Applications/DataExplorer/VtkVis/VtkCompositeNodeSelectionFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeNodeSelectionFilter.cpp
@@ -65,9 +65,9 @@ void VtkCompositeNodeSelectionFilter::setSelectionArray(const std::vector<unsign
 	for (unsigned i=0; i<point_indeces.size(); ++i)
 	{
 		double * coords = static_cast<vtkDataSetAlgorithm*>(_inputAlgorithm)->GetOutput()->GetPoint(point_indeces[i]);
-		GeoLib::Point* p (new GeoLib::Point(coords));
+		GeoLib::Point* p (new GeoLib::Point(coords[0], coords[1], coords[2]));
 		_selection.push_back(p);
 	}
-	init(); 
+	init();
 }
 

--- a/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
+++ b/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
@@ -51,7 +51,7 @@ void convertMeshNodesToGeometry(std::vector<MeshLib::Node*> const& nodes,
 		new std::map<std::string, std::size_t>);
 	std::size_t cnt(0);
 	for (std::size_t id: node_ids) {
-		pnts->push_back(new GeoLib::Point(nodes[id]->getCoords()));
+		pnts->push_back(new GeoLib::Point(*(nodes[id]), nodes[id]->getID()));
 		pnt_names->insert(std::pair<std::string, std::size_t>(
 			geo_name+"-PNT-"+std::to_string(cnt), cnt));
 		cnt++;

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -47,7 +47,7 @@ std::vector<bool> markNodesOutSideOfPolygon(
 	// 1 copy all mesh nodes to GeoLib::Points
 	std::vector<GeoLib::Point*> rotated_nodes;
 	for (std::size_t j(0); j < nodes.size(); j++)
-		rotated_nodes.push_back(new GeoLib::Point(nodes[j]->getCoords()));
+		rotated_nodes.push_back(new GeoLib::Point(*nodes[j], nodes[j]->getID()));
 	// 2 rotate the Points
 	MathLib::DenseMatrix<double> rot_mat(3,3);
 	GeoLib::computeRotationMatrixToXY(normal, rot_mat);

--- a/FileIO/GmshIO/GMSHAdaptiveMeshDensity.cpp
+++ b/FileIO/GmshIO/GMSHAdaptiveMeshDensity.cpp
@@ -52,7 +52,7 @@ void GMSHAdaptiveMeshDensity::init(std::vector<GeoLib::Point const*> const& pnts
 	// *** QuadTree - determining bounding box
 	DBUG("GMSHAdaptiveMeshDensity::init(): computing axis aligned bounding box (2D) for quadtree.");
 
-	GeoLib::Point min(pnts[0]->getCoords()), max(pnts[0]->getCoords());
+	GeoLib::Point min(*pnts[0]), max(*pnts[0]);
 	std::size_t n_pnts(pnts.size());
 	for (std::size_t k(1); k<n_pnts; k++) {
 		for (std::size_t j(0); j < 2; j++)

--- a/FileIO/TetGenInterface.cpp
+++ b/FileIO/TetGenInterface.cpp
@@ -70,7 +70,7 @@ bool TetGenInterface::readTetGenGeometry (std::string const& geo_fname,
 	points->reserve(nNodes);
 	for (std::size_t k(0); k<nNodes; ++k)
 	{
-		points->push_back(new GeoLib::Point(nodes[k]->getCoords()));
+		points->push_back(new GeoLib::Point(*(nodes[k]), nodes[k]->getID()));
 		delete nodes[k];
 	}
 	std::string geo_name (BaseLib::extractBaseNameWithoutExtension(geo_fname));

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -130,14 +130,14 @@ public:
 	}
 
 protected:
-	MathLib::Point3d _min_pnt = std::array<double,3>{{
+	MathLib::Point3d _min_pnt = MathLib::Point3d{std::array<double,3>{{
 		std::numeric_limits<double>::max(),
 		std::numeric_limits<double>::max(),
-		std::numeric_limits<double>::max()}};
-	MathLib::Point3d _max_pnt = std::array<double,3>{{
+		std::numeric_limits<double>::max()}}};
+	MathLib::Point3d _max_pnt = MathLib::Point3d{std::array<double,3>{{
 		std::numeric_limits<double>::lowest(),
 		std::numeric_limits<double>::lowest(),
-		std::numeric_limits<double>::lowest()}};
+		std::numeric_limits<double>::lowest()}}};
 private:
 	void init(PNT_TYPE const & pnt)
 	{

--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -330,14 +330,6 @@ double calcTriangleArea(MathLib::Point3d const& a,
 	return 0.5 * w.getLength();
 }
 
-double calcTetrahedronVolume(const double* x1, const double* x2, const double* x3, const double* x4)
-{
-	const MathLib::Vector3 ab(x1, x2);
-	const MathLib::Vector3 ac(x1, x3);
-	const MathLib::Vector3 ad(x1, x4);
-	return std::abs(GeoLib::scalarTriple(ac, ad, ab)) / 6.0;
-}
-
 double calcTetrahedronVolume(MathLib::Point3d const& x1,
 	MathLib::Point3d const& x2,
 	MathLib::Point3d const& x3,

--- a/GeoLib/AnalyticalGeometry.h
+++ b/GeoLib/AnalyticalGeometry.h
@@ -139,7 +139,6 @@ double calcTriangleArea(MathLib::Point3d const& a, MathLib::Point3d const& b,
  * Calculates the volume of a tetrahedron.
  * The formula is V=1/6*|a(b x c)| with a=x1->x2, b=x1->x3 and c=x1->x4.
  */
-double calcTetrahedronVolume(const double* x1, const double* x2, const double* x3, const double* x4);
 double calcTetrahedronVolume(MathLib::Point3d const& x1,
 	MathLib::Point3d const& x2,
 	MathLib::Point3d const& x3,

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -479,7 +479,7 @@ GeoLib::Polygon* createPolygonFromCircle (GeoLib::Point const& middle_pnt, doubl
 	double angle (2.0 * M_PI / resolution);
 	for (std::size_t k(0); k < resolution; k++)
 	{
-		GeoLib::Point* pnt (new GeoLib::Point(middle_pnt.getCoords()));
+		GeoLib::Point* pnt(new GeoLib::Point(middle_pnt));
 		(*pnt)[0] += radius * cos (k * angle);
 		(*pnt)[1] += radius * sin (k * angle);
 		pnts.push_back (pnt);

--- a/GeoLib/Station.cpp
+++ b/GeoLib/Station.cpp
@@ -40,7 +40,7 @@ Station::Station(Point* coords, std::string name) :
 {}
 
 Station::Station(Station const& src) :
-	Point(src.getCoords()), _name(src._name), _type(src._type),
+	Point(src), _name(src._name), _type(src._type),
 	_station_value(src._station_value), _sensor_data(nullptr)
 {}
 

--- a/MathLib/Point3dWithID.h
+++ b/MathLib/Point3dWithID.h
@@ -41,7 +41,7 @@ public:
 	/// the provided id.
 	/// @param coords coordinates of the point
 	/// @param id the id of the object [default: max of std::size_t]
-	Point3dWithID(std::array<double,3> & coords,
+	Point3dWithID(std::array<double,3> const& coords,
 		std::size_t id = std::numeric_limits<std::size_t>::max())
 		: Point3d(coords), _id(id)
 	{}

--- a/MathLib/TemplatePoint.h
+++ b/MathLib/TemplatePoint.h
@@ -44,10 +44,6 @@ public:
 	 */
 	explicit TemplatePoint(std::array<T,DIM> const& x);
 
-	/** constructor - constructs a TemplatePoint object
-	   \param x values for three coordinates
-	 */
-	explicit TemplatePoint (T const* x);
 
 	/** virtual destructor */
 	virtual ~TemplatePoint() {}
@@ -112,12 +108,6 @@ template <typename T, std::size_t DIM>
 TemplatePoint<T,DIM>::TemplatePoint(std::array<T,DIM> const& x) :
 	_x(x)
 {}
-
-template <typename T, std::size_t DIM>
-TemplatePoint<T, DIM>::TemplatePoint (T const* x)
-{
-	std::copy_n(x, DIM, _x.begin());
-}
 
 /** overload the output operator for class Point */
 template <typename T, std::size_t DIM>

--- a/MathLib/TemplatePoint.h
+++ b/MathLib/TemplatePoint.h
@@ -42,12 +42,12 @@ public:
 	 *
 	 * @param x std::array containing the coordinates of the point
 	 */
-	TemplatePoint(std::array<T,DIM> const& x);
+	explicit TemplatePoint(std::array<T,DIM> const& x);
 
 	/** constructor - constructs a TemplatePoint object
 	   \param x values for three coordinates
 	 */
-	TemplatePoint (T const* x);
+	explicit TemplatePoint (T const* x);
 
 	/** virtual destructor */
 	virtual ~TemplatePoint() {}

--- a/MeshLib/convertMeshToGeo.cpp
+++ b/MeshLib/convertMeshToGeo.cpp
@@ -41,7 +41,7 @@ bool convertMeshToGeo(const MeshLib::Mesh &mesh, GeoLib::GEOObjects &geo_objects
 	const std::vector<MeshLib::Node*> &nodes = mesh.getNodes();
 
 	for (unsigned i=0; i<nNodes; ++i)
-		(*points)[i] = new GeoLib::Point(nodes[i]->getCoords());
+		(*points)[i] = new GeoLib::Point(*nodes[i], nodes[i]->getID());
 
 	std::string mesh_name (mesh.getName());
 	geo_objects.addPointVec(points, mesh_name, nullptr, eps);


### PR DESCRIPTION
The reason for this PR is the same as for PR #749, i.e. to make OGS more secure and to avoid the creation of unnecessary temporary objects. The PR is based on PR #749 and should be merged after 749 is merged.

The main point is the introduction of the keyword `explicit` in `TemplateVector` constructors (commit 14e2702) and removing the potential insecure constructor (commit 93741af). 