### PR TITLE
Move linear solver creation back process construction

### DIFF
--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -32,16 +32,17 @@ public:
     explicit EigenDirectLinearSolver(EigenMatrix::RawMatrixType &A) : _A(A)
     {
         INFO("-> initialize with the coefficient matrix");
-        _solver.compute(A);
-        if(_solver.info()!=Eigen::Success) {
-            ERR("Failed during Eigen linear solver initialization");
-            return;
-        }
     }
 
     void solve(EigenVector::RawVectorType &b, EigenVector::RawVectorType &x, EigenOption &/*opt*/) override
     {
         INFO("-> solve");
+        _solver.compute(_A);
+        if(_solver.info()!=Eigen::Success) {
+            ERR("Failed during Eigen linear solver initialization");
+            return;
+        }
+
         x = _solver.solve(b);
         if(_solver.info()!=Eigen::Success) {
             ERR("Failed during Eigen linear solve");
@@ -62,11 +63,6 @@ public:
     explicit EigenIterativeLinearSolver(EigenMatrix::RawMatrixType &A) : _A(A)
     {
         INFO("-> initialize with the coefficient matrix");
-        _solver.compute(A);
-        if(_solver.info()!=Eigen::Success) {
-            ERR("Failed during Eigen linear solver initialization");
-            return;
-        }
     }
 
     void solve(EigenVector::RawVectorType &b, EigenVector::RawVectorType &x, EigenOption &opt) override
@@ -74,6 +70,11 @@ public:
         INFO("-> solve");
         _solver.setTolerance(opt.error_tolerance);
         _solver.setMaxIterations(opt.max_iterations);
+        _solver.compute(_A);
+        if(_solver.info()!=Eigen::Success) {
+            ERR("Failed during Eigen linear solver initialization");
+            return;
+        }
         x = _solver.solveWithGuess(b, x);
         if(_solver.info()!=Eigen::Success) {
             ERR("Failed during Eigen linear solve");

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -37,6 +37,8 @@ public:
     void solve(EigenVector::RawVectorType &b, EigenVector::RawVectorType &x, EigenOption &/*opt*/) override
     {
         INFO("-> solve");
+        if (!_A.isCompressed())
+            _A.makeCompressed();
         _solver.compute(_A);
         if(_solver.info()!=Eigen::Success) {
             ERR("Failed during Eigen linear solver initialization");
@@ -70,6 +72,8 @@ public:
         INFO("-> solve");
         _solver.setTolerance(opt.error_tolerance);
         _solver.setMaxIterations(opt.max_iterations);
+        if (!_A.isCompressed())
+            _A.makeCompressed();
         _solver.compute(_A);
         if(_solver.info()!=Eigen::Success) {
             ERR("Failed during Eigen linear solver initialization");

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -215,6 +215,8 @@ public:
         _A.reset(_global_setup.createMatrix(_local_to_global_index_map->dofSize()));
         _x.reset(_global_setup.createVector(_local_to_global_index_map->dofSize()));
         _rhs.reset(_global_setup.createVector(_local_to_global_index_map->dofSize()));
+        _linearSolver.reset(new typename GlobalSetup::LinearSolver(*_A));
+
 
         setInitialConditions(*_hydraulic_head);
 
@@ -261,8 +263,7 @@ public:
         // Apply known values from the Dirichlet boundary conditions.
         MathLib::applyKnownSolution(*_A, *_rhs, _dirichlet_bc.global_ids, _dirichlet_bc.values);
 
-        typename GlobalSetup::LinearSolver linearSolver(*_A);
-        linearSolver.solve(*_rhs, *_x);
+        _linearSolver->solve(*_rhs, *_x);
 
         return true;
     }
@@ -325,6 +326,7 @@ private:
     std::vector<MeshLib::MeshSubsets*> _all_mesh_subsets;
 
     GlobalSetup _global_setup;
+    std::unique_ptr<typename GlobalSetup::LinearSolver> _linearSolver;
     std::unique_ptr<typename GlobalSetup::MatrixType> _A;
     std::unique_ptr<typename GlobalSetup::VectorType> _rhs;
     std::unique_ptr<typename GlobalSetup::VectorType> _x;


### PR DESCRIPTION
Revert a bug fix and fix it in the same way at a different place.
This is better because it is Eigen specific.

This is *important* change unifying the LinearSolver concept.