### PR TITLE
Initial conditions

### DIFF
--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -78,8 +78,13 @@ public:
     LineIndex rowIndices(std::size_t const mesh_item_id) const;
     LineIndex columnIndices(std::size_t const mesh_item_id) const;
 
-private:
+    std::size_t getGlobalIndex(MeshLib::Location const& l,
+                               std::size_t const c) const
+    {
+        return _mesh_component_map.getGlobalIndex(l, c);
+    }
 
+private:
     /// Private constructor used by internally created local-to-global index
     /// maps. The mesh_component_map is passed as argument instead of being
     /// created by the constructor.

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -233,7 +233,8 @@ public:
         std::size_t const n = _mesh.getNNodes();
         for (std::size_t i = 0; i < n; ++i)
         {
-            MeshLib::Location l(_mesh.getID(), MeshLib::MeshItemType::Node, i);
+            MeshLib::Location const l(_mesh.getID(),
+                                      MeshLib::MeshItemType::Node, i);
             std::size_t const global_index =
                 _local_to_global_index_map->getGlobalIndex(
                     l, 0);  // 0 is the component id.

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -216,6 +216,8 @@ public:
         _x.reset(_global_setup.createVector(_local_to_global_index_map->dofSize()));
         _rhs.reset(_global_setup.createVector(_local_to_global_index_map->dofSize()));
 
+        setInitialConditions(*_hydraulic_head);
+
         if (_mesh.getDimension()==1)
             createLocalAssemblers<1>();
         else if (_mesh.getDimension()==2)
@@ -224,6 +226,20 @@ public:
             createLocalAssemblers<3>();
         else
             assert(false);
+    }
+
+    void setInitialConditions(ProcessVariable const& variable)
+    {
+        std::size_t const n = _mesh.getNNodes();
+        for (std::size_t i = 0; i < n; ++i)
+        {
+            MeshLib::Location l(_mesh.getID(), MeshLib::MeshItemType::Node, i);
+            std::size_t const global_index =
+                _local_to_global_index_map->getGlobalIndex(
+                    l, 0);  // 0 is the component id.
+            _x->set(global_index,
+                   variable.getInitialConditionValue(*_mesh.getNode(i)));
+        }
     }
 
     void solve()

--- a/ProcessLib/InitialCondition.cpp
+++ b/ProcessLib/InitialCondition.cpp
@@ -1,0 +1,39 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "InitialCondition.h"
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/optional.hpp>
+#include <logog/include/logog.hpp>
+
+#include "MathLib/Point3d.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Mesh.h"
+
+namespace ProcessLib
+{
+using ConfigTree = boost::property_tree::ptree;
+
+std::unique_ptr<InitialCondition> createUniformInitialCondition(
+    ConfigTree const& config)
+{
+	auto value = config.get_optional<double>("value");
+	if (!value)
+	{
+		ERR("Could not find required parameter value.");
+		std::abort();
+	}
+	DBUG("Using value %g", *value);
+
+	return std::unique_ptr<InitialCondition>(
+	    new UniformInitialCondition(*value));
+}
+
+}  // namespace ProcessLib

--- a/ProcessLib/InitialCondition.cpp
+++ b/ProcessLib/InitialCondition.cpp
@@ -36,4 +36,34 @@ std::unique_ptr<InitialCondition> createUniformInitialCondition(
 	    new UniformInitialCondition(*value));
 }
 
+std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
+    ConfigTree const& config, MeshLib::Mesh const& mesh)
+{
+	auto field_name = config.get_optional<std::string>("field_name");
+	if (!field_name)
+	{
+		ERR("Could not find required parameter field_name.");
+		std::abort();
+	}
+	DBUG("Using field_name %s", field_name->c_str());
+
+	if (!mesh.getProperties().hasPropertyVector(*field_name))
+	{
+		ERR("The required property %s does not exists in the mesh.",
+		    field_name->c_str());
+		std::abort();
+	}
+	auto const& property =
+	    mesh.getProperties().template getPropertyVector<double>(*field_name);
+	if (!property)
+	{
+		ERR("The required property %s is not of the requested type.",
+		    field_name->c_str());
+		std::abort();
+	}
+
+	return std::unique_ptr<InitialCondition>(
+	    new MeshPropertyInitialCondition(*property));
+}
+
 }  // namespace ProcessLib

