### PR TITLE
Use new travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,68 +1,64 @@
+sudo: false
 language: cpp
 
 compiler:
   - gcc
   - clang
 
+addons:
+  apt:
+    sources:
+      - boost-latest
+      - ubuntu-toolchain-r-test
+      # TODO: feelpp/petsc
+    packages:
+      - g++-4.8
+      - libeigen3-dev
+      - libboost1.55-dev
+      - libboost-date-time1.55-dev
+      - libboost-filesystem1.55-dev
+      - libboost-program-options1.55-dev
+      - libboost-system1.55-dev
+      - qt4-dev-tools
+      - libxt-dev
+      # TODO
+      # - libpetsc3.4.2-dev
+      # Not allowed yet:
+      # - numdiff
+      # - libshp-dev
+      # - libgeotiff-dev
+
+
+
 cache:
-  - apt
+  directories:
+    - $HOME/cmake-3.1.1-Linux-x86_64
+    - $HOME/VTK-Install
 
 env:
-  - CASE=CLI CMAKE_ARGS="-DOGS_BUILD_GUI=OFF -DOGS_BUILD_UTILS=ON"
-  - CASE=CLI_PETSC CMAKE_ARGS="-DOGS_BUILD_GUI=OFF -DOGS_BUILD_UTILS=OFF -DOGS_USE_PETSC=ON -DPETSC_DIR=/usr/lib/petscdir/3.4.2/"
-  - CASE=GUI CMAKE_ARGS="-DOGS_BUILD_GUI=ON"
+  global:
+    - VTK_DIR=VTK-Install/lib/cmake/vtk-6.1
+  matrix:
+    - CASE=CLI CMAKE_ARGS="-DOGS_BUILD_GUI=OFF -DOGS_BUILD_UTILS=ON -DVTK_DIR=$HOME/$VTK_DIR"
+    # - CASE=CLI_PETSC CMAKE_ARGS="-DOGS_BUILD_GUI=OFF -DOGS_BUILD_UTILS=OFF -DOGS_USE_PETSC=ON -DPETSC_DIR=/usr/lib/petscdir/3.4.2/"
+    - CASE=GUI CMAKE_ARGS="-DOGS_BUILD_GUI=ON -DOGS_BUILD_CLI=OFF -DOGS_BUILD_TESTS=OFF -DVTK_DIR=$HOME/$VTK_DIR"
 
 before_install:
-  # -- External package sources --
-  - travis_retry sudo add-apt-repository --yes ppa:boost-latest
-  - travis_retry sudo apt-get install python-software-properties
-  - travis_retry sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
-  - if [[ "$CASE" == "CLI_PETSC" ]]; then sudo add-apt-repository --yes ppa:feelpp/petsc; fi
-  - travis_retry sudo apt-get update -qq;
+  - bash scripts/travis/cmake.sh
+  - bash scripts/travis/vtk.sh
 
