### PR TITLE
[Mesh] rework on ElementStatus. no changes allowed after construction

### DIFF
--- a/MeshLib/ElementStatus.h
+++ b/MeshLib/ElementStatus.h
@@ -20,53 +20,52 @@
 namespace MeshLib {
 	class Mesh;
 	class Element;
+	class Node;
 
-/**
- * Manages the active/inactive flags for mesh elements and their nodes
- */
 class ElementStatus
 {
 
 public:
-	/// Constructor
+	/// Constructor assuming all nodes and elements
 	explicit ElementStatus(MeshLib::Mesh const*const mesh);
 
+	/// Constructor taking a vector of inactive material IDs
+	ElementStatus(MeshLib::Mesh const*const mesh, std::vector<unsigned> const& vec_inactive_matIDs);
+
 	/// Returns a vector of active element IDs
-	std::vector<std::size_t> getActiveElements() const;
+	std::vector<MeshLib::Element*> const& getActiveElements() const;
 
 	/// Returns a vector of active node IDs
-	std::vector<std::size_t> getActiveNodes() const;
-	
+	std::vector<MeshLib::Node*> const& getActiveNodes() const;
+
 	/// Returns the status of element i
-	bool getElementStatus(std::size_t i) const { return _element_status[i]; }
+	bool isActive(std::size_t i) const { return _element_status[i]; }
 
 	/// Returns a vector of active elements connected to a node
-	std::vector<std::size_t> getActiveElementsAtNode(std::size_t node_id) const;
-	
+	std::vector<MeshLib::Element*> getActiveElementsAtNode(std::size_t node_id) const;
+
 	/// Returns the total number of active nodes
 	std::size_t getNActiveNodes() const;
 
 	/// Returns the total number of active elements
 	std::size_t getNActiveElements() const;
 
-	/// Activates/Deactives all mesh elements
-	void setAll(bool status);
-
-	/// Sets the status of element i
-	void setElementStatus(std::size_t i, bool status);
-
-	/// Sets the status of material group i
-	void setMaterialStatus(unsigned material_id, bool status);
-
 	~ElementStatus() {}
 
 protected:
+	/// Sets the status of element i
+	void setElementStatus(std::size_t i, bool status);
+
 	/// The mesh for which the element status is administrated
 	MeshLib::Mesh const*const _mesh;
 	/// Element status for each mesh element (active/inactive = true/false)
 	std::vector<bool> _element_status;
 	/// Node status for each mesh node (value = number of active elements connected to node, 0 means inactive)
 	std::vector<unsigned char> _active_nodes;
+
+	bool _hasAnyInactive;
+	std::vector<MeshLib::Node*> _vec_active_nodes;
+	std::vector<MeshLib::Element*> _vec_active_eles;
 
 }; /* class */
 

--- a/Tests/MeshLib/TestElementStatus.cpp
+++ b/Tests/MeshLib/TestElementStatus.cpp
@@ -46,14 +46,14 @@ TEST(MeshLib, ElementStatus)
 
 	{
 		// set material 1 to false
-		std::vector<unsigned> inactiveMat({1});
+		std::vector<unsigned> inactiveMat{1};
 		MeshLib::ElementStatus status(mesh.get(), inactiveMat);
 		ASSERT_EQ (elements.size()-elements_per_side, status.getNActiveElements());
 	}
 
 	{
 		// set material 0 and 1 to false
-		std::vector<unsigned> inactiveMat({0, 1});
+		std::vector<unsigned> inactiveMat{0, 1};
 		MeshLib::ElementStatus status(mesh.get(), inactiveMat);
 		ASSERT_EQ (elements.size()-(2*elements_per_side), status.getNActiveElements());
 

--- a/Tests/MeshLib/TestElementStatus.cpp
+++ b/Tests/MeshLib/TestElementStatus.cpp
@@ -29,7 +29,6 @@ TEST(MeshLib, ElementStatus)
 	auto const mesh = std::unique_ptr<MeshLib::Mesh>{
         MeshLib::MeshGenerator::generateRegularQuadMesh(width, elements_per_side)};
 
-	MeshLib::ElementStatus status(mesh.get());
 	const std::vector<MeshLib::Element*> elements (mesh->getElements());
 
 	for (unsigned i=0; i<elements_per_side; ++i)
@@ -38,57 +37,32 @@ TEST(MeshLib, ElementStatus)
 			elements[i*elements_per_side + j]->setValue(i);
 	}
 
-	// all elements active
-	ASSERT_EQ (elements.size(), status.getNActiveElements());
-	// all nodes active
-	ASSERT_EQ (mesh->getNNodes(), status.getNActiveNodes());
+	{
+		// all elements and ndoes active
+		MeshLib::ElementStatus status(mesh.get());
+		ASSERT_EQ (elements.size(), status.getNActiveElements());
+		ASSERT_EQ (mesh->getNNodes(), status.getNActiveNodes());
+	}
 
-	// set material 1 to false
-	status.setMaterialStatus(1, false);
-	ASSERT_EQ (elements.size()-elements_per_side, status.getNActiveElements());
+	{
+		// set material 1 to false
+		std::vector<unsigned> inactiveMat({1});
+		MeshLib::ElementStatus status(mesh.get(), inactiveMat);
+		ASSERT_EQ (elements.size()-elements_per_side, status.getNActiveElements());
+	}
 
-	// set material 1 to false (again)
-	status.setMaterialStatus(1, false);
-	ASSERT_EQ (elements.size()-elements_per_side, status.getNActiveElements());
+	{
+		// set material 0 and 1 to false
+		std::vector<unsigned> inactiveMat({0, 1});
+		MeshLib::ElementStatus status(mesh.get(), inactiveMat);
+		ASSERT_EQ (elements.size()-(2*elements_per_side), status.getNActiveElements());
 
-	// set material 0 to false
-	status.setMaterialStatus(0, false);
-	ASSERT_EQ (elements.size()-(2*elements_per_side), status.getNActiveElements());
+		// active elements
+		auto &active_elements (status.getActiveElements());
+		ASSERT_EQ (active_elements.size(), status.getNActiveElements());
 
-	// active elements
-	std::vector<std::size_t> active_elements (status.getActiveElements());
-	ASSERT_EQ (active_elements.size(), status.getNActiveElements());
-
-	// active nodes
-	std::vector<std::size_t> active_nodes (status.getActiveNodes());
-	ASSERT_EQ (active_nodes.size(), status.getNActiveNodes());
-
-	// set element 1 to false (yet again)
-	status.setElementStatus(1, false);
-	status.getElementStatus(1);
-	ASSERT_EQ (elements.size()-(2*elements_per_side), status.getNActiveElements());
-	ASSERT_EQ (mesh->getNNodes()-(2*(elements_per_side+1)), status.getNActiveNodes());
-
-	// set element 1 to true
-	status.setElementStatus(1, true);
-	ASSERT_EQ (elements.size()-(2*elements_per_side)+1, status.getNActiveElements());
-	ASSERT_EQ (mesh->getNNodes()-(2*(elements_per_side+1))+4, status.getNActiveNodes());
-	ASSERT_EQ(status.getElementStatus(1), true);
-
-	std::vector<std::size_t> active_elements_at_node (status.getActiveElementsAtNode(2));
-	ASSERT_EQ(1u, active_elements_at_node.size());
-	active_elements_at_node = status.getActiveElementsAtNode(22);
-	ASSERT_EQ(1u, active_elements_at_node.size());
-	active_elements_at_node = status.getActiveElementsAtNode(44);
-	ASSERT_EQ(2u, active_elements_at_node.size());
-	active_elements_at_node = status.getActiveElementsAtNode(102);
-	ASSERT_EQ(4u, active_elements_at_node.size());
-
-	status.setAll(true);
-	ASSERT_EQ(elements.size(), status.getNActiveElements());
-	ASSERT_EQ(mesh->getNNodes(), status.getNActiveNodes());
-
-	status.setAll(false);
-	ASSERT_EQ(0u, status.getNActiveElements());
-	ASSERT_EQ(0u, status.getNActiveNodes());
+		// active nodes
+		auto& active_nodes (status.getActiveNodes());
+		ASSERT_EQ (active_nodes.size(), status.getNActiveNodes());
+	}
 }


### PR DESCRIPTION
`MeshLib::ElementStatus` class was reworked in order to cache searched active nodes and elements  for the given condition. To enable this, all set functions in the class were removed and one can set active elements only via constructors. 