### PR TITLE
MATERIAL is not in UseIntensityAs anymore

### DIFF
--- a/Applications/Utils/SimpleMeshCreation/createMeshElemPropertiesFromASCRaster.cpp
+++ b/Applications/Utils/SimpleMeshCreation/createMeshElemPropertiesFromASCRaster.cpp
@@ -174,7 +174,7 @@ int main (int argc, char* argv[])
 	}
 
 	MeshLib::Mesh* src_mesh(MeshLib::ConvertRasterToMesh(*raster, MeshLib::MeshElemType::QUAD,
-					MeshLib::UseIntensityAs::MATERIAL).execute());
+					MeshLib::UseIntensityAs::DATAVECTOR).execute());
 
 	std::vector<std::size_t> src_perm(size);
 	std::iota(src_perm.begin(), src_perm.end(), 0);

--- a/Applications/Utils/SimpleMeshCreation/generateStructuredQuadMesh.cpp
+++ b/Applications/Utils/SimpleMeshCreation/generateStructuredQuadMesh.cpp
@@ -50,7 +50,7 @@ int main (int argc, char* argv[])
 	const double origin[3] = {origin_x_arg.getValue() + edge_length/2, origin_y_arg.getValue() + edge_length/2, origin_z_arg.getValue()};
 	for (unsigned i=0; i<size; ++i) values[i]=0;
 	MeshLib::Mesh* mesh(MeshLib::VtkMeshConverter::convertImgToMesh(values, origin, height, width,
-		edge_length, MeshLib::MeshElemType::QUAD, MeshLib::UseIntensityAs::MATERIAL));
+		edge_length, MeshLib::MeshElemType::QUAD, MeshLib::UseIntensityAs::DATAVECTOR));
 
 	delete [] values;
 


### PR DESCRIPTION
This PR fixes compiling errors due to missing MATERIAL enum type in MeshLib::UseIntensityAs, though Jenkins is strangely not complaining it. 

In this PR, I replaced MATERIAL with DATAVECTOR, but I have no idea which one should be used. Let me know if this is wrong.