### PR TITLE
Added function for shape matrix interpolation.

### DIFF
--- a/NumLib/Function/Interpolation.h
+++ b/NumLib/Function/Interpolation.h
@@ -1,0 +1,43 @@
+#ifndef NUMLIB_INTERPOLATION_H
+#define NUMLIB_INTERPOLATION_H
+
+namespace NumLib
+{
+
+/**
+ * Interpolates variables given at element nodes according to the given shape matrix.
+ *
+ * This function simply does the usual finite-element interpolation, i.e. multiplication
+ * of nodal values with the shape function.
+ *
+ * @param nodal_values   vector of nodal values
+ * @param shape_matrix_N shape matrix of the point to which will be interpolated
+ * @param num_nodal_dof  number of nodal variables that will be interpolated
+ * @param interpolated_values array of addresses to which the interpolated values will be written
+ *
+ * The size of interpolated_values must be equal to num_nodal_dof.
+ */
+template<typename NodalValues, typename ShapeMatrix>
+void shapeFunctionInterpolate(
+        const NodalValues& nodal_values,
+        const ShapeMatrix& shape_matrix_N,
+        const unsigned num_nodal_dof,
+        double** interpolated_values
+        )
+{
+    auto const num_nodes = shape_matrix_N.size();
+
+    for (unsigned d=0; d<num_nodal_dof; ++d)
+    {
+        *interpolated_values[d] = 0.0;
+
+        for (unsigned n=0; n<num_nodes; ++n)
+        {
+            *interpolated_values[d] += nodal_values[d*num_nodes+n] * shape_matrix_N(n);
+        }
+    }
+}
+
+}
+
+#endif // NUMLIB_INTERPOLATION_H

--- a/NumLib/Function/Interpolation.h
+++ b/NumLib/Function/Interpolation.h
@@ -11,6 +11,7 @@
 #define NUMLIB_INTERPOLATION_H
 
 #include<array>