--- a/ProcessLib/InitialCondition.h
+++ b/ProcessLib/InitialCondition.h
@@ -17,12 +17,15 @@
 
 namespace ProcessLib
 {
+/// The InitialCondition is a base class for spatial distributions of values
+/// defined on mesh nodes.
 class InitialCondition
 {
 public:
 	virtual ~InitialCondition() = default;
 };
 
+/// Uniform value initial condition
 class UniformInitialCondition : public InitialCondition
 {
 	using ConfigTree = boost::property_tree::ptree;

--- a/ProcessLib/InitialCondition.h
+++ b/ProcessLib/InitialCondition.h
@@ -50,10 +50,9 @@ private:
 	double _value;
 };
 
-using ConfigTree = boost::property_tree::ptree;
 /// Construct a UniformInitialCondition from configuration.
 std::unique_ptr<InitialCondition> createUniformInitialCondition(
-    ConfigTree const& config);
+    boost::property_tree::ptree const& config);
 
 /// Distribution of values given by a mesh property defined on nodes.
 class MeshPropertyInitialCondition : public InitialCondition
@@ -77,7 +76,7 @@ private:
 
 /// Construct a MeshPropertyInitialCondition from configuration.
 std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
-    ConfigTree const& config, MeshLib::Mesh const& mesh);
+    boost::property_tree::ptree const& config, MeshLib::Mesh const& mesh);
 
 }  // namespace ProcessLib
 

--- a/ProcessLib/InitialCondition.h
+++ b/ProcessLib/InitialCondition.h
@@ -10,9 +10,17 @@
 #ifndef PROCESS_LIB_INITIAL_CONDITION_H_
 #define PROCESS_LIB_INITIAL_CONDITION_H_
 
+#include <cassert>
 #include <boost/property_tree/ptree_fwd.hpp>
 #include "MeshLib/Node.h"
 #include "MeshLib/PropertyVector.h"
+
+namespace MeshLib
+{
+template <typename>
+class PropertyVector;
+class Mesh;
+}
 
 namespace ProcessLib
 {
@@ -46,6 +54,30 @@ using ConfigTree = boost::property_tree::ptree;
 /// Construct a UniformInitialCondition from configuration.
 std::unique_ptr<InitialCondition> createUniformInitialCondition(
     ConfigTree const& config);
+
+/// Distribution of values given by a mesh property defined on nodes.
+class MeshPropertyInitialCondition : public InitialCondition
+{
+public:
+	MeshPropertyInitialCondition(
+	    MeshLib::PropertyVector<double> const& property)
+	    : _property(property)
+	{
+		assert(_property.getMeshItemType() == MeshLib::MeshItemType::Node);
+	}
+
+	virtual double getValue(MeshLib::Node const& n) const override
+	{
+		return _property[n.getID()];
+	}
+
+private:
+	MeshLib::PropertyVector<double> const& _property;
+};
+
+/// Construct a MeshPropertyInitialCondition from configuration.
+std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
+    ConfigTree const& config, MeshLib::Mesh const& mesh);
 
 }  // namespace ProcessLib
 

--- a/ProcessLib/InitialCondition.h
+++ b/ProcessLib/InitialCondition.h
@@ -10,11 +10,9 @@
 #ifndef PROCESS_LIB_INITIAL_CONDITION_H_
 #define PROCESS_LIB_INITIAL_CONDITION_H_
 
-#include <boost/property_tree/ptree.hpp>
-#include "logog/include/logog.hpp"
-
-#include "MeshLib/Mesh.h"
+#include <boost/property_tree/ptree_fwd.hpp>
 #include "MeshLib/Node.h"
+#include "MeshLib/PropertyVector.h"
 
 namespace ProcessLib
 {
@@ -30,15 +28,9 @@ public:
 /// Uniform value initial condition
 class UniformInitialCondition : public InitialCondition
 {
-	using ConfigTree = boost::property_tree::ptree;
-
 public:
-	UniformInitialCondition(ConfigTree const& config)
+	UniformInitialCondition(double const value) : _value(value)
 	{
-		DBUG("Constructing Uniform initial condition");
-
-		_value = config.get<double>("value", 0);
-		DBUG("Read value %g", _value);
 	}
 
 	virtual double getValue(MeshLib::Node const&) const override
@@ -49,6 +41,11 @@ public:
 private:
 	double _value;
 };
+
+using ConfigTree = boost::property_tree::ptree;
+/// Construct a UniformInitialCondition from configuration.
+std::unique_ptr<InitialCondition> createUniformInitialCondition(
+    ConfigTree const& config);
 
 }  // namespace ProcessLib
 

