### PR TITLE
Small fix for error in GeoLib::gaussPointInTriangle.

### DIFF
--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -248,7 +248,7 @@ bool gaussPointInTriangle(MathLib::Point3d const& q,
 			a[1] + y[0] * v[1] + y[1] * w[1],
 			a[2] + y[0] * v[2] + y[1] * w[2]
 		}});
-		if (MathLib::sqrDist(q, q_projected) < eps_pnt_out_of_plane)
+		if (MathLib::sqrDist(q, q_projected) <= eps_pnt_out_of_plane)
 			return true;
 	}
 


### PR DESCRIPTION
PR fixes an error in `GeoLib::gaussPointInTriangle(MathLib::Point3d const& q, ...)`. In cases the point `q` and the orthogonal projection of `q` into the plane defined by the triangle are identical **and** the tolerance (`eps_pnt_out_of_plane`) is zero, the algorithm returned a wrong result.