### PR TITLE
fix includes in MeshLib and MeshGeoToolsLib

### DIFF
--- a/MeshGeoToolsLib/AppendLinesAlongPolyline.cpp
+++ b/MeshGeoToolsLib/AppendLinesAlongPolyline.cpp
@@ -9,16 +9,16 @@
 
 #include "AppendLinesAlongPolyline.h"
 
-// ThirdParty/logog
-#include "logog/include/logog.hpp"
+#include <logog/include/logog.hpp>
 
-// MeshLib
-#include "Mesh.h"
+#include "GeoLib/Polyline.h"
+
+#include "MeshLib/Mesh.h"
 #include "MeshLib/Node.h"
-#include "Elements/Line.h"
-#include "Elements/Element.h"
-#include "MeshEnums.h"
-#include "MeshEditing/DuplicateMeshComponents.h"
+#include "MeshLib/Elements/Line.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/MeshEnums.h"
+#include "MeshLib/MeshEditing/DuplicateMeshComponents.h"
 
 #include "MeshGeoToolsLib/MeshNodesAlongPolyline.h"
 

--- a/MeshGeoToolsLib/GeoMapper.cpp
+++ b/MeshGeoToolsLib/GeoMapper.cpp
@@ -12,19 +12,19 @@
  *
  */
 
-// ThirdParty/logog
-#include "logog/include/logog.hpp"
-
 #include "GeoMapper.h"
 
 #include <algorithm>
 #include <numeric>
+
+#include <logog/include/logog.hpp>
 
 #include "FileIO/AsciiRasterInterface.h"
 #include "FileIO/readMeshFromFile.h"
 
 #include "GeoLib/AABB.h"
 #include "GeoLib/AnalyticalGeometry.h"
+#include "GeoLib/GEOObjects.h"
 #include "GeoLib/Raster.h"
 #include "GeoLib/StationBorehole.h"
 

--- a/MeshGeoToolsLib/GeoMapper.h
+++ b/MeshGeoToolsLib/GeoMapper.h
@@ -18,11 +18,9 @@
 #include <cstddef>
 #include <vector>
 
-#include "GEOObjects.h"
-#include "Point.h"
-#include "Grid.h"
+#include "GeoLib/Point.h"
+#include "GeoLib/Grid.h"
 
