### PR TITLE
Generalized interfaces to avoid temporaries.

### DIFF
--- a/GeoLib/Grid.h
+++ b/GeoLib/Grid.h
@@ -131,7 +131,8 @@ public:
 	 * @return a pointer to the point with the smallest distance within the grid cells that are
 	 * outlined above or nullptr
 	 */
-	POINT* getNearestPoint(POINT const& pnt) const
+	template <typename P>
+	POINT* getNearestPoint(P const& pnt) const
 	{
 		std::size_t coords[3];
 		getGridCoords(pnt, coords);
@@ -201,7 +202,7 @@ public:
 			} // end while
 		} // end else
 
-		double len (sqrt(MathLib::sqrDist(pnt.getCoords(), nearest_pnt->getCoords())));
+		double len(sqrt(MathLib::sqrDist(pnt, *nearest_pnt)));
 		// search all other grid cells within the cube with the edge nodes
 		std::vector<std::vector<POINT*> const*> vecs_of_pnts;
 		getPntVecsOfGridCellsIntersectingCube(pnt, len, vecs_of_pnts);
@@ -211,7 +212,7 @@ public:
 			std::vector<POINT*> const& pnts(*(vecs_of_pnts[j]));
 			const std::size_t n_pnts(pnts.size());
 			for (std::size_t k(0); k<n_pnts; k++) {
-				const double sqr_dist (MathLib::sqrDist(pnt.getCoords(), pnts[k]->getCoords()));
+				const double sqr_dist(MathLib::sqrDist(pnt, *pnts[k]));
 				if (sqr_dist < sqr_min_dist) {
 					sqr_min_dist = sqr_dist;
 					nearest_pnt = pnts[k];
@@ -232,7 +233,9 @@ public:
 	 * @param pnts (output) vector of vectors of points within grid cells that intersects
 	 * the axis aligned cube
 	 */
-	void getPntVecsOfGridCellsIntersectingCube(POINT const& center, double half_len, std::vector<std::vector<POINT*> const*>& pnts) const;
+	template <typename P>
+	void getPntVecsOfGridCellsIntersectingCube(P const& center, double half_len,
+		std::vector<std::vector<POINT*> const*>& pnts) const;
 
 	void getPntVecsOfGridCellsIntersectingCuboid(
 		MathLib::Point3d const& min_pnt,
@@ -354,11 +357,13 @@ private:
 	 * ordered in the same sequence as above described
 	 * @param coords coordinates of the grid cell
 	 */
-	void getPointCellBorderDistances(POINT const& pnt,
+	template <typename P>
+	void getPointCellBorderDistances(P const& pnt,
 	                                 double dists[6],
 	                                 std::size_t const* const coords) const;
 
-	bool calcNearestPointInGridCell(POINT const& pnt, std::size_t const* const coords,
+	template <typename P>
+	bool calcNearestPointInGridCell(P const& pnt, std::size_t const* const coords,
 	                                double &sqr_min_dist,
 	                                POINT* &nearest_pnt) const
 	{
@@ -367,7 +372,7 @@ private:
 		if (pnts.empty()) return false;
 
 		const std::size_t n_pnts(pnts.size());
-		sqr_min_dist = MathLib::sqrDist(pnts[0]->getCoords(), pnt.getCoords());
+		sqr_min_dist = MathLib::sqrDist(*pnts[0], pnt);
 		nearest_pnt = pnts[0];
 		for (std::size_t i(1); i < n_pnts; i++) {
 			const double sqr_dist(MathLib::sqrDist(pnts[i]->getCoords(), pnt.getCoords()));
@@ -393,11 +398,13 @@ private:
 };
 
 template<typename POINT>
-void Grid<POINT>::getPntVecsOfGridCellsIntersectingCube(POINT const& center,
+template <typename P>
+void Grid<POINT>::getPntVecsOfGridCellsIntersectingCube(P const& center,
                                                         double half_len,
                                                         std::vector<std::vector<POINT*> const*>& pnts) const
 {
-	double tmp_pnt[3] = { center[0] - half_len, center[1] - half_len, center[2] - half_len }; // min
+	MathLib::Point3d tmp_pnt{
+		{{center[0]-half_len, center[1]-half_len, center[2]-half_len}}}; // min
 	std::size_t min_coords[3];
 	getGridCoords(tmp_pnt, min_coords);
 
@@ -543,7 +550,8 @@ void Grid<POINT>::getGridCoords(T const& pnt, std::size_t* coords) const
 }
 
 template <typename POINT>
-void Grid<POINT>::getPointCellBorderDistances(POINT const& pnt,
+template <typename P>
+void Grid<POINT>::getPointCellBorderDistances(P const& pnt,
                                               double dists[6],
                                               std::size_t const* const coords) const
 {

--- a/GeoLib/Point.h
+++ b/GeoLib/Point.h
@@ -43,11 +43,6 @@ public:
 		MathLib::Point3dWithID(), GeoLib::GeoObject()
 	{}
 
-	Point(double const* x) :
-		MathLib::Point3dWithID(std::array<double,3>({{x[0], x[1], x[2]}}), 0),
-		GeoLib::GeoObject()
-	{}
-
 	Point(MathLib::Point3d const& x, std::size_t id) :
 		MathLib::Point3dWithID(x, id), GeoLib::GeoObject()
 	{}

--- a/GeoLib/Surface.cpp
+++ b/GeoLib/Surface.cpp
@@ -115,17 +115,17 @@ const Triangle* Surface::operator[] (std::size_t i) const
 	return _sfc_triangles[i];
 }
 
-bool Surface::isPntInBoundingVolume(Point const& pnt) const
+bool Surface::isPntInBoundingVolume(MathLib::Point3d const& pnt) const
 {
 	return _bounding_volume->containsPoint (pnt);
 }
 
-bool Surface::isPntInSfc (Point const& pnt) const
+bool Surface::isPntInSfc(MathLib::Point3d const& pnt) const
 {
 	return (findTriangle(pnt)!=nullptr);
 }
 
-const Triangle* Surface::findTriangle (Point const& pnt) const
+const Triangle* Surface::findTriangle (MathLib::Point3d const& pnt) const
 {
 	for (std::size_t k(0); k<_sfc_triangles.size(); k++) {
 		if (_sfc_triangles[k]->containsPoint (pnt)) {

--- a/GeoLib/Surface.h
+++ b/GeoLib/Surface.h
@@ -61,14 +61,14 @@ public:
 	/**
 	 * is the given point in the bounding volume of the surface
 	 */
-	bool isPntInBoundingVolume(Point const& pnt) const;
+	bool isPntInBoundingVolume(MathLib::Point3d const& pnt) const;
 
 	/**
 	 * is the given point pnt located in the surface
 	 * @param pnt the point
 	 * @return true if the point is contained in the surface
 	 */
-	bool isPntInSfc (Point const& pnt) const;
+	bool isPntInSfc(MathLib::Point3d const& pnt) const;
 
 	/**
 	 * find a triangle in which the given point is located
@@ -76,7 +76,7 @@ public:
 	 * @return a pointer to a triangle. nullptr is returned if the point is not
 	 * contained in the surface
 	 */
-	const Triangle* findTriangle (Point const& pnt) const;
+	const Triangle* findTriangle(MathLib::Point3d const& pnt) const;
 
 	const std::vector<Point*> *getPointVec() const { return &_sfc_pnts; }
 

--- a/GeoLib/Triangle.cpp
+++ b/GeoLib/Triangle.cpp
@@ -63,7 +63,7 @@ void Triangle::setTriangle (std::size_t pnt_a, std::size_t pnt_b, std::size_t pn
 	_longest_edge = sqrt (_longest_edge);
 }
 
-bool Triangle::containsPoint(Point const& q, double eps) const
+bool Triangle::containsPoint(MathLib::Point3d const& q, double eps) const
 {
 	GeoLib::Point const& a(*(_pnts[_pnt_ids[0]]));
 	GeoLib::Point const& b(*(_pnts[_pnt_ids[1]]));

--- a/GeoLib/Triangle.h
+++ b/GeoLib/Triangle.h
@@ -68,7 +68,7 @@ public:
 	 * @param eps Checks the 'epsilon'-neighbourhood
 	 * @return true, if point is in triangle, else false
 	 */
-	bool containsPoint(Point const& q, double eps = std::numeric_limits<float>::epsilon()) const;
+	bool containsPoint(MathLib::Point3d const& q, double eps = std::numeric_limits<float>::epsilon()) const;
 
 	/**
 	 * projects the triangle points to the x-y-plane and

--- a/MathLib/MathTools.h
+++ b/MathLib/MathTools.h
@@ -23,7 +23,7 @@
 #include <omp.h>
 #endif
 
-#include "TemplatePoint.h"
+#include "Point3d.h"
 
 namespace MathLib
 {
@@ -107,18 +107,19 @@ void crossProd (const double u[3], const double v[3], double r[3]);
 double calcProjPntToLineAndDists(const double p[3], const double a[3],
                                  const double b[3], double &lambda, double &d0);
 
-template <typename POINT_T>
-typename POINT_T::FP_T sqrDist(POINT_T const& p0, POINT_T const& p1)
-{
-	typename POINT_T::FP_T const v[3] = {p1[0]-p0[0], p1[1]-p0[1], p1[2]-p0[2]};
-	return MathLib::scalarProduct<typename POINT_T::FP_T,3>(v,v);
-}
-
 template <typename T, std::size_t DIM>
 bool operator==(TemplatePoint<T,DIM> const& a, TemplatePoint<T,DIM> const& b)
 {
 	T const sqr_dist(sqrDist(a,b));
 	return (sqr_dist < pow(std::numeric_limits<T>::epsilon(),2));
+}
+
+/// Computes the squared dist between the two points p0 and p1.
+inline
+double sqrDist(MathLib::Point3d const& p0, MathLib::Point3d const& p1)
+{
+	const double v[3] = {p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]};
+	return scalarProduct<double,3>(v,v);
 }
 
 /** squared dist between double arrays p0 and p1 (size of arrays is 3) */

--- a/MeshGeoToolsLib/GeoMapper.cpp
+++ b/MeshGeoToolsLib/GeoMapper.cpp
@@ -153,8 +153,7 @@ float GeoMapper::getDemElevation(GeoLib::Point const& pnt) const
 
 double GeoMapper::getMeshElevation(double x, double y, double min_val, double max_val) const
 {
-	double coords[3] = {x,y,0};
-	const MeshLib::Node* pnt = _grid->getNearestPoint(coords);
+	const MeshLib::Node* pnt = _grid->getNearestPoint(MathLib::Point3d{{{x,y,0}}});
 	const std::vector<MeshLib::Element*> elements (_mesh->getNode(pnt->getID())->getElements());
 	GeoLib::Point* intersection (nullptr);
 

--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -74,7 +74,7 @@ std::vector<std::size_t> MeshNodeSearcher::getMeshNodeIDs(GeoLib::GeoObject cons
 
 boost::optional<std::size_t> MeshNodeSearcher::getMeshNodeIDForPoint(GeoLib::Point const& pnt) const
 {
-	const MeshLib::Node* found = _mesh_grid.getNearestPoint(pnt.getCoords());
+	const MeshLib::Node* found = _mesh_grid.getNearestPoint(pnt);
 	if (found)
 		return found->getID();
 	else

--- a/MeshGeoToolsLib/MeshNodesAlongSurface.cpp
+++ b/MeshGeoToolsLib/MeshNodesAlongSurface.cpp
@@ -32,9 +32,9 @@ MeshNodesAlongSurface::MeshNodesAlongSurface(
 	// loop over all nodes
 	for (std::size_t i = 0; i < n_nodes; i++) {
 		auto* node = mesh_nodes[i];
-		if (!sfc.isPntInBoundingVolume(node->getCoords()))
+		if (!sfc.isPntInBoundingVolume(*node))
 			continue;
-		if (sfc.isPntInSfc(node->getCoords())) {
+		if (sfc.isPntInSfc(*node)) {
 			_msh_node_ids.push_back(node->getID());
 		}
 	}

--- a/MeshLib/MeshEditing/MeshRevision.cpp
+++ b/MeshLib/MeshEditing/MeshRevision.cpp
@@ -200,7 +200,7 @@ std::vector<std::size_t> MeshRevision::collapseNodeIndices(double eps) const
 		MeshLib::Node const*const node(nodes[k]);
 		if (node->getID() != k)
 			continue;
-		grid.getPntVecsOfGridCellsIntersectingCube(node->getCoords(), half_eps, node_vectors);
+		grid.getPntVecsOfGridCellsIntersectingCube(*node, half_eps, node_vectors);
 
 		const std::size_t nVectors(node_vectors.size());
 		for (std::size_t i = 0; i < nVectors; ++i)

--- a/NumLib/Function/LinearInterpolationOnSurface.cpp
+++ b/NumLib/Function/LinearInterpolationOnSurface.cpp
@@ -41,10 +41,9 @@ LinearInterpolationOnSurface::LinearInterpolationOnSurface(
 
 double LinearInterpolationOnSurface::operator()(const MathLib::Point3d& pnt) const
 {
-	const double* coords = pnt.getCoords();
-	if (!_sfc.isPntInBoundingVolume(coords))
+	if (!_sfc.isPntInBoundingVolume(pnt))
 		return _default_value;
-	auto* tri = _sfc.findTriangle(coords);
+	auto* tri = _sfc.findTriangle(pnt);
 	if (tri == nullptr)
 		return _default_value;
 
@@ -58,7 +57,7 @@ double LinearInterpolationOnSurface::operator()(const MathLib::Point3d& pnt) con
 			pnt_values[j] = _default_value;
 		}
 	}
-	double val = interpolateInTri(*tri, pnt_values.data(), coords);
+	double val = interpolateInTri(*tri, pnt_values.data(), pnt);
 	return val;
 }
 

--- a/NumLib/Function/LinearInterpolationOnSurface.cpp
+++ b/NumLib/Function/LinearInterpolationOnSurface.cpp
@@ -62,7 +62,10 @@ double LinearInterpolationOnSurface::operator()(const MathLib::Point3d& pnt) con
 	return val;
 }
 
-double LinearInterpolationOnSurface::interpolateInTri(const GeoLib::Triangle &tri, double const* const vertex_values, double const* const pnt) const
+double LinearInterpolationOnSurface::interpolateInTri(
+	const GeoLib::Triangle &tri,
+	double const* const vertex_values,
+	MathLib::Point3d const& pnt) const
 {
 	std::vector<GeoLib::Point> pnts;
 	for (unsigned i=0; i<3; i++)

--- a/NumLib/Function/LinearInterpolationOnSurface.h
+++ b/NumLib/Function/LinearInterpolationOnSurface.h
@@ -81,7 +81,9 @@ private:
 	 * @param pnt
 	 * @return
 	 */
-	double interpolateInTri(const GeoLib::Triangle &tri, double const* const vertex_values, double const* const pnt) const;
+	double interpolateInTri(const GeoLib::Triangle &tri,
+		double const* const vertex_values,
+		MathLib::Point3d const& pnt) const;
 
 	/// a surface object
 	const GeoLib::Surface& _sfc;

--- a/SimpleTests/MeshTests/MeshSearchTest.cpp
+++ b/SimpleTests/MeshTests/MeshSearchTest.cpp
@@ -59,7 +59,7 @@ void testMeshGridAlgorithm(MeshLib::Mesh const*const mesh,
 		INFO ("[MeshGridAlgorithm] searching %d points ...", pnts_for_search.size());
 		clock_t start = clock();
 		for (size_t k(0); k<n_pnts_for_search; k++) {
-			MeshLib::Node const* node(mesh_grid.getNearestPoint(pnts_for_search[k]->getCoords()));
+			MeshLib::Node const* node(mesh_grid.getNearestPoint(*pnts_for_search[k]));
 			idx_found_nodes.push_back(node->getID());
 		}
 		clock_t stop = clock();
@@ -83,7 +83,7 @@ void testMeshGridAlgorithm(MeshLib::Mesh const*const mesh,
 		INFO ("[MeshGridAlgorithm] searching %d points ...", pnts_for_search.size());
 		clock_t start = clock();
 		for (size_t k(0); k<n_pnts_for_search; k++) {
-			MeshLib::Node const* node(mesh_grid.getNearestPoint(pnts_for_search[k]->getCoords()));
+			MeshLib::Node const* node(mesh_grid.getNearestPoint(pnts_for_search[k]));
 			idx_found_nodes.push_back(node->getID());
 		}
 		clock_t stop = clock();
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
 	std::vector<GeoLib::Point*> pnts_for_search;
 	unsigned n(std::min(static_cast<unsigned>(nodes.size()), number_arg.getValue()));
 	for (size_t k(0); k<n; k++) {
-		pnts_for_search.push_back(new GeoLib::Point(nodes[k]->getCoords()));
+		pnts_for_search.push_back(new GeoLib::Point(nodes[k]));
 	}
 
 	std::vector<size_t> idx_found_nodes;


### PR DESCRIPTION
PR is based on PR #750.
- It generalizes the interfaces in classes `Surface`, `Triangle` and `Grid`such that some of the methods accept `MathLib::Point3d` instead of `GeoLib::Point`. This avoids creating temporary objects.
- Because of the changes of 1. it is possible to remove the potential insecure constructor in class `GeoLib::Point` (commit eaf7f10).
- At the moment there is no need to have a templated version of `sqrDist()`. For this reason the template version is substituted with a version that takes to `MathLib::Point3d` objects. `MathLib::Point3d` is the base class of most of the in OGS used point types.