### PR TITLE
Jenkins Docker workflow script for gcc cli and gui

### DIFF
--- a/scripts/jenkins/gcc.groovy
+++ b/scripts/jenkins/gcc.groovy
@@ -1,0 +1,72 @@
+node('docker')
+{
+	// Checks out into subdirectory ogs
+	stage 'Checkout'
+	checkout([$class: 'GitSCM',
+		branches: [[name: '*/master']],
+		doGenerateSubmoduleConfigurations: false,
+		extensions:
+			[[$class: 'RelativeTargetDirectory', relativeTargetDir: 'ogs']],
+		submoduleCfg: [],
+		userRemoteConfigs:
+			[[url: 'https://github.com/ufz/ogs']]])
+
+
+	// Multiple configurations are build in parallel
+	parallel linux: {
+		docker.image('ogs6/gcc-ogs-cli').inside
+		{
+			build 'build', '', 'package'
+
+			stage 'Test'
+			sh '''cd build
+			      rm -rf tests/testrunner.xml
+			      bin/testrunner --gtest_output=xml:./tests/testrunner.xml'''
+		}
+	},
+
+	linux_gui: {
+		docker.image('ogs6/gcc-ogs-gui').inside {
+			build 'build_gui', '-DOGS_BUILD_GUI=ON -DOGS_BUILD_TESTS=OFF -DOGS_BUILD_CLI=OFF', 'package'
+		}
+	}
+
+//	windows: {
+//		docker.image('ogs6/mingw-ogs-gui').inside
+//		{
+//			build 'build_win', '-DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE', 'package'
+//
+//			stage 'Test'
+//			sh '''cd build_win
+//						rm -rf tests/testrunner.xml
+//						wine bin/testrunner.exe --gtest_output=xml:./tests/testrunner.xml'''
+//		}
+//	},
+//
+//	windows_gui: {
+//		docker.image('ogs6/mingw-ogs-gui').inside
+//		{
+//			build 'build_win_gui',
+//						'-DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE -DOGS_BUILD_GUI=ON -DOGS_BUILD_TESTS=OFF -DOGS_BUILD_CLI=OFF',
+//						'package'
+//		}
+//	}
+
+	// end parallel
+
+	step([$class: 'JUnitResultArchiver',
+		testResults: 'build/tests/testrunner.xml,build_win/tests/testrunner.xml'])
+
+	archive 'build*/*.tar.gz,build_win*/*.zip'
+} // end node
+
+
+def build(buildDir, cmakeOptions, target) {
+	sh "rm -rf ${buildDir} && mkdir ${buildDir}"
+
+	stage 'Configure'
+	sh "cd ${buildDir} && cmake ../ogs ${cmakeOptions}"
+
+	stage 'Build'
+	sh "cd ${buildDir} && make -j 2 ${target}"
+}


### PR DESCRIPTION
Thanks to the [Workflow-plugin](https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md) Jenkins jobs can now be configured via scripts similar to Travis. This has the advantage that the Jenkins config is now part of the code itself and it allows for a compact representation of the Jenkins logic.

The script compiles the cli and gui config with gcc (via a [Docker](https://www.docker.com/whatisdocker)-environment, configuration can be found [here](https://github.com/ufz/dockerfiles/tree/master/gcc)) and runs the testrunner.

See the [Jenkins job](https://svn.ufz.de:8443/job/OGS-6/job/Docker/job/gcc-scm/) and also how the [output of every step](https://svn.ufz.de:8443/job/OGS-6/job/Docker/job/gcc-scm/5/flowGraphTable/) can be examined (click on the console icons).

Already includes (commented out) instructions for cross-compiling for Windows (see also #767).

**Note:** This will not replace the current Jenkins jobs in the near future because at the moment not the full Jenkins functionality can be used in a Workflow script.