### PR TITLE
Add SurfaceGrid for the accelaration of searching

### DIFF
--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -86,14 +86,20 @@ public:
 		}
 	}
 
-	void update(PNT_TYPE const & pnt)
+	bool update(PNT_TYPE const & pnt)
 	{
+		bool updated(false);
 		for (std::size_t k(0); k<3; k++) {
-			if (pnt[k] < _min_pnt[k])
+			if (pnt[k] < _min_pnt[k]) {
 				_min_pnt[k] = pnt[k];
-			if (_max_pnt[k] < pnt[k])
+				updated = true;
+			}
+			if (_max_pnt[k] < pnt[k]) {
 				_max_pnt[k] = pnt[k];
+				updated = true;
+			}
 		}
+		return updated;
 	}
 
 	/**

--- a/GeoLib/AnalyticalGeometry-impl.h
+++ b/GeoLib/AnalyticalGeometry-impl.h
@@ -210,5 +210,12 @@ void rotatePointsToXY(
         (*(*it))[2] = 0.0; // should be -= d but there are numerical errors
 }
 
+template <typename P>
+void rotatePoints(MathLib::DenseMatrix<double> const& rot_mat,
+	std::vector<P*> const& pnts)
+{
+	rotatePoints(rot_mat, pnts.begin(), pnts.end());
+}
+
 } // end namespace GeoLib
 

--- a/GeoLib/AnalyticalGeometry.h
+++ b/GeoLib/AnalyticalGeometry.h
@@ -138,7 +138,9 @@ void rotatePoints(
  * @param rot_mat 3x3 dimensional rotation matrix
  * @param pnts vector of points
  */
-void rotatePoints(MathLib::DenseMatrix<double> const& rot_mat, std::vector<GeoLib::Point*> &pnts);
+template <typename P>
+void rotatePoints(MathLib::DenseMatrix<double> const& rot_mat,
+	std::vector<P*> const& pnts);
 
 /**
  * rotate points to X-Y plane

--- a/GeoLib/Surface.h
+++ b/GeoLib/Surface.h
@@ -26,12 +26,14 @@ namespace GeoLib {
 class Polyline;
 
 class Triangle;
+class SurfaceGrid;
+
 /**
  * \ingroup GeoLib
  *
  * \brief A Surface is represented by Triangles. It consists of a reference
- * to a vector of (pointers to) points (m_sfc_pnts) and a vector that stores
- * the Triangles consisting of points from m_sfc_pnts.
+ * to a vector of (pointers to) points (_sfc_pnts) and a vector that stores
+ * the Triangles consisting of points from _sfc_pnts.
  * */
 class Surface : public GeoObject
 {
@@ -94,6 +96,8 @@ protected:
 	std::vector<Triangle*> _sfc_triangles;
 	/** bounding volume is an axis aligned bounding box */
 	AABB<GeoLib::Point> *_bounding_volume;
+	/** a helper structure to accelerate the search */
+	SurfaceGrid * _surface_grid;
 };
 
 }

