### PR TITLE
Cleanup

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -192,7 +192,7 @@ void ProjectData::parseProcessVariables(
 
 void ProjectData::parseProcesses(ConfigTree const& processes_config)
 {
-	DBUG("Reading processes:\n");
+	DBUG("Reading processes:");
 	for (auto pc_it : processes_config) {
 		ConfigTree const& process_config = pc_it.second;
 
@@ -209,7 +209,7 @@ void ProjectData::parseProcesses(ConfigTree const& processes_config)
 void ProjectData::parseOutput(ConfigTree const& output_config,
 	std::string const& path)
 {
-	DBUG("Parse output configuration:\n");
+	DBUG("Parse output configuration:");
 
 	auto const file = output_config.get_optional<std::string>("file");
 	if (!file) {

--- a/AssemblerLib/LocalDataInitializer.h
+++ b/AssemblerLib/LocalDataInitializer.h
@@ -65,36 +65,36 @@ class LocalDataInitializer
 public:
     LocalDataInitializer()
     {
-        _builder[std::type_index(typeid(MeshLib::Hex20    ))] =
-            [](){ return new LAData<NumLib::ShapeHex20  >; };
-        _builder[std::type_index(typeid(MeshLib::Hex      ))] =
-            [](){ return new LAData<NumLib::ShapeHex8   >; };
-        _builder[std::type_index(typeid(MeshLib::Line     ))] =
-            [](){ return new LAData<NumLib::ShapeLine2  >; };
-        _builder[std::type_index(typeid(MeshLib::Line3    ))] =
-            [](){ return new LAData<NumLib::ShapeLine3  >; };
-        _builder[std::type_index(typeid(MeshLib::Prism15  ))] =
+        _builder[std::type_index(typeid(MeshLib::Hex20))] =
+            [](){ return new LAData<NumLib::ShapeHex20>; };
+        _builder[std::type_index(typeid(MeshLib::Hex))] =
+            [](){ return new LAData<NumLib::ShapeHex8>; };
+        _builder[std::type_index(typeid(MeshLib::Line))] =
+            [](){ return new LAData<NumLib::ShapeLine2>; };
+        _builder[std::type_index(typeid(MeshLib::Line3))] =
+            [](){ return new LAData<NumLib::ShapeLine3>; };
+        _builder[std::type_index(typeid(MeshLib::Prism15))] =
             [](){ return new LAData<NumLib::ShapePrism15>; };
-        _builder[std::type_index(typeid(MeshLib::Prism    ))] =
-            [](){ return new LAData<NumLib::ShapePrism6 >; };
+        _builder[std::type_index(typeid(MeshLib::Prism))] =
+            [](){ return new LAData<NumLib::ShapePrism6>; };
         _builder[std::type_index(typeid(MeshLib::Pyramid13))] =
-            [](){ return new LAData<NumLib::ShapePyra13 >; };
-        _builder[std::type_index(typeid(MeshLib::Pyramid  ))] =
-            [](){ return new LAData<NumLib::ShapePyra5  >; };
-        _builder[std::type_index(typeid(MeshLib::Quad     ))] =
-            [](){ return new LAData<NumLib::ShapeQuad4  >; };
-        _builder[std::type_index(typeid(MeshLib::Quad8    ))] =
-            [](){ return new LAData<NumLib::ShapeQuad8  >; };
-        _builder[std::type_index(typeid(MeshLib::Quad9    ))] =
-            [](){ return new LAData<NumLib::ShapeQuad9  >; };
-        _builder[std::type_index(typeid(MeshLib::Tet10    ))] =
-            [](){ return new LAData<NumLib::ShapeTet10  >; };
-        _builder[std::type_index(typeid(MeshLib::Tet      ))] =
-            [](){ return new LAData<NumLib::ShapeTet4   >; };
-        _builder[std::type_index(typeid(MeshLib::Tri      ))] =
-            [](){ return new LAData<NumLib::ShapeTri3   >; };
-        _builder[std::type_index(typeid(MeshLib::Tri6     ))] =
-            [](){ return new LAData<NumLib::ShapeTri6   >; };
+            [](){ return new LAData<NumLib::ShapePyra13>; };
+        _builder[std::type_index(typeid(MeshLib::Pyramid))] =
+            [](){ return new LAData<NumLib::ShapePyra5>; };
+        _builder[std::type_index(typeid(MeshLib::Quad))] =
+            [](){ return new LAData<NumLib::ShapeQuad4>; };
+        _builder[std::type_index(typeid(MeshLib::Quad8))] =
+            [](){ return new LAData<NumLib::ShapeQuad8>; };
+        _builder[std::type_index(typeid(MeshLib::Quad9))] =
+            [](){ return new LAData<NumLib::ShapeQuad9>; };
+        _builder[std::type_index(typeid(MeshLib::Tet10))] =
+            [](){ return new LAData<NumLib::ShapeTet10>; };
+        _builder[std::type_index(typeid(MeshLib::Tet))] =
+            [](){ return new LAData<NumLib::ShapeTet4>; };
+        _builder[std::type_index(typeid(MeshLib::Tri))] =
+            [](){ return new LAData<NumLib::ShapeTri3>; };
+        _builder[std::type_index(typeid(MeshLib::Tri6))] =
+            [](){ return new LAData<NumLib::ShapeTri6>; };
     }
 
     /// Sets the provided data_ptr to the newly created local assembler data and

--- a/GeoLib/Point.cpp
+++ b/GeoLib/Point.cpp
@@ -1,0 +1,17 @@
+/**
+ * \file
+ *
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "Point.h"
+
+namespace GeoLib
+{
+    const Point ORIGIN(0, 0, 0);
+}

--- a/GeoLib/Point.h
+++ b/GeoLib/Point.h
@@ -66,7 +66,7 @@ protected:
 	void setID(std::size_t id) { _id = id; }
 };
 
-static const Point ORIGIN(0, 0, 0);
+extern const Point ORIGIN;
 }
 
 #endif /* POINT_H_ */

--- a/MeshLib/Elements/TemplateElement.cpp
+++ b/MeshLib/Elements/TemplateElement.cpp
@@ -29,18 +29,18 @@ template <class ELEMENT_RULE>
 const unsigned MeshLib::TemplateElement<ELEMENT_RULE>::dimension;
 #endif // WIN32
 
-template class MeshLib::TemplateElement<MeshLib::HexRule20    >;
-template class MeshLib::TemplateElement<MeshLib::HexRule8     >;
-template class MeshLib::TemplateElement<MeshLib::LineRule2    >;
-template class MeshLib::TemplateElement<MeshLib::LineRule3    >;
-template class MeshLib::TemplateElement<MeshLib::PrismRule15  >;
-template class MeshLib::TemplateElement<MeshLib::PrismRule6   >;
+template class MeshLib::TemplateElement<MeshLib::HexRule20>;
+template class MeshLib::TemplateElement<MeshLib::HexRule8>;
+template class MeshLib::TemplateElement<MeshLib::LineRule2>;
+template class MeshLib::TemplateElement<MeshLib::LineRule3>;
+template class MeshLib::TemplateElement<MeshLib::PrismRule15>;
+template class MeshLib::TemplateElement<MeshLib::PrismRule6>;
 template class MeshLib::TemplateElement<MeshLib::PyramidRule13>;
-template class MeshLib::TemplateElement<MeshLib::PyramidRule5 >;
-template class MeshLib::TemplateElement<MeshLib::QuadRule4    >;
-template class MeshLib::TemplateElement<MeshLib::QuadRule8    >;
-template class MeshLib::TemplateElement<MeshLib::QuadRule9    >;
-template class MeshLib::TemplateElement<MeshLib::TetRule10    >;
-template class MeshLib::TemplateElement<MeshLib::TetRule4     >;
-template class MeshLib::TemplateElement<MeshLib::TriRule3     >;
-template class MeshLib::TemplateElement<MeshLib::TriRule6     >;
+template class MeshLib::TemplateElement<MeshLib::PyramidRule5>;
+template class MeshLib::TemplateElement<MeshLib::QuadRule4>;
+template class MeshLib::TemplateElement<MeshLib::QuadRule8>;
+template class MeshLib::TemplateElement<MeshLib::QuadRule9>;
+template class MeshLib::TemplateElement<MeshLib::TetRule10>;
+template class MeshLib::TemplateElement<MeshLib::TetRule4>;
+template class MeshLib::TemplateElement<MeshLib::TriRule3>;
+template class MeshLib::TemplateElement<MeshLib::TriRule6>;

--- a/Tests/NumLib/TestCoordinatesMapping.cpp
+++ b/Tests/NumLib/TestCoordinatesMapping.cpp
@@ -311,7 +311,7 @@ TEST(NumLib, FemNaturalCoordinatesMappingLineY)
 	double exp_dNdx[2*e_nnodes] = {0, 0, -0.5, 0.5};
 	ASSERT_ARRAY_NEAR(exp_dNdx, shape.dNdx.data(), shape.dNdx.size(), eps);
 
-	for (auto n = 0; n < line->getNNodes(); ++n)
+	for (auto n = 0u; n < line->getNNodes(); ++n)
 		delete line->getNode(n);
 	delete line;
 }


### PR DESCRIPTION
White space, newline, signedness changes.
Create GeoLib::ORIGIN only once in libGeoLib, instead of instantiating it in every compilation unit. This saves a little of build time.