### PR TITLE
Add clang-format.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+---
+Language:        Cpp
+BasedOnStyle:    Google
+
+AccessModifierOffset: -4
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+BreakBeforeBraces: Allman
+IndentWidth:     4
+TabWidth:        4
+UseTab:          ForIndentation
+ExperimentalAutoDetectBinPacking: true
+Standard:        C++11


### PR DESCRIPTION
In consequence of ufz/ogs#799 a *suggested* .clang-format.
See http://clang.llvm.org/docs/ClangFormatStyleOptions.html for more options.

Fixes  ufz/ogs#799

See [available IDE / editor integrations](http://clang.llvm.org/docs/ClangFormat.html) or [this Sublime-plugin](https://packagecontrol.io/packages/Clang%20Format).