--- a/GeoLib/SurfaceGrid.cpp
+++ b/GeoLib/SurfaceGrid.cpp
@@ -1,0 +1,207 @@
+/*
+ * \date 2012-09-22
+ * \brief Definition of the SurfaceGrid class.
+ *
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ */
+
+#include <algorithm>
+#include <bitset>
+
+#include <logog/include/logog.hpp>
+
+#include "SurfaceGrid.h"
+
+#include "Surface.h"
+#include "Triangle.h"
+
+#include "MathLib/Point3d.h"
+
+namespace GeoLib {
+
+SurfaceGrid::SurfaceGrid(Surface const*const sfc) :
+	AABB(sfc->getAABB()), _n_steps({{1,1,1}})
+{
+	// enlarge the bounding, such that the points with maximal coordinates
+	// fits into the grid
+	for (std::size_t k(0); k<3; ++k) {
+		_max_pnt[k] += std::abs(_max_pnt[k]) * 1e-6;
+		if (std::abs(_max_pnt[k]) < std::numeric_limits<double>::epsilon()) {
+			_max_pnt[k] = (_max_pnt[k] - _min_pnt[k]) * (1.0 + 1e-6);
+		}
+	}
+
+	std::array<double, 3> delta{{ _max_pnt[0] - _min_pnt[0],
+		_max_pnt[1] - _min_pnt[1], _max_pnt[2] - _min_pnt[2] }};
+
+	if (delta[0] < std::numeric_limits<double>::epsilon()) {
+		const double max_delta(std::max(delta[1], delta[2]));
+		_min_pnt[0] -= max_delta * 0.5e-3;
+		_max_pnt[0] += max_delta * 0.5e-3;
+		delta[0] = _max_pnt[0] - _min_pnt[0];
+	}
+
+	if (delta[1] < std::numeric_limits<double>::epsilon()) {
+		const double max_delta(std::max(delta[0], delta[2]));
+		_min_pnt[1] -= max_delta * 0.5e-3;
+		_max_pnt[1] += max_delta * 0.5e-3;
+		delta[1] = _max_pnt[1] - _min_pnt[1];
+	}
+
+	if (delta[2] < std::numeric_limits<double>::epsilon()) {
+		const double max_delta(std::max(delta[0], delta[1]));
+		_min_pnt[2] -= max_delta * 0.5e-3;
+		_max_pnt[2] += max_delta * 0.5e-3;
+		delta[2] = _max_pnt[2] - _min_pnt[2];
+	}
+
+	const std::size_t n_tris(sfc->getNTriangles());
+	const std::size_t n_tris_per_cell(5);
+
+	std::bitset<3> dim; // all bits are set to zero.
+	for (std::size_t k(0); k<3; ++k)
+		if (std::abs(delta[k]) >= std::numeric_limits<double>::epsilon())
+			dim[k] = true;
+
+	// *** condition: n_tris / n_cells < n_tris_per_cell
+	//                where n_cells = _n_steps[0] * _n_steps[1] * _n_steps[2]
+	// *** with _n_steps[0] = ceil(pow(n_tris*delta[0]*delta[0]/(n_tris_per_cell*delta[1]*delta[2]), 1/3.)));
+	//          _n_steps[1] = _n_steps[0] * delta[1]/delta[0],
+	//          _n_steps[2] = _n_steps[0] * delta[2]/delta[0]
+	auto sc_ceil = [](double v){
+		return static_cast<std::size_t>(std::ceil(v));
+	};
+	switch (dim.count()) {
+	case 3: // 3d case
+		_n_steps[0] = sc_ceil(std::cbrt(
+			n_tris*delta[0]*delta[0]/(n_tris_per_cell*delta[1]*delta[2])));
+		_n_steps[1] = sc_ceil(_n_steps[0] * std::min(delta[1] / delta[0], 100.0));
+		_n_steps[2] = sc_ceil(_n_steps[0] * std::min(delta[2] / delta[0], 100.0));
+		break;
+	case 2: // 2d cases
+		if (dim[0] && dim[2]) { // 2d case: xz plane, y = const
+			_n_steps[0] = sc_ceil(std::sqrt(n_tris*delta[0]/(n_tris_per_cell*delta[2])));
+			_n_steps[2] = sc_ceil(_n_steps[0]*delta[2]/delta[0]);
+		}
+		else if (dim[0] && dim[1]) { // 2d case: xy plane, z = const
+			_n_steps[0] = sc_ceil(std::sqrt(n_tris*delta[0]/(n_tris_per_cell*delta[1])));
+			_n_steps[1] = sc_ceil(_n_steps[0] * delta[1]/delta[0]);
+		}
+		else if (dim[1] && dim[2]) { // 2d case: yz plane, x = const
+			_n_steps[1] = sc_ceil(std::sqrt(n_tris*delta[1]/(n_tris_per_cell*delta[2])));
+			_n_steps[2] = sc_ceil(n_tris * delta[2] / (n_tris_per_cell*delta[1]));
+		}
+		break;
+	case 1: // 1d cases
+		for (std::size_t k(0); k<3; ++k) {
+			if (dim[k]) {
+				_n_steps[k] = sc_ceil(static_cast<double>(n_tris)/n_tris_per_cell);
+			}
+		}
+	}
+
+	// some frequently used expressions to fill the grid vectors
+	for (std::size_t k(0); k<3; k++) {
+		_step_sizes[k] = delta[k] / _n_steps[k];
+		_inverse_step_sizes[k] = 1.0 / _step_sizes[k];
+	}
+
+	_triangles_in_grid_box.resize(_n_steps[0]*_n_steps[1]*_n_steps[2]);
+	sortTrianglesInGridCells(sfc);
+}
+
+void SurfaceGrid::sortTrianglesInGridCells(Surface const*const sfc)
+{
+	for (std::size_t l(0); l<sfc->getNTriangles(); l++) {
+		if (! sortTriangleInGridCells((*sfc)[l])) {
+			Point const& p0(*((*sfc)[l]->getPoint(0)));
+			Point const& p1(*((*sfc)[l]->getPoint(1)));
+			Point const& p2(*((*sfc)[l]->getPoint(2)));
+			ERR("Sorting triangle %d [(%f,%f,%f), (%f,%f,%f), (%f,%f,%f) into "
+				"grid.",
+				l, p0[0], p0[1], p0[2], p1[0], p1[1], p1[2], p2[0], p2[1], p2[2]
+			);
+		}
+	}
+}
+
+bool SurfaceGrid::sortTriangleInGridCells(Triangle const*const triangle)
+{
+	// compute grid coordinates for each triangle point
+	boost::optional<std::array<std::size_t, 3> const> c_p0(
+		getGridCellCoordinates(*(triangle->getPoint(0))));
+	if (!c_p0)
+		return false;
+	boost::optional<std::array<std::size_t, 3> const> c_p1(
+		getGridCellCoordinates(*(triangle->getPoint(1))));
+	if (!c_p1)
+		return false;
+	boost::optional<std::array<std::size_t, 3> const> c_p2(
+		getGridCellCoordinates(*(triangle->getPoint(2))));
+	if (!c_p2)
+		return false;
+
+	// determine interval in grid (grid cells the triangle will be inserted)
+	std::size_t const i_min(std::min(std::min((*c_p0)[0], (*c_p1)[0]), (*c_p2)[0]));
+	std::size_t const i_max(std::max(std::max((*c_p0)[0], (*c_p1)[0]), (*c_p2)[0]));
+	std::size_t const j_min(std::min(std::min((*c_p0)[1], (*c_p1)[1]), (*c_p2)[1]));
+	std::size_t const j_max(std::max(std::max((*c_p0)[1], (*c_p1)[1]), (*c_p2)[1]));
+	std::size_t const k_min(std::min(std::min((*c_p0)[2], (*c_p1)[2]), (*c_p2)[2]));
+	std::size_t const k_max(std::max(std::max((*c_p0)[2], (*c_p1)[2]), (*c_p2)[2]));
+
+	const std::size_t n_plane(_n_steps[0]*_n_steps[1]);
+
+	// insert the triangle into the grid cells
+	for (std::size_t i(i_min); i<=i_max; i++) {
+		for (std::size_t j(j_min); j<=j_max; j++) {
+			for (std::size_t k(k_min); k<=k_max; k++) {
+				_triangles_in_grid_box[i+j*_n_steps[0]+k*n_plane].push_back(triangle);
+			}
+		}
+	}
+
+	return true;
+}
+
+boost::optional<std::array<std::size_t, 3>>
+SurfaceGrid::getGridCellCoordinates(MathLib::Point3d const& p) const
+{
+	std::array<std::size_t, 3> coords{{
+		static_cast<std::size_t>((p[0]-_min_pnt[0]) * _inverse_step_sizes[0]),
+		static_cast<std::size_t>((p[1]-_min_pnt[1]) * _inverse_step_sizes[1]),
+		static_cast<std::size_t>((p[2]-_min_pnt[2]) * _inverse_step_sizes[2])
+	}};
+
+	if (coords[0]>=_n_steps[0] || coords[1]>=_n_steps[1] || coords[2]>=_n_steps[2]) {
+		WARN("Computed indices (%d,%d,%d), max grid cell indices (%d,%d,%d)",
+			coords[0], coords[1], coords[2], _n_steps[0], _n_steps[1], _n_steps[2]);
+		return boost::optional<std::array<std::size_t, 3>>();
+	}
+	return boost::optional<std::array<std::size_t, 3>>(coords);
+}
+
+bool SurfaceGrid::isPointInSurface(MathLib::Point3d const& p, double eps) const
+{
+	boost::optional<std::array<std::size_t,3>> optional_c(getGridCellCoordinates(p));
+	if (!optional_c) {
+		return false;
+	}
+	std::array<std::size_t,3> c(optional_c.get());
+
+	std::size_t const grid_cell_idx(c[0]+c[1]*_n_steps[0]+c[2]*_n_steps[0]*_n_steps[1]);
+	std::vector<Triangle const*> const& triangles(_triangles_in_grid_box[grid_cell_idx]);
+	bool nfound(true);
+	const std::size_t n_triangles(triangles.size());
+	for (std::size_t k(0); k < n_triangles && nfound; k++) {
+		if (triangles[k]->containsPoint(p, eps)) {
+			nfound = false;
+		}
+	}
+
+	return !nfound;
+}
+
+} // end namespace GeoLib

