### PR TITLE
Raster intensity to scalar array

### DIFF
--- a/Applications/DataExplorer/DataView/NetCdfConfigureDialog.cpp
+++ b/Applications/DataExplorer/DataView/NetCdfConfigureDialog.cpp
@@ -362,7 +362,7 @@ void NetCdfConfigureDialog::createDataObject()
 	if (this->radioMesh->isChecked())
 	{
 		MeshLib::MeshElemType meshElemType = MeshLib::MeshElemType::QUAD;
-		MeshLib::UseIntensityAs useIntensity = MeshLib::UseIntensityAs::MATERIAL;
+		MeshLib::UseIntensityAs useIntensity = MeshLib::UseIntensityAs::DATAVECTOR;
 		if (comboBoxMeshElemType->currentIndex() == 1)
 		{
 			meshElemType = MeshLib::MeshElemType::TRIANGLE;
@@ -373,7 +373,7 @@ void NetCdfConfigureDialog::createDataObject()
 		{
 			useIntensity = MeshLib::UseIntensityAs::ELEVATION;
 		}else{
-			useIntensity = MeshLib::UseIntensityAs::MATERIAL;
+			useIntensity = MeshLib::UseIntensityAs::DATAVECTOR;
 		}
 
 		_currentMesh = MeshLib::VtkMeshConverter::convertImgToMesh(data_array,originNetCdf,sizeLon,sizeLat,resolution,meshElemType,useIntensity);

--- a/Applications/DataExplorer/VtkVis/MeshFromRasterDialog.cpp
+++ b/Applications/DataExplorer/VtkVis/MeshFromRasterDialog.cpp
@@ -35,7 +35,7 @@ MeshFromRasterDialog::~MeshFromRasterDialog()
 void MeshFromRasterDialog::accept()
 {
 	MeshLib::UseIntensityAs i_type(MeshLib::UseIntensityAs::ELEVATION);
-	if (this->materialButton->isChecked()) i_type = MeshLib::UseIntensityAs::MATERIAL;
+	if (this->materialButton->isChecked()) i_type = MeshLib::UseIntensityAs::DATAVECTOR;
 	else if (this->ignoreButton->isChecked()) i_type = MeshLib::UseIntensityAs::NONE;
 
 	MeshLib::MeshElemType e_type(MeshLib::MeshElemType::TRIANGLE);

--- a/Applications/DataExplorer/VtkVis/MeshFromRasterDialog.h
+++ b/Applications/DataExplorer/VtkVis/MeshFromRasterDialog.h
@@ -17,7 +17,7 @@
 
 #include "ui_MeshFromRaster.h"
 
-#include <QtGui/QDialog>
+#include <QDialog>
 
 namespace MeshLib {
 	enum class MeshElemType;

--- a/Applications/DataExplorer/VtkVis/VtkVisPipelineView.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkVisPipelineView.cpp
@@ -196,7 +196,7 @@ void VtkVisPipelineView::addPipelineFilterItem()
 
 void VtkVisPipelineView::showImageToMeshConversionDialog()
 {
-	MeshFromRasterDialog* dlg = new MeshFromRasterDialog();
+	MeshFromRasterDialog* dlg = new MeshFromRasterDialog;
 	connect(dlg, SIGNAL(setMeshParameters(QString, MeshLib::MeshElemType, MeshLib::UseIntensityAs)),
 	        this, SLOT(constructMeshFromImage(QString, MeshLib::MeshElemType, MeshLib::UseIntensityAs)));
 	dlg->exec();

--- a/MeshLib/MeshEnums.h
+++ b/MeshLib/MeshEnums.h
@@ -80,7 +80,7 @@ enum class MeshQualityType
 enum class UseIntensityAs
 {
 	ELEVATION,
-	MATERIAL,
+	DATAVECTOR,
 	NONE
 };
 

--- a/MeshLib/MeshGenerators/ConvertRasterToMesh.cpp
+++ b/MeshLib/MeshGenerators/ConvertRasterToMesh.cpp
@@ -120,7 +120,7 @@ MeshLib::Mesh* ConvertRasterToMesh::constructMesh(const double* pix_vals, const 
 					&& (node_idx_map[index + width] != -1)
 					&& (node_idx_map[index + width + 1] != -1)
 					&& (vis_nodes[index + width])) {
-				const int mat = (_intensity_type != UseIntensityAs::MATERIAL) ? 0
+				const int mat = (_intensity_type != UseIntensityAs::DATAVECTOR) ? 0
 								: static_cast<int> (pix_vals[index + width]);
 				if (_elem_type == MeshElemType::TRIANGLE) {
 					MeshLib::Node** tri1_nodes = new MeshLib::Node*[3];

--- a/MeshLib/MeshGenerators/VtkMeshConverter.cpp
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.cpp
@@ -204,7 +204,7 @@ MeshLib::Mesh* VtkMeshConverter::constructMesh(const double* pixVal,
 
 			if (set_node)
 			{
-				double zValue = (intensity_type == UseIntensityAs::ELEVATION) ? pixVal[index] : origin[2];
+				double zValue = (intensity_type == UseIntensityAs::ELEVATION) ? pixVal[index] : 0;
 				MeshLib::Node* node (new MeshLib::Node(x_offset + (scalingFactor * j), y_offset + (scalingFactor * i), zValue));
 				nodes.push_back(node);
 				node_idx_map[index] = node_idx_count;
@@ -212,14 +212,17 @@ MeshLib::Mesh* VtkMeshConverter::constructMesh(const double* pixVal,
 			}
 		}
 
+	MeshLib::Properties properties;
+	boost::optional< MeshLib::PropertyVector<double>& > value_vec =
+		properties.createNewPropertyVector<double>("Colour", MeshLib::MeshItemType::Cell, 1);
+
 	// set mesh elements
 	for (size_t i = 0; i < imgWidth; i++)
 		for (size_t j = 0; j < imgHeight; j++)
 		{
-			const int index = i * incHeight + j;
+			int const index = i * incHeight + j;
 			if ((node_idx_map[index]!=-1) && (node_idx_map[index+1]!=-1) && (node_idx_map[index+incHeight]!=-1) && (node_idx_map[index+incHeight+1]!=-1) && (visNodes[index+incHeight]))
 			{
-				const int mat = (intensity_type != UseIntensityAs::MATERIAL) ? 0 : static_cast<int>(pixVal[index+incHeight]);
 				if (elem_type == MeshElemType::TRIANGLE)
 				{
 					MeshLib::Node** tri1_nodes = new MeshLib::Node*[3];
@@ -232,8 +235,13 @@ MeshLib::Mesh* VtkMeshConverter::constructMesh(const double* pixVal,
 					tri2_nodes[1] = nodes[node_idx_map[index+incHeight+1]];
 					tri2_nodes[2] = nodes[node_idx_map[index+incHeight]];
 
-					elements.push_back(new MeshLib::Tri(tri1_nodes, mat)); // upper left triangle
-					elements.push_back(new MeshLib::Tri(tri2_nodes, mat)); // lower right triangle
+					elements.push_back(new MeshLib::Tri(tri1_nodes)); // upper left triangle
+					elements.push_back(new MeshLib::Tri(tri2_nodes)); // lower right triangle
+					if (intensity_type == UseIntensityAs::DATAVECTOR)
+					{
+						value_vec->push_back(pixVal[index+incHeight]);
+						value_vec->push_back(pixVal[index+incHeight]);
+					}
 				}
 				if (elem_type == MeshElemType::QUAD)
 				{
@@ -242,7 +250,9 @@ MeshLib::Mesh* VtkMeshConverter::constructMesh(const double* pixVal,
 					quad_nodes[1] = nodes[node_idx_map[index + 1]];
 					quad_nodes[2] = nodes[node_idx_map[index + incHeight + 1]];
 					quad_nodes[3] = nodes[node_idx_map[index + incHeight]];
-					elements.push_back(new MeshLib::Quad(quad_nodes, mat));
+					elements.push_back(new MeshLib::Quad(quad_nodes));
+					if (intensity_type == UseIntensityAs::DATAVECTOR)
+						value_vec->push_back(pixVal[index+incHeight]);
 				}
 			}
 		}
@@ -250,7 +260,14 @@ MeshLib::Mesh* VtkMeshConverter::constructMesh(const double* pixVal,
 	if (elements.empty())
 		return nullptr;
 
-	return new MeshLib::Mesh("RasterDataMesh", nodes, elements); // the name is only a temp-name, the name given in the dialog is set later
+	if (value_vec->empty())
+		properties.removePropertyVector("Colour");
+
+	boost::optional< MeshLib::PropertyVector<unsigned>& > materials =
+		properties.createNewPropertyVector<unsigned>("MaterialIDs", MeshLib::MeshItemType::Cell, 1);
+	materials->insert(materials->begin(), elements.size(), 0);
+
+	return new MeshLib::Mesh("RasterDataMesh", nodes, elements, properties); // the name is only a temp-name, the name given in the dialog is set later
 }
 
 MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(vtkUnstructuredGrid* grid, std::string const& mesh_name)

--- a/MeshLib/MeshGenerators/VtkMeshConverter.cpp
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.cpp
@@ -265,7 +265,7 @@ MeshLib::Mesh* VtkMeshConverter::constructMesh(const double* pixVal,
 
 	boost::optional< MeshLib::PropertyVector<unsigned>& > materials =
 		properties.createNewPropertyVector<unsigned>("MaterialIDs", MeshLib::MeshItemType::Cell, 1);
-	materials->insert(materials->begin(), elements.size(), 0);
+	materials->insert(materials->end(), elements.size(), 0);
 
 	return new MeshLib::Mesh("RasterDataMesh", nodes, elements, properties); // the name is only a temp-name, the name given in the dialog is set later
 }


### PR DESCRIPTION
When raster files are converted into meshes, intensity can now be interpreted as a scalar array.