### PR TITLE
Quicksort: fix error.

### DIFF
--- a/BaseLib/quicksort.h
+++ b/BaseLib/quicksort.h
@@ -77,7 +77,7 @@ void quicksort(std::vector<T1*>& array, std::size_t beg, std::size_t end, std::v
 }
 
 template <typename T1, typename T2 = std::size_t>
-void quicksort(T1* & array, std::size_t beg, std::size_t end, T2* & perm)
+void quicksort(T1* array, std::size_t beg, std::size_t end, T2* perm)
 {
 	// Zip input arrays.
 	std::vector<std::pair<T1, T2>> data;
@@ -103,6 +103,7 @@ void quicksort(T1* & array, std::size_t beg, std::size_t end, T2* & perm)
 		perm[beg+i] = data[i].second;
 	}
 }
+
 } // end namespace BaseLib
 
 #endif /* QUICKSORT_H_ */

--- a/BaseLib/quicksort.h
+++ b/BaseLib/quicksort.h
@@ -25,8 +25,8 @@ void quicksort(std::vector<T1>& array, std::size_t beg, std::size_t end, std::ve
 {
 	// Zip input arrays.
 	std::vector<std::pair<T1, T2>> data;
-	data.reserve(array.size());
-	std::transform(array.begin(), array.end(), perm.begin(),
+	data.reserve(end-beg);
+	std::transform(array.begin()+beg, array.begin()+end, perm.begin()+beg,
 		std::back_inserter(data),
 		[](T1 const& t1, T2 const& t2)
 		{
@@ -41,10 +41,10 @@ void quicksort(std::vector<T1>& array, std::size_t beg, std::size_t end, std::ve
 		});
 
 	// Unzip sorted data.
-	for (std::size_t i = 0; i < data.size(); i++)
+	for (std::size_t i = beg; i < end; i++)
 	{
-		array[i] = data[i].first;
-		perm[i] = data[i].second;
+		array[i] = data[i-beg].first;
+		perm[i] = data[i-beg].second;
 	}
 }
 
@@ -53,8 +53,8 @@ void quicksort(std::vector<T1*>& array, std::size_t beg, std::size_t end, std::v
 {
 	// Zip input arrays.
 	std::vector<std::pair<T1*, T2>> data;
-	data.reserve(array.size());
-	std::transform(array.begin(), array.end(), perm.begin(),
+	data.reserve(end-beg);
+	std::transform(array.begin()+beg, array.begin()+(end-beg), perm.begin()+beg,
 		std::back_inserter(data),
 		[](T1* const& t1, T2 const& t2)
 		{
@@ -71,8 +71,8 @@ void quicksort(std::vector<T1*>& array, std::size_t beg, std::size_t end, std::v
 	// Unzip sorted data.
 	for (std::size_t i = 0; i < data.size(); i++)
 	{
-		array[i] = data[i].first;
-		perm[i] = data[i].second;
+		array[beg+i] = data[i].first;
+		perm[beg+i] = data[i].second;
 	}
 }
 
@@ -82,7 +82,7 @@ void quicksort(T1* & array, std::size_t beg, std::size_t end, T2* & perm)
 	// Zip input arrays.
 	std::vector<std::pair<T1, T2>> data;
 	data.reserve(end-beg);
-	std::transform(array+beg, array+(end-beg), perm+beg,
+	std::transform(array+beg, array+end, perm+beg,
 		std::back_inserter(data),
 		[](T1 const& t1, T2 const& t2)
 		{

--- a/BaseLib/quicksort.h
+++ b/BaseLib/quicksort.h
@@ -21,6 +21,34 @@ namespace BaseLib
 {
 
 template <typename T1, typename T2 = std::size_t>
+void quicksort(T1* array, std::size_t beg, std::size_t end, T2* perm)
+{
+	// Zip input arrays.
+	std::vector<std::pair<T1, T2>> data;
+	data.reserve(end-beg);
+	std::transform(array+beg, array+(end-beg), perm+beg,
+		std::back_inserter(data),
+		[](T1 const& t1, T2 const& t2)
+		{
+			return std::make_pair(t1, t2);
+		});
+
+	// Sort data using first element of the pair.
+	std::sort(data.begin(), data.end(),
+		[](std::pair<T1, T2> const& a, std::pair<T1, T2> const& b)
+		{
+			return (a.first < b.first);
+		});
+
+	// Unzip sorted data.
+	for (std::size_t i = 0; i < data.size(); i++)
+	{
+		array[beg+i] = data[i].first;
+		perm[beg+i] = data[i].second;
+	}
+}
+
+template <typename T1, typename T2 = std::size_t>
 void quicksort(std::vector<T1>& array, std::size_t beg, std::size_t end, std::vector<T2>& perm)
 {
 	quicksort(array.data(), beg, end, perm.data());
@@ -44,34 +72,6 @@ void quicksort(std::vector<T1*>& array, std::size_t beg, std::size_t end, std::v
 		[](std::pair<T1*, T2> const& a, std::pair<T1*, T2> const& b)
 		{
 			return (*a.first < *b.first);
-		});
-
-	// Unzip sorted data.
-	for (std::size_t i = 0; i < data.size(); i++)
-	{
-		array[beg+i] = data[i].first;
-		perm[beg+i] = data[i].second;
-	}
-}
-
-template <typename T1, typename T2 = std::size_t>
-void quicksort(T1* array, std::size_t beg, std::size_t end, T2* perm)
-{
-	// Zip input arrays.
-	std::vector<std::pair<T1, T2>> data;
-	data.reserve(end-beg);
-	std::transform(array+beg, array+end, perm+beg,
-		std::back_inserter(data),
-		[](T1 const& t1, T2 const& t2)
-		{
-			return std::make_pair(t1, t2);
-		});
-
-	// Sort data using first element of the pair.
-	std::sort(data.begin(), data.end(),
-		[](std::pair<T1, T2> const& a, std::pair<T1, T2> const& b)
-		{
-			return (a.first < b.first);
 		});
 
 	// Unzip sorted data.

--- a/BaseLib/quicksort.h
+++ b/BaseLib/quicksort.h
@@ -13,6 +13,7 @@
 #define QUICKSORT_H_
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <iterator>
 #include <vector>
@@ -20,9 +21,12 @@
 namespace BaseLib
 {
 
+/// @pre {end<=array.size() and perm.size()==array.size()}
 template <typename T1, typename T2 = std::size_t>
 void quicksort(T1* array, std::size_t beg, std::size_t end, T2* perm)
 {
+	assert (beg <= end);
+
 	// Zip input arrays.
 	std::vector<std::pair<T1, T2>> data;
 	data.reserve(end-beg);
@@ -51,12 +55,20 @@ void quicksort(T1* array, std::size_t beg, std::size_t end, T2* perm)
 template <typename T1, typename T2 = std::size_t>
 void quicksort(std::vector<T1>& array, std::size_t beg, std::size_t end, std::vector<T2>& perm)
 {
+	assert (beg<=end);
+	assert (end<=array.size());
+	assert (perm.size()==array.size());
+
 	quicksort(array.data(), beg, end, perm.data());
 }
 
 template <typename T1, typename T2 = std::size_t>
 void quicksort(std::vector<T1*>& array, std::size_t beg, std::size_t end, std::vector<T2>& perm)
 {
+	assert (beg<=end);
+	assert (end<=array.size());
+	assert (perm.size()==array.size());
+
 	// Zip input arrays.
 	std::vector<std::pair<T1*, T2>> data;
 	data.reserve(end-beg);

--- a/BaseLib/quicksort.h
+++ b/BaseLib/quicksort.h
@@ -23,29 +23,7 @@ namespace BaseLib
 template <typename T1, typename T2 = std::size_t>
 void quicksort(std::vector<T1>& array, std::size_t beg, std::size_t end, std::vector<T2>& perm)
 {
-	// Zip input arrays.
-	std::vector<std::pair<T1, T2>> data;
-	data.reserve(end-beg);
-	std::transform(array.begin()+beg, array.begin()+end, perm.begin()+beg,
-		std::back_inserter(data),
-		[](T1 const& t1, T2 const& t2)
-		{
-			return std::make_pair(t1, t2);
-		});
-
-	// Sort data using first element of the pair.
-	std::sort(data.begin(), data.end(),
-		[](std::pair<T1, T2> const& a, std::pair<T1, T2> const& b)
-		{
-			return (a.first < b.first);
-		});
-
-	// Unzip sorted data.
-	for (std::size_t i = beg; i < end; i++)
-	{
-		array[i] = data[i-beg].first;
-		perm[i] = data[i-beg].second;
-	}
+	quicksort(array.data(), beg, end, perm.data());
 }
 
 template <typename T1, typename T2 = std::size_t>


### PR DESCRIPTION
Quicksort sorts only the part [beg, end) of the array now.