--- a/GeoLib/SurfaceGrid.cpp
+++ b/GeoLib/SurfaceGrid.cpp
@@ -8,12 +8,12 @@
  *              See accompanying file LICENSE.txt or
  */
 
+#include "SurfaceGrid.h"
+
 #include <algorithm>
 #include <bitset>
 
 #include <logog/include/logog.hpp>
-
-#include "SurfaceGrid.h"
 
 #include "Surface.h"
 #include "Triangle.h"

--- a/GeoLib/SurfaceGrid.h
+++ b/GeoLib/SurfaceGrid.h
@@ -1,0 +1,50 @@
+/*
+ * \date 2012-09-22
+ * \brief Declaration of the SurfaceGrid class.
+ *
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ */
+
+#ifndef SURFACEGRID_H_
+#define SURFACEGRID_H_
+
+#include <array>
+#include <limits>
+#include <vector>
+
+#include <boost/optional.hpp>
+
+#include "AABB.h"
+#include "Point.h"
+
+namespace GeoLib {
+
+// forward declarations
+class Triangle;
+class Surface;
+
+class SurfaceGrid : public AABB<GeoLib::Point> {
+public:
+	explicit SurfaceGrid(GeoLib::Surface const*const sfc);
+	bool isPointInSurface(MathLib::Point3d const & pnt,
+		double eps = std::numeric_limits<double>::epsilon()) const;
+
+private:
+	friend GeoLib::Surface;
+	void sortTrianglesInGridCells(GeoLib::Surface const*const surface);
+	bool sortTriangleInGridCells(GeoLib::Triangle const*const triangle);
+	boost::optional<std::array<std::size_t,3>>
+		getGridCellCoordinates(MathLib::Point3d const& p) const;
+	std::array<double,3> _step_sizes;
+	std::array<double,3> _inverse_step_sizes;
+	std::array<std::size_t,3> _n_steps;
+	std::vector<std::vector<GeoLib::Triangle const*>> _triangles_in_grid_box;
+};
+
+} // end namespace GeoLib
+
+#endif /* SURFACEGRID_H_ */

