### PR TITLE
Erase vtk filename extension from the base name.

### DIFF
--- a/FileIO/MPI_IO/NodePartitionedMeshReader.cpp
+++ b/FileIO/MPI_IO/NodePartitionedMeshReader.cpp
@@ -73,8 +73,8 @@ MeshLib::NodePartitionedMesh* NodePartitionedMeshReader::read(
     MeshLib::NodePartitionedMesh* mesh = nullptr;
 
     /// Prefix of the filename of the partitioned mesh files.
-    std::string filename_prefix = file_name_base;
-    boost::erase_last(filename_prefix, ".vtk");
+    std::string const filename_prefix =
+        boost::erase_last_copy(file_name_base, ".vtk");
 
     // Always try binary file first
     std::string const fname_new = filename_prefix + "_partitioned_msh_cfg" +

--- a/FileIO/MPI_IO/NodePartitionedMeshReader.cpp
+++ b/FileIO/MPI_IO/NodePartitionedMeshReader.cpp
@@ -15,6 +15,7 @@
 #include "NodePartitionedMeshReader.h"
 
 #include <logog/include/logog.hpp>
+#include <boost/algorithm/string/erase.hpp>
 
 #include "BaseLib/FileTools.h"
 #include "BaseLib/RunTime.h"
@@ -71,21 +72,25 @@ MeshLib::NodePartitionedMesh* NodePartitionedMeshReader::read(
 
     MeshLib::NodePartitionedMesh* mesh = nullptr;
 
+    /// Prefix of the filename of the partitioned mesh files.
+    std::string filename_prefix = file_name_base;
+    boost::erase_last(filename_prefix, ".vtk");
+
     // Always try binary file first
-    std::string const fname_new = file_name_base + "_partitioned_msh_cfg" +
+    std::string const fname_new = filename_prefix + "_partitioned_msh_cfg" +
         std::to_string(_mpi_comm_size) + ".bin";
 
     if(!BaseLib::IsFileExisting(fname_new)) // doesn't exist binary file.
     {
         INFO("-->Reading ASCII mesh file ...");
 
-        mesh = readASCII(file_name_base);
+        mesh = readASCII(filename_prefix);
     }
     else
     {
         INFO("-->Reading binary mesh file ...");
 
-        mesh = readBinary(file_name_base);
+        mesh = readBinary(filename_prefix);
     }
 
     INFO("\t\n>>Total elapsed time in reading mesh:%f s\n", timer.elapsed());

--- a/FileIO/MPI_IO/NodePartitionedMeshReader.cpp
+++ b/FileIO/MPI_IO/NodePartitionedMeshReader.cpp
@@ -15,7 +15,6 @@
 #include "NodePartitionedMeshReader.h"
 
 #include <logog/include/logog.hpp>
-#include <boost/algorithm/string/erase.hpp>
 
 #include "BaseLib/FileTools.h"
 #include "BaseLib/RunTime.h"
@@ -72,25 +71,21 @@ MeshLib::NodePartitionedMesh* NodePartitionedMeshReader::read(
 
     MeshLib::NodePartitionedMesh* mesh = nullptr;
 
-    /// Prefix of the filename of the partitioned mesh files.
-    std::string const filename_prefix =
-        boost::erase_last_copy(file_name_base, ".vtk");
-
     // Always try binary file first
-    std::string const fname_new = filename_prefix + "_partitioned_msh_cfg" +
+    std::string const fname_new = file_name_base + "_partitioned_msh_cfg" +
         std::to_string(_mpi_comm_size) + ".bin";
 
     if(!BaseLib::IsFileExisting(fname_new)) // doesn't exist binary file.
     {
         INFO("-->Reading ASCII mesh file ...");
 
-        mesh = readASCII(filename_prefix);
+        mesh = readASCII(file_name_base);
     }
     else
     {
         INFO("-->Reading binary mesh file ...");
 
-        mesh = readBinary(filename_prefix);
+        mesh = readBinary(file_name_base);
     }
 
     INFO("\t\n>>Total elapsed time in reading mesh:%f s\n", timer.elapsed());

--- a/FileIO/readMeshFromFile.cpp
+++ b/FileIO/readMeshFromFile.cpp
@@ -21,6 +21,8 @@
 #include <petsc.h>
 #endif
 
+#include <boost/algorithm/string/erase.hpp>
+
 #include <logog/include/logog.hpp>
 
 #include "BaseLib/FileTools.h"
@@ -42,6 +44,8 @@ MeshLib::Mesh* readMeshFromFile(const std::string &file_name)
 {
 #ifdef USE_PETSC
 	NodePartitionedMeshReader read_pmesh(PETSC_COMM_WORLD);
+	std::string const file_name_base =
+	    boost::erase_last_copy(file_name, ".vtk");
 	return read_pmesh.read(file_name);
 #else
 	if (BaseLib::hasFileExtension("msh", file_name))


### PR DESCRIPTION
*Forgot to include this one yesterday into the NodePartitionedMesh PR.*

This makes a file name with ".vtk" extension a valid input for the partitioned mesh reader.