### PR TITLE
Cleanup mesh lib search classes

### DIFF
--- a/MeshLib/MeshEditing/RemoveMeshComponents.cpp
+++ b/MeshLib/MeshEditing/RemoveMeshComponents.cpp
@@ -63,7 +63,7 @@ MeshLib::Mesh* removeElements(const MeshLib::Mesh& mesh, const std::vector<std::
 
 	// delete unused nodes
 	NodeSearch ns(mesh);
-	ns.markNodesConnectedToElements(removed_element_ids);
+	ns.searchNodesConnectedToOnlyGivenElements(removed_element_ids);
 	auto &removed_node_ids(ns.getSearchedNodeIDs());
 	INFO("Removing total %d nodes...", removed_node_ids.size());
 	for (auto nodeid : removed_node_ids)

--- a/MeshLib/MeshEditing/RemoveMeshComponents.cpp
+++ b/MeshLib/MeshEditing/RemoveMeshComponents.cpp
@@ -63,7 +63,7 @@ MeshLib::Mesh* removeElements(const MeshLib::Mesh& mesh, const std::vector<std::
 
 	// delete unused nodes
 	NodeSearch ns(mesh);
-	ns.searchByElementIDs(removed_element_ids);
+	ns.markNodesConnectedToElements(removed_element_ids);
 	auto &removed_node_ids(ns.getSearchedNodeIDs());
 	INFO("Removing total %d nodes...", removed_node_ids.size());
 	for (auto nodeid : removed_node_ids)

--- a/MeshLib/MeshEditing/RemoveMeshComponents.cpp
+++ b/MeshLib/MeshEditing/RemoveMeshComponents.cpp
@@ -63,7 +63,7 @@ MeshLib::Mesh* removeElements(const MeshLib::Mesh& mesh, const std::vector<std::
 
 	// delete unused nodes
 	NodeSearch ns(mesh);
-	ns.searchByElementIDs(removed_element_ids, true);
+	ns.searchByElementIDs(removed_element_ids);
 	auto &removed_node_ids(ns.getSearchedNodeIDs());
 	INFO("Removing total %d nodes...", removed_node_ids.size());
 	for (auto nodeid : removed_node_ids)

--- a/MeshLib/MeshSearch/NodeSearch.cpp
+++ b/MeshLib/MeshSearch/NodeSearch.cpp
@@ -24,7 +24,7 @@ NodeSearch::NodeSearch(const MeshLib::Mesh &mesh)
 {
 }
 
-std::size_t NodeSearch::markNodesConnectedToElements(
+std::size_t NodeSearch::searchNodesConnectedToOnlyGivenElements(
 		const std::vector<std::size_t> &elements)
 {
 	// Find out by how many elements a node would be removed.

--- a/MeshLib/MeshSearch/NodeSearch.cpp
+++ b/MeshLib/MeshSearch/NodeSearch.cpp
@@ -24,40 +24,44 @@ NodeSearch::NodeSearch(const MeshLib::Mesh &mesh)
 {
 }
 
-std::size_t NodeSearch::searchByElementIDs(const std::vector<std::size_t> &elements, bool only_match_all_connected_elements)
+std::vector<std::size_t> NodeSearch::searchByElementIDsMatchAllConnectedElements(const std::vector<std::size_t> &elements)
 {
 	std::vector<std::size_t> connected_nodes;
-	if (only_match_all_connected_elements)
-	{
-		std::vector<std::size_t> node_marked_counts(_mesh.getNNodes(), 0); //this approach is not optimum for memory size
-		std::for_each(elements.begin(), elements.end(),
-			[&](std::size_t eid)
-			{
-				auto* e = _mesh.getElement(eid);
-				for (unsigned i=0; i<e->getNBaseNodes(); i++) {
-					node_marked_counts[e->getNodeIndex(i)]++;
-				}
-			});
-		for (std::size_t i=0; i<node_marked_counts.size(); i++)
+
+	std::vector<std::size_t> node_marked_counts(_mesh.getNNodes(), 0); //this approach is not optimum for memory size
+	std::for_each(elements.begin(), elements.end(),
+		[&](std::size_t eid)
 		{
-			if (node_marked_counts[i] == _mesh.getNode(i)->getElements().size())
-				connected_nodes.push_back(i);
-		}
-	} else {
-		std::for_each(elements.begin(), elements.end(),
-			[&](std::size_t eid)
-			{
-				auto* e = _mesh.getElement(eid);
-				for (unsigned i=0; i<e->getNBaseNodes(); i++) {
-					connected_nodes.push_back(e->getNodeIndex(i));
-				}
-			});
-		std::sort(connected_nodes.begin(), connected_nodes.end());
-		auto it = std::unique(connected_nodes.begin(), connected_nodes.end());
-		connected_nodes.resize(std::distance(connected_nodes.begin(),it));
+			auto* e = _mesh.getElement(eid);
+			for (unsigned i=0; i<e->getNBaseNodes(); i++) {
+				node_marked_counts[e->getNodeIndex(i)]++;
+			}
+		});
+	for (std::size_t i=0; i<node_marked_counts.size(); i++)
+	{
+		if (node_marked_counts[i] == _mesh.getNode(i)->getElements().size())
+			connected_nodes.push_back(i);
 	}
-	this->updateUnion(connected_nodes);
-	return connected_nodes.size();
+	return connected_nodes;
+}
+
+std::vector<std::size_t> NodeSearch::searchByElementIDsNotMatchAllConnectedElements(const std::vector<std::size_t> &elements)
+{
+	std::vector<std::size_t> connected_nodes;
+
+	std::for_each(elements.begin(), elements.end(),
+		[&](std::size_t eid)
+		{
+			auto* e = _mesh.getElement(eid);
+			for (unsigned i=0; i<e->getNBaseNodes(); i++) {
+				connected_nodes.push_back(e->getNodeIndex(i));
+			}
+		});
+	std::sort(connected_nodes.begin(), connected_nodes.end());
+	auto it = std::unique(connected_nodes.begin(), connected_nodes.end());
+	connected_nodes.resize(std::distance(connected_nodes.begin(),it));
+
+	return connected_nodes;
 }
 
 std::size_t NodeSearch::searchUnused()

--- a/MeshLib/MeshSearch/NodeSearch.cpp
+++ b/MeshLib/MeshSearch/NodeSearch.cpp
@@ -26,10 +26,11 @@ NodeSearch::NodeSearch(const MeshLib::Mesh &mesh)
 
 std::vector<std::size_t> NodeSearch::searchByElementIDsMatchAllConnectedElements(const std::vector<std::size_t> &elements)
 {
-	std::vector<std::size_t> connected_nodes;
-
+	// Find out by how many elements a node would be removed.
+	//
+	// Note: If there are only few elements to be removed, using a different
+	// algorithm might be more memory efficient.
 	std::vector<std::size_t> node_marked_counts(_mesh.getNNodes(), 0);
-	//this approach is not optimal for memory size
 
 	for(std::size_t eid : elements)
 	{
@@ -39,6 +40,10 @@ std::vector<std::size_t> NodeSearch::searchByElementIDsMatchAllConnectedElements
 		}
 	}
 
+
+	// Push back nodes which counts are equal to number of connected elements to
+	// that node.
+	std::vector<std::size_t> connected_nodes;
 	for (std::size_t i=0; i<node_marked_counts.size(); i++)
 	{
 		if (node_marked_counts[i] == _mesh.getNode(i)->getElements().size())

--- a/MeshLib/MeshSearch/NodeSearch.cpp
+++ b/MeshLib/MeshSearch/NodeSearch.cpp
@@ -24,7 +24,8 @@ NodeSearch::NodeSearch(const MeshLib::Mesh &mesh)
 {
 }
 
-std::vector<std::size_t> NodeSearch::searchByElementIDsMatchAllConnectedElements(const std::vector<std::size_t> &elements)
+std::size_t NodeSearch::markNodesConnectedToElements(
+		const std::vector<std::size_t> &elements)
 {
 	// Find out by how many elements a node would be removed.
 	//
@@ -49,7 +50,9 @@ std::vector<std::size_t> NodeSearch::searchByElementIDsMatchAllConnectedElements
 		if (node_marked_counts[i] == _mesh.getNode(i)->getElements().size())
 			connected_nodes.push_back(i);
 	}
-	return connected_nodes;
+
+	this->updateUnion(connected_nodes);
+	return connected_nodes.size();
 }
 
 std::size_t NodeSearch::searchUnused()

--- a/MeshLib/MeshSearch/NodeSearch.cpp
+++ b/MeshLib/MeshSearch/NodeSearch.cpp
@@ -47,25 +47,6 @@ std::vector<std::size_t> NodeSearch::searchByElementIDsMatchAllConnectedElements
 	return connected_nodes;
 }
 
-std::vector<std::size_t> NodeSearch::searchByElementIDsNotMatchAllConnectedElements(const std::vector<std::size_t> &elements)
-{
-	std::vector<std::size_t> connected_nodes;
-
-	for(std::size_t eid : elements)
-	{
-		auto* e = _mesh.getElement(eid);
-		for (unsigned i=0; i<e->getNBaseNodes(); i++) {
-			connected_nodes.push_back(e->getNodeIndex(i));
-		}
-	}
-
-	std::sort(connected_nodes.begin(), connected_nodes.end());
-	auto it = std::unique(connected_nodes.begin(), connected_nodes.end());
-	connected_nodes.resize(std::distance(connected_nodes.begin(),it));
-
-	return connected_nodes;
-}
-
 std::size_t NodeSearch::searchUnused()
 {
 	const size_t nNodes (_mesh.getNNodes());

--- a/MeshLib/MeshSearch/NodeSearch.cpp
+++ b/MeshLib/MeshSearch/NodeSearch.cpp
@@ -28,15 +28,17 @@ std::vector<std::size_t> NodeSearch::searchByElementIDsMatchAllConnectedElements
 {
 	std::vector<std::size_t> connected_nodes;
 
-	std::vector<std::size_t> node_marked_counts(_mesh.getNNodes(), 0); //this approach is not optimum for memory size
-	std::for_each(elements.begin(), elements.end(),
-		[&](std::size_t eid)
-		{
-			auto* e = _mesh.getElement(eid);
-			for (unsigned i=0; i<e->getNBaseNodes(); i++) {
-				node_marked_counts[e->getNodeIndex(i)]++;
-			}
-		});
+	std::vector<std::size_t> node_marked_counts(_mesh.getNNodes(), 0);
+	//this approach is not optimal for memory size
+
+	for(std::size_t eid : elements)
+	{
+		auto* e = _mesh.getElement(eid);
+		for (unsigned i=0; i<e->getNBaseNodes(); i++) {
+			node_marked_counts[e->getNodeIndex(i)]++;
+		}
+	}
+
 	for (std::size_t i=0; i<node_marked_counts.size(); i++)
 	{
 		if (node_marked_counts[i] == _mesh.getNode(i)->getElements().size())
@@ -49,14 +51,14 @@ std::vector<std::size_t> NodeSearch::searchByElementIDsNotMatchAllConnectedEleme
 {
 	std::vector<std::size_t> connected_nodes;
 
-	std::for_each(elements.begin(), elements.end(),
-		[&](std::size_t eid)
-		{
-			auto* e = _mesh.getElement(eid);
-			for (unsigned i=0; i<e->getNBaseNodes(); i++) {
-				connected_nodes.push_back(e->getNodeIndex(i));
-			}
-		});
+	for(std::size_t eid : elements)
+	{
+		auto* e = _mesh.getElement(eid);
+		for (unsigned i=0; i<e->getNBaseNodes(); i++) {
+			connected_nodes.push_back(e->getNodeIndex(i));
+		}
+	}
+
 	std::sort(connected_nodes.begin(), connected_nodes.end());
 	auto it = std::unique(connected_nodes.begin(), connected_nodes.end());
 	connected_nodes.resize(std::distance(connected_nodes.begin(),it));

--- a/MeshLib/MeshSearch/NodeSearch.h
+++ b/MeshLib/MeshSearch/NodeSearch.h
@@ -37,8 +37,6 @@ public:
 	std::size_t searchUnused();
 
 private:
-	std::vector<std::size_t> searchByElementIDsMatchAllConnectedElements(const std::vector<std::size_t> &element_ids);
-
 	/// Updates the vector of marked items with values from vec.
 	void updateUnion(const std::vector<std::size_t> &vec);
 

--- a/MeshLib/MeshSearch/NodeSearch.h
+++ b/MeshLib/MeshSearch/NodeSearch.h
@@ -31,7 +31,7 @@ public:
 
 	/// Marks all nodes connected to any of the given elements ids.
     /// \return number of connected nodes.
-	std::size_t markNodesConnectedToElements(const std::vector<std::size_t> &element_ids);
+	std::size_t searchNodesConnectedToOnlyGivenElements(const std::vector<std::size_t> &element_ids);
 
 	/// Marks all unused nodes
 	std::size_t searchUnused();

--- a/MeshLib/MeshSearch/NodeSearch.h
+++ b/MeshLib/MeshSearch/NodeSearch.h
@@ -30,14 +30,8 @@ public:
 	const std::vector<std::size_t>& getSearchedNodeIDs() const {return _marked_nodes; }
 
 	/// Marks all nodes connected to any of the given elements ids.
-	std::size_t searchByElementIDs(const std::vector<std::size_t> &element_ids)
-	{
-		std::vector<std::size_t> connected_nodes =
-				searchByElementIDsMatchAllConnectedElements(element_ids);
-
-		this->updateUnion(connected_nodes);
-		return connected_nodes.size();
-	}
+    /// \return number of connected nodes.
+	std::size_t markNodesConnectedToElements(const std::vector<std::size_t> &element_ids);
 
 	/// Marks all unused nodes
 	std::size_t searchUnused();

--- a/MeshLib/MeshSearch/NodeSearch.h
+++ b/MeshLib/MeshSearch/NodeSearch.h
@@ -30,12 +30,24 @@ public:
 	const std::vector<std::size_t>& getSearchedNodeIDs() const {return _marked_nodes; }
 
 	/// Marks all nodes connecting to any of the given elements
-	std::size_t searchByElementIDs(const std::vector<std::size_t> &element_ids, bool only_match_all_connected_elements = false);
+	std::size_t searchByElementIDs(const std::vector<std::size_t> &element_ids, bool only_match_all_connected_elements = false)
+	{
+		std::vector<std::size_t> connected_nodes =
+			(only_match_all_connected_elements
+				? searchByElementIDsMatchAllConnectedElements(element_ids)
+				: searchByElementIDsNotMatchAllConnectedElements(element_ids));
+
+		this->updateUnion(connected_nodes);
+		return connected_nodes.size();
+	}
 
 	/// Marks all unused nodes
 	std::size_t searchUnused();
 
 private:
+	std::vector<std::size_t> searchByElementIDsMatchAllConnectedElements(const std::vector<std::size_t> &element_ids);
+	std::vector<std::size_t> searchByElementIDsNotMatchAllConnectedElements(const std::vector<std::size_t> &element_ids);
+
 	/// Updates the vector of marked items with values from vec.
 	void updateUnion(const std::vector<std::size_t> &vec);
 

--- a/MeshLib/MeshSearch/NodeSearch.h
+++ b/MeshLib/MeshSearch/NodeSearch.h
@@ -29,13 +29,11 @@ public:
 	/// return marked node IDs
 	const std::vector<std::size_t>& getSearchedNodeIDs() const {return _marked_nodes; }
 
-	/// Marks all nodes connecting to any of the given elements
-	std::size_t searchByElementIDs(const std::vector<std::size_t> &element_ids, bool only_match_all_connected_elements = false)
+	/// Marks all nodes connected to any of the given elements ids.
+	std::size_t searchByElementIDs(const std::vector<std::size_t> &element_ids)
 	{
 		std::vector<std::size_t> connected_nodes =
-			(only_match_all_connected_elements
-				? searchByElementIDsMatchAllConnectedElements(element_ids)
-				: searchByElementIDsNotMatchAllConnectedElements(element_ids));
+				searchByElementIDsMatchAllConnectedElements(element_ids);
 
 		this->updateUnion(connected_nodes);
 		return connected_nodes.size();
@@ -46,7 +44,6 @@ public:
 
 private:
 	std::vector<std::size_t> searchByElementIDsMatchAllConnectedElements(const std::vector<std::size_t> &element_ids);
-	std::vector<std::size_t> searchByElementIDsNotMatchAllConnectedElements(const std::vector<std::size_t> &element_ids);
 
 	/// Updates the vector of marked items with values from vec.
 	void updateUnion(const std::vector<std::size_t> &vec);


### PR DESCRIPTION
 - Remove unused algorithm branch from `NodeSearch::searchByElementIDs()`, cleaned up and renamed the remains.
 - Implement a common `ElementSearch::filter()` (private) algorithm which is common to most of the `ElementSearch` class methods.