--- a/MathLib/LinAlg/Dense/DenseMatrix-impl.h
+++ b/MathLib/LinAlg/Dense/DenseMatrix-impl.h
@@ -147,6 +147,23 @@ V DenseMatrix<FP_TYPE, IDX_TYPE>::operator* (V const& x) const
 }
 
 template<typename FP_TYPE, typename IDX_TYPE>
+MathLib::Vector3
+DenseMatrix<FP_TYPE, IDX_TYPE>::operator*(MathLib::Vector3 const& x) const
+{
+	assert(_n_rows>2);
+
+	MathLib::Vector3 y;
+	for (IDX_TYPE i(0); i < _n_rows; i++) {
+		y[i] = 0.0;
+		for (IDX_TYPE j(0); j < _n_cols; j++) {
+			y[i] += _data[address(i, j)] * x[j];
+		}
+	}
+
+	return y;
+}
+
+template<typename FP_TYPE, typename IDX_TYPE>
 DenseMatrix<FP_TYPE, IDX_TYPE>*
 DenseMatrix<FP_TYPE, IDX_TYPE>::operator+(const DenseMatrix<FP_TYPE, IDX_TYPE>& mat) const
 {

--- a/MathLib/LinAlg/Dense/DenseMatrix.h
+++ b/MathLib/LinAlg/Dense/DenseMatrix.h
@@ -20,6 +20,8 @@
 #include <stdexcept>
 #include <iostream>
 
+#include "MathLib/Vector3.h"
+
 namespace MathLib {
 
 /**
@@ -94,6 +96,7 @@ public:
    FP_TYPE* operator* (FP_TYPE* const& x) const;
    FP_TYPE* operator* (FP_TYPE const* const& x) const;
    template <typename V> V operator* (V const& x) const;
+   MathLib::Vector3 operator*(MathLib::Vector3 const& x) const;
 
    /**
     * DenseMatrix matrix addition.

--- a/Tests/GeoLib/TestSurfaceIsPointInSurface.cpp
+++ b/Tests/GeoLib/TestSurfaceIsPointInSurface.cpp
@@ -1,0 +1,157 @@
+/**
+ * @brief Tests for GeoLib::Surface::isPntInSfc()
+ *
+ * @copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include <array>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include <boost/math/constants/constants.hpp>
+
+#include "GeoLib/GEOObjects.h"
+#include "GeoLib/Point.h"
+#include "GeoLib/Surface.h"
+#include "GeoLib/Triangle.h"
+#include "GeoLib/AnalyticalGeometry.h"
+
+#include "MathLib/LinAlg/Dense/DenseMatrix.h"
+#include "MathLib/Point3d.h"
+
+#include "MeshLib/Mesh.h"
+#include "MeshLib/Node.h"
+#include "MeshLib/convertMeshToGeo.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
+
+inline double constant(double , double )
+{
+	return 0.0;
+}
+
+inline double coscos(double x, double y)
+{
+	return std::cos(x) * std::cos(y);
+}
+
+inline MathLib::Point3d
+getEdgeMiddlePoint(MathLib::Point3d const&a, MathLib::Point3d const& b)
+{
+	return MathLib::Point3d(std::array<double,3>({{
+		(a[0]+b[0])/2, (a[1]+b[1])/2, (a[2]+b[2])/2}}));
+}
+
+inline std::tuple<MathLib::Point3d, MathLib::Point3d, MathLib::Point3d>
+getEdgeMiddlePoints(GeoLib::Triangle const& tri)
+{
+	return std::make_tuple(
+		getEdgeMiddlePoint(*tri.getPoint(0), *tri.getPoint(1)),
+		getEdgeMiddlePoint(*tri.getPoint(1), *tri.getPoint(2)),
+		getEdgeMiddlePoint(*tri.getPoint(2), *tri.getPoint(0)));
+}
+
+/// Computes rotation matrix according to the z,x',z'' convention
+inline MathLib::DenseMatrix<double, std::size_t>
+getRotMat(double alpha, double beta, double gamma)
+{
+	MathLib::DenseMatrix<double, std::size_t> rot_mat(3,3);
+	rot_mat(0,0) = cos(alpha)*cos(gamma) - sin(alpha)*cos(beta)*sin(gamma);
+	rot_mat(0,1) = sin(alpha)*cos(gamma) + cos(alpha)*cos(beta)*sin(gamma);
+	rot_mat(0,2) = sin(beta)*sin(gamma);
+	rot_mat(1,0) = -cos(alpha)*sin(gamma) - sin(alpha)*cos(beta)*cos(gamma);
+	rot_mat(1,1) = -sin(alpha)*sin(gamma) + cos(alpha)*cos(beta)*cos(gamma);
+	rot_mat(1,2) = sin(beta)*cos(gamma);
+	rot_mat(2,0) = sin(alpha)*sin(beta);
+	rot_mat(2,1) = -cos(alpha)*sin(beta);
+	rot_mat(2,2) = cos(beta);
+	return rot_mat;
+}
+
+TEST(GeoLib, SurfaceIsPointInSurface)
+{
+	std::vector<std::function<double(double, double)>> surface_functions;
+	surface_functions.push_back(constant);
+	surface_functions.push_back(coscos);
+
+	for (auto f : surface_functions) {
+		std::random_device rd;
+
+		std::string name("Surface");
+		// generate ll and ur in random way
+		std::mt19937 random_engine_mt19937(rd());
+		std::normal_distribution<> normal_dist_ll(-10, 2);
+		std::normal_distribution<> normal_dist_ur(10, 2);
+		MathLib::Point3d ll(std::array<double,3>({{
+			normal_dist_ll(random_engine_mt19937),
+			normal_dist_ll(random_engine_mt19937),
+			0.0}}));
+		MathLib::Point3d ur(std::array<double,3>({{
+			normal_dist_ur(random_engine_mt19937),
+			normal_dist_ur(random_engine_mt19937),
+			0.0}}));
+		for (std::size_t k(0); k<3; ++k)
+			if (ll[k] > ur[k])
+				std::swap(ll[k], ur[k]);
+
+		// random discretization of the domain
+		std::default_random_engine re(rd());
+	    std::uniform_int_distribution<std::size_t> uniform_dist(2, 25);
+		std::array<std::size_t,2> n_steps = {{uniform_dist(re),uniform_dist(re)}};
+
+		std::unique_ptr<MeshLib::Mesh> sfc_mesh(
+			MeshLib::MeshGenerator::createSurfaceMesh(
+				name, ll, ur, n_steps, f
+			)
+		);
+
+		// random rotation angles
+		std::normal_distribution<> normal_dist_angles(
+			0, boost::math::double_constants::two_pi);
+		std::array<double,3> euler_angles = {{
+			normal_dist_angles(random_engine_mt19937),
+			normal_dist_angles(random_engine_mt19937),
+			normal_dist_angles(random_engine_mt19937)
+			}};
+
+		MathLib::DenseMatrix<double, std::size_t> rot_mat(getRotMat(
+			euler_angles[0], euler_angles[1], euler_angles[2]));
+
+		std::vector<MeshLib::Node*> const& nodes(sfc_mesh->getNodes());
+		GeoLib::rotatePoints<MeshLib::Node>(rot_mat, nodes);
+
+		MathLib::Vector3 const normal(0,0,1.0);
+		MathLib::Vector3 const surface_normal(rot_mat * normal);
+		double const eps(1e-6);
+		MathLib::Vector3 const displacement(eps * surface_normal);
+
+		GeoLib::GEOObjects geometries;
+		MeshLib::convertMeshToGeo(*sfc_mesh, geometries);
+
+		std::vector<GeoLib::Surface*> const& sfcs(*geometries.getSurfaceVec(name));
+		GeoLib::Surface const*const sfc(sfcs.front());
+		std::vector<GeoLib::Point*> const& pnts(*geometries.getPointVec(name));
+		// test triangle edge point of the surface triangles
+		for (auto const p : pnts) {
+			EXPECT_TRUE(sfc->isPntInSfc(*p));
+			MathLib::Point3d q(*p);
+			for (std::size_t k(0); k<3; ++k)
+				q[k] += displacement[k];
+			EXPECT_FALSE(sfc->isPntInSfc(q));
+		}
+		// test edge middle points of the triangles
+		for (std::size_t k(0); k<sfc->getNTriangles(); ++k) {
+			MathLib::Point3d p, q, r;
+			std::tie(p,q,r) = getEdgeMiddlePoints(*(*sfc)[k]);
+			EXPECT_TRUE(sfc->isPntInSfc(p));
+			EXPECT_TRUE(sfc->isPntInSfc(q));
+			EXPECT_TRUE(sfc->isPntInSfc(r));
+		}
+	}
+}


### PR DESCRIPTION
In this PR class `SurfaceGrid` is used to accelerate the method `Surface::isPntInSfc(Point3d const& p)`. For this reason, the triangles of the `Surface` are sorted in an axis aligned structured grid - the `SurfaceGrid`. The cell of the axis aligned structured grid that contains the point p can be computed in O(1). Then only the triangles within the computed grid cell has to be tested.