### PR TITLE
0d element

### DIFF
--- a/AssemblerLib/LocalDataInitializer.h
+++ b/AssemblerLib/LocalDataInitializer.h
@@ -23,6 +23,7 @@
 #include "NumLib/Fem/ShapeFunction/ShapeHex8.h"
 #include "NumLib/Fem/ShapeFunction/ShapeLine2.h"
 #include "NumLib/Fem/ShapeFunction/ShapeLine3.h"
+#include "NumLib/Fem/ShapeFunction/ShapePoint1.h"
 #include "NumLib/Fem/ShapeFunction/ShapePrism15.h"
 #include "NumLib/Fem/ShapeFunction/ShapePrism6.h"
 #include "NumLib/Fem/ShapeFunction/ShapePyra13.h"
@@ -73,6 +74,8 @@ public:
             [](){ return new LAData<NumLib::ShapeLine2>; };
         _builder[std::type_index(typeid(MeshLib::Line3))] =
             [](){ return new LAData<NumLib::ShapeLine3>; };
+        _builder[std::type_index(typeid(MeshLib::Point))] =
+            [](){ return new LAData<NumLib::ShapePoint1>; };
         _builder[std::type_index(typeid(MeshLib::Prism15))] =
             [](){ return new LAData<NumLib::ShapePrism15>; };
         _builder[std::type_index(typeid(MeshLib::Prism))] =