-// MathLib
 #include "MathLib/Point3d.h"
 
 namespace MeshLib {

--- a/MeshGeoToolsLib/HeuristicSearchLength.cpp
+++ b/MeshGeoToolsLib/HeuristicSearchLength.cpp
@@ -12,7 +12,7 @@
 #include "HeuristicSearchLength.h"
 
 // ThirdParty/logog
-#include "logog/include/logog.hpp"
+#include <logog/include/logog.hpp>
 
 #include "MeshLib/Elements/Element.h"
 

--- a/MeshGeoToolsLib/HeuristicSearchLength.h
+++ b/MeshGeoToolsLib/HeuristicSearchLength.h
@@ -14,6 +14,11 @@
 
 #include "MeshGeoToolsLib/SearchLength.h"
 
+namespace MeshLib
+{
+class Mesh;
+}
+
 namespace MeshGeoToolsLib
 {
 

--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -11,13 +11,16 @@
 #include "MeshGeoToolsLib/MeshNodeSearcher.h"
 
 // ThirdParty/logog
-#include "logog/include/logog.hpp"
+#include <logog/include/logog.hpp>
 
 // GeoLib
 #include "GeoLib/Point.h"
+#include "GeoLib/Polyline.h"
 
 // MeshLib
 #include "MeshLib/Elements/Element.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/Node.h"
 
 // MeshGeoToolsLib
 #include "MeshGeoToolsLib/HeuristicSearchLength.h"

--- a/MeshGeoToolsLib/MeshNodeSearcher.h
+++ b/MeshGeoToolsLib/MeshNodeSearcher.h
@@ -13,21 +13,27 @@
 #include <memory>
 #include <vector>
 
-#include "boost/optional.hpp"
+#include <boost/optional.hpp>
 
 // GeoLib
-#include "GeoLib/Point.h"
-#include "GeoLib/Polyline.h"
 #include "GeoLib/Grid.h"
-
-// MeshLib
-#include "MeshLib/Mesh.h"
-#include "MeshLib/Node.h"
 
 // MeshGeoToolsLib
 #include "MeshGeoToolsLib/SearchLength.h"
 
 // forward declaration
+namespace GeoLib
+{
+class Point;
+class Polyline;
+}
+
+namespace MeshLib
+{
+class Mesh;
+class Node;
+}
+
 namespace MeshGeoToolsLib
 {
 class MeshNodesAlongPolyline;

--- a/MeshGeoToolsLib/MeshNodesAlongPolyline.cpp
+++ b/MeshGeoToolsLib/MeshNodesAlongPolyline.cpp
@@ -10,15 +10,15 @@
  *              http://www.opengeosys.org/LICENSE.txt
  */
 
-// BaseLib
-#include "quicksort.h"
-
-// MeshGeoToolsLib
 #include "MeshNodesAlongPolyline.h"
 
-#include "MathTools.h"
-
 #include <algorithm>
+
+#include "BaseLib/quicksort.h"
+#include "MathLib/MathTools.h"
+#include "GeoLib/Polyline.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/Node.h"
 
 namespace MeshGeoToolsLib
 {

--- a/MeshGeoToolsLib/MeshNodesAlongPolyline.h
+++ b/MeshGeoToolsLib/MeshNodesAlongPolyline.h
@@ -15,11 +15,15 @@
 
 #include <vector>
 
-// GeoLib
-#include "Polyline.h"
+namespace GeoLib
+{
+class Polyline;
+}
 
-// MeshLib
-#include "MeshLib/Node.h"
+namespace MeshLib
+{
+class Mesh;
+}
 
 namespace MeshGeoToolsLib
 {

--- a/MeshGeoToolsLib/MeshNodesAlongSurface.cpp
+++ b/MeshGeoToolsLib/MeshNodesAlongSurface.cpp
@@ -14,9 +14,11 @@
 
 #include <algorithm>
 
-#include "quicksort.h"
-#include "MathTools.h"
-
+#include "BaseLib/quicksort.h"
+#include "MathLib/MathTools.h"
+#include "GeoLib/Surface.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/Node.h"
 
 namespace MeshGeoToolsLib
 {

--- a/MeshGeoToolsLib/MeshNodesAlongSurface.h
+++ b/MeshGeoToolsLib/MeshNodesAlongSurface.h
@@ -15,11 +15,15 @@
 
 #include <vector>
 
-// GeoLib
-#include "Surface.h"
+namespace GeoLib
+{
+class Surface;
+}
 
-// MeshLib
-#include "MeshLib/Node.h"
+namespace MeshLib
+{
+class Mesh;
+}
 
 namespace MeshGeoToolsLib
 {

--- a/MeshGeoToolsLib/SearchLength.h
+++ b/MeshGeoToolsLib/SearchLength.h
@@ -12,8 +12,6 @@
 #ifndef SEARCHLENGTH_H_
 #define SEARCHLENGTH_H_
 
-#include "MeshLib/Mesh.h"
-
 namespace MeshGeoToolsLib
 {
 

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -16,8 +16,8 @@
 #include <string>
 #include <vector>
 
-#include "Location.h"
 #include "BaseLib/excludeObjectCopy.h"
+#include "Location.h"
 
 namespace MeshLib
 {

--- a/NumLib/Function/LinearInterpolationAlongPolyline.cpp
+++ b/NumLib/Function/LinearInterpolationAlongPolyline.cpp
@@ -12,6 +12,7 @@
 
 #include "LinearInterpolationAlongPolyline.h"
 
+#include "GeoLib/Polyline.h"
 #include "MeshLib/Mesh.h"
 #include "MeshGeoToolsLib/MeshNodesAlongPolyline.h"
 

--- a/Tests/MeshLib/TestBoundaryElementSearch.cpp
+++ b/Tests/MeshLib/TestBoundaryElementSearch.cpp
@@ -12,6 +12,7 @@
 #include <numeric>
 
 #include "MeshLib/Mesh.h"
+#include "MeshLib/Node.h"
 #include "MeshLib/Elements/Element.h"
 #include "MeshLib/MeshGenerators/MeshGenerator.h"
 #include "MeshLib/MeshSearcher.h"


### PR DESCRIPTION
This PR ~~is based on #759 and~~ fixes some include issues in MeshLib and MeshGeoToolsLib, i.e. adding absolute path, forward declarations, correcting order.