### PR TITLE
Add a member to PETSc matrix for adding submatrix

### DIFF
--- a/MathLib/LinAlg/PETSc/PETScMatrix.h
+++ b/MathLib/LinAlg/PETSc/PETScMatrix.h
@@ -164,10 +164,10 @@ class PETScMatrix
         void add(RowColumnIndices<PetscInt> const& indices,
                  T_DENSE_MATRIX &sub_matrix)
         {
-            for(std::size_t i=0; i<indices.non_ghost_local_ids.size(); i++)
+            for(std::size_t i=0; i<indices.ghost_local_ids.size(); i++)
             {
-                const std::size_t non_ghost_id = indices.non_ghost_local_ids[i];
-                sub_matrix->row(non_ghost_id).setZero();
+                const std::size_t ghost_ids = indices.ghost_local_ids[i];
+                sub_matrix->row(ghost_ids).setZero();
             }
             this->add(indices.rows, indices.columns, sub_matrix);
         }

--- a/MathLib/LinAlg/PETSc/PETScMatrix.h
+++ b/MathLib/LinAlg/PETSc/PETScMatrix.h
@@ -159,6 +159,19 @@ class PETScMatrix
             MatSetValue(_A, i, j, value, ADD_VALUES);
         }
 
+        /// Add sub-matrix at positions given by \c indices.
+        template<class T_DENSE_MATRIX>
+        void add(RowColumnIndices<PetscInt> const& indices,
+                 T_DENSE_MATRIX &sub_matrix)
+        {
+            for(std::size_t i=0; i<indices.non_ghost_local_ids.size(); i++)
+            {
+                const std::size_t non_ghost_id = indices.non_ghost_local_ids[i];
+                sub_matrix->row(non_ghost_id).setZero();
+            }
+            this->add(indices.rows, indices.columns, sub_matrix);
+        }
+
         /*!
           \brief         Add a submatrix to this.
           \param row_pos The row indices of the entries of the submatrix.

--- a/MathLib/LinAlg/RowColumnIndices.h
+++ b/MathLib/LinAlg/RowColumnIndices.h
@@ -16,22 +16,22 @@ namespace MathLib
 {
 // A dummy vector as the default value of the third argument of
 // the constructor.
-static std::vector<std::size_t> dummy_non_ghost_local_ids;
+static std::vector<std::size_t> dummy_ghost_local_ids;
 
 template <typename IDX_TYPE>
 struct RowColumnIndices
 {
 	typedef typename std::vector<IDX_TYPE> LineIndex;
 	RowColumnIndices(LineIndex const& rows_, LineIndex const& columns_,
-	                 const std::vector<std::size_t>& non_ghost_local_ids_
-	                 = dummy_non_ghost_local_ids)
-		: rows(rows_), columns(columns_), non_ghost_local_ids(non_ghost_local_ids_)
+	                 const std::vector<std::size_t>& ghost_local_ids_
+	                 = dummy_ghost_local_ids)
+		: rows(rows_), columns(columns_), ghost_local_ids(ghost_local_ids_)
 	{ }
 
 	LineIndex const& rows;
 	LineIndex const& columns;
 
-	std::vector<std::size_t> const& non_ghost_local_ids;
+	std::vector<std::size_t> const& ghost_local_ids;
 };
 } // MathLib
 

--- a/MathLib/LinAlg/RowColumnIndices.h
+++ b/MathLib/LinAlg/RowColumnIndices.h
@@ -14,19 +14,25 @@
 
 namespace MathLib
 {
+// A dummy vector as the default value of the third argument of
+// the constructor.
+static std::vector<std::size_t> dummy_non_ghost_local_ids;
 
 template <typename IDX_TYPE>
 struct RowColumnIndices
 {
 	typedef typename std::vector<IDX_TYPE> LineIndex;
-	RowColumnIndices(LineIndex const& rows_, LineIndex const& columns_)
-		: rows(rows_), columns(columns_)
+	RowColumnIndices(LineIndex const& rows_, LineIndex const& columns_,
+	                 const std::vector<std::size_t>& non_ghost_local_ids_
+	                 = dummy_non_ghost_local_ids)
+		: rows(rows_), columns(columns_), non_ghost_local_ids(non_ghost_local_ids_)
 	{ }
 
 	LineIndex const& rows;
 	LineIndex const& columns;
-};
 
+	std::vector<std::size_t> const& non_ghost_local_ids;
+};
 } // MathLib
 
 #endif  // ROWCOLUMNINDICES_H_


### PR DESCRIPTION
Add a member to PETSc matrix for adding submatrix with ghost entry checking.
With the change and the next two PRs, the ghost entry checking in PR #580 (https://github.com/ufz/ogs/pull/580/files#r39689719) under ifdef disappears.

Next two PRs:
1. In order to make consistency with the type of the submatrix argument in member ``add``,   the const modifier of the same argument of member ``add`` of other matrix classes will be removed. 
2. The const modifier of the same argument of member ``add`` of Vector classes will be removed too. 