--- a/MeshGeoToolsLib/BoundaryElementsAtPoint.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsAtPoint.cpp
@@ -1,0 +1,41 @@
+/**
+ * @copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include "BoundaryElementsAtPoint.h"
+
+#include "GeoLib/Point.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Elements/Point.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshSearch/ElementSearch.h"
+#include "MeshLib/Node.h"
+
+#include "MeshGeoToolsLib/MeshNodeSearcher.h"
+
+namespace MeshGeoToolsLib
+{
+BoundaryElementsAtPoint::BoundaryElementsAtPoint(
+    MeshLib::Mesh const &mesh, MeshNodeSearcher &mshNodeSearcher,
+    GeoLib::Point const &point)
+    : _mesh(mesh), _point(point)
+{
+	auto const node_ids = mshNodeSearcher.getMeshNodeIDs(_point);
+	assert(node_ids.size() == 1);
+	std::array<MeshLib::Node*, 1> const nodes = {
+	    const_cast<MeshLib::Node*>(_mesh.getNode(node_ids[0]))};
+
+	_boundary_elements.push_back(new MeshLib::Point(nodes, 0, node_ids[0]));
+}
+
+BoundaryElementsAtPoint::~BoundaryElementsAtPoint()
+{
+	for (auto p : _boundary_elements)
+		delete p;
+}
+
+}  // MeshGeoToolsLib

--- a/MeshGeoToolsLib/BoundaryElementsAtPoint.h
+++ b/MeshGeoToolsLib/BoundaryElementsAtPoint.h
@@ -1,0 +1,69 @@
+/**
+ * @copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#ifndef BOUNDARYELEMENTSATPOINT_H_
+#define BOUNDARYELEMENTSATPOINT_H_
+
+#include <vector>
+
+namespace GeoLib
+{
+class Point;
+}
+
+namespace MeshLib
+{
+class Mesh;
+class Element;
+}
+
+namespace MeshGeoToolsLib
+{
+class MeshNodeSearcher;
+
+/// This class collects point elements located at a given geometrical point.
+class BoundaryElementsAtPoint final
+{
+public:
+	/// Constructor
+	/// @param mesh             a mesh object
+	/// @param mshNodeSearcher  a MeshNodeSearcher object which is internally
+	/// used to search mesh nodes
+	/// @param point            a point object where edges are searched
+	BoundaryElementsAtPoint(MeshLib::Mesh const& mesh,
+	                       MeshNodeSearcher& mshNodeSearcher,
+	                       GeoLib::Point const& point);
+
+	/// destructor
+	~BoundaryElementsAtPoint();
+
+	MeshLib::Mesh const& getMesh() const
+	{
+		return _mesh;
+	}
+
+	GeoLib::Point const& getPoint() const
+	{
+		return _point;
+	}
+
+	/// Return the vector of boundary elements (i.e. points).
+	std::vector<MeshLib::Element*> const& getBoundaryElements() const
+	{
+		return _boundary_elements;
+	}
+
+private:
+	MeshLib::Mesh const& _mesh;
+	GeoLib::Point const& _point;
+	std::vector<MeshLib::Element*> _boundary_elements;
+};
+
+}  // end namespace MeshGeoToolsLib
+
+#endif  // BOUNDARYELEMENTSATPOINT_H_

--- a/MeshGeoToolsLib/BoundaryElementsSearcher.h
+++ b/MeshGeoToolsLib/BoundaryElementsSearcher.h
@@ -13,6 +13,7 @@
 namespace GeoLib
 {
 class GeoObject;
+class Point;
 class Polyline;
 class Surface;
 }
@@ -26,6 +27,7 @@ class Element;
 namespace MeshGeoToolsLib
 {
 class MeshNodeSearcher;
+class BoundaryElementsAtPoint;
 class BoundaryElementsAlongPolyline;
 class BoundaryElementsOnSurface;
 
@@ -55,6 +57,13 @@ public:
 	std::vector<MeshLib::Element*> const& getBoundaryElements(GeoLib::GeoObject const& geoObj);
 
 	/**
+	 * generate boundary elements at the given point.
+	 * @param point Search the mesh for given point
+	 * @return a vector of boundary elements
+	 */
+	std::vector<MeshLib::Element*> const& getBoundaryElementsAtPoint(
+	    GeoLib::Point const& point);
+	/**
 	 * generate boundary elements on the given polyline.
 	 * @param ply the GeoLib::Polyline the nearest mesh nodes are searched for
 	 * @return a vector of boundary element objects
@@ -72,6 +81,7 @@ public:
 private:
 	MeshLib::Mesh const& _mesh;
 	MeshNodeSearcher &_mshNodeSearcher;
+	std::vector<BoundaryElementsAtPoint*> _boundary_elements_at_point;
 	std::vector<BoundaryElementsAlongPolyline*> _boundary_elements_along_polylines;
 	std::vector<BoundaryElementsOnSurface*> _boundary_elements_along_surfaces;
 };

--- a/MeshLib/Elements/Elements.h
+++ b/MeshLib/Elements/Elements.h
@@ -16,6 +16,7 @@
 #include "MeshLib/Elements/Element.h"
 #include "MeshLib/Elements/Line.h"
 #include "MeshLib/Elements/Hex.h"
+#include "MeshLib/Elements/Point.h"
 #include "MeshLib/Elements/Prism.h"
 #include "MeshLib/Elements/Pyramid.h"
 #include "MeshLib/Elements/Quad.h"

--- a/MeshLib/Elements/Point.h
+++ b/MeshLib/Elements/Point.h
@@ -1,0 +1,23 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef MESHLIB_POINT_H_
+#define MESHLIB_POINT_H_
+
+#include "TemplateElement.h"
+#include "PointRule1.h"
+
+extern template class MeshLib::TemplateElement<MeshLib::PointRule1>;
+
+namespace MeshLib
+{
+	using Point = TemplateElement<PointRule1>;
+}
+
+#endif  // MESHLIB_POINT_H_

--- a/MeshLib/Elements/PointRule1.cpp
+++ b/MeshLib/Elements/PointRule1.cpp
@@ -1,0 +1,47 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "PointRule1.h"
+
+#include "MathLib/Point3d.h"
+#include "MeshLib/Node.h"
+
+namespace MeshLib {
+
+const unsigned PointRule1::edge_nodes[1][1] =
+{
+	{0}
+};
+
+double PointRule1::computeVolume(Node const* const* _nodes)
+{
+	return 0;
+}
+
+bool PointRule1::isPntInElement(Node const* const* _nodes, MathLib::Point3d const& pnt, double eps)
+{
+	double const dist = MathLib::sqrDist(*_nodes[0], pnt);
+	return (dist < eps);
+}
+
+unsigned PointRule1::identifyFace(Node const* const* _nodes, Node* nodes[1])
+{
+	if (nodes[0] == _nodes[0])
+		return 0;
+	return std::numeric_limits<unsigned>::max();
+}
+
+ElementErrorCode PointRule1::validate(const Element* e)
+{
+	ElementErrorCode error_code;
+	error_code[ElementErrorFlag::ZeroVolume] = e->hasZeroVolume();
+	return error_code;
+}
+
+} // end namespace MeshLib

--- a/MeshLib/Elements/PointRule1.h
+++ b/MeshLib/Elements/PointRule1.h
@@ -1,0 +1,75 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef MESHLIB_POINTRULE_H_
+#define MESHLIB_POINTRULE_H_
+
+#include "MeshLib/MeshEnums.h"
+#include "Element.h"
+#include "VertexRule.h"
+#include "EdgeReturn.h"
+
+namespace MeshLib
+{
+
+/**
+ * A 0d point element.
+ * @code
+ *  0
+ * @endcode
+ */
+class PointRule1 : public VertexRule
+{
+public:
+	/// Constant: The number of base nodes for this element
+	static const unsigned n_base_nodes = 1u;
+
+	/// Constant: The number of all nodes for this element
+	static const unsigned n_all_nodes = 1u;
+
+	/// Constant: The geometric type of the element
+	static const MeshElemType mesh_elem_type = MeshElemType::POINT;
+
+	/// Constant: The FEM type of the element
+	static const CellType cell_type = CellType::POINT1;
+
+	/// Constant: The number of neighbors
+	static const unsigned n_neighbors = 2;
+
+	/// Constant: Local node index table for edge
+	static const unsigned edge_nodes[1][1];
+
+	/// Edge rule
+	typedef NoEdgeReturn EdgeReturn;
+
+	/**
+	 * Checks if a point is inside the element.
+	 * @param pnt a 3D MathLib::Point3d object
+	 * @param eps tolerance for numerical algorithm used or computing the property
+	 * @return true if the point is not outside the element, false otherwise
+	 */
+	static bool isPntInElement(Node const* const* _nodes, MathLib::Point3d const& pnt, double eps);
+
+	/**
+	 * Tests if the element is geometrically valid.
+	 */
+	static ElementErrorCode validate(const Element* e);
+
+	/// Returns the ID of a face given an array of nodes.
+	static unsigned identifyFace(Node const* const*, Node* nodes[1]);
+
+	/// Calculates the length of a line
+	static double computeVolume(Node const* const* _nodes);
+
+}; /* class */
+
+} /* namespace */
+
+#endif /* LINERULE2_H_ */
+

