### PR TITLE
Restrict the interface of class MeshLib::Node.

### DIFF
--- a/Applications/DataExplorer/DataView/MeshLayerEditDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshLayerEditDialog.cpp
@@ -194,7 +194,7 @@ MeshLib::Mesh* MeshLayerEditDialog::createPrismMesh()
 {
 	const unsigned nLayers = _layerEdit->text().toInt();
 
-	MeshLayerMapper mapper;
+	MeshLib::MeshLayerMapper mapper;
 	MeshLib::Mesh* new_mesh (nullptr);
 
 	QTime myTimer0;
@@ -258,7 +258,7 @@ MeshLib::Mesh* MeshLayerEditDialog::createTetMesh()
 		std::vector<float> layer_thickness;
 		for (unsigned i=0; i<nLayers; ++i)
 			layer_thickness.push_back(this->_edits[i]->text().toFloat());
-		tg_mesh = MeshLayerMapper::createStaticLayers(*_msh, layer_thickness);
+		tg_mesh = MeshLib::MeshLayerMapper::createStaticLayers(*_msh, layer_thickness);
 		std::vector<MeshLib::Node> tg_attr;
 		FileIO::TetGenInterface tetgen_interface;
 		tetgen_interface.writeTetGenSmesh(filename.toStdString(), *tg_mesh, tg_attr);
@@ -304,7 +304,7 @@ void MeshLayerEditDialog::accept()
 		new_mesh = new MeshLib::Mesh(*_msh);
 		const std::string imgPath ( this->_edits[0]->text().toStdString() );
 		const double noDataReplacementValue = this->_noDataReplacementEdit->text().toDouble();
-		if (!MeshLayerMapper::layerMapping(*new_mesh, imgPath, noDataReplacementValue))
+		if (!MeshLib::MeshLayerMapper::layerMapping(*new_mesh, imgPath, noDataReplacementValue))
 		{
 			delete new_mesh;
 			return;

--- a/MeshLib/MeshGenerators/LayeredVolume.cpp
+++ b/MeshLib/MeshGenerators/LayeredVolume.cpp
@@ -45,11 +45,11 @@ bool LayeredVolume::createRasterLayers(const MeshLib::Mesh &mesh,
 	if (top==nullptr)
 		top = new MeshLib::Mesh(mesh);
 
-	if (!MeshLayerMapper::layerMapping(*top, *rasters.back(), noDataReplacementValue))
+	if (!MeshLib::MeshLayerMapper::layerMapping(*top, *rasters.back(), noDataReplacementValue))
 		return false;
 
 	MeshLib::Mesh* bottom (new MeshLib::Mesh(*top));
-	if (!MeshLayerMapper::layerMapping(*bottom, *rasters[0], 0))
+	if (!MeshLib::MeshLayerMapper::layerMapping(*bottom, *rasters[0], 0))
 	{
 		delete top;
 		return false;

--- a/MeshLib/MeshGenerators/MeshLayerMapper.cpp
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.cpp
@@ -30,6 +30,9 @@
 #include "MeshLib/Elements/Prism.h"
 #include "MeshLib/MeshSurfaceExtraction.h"
 
+namespace MeshLib
+{
+
 MeshLib::Mesh* MeshLayerMapper::createStaticLayers(MeshLib::Mesh const& mesh, std::vector<float> const& layer_thickness_vector, std::string const& mesh_name)
 {
 	std::vector<float> thickness;
@@ -258,3 +261,4 @@ bool MeshLayerMapper::layerMapping(MeshLib::Mesh &new_mesh, GeoLib::Raster const
 
 	return true;
 }
+} // end namespace MeshLib

--- a/MeshLib/MeshGenerators/MeshLayerMapper.h
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.h
@@ -17,6 +17,9 @@
 
 #include "LayeredMeshGenerator.h"
 
+namespace MeshLib
+{
+
 /**
  * \brief Manipulating and adding prism element layers to an existing 2D mesh
  */
@@ -68,5 +71,7 @@ private:
 	/// Adds another layer to a subsurface mesh
 	void addLayerToMesh(const MeshLib::Mesh &mesh_layer, unsigned layer_id, GeoLib::Raster const& raster);
 };
+
+} // end namespace MeshLib
 
 #endif //MESHLAYERMAPPER_H

--- a/MeshLib/Node.h
+++ b/MeshLib/Node.h
@@ -35,6 +35,7 @@ class Node : public MathLib::Point3dWithID
 	friend class Mesh;
 	friend class MeshSurfaceExtraction;
 	friend class MeshRevision;
+	friend class MeshLayerMapper;
 
 public:
 	/// Constructor using a coordinate array
@@ -70,11 +71,11 @@ public:
 		return Node(_x[0]-v[0], _x[1]-v[1], _x[2]-v[2]);
 	}
 
+protected:
 	/// Update coordinates of a node.
 	/// This method automatically also updates the areas/volumes of all connected elements.
 	virtual void updateCoordinates(double x, double y, double z);
 
-protected:
 	/**
 	 * Add an element the node is part of.
 	 * This method is called by Mesh::addElement(Element*), see friend definition.


### PR DESCRIPTION
- Moved class `MeshLayerMapper` into namespace `MeshLib`.
- Moved method `Node::updateCoordinates()` form public to protected, which reduces the interface of class `Node`.