### PR TITLE
Math lib geo lib includes cleanup

### DIFF
--- a/Applications/DataExplorer/Base/CMakeLists.txt
+++ b/Applications/DataExplorer/Base/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
 	# modeltest.cpp # Not needed
 	CheckboxDelegate.cpp
 	QValueTooltipSlider.cpp
+	Color.cpp
 )
 
 # Moc headers

--- a/Applications/DataExplorer/Base/Color.cpp
+++ b/Applications/DataExplorer/Base/Color.cpp
@@ -12,14 +12,14 @@
  *
  */
 
-#include <iostream>
+#include "Color.h"
+
 #include <fstream>
 #include <sstream>
 
 #include <logog/include/logog.hpp>
 
-#include "Color.h"
-#include "StringTools.h"
+#include "BaseLib/StringTools.h"
 
 namespace GeoLib {
 

--- a/Applications/DataExplorer/Base/Color.h
+++ b/Applications/DataExplorer/Base/Color.h
@@ -16,10 +16,10 @@
 #ifndef COLOR_H_
 #define COLOR_H_
 
-#include "TemplatePoint.h"
-
 #include <map>
 #include <string>
+
+#include "MathLib/TemplatePoint.h"
 
 namespace GeoLib
 {

--- a/Applications/DataExplorer/Base/Color.h
+++ b/Applications/DataExplorer/Base/Color.h
@@ -16,14 +16,13 @@
 #ifndef COLOR_H_
 #define COLOR_H_
 
+#include <array>
 #include <map>
 #include <string>
 
-#include "MathLib/TemplatePoint.h"
-
 namespace GeoLib
 {
-typedef MathLib::TemplatePoint<unsigned char> Color;
+using Color = std::array<unsigned char, 3>;
 
 /// Returns a random RGB colour.
 Color* getRandomColor();

--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -16,23 +16,14 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstdlib> // for exit
-#include <fstream>
 #include <limits>
-#include <list>
 
-#include "logog/include/logog.hpp"
+#include <logog/include/logog.hpp>
 
-// BaseLib
-#include "quicksort.h"
-
-// GeoLib
 #include "Polyline.h"
-#include "Triangle.h"
+#include "PointVec.h"
 
-// MathLib
-#include "LinAlg/Solvers/GaussAlgorithm.h"
-#include "MathTools.h"
+#include "MathLib/LinAlg/Solvers/GaussAlgorithm.h"
 
 namespace GeoLib
 {

--- a/GeoLib/AnalyticalGeometry.h
+++ b/GeoLib/AnalyticalGeometry.h
@@ -15,12 +15,15 @@
 #ifndef ANALYTICAL_GEOMETRY_H_
 #define ANALYTICAL_GEOMETRY_H_
 
-#include "MathLib/LinAlg/Dense/DenseMatrix.h"
 #include "MathLib/Vector3.h"
+#include "MathLib/LinAlg/Dense/DenseMatrix.h"
 
-#include "Triangle.h"
-#include "PointVec.h"
 #include "Polygon.h"
+
+namespace MathLib
+{
+    class PointVec;
+}
 
 namespace GeoLib
 {

--- a/GeoLib/CMakeLists.txt
+++ b/GeoLib/CMakeLists.txt
@@ -6,8 +6,6 @@ add_library(GeoLib STATIC ${SOURCES_GeoLib})
 
 include_directories(
 	.
-	${CMAKE_CURRENT_SOURCE_DIR}/../BaseLib
-	${CMAKE_CURRENT_SOURCE_DIR}/../MathLib
 )
 
 target_link_libraries(GeoLib

--- a/GeoLib/EarClippingTriangulation.cpp
+++ b/GeoLib/EarClippingTriangulation.cpp
@@ -12,17 +12,13 @@
  *
  */
 
-// GeoLib
 #include "EarClippingTriangulation.h"
 
-// STL
-#include <vector>
+#include "BaseLib/uniqueInsert.h"
 
-// ThirdParty/logog
-#include "logog/include/logog.hpp"
-
-// BaseLib
-#include "uniqueInsert.h"
+#include "Polygon.h"
+#include "Triangle.h"
+#include "Point.h"
 
 namespace GeoLib
 {

--- a/GeoLib/EarClippingTriangulation.h
+++ b/GeoLib/EarClippingTriangulation.h
@@ -15,18 +15,17 @@
 #ifndef EARCLIPPINGTRIANGULATION_H_
 #define EARCLIPPINGTRIANGULATION_H_
 
-// STL
 #include <list>
+#include <vector>
 
-// GeoLib
-#include "Polygon.h"
-#include "Triangle.h"
-
-// MathLib
 #include "AnalyticalGeometry.h"
 
 namespace GeoLib
 {
+
+class Polygon;
+class Triangle;
+
 class EarClippingTriangulation
 {
 public:

--- a/GeoLib/MinimalBoundingSphere.cpp
+++ b/GeoLib/MinimalBoundingSphere.cpp
@@ -16,7 +16,9 @@
 
 #include <ctime>
 
-#include "MathTools.h"
+#include "MathLib/Point3d.h"
+#include "MathLib/Vector3.h"
+
 #include "AnalyticalGeometry.h"
 
 namespace GeoLib {

--- a/GeoLib/PointVec.cpp
+++ b/GeoLib/PointVec.cpp
@@ -33,7 +33,7 @@ PointVec::PointVec (const std::string& name, std::vector<Point*>* points,
 	TemplateVec<Point> (name, points, name_id_map),
 	_type(type),
 	_aabb(points->begin(), points->end()),
-	_rel_eps(rel_eps*sqrt(MathLib::sqrDist(_aabb.getMinPoint(), _aabb.getMaxPoint()))),
+	_rel_eps(rel_eps*std::sqrt(MathLib::sqrDist(_aabb.getMinPoint(), _aabb.getMaxPoint()))),
 	_oct_tree(OctTree<GeoLib::Point, 16>::createOctTree(
 		_aabb.getMinPoint(), _aabb.getMaxPoint(), _rel_eps))
 {

--- a/GeoLib/PointVec.cpp
+++ b/GeoLib/PointVec.cpp
@@ -14,17 +14,11 @@
 
 #include <numeric>
 
-// ThirdParty/logog
-#include "logog/include/logog.hpp"
+#include <logog/include/logog.hpp>
 
-// GeoLib
 #include "PointVec.h"
 
-// BaseLib
-#include "quicksort.h"
-
-// MathLib
-#include "MathTools.h"
+#include "MathLib/MathTools.h"
 
 namespace GeoLib
 {

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -12,23 +12,14 @@
  *
  */
 
-#include <cmath>
-#include <cstdlib> // for exit
-
-// ThirdParty/logog
-#include "logog/include/logog.hpp"
-
-#include <boost/math/constants/constants.hpp>
-
 #include "Polygon.h"
 
-// MathLib
-#include "AnalyticalGeometry.h"
-#include "MathTools.h"
-#include "Vector3.h"
+#include <logog/include/logog.hpp>
+#include <boost/math/constants/constants.hpp>
 
-// BaseLib
-#include "quicksort.h"
+#include "BaseLib/quicksort.h"
+
+#include "AnalyticalGeometry.h"
 
 namespace GeoLib
 {

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -18,9 +18,7 @@
 // ThirdParty/logog
 #include "logog/include/logog.hpp"
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
+#include <boost/math/constants/constants.hpp>
 
 #include "Polygon.h"
 
@@ -476,7 +474,7 @@ GeoLib::Polygon* createPolygonFromCircle (GeoLib::Point const& middle_pnt, doubl
 {
 	const std::size_t off_set (pnts.size());
 	// create points
-	double angle (2.0 * M_PI / resolution);
+	double angle (boost::math::double_constants::two_pi / resolution);
 	for (std::size_t k(0); k < resolution; k++)
 	{
 		GeoLib::Point* pnt(new GeoLib::Point(middle_pnt));

--- a/GeoLib/Polygon.h
+++ b/GeoLib/Polygon.h
@@ -15,11 +15,11 @@
 #ifndef POLYGON_H_
 #define POLYGON_H_
 
-// STL
 #include <list>
+#include <vector>
 
-// GeoLib
 #include "AABB.h"
+#include "Point.h"
 #include "Polyline.h"
 
 namespace GeoLib

--- a/GeoLib/Polyline.cpp
+++ b/GeoLib/Polyline.cpp
@@ -15,13 +15,9 @@
 // STL
 #include <algorithm>
 
-// ThirdParty/logog
-#include "logog/include/logog.hpp"
+#include <logog/include/logog.hpp>
 
-// GeoLib
 #include "Polyline.h"
-
-// MathLib
 #include "AnalyticalGeometry.h"
 
 namespace GeoLib

--- a/GeoLib/Polyline.cpp
+++ b/GeoLib/Polyline.cpp
@@ -63,7 +63,7 @@ void Polyline::addPoint(std::size_t pnt_id)
 
 	if (n_pnts > 0)
 	{
-		double act_dist (sqrt(MathLib::sqrDist (*_ply_pnts[_ply_pnt_ids[n_pnts - 1]],
+		double act_dist (std::sqrt(MathLib::sqrDist (*_ply_pnts[_ply_pnt_ids[n_pnts - 1]],
 		                                        *_ply_pnts[pnt_id])));
 		double dist_until_now (0.0);
 		if (n_pnts > 1)
@@ -105,7 +105,7 @@ void Polyline::insertPoint(std::size_t pos, std::size_t pnt_id)
 		// update the _length vector
 		if (pos == 0) {
 			// insert at first position
-			double act_dist(sqrt(MathLib::sqrDist(*_ply_pnts[_ply_pnt_ids[1]],
+			double act_dist(std::sqrt(MathLib::sqrDist(*_ply_pnts[_ply_pnt_ids[1]],
 			                                      *_ply_pnts[pnt_id])));
 			_length.insert(_length.begin() + 1, act_dist);
 			const std::size_t s(_length.size());
@@ -114,7 +114,7 @@ void Polyline::insertPoint(std::size_t pos, std::size_t pnt_id)
 		} else {
 			if (pos == _ply_pnt_ids.size() - 1) {
 				// insert at last position
-				double act_dist(sqrt(MathLib::sqrDist(
+				double act_dist(std::sqrt(MathLib::sqrDist(
 				                             *_ply_pnts[_ply_pnt_ids[_ply_pnt_ids.size() - 2]],
 				                             *_ply_pnts[pnt_id])));
 				double dist_until_now (0.0);
@@ -127,10 +127,10 @@ void Polyline::insertPoint(std::size_t pos, std::size_t pnt_id)
 				double dist_until_now (0.0);
 				if (pos > 1)
 					dist_until_now = _length[pos - 1];
-				double len_seg0(sqrt(MathLib::sqrDist(
+				double len_seg0(std::sqrt(MathLib::sqrDist(
 				                             *_ply_pnts[_ply_pnt_ids[pos - 1]],
 				                             *_ply_pnts[pnt_id])));
-				double len_seg1(sqrt(MathLib::sqrDist(
+				double len_seg1(std::sqrt(MathLib::sqrDist(
 				                             *_ply_pnts[_ply_pnt_ids[pos + 1]],
 				                             *_ply_pnts[pnt_id])));
 				double update_dist(
@@ -168,7 +168,7 @@ void Polyline::removePoint(std::size_t pos)
 		const double len_seg0(_length[pos] - _length[pos - 1]);
 		const double len_seg1(_length[pos + 1] - _length[pos]);
 		_length.erase(_length.begin() + pos);
-		const double len_new_seg(sqrt(MathLib::sqrDist(*_ply_pnts[_ply_pnt_ids[pos - 1]],
+		const double len_new_seg(std::sqrt(MathLib::sqrDist(*_ply_pnts[_ply_pnt_ids[pos - 1]],
 		                                               *_ply_pnts[_ply_pnt_ids[pos]])));
 		double seg_length_diff(len_new_seg - len_seg0 - len_seg1);
 
@@ -373,7 +373,7 @@ Location Polyline::getLocationOfPoint (std::size_t k, GeoLib::Point const & pnt)
 		return Location::SOURCE;
 	if (MathLib::sqrDist (pnt,
 	                      *_ply_pnts[_ply_pnt_ids[k + 1]]) <
-	    sqrt(std::numeric_limits<double>::epsilon()))
+	    std::sqrt(std::numeric_limits<double>::epsilon()))
 		return Location::DESTINATION;
 	return Location::BETWEEN;
 }

--- a/GeoLib/SensorData.cpp
+++ b/GeoLib/SensorData.cpp
@@ -12,17 +12,15 @@
  *
  */
 
+#include "SensorData.h"
+
 #include <cstdlib>
 #include <fstream>
 
-// ThirdParty/logog
-#include "logog/include/logog.hpp"
+#include <logog/include/logog.hpp>
 
-#include "SensorData.h"
-
-#include "StringTools.h"
-#include "DateTools.h"
-
+#include "BaseLib/StringTools.h"
+#include "BaseLib/DateTools.h"
 
 SensorData::SensorData(const std::string &file_name)
 : _start(0), _end(0), _step_size(0), _time_unit(TimeStepType::NONE)

--- a/GeoLib/Station.cpp
+++ b/GeoLib/Station.cpp
@@ -44,18 +44,17 @@ Station::~Station()
 
 Station* Station::createStation(const std::string & line)
 {
-	std::list<std::string>::const_iterator it;
 	Station* station = new Station();
 	std::list<std::string> fields = BaseLib::splitString(line, '\t');
 
 	if (fields.size() >= 3)
 	{
-		it = fields.begin();
+		auto it = fields.begin();
 		station->_name = *it;
-		(*station)[0] = strtod((BaseLib::replaceString(",", ".", *(++it))).c_str(), nullptr);
-		(*station)[1] = strtod((BaseLib::replaceString(",", ".", *(++it))).c_str(), nullptr);
+		(*station)[0] = std::strtod((BaseLib::replaceString(",", ".", *(++it))).c_str(), nullptr);
+		(*station)[1] = std::strtod((BaseLib::replaceString(",", ".", *(++it))).c_str(), nullptr);
 		if (++it != fields.end())
-			(*station)[2] = strtod((BaseLib::replaceString(",", ".", *it)).c_str(), nullptr);
+			(*station)[2] = std::strtod((BaseLib::replaceString(",", ".", *it)).c_str(), nullptr);
 	}
 	else
 	{

--- a/GeoLib/Station.cpp
+++ b/GeoLib/Station.cpp
@@ -12,20 +12,13 @@
  *
  */
 
-
-#include <cmath>
-#include <cstdlib>
-#include <fstream>
-#include <iomanip>
-
-// ThirdParty/logog
-#include "logog/include/logog.hpp"
-
-// BaseLib
-#include "DateTools.h"
-#include "StringTools.h"
-// GeoLib
 #include "Station.h"
+
+#include <cstdlib>
+
+#include <logog/include/logog.hpp>
+
+#include "BaseLib/StringTools.h"
 
 namespace GeoLib
 {

--- a/GeoLib/Station.h
+++ b/GeoLib/Station.h
@@ -17,10 +17,8 @@
 #define GEO_STATION_H
 
 #include <string>
-#include <vector>
 
 #include "Point.h"
-#include "Polyline.h"
 #include "SensorData.h"
 
 namespace GeoLib

--- a/GeoLib/StationBorehole.cpp
+++ b/GeoLib/StationBorehole.cpp
@@ -12,20 +12,16 @@
  *
  */
 
+#include "StationBorehole.h"
 
 #include <cmath>
 #include <cstdlib>
 #include <fstream>
-#include <iomanip>
 
-// ThirdParty/logog
-#include "logog/include/logog.hpp"
+#include <logog/include/logog.hpp>
 
-// BaseLib
-#include "StringTools.h"
-#include "DateTools.h"
-// GeoLib
-#include "StationBorehole.h"
+#include "BaseLib/StringTools.h"
+#include "BaseLib/DateTools.h"
 
 namespace GeoLib
 {

--- a/GeoLib/StationBorehole.h
+++ b/GeoLib/StationBorehole.h
@@ -19,6 +19,8 @@
 #include "Station.h"
 
 #include <list>
+#include <string>
+#include <vector>
 
 namespace GeoLib
 {

--- a/GeoLib/Triangle.cpp
+++ b/GeoLib/Triangle.cpp
@@ -14,14 +14,10 @@
 
 #include "Triangle.h"
 
-// GeoLib
+#include "Point.h"
 #include "AnalyticalGeometry.h"
 
-// MathLib
-#include "LinAlg/Solvers/GaussAlgorithm.h"
-#include "MathTools.h"
-#include "LinAlg/Dense/DenseMatrix.h"
-#include "Vector3.h"
+#include "MathLib/LinAlg/Solvers/GaussAlgorithm.h"
 
 namespace GeoLib {
 

--- a/GeoLib/Triangle.h
+++ b/GeoLib/Triangle.h
@@ -17,10 +17,11 @@
 
 #include <vector>
 
-// GeoLib
-#include "Point.h"
+#include "MathLib/Point3d.h"
 
 namespace GeoLib {
+
+class Point;
 
 /** \brief Class Triangle consists of a reference to a point vector and
  * a vector that stores the indices in the point vector.

--- a/MathLib/CMakeLists.txt
+++ b/MathLib/CMakeLists.txt
@@ -53,8 +53,6 @@ set(SOURCES ${SOURCES} ${SOURCES_NONLINEAR})
 
 include_directories(
 	.
-	../BaseLib
-	../GeoLib
 )
 
 if(METIS_FOUND)

--- a/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.cpp
+++ b/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.cpp
@@ -16,8 +16,7 @@
 
 #include "PiecewiseLinearInterpolation.h"
 
-// BaseLib
-#include "quicksort.h"
+#include "BaseLib/quicksort.h"
 
 namespace MathLib
 {

--- a/MathLib/LinAlg/Sparse/NestedDissectionPermutation/AdjMat.cpp
+++ b/MathLib/LinAlg/Sparse/NestedDissectionPermutation/AdjMat.cpp
@@ -12,10 +12,11 @@
  *
  */
 
-// Base
-#include "quicksort.h"
+#include "AdjMat.h"
 
-#include "LinAlg/Sparse/NestedDissectionPermutation/AdjMat.h"
+#include <utility>
+
+#include "BaseLib/quicksort.h"
 
 namespace MathLib {
 

--- a/MathLib/LinAlg/Sparse/NestedDissectionPermutation/CRSMatrixReordered.cpp
+++ b/MathLib/LinAlg/Sparse/NestedDissectionPermutation/CRSMatrixReordered.cpp
@@ -64,7 +64,7 @@ void CRSMatrixReordered::reorderMatrix(unsigned const*const op_perm, unsigned co
 
 	delete[] pos;
 	for (i = 0; i < size; ++i)
-		BaseLib::quicksort(jAn, static_cast<size_t>(iAn[i]), static_cast<size_t>(iAn[i + 1]), An);
+		BaseLib::quicksort(jAn, static_cast<std::size_t>(iAn[i]), static_cast<std::size_t>(iAn[i + 1]), An);
 
 	std::swap(iAn, _row_ptr);
 	std::swap(jAn, _col_idx);

--- a/MathLib/LinAlg/Sparse/NestedDissectionPermutation/CRSMatrixReordered.cpp
+++ b/MathLib/LinAlg/Sparse/NestedDissectionPermutation/CRSMatrixReordered.cpp
@@ -12,10 +12,11 @@
  *
  */
 
-// BaseLib
-#include "quicksort.h"
+#include "CRSMatrixReordered.h"
 
-#include "LinAlg/Sparse/NestedDissectionPermutation/CRSMatrixReordered.h"
+#include <utility>
+
+#include "BaseLib/quicksort.h"
 
 namespace MathLib {
 

--- a/MathLib/LinAlg/Sparse/NestedDissectionPermutation/CRSMatrixReordered.h
+++ b/MathLib/LinAlg/Sparse/NestedDissectionPermutation/CRSMatrixReordered.h
@@ -15,6 +15,8 @@
 #ifndef CRSMATRIXREORDERED_H_
 #define CRSMATRIXREORDERED_H_
 
+#include <string>
+
 #include "LinAlg/Sparse/CRSMatrix.h"
 
 namespace MathLib {

--- a/MathLib/MathTools.cpp
+++ b/MathLib/MathTools.cpp
@@ -34,12 +34,12 @@ double calcProjPntToLineAndDists(const double p[3], const double a[3],
 
 	// compute projected point
 	double proj_pnt[3];
-	for (size_t k(0); k < 3; k++)
+	for (std::size_t k(0); k < 3; k++)
 		proj_pnt[k] = a[k] + lambda * v[k];
 
-	d0 = sqrt (sqrDist (proj_pnt, a));
+	d0 = std::sqrt (sqrDist (proj_pnt, a));
 
-	return sqrt (sqrDist (p, proj_pnt));
+	return std::sqrt (sqrDist (p, proj_pnt));
 }
 
 double getAngle (const double p0[3], const double p1[3], const double p2[3])
@@ -48,7 +48,7 @@ double getAngle (const double p0[3], const double p1[3], const double p2[3])
 	const double v1[3] = {p2[0]-p1[0], p2[1]-p1[1], p2[2]-p1[2]};
 
 	// apply Cauchy Schwarz inequality
-	return acos (scalarProduct<double,3> (v0,v1) / (sqrt(scalarProduct<double,3>(v0,v0)) * sqrt(scalarProduct<double,3>(v1,v1))));
+	return std::acos (scalarProduct<double,3> (v0,v1) / (std::sqrt(scalarProduct<double,3>(v0,v0)) * sqrt(scalarProduct<double,3>(v1,v1))));
 }
 
 

--- a/MathLib/MathTools.cpp
+++ b/MathLib/MathTools.cpp
@@ -12,6 +12,8 @@
  *
  */
 
+#include <cmath>
+
 #include "MathTools.h"
 
 namespace MathLib

--- a/MathLib/MathTools.h
+++ b/MathLib/MathTools.h
@@ -111,7 +111,8 @@ template <typename T, std::size_t DIM>
 bool operator==(TemplatePoint<T,DIM> const& a, TemplatePoint<T,DIM> const& b)
 {
 	T const sqr_dist(sqrDist(a,b));
-	return (sqr_dist < pow(std::numeric_limits<T>::epsilon(),2));
+	auto const eps = std::numeric_limits<T>::epsilon();
+	return (sqr_dist < eps*eps);
 }
 
 /// Computes the squared dist between the two points p0 and p1.

--- a/MathLib/MathTools.h
+++ b/MathLib/MathTools.h
@@ -15,6 +15,8 @@
 #ifndef MATHTOOLS_H_
 #define MATHTOOLS_H_
 
+#include <cstddef>
+
 #ifdef _OPENMP
 #include <omp.h>
 #endif

--- a/MathLib/MathTools.h
+++ b/MathLib/MathTools.h
@@ -15,10 +15,6 @@
 #ifndef MATHTOOLS_H_
 #define MATHTOOLS_H_
 
-#include <cmath>
-#include <limits>
-#include <vector>
-
 #ifdef _OPENMP
 #include <omp.h>
 #endif

--- a/MathLib/MathTools.h
+++ b/MathLib/MathTools.h
@@ -23,8 +23,6 @@
 #include <omp.h>
 #endif
 
-#include "Point3d.h"
-
 namespace MathLib
 {
 /**
@@ -106,14 +104,6 @@ void crossProd (const double u[3], const double v[3], double r[3]);
  */
 double calcProjPntToLineAndDists(const double p[3], const double a[3],
                                  const double b[3], double &lambda, double &d0);
-
-/// Computes the squared dist between the two points p0 and p1.
-inline
-double sqrDist(MathLib::Point3d const& p0, MathLib::Point3d const& p1)
-{
-	const double v[3] = {p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]};
-	return scalarProduct<double,3>(v,v);
-}
 
 /** squared dist between double arrays p0 and p1 (size of arrays is 3) */
 inline

--- a/MathLib/MathTools.h
+++ b/MathLib/MathTools.h
@@ -107,14 +107,6 @@ void crossProd (const double u[3], const double v[3], double r[3]);
 double calcProjPntToLineAndDists(const double p[3], const double a[3],
                                  const double b[3], double &lambda, double &d0);
 
-template <typename T, std::size_t DIM>
-bool operator==(TemplatePoint<T,DIM> const& a, TemplatePoint<T,DIM> const& b)
-{
-	T const sqr_dist(sqrDist(a,b));
-	auto const eps = std::numeric_limits<T>::epsilon();
-	return (sqr_dist < eps*eps);
-}
-
 /// Computes the squared dist between the two points p0 and p1.
 inline
 double sqrDist(MathLib::Point3d const& p0, MathLib::Point3d const& p1)
@@ -129,17 +121,6 @@ double sqrDist(const double* p0, const double* p1)
 {
 	const double v[3] = {p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]};
 	return scalarProduct<double,3>(v,v);
-}
-
-/** Distance between points p0 and p1 in the maximum norm. */
-template <typename T>
-T maxNormDist(const MathLib::TemplatePoint<T>* p0, const MathLib::TemplatePoint<T>* p1)
-{
-	const T x = fabs((*p1)[0] - (*p0)[0]);
-	const T y = fabs((*p1)[1] - (*p0)[1]);
-	const T z = fabs((*p1)[2] - (*p0)[2]);
-
-	return std::max(x, std::max(y, z));
 }
 
 /**

--- a/MathLib/Point3d.cpp
+++ b/MathLib/Point3d.cpp
@@ -15,6 +15,9 @@
 
 #include "Point3d.h"
 
+namespace MathLib
+{
+
 bool operator< (const MathLib::Point3d& p0, const MathLib::Point3d& p1)
 {
 	if (p0[0] > p1[0]) {
@@ -101,3 +104,4 @@ bool lessEq(const MathLib::Point3d& p0, const MathLib::Point3d& p1, double tol)
 	}
 }
 
+}	// namespace MathLib

--- a/MathLib/Point3d.h
+++ b/MathLib/Point3d.h
@@ -17,11 +17,11 @@
 #include <limits>
 
 #include "TemplatePoint.h"
+#include "MathTools.h"
 
 namespace MathLib
 {
 typedef MathLib::TemplatePoint<double,3> Point3d;
-} // end namespace MathLib
 
 bool operator< (MathLib::Point3d const & p0, MathLib::Point3d const & p1);
 
@@ -59,6 +59,17 @@ inline MathLib::Point3d operator*(MATRIX const& mat, MathLib::Point3d const& p)
     }
     return new_p;
 }
+
+/** Computes the squared dist between the two points p0 and p1.
+ */
+inline
+double sqrDist(MathLib::Point3d const& p0, MathLib::Point3d const& p1)
+{
+	const double v[3] = {p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]};
+	return MathLib::scalarProduct<double,3>(v,v);
+}
+
+} // end namespace MathLib
 
 #endif /* POINT3D_H_ */
 

--- a/MathLib/TemplatePoint.h
+++ b/MathLib/TemplatePoint.h
@@ -101,6 +101,27 @@ TemplatePoint<T,DIM>::TemplatePoint(std::array<T,DIM> const& x) :
 	_x(x)
 {}
 
+/** Equality of TemplatePoint's up to an epsilon.
+ */
+template <typename T, std::size_t DIM>
+bool operator==(TemplatePoint<T,DIM> const& a, TemplatePoint<T,DIM> const& b)
+{
+	T const sqr_dist(sqrDist(a,b));
+	auto const eps = std::numeric_limits<T>::epsilon();
+	return (sqr_dist < eps*eps);
+}
+
+/** Distance between points p0 and p1 in the maximum norm. */
+template <typename T>
+T maxNormDist(const MathLib::TemplatePoint<T>* p0, const MathLib::TemplatePoint<T>* p1)
+{
+	const T x = fabs((*p1)[0] - (*p0)[0]);
+	const T y = fabs((*p1)[1] - (*p0)[1]);
+	const T z = fabs((*p1)[2] - (*p0)[2]);
+
+	return std::max(x, std::max(y, z));
+}
+
 /** overload the output operator for class Point */
 template <typename T, std::size_t DIM>
 std::ostream& operator<< (std::ostream &os, const TemplatePoint<T,DIM> &p)

--- a/MeshLib/MeshQuality/AngleSkewMetric.cpp
+++ b/MeshLib/MeshQuality/AngleSkewMetric.cpp
@@ -15,23 +15,18 @@
 #include "AngleSkewMetric.h"
 
 #include <cmath>
+#include <boost/math/constants/constants.hpp>
 
 #include "MeshLib/Node.h"
 
 #include "MathLib/MathTools.h"
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
-#ifndef M_PI_2
-#define M_PI_2 1.57079632679489661923
-#endif
+using namespace boost::math::double_constants;
 
 namespace MeshLib
 {
 AngleSkewMetric::AngleSkewMetric(Mesh const& mesh) :
-	ElementQualityMetric(mesh), M_PI_THIRD (M_PI / 3.0), TWICE_M_PI (2 * M_PI)
+	ElementQualityMetric(mesh)
 {}
 
 AngleSkewMetric::~AngleSkewMetric()
@@ -77,12 +72,12 @@ double AngleSkewMetric::checkTriangle (Element const& elem) const
 	double const* const node1 (elem.getNode(1)->getCoords());
 	double const* const node2 (elem.getNode(2)->getCoords());
 
-	double min_angle (M_PI_2), max_angle (0.0);
+	double min_angle (two_pi), max_angle (0.0);
 	getMinMaxAngleFromTriangle (node0, node1, node2, min_angle, max_angle);
 
 	return 1.0 -
-	       std::max((max_angle - M_PI_THIRD) / (M_PI - M_PI_THIRD),
-	                (M_PI_THIRD - min_angle) / (M_PI_THIRD));
+	       std::max((max_angle - third_pi) / two_thirds_pi,
+	                (third_pi - min_angle) / third_pi);
 }
 
 double AngleSkewMetric::checkQuad (Element const& elem) const
@@ -92,13 +87,13 @@ double AngleSkewMetric::checkQuad (Element const& elem) const
 	double const* const node2 (elem.getNode(2)->getCoords());
 	double const* const node3 (elem.getNode(3)->getCoords());
 
-	double min_angle (TWICE_M_PI);
+	double min_angle (two_pi);
 	double max_angle (0.0);
 
 	getMinMaxAngleFromQuad (node0, node1, node2, node3, min_angle, max_angle);
 
 	return 1.0 -
-	       std::max((max_angle - M_PI_2) / (M_PI - M_PI_2), (M_PI_2 - min_angle) / (M_PI_2));
+	       std::max((max_angle - two_pi) / (-pi), (two_pi - min_angle) / (two_pi));
 }
 
 double AngleSkewMetric::checkTetrahedron (Element const& elem) const
@@ -108,7 +103,7 @@ double AngleSkewMetric::checkTetrahedron (Element const& elem) const
 	double const* const node2 (elem.getNode(2)->getCoords());
 	double const* const node3 (elem.getNode(3)->getCoords());
 
-	double min_angle (M_PI_2);
+	double min_angle (two_pi);
 	double max_angle (0.0);
 
 	// first triangle (0,1,2)
@@ -120,8 +115,8 @@ double AngleSkewMetric::checkTetrahedron (Element const& elem) const
 	// fourth triangle (1,2,3)
 	getMinMaxAngleFromTriangle(node1, node2, node3, min_angle, max_angle);
 
-	return 1.0 - std::max((max_angle - M_PI_2) / (M_PI - M_PI_THIRD),
-	                      (M_PI_THIRD - min_angle) / (M_PI_THIRD));
+	return 1.0 - std::max((max_angle - two_pi) / two_thirds_pi,
+	                      (third_pi - min_angle) / third_pi);
 }
 
 double AngleSkewMetric::checkHexahedron (Element const& elem) const
@@ -135,7 +130,7 @@ double AngleSkewMetric::checkHexahedron (Element const& elem) const
 	double const* const node6 (elem.getNode(6)->getCoords());
 	double const* const node7 (elem.getNode(7)->getCoords());
 
-	double min_angle (2 * M_PI);
+	double min_angle (two_pi);
 	double max_angle (0.0);
 
 	// first surface (0,1,2,3)
@@ -152,7 +147,7 @@ double AngleSkewMetric::checkHexahedron (Element const& elem) const
 	getMinMaxAngleFromQuad (node6, node2, node3, node7, min_angle, max_angle);
 
 	return 1.0 -
-	       std::max((max_angle - M_PI_2) / (M_PI - M_PI_2), (M_PI_2 - min_angle) / (M_PI_2));
+	       std::max((max_angle - two_pi) / (-pi), (two_pi - min_angle) / two_pi);
 }
 
 double AngleSkewMetric::checkPrism (Element const& elem) const
@@ -164,7 +159,7 @@ double AngleSkewMetric::checkPrism (Element const& elem) const
 	double const* const node4 (elem.getNode(4)->getCoords());
 	double const* const node5 (elem.getNode(5)->getCoords());
 
-	double min_angle_tri (2 * M_PI);
+	double min_angle_tri (two_pi);
 	double max_angle_tri (0.0);
 
 	// first triangle (0,1,2)
@@ -172,10 +167,10 @@ double AngleSkewMetric::checkPrism (Element const& elem) const
 	// second surface (3,4,5)
 	getMinMaxAngleFromTriangle (node3, node4, node5, min_angle_tri, max_angle_tri);
 
-	double tri_criterion (1.0 - std::max((max_angle_tri - M_PI_2) / (M_PI - M_PI_THIRD),
-	                                     (M_PI_THIRD - min_angle_tri) / (M_PI_THIRD)));
+	double tri_criterion (1.0 - std::max((max_angle_tri - two_pi) / two_thirds_pi,
+	                                     (third_pi - min_angle_tri) / third_pi));
 
-	double min_angle_quad (2 * M_PI);
+	double min_angle_quad (two_pi);
 	double max_angle_quad (0.0);
 	// surface (0,3,4,1)
 	getMinMaxAngleFromQuad (node0, node3, node4, node1, min_angle_quad, max_angle_quad);
@@ -184,8 +179,8 @@ double AngleSkewMetric::checkPrism (Element const& elem) const
 	// surface (1,2,5,4)
 	getMinMaxAngleFromQuad (node1, node2, node5, node4, min_angle_quad, max_angle_quad);
 
-	double quad_criterion (1.0 - std::max((max_angle_quad - M_PI_2) / (M_PI - M_PI_2),
-	                                      (M_PI_2 - min_angle_quad) / (M_PI_2)));
+	double quad_criterion (1.0 - std::max((max_angle_quad - two_pi) / (-pi),
+	                                      (two_pi - min_angle_quad) / two_pi));
 
 	return std::min (tri_criterion, quad_criterion);
 }

--- a/MeshLib/MeshQuality/AngleSkewMetric.h
+++ b/MeshLib/MeshQuality/AngleSkewMetric.h
@@ -44,9 +44,6 @@ private:
 	void getMinMaxAngleFromTriangle(double const* const n0,
 	                                double const* const n1, double const* const n2,
 	                                double &min_angle, double &max_angle) const;
-
-	const double M_PI_THIRD;
-	const double TWICE_M_PI;
 };
 }
 

--- a/Tests/MathLib/TestPoint3d.cpp
+++ b/Tests/MathLib/TestPoint3d.cpp
@@ -13,8 +13,7 @@
 #include <ctime>
 #include "gtest/gtest.h"
 
-#include "Point3d.h"
-#include "MathTools.h"
+#include "MathLib/Point3d.h"
 
 using namespace MathLib;
 

--- a/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
+++ b/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <vector>
 #include <cmath>
+#include <memory>
 
 #ifdef OGS_USE_EIGEN
 #include <Eigen/Eigen>


### PR DESCRIPTION
No algorithm changes.
Moved Point3d operators into Point3d header from MathTools, and same for TemplatePoint.
Moved Color class into DataExlorer tree, where it is used.
Use consistent pi-related constants from boost.
Use std namespace.

And the usual include's cleanup: full path, remove superfluous, include missing, fwd decls.