### PR TITLE
Remove some try catch blocks

### DIFF
--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -17,6 +17,7 @@
 
 #include <limits>
 #include <cstddef>
+#include <cstdlib>
 #include <iterator>
 #include <cassert>
 #include <vector>
@@ -72,9 +73,11 @@ public:
 	template <typename InputIterator>
 	AABB(InputIterator first, InputIterator last)
 	{
-		if (!(std::distance(first,last) > 0))
+		if (std::distance(first,last) <= 0)
+		{
 			ERR("AABB::AABB(InputIterator first, InputIterator last): first > last");
-		assert(std::distance(first,last) > 0);
+			std::abort();
+		}
 		init(*first);
 		InputIterator it(first);
 		while (it != last) {

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -21,6 +21,8 @@
 #include <cassert>
 #include <vector>
 
+#include <logog/include/logog.hpp>
+
 #include "MathLib/Point3d.h"
 #include "MathLib/MathTools.h"
 #include "Point.h"
@@ -70,9 +72,9 @@ public:
 	template <typename InputIterator>
 	AABB(InputIterator first, InputIterator last)
 	{
-		if (! (std::distance(first,last) > 0)) {
-			throw std::invalid_argument("AABB::AABB(InputIterator first, InputIterator last): first == last");
-		}
+		if (!(std::distance(first,last) > 0))
+			ERR("AABB::AABB(InputIterator first, InputIterator last): first > last");
+		assert(std::distance(first,last) > 0);
 		init(*first);
 		InputIterator it(first);
 		while (it != last) {

--- a/GeoLib/TemplateVec.h
+++ b/GeoLib/TemplateVec.h
@@ -17,7 +17,6 @@
 #define TEMPLATEVEC_H_
 
 #include <algorithm>
-#include <stdexcept>
 #include <map>
 #include <vector>
 #include <string>
@@ -58,9 +57,10 @@ public:
 	             NameIdMap* elem_name_map = nullptr) :
 		_name(name), _data_vec(data_vec), _name_id_map (elem_name_map)
 	{
-		if (_data_vec == nullptr) {
-			throw std::invalid_argument("Constructor TemplateVec: vector of data elements is a nullptr.");
-		}
+		if (_data_vec == nullptr)
+			ERR("Constructor TemplateVec: vector of data elements is a nullptr.");
+		assert(_data_vec);
+
 		if (!_name_id_map)
 			_name_id_map = new NameIdMap;
 	}

--- a/GeoLib/TemplateVec.h
+++ b/GeoLib/TemplateVec.h
@@ -17,12 +17,12 @@
 #define TEMPLATEVEC_H_
 
 #include <algorithm>
+#include <cstdlib>
 #include <map>
 #include <vector>
 #include <string>
 
-// ThirdParty/logog
-#include "logog/include/logog.hpp"
+#include <logog/include/logog.hpp>
 
 namespace GeoLib
 {
@@ -58,8 +58,10 @@ public:
 		_name(name), _data_vec(data_vec), _name_id_map (elem_name_map)
 	{
 		if (_data_vec == nullptr)
+		{
 			ERR("Constructor TemplateVec: vector of data elements is a nullptr.");
-		assert(_data_vec);
+			std::abort();
+		}
 
 		if (!_name_id_map)
 			_name_id_map = new NameIdMap;

--- a/MathLib/LinAlg/Lis/LisMatrix.cpp
+++ b/MathLib/LinAlg/Lis/LisMatrix.cpp
@@ -15,7 +15,7 @@
 #include "LisMatrix.h"
 
 #include <cmath>
-#include <stdexcept>
+#include <cassert>
 
 #include "LisVector.h"
 #include "LisCheck.h"
@@ -79,8 +79,7 @@ int LisMatrix::add(std::size_t rowId, std::size_t colId, double v)
 
 void LisMatrix::write(const std::string &filename) const
 {
-    if (!_is_assembled)
-        throw std::logic_error("LisMatrix::write(): matrix not assembled.");
+    assert(_is_assembled);
     lis_output_matrix(_AA, LIS_FMT_MM, const_cast<char*>(filename.c_str()));
 }
 
@@ -104,8 +103,7 @@ double LisMatrix::getMaxDiagCoeff()
 
 void LisMatrix::multiply(const LisVector &x, LisVector &y) const
 {
-    if (!_is_assembled)
-        throw std::logic_error("LisMatrix::matvec(): matrix not assembled.");
+    assert(_is_assembled);
     int ierr = lis_matvec(_AA, const_cast<LisVector*>(&x)->getRawVector(), y.getRawVector());
     checkLisError(ierr);
 }

--- a/MathLib/LinAlg/Lis/LisMatrix.cpp
+++ b/MathLib/LinAlg/Lis/LisMatrix.cpp
@@ -15,7 +15,9 @@
 #include "LisMatrix.h"
 
 #include <cmath>
-#include <cassert>
+#include <cstdlib>
+
+#include <logog/include/logog.hpp>
 
 #include "LisVector.h"
 #include "LisCheck.h"
@@ -79,7 +81,11 @@ int LisMatrix::add(std::size_t rowId, std::size_t colId, double v)
 
 void LisMatrix::write(const std::string &filename) const
 {
-    assert(_is_assembled);
+    if (!_is_assembled)
+    {
+        ERR("LisMatrix::write(): matrix not assembled.");
+        std::abort();
+    }
     lis_output_matrix(_AA, LIS_FMT_MM, const_cast<char*>(filename.c_str()));
 }
 
@@ -103,7 +109,11 @@ double LisMatrix::getMaxDiagCoeff()
 
 void LisMatrix::multiply(const LisVector &x, LisVector &y) const
 {
-    assert(_is_assembled);
+    if (!_is_assembled)
+    {
+        ERR("LisMatrix::multiply(): matrix not assembled.");
+        std::abort();
+    }
     int ierr = lis_matvec(_AA, const_cast<LisVector*>(&x)->getRawVector(), y.getRawVector());
     checkLisError(ierr);
 }

--- a/MeshLib/MeshSubsets.h
+++ b/MeshLib/MeshSubsets.h
@@ -14,9 +14,12 @@
 #define MESHSUBSETS_H_
 
 #include <algorithm>
+#include <cstdlib>
 #include <functional>
 #include <numeric>
 #include <vector>
+
+#include <logog/include/logog.hpp>
 
 #include "MeshSubset.h"
 
@@ -44,8 +47,10 @@ public:
         : _mesh_subsets(first, last)
     {
         if (!areMeshSubsetMeshesUnique())
+        {
             ERR("Mesh ids of input mesh subsets are not unique.");
-        assert(areMeshSubsetMeshesUnique());
+            std::abort();
+        }
 
         _n_total_items = std::accumulate(first, last, 0u,
             [](std::size_t const& sum, MeshSubset const* const mesh_subset)

--- a/MeshLib/MeshSubsets.h
+++ b/MeshLib/MeshSubsets.h
@@ -16,7 +16,6 @@
 #include <algorithm>
 #include <functional>
 #include <numeric>
-#include <stdexcept>
 #include <vector>
 
 #include "MeshSubset.h"
@@ -45,7 +44,8 @@ public:
         : _mesh_subsets(first, last)
     {
         if (!areMeshSubsetMeshesUnique())
-            throw std::logic_error("Mesh ids of input mesh subsets are not unique.");
+            ERR("Mesh ids of input mesh subsets are not unique.");
+        assert(areMeshSubsetMeshesUnique());
 
         _n_total_items = std::accumulate(first, last, 0u,
             [](std::size_t const& sum, MeshSubset const* const mesh_subset)

--- a/Tests/GeoLib/TestGrid.cpp
+++ b/Tests/GeoLib/TestGrid.cpp
@@ -23,7 +23,7 @@
 TEST(GeoLib, InsertZeroPointsInGrid)
 {
 	std::vector<GeoLib::Point*> pnts;
-	ASSERT_THROW(GeoLib::Grid<GeoLib::Point> grid(pnts.begin(), pnts.end()), std::invalid_argument);
+	ASSERT_DEATH(GeoLib::Grid<GeoLib::Point> grid(pnts.begin(), pnts.end()), "");
 }
 
 TEST(GeoLib, InsertOnePointInGrid)

--- a/Tests/GeoLib/TestPointVec.cpp
+++ b/Tests/GeoLib/TestPointVec.cpp
@@ -46,14 +46,14 @@ protected:
 // Testing nullptr input vector.
 TEST_F(PointVecTest, TestPointVecCtorNullptr)
 {
-	ASSERT_ANY_THROW(GeoLib::PointVec(name, nullptr));
+	ASSERT_DEATH(GeoLib::PointVec(name, nullptr), "");
 	delete ps_ptr;
 }
 
 // Testing empty input vector.
 TEST_F(PointVecTest, TestPointVecCtorEmpty)
 {
-	ASSERT_ANY_THROW(GeoLib::PointVec(name, ps_ptr));
+	ASSERT_DEATH(GeoLib::PointVec(name, ps_ptr), "");
 }
 
 // Testing input vector with single point.
@@ -61,7 +61,7 @@ TEST_F(PointVecTest, TestPointVecCtorSinglePoint)
 {
 	ps_ptr->push_back(new GeoLib::Point(0,0,0,0));
 	GeoLib::PointVec* point_vec = nullptr;
-	ASSERT_NO_THROW(point_vec = new GeoLib::PointVec(name, ps_ptr));
+	point_vec = new GeoLib::PointVec(name, ps_ptr);
 	ASSERT_EQ(std::size_t(1), point_vec->size());
 
 	delete point_vec;
@@ -74,7 +74,7 @@ TEST_F(PointVecTest, TestPointVecCtorTwoDiffPoints)
 	ps_ptr->push_back(new GeoLib::Point(1,0,0,1));
 
 	GeoLib::PointVec* point_vec = nullptr;
-	ASSERT_NO_THROW(point_vec = new GeoLib::PointVec(name, ps_ptr));
+	point_vec = new GeoLib::PointVec(name, ps_ptr);
 	ASSERT_EQ(std::size_t(2), point_vec->size());
 
 	delete point_vec;
@@ -87,7 +87,7 @@ TEST_F(PointVecTest, TestPointVecCtorTwoEqualPoints)
 	ps_ptr->push_back(new GeoLib::Point(0,0,0,1));
 
 	GeoLib::PointVec* point_vec = nullptr;
-	ASSERT_NO_THROW(point_vec = new GeoLib::PointVec(name, ps_ptr));
+	point_vec = new GeoLib::PointVec(name, ps_ptr);
 	ASSERT_EQ(std::size_t(1), point_vec->size());
 
 	delete point_vec;
@@ -187,7 +187,7 @@ TEST_F(PointVecTest, TestPointVecCtorRandomPoints)
 	generateRandomPoints(10000);
 
 	GeoLib::PointVec* point_vec = nullptr;
-	ASSERT_NO_THROW(point_vec = new GeoLib::PointVec(name, ps_ptr));
+	point_vec = new GeoLib::PointVec(name, ps_ptr);
 
 	delete point_vec;
 }
@@ -196,8 +196,8 @@ TEST_F(PointVecTest, TestPointVecCtorRandomPointsLargeEps)
 	generateRandomPoints(10000);
 
 	GeoLib::PointVec* point_vec = nullptr;
-	ASSERT_NO_THROW(point_vec = new GeoLib::PointVec(name, ps_ptr,
-					nullptr, GeoLib::PointVec::PointType::POINT, 1e-2));
+	point_vec = new GeoLib::PointVec(name, ps_ptr,
+					nullptr, GeoLib::PointVec::PointType::POINT, 1e-2);
 
 	delete point_vec;
 }

--- a/Tests/MeshLib/MeshSubsets.cpp
+++ b/Tests/MeshLib/MeshSubsets.cpp
@@ -30,9 +30,11 @@ TEST(MeshLibMeshSubsets, UniqueMeshIds)
 
 	MeshSubset const* const mesh_subsets[3] = {&ms0, &ms1, &ms1a};
 
-	EXPECT_NO_THROW(MeshSubsets(&mesh_subsets[0], &mesh_subsets[0] + 2));
-	EXPECT_THROW(MeshSubsets(&mesh_subsets[1], &mesh_subsets[1] + 2), std::logic_error);
-	EXPECT_THROW(MeshSubsets(&mesh_subsets[0], &mesh_subsets[0] + 3), std::logic_error);
+	// EXPECT_NO_DEATH
+	MeshSubsets(&mesh_subsets[0], &mesh_subsets[0] + 2);
+
+	EXPECT_DEATH(MeshSubsets(&mesh_subsets[1], &mesh_subsets[1] + 2), "");
+	EXPECT_DEATH(MeshSubsets(&mesh_subsets[0], &mesh_subsets[0] + 3), "");
 }
 
 


### PR DESCRIPTION
This are the leftovers of my DisableExceptions branch.

__Update:__ There are no logic changes anymore compared to the original PR. Only replace `throw` with ERR() + `std::abort`.


I checked on a small code sample that removing `throw`s indeed decreases binary size (by 8 bytes :-). Unfortunately this is not the case with logog messages, which are quite expensive (much more expensive as the throw solution).

bin/ogs sizes in byte (clang, O3, march=native, stripped.) :

  | with logog | without logog | saved by removing logog 
---- | ------------ | ----------------- | ----------------------
base ufz/master | 1839296 | 1739496 | 99800
this PR | 1841984 | 1739472 | 102512
saved by this PR | -2688 | 24 | 


Removing logog means replacing DBUG, INFO, ERR macros with a std::printf calls, not removing the messages entirely.