+#include<cassert>
 
 namespace NumLib
 {
@@ -34,13 +35,15 @@ void shapeFunctionInterpolate(
 {
     auto const num_nodes = shape_matrix_N.size();
 
+    assert(num_nodes*NodalDOF == nodal_values.size());
+
     for (unsigned d=0; d<NodalDOF; ++d)
     {
         *interpolated_values[d] = 0.0;
 
         for (unsigned n=0; n<num_nodes; ++n)
         {
-            *interpolated_values[d] += nodal_values[d*num_nodes+n] * shape_matrix_N(n);
+            *interpolated_values[d] += nodal_values[d*num_nodes+n] * shape_matrix_N[n];
         }
     }
 }

--- a/NumLib/Function/Interpolation.h
+++ b/NumLib/Function/Interpolation.h
@@ -10,6 +10,8 @@
 #ifndef NUMLIB_INTERPOLATION_H
 #define NUMLIB_INTERPOLATION_H
 
+#include<array>
+
 namespace NumLib
 {
 
@@ -19,24 +21,20 @@ namespace NumLib
  * This function simply does the usual finite-element interpolation, i.e. multiplication
  * of nodal values with the shape function.
  *
- * @param nodal_values   vector of nodal values
+ * @param nodal_values   vector of nodal values, ordered by component
  * @param shape_matrix_N shape matrix of the point to which will be interpolated
- * @param num_nodal_dof  number of nodal variables that will be interpolated
  * @param interpolated_values array of addresses to which the interpolated values will be written
- *
- * The size of interpolated_values must be equal to num_nodal_dof.
  */
-template<typename NodalValues, typename ShapeMatrix>
+template<typename NodalValues, typename ShapeMatrix, std::size_t NodalDOF>
 void shapeFunctionInterpolate(
         const NodalValues& nodal_values,
         const ShapeMatrix& shape_matrix_N,
-        const unsigned num_nodal_dof,
-        double** interpolated_values
+        std::array<double*, NodalDOF> interpolated_values
         )
 {
     auto const num_nodes = shape_matrix_N.size();
 
-    for (unsigned d=0; d<num_nodal_dof; ++d)
+    for (unsigned d=0; d<NodalDOF; ++d)
     {
         *interpolated_values[d] = 0.0;
 

--- a/NumLib/Function/Interpolation.h
+++ b/NumLib/Function/Interpolation.h
@@ -1,3 +1,12 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
 #ifndef NUMLIB_INTERPOLATION_H
 #define NUMLIB_INTERPOLATION_H
 

--- a/NumLib/Function/Interpolation.h
+++ b/NumLib/Function/Interpolation.h
@@ -37,11 +37,11 @@ void shapeFunctionInterpolate(
 
     assert(num_nodes*NodalDOF == nodal_values.size());
 
-    for (unsigned d=0; d<NodalDOF; ++d)
+    for (auto d=decltype(NodalDOF){0}; d<NodalDOF; ++d)
     {
         *interpolated_values[d] = 0.0;
 
-        for (unsigned n=0; n<num_nodes; ++n)
+        for (auto n=decltype(num_nodes){0}; n<num_nodes; ++n)
         {
             *interpolated_values[d] += nodal_values[d*num_nodes+n] * shape_matrix_N[n];
         }

--- a/Tests/NumLib/TestFunctionInterpolation.cpp
+++ b/Tests/NumLib/TestFunctionInterpolation.cpp
@@ -21,8 +21,6 @@
 
 #include "NumLib/Fem/Integration/GaussIntegrationPolicy.h"
 
-#include <iostream>
-
 
 TEST(NumLibFunctionInterpolationTest, TwoVariablesTwoNodes)
 {

--- a/Tests/NumLib/TestFunctionInterpolation.cpp
+++ b/Tests/NumLib/TestFunctionInterpolation.cpp
@@ -1,0 +1,33 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+
+#include "NumLib/Function/Interpolation.h"
+
+TEST(NumLibFunctionInterpolationTest, TwoVariablesTwoNodes)
+{
+    double v1 = 0.0, v2 = 0.0;
+    std::array<double*, 2> interpolated_values = { &v1, &v2 };
+
+    const std::array<double, 4> nodal_values = {
+        0.0, 1.0, // v1
+        -1.0, 1.0  // v2
+    };
+
+    const std::array<double, 2> shape_matrix = { 0.25, 0.75 };
+
+    NumLib::shapeFunctionInterpolate(nodal_values, shape_matrix,
+                                     interpolated_values);
+
+    ASSERT_EQ(0.75, v1);
+    ASSERT_EQ(0.5,  v2);
+}
+

--- a/Tests/NumLib/TestFunctionInterpolation.cpp
+++ b/Tests/NumLib/TestFunctionInterpolation.cpp
@@ -12,14 +12,27 @@
 
 #include "NumLib/Function/Interpolation.h"
 
+#include "NumLib/Fem/FiniteElement/TemplateIsoparametric.h"
+#include "NumLib/Fem/ShapeFunction/ShapeLine2.h"
+
+#include "NumLib/Fem/ShapeMatrixPolicy.h"
+
+#include "MeshLib/Elements/Element.h"
+
+#include "NumLib/Fem/Integration/GaussIntegrationPolicy.h"
+
+#include <iostream>
+
+
 TEST(NumLibFunctionInterpolationTest, TwoVariablesTwoNodes)
 {
-    double v1 = 0.0, v2 = 0.0;
-    std::array<double*, 2> interpolated_values = { &v1, &v2 };
+    double variable1 = 0.0;
+    double variable2 = 0.0;
+    std::array<double*, 2> interpolated_values = { &variable1, &variable2 };
 
     const std::array<double, 4> nodal_values = {
-        0.0, 1.0, // v1
-        -1.0, 1.0  // v2
+        0.0, 1.0, // for variable1
+        -1.0, 1.0  // for variable2
     };
 
     const std::array<double, 2> shape_matrix = { 0.25, 0.75 };
@@ -27,7 +40,61 @@ TEST(NumLibFunctionInterpolationTest, TwoVariablesTwoNodes)
     NumLib::shapeFunctionInterpolate(nodal_values, shape_matrix,
                                      interpolated_values);
 
-    ASSERT_EQ(0.75, v1);
-    ASSERT_EQ(0.5,  v2);
+    ASSERT_EQ(0.75, variable1);
+    ASSERT_EQ(0.5,  variable2);
 }
+
+
+TEST(NumLibFunctionInterpolationTest, Linear1DElement)
+{
+    // typedefs
+    using ShapeFunction = NumLib::ShapeLine2;
+    using ShapeMatricesType = ShapeMatrixPolicyType<ShapeFunction, 1u>;
+
+    using FemType = NumLib::TemplateIsoparametric<ShapeFunction, ShapeMatricesType>;
+
+    using IntegrationMethod = NumLib::GaussIntegrationPolicy<
+        ShapeFunction::MeshElement>::IntegrationMethod;
+
+    // set up mesh element
+    auto pt_a = MeshLib::Node({ 0.0, 0.0, 0.0 }, 0);
+    auto pt_b = MeshLib::Node({ 1.0, 0.0, 0.0 }, 0);
+
+    auto const element = MeshLib::Line(std::array<MeshLib::Node*, 2>{
+                                           &pt_a, &pt_b
+                                       }, 0u, 0u);
+
+    // set up shape function
+    FemType finite_element(*static_cast<const typename ShapeFunction::MeshElement*>(&element));
+
+    const unsigned integration_order = 2;
+    IntegrationMethod integration_method(integration_order);
+
+    ShapeMatricesType::ShapeMatrices shape_matrix;
+
+    finite_element.computeShapeFunctions(
+            integration_method.getWeightedPoint(0).getCoords(),
+            shape_matrix);
+    ASSERT_EQ(2, shape_matrix.N.size());
+
+    // actual test
+    double variable1 = 0.0;
+    double variable2 = 0.0;
+    std::array<double*, 2> interpolated_values = { &variable1, &variable2 };
+
+    const std::array<double, 4> nodal_values = {
+        0.0, 1.0, // for variable1
+        -1.0, 1.0  // for variable2
+    };
+
+    NumLib::shapeFunctionInterpolate(nodal_values, shape_matrix.N,
+                                     interpolated_values);
+
+    const double n0 = shape_matrix.N[0];
+    const double n1 = shape_matrix.N[1];
+
+    ASSERT_EQ( 0.0 * n0 + 1.0 * n1, variable1);
+    ASSERT_EQ(-1.0 * n0 + 1.0 * n1, variable2);
+}
+
 

--- a/Tests/NumLib/TestFunctionInterpolation.cpp
+++ b/Tests/NumLib/TestFunctionInterpolation.cpp
@@ -65,7 +65,7 @@ TEST(NumLibFunctionInterpolationTest, Linear1DElement)
                                        }, 0u, 0u);
 
     // set up shape function
-    FemType finite_element(*static_cast<const typename ShapeFunction::MeshElement*>(&element));
+    FemType finite_element(*static_cast<const ShapeFunction::MeshElement*>(&element));
 
     const unsigned integration_order = 2;
     IntegrationMethod integration_method(integration_order);


### PR DESCRIPTION
The provided function implements the usual shape matrix interpolation of nodal values to integration points. It can be used, e.g. in any local assembly where matrix coefficients depend on the value of the unknowns.