### PR TITLE
support ELEMENTALSETS in FEFLOW import

### DIFF
--- a/BaseLib/StringTools.cpp
+++ b/BaseLib/StringTools.cpp
@@ -21,7 +21,7 @@
 #include "logog/include/logog.hpp"
 
 #include <boost/property_tree/json_parser.hpp>
-
+#include <boost/algorithm/string/replace.hpp>
 
 namespace BaseLib
 {
@@ -39,13 +39,7 @@ std::string replaceString(const std::string &searchString,
                           const std::string &replaceString,
                           std::string stringToReplace)
 {
-	std::string::size_type pos = stringToReplace.find(searchString, 0);
-	std::string::size_type const intLengthSearch = searchString.length();
-
-	while (std::string::npos != pos) {
-		stringToReplace.replace(pos, intLengthSearch, replaceString);
-		pos = stringToReplace.find(searchString, 0);
-	}
+	boost::replace_all(stringToReplace, searchString, replaceString);
 	return stringToReplace;
 }
 

--- a/FileIO/FEFLOWInterface.cpp
+++ b/FileIO/FEFLOWInterface.cpp
@@ -415,7 +415,7 @@ void FEFLOWInterface::readELEMENTALSETS(std::ifstream &in, std::vector<std::vect
 
 	std::string line_string;
 	std::string str_idList;
-	int pos_prev_line = 0;
+	std::streampos pos_prev_line = 0;
 	while (true)
 	{
 		pos_prev_line = in.tellg();
@@ -459,7 +459,7 @@ void FEFLOWInterface::readELEMENTALSETS(std::ifstream &in, std::vector<std::vect
 				set_name = line_string.substr(0, pos);
 				ids = line_string.substr(pos+1);
 			}
-			INFO("Found a element group - %s", set_name.data());
+			INFO("Found an element group - %s", set_name.data());
 			str_idList += compressSpaces(ids);
 		} else {
 			// continue reading a element ids

--- a/FileIO/FEFLOWInterface.cpp
+++ b/FileIO/FEFLOWInterface.cpp
@@ -202,7 +202,8 @@ MeshLib::Mesh* FEFLOWInterface::readFEFLOWFile(const std::string &filename)
 void FEFLOWInterface::readNodeCoordinates(std::ifstream &in, const FEM_CLASS &fem_class, const FEM_DIM &fem_dim, std::vector<MeshLib::Node*> &vec_nodes)
 {
 	const size_t no_nodes_per_layer = (fem_class.dimension == 2) ? fem_dim.n_nodes : fem_dim.n_nodes / (fem_class.n_layers3d + 1);
-	const size_t n_lines = no_nodes_per_layer / 12 + 1;
+	assert(no_nodes_per_layer>0);
+	const size_t n_lines = (no_nodes_per_layer-1) / 12 + 1;
 	const size_t n_layers = (fem_class.dimension == 3) ? fem_class.n_layers3d + 1 : 1;
 	std::string line_string;
 	std::stringstream line_stream;

--- a/FileIO/FEFLOWInterface.h
+++ b/FileIO/FEFLOWInterface.h
@@ -138,6 +138,9 @@ private:
 	//// parse node lists
 	std::vector<size_t> getIndexList(const std::string &str_ranges);
 
+	/// parse ELEMENTALSETS
+	void readELEMENTALSETS(std::ifstream &in, std::vector<std::vector<std::size_t>> &vec_elementsets);
+
 	/// read Supermesh data
 	///
 	/// A super mesh is a collection of polygons, lines and points in the 2D plane

--- a/FileIO/FEFLOWInterface.h
+++ b/FileIO/FEFLOWInterface.h
@@ -136,7 +136,7 @@ private:
 	void readElevation(std::ifstream &in, const FEM_CLASS &fem_class, const FEM_DIM &fem_dim, std::vector<MeshLib::Node*> &vec_nodes);
 
 	//// parse node lists
-	std::vector<size_t> getNodeList(const std::string &str_ranges);
+	std::vector<size_t> getIndexList(const std::string &str_ranges);
 
 	/// read Supermesh data
 	///
@@ -148,7 +148,7 @@ private:
 	void readPoints(QDomElement &nodesEle, const std::string &tag, int dim, std::vector<GeoLib::Point*> &points);
 
 	/// set element material IDs
-	void setMaterialID(const FEM_CLASS &fem_class, const FEM_DIM &fem_dim, const std::vector<GeoLib::Polyline*>* lines, std::vector<MeshLib::Element*> &vec_elements);
+	void setMaterialID(const FEM_CLASS &fem_class, const FEM_DIM &fem_dim, const std::vector<GeoLib::Polyline*>* lines, const std::vector<std::vector<std::size_t>> &vec_elementsets, std::vector<MeshLib::Element*> &vec_elements);
 
 	//// Geometric objects
 	GeoLib::GEOObjects* _geoObjects;


### PR DESCRIPTION
This PR supports the keyword ELEMENTALSETS added in recent FEFLOW version to set material IDs to imported elements. joint work with @fabienma