--- a/MeshLib/Elements/TemplateElement.cpp
+++ b/MeshLib/Elements/TemplateElement.cpp
@@ -10,6 +10,7 @@
 #include "TemplateElement.h"
 
 #include "MeshLib/Elements/Hex.h"
+#include "MeshLib/Elements/Point.h"
 #include "MeshLib/Elements/Line.h"
 #include "MeshLib/Elements/Prism.h"
 #include "MeshLib/Elements/Pyramid.h"
@@ -33,6 +34,7 @@ template class MeshLib::TemplateElement<MeshLib::HexRule20>;
 template class MeshLib::TemplateElement<MeshLib::HexRule8>;
 template class MeshLib::TemplateElement<MeshLib::LineRule2>;
 template class MeshLib::TemplateElement<MeshLib::LineRule3>;
+template class MeshLib::TemplateElement<MeshLib::PointRule1>;
 template class MeshLib::TemplateElement<MeshLib::PrismRule15>;
 template class MeshLib::TemplateElement<MeshLib::PrismRule6>;
 template class MeshLib::TemplateElement<MeshLib::PyramidRule13>;

--- a/MeshLib/Elements/VertexRule.h
+++ b/MeshLib/Elements/VertexRule.h
@@ -1,0 +1,53 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef MESHLIB_VERTEX_RULE_H
+#define MESHLIB_VERTEX_RULE_H
+
+namespace MeshLib
+{
+
+class Element;
+
+class VertexRule
+{
+public:
+	/// Constant: Dimension of this mesh element
+	static const unsigned dimension = 0u;
+
+	/// Constant: The number of faces
+	static const unsigned n_faces = 0;
+
+	/// Constant: The number of edges
+	static const unsigned n_edges = 0;
+
+	/// Get the number of nodes for face i.
+	static unsigned getNFaceNodes(unsigned /*i*/)
+	{
+		return 0;
+	}
+
+	/// Returns the i-th face of the element.
+	static const Element* getFace(const Element* /*e*/, unsigned /*i*/)
+	{
+		return nullptr;
+	}
+
+	/**
+	* Checks if the node order of an element is correct by testing surface
+	* normals.  For 0D elements this always returns true.
+	*/
+	static bool testElementNodeOrder(const Element* /*e*/) { return true; }
+
+};
+
+}
+
+#endif // MESHLIB_VERTEX_RULE_H
+

