### PR TITLE
Full path includes cleanup

### DIFF
--- a/AssemblerLib/CMakeLists.txt
+++ b/AssemblerLib/CMakeLists.txt
@@ -5,14 +5,6 @@ set(SOURCES ${SOURCES_ASSEMBLERLIB})
 # Create the library
 add_library(AssemblerLib STATIC ${SOURCES})
 
-include_directories(
-	.
-	../BaseLib
-	../GeoLib
-	../MathLib
-	../MeshLib
-)
-
 target_link_libraries(AssemblerLib INTERFACE
 	MeshLib
 )

--- a/BaseLib/CMakeLists.txt
+++ b/BaseLib/CMakeLists.txt
@@ -7,10 +7,6 @@ add_library(BaseLib STATIC ${SOURCES})
 
 set_target_properties(BaseLib PROPERTIES LINKER_LANGUAGE CXX)
 
-include_directories(
-	.
-)
-
 target_link_libraries(BaseLib INTERFACE
 	logog
 	${Boost_LIBRARIES}

--- a/FileIO/CMakeLists.txt
+++ b/FileIO/CMakeLists.txt
@@ -48,11 +48,6 @@ endif()
 # Create the library
 add_library(FileIO STATIC ${SOURCES})
 
-include_directories(
-	.
-	${CMAKE_CURRENT_BINARY_DIR}/../BaseLib
-)
-
 target_link_libraries(FileIO INTERFACE
 	GeoLib
 	InSituLib

--- a/GeoLib/CMakeLists.txt
+++ b/GeoLib/CMakeLists.txt
@@ -4,10 +4,6 @@ GET_SOURCE_FILES(SOURCES_GeoLib)
 # Create the library
 add_library(GeoLib STATIC ${SOURCES_GeoLib})
 
-include_directories(
-	.
-)
-
 target_link_libraries(GeoLib INTERFACE
 	BaseLib
 	MathLib

--- a/InSituLib/CMakeLists.txt
+++ b/InSituLib/CMakeLists.txt
@@ -1,10 +1,3 @@
-include_directories(
-	${CMAKE_CURRENT_SOURCE_DIR}/../GeoLib
-	${CMAKE_CURRENT_SOURCE_DIR}/../MathLib
-	${CMAKE_CURRENT_SOURCE_DIR}/../MeshLib
-	${CMAKE_CURRENT_SOURCE_DIR}/../MeshLib/Elements
-)
-
 add_library(InSituLib
 	VtkMappedMesh.h
 	VtkMappedMesh.cpp

--- a/InSituLib/VtkMappedMesh.cpp
+++ b/InSituLib/VtkMappedMesh.cpp
@@ -25,10 +25,10 @@
 #include <vtkObjectFactory.h>
 #include <vtkPoints.h>
 
-#include "Element.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/MeshEnums.h"
 #include "MeshLib/Node.h"
-#include "MeshEnums.h"
-#include "VtkOGSEnum.h"
+#include "MeshLib/VtkOGSEnum.h"
 
 namespace InSituLib {
 

--- a/InSituLib/VtkMappedMesh.h
+++ b/InSituLib/VtkMappedMesh.h
@@ -20,8 +20,6 @@
 #include <vtkObject.h>
 #include <vtkMappedUnstructuredGrid.h>
 
-#include "MeshEnums.h"
-
 class vtkGenericCell;
 namespace MeshLib {
 	class Element;

--- a/InSituLib/VtkMeshNodalCoordinatesTemplate.h
+++ b/InSituLib/VtkMeshNodalCoordinatesTemplate.h
@@ -20,6 +20,11 @@
 #include <vtkTypeTemplate.h>    // For templated vtkObject API
 #include <vtkObjectFactory.h>   // for vtkStandardNewMacro
 
+namespace MeshLib
+{
+	class Node;
+}
+
 namespace InSituLib
 {
 

--- a/MathLib/CMakeLists.txt
+++ b/MathLib/CMakeLists.txt
@@ -51,10 +51,6 @@ endif ()
 GET_SOURCE_FILES(SOURCES_NONLINEAR Nonlinear)
 set(SOURCES ${SOURCES} ${SOURCES_NONLINEAR})
 
-include_directories(
-	.
-)
-
 if(METIS_FOUND)
 	include_directories(${METIS_INCLUDE_DIR})
 endif()

--- a/MathLib/Nonlinear/NewtonRaphson.h
+++ b/MathLib/Nonlinear/NewtonRaphson.h
@@ -13,7 +13,7 @@
 #ifndef MATHLIB_NONLINEAR_NEWTONRAPHSON_H_
 #define MATHLIB_NONLINEAR_NEWTONRAPHSON_H_
 
-#include "LinAlg/VectorNorms.h"
+#include "MathLib/LinAlg/VectorNorms.h"
 
 namespace MathLib
 {

--- a/MathLib/Nonlinear/Picard.h
+++ b/MathLib/Nonlinear/Picard.h
@@ -13,7 +13,7 @@
 #ifndef MATHLIB_NONLINEAR_PICARD_H_
 #define MATHLIB_NONLINEAR_PICARD_H_
 
-#include "LinAlg/VectorNorms.h"
+#include "MathLib/LinAlg/VectorNorms.h"
 
 namespace MathLib
 {

--- a/MeshGeoToolsLib/AppendLinesAlongPolyline.cpp
+++ b/MeshGeoToolsLib/AppendLinesAlongPolyline.cpp
@@ -12,6 +12,7 @@
 #include <logog/include/logog.hpp>
 
 #include "GeoLib/Polyline.h"
+#include "GeoLib/PolylineVec.h"
 
 #include "MeshLib/Mesh.h"
 #include "MeshLib/Node.h"

--- a/MeshGeoToolsLib/AppendLinesAlongPolyline.h
+++ b/MeshGeoToolsLib/AppendLinesAlongPolyline.h
@@ -9,8 +9,12 @@
 #ifndef APPENDLINESALONGPOLYLINES_H_
 #define APPENDLINESALONGPOLYLINES_H_
 
-// GeoLib
-#include "PolylineVec.h"
+namespace GeoLib
+{
+class Polyline;
+template <typename T> class TemplateVec;
+typedef TemplateVec<Polyline> PolylineVec;
+}
 
 namespace MeshLib
 {

--- a/MeshGeoToolsLib/CMakeLists.txt
+++ b/MeshGeoToolsLib/CMakeLists.txt
@@ -5,7 +5,6 @@ GET_SOURCE_FILES(SOURCES_MeshGeoToolsLib)
 add_library(MeshGeoToolsLib STATIC ${SOURCES_MeshGeoToolsLib})
 
 include_directories(
-	.
 	${CMAKE_CURRENT_SOURCE_DIR}/../BaseLib
 	${CMAKE_CURRENT_SOURCE_DIR}/../MathLib
 	${CMAKE_CURRENT_SOURCE_DIR}/../MeshLib

--- a/MeshGeoToolsLib/CMakeLists.txt
+++ b/MeshGeoToolsLib/CMakeLists.txt
@@ -4,13 +4,6 @@ GET_SOURCE_FILES(SOURCES_MeshGeoToolsLib)
 # Create the library
 add_library(MeshGeoToolsLib STATIC ${SOURCES_MeshGeoToolsLib})
 
-include_directories(
-	${CMAKE_CURRENT_SOURCE_DIR}/../BaseLib
-	${CMAKE_CURRENT_SOURCE_DIR}/../MathLib
-	${CMAKE_CURRENT_SOURCE_DIR}/../MeshLib
-	${CMAKE_CURRENT_SOURCE_DIR}/../GeoLib
-)
-
 target_link_libraries(MeshGeoToolsLib INTERFACE
 	BaseLib
 	MathLib

--- a/NumLib/CMakeLists.txt
+++ b/NumLib/CMakeLists.txt
@@ -22,17 +22,6 @@ set(SOURCES ${SOURCES} ${SOURCES_FUNCTION})
 GET_SOURCE_FILES(SOURCES_DISTRIBUTION Distribution)
 set(SOURCES ${SOURCES} ${SOURCES_DISTRIBUTION})
 
-
-include_directories(
-	.
-	${CMAKE_CURRENT_SOURCE_DIR}/../BaseLib
-	${CMAKE_CURRENT_SOURCE_DIR}/../GeoLib
-	${CMAKE_CURRENT_SOURCE_DIR}/../MathLib
-	${CMAKE_CURRENT_SOURCE_DIR}/../MeshLib
-	${CMAKE_CURRENT_SOURCE_DIR}/../MeshGeoToolsLib
-)
-
-
 # Create the library
 add_library(NumLib STATIC ${SOURCES})
 

--- a/SimpleTests/MatrixTests/CMakeLists.txt
+++ b/SimpleTests/MatrixTests/CMakeLists.txt
@@ -7,13 +7,6 @@ if(CMAKE_USE_PTHREADS_INIT)
 	set(HAVE_PTHREADS TRUE)
 endif()
 
-include_directories(
-	.
-	${CMAKE_SOURCE_DIR}/BaseLib/
-	${CMAKE_BINARY_DIR}/BaseLib/
-	${CMAKE_SOURCE_DIR}/MathLib/
-)
-
 # Create the executable
 add_executable(MatMult
 	MatMult.cpp

--- a/SimpleTests/MeshTests/CMakeLists.txt
+++ b/SimpleTests/MeshTests/CMakeLists.txt
@@ -2,15 +2,6 @@ if(WIN32)
 	set(ADDITIONAL_LIBS Winmm.lib)
 endif()
 
-include_directories(
-	.
-	${CMAKE_SOURCE_DIR}/BaseLib/
-	${CMAKE_SOURCE_DIR}/FileIO/
-	${CMAKE_SOURCE_DIR}/GeoLib/
-	${CMAKE_SOURCE_DIR}/MathLib/
-	${CMAKE_SOURCE_DIR}/MeshLib/
-)
-
 # Create the executable
 add_executable(MeshRead
 	MeshRead.cpp

--- a/SimpleTests/MeshTests/MPI/CMakeLists.txt
+++ b/SimpleTests/MeshTests/MPI/CMakeLists.txt
@@ -1,10 +1,3 @@
-include_directories(
-	.
-	${CMAKE_SOURCE_DIR}/BaseLib/
-	${CMAKE_SOURCE_DIR}/FileIO/
-	${CMAKE_SOURCE_DIR}/MeshLib/
-)
-
 add_executable(test_node_partitioned_mesh
 	NodePartitionedMeshTester.cpp
 )

--- a/SimpleTests/SolverTests/CMakeLists.txt
+++ b/SimpleTests/SolverTests/CMakeLists.txt
@@ -2,12 +2,6 @@ if(WIN32)
 	set(ADDITIONAL_LIBS Winmm.lib)
 endif()
 
-include_directories(
-	.
-	../../BaseLib/
-	../../MathLib/
-)
-
 add_executable(ConjugateGradientUnpreconditioned
 	ConjugateGradientUnpreconditioned.cpp
 	${SOURCES}

--- a/Tests/BaseLib/TestFilePathStringManipulation.cpp
+++ b/Tests/BaseLib/TestFilePathStringManipulation.cpp
@@ -13,8 +13,10 @@
 
 #include "gtest/gtest.h"
 
-#include "FileTools.h"
-#include "FileTools.cpp"
+#include "BaseLib/FileTools.h"
+
+// For testing of some internal functions used inside FileTools.cpp.
+#include "BaseLib/FileTools.cpp"
 
 TEST(BaseLib, FindLastPathSeparatorWin)
 {

--- a/Tests/BaseLib/TestSystemTools.cpp
+++ b/Tests/BaseLib/TestSystemTools.cpp
@@ -15,7 +15,7 @@
 // ** INCLUDES **
 #include "gtest/gtest.h"
 
-#include "SystemTools.h"
+#include "BaseLib/SystemTools.h"
 
 TEST(BaseLib, EndianLittle) {
     bool isLittle = false;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -26,19 +26,6 @@ if(OGS_USE_PETSC OR OGS_USE_MPI)
 	list(REMOVE_ITEM TEST_SOURCES AssemblerLib/TestSerialLinearSolver.cpp)
 endif()
 
-include_directories(
-	${CMAKE_SOURCE_DIR}/AssemblerLib
-	${CMAKE_SOURCE_DIR}/BaseLib
-	${CMAKE_SOURCE_DIR}/FileIO
-	${CMAKE_SOURCE_DIR}/GeoLib
-	${CMAKE_SOURCE_DIR}/InSituLib
-	${CMAKE_SOURCE_DIR}/MathLib
-	${CMAKE_SOURCE_DIR}/MeshLib
-	${CMAKE_SOURCE_DIR}/MeshGeoToolsLib
-	${CMAKE_SOURCE_DIR}/NumLib
-	${CMAKE_BINARY_DIR}/BaseLib
-)
-
 add_executable(testrunner testrunner.cpp ${TEST_SOURCES})
 set_target_properties(testrunner PROPERTIES FOLDER Testing)
 

--- a/Tests/FileIO/TestXmlGmlReader.cpp
+++ b/Tests/FileIO/TestXmlGmlReader.cpp
@@ -15,13 +15,10 @@
 #include <boost/filesystem.hpp>
 
 #include "gtest/gtest.h"
-#include "BaseLib/BuildInfo.h"
-
-// FileIO
-#include "XmlIO/Qt/XmlGmlInterface.h"
 
 #include "Applications/ApplicationsLib/ProjectData.h"
-
+#include "BaseLib/BuildInfo.h"
+#include "FileIO/XmlIO/Qt/XmlGmlInterface.h"
 #include "GeoLib/Polyline.h"
 #include "GeoLib/Triangle.h"
 

--- a/Tests/GeoLib/TestAABB.cpp
+++ b/Tests/GeoLib/TestAABB.cpp
@@ -12,18 +12,16 @@
  *
  */
 
-// ** INCLUDES **
-#include "gtest/gtest.h"
-
-// std lib
 #include <cstdlib>
 #include <ctime>
 #include <list>
 #include <iostream>
 
+#include "gtest/gtest.h"
+
+#include "GeoLib/AABB.h"
+#include "GeoLib/Point.h"
 #include "MathLib/Point3d.h"
-#include "Point.h"
-#include "AABB.h"
 
 TEST(GeoLibAABB, RandomNumberOfPointersToRandomPoints)
 {

--- a/Tests/GeoLib/TestComputeAndInsertAllIntersectionPoints.cpp
+++ b/Tests/GeoLib/TestComputeAndInsertAllIntersectionPoints.cpp
@@ -14,10 +14,10 @@
 
 #include "gtest/gtest.h"
 
-#include "Point.h"
-#include "Polyline.h"
-#include "GEOObjects.h"
-#include "AnalyticalGeometry.h"
+#include "GeoLib/AnalyticalGeometry.h"
+#include "GeoLib/GEOObjects.h"
+#include "GeoLib/Point.h"
+#include "GeoLib/Polyline.h"
 
 TEST(GeoLib, TestComputeAndInsertAllIntersectionPoints)
 {

--- a/Tests/GeoLib/TestComputeRotationMatrix.cpp
+++ b/Tests/GeoLib/TestComputeRotationMatrix.cpp
@@ -10,7 +10,8 @@
  */
 
 #include "gtest/gtest.h"
-#include "AnalyticalGeometry.h"
+
+#include "GeoLib/AnalyticalGeometry.h"
 
 auto test3equal = [](double a, double b, double c, double const* result)
 {

--- a/Tests/GeoLib/TestGEOObjectsMerge.cpp
+++ b/Tests/GeoLib/TestGEOObjectsMerge.cpp
@@ -11,16 +11,13 @@
  *              http://www.opengeosys.org/LICENSE.txt
  */
 
-// google test include
-#include "gtest/gtest.h"
-
-// STL
-#include <vector>
 #include <map>
 #include <string>
+#include <vector>
 
-// GeoLib
-#include "GEOObjects.h"
+#include "gtest/gtest.h"
+
+#include "GeoLib/GEOObjects.h"
 
 void createSetOfTestPointsAndAssociatedNames(GeoLib::GEOObjects & geo_objs, std::string &name, GeoLib::Point const& shift)
 {

--- a/Tests/GeoLib/TestGrid.cpp
+++ b/Tests/GeoLib/TestGrid.cpp
@@ -18,7 +18,7 @@
 #include "GeoLib/Point.h"
 #include "GeoLib/Grid.h"
 
-#include "MathTools.h"
+#include "MathLib/MathTools.h"
 
 TEST(GeoLib, InsertZeroPointsInGrid)
 {

--- a/Tests/GeoLib/TestIsPointInTriangle.cpp
+++ b/Tests/GeoLib/TestIsPointInTriangle.cpp
@@ -11,7 +11,7 @@
 
 #include "gtest/gtest.h"
 
-#include "AnalyticalGeometry.h"
+#include "GeoLib/AnalyticalGeometry.h"
 
 TEST(GeoLib, IsPointInTriangle)
 {

--- a/Tests/GeoLib/TestLineSegmentIntersect.cpp
+++ b/Tests/GeoLib/TestLineSegmentIntersect.cpp
@@ -14,8 +14,8 @@
 
 #include "gtest/gtest.h"
 
-#include "Point.h"
-#include "AnalyticalGeometry.h"
+#include "GeoLib/Point.h"
+#include "GeoLib/AnalyticalGeometry.h"
 
 TEST(GeoLib, TestXAxisParallelLineSegmentIntersection2d)
 {

--- a/Tests/GeoLib/TestParallel.cpp
+++ b/Tests/GeoLib/TestParallel.cpp
@@ -11,10 +11,8 @@
 
 #include "gtest/gtest.h"
 
-#include "AnalyticalGeometry.h"
-
-// MathLib
-#include "Vector3.h"
+#include "GeoLib/AnalyticalGeometry.h"
+#include "MathLib/Vector3.h"
 
 TEST(GeoLib, TestParallel)
 {

--- a/Tests/GeoLib/TestPolygon.cpp
+++ b/Tests/GeoLib/TestPolygon.cpp
@@ -13,8 +13,8 @@
 
 #include "gtest/gtest.h"
 
-#include "Point.h"
-#include "Polygon.h"
+#include "GeoLib/Point.h"
+#include "GeoLib/Polygon.h"
 
 /**
  * Polygon:

--- a/Tests/GeoLib/TestPolyline.cpp
+++ b/Tests/GeoLib/TestPolyline.cpp
@@ -10,10 +10,11 @@
  *              http://www.opengeosys.org/LICENSE.txt
  */
 
-#include "gtest/gtest.h"
 #include <ctime>
 
-#include "Polyline.h"
+#include "gtest/gtest.h"
+
+#include "GeoLib/Polyline.h"
 
 TEST(GeoLib, PolylineTest)
 {

--- a/Tests/GeoLib/TestSimplePolygonTree.cpp
+++ b/Tests/GeoLib/TestSimplePolygonTree.cpp
@@ -15,9 +15,9 @@
 
 #include "gtest/gtest.h"
 
-#include "Point.h"
-#include "Polygon.h"
-#include "SimplePolygonTree.h"
+#include "GeoLib/Point.h"
+#include "GeoLib/Polygon.h"
+#include "GeoLib/SimplePolygonTree.h"
 
 /**
  *       2

--- a/Tests/InSituLib/TestVtkMappedPropertyVector.cpp
+++ b/Tests/InSituLib/TestVtkMappedPropertyVector.cpp
@@ -18,10 +18,9 @@
 
 #include "gtest/gtest.h"
 
-#include "Mesh.h"
-#include "MeshGenerators/MeshGenerator.h"
-
-#include "VtkMappedPropertyVectorTemplate.h"
+#include "InSituLib/VtkMappedPropertyVectorTemplate.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
 
 // Creates a PropertyVector<double> and maps it into a vtkDataArray-equivalent
 TEST(InSituLibMappedPropertyVector, Double)

--- a/Tests/InSituLib/TestVtkMeshNodalCoordinatesTemplate.cpp
+++ b/Tests/InSituLib/TestVtkMeshNodalCoordinatesTemplate.cpp
@@ -16,10 +16,9 @@
 
 #include "gtest/gtest.h"
 
-#include "Mesh.h"
-#include "MeshGenerators/MeshGenerator.h"
-
-#include "VtkMeshNodalCoordinatesTemplate.h"
+#include "InSituLib/VtkMeshNodalCoordinatesTemplate.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
 
 TEST(InSituLibNodalCoordinates, Init)
 {

--- a/Tests/MathLib/TestDenseGaussAlgorithm.cpp
+++ b/Tests/MathLib/TestDenseGaussAlgorithm.cpp
@@ -11,16 +11,16 @@
  *              http://www.opengeosys.org/LICENSE.txt
  */
 
-#include <gtest/gtest.h>
-
 #include <cstdlib>
 #include <ctime>
 #include <limits>
 #include <algorithm>
 
-#include "LinAlg/Dense/DenseMatrix.h"
-#include "LinAlg/Dense/DenseVector.h"
-#include "LinAlg/Solvers/GaussAlgorithm.h"
+#include <gtest/gtest.h>
+
+#include "MathLib/LinAlg/Dense/DenseMatrix.h"
+#include "MathLib/LinAlg/Dense/DenseVector.h"
+#include "MathLib/LinAlg/Solvers/GaussAlgorithm.h"
 
 TEST(MathLib, DenseGaussAlgorithm)
 {

--- a/Tests/MathLib/TestGlobalDenseMatrix.cpp
+++ b/Tests/MathLib/TestGlobalDenseMatrix.cpp
@@ -11,11 +11,11 @@
  *              http://www.opengeosys.org/LICENSE.txt
  */
 
-#include <gtest/gtest.h>
-
 #include <limits>
 
-#include "LinAlg/Dense/GlobalDenseMatrix.h"
+#include <gtest/gtest.h>
+
+#include "MathLib/LinAlg/Dense/GlobalDenseMatrix.h"
 
 
 TEST(MathLib, GlobalDenseMatrix)

--- a/Tests/MathLib/TestMatrixAssemblyTemplate.cpp
+++ b/Tests/MathLib/TestMatrixAssemblyTemplate.cpp
@@ -13,8 +13,8 @@
 
 #include <gtest/gtest.h>
 
-#include "LinAlg/FinalizeMatrixAssembly.h"
-#include "LinAlg/Dense/GlobalDenseMatrix.h"
+#include "MathLib/LinAlg/FinalizeMatrixAssembly.h"
+#include "MathLib/LinAlg/Dense/GlobalDenseMatrix.h"
 
 TEST(MathLib, GlobalDenseMatrixAssembly)
 {

--- a/Tests/MathLib/TestPoint3dWithID.cpp
+++ b/Tests/MathLib/TestPoint3dWithID.cpp
@@ -10,9 +10,10 @@
  */
 
 #include <ctime>
+
 #include "gtest/gtest.h"
 
-#include "Point3dWithID.h"
+#include "MathLib/Point3dWithID.h"
 
 using namespace MathLib;
 

--- a/Tests/MathLib/TestTemplatePoint.cpp
+++ b/Tests/MathLib/TestTemplatePoint.cpp
@@ -13,7 +13,7 @@
 
 #include "gtest/gtest.h"
 
-#include "TemplatePoint.h"
+#include "MathLib/TemplatePoint.h"
 
 using namespace MathLib;
 

--- a/Tests/MathLib/TestVector3.cpp
+++ b/Tests/MathLib/TestVector3.cpp
@@ -13,8 +13,8 @@
 
 #include "gtest/gtest.h"
 
-#include "Point.h"
-#include "Vector3.h"
+#include "MathLib/Vector3.h"
+#include "GeoLib/Point.h"
 
 using namespace MathLib;
 

--- a/Tests/MathLib/TestWeightedPoint.cpp
+++ b/Tests/MathLib/TestWeightedPoint.cpp
@@ -8,10 +8,9 @@
  *              http://www.opengeosys.org/LICENSE.txt
  */
 
-// google test
 #include "gtest/gtest.h"
 
-#include "TemplateWeightedPoint.h"
+#include "MathLib/TemplateWeightedPoint.h"
 
 TEST(MathLib, WeightedPoint1D)
 {

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -6,17 +6,17 @@
  *			  http://www.opengeosys.org/LICENSE.txt
  */
 
-#include <ctime>
 #include <numeric>
-#include "gtest/gtest.h"
-
-#include "MeshLib/MeshGenerators/MeshGenerator.h"
-#include "MeshLib/Mesh.h"
-#include "PropertyVector.h"
 
 #ifdef OGS_USE_EIGEN
 #include <Eigen/Eigen>
 #endif
+
+#include "gtest/gtest.h"
+
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/PropertyVector.h"
 
 class MeshLibProperties : public ::testing::Test
 {

--- a/Tests/MeshLib/TestDuplicate.cpp
+++ b/Tests/MeshLib/TestDuplicate.cpp
@@ -15,14 +15,14 @@
 
 #include "gtest/gtest.h"
 
-#include "Mesh.h"
+#include "MathLib/MathTools.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshEditing/DuplicateMeshComponents.h"
+#include "MeshLib/MeshEditing/RemoveMeshComponents.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
+#include "MeshLib/MeshQuality/MeshValidation.h"
 #include "MeshLib/Node.h"
-#include "Elements/Element.h"
-#include "MeshEditing/DuplicateMeshComponents.h"
-#include "MeshEditing/RemoveMeshComponents.h"
-#include "MeshGenerators/MeshGenerator.h"
-#include "MeshQuality/MeshValidation.h"
-#include "MathTools.h"
 
 TEST(MeshLib, Duplicate)
 {

--- a/Tests/MeshLib/TestElementConstants.cpp
+++ b/Tests/MeshLib/TestElementConstants.cpp
@@ -8,9 +8,9 @@
 
 #include "gtest/gtest.h"
 
-#include "Elements/Quad.h"
-#include "Elements/Hex.h"
-#include "Elements/Tet.h"
+#include "MeshLib/Elements/Quad.h"
+#include "MeshLib/Elements/Hex.h"
+#include "MeshLib/Elements/Tet.h"
 
 using namespace MeshLib;
 

--- a/Tests/MeshLib/TestElementStatus.cpp
+++ b/Tests/MeshLib/TestElementStatus.cpp
@@ -15,11 +15,11 @@
 
 #include "gtest/gtest.h"
 
-#include "Mesh.h"
+#include "MeshLib/Mesh.h"
 #include "MeshLib/Node.h"
-#include "Elements/Element.h"
-#include "ElementStatus.h"
-#include "MeshGenerators/MeshGenerator.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/ElementStatus.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
 
 
 TEST(MeshLib, ElementStatus)

--- a/Tests/MeshLib/TestMeshGenerator.cpp
+++ b/Tests/MeshLib/TestMeshGenerator.cpp
@@ -6,17 +6,17 @@
  *              http://www.opengeosys.org/LICENSE.txt
  */
 
-#include "gtest/gtest.h"
-
 #include <memory>
 #include <cmath>
 
-#include "MathTools.h"
-#include "Mesh.h"
+#include "gtest/gtest.h"
+
+#include "MathLib/MathTools.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Elements/Hex.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
 #include "MeshLib/Node.h"
-#include "MeshGenerators/MeshGenerator.h"
-#include "Elements/Element.h"
-#include "Elements/Hex.h"
 
 using namespace MeshLib;
 

--- a/Tests/MeshLib/TestMeshNodeSearch.cpp
+++ b/Tests/MeshLib/TestMeshNodeSearch.cpp
@@ -11,12 +11,12 @@
  *              http://www.opengeosys.org/LICENSE.txt
  */
 
-#include "gtest/gtest.h"
-
 #include <memory>
 
-#include "Mesh.h"
-#include "MeshGenerators/MeshGenerator.h"
+#include "gtest/gtest.h"
+
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
 #include "MeshGeoToolsLib/MeshNodeSearcher.h"
 #include "MeshGeoToolsLib/HeuristicSearchLength.h"
 

--- a/Tests/MeshLib/TestMeshRevision.cpp
+++ b/Tests/MeshLib/TestMeshRevision.cpp
@@ -13,16 +13,16 @@
 
 #include "gtest/gtest.h"
 
-#include "Mesh.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Elements/Hex.h"
+#include "MeshLib/Elements/Prism.h"
+#include "MeshLib/Elements/Pyramid.h"
+#include "MeshLib/Elements/Quad.h"
+#include "MeshLib/Elements/Tet.h"
+#include "MeshLib/Elements/Tri.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshEditing/MeshRevision.h"
 #include "MeshLib/Node.h"
-#include "MeshEditing/MeshRevision.h"
-#include "Elements/Element.h"
-#include "Elements/Tri.h"
-#include "Elements/Quad.h"
-#include "Elements/Tet.h"
-#include "Elements/Hex.h"
-#include "Elements/Pyramid.h"
-#include "Elements/Prism.h"
 
 
 TEST(MeshEditing, Tri)

--- a/Tests/MeshLib/TestMoveMeshNodes.cpp
+++ b/Tests/MeshLib/TestMoveMeshNodes.cpp
@@ -6,14 +6,15 @@
  *              http://www.opengeosys.org/project/license
  */
 
-#include "gtest/gtest.h"
-
-#include <vector>
 #include <cstdlib>
 #include <ctime>
+#include <numeric>
+#include <vector>
 
+#include "gtest/gtest.h"
+
+#include "MeshLib/MeshEditing/moveMeshNodes.h"
 #include "MeshLib/Node.h"
-#include "MeshEditing/moveMeshNodes.h"
 
 TEST(MeshLib, moveMeshNodes)
 {

--- a/Tests/MeshLib/TestPntInElement.cpp
+++ b/Tests/MeshLib/TestPntInElement.cpp
@@ -15,16 +15,16 @@
 
 #include "GeoLib/Point.h"
 
-#include "Mesh.h"
-#include "Node.h"
-#include "MeshEditing/MeshRevision.h"
-#include "Elements/Element.h"
-#include "Elements/Tri.h"
-#include "Elements/Quad.h"
-#include "Elements/Tet.h"
-#include "Elements/Hex.h"
-#include "Elements/Pyramid.h"
-#include "Elements/Prism.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/Node.h"
+#include "MeshLib/MeshEditing/MeshRevision.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Elements/Tri.h"
+#include "MeshLib/Elements/Quad.h"
+#include "MeshLib/Elements/Tet.h"
+#include "MeshLib/Elements/Hex.h"
+#include "MeshLib/Elements/Pyramid.h"
+#include "MeshLib/Elements/Prism.h"
 
 
 std::vector<MeshLib::Node*> createNodes()

--- a/Tests/MeshLib/TestProjectMeshOnPlane.cpp
+++ b/Tests/MeshLib/TestProjectMeshOnPlane.cpp
@@ -15,11 +15,11 @@
 
 #include "gtest/gtest.h"
 
-#include "Mesh.h"
-#include "MeshLib/Node.h"
-#include "Elements/Element.h"
-#include "Elements/Line.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Elements/Line.h"
+#include "MeshLib/Mesh.h"
 #include "MeshLib/MeshEditing/projectMeshOntoPlane.h"
+#include "MeshLib/Node.h"
 
 class ProjectionTest : public ::testing::Test
 {

--- a/Tests/MeshLib/TestUniqueMeshId.cpp
+++ b/Tests/MeshLib/TestUniqueMeshId.cpp
@@ -6,10 +6,9 @@
  *              http://www.opengeosys.org/LICENSE.txt
  */
 
-#include <ctime>
 #include "gtest/gtest.h"
 
-#include "Mesh.h"
+#include "MeshLib/Mesh.h"
 
 using namespace MeshLib;
 

--- a/Tests/NumLib/TestDistribution.cpp
+++ b/Tests/NumLib/TestDistribution.cpp
@@ -7,13 +7,12 @@
  *
  */
 
-#include <gtest/gtest.h>
-
 #include <vector>
 #include <memory>
 
-#include "GEOObjects.h"
+#include <gtest/gtest.h>
 
+#include "GeoLib/GEOObjects.h"
 #include "MeshLib/Mesh.h"
 #include "MeshLib/MeshGenerators/MeshGenerator.h"
 #include "MeshGeoToolsLib/HeuristicSearchLength.h"

--- a/Tests/NumLib/TestSpatialFunction.cpp
+++ b/Tests/NumLib/TestSpatialFunction.cpp
@@ -7,13 +7,12 @@
  *
  */
 
-#include <gtest/gtest.h>
-
 #include <vector>
 #include <memory>
 
-#include "GEOObjects.h"
+#include <gtest/gtest.h>
 
+#include "GeoLib/GEOObjects.h"
 #include "MeshLib/Mesh.h"
 #include "MeshLib/MeshGenerators/MeshGenerator.h"
 #include "NumLib/Function/LinearInterpolationAlongPolyline.h"


### PR DESCRIPTION
Now only the DataExplorer and SimpleTests take advantage of cmake's include_directories.