--- a/ProcessLib/InitialCondition.h
+++ b/ProcessLib/InitialCondition.h
@@ -17,31 +17,29 @@
 
 namespace ProcessLib
 {
-
 class InitialCondition
 {
 public:
-    virtual ~InitialCondition() = default;
+	virtual ~InitialCondition() = default;
 };
-
 
 class UniformInitialCondition : public InitialCondition
 {
-    using ConfigTree = boost::property_tree::ptree;
-public:
-    UniformInitialCondition(ConfigTree const& config)
-    {
-        DBUG("Constructing Uniform initial condition");
+	using ConfigTree = boost::property_tree::ptree;
 
-        _value = config.get<double>("value", 0);
-        DBUG("Read value %g", _value);
-    }
+public:
+	UniformInitialCondition(ConfigTree const& config)
+	{
+		DBUG("Constructing Uniform initial condition");
+
+		_value = config.get<double>("value", 0);
+		DBUG("Read value %g", _value);
+	}
 
 private:
-    double _value;
+	double _value;
 };
 
-
-}   // namespace ProcessLib
+}  // namespace ProcessLib
 
 #endif  // PROCESS_LIB_INITIAL_CONDITION_H_

--- a/ProcessLib/InitialCondition.h
+++ b/ProcessLib/InitialCondition.h
@@ -14,6 +14,7 @@
 #include "logog/include/logog.hpp"
 
 #include "MeshLib/Mesh.h"