-  # GCC 4.8
-  - travis_retry sudo apt-get install -qq g++-4.8
-  - export CXX="g++-4.8" CC="gcc-4.8"
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
-
-install:
-  # -- Install packages --
-  - travis_retry sudo apt-get install -qq libeigen3-dev numdiff
-
-  # Boost
-  - travis_retry sudo apt-get install -qq libboost1.55-dev libboost-date-time1.55-dev libboost-filesystem1.55-dev libboost-program-options1.55-dev libboost-system1.55-dev
-
-  # Eigen
-  - travis_retry wget http://bitbucket.org/eigen/eigen/get/3.2.5.tar.gz
-  - tar -xzf 3.2.5.tar.gz
-  - sudo cp -fR eigen-eigen-bdd17ee3b1b3/* /usr/include/eigen3/
-
-  # CMake
-  - travis_retry wget http://www.cmake.org/files/v3.1/cmake-3.1.1-Linux-x86_64.tar.gz
-  - tar -xzf cmake-3.1.1-Linux-x86_64.tar.gz
-  - sudo cp -fR cmake-3.1.1-Linux-x86_64/* /usr
-  - rm -rf cmake-3.1.1-Linux-x86_64.tar.gz cmake-3.1.1-Linux-x86_64
-
-  # Qt
-  - if [[ "$CASE" == "GUI" ]]; then travis_retry sudo apt-get install -qq qt4-dev-tools libshp-dev libgeotiff-dev libxt-dev; fi
-
-  # VTK
-  - travis_retry wget http://www.opengeosys.org/images/dev/vtk-6.1.0.tar.gz
-  - tar -xzf vtk-6.1.0.tar.gz
-  - sudo cp -fR VTK-Install/* /usr
-  - rm -rf vtk-6.1.0.tar.gz VTK-Install
-
-  # PetSc
-  - if [[ "$CASE" == "CLI_PETSC" ]]; then travis_retry sudo apt-get install -qq libpetsc3.4.2-dev; fi
+before_script:
+  - export PATH=$HOME/cmake-3.1.1-Linux-x86_64/bin:$PATH
+  - export CXX=g++-4.8 CC=gcc-4.8
 
 script:
   - mkdir build
   - cd build
   - cmake $CMAKE_ARGS ..
-  - make
-  - make tests
+  - make -j 2
+  - if [[ "$CASE" == "CLI" ]]; then make tests; fi
   # PetSc
-  - if [[ "$CASE" == "CLI_PETSC" ]]; then make tests_mpi; fi
+  #- if [[ "$CASE" == "CLI_PETSC" ]]; then make tests_mpi; fi
 
 notifications:
   hipchat:

--- a/Applications/ApplicationsLib/CMakeLists.txt
+++ b/Applications/ApplicationsLib/CMakeLists.txt
@@ -16,3 +16,7 @@ ADD_CATALYST_DEPENDENCY(ApplicationsLib)
 if(OGS_BUILD_GUI)
 	target_link_libraries(ApplicationsLib PUBLIC Qt4::QtCore)
 endif()
+
+if(TARGET Eigen)
+	add_dependencies(ApplicationsLib Eigen)
+endif()

--- a/NumLib/CMakeLists.txt
+++ b/NumLib/CMakeLists.txt
@@ -47,3 +47,6 @@ target_link_libraries(NumLib INTERFACE
 	logog
 )
 
+if(TARGET Eigen)
+	add_dependencies(NumLib Eigen)
+endif()

--- a/scripts/cmake/ExternalProjectEigen.cmake
+++ b/scripts/cmake/ExternalProjectEigen.cmake
@@ -6,7 +6,7 @@ endif()
 
 # First check for system Eigen
 if(NOT EIGEN3_INCLUDE_DIR)
-	find_package(Eigen3)
+	find_package(Eigen3 3.2.5)
 	if(EIGEN3_FOUND)
 		set(EIGEN3_FOUND TRUE CACHE BOOL "Was Eigen found?" FORCE)
 		set(EIGEN3_INCLUDE_DIR "${EIGEN3_INCLUDE_DIR}" CACHE STRING "Eigen include dir" FORCE)

--- a/scripts/cmake/ThirdPartyLibVersions.cmake
+++ b/scripts/cmake/ThirdPartyLibVersions.cmake
@@ -1,7 +1,7 @@
 set(OGS_BOOST_URL "http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2/download")
 set(OGS_BOOST_MD5 "b8839650e61e9c1c0a89f371dd475546")
 
-set(OGS_EIGEN_URL "http://bitbucket.org/eigen/eigen/get/3.2.5.tar.gz")
+set(OGS_EIGEN_URL "http://opengeosys.s3.amazonaws.com/ogs6-lib-sources/eigen-3.2.5.tar.gz")
 set(OGS_EIGEN_MD5 "8cc513ac6ec687117acadddfcacf551b")
 
 set(OGS_VTK_VERSION 6.1.0)

--- a/scripts/travis/cmake.sh
+++ b/scripts/travis/cmake.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+# check to see if cmake folder is empty
+if [ ! -d "$HOME/cmake-3.1.1-Linux-x86_64/bin" ]; then
+	cd $HOME
+	wget http://www.cmake.org/files/v3.1/cmake-3.1.1-Linux-x86_64.tar.gz;
+	tar -xzvf cmake-3.1.1-Linux-x86_64.tar.gz;
+else
+	echo 'Using cached cmake directory.';
+fi

--- a/scripts/travis/vtk.sh
+++ b/scripts/travis/vtk.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+if [ ! -d "$HOME/VTK-Install/include" ]; then
+	cd $HOME
+	wget http://www.opengeosys.org/images/dev/vtk-6.1.0.tar.gz
+	tar -xzf vtk-6.1.0.tar.gz
+else
+  echo 'Using cached vtk directory.';
+fi


### PR DESCRIPTION
Travis migrates its infrastructure to a Docker-based one, all jobs then run in a Linux container. They propose to [migrate](http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade) Travis scripts to the new infrastructure because they start almost instantly and the average build time is almost halved. Another advantage that installed dependencies such as CMake and VTK get cached between builds.

Installation of packages is now limited to a [whitelisted set](https://github.com/travis-ci/apt-package-whitelist) and I have not found a way to install PetSc. So PetSc builds are currently disabled.