### PR TITLE
change std::vector<MeshLib::Element const*> to std::vector<MeshLib::Element*>

### DIFF
--- a/AssemblerLib/LocalToGlobalIndexMap.cpp
+++ b/AssemblerLib/LocalToGlobalIndexMap.cpp
@@ -37,7 +37,7 @@ LocalToGlobalIndexMap::LocalToGlobalIndexMap(
 
 LocalToGlobalIndexMap::LocalToGlobalIndexMap(
     std::vector<MeshLib::MeshSubsets*> const& mesh_subsets,
-    std::vector<MeshLib::Element const*> const& elements,
+    std::vector<MeshLib::Element*> const& elements,
     AssemblerLib::MeshComponentMap&& mesh_component_map,
     AssemblerLib::ComponentOrder const order)
     : _mesh_subsets(mesh_subsets), _mesh_component_map(std::move(mesh_component_map))
@@ -58,7 +58,7 @@ LocalToGlobalIndexMap::LocalToGlobalIndexMap(
 LocalToGlobalIndexMap*
 LocalToGlobalIndexMap::deriveBoundaryConstrainedMap(
     std::vector<MeshLib::MeshSubsets*> const& mesh_subsets,
-    std::vector<MeshLib::Element const*> const& elements,
+    std::vector<MeshLib::Element*> const& elements,
     AssemblerLib::ComponentOrder const order) const
 {
     DBUG("Construct reduced local to global index map.");

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -64,7 +64,7 @@ public:
     /// \note The elements are not necessary those used in the mesh_subsets.
     LocalToGlobalIndexMap* deriveBoundaryConstrainedMap(
         std::vector<MeshLib::MeshSubsets*> const& mesh_subsets,
-        std::vector<MeshLib::Element const*> const& elements,
+        std::vector<MeshLib::Element*> const& elements,
         AssemblerLib::ComponentOrder const order =
             AssemblerLib::ComponentOrder::BY_COMPONENT) const;
 
@@ -87,7 +87,7 @@ private:
     /// this construtor.
     explicit LocalToGlobalIndexMap(
         std::vector<MeshLib::MeshSubsets*> const& mesh_subsets,
-        std::vector<MeshLib::Element const*> const& elements,
+        std::vector<MeshLib::Element*> const& elements,
         AssemblerLib::MeshComponentMap&& mesh_component_map,
         AssemblerLib::ComponentOrder const order);
 

--- a/MeshLib/MeshSearcher.cpp
+++ b/MeshLib/MeshSearcher.cpp
@@ -50,7 +50,7 @@ std::vector<std::size_t> getConnectedNodeIDs(const std::vector<MeshLib::Element*
 }
 
 std::vector<Node*>
-selectNodes(std::vector<Element const*> const& elements)
+selectNodes(std::vector<Element*> const& elements)
 {
 	std::set<Node*> nodes_set;
 	for (auto e : elements)

--- a/MeshLib/MeshSearcher.h
+++ b/MeshLib/MeshSearcher.h
@@ -36,7 +36,7 @@ std::vector<std::size_t> getConnectedElementIDs(MeshLib::Mesh const& msh, const 
 std::vector<std::size_t> getConnectedNodeIDs(const std::vector<MeshLib::Element*> &elements);
 
 /// Create a vector of unique nodes used by given elements.
-std::vector<Node*> selectNodes(std::vector<Element const*> const& elements);
+std::vector<Node*> selectNodes(std::vector<Element*> const& elements);
 
 } // end namespace MeshLib
 

--- a/ProcessLib/NeumannBc.h
+++ b/ProcessLib/NeumannBc.h
@@ -167,7 +167,7 @@ private:
 
     /// Vector of lower-dimensional elements on which the boundary condition is
     /// defined.
-    std::vector<MeshLib::Element const*> _elements;
+    std::vector<MeshLib::Element*> _elements;
 
     MeshLib::MeshSubset const* _mesh_subset_all_nodes = nullptr;
     std::vector<MeshLib::MeshSubsets*> _all_mesh_subsets;

--- a/Tests/AssemblerLib/LocalToGlobalIndexMap.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMap.cpp
@@ -83,9 +83,9 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapTest, SubsetByComponent)
 
     // Select some elements from the full mesh.
     std::array<std::size_t, 3> const ids = {{ 0, 5, 8 }};
-    std::vector<MeshLib::Element const*> some_elements;
+    std::vector<MeshLib::Element*> some_elements;
     for (std::size_t id : ids)
-        some_elements.push_back(mesh->getElement(id));
+        some_elements.push_back(const_cast<MeshLib::Element*>(mesh->getElement(id)));
 
     // Find unique node ids of the selected elements for testing.
     std::vector<MeshLib::Node*> selected_nodes = MeshLib::selectNodes(some_elements);


### PR DESCRIPTION
as titled. I suggest not using `std::vector<MeshLib::Element const*>` if there is no easy way to cast it to `std::vector<MeshLib::Element*>`. 