--- a/MeshLib/MeshEnums.cpp
+++ b/MeshLib/MeshEnums.cpp
@@ -18,6 +18,8 @@ namespace MeshLib {
 
 const std::string MeshElemType2String(const MeshElemType t)
 {
+	if (t == MeshElemType::POINT)
+		return "Point";
 	if (t == MeshElemType::LINE)
 		return "Line";
 	if (t == MeshElemType::QUAD)
@@ -37,6 +39,8 @@ const std::string MeshElemType2String(const MeshElemType t)
 
 const std::string MeshElemType2StringShort(const MeshElemType t)
 {
+	if (t == MeshElemType::POINT)
+		return "point";
 	if (t == MeshElemType::LINE)
 		return "line";
 	if (t == MeshElemType::QUAD)
@@ -56,6 +60,8 @@ const std::string MeshElemType2StringShort(const MeshElemType t)
 
 MeshElemType String2MeshElemType(const std::string &s)
 {
+	if ((s.compare("point") == 0) || (s.compare("Point") == 0))
+		return MeshElemType::POINT;
 	if ((s.compare("line") == 0) || (s.compare("Line") == 0))
 		return MeshElemType::LINE;
 	if ((s.compare("quad") == 0) || (s.compare("Quadrilateral") == 0))
@@ -76,6 +82,7 @@ MeshElemType String2MeshElemType(const std::string &s)
 std::vector<MeshElemType> getMeshElemTypes()
 {
 	std::vector<MeshElemType> vec;
+	vec.push_back(MeshElemType::POINT);
 	vec.push_back(MeshElemType::LINE);
 	vec.push_back(MeshElemType::QUAD);
 	vec.push_back(MeshElemType::HEXAHEDRON);
@@ -100,6 +107,7 @@ const std::string CellType2String(const CellType t)
 	if (t == CellType::type)\
 		return #type;
 
+	RETURN_CELL_TYPE_STR(t, POINT1);
 	RETURN_CELL_TYPE_STR(t, LINE2);
 	RETURN_CELL_TYPE_STR(t, LINE3);
 	RETURN_CELL_TYPE_STR(t, QUAD4);

--- a/MeshLib/MeshEnums.h
+++ b/MeshLib/MeshEnums.h
@@ -27,6 +27,7 @@ namespace MeshLib {
 enum class MeshElemType
 {
 	INVALID = 0,
+	POINT = 1,
 	LINE = 3,
 	QUAD = 9,
 	HEXAHEDRON = 12,
@@ -42,6 +43,7 @@ enum class MeshElemType
 enum class CellType
 {
 	INVALID,
+	POINT1,
 	LINE2,
 	LINE3,
 	TRI3,

--- a/NumLib/Fem/FiniteElement/C0IsoparametricElements.h
+++ b/NumLib/Fem/FiniteElement/C0IsoparametricElements.h
@@ -14,6 +14,7 @@
 #ifndef C0ISOPARAMETRICELEMENTS_H_
 #define C0ISOPARAMETRICELEMENTS_H_
 
+#include "NumLib/Fem/ShapeFunction/ShapePoint1.h"
 #include "NumLib/Fem/ShapeFunction/ShapeLine2.h"
 #include "NumLib/Fem/ShapeFunction/ShapeLine3.h"
 #include "NumLib/Fem/ShapeFunction/ShapeTri3.h"
@@ -34,6 +35,12 @@
 
 namespace NumLib
 {
+
+template <template <typename> class T_SHAPE_MATRIX_POLICY>
+struct FePOINT1
+{
+    typedef TemplateIsoparametric<ShapePoint1, T_SHAPE_MATRIX_POLICY<ShapePoint1>> type;
+};
 
 template <template <typename> class T_SHAPE_MATRIX_POLICY>
 struct FeLINE2

--- a/NumLib/Fem/Integration/GaussIntegrationPolicy.h
+++ b/NumLib/Fem/Integration/GaussIntegrationPolicy.h
@@ -10,6 +10,7 @@
 #ifndef NUMLIB_GAUSSINTEGRATIONPOLICY_H_
 #define NUMLIB_GAUSSINTEGRATIONPOLICY_H_
 
+#include "MeshLib/Elements/Point.h"
 #include "MeshLib/Elements/Tri.h"
 #include "MeshLib/Elements/Tet.h"
 #include "MeshLib/Elements/Prism.h"
@@ -20,6 +21,7 @@
 #include "NumLib/Fem/Integration/IntegrationGaussTet.h"
 #include "NumLib/Fem/Integration/IntegrationGaussPrism.h"
 #include "NumLib/Fem/Integration/IntegrationGaussPyramid.h"
+#include "NumLib/Fem/Integration/IntegrationPoint.h"
 
 namespace NumLib
 {
@@ -38,6 +40,13 @@ struct GaussIntegrationPolicy
     using MeshElement = MeshElement_;
     using IntegrationMethod =
         NumLib::IntegrationGaussRegular<MeshElement::dimension>;
+};
+
+template<>
+struct GaussIntegrationPolicy<MeshLib::Point>
+{
+    using MeshElement = MeshLib::Point;
+    using IntegrationMethod = NumLib::IntegrationPoint;
 };
 
 template<>

--- a/NumLib/Fem/Integration/IntegrationPoint.h
+++ b/NumLib/Fem/Integration/IntegrationPoint.h
@@ -1,0 +1,88 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef NUMLIB_INTEGRATIONPOINT_H_
+#define NUMLIB_INTEGRATIONPOINT_H_
+
+namespace NumLib
+{
+/// Integration rule for point elements.
+///
+/// The integration order is not stored or used for point integration. It is
+/// only needed to satisfy the common integration rule concepts.
+class IntegrationPoint
+{
+	typedef MathLib::TemplateWeightedPoint<double, double, 1> WeightedPoint;
+
+public:
+	/// IntegrationPoint constructor for given order.
+	explicit IntegrationPoint(std::size_t /* order */)
+	{
+	}
+
+	/// Change the integration order.
+	void setIntegrationOrder(std::size_t /* order */)
+	{
+	}
+
+	/// return current integration order.
+	std::size_t getIntegrationOrder() const
+	{
+		return 0;
+	}
+
+	/// return the number of sampling points
+	std::size_t getNPoints() const
+	{
+		return 1;
+	}
+
+	/**
+	 * get coordinates of a integration point
+	 *
+	 * @param igp      The integration point index
+	 * @return a weighted point
+	 */
+	WeightedPoint getWeightedPoint(std::size_t igp)
+	{
+		return getWeightedPoint(getIntegrationOrder(), igp);
+	}
+
+	/**
+	 * get coordinates of a integration point
+	 *
+	 * @param order    the number of integration points
+	 * @param pt_id     the sampling point id
+	 * @return weight
+	 */
+	static WeightedPoint getWeightedPoint(std::size_t /* order */, std::size_t /*igp*/)
+	{
+		return WeightedPoint({{1}}, 1);
+	}
+
+	template <typename Method>
+	static WeightedPoint getWeightedPoint(std::size_t /*igp*/)
+	{
+		return WeightedPoint({{1}}, 1);
+	}
+
+	/**
+	 * get the number of integration points
+	 *
+	 * @param order    the number of integration points
+	 * @return the number of points
+	 */
+	static std::size_t getNPoints(std::size_t /* order */)
+	{
+		return 1;
+	}
+};
+}
+
+#endif  // NUMLIB_INTEGRATIONPOINT_H_

--- a/NumLib/Fem/ShapeFunction/ShapePoint1-impl.h
+++ b/NumLib/Fem/ShapeFunction/ShapePoint1-impl.h
@@ -1,0 +1,25 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+namespace NumLib
+{
+
+template <class T_X, class T_N>
+void ShapePoint1::computeShapeFunction(const T_X &/*r*/, T_N &N)
+{
+    N[0] = 1;
+}
+
+template <class T_X, class T_N>
+void ShapePoint1::computeGradShapeFunction(const T_X &/*r*/, T_N &/*dN*/)
+{
+}
+
+}
+

--- a/NumLib/Fem/ShapeFunction/ShapePoint1.h
+++ b/NumLib/Fem/ShapeFunction/ShapePoint1.h
@@ -1,0 +1,51 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef SHAPEPOINT1_H_
+#define SHAPEPOINT1_H_
+
+#include "MeshLib/Elements/Point.h"
+
+namespace NumLib
+{
+
+/**
+ *  Shape function for a point element in natural coordinates.
+ */
+class ShapePoint1
+{
+public:
+    /**
+     * Evaluate the shape function at the given point
+     *
+     * @param [in]  r    point coordinates
+     * @param [out] N   a vector of calculated shape function.
+     */
+    template <class T_X, class T_N>
+    static void computeShapeFunction(const T_X &r, T_N &N);
+
+    /**
+     * Evaluate derivatives of the shape function at the given point
+     *
+     * @param [in]  r    point coordinates
+     * @param [out] dN  a matrix of the derivatives
+     */
+    template <class T_X, class T_N>
+    static void computeGradShapeFunction(const T_X &r, T_N &dN);
+
+    using MeshElement = MeshLib::Point;
+    static const std::size_t DIM = MeshElement::dimension;
+    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+};
+
+}
+
+#include "ShapePoint1-impl.h"
+
+#endif //SHAPEPOINT1_H_

--- a/NumLib/Fem/ShapeMatrixPolicy.h
+++ b/NumLib/Fem/ShapeMatrixPolicy.h
@@ -15,15 +15,38 @@
 #ifdef OGS_USE_EIGEN
 #include <Eigen/Eigen>
 
+namespace detail
+{
+    /// Forwards the Eigen::Matrix type for general N and M.
+    /// There is a partial specialization for M = 1 to store the matrix in
+    /// column major storage order.
+    template <int N, int M>
+    struct EigenMatrixType
+    {
+        using type = Eigen::Matrix<double, N, M, Eigen::RowMajor>;
+    };
+
+    /// Specialisation for Nx1 matrices which can be stored only in column major
+    /// form in Eigen-3.2.5.
+    template <int N>
+    struct EigenMatrixType<N, 1>
+    {
+        using type = Eigen::Matrix<double, N, 1, Eigen::ColMajor>;
+    };
+
+
+}   // detail
+
 /// An implementation of ShapeMatrixPolicy using fixed size (compile-time) eigen
 /// matrices and vectors.
 template <typename ShapeFunction, unsigned GlobalDim>
 struct EigenFixedShapeMatrixPolicy
 {
-    template <int N, int M>
-    using _MatrixType = Eigen::Matrix<double, N, M, Eigen::RowMajor>;
     template <int N>
     using _VectorType = Eigen::Matrix<double, N, 1>;
+
+    template <int N, int M>
+    using _MatrixType = typename detail::EigenMatrixType<N, M>::type;
 
     using NodalMatrixType = _MatrixType<ShapeFunction::NPOINTS, ShapeFunction::NPOINTS>;
     using NodalVectorType = _VectorType<ShapeFunction::NPOINTS>;

--- a/NumLib/Fem/ShapeMatrixPolicy.h
+++ b/NumLib/Fem/ShapeMatrixPolicy.h
@@ -15,6 +15,8 @@
 #ifdef OGS_USE_EIGEN
 #include <Eigen/Eigen>
 
+namespace NumLib
+{
 namespace detail
 {
     /// Forwards the Eigen::Matrix type for general N and M.
@@ -36,6 +38,7 @@ namespace detail
 
 
 }   // detail
+}   // NumLib
 
 /// An implementation of ShapeMatrixPolicy using fixed size (compile-time) eigen
 /// matrices and vectors.
@@ -46,7 +49,7 @@ struct EigenFixedShapeMatrixPolicy
     using _VectorType = Eigen::Matrix<double, N, 1>;
 
     template <int N, int M>
-    using _MatrixType = typename detail::EigenMatrixType<N, M>::type;
+    using _MatrixType = typename NumLib::detail::EigenMatrixType<N, M>::type;
 
     using NodalMatrixType = _MatrixType<ShapeFunction::NPOINTS, ShapeFunction::NPOINTS>;
     using NodalVectorType = _VectorType<ShapeFunction::NPOINTS>;

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -40,7 +40,7 @@ ProcessVariable::ProcessVariable(ConfigTree const& config,
 			_initial_condition =
 			    createUniformInitialCondition(ic_config->second);
 		}
-		if (type == "MeshProperty")
+		else if (type == "MeshProperty")
 		{
 			_initial_condition =
 			    createMeshPropertyInitialCondition(ic_config->second, _mesh);

--- a/Tests/LineTest/line_1.gml
+++ b/Tests/LineTest/line_1.gml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml-stylesheet type="text/xsl" href="OpenGeoSysGLI.xsl"?>
+
+<OpenGeoSysGLI xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.opengeosys.org/images/xsd/OpenGeoSysGLI.xsd" xmlns:ogs="http://www.opengeosys.org">
+    <name>line_1_geometry</name>
+    <points>
+        <point id="0" x="0" y="0" z="0" name="left"/>
+        <point id="1" x="1" y="0" z="0" name="right"/>
+    </points>
+
+</OpenGeoSysGLI>

--- a/Tests/LineTest/line_1.vtu
+++ b/Tests/LineTest/line_1.vtu
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="11" NumberOfCells="10">
+      <PointData>
+      </PointData>
+      <CellData>
+        <DataArray type="Int32" Name="MaterialIDs" format="binary" RangeMin="0" RangeMax="0">
+          AQAAAACAAAAoAAAADAAAAA==eJxjYCAOAAAAKAAB
+        </DataArray>
+      </CellData>
+      <Points>
+        <DataArray type="Float64" Name="Points" NumberOfComponents="3" format="binary" RangeMin="0" RangeMax="1">
+          AQAAAACAAAAIAQAAOwAAAA==eJxjYMAOZs0EgZ322MVPYogbg8FlHOpvYohDwAMc5jzGEE8Dg2c4zH+JIX72DAi8wWHvBwxxAA+QIwA=
+        </DataArray>
+      </Points>
+      <Cells>
+        <DataArray type="Int64" Name="connectivity" format="binary" RangeMin="0" RangeMax="10">
+          AQAAAACAAACgAAAAJgAAAA==eJxdxTkCABAMALA6i/8/2MCULIl4Cldu3Hnw5OTFm8//Ahb4AGU=
+        </DataArray>
+        <DataArray type="Int64" Name="offsets" format="binary" RangeMin="2" RangeMax="20">
+          AQAAAACAAABQAAAAIwAAAA==eJxjYoAAFijNBqU5oDQXlOaB0nxQWgBKC0FpESgNAA4QAG8=
+        </DataArray>
+        <DataArray type="UInt8" Name="types" format="binary" RangeMin="3" RangeMax="3">
+          AQAAAACAAAAKAAAACwAAAA==eJxjZoYBAACvAB8=
+        </DataArray>
+        <DataArray type="Int64" Name="faces" format="binary" RangeMin="0" RangeMax="0">
+          AQAAAACAAABQAAAADAAAAA==eJxjYKAuAAAAUAAB
+        </DataArray>
+        <DataArray type="Int64" Name="faceoffsets" format="binary" RangeMin="1" RangeMax="10">
+          AQAAAACAAABQAAAAIgAAAA==eJwtxbcBACAIADA76v8HM5As6a0MTy9vH4evn78TBzAAOA==
+        </DataArray>
+      </Cells>
+    </Piece>
+  </UnstructuredGrid>
+</VTKFile>

--- a/Tests/LineTest/line_1e1.prj
+++ b/Tests/LineTest/line_1e1.prj
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<OpenGeoSysProject>
+    <mesh>line_1.vtu</mesh>
+    <geometry>line_1.gml</geometry>
+
+    <processes>
+        <process>
+            <name>GW23</name>
+            <type>GROUNDWATER_FLOW</type>
+            <process_variable>pressure</process_variable>
+            <hydraulic_conductivity>K</hydraulic_conductivity>
+            <numerics>LIS</numerics>
+        </process>
+    </processes>
+
+    <parameters>
+        <parameter>
+            <name>K</name>
+            <type>Constant</type>
+            <value>1</value>
+        </parameter>
+    </parameters>
+
+    <process_variables>
+        <process_variable>
+            <name>pressure</name>
+
+            <initial_condition>
+                <type>Uniform</type>
+                <value>0</value>
+            </initial_condition>
+
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>line_1_geometry</geometrical_set>
+                    <geometry>left</geometry>
+                    <type>UniformDirichlet</type>
+                    <value>1</value>
+                </boundary_condition>
+
+                <boundary_condition>
+                    <geometrical_set>line_1_geometry</geometrical_set>
+                    <geometry>right</geometry>
+                    <type>UniformDirichlet</type>
+                    <value>-1</value>
+                </boundary_condition>
+            </boundary_conditions>
+
+            <source_terms>
+            </source_terms>
+        </process_variable>
+    </process_variables>
+
+    <time_stepping>
+        <type>SingleStep</type>
+    </time_stepping>
+
+    <output>
+        <type>VTK</type>
+        <file>line_1e1</file>
+    </output>
+
+</OpenGeoSysProject>

--- a/Tests/LineTest/line_1e1_neumann.prj
+++ b/Tests/LineTest/line_1e1_neumann.prj
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<OpenGeoSysProject>
+    <mesh>line_1.vtu</mesh>
+    <geometry>line_1.gml</geometry>
+
+    <processes>
+        <process>
+            <name>GW23</name>
+            <type>GROUNDWATER_FLOW</type>
+            <process_variable>pressure</process_variable>
+            <hydraulic_conductivity>K</hydraulic_conductivity>
+            <numerics>LIS</numerics>
+        </process>
+    </processes>
+
+    <parameters>
+        <parameter>
+            <name>K</name>
+            <type>Constant</type>
+            <value>1</value>
+        </parameter>
+    </parameters>
+
+    <process_variables>
+        <process_variable>
+            <name>pressure</name>
+
+            <initial_condition>
+                <type>Uniform</type>
+                <value>0</value>
+            </initial_condition>
+
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>line_1_geometry</geometrical_set>
+                    <geometry>left</geometry>
+                    <type>UniformDirichlet</type>
+                    <value>1</value>
+                </boundary_condition>
+
+                <boundary_condition>
+                    <geometrical_set>line_1_geometry</geometrical_set>
+                    <geometry>right</geometry>
+                    <type>UniformNeumann</type>
+                    <value>1</value>
+                </boundary_condition>
+            </boundary_conditions>
+
+            <source_terms>
+            </source_terms>
+        </process_variable>
+    </process_variables>
+
+    <time_stepping>
+        <type>SingleStep</type>
+    </time_stepping>
+
+    <output>
+        <type>VTK</type>
+        <file>line_1e1_neumann</file>
+    </output>
+
+</OpenGeoSysProject>


### PR DESCRIPTION
This adds a point element to the mesh lib, suitable shape function, and makes it available for the local assemblers.

The reason behind this element is that the boundary of a line mesh consists of point elements and to implement Neumann boundary conditions, for example, integration over such elements must be performed.

The only work-in-progress item is to update the ctest suite.
- [ ] Update ctests.