+#include "MeshLib/Node.h"
 
 namespace ProcessLib
 {
@@ -23,6 +24,7 @@ class InitialCondition
 {
 public:
 	virtual ~InitialCondition() = default;
+	virtual double getValue(MeshLib::Node const&) const = 0;
 };
 
 /// Uniform value initial condition
@@ -37,6 +39,11 @@ public:
 
 		_value = config.get<double>("value", 0);
 		DBUG("Read value %g", _value);
+	}
+
+	virtual double getValue(MeshLib::Node const&) const override
+	{
+		return _value;
 	}
 
 private:

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -37,8 +37,8 @@ ProcessVariable::ProcessVariable(ConfigTree const& config,
 		    config.get<std::string>("initial_condition.type");
 		if (type == "Uniform")
 		{
-			_initial_condition.reset(
-			    new UniformInitialCondition(ic_config->second));
+			_initial_condition =
+			    createUniformInitialCondition(ic_config->second);
 		}
 		else
 		{

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -18,81 +18,76 @@
 #include "UniformDirichletBoundaryCondition.h"
 #include "InitialCondition.h"
 
-
 namespace ProcessLib
 {
-
-ProcessVariable::ProcessVariable(
-    ConfigTree const& config,
-    MeshLib::Mesh const& mesh,
-    GeoLib::GEOObjects const& geometries)
-    : _name(config.get<std::string>("name")),
-      _mesh(mesh)
+ProcessVariable::ProcessVariable(ConfigTree const& config,
+                                 MeshLib::Mesh const& mesh,
+                                 GeoLib::GEOObjects const& geometries)
+    : _name(config.get<std::string>("name")), _mesh(mesh)
 {
-    DBUG("Constructing process variable %s", this->_name.c_str());
+	DBUG("Constructing process variable %s", this->_name.c_str());
 
-    // Initial condition
-    {
-        auto const& ic_config = config.find("initial_condition");
-        if (ic_config == config.not_found())
-            INFO("No initial condition found.");
+	// Initial condition
+	{
+		auto const& ic_config = config.find("initial_condition");
+		if (ic_config == config.not_found())
+			INFO("No initial condition found.");
 
+		std::string const type =
+		    config.get<std::string>("initial_condition.type");
+		if (type == "Uniform")
+		{
+			_initial_condition.reset(
+			    new UniformInitialCondition(ic_config->second));
+		}
+		else
+		{
+			ERR("Unknown type of the initial condition.");
+		}
+	}
 
-        std::string const type =
-            config.get<std::string>("initial_condition.type");
-        if (type == "Uniform")
-        {
-            _initial_condition.reset(new UniformInitialCondition(ic_config->second));
-        }
-        else
-        {
-            ERR("Unknown type of the initial condition.");
-        }
-    }
+	// Boundary conditions
+	{
+		auto const& bcs_config = config.find("boundary_conditions");
+		if (bcs_config == config.not_found())
+			INFO("No boundary conditions found.");
 
-    // Boundary conditions
-    {
-        auto const& bcs_config = config.find("boundary_conditions");
-        if (bcs_config == config.not_found())
-            INFO("No boundary conditions found.");
+		for (auto const& bc_iterator : bcs_config->second)
+		{
+			ConfigTree const& bc_config = bc_iterator.second;
 
-        for (auto const& bc_iterator : bcs_config->second)
-        {
-            ConfigTree const& bc_config = bc_iterator.second;
+			// Find corresponding GeoObject
+			std::string const geometrical_set_name =
+			    bc_config.get<std::string>("geometrical_set");
+			std::string const geometry_name =
+			    bc_config.get<std::string>("geometry");
 
-            // Find corresponding GeoObject
-            std::string const geometrical_set_name =
-                bc_config.get<std::string>("geometrical_set");
-            std::string const geometry_name =
-                bc_config.get<std::string>("geometry");
+			GeoLib::GeoObject const* const geometry =
+			    geometries.getGeoObject(geometrical_set_name, geometry_name);
+			DBUG(
+			    "Found geometry type \"%s\"",
+			    GeoLib::convertGeoTypeToString(geometry->getGeoType()).c_str());
 
-            GeoLib::GeoObject const* const geometry = geometries.getGeoObject(
-                    geometrical_set_name, geometry_name);
-            DBUG("Found geometry type \"%s\"",
-                GeoLib::convertGeoTypeToString(geometry->getGeoType()).c_str());
+			// Construct type dependent boundary condition
+			std::string const type = bc_config.get<std::string>("type");
 
-            // Construct type dependent boundary condition
-            std::string const type = bc_config.get<std::string>("type");
-
-            if (type == "UniformDirichlet")
-            {
-                _dirichlet_bcs.emplace_back(
-                    new UniformDirichletBoundaryCondition(
-                        geometry, bc_config));
-            }
-            else if (type == "UniformNeumann")
-            {
-                _neumann_bc_configs.emplace_back(
-                    new NeumannBcConfig(geometry, bc_config));
-            }
-            else
-            {
-                ERR("Unknown type \'%s\' of the boundary condition.",
-                        type.c_str());
-            }
-        }
-
-    }
+			if (type == "UniformDirichlet")
+			{
+				_dirichlet_bcs.emplace_back(
+				    new UniformDirichletBoundaryCondition(geometry, bc_config));
+			}
+			else if (type == "UniformNeumann")
+			{
+				_neumann_bc_configs.emplace_back(
+				    new NeumannBcConfig(geometry, bc_config));
+			}
+			else
+			{
+				ERR("Unknown type \'%s\' of the boundary condition.",
+				    type.c_str());
+			}
+		}
+	}
 }
 
 ProcessVariable::ProcessVariable(ProcessVariable&& other)
@@ -101,24 +96,25 @@ ProcessVariable::ProcessVariable(ProcessVariable&& other)
       _initial_condition(std::move(other._initial_condition)),
       _dirichlet_bcs(std::move(other._dirichlet_bcs)),
       _neumann_bc_configs(std::move(other._neumann_bc_configs))
-{}
+{
+}
 
 std::string const& ProcessVariable::getName() const
 {
-    return _name;
+	return _name;
 }
 
 MeshLib::Mesh const& ProcessVariable::getMesh() const
 {
-    return _mesh;
+	return _mesh;
 }
 
 void ProcessVariable::initializeDirichletBCs(
     MeshGeoToolsLib::MeshNodeSearcher& searcher,
     std::vector<std::size_t>& global_ids, std::vector<double>& values)
 {
-    for (auto& bc : _dirichlet_bcs)
-        bc->initialize(searcher, global_ids, values);
+	for (auto& bc : _dirichlet_bcs)
+		bc->initialize(searcher, global_ids, values);
 }
 
-}   // namespace ProcessLib
+}  // namespace ProcessLib

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -40,6 +40,11 @@ ProcessVariable::ProcessVariable(ConfigTree const& config,
 			_initial_condition =
 			    createUniformInitialCondition(ic_config->second);
 		}
+		if (type == "MeshProperty")
+		{
+			_initial_condition =
+			    createMeshPropertyInitialCondition(ic_config->second, _mesh);
+		}
 		else
 		{
 			ERR("Unknown type of the initial condition.");

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -18,71 +18,73 @@
 
 namespace MeshGeoToolsLib
 {
-    class MeshNodeSearcher;
-    class BoundaryElementsSearcher;
+class MeshNodeSearcher;
+class BoundaryElementsSearcher;
 }
 
 namespace MeshLib
 {
-    class Mesh;
+class Mesh;
 }
 
 namespace GeoLib
 {
-    class GEOObjects;
+class GEOObjects;
 }
 
 namespace ProcessLib
 {
-    class NeumannBcConfig;
-    class InitialCondition;
-    class UniformDirichletBoundaryCondition;
+class NeumannBcConfig;
+class InitialCondition;
+class UniformDirichletBoundaryCondition;
 }
 
 namespace ProcessLib
 {
-
 /// A named process variable. Its properties includes the mesh, and the initial
 /// and boundary conditions.
 class ProcessVariable
 {
-    using ConfigTree = boost::property_tree::ptree;
+	using ConfigTree = boost::property_tree::ptree;
 
 public:
-    ProcessVariable(ConfigTree const& config, MeshLib::Mesh const& mesh,
-            GeoLib::GEOObjects const& geometries);
+	ProcessVariable(ConfigTree const& config, MeshLib::Mesh const& mesh,
+	                GeoLib::GEOObjects const& geometries);
 
-    ProcessVariable(ProcessVariable&&);
+	ProcessVariable(ProcessVariable&&);
 
-    std::string const& getName() const;
+	std::string const& getName() const;
 
-    /// Returns a mesh on which the process variable is defined.
-    MeshLib::Mesh const& getMesh() const;
+	/// Returns a mesh on which the process variable is defined.
+	MeshLib::Mesh const& getMesh() const;
 
-    void initializeDirichletBCs(MeshGeoToolsLib::MeshNodeSearcher& searcher,
-            std::vector<std::size_t>& global_ids, std::vector<double>& values);
+	void initializeDirichletBCs(MeshGeoToolsLib::MeshNodeSearcher& searcher,
+	                            std::vector<std::size_t>& global_ids,
+	                            std::vector<double>& values);
 
-    template <typename OutputIterator, typename GlobalSetup, typename ...Args>
-    void createNeumannBcs(OutputIterator bcs,
-        MeshGeoToolsLib::BoundaryElementsSearcher& searcher,
-        GlobalSetup const&,
-        Args&&... args)
-    {
-        for (auto& config : _neumann_bc_configs)
-        {
-            config->initialize(searcher);
-            bcs = new NeumannBc<GlobalSetup>(*config, std::forward<Args>(args)...);
-        }
-    }
+	template <typename OutputIterator, typename GlobalSetup, typename... Args>
+	void createNeumannBcs(OutputIterator bcs,
+	                      MeshGeoToolsLib::BoundaryElementsSearcher& searcher,
+	                      GlobalSetup const&,
+	                      Args&&... args)
+	{
+		for (auto& config : _neumann_bc_configs)
+		{
+			config->initialize(searcher);
+			bcs = new NeumannBc<GlobalSetup>(*config,
+			                                 std::forward<Args>(args)...);
+		}
+	}
 
 private:
-    std::string const _name;
-    MeshLib::Mesh const& _mesh;
-    std::unique_ptr<InitialCondition> _initial_condition;
-    std::vector<std::unique_ptr<UniformDirichletBoundaryCondition> > _dirichlet_bcs;
-    std::vector<std::unique_ptr<NeumannBcConfig> > _neumann_bc_configs;
+	std::string const _name;
+	MeshLib::Mesh const& _mesh;
+	std::unique_ptr<InitialCondition> _initial_condition;
+	std::vector<std::unique_ptr<UniformDirichletBoundaryCondition>>
+	    _dirichlet_bcs;
+	std::vector<std::unique_ptr<NeumannBcConfig>> _neumann_bc_configs;
 };
 
-}   // namespace ProcessLib
+}  // namespace ProcessLib
 
 #endif  // PROCESS_LIB_PROCESS_VARIABLE_H_

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -25,6 +25,7 @@ class BoundaryElementsSearcher;
 namespace MeshLib
 {
 class Mesh;
+class Node;
 }
 
 namespace GeoLib
@@ -74,6 +75,11 @@ public:
 			bcs = new NeumannBc<GlobalSetup>(*config,
 			                                 std::forward<Args>(args)...);
 		}
+	}
+
+	double getInitialConditionValue(MeshLib::Node const& n) const
+	{
+		return _initial_condition->getValue(n);
 	}
 
 private:


### PR DESCRIPTION
This adds an initial condition handling to set the start vector for the linear solver.
Aside the uniform value a mesh property based initial condition is added; the latter allows one to reuse previous solutions.

There are three parts:
 - clang-format
 - Adding/moving InitialConditions code [middle four commits](https://github.com/endJunction/ogs/compare/a6ac6a1...496bb2c)
 - Using the initial conditions in GroundwaterFlowProcess [last three commits]
(https://github.com/endJunction/ogs/compare/496bb2c...InitialConditions)

*(The commits below are ordered differently)*