### PR TITLE
Avoid cmake error if there are git tags

### DIFF
--- a/scripts/cmake/CMakeSetup.cmake
+++ b/scripts/cmake/CMakeSetup.cmake
@@ -35,7 +35,7 @@ elseif(IS_SUBPROJECT)
 else()
 	GIT_GET_TAG(GIT_DESCRIBE)
 	if(GIT_DESCRIBE)
-		string(REGEX MATCH ^[0-9|\\.]* GIT_TAG ${GIT_DESCRIBE})
+		string(REGEX MATCH ^[0-9|\\.]+ GIT_TAG ${GIT_DESCRIBE})
 		set(OGS_VERSION ${GIT_TAG})
 
 		if(GIT_DESCRIBE MATCHES ".*-.*-.*")


### PR DESCRIPTION
I had a custom tag on the current commit. That made cmake raise the error message:
```
CMake Error at scripts/cmake/CMakeSetup.cmake:38 (string):
  string sub-command REGEX, mode MATCH regex "^[0-9|\.]*" matched an empty
  string.
Call Stack (most recent call first):
  CMakeLists.txt:25 (include)
```
I hope, this commit prevents the cmake error. I don't know, however, if there are related issues with cmake parsing git commits in our setup.