### PR TITLE
add MeshNodesOnPoint

### DIFF
--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -103,7 +103,7 @@ MeshNodesOnPoint& MeshNodeSearcher::getMeshNodesOnPoint(GeoLib::Point const& pnt
 {
 	std::vector<MeshNodesOnPoint*>::const_iterator it(_mesh_nodes_on_points.begin());
 	for (; it != _mesh_nodes_on_points.end(); ++it) {
-		if (&(*it)->getPoint() == &pnt) {
+		if ((*it)->getPoint() == pnt) {
 			return *(*it);
 		}
 	}

--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -14,8 +14,10 @@
 #include <logog/include/logog.hpp>
 
 // GeoLib
+#include "GeoLib/GeoObject.h"
 #include "GeoLib/Point.h"
 #include "GeoLib/Polyline.h"
+#include "GeoLib/Surface.h"
 
 // MeshLib
 #include "MeshLib/Elements/Element.h"

--- a/MeshGeoToolsLib/MeshNodeSearcher.h
+++ b/MeshGeoToolsLib/MeshNodeSearcher.h
@@ -132,7 +132,7 @@ private:
 	double _search_length;
 	bool _search_all_nodes;
 	// with newer compiler we can omit to use a pointer here
-    std::vector<MeshNodesOnPoint*> _mesh_nodes_on_points;
+	std::vector<MeshNodesOnPoint*> _mesh_nodes_on_points;
 	std::vector<MeshNodesAlongPolyline*> _mesh_nodes_along_polylines;
 	std::vector<MeshNodesAlongSurface*> _mesh_nodes_along_surfaces;
 

--- a/MeshGeoToolsLib/MeshNodeSearcher.h
+++ b/MeshGeoToolsLib/MeshNodeSearcher.h
@@ -21,6 +21,7 @@
 // forward declaration
 namespace GeoLib
 {
+class GeoObject;
 class Point;
 class Polyline;
 class Surface;

--- a/MeshGeoToolsLib/MeshNodeSearcher.h
+++ b/MeshGeoToolsLib/MeshNodeSearcher.h
@@ -15,9 +15,6 @@
 
 #include <boost/optional.hpp>
 
-// GeoLib
-#include "GeoLib/Grid.h"
-
 // MeshGeoToolsLib
 #include "MeshGeoToolsLib/SearchLength.h"
 
@@ -26,6 +23,7 @@ namespace GeoLib
 {
 class Point;
 class Polyline;
+class Surface;
 }
 
 namespace MeshLib
@@ -36,6 +34,7 @@ class Node;
 
 namespace MeshGeoToolsLib
 {
+class MeshNodesOnPoint;
 class MeshNodesAlongPolyline;
 class MeshNodesAlongSurface;
 }
@@ -76,9 +75,9 @@ public:
 	 * returned. The algorithm for the search is using GeoLib::Grid data
 	 * structure.
 	 * @param pnt a GeoLib::Point the nearest mesh node is searched for
-	 * @return the id of the nearest mesh node
+	 * @return  a vector of mesh node ids
 	 */
-	boost::optional<std::size_t> getMeshNodeIDForPoint(GeoLib::Point const& pnt) const;
+	std::vector<std::size_t> const& getMeshNodeIDForPoint(GeoLib::Point const& pnt);
 
 	/**
 	 * Searches for the nearest mesh nodes along a GeoLib::Polyline.
@@ -99,6 +98,13 @@ public:
 	 * @return a vector of mesh node ids
 	 */
 	std::vector<std::size_t> const& getMeshNodeIDsAlongSurface(GeoLib::Surface const& sfc);
+
+	/**
+	 * Return a MeshNodesOnPoint object for the given GeoLib::Point object.
+	 * @param pnt the GeoLib::Point the nearest mesh nodes are searched for
+	 * @return a reference to a MeshNodesOnPoint object
+	 */
+	MeshNodesOnPoint& getMeshNodesOnPoint(GeoLib::Point const& pnt);
 
 	/**
 	 * Return a MeshNodesAlongPolyline object for the given GeoLib::Polyline object.
@@ -122,10 +128,10 @@ public:
 
 private:
 	MeshLib::Mesh const& _mesh;
-	GeoLib::Grid<MeshLib::Node> _mesh_grid;
 	double _search_length;
 	bool _search_all_nodes;
 	// with newer compiler we can omit to use a pointer here
+    std::vector<MeshNodesOnPoint*> _mesh_nodes_on_points;
 	std::vector<MeshNodesAlongPolyline*> _mesh_nodes_along_polylines;
 	std::vector<MeshNodesAlongSurface*> _mesh_nodes_along_surfaces;
 

--- a/MeshGeoToolsLib/MeshNodesOnPoint.cpp
+++ b/MeshGeoToolsLib/MeshNodesOnPoint.cpp
@@ -18,8 +18,10 @@ MeshNodesOnPoint::MeshNodesOnPoint(MeshLib::Mesh const& mesh,
         GeoLib::Point const& pnt, double epsilon_radius, bool search_all_nodes)
 : _mesh(mesh), _pnt(pnt)
 {
-	for (auto node : mesh.getNodes())
+	auto const n_nodes = (search_all_nodes ? mesh.getNNodes() : mesh.getNBaseNodes());
+	for (std::size_t i=0; i< n_nodes; i++)
 	{
+		auto node = mesh.getNode(i);
 		double len(sqrt(MathLib::sqrDist(pnt, *node)));
 		if (len < epsilon_radius)
 			_msh_node_ids.push_back(node->getID());

--- a/MeshGeoToolsLib/MeshNodesOnPoint.cpp
+++ b/MeshGeoToolsLib/MeshNodesOnPoint.cpp
@@ -1,0 +1,31 @@
+/**
+ * @copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include "MeshNodesOnPoint.h"
+
+#include "MeshLib/Mesh.h"
+#include "MeshLib/Node.h"
+
+namespace MeshGeoToolsLib
+{
+
+MeshNodesOnPoint::MeshNodesOnPoint(MeshLib::Mesh const& mesh,
+        GeoLib::Point const& pnt, double epsilon_radius, bool search_all_nodes)
+: _mesh(mesh), _pnt(pnt)
+{
+	for (auto node : mesh.getNodes())
+	{
+		double len(sqrt(MathLib::sqrDist(pnt, *node)));
+		if (len < epsilon_radius)
+			_msh_node_ids.push_back(node->getID());
+	}
+
+}
+
+} // end namespace MeshGeoToolsLib
+

--- a/MeshGeoToolsLib/MeshNodesOnPoint.h
+++ b/MeshGeoToolsLib/MeshNodesOnPoint.h
@@ -54,7 +54,7 @@ public:
 
 private:
 	MeshLib::Mesh const& _mesh;
-	GeoLib::Point const& _pnt;
+	GeoLib::Point const _pnt;
 	std::vector<std::size_t> _msh_node_ids;
 };
 } // end namespace MeshGeoToolsLib

--- a/MeshGeoToolsLib/MeshNodesOnPoint.h
+++ b/MeshGeoToolsLib/MeshNodesOnPoint.h
@@ -1,0 +1,62 @@
+/**
+ * @copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#ifndef MESHNODESONPOINT_H_
+#define MESHNODESONPOINT_H_
+
+#include <vector>
+
+#include "GeoLib/Point.h"
+
+namespace MeshLib
+{
+class Mesh;
+}
+
+namespace MeshGeoToolsLib
+{
+/**
+ * This class computes the ids of the mesh nodes located at a given point.
+ */
+class MeshNodesOnPoint
+{
+public:
+	/**
+	 * Constructor of object, that search mesh nodes at a GeoLib::Point point 
+	 * within a given search radius. 
+	 * @param mesh_nodes Nodes the search will be performed on.
+	 * @param pnt a point
+	 * @param epsilon_radius Search radius
+	 */
+	MeshNodesOnPoint(MeshLib::Mesh const& mesh,
+			GeoLib::Point const& pnt, double epsilon_radius, bool search_all_nodes = true);
+
+	/// return the mesh object
+	MeshLib::Mesh const& getMesh() const { return _mesh; }
+
+	/**
+	 * Access the vector of mesh node ids.
+	 * @return The vector of mesh node ids calculated in the constructor
+	 */
+	std::vector<std::size_t> const& getNodeIDs () const { return _msh_node_ids; }
+
+	/**
+	 * Deploying this method the user can get access to the underlying
+	 * GeoLib::Point.
+	 * @return the underlying GeoLib::Point
+	 */
+	GeoLib::Point const& getPoint () const { return _pnt; }
+
+private:
+	MeshLib::Mesh const& _mesh;
+	GeoLib::Point const& _pnt;
+	std::vector<std::size_t> _msh_node_ids;
+};
+} // end namespace MeshGeoToolsLib
+
+#endif /* MESHNODESONPOINT_H_ */

--- a/Tests/MeshLib/TestBoundaryElementSearch.cpp
+++ b/Tests/MeshLib/TestBoundaryElementSearch.cpp
@@ -11,6 +11,10 @@
 #include <memory>
 #include <numeric>
 
+#include "GeoLib/Point.h"
+#include "GeoLib/Polyline.h"
+#include "GeoLib/Surface.h"
+
 #include "MeshLib/Mesh.h"
 #include "MeshLib/Node.h"
 #include "MeshLib/Elements/Element.h"

--- a/Tests/MeshLib/TestMeshNodeSearch.cpp
+++ b/Tests/MeshLib/TestMeshNodeSearch.cpp
@@ -72,27 +72,27 @@ TEST_F(MeshLibMeshNodeSearchInSimpleQuadMesh, PointSearch)
 		search_length);
 
 	// find ORIGIN
-	ASSERT_EQ(0u, *mesh_node_searcher.getMeshNodeIDForPoint(pnt));
+	ASSERT_EQ(0u, mesh_node_searcher.getMeshNodeIDForPoint(pnt)[0]);
 
 	pnt[0] = 0.049;
 	pnt[1] = 0.049;
-	ASSERT_EQ(0u, *mesh_node_searcher.getMeshNodeIDForPoint(pnt));
+	ASSERT_EQ(0u, mesh_node_searcher.getMeshNodeIDForPoint(pnt)[0]);
 
 	pnt[0] = 0.051;
 	pnt[1] = 0.049;
-	ASSERT_EQ(1u, *mesh_node_searcher.getMeshNodeIDForPoint(pnt));
+	ASSERT_EQ(1u, mesh_node_searcher.getMeshNodeIDForPoint(pnt)[0]);
 
 	pnt[0] = 0.049;
 	pnt[1] = 0.051;
-	ASSERT_EQ(100u, *mesh_node_searcher.getMeshNodeIDForPoint(pnt));
+	ASSERT_EQ(100u, mesh_node_searcher.getMeshNodeIDForPoint(pnt)[0]);
 
 	pnt[0] = 0.051;
 	pnt[1] = 0.051;
-	ASSERT_EQ(101u, *mesh_node_searcher.getMeshNodeIDForPoint(pnt));
+	ASSERT_EQ(101u, mesh_node_searcher.getMeshNodeIDForPoint(pnt)[0]);
 
 	pnt[0] = 9.951;
 	pnt[1] = 9.951;
-	ASSERT_EQ((_number_of_subdivisions_per_direction+1) * (_number_of_subdivisions_per_direction+1) - 1, *mesh_node_searcher.getMeshNodeIDForPoint(pnt));
+	ASSERT_EQ((_number_of_subdivisions_per_direction+1) * (_number_of_subdivisions_per_direction+1) - 1, mesh_node_searcher.getMeshNodeIDForPoint(pnt)[0]);
 }
 
 TEST_F(MeshLibMeshNodeSearchInSimpleQuadMesh, PolylineSearch)

--- a/Tests/MeshLib/TestMeshNodeSearch.cpp
+++ b/Tests/MeshLib/TestMeshNodeSearch.cpp
@@ -15,8 +15,11 @@
 
 #include <memory>
 
-#include "Mesh.h"
-#include "MeshGenerators/MeshGenerator.h"
+#include "GeoLib/Point.h"
+#include "GeoLib/Polyline.h"
+#include "GeoLib/Surface.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
 #include "MeshGeoToolsLib/MeshNodeSearcher.h"
 #include "MeshGeoToolsLib/HeuristicSearchLength.h"
 


### PR DESCRIPTION
This PR suggests adding `MeshNodesOnPoint` class which is used to search nodes near the given point for Dirichlet BC, assuming the number of points given in a geometry file is not quite large. We used `GeoLib::Grid<MeshLib::Node>` until now but it is not supporting 
 * a case when more than one nodes exist at the given location
 * a case when no node is located at the location (maybe search radius is not considered?)

it is also possible to extend GeoLib::Grid, however I don't think we need such a sophisticated algorithm to search nodes for boundary conditions because the number of geometric points we give in simulations are not so large. how do you think?
