### PR TITLE
Make solver interface unique

### DIFF
--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -153,10 +153,6 @@ int main(int argc, char *argv[])
 	solveProcesses(project);
 
 #ifdef USE_PETSC
-	for (auto p_it = project.processesBegin(); p_it != project.processesEnd(); ++p_it)
-	{
-		(*p_it)->releaseEquationMemory();
-	}
 	PetscFinalize();
 #endif
 

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -95,7 +95,9 @@ private:
 
 } // details
 
-EigenLinearSolver::EigenLinearSolver(EigenMatrix &A, ptree const*const option)
+EigenLinearSolver::EigenLinearSolver(EigenMatrix &A,
+                            const std::string& /*solver_name*/,
+                            ptree const*const option)
 {
     if (option)
         setOption(*option);

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -96,7 +96,7 @@ private:
 } // details
 
 EigenLinearSolver::EigenLinearSolver(EigenMatrix &A,
-                            const std::string& /*solver_name*/,
+                            const std::string /*solver_name*/,
                             ptree const*const option)
 {
     if (option)

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.h
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.h
@@ -25,7 +25,17 @@ class EigenMatrix;
 class EigenLinearSolver final
 {
 public:
-    EigenLinearSolver(EigenMatrix &A, boost::property_tree::ptree const*const option = nullptr);
+    /**
+     * Constructor
+     * @param A           Coefficient matrix object
+     * @param solver_name A name used as a prefix for command line options
+     *                    if there are such options available.
+     * @param option      A pointer to a linear solver option. In case you omit
+     *                    this argument, default settings follow those of
+     *                    LisOption struct.
+     */
+    EigenLinearSolver(EigenMatrix &A, const std::string& solver_name = "",
+                      boost::property_tree::ptree const*const option = nullptr);
 
     ~EigenLinearSolver()
     {

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.h
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.h
@@ -34,7 +34,7 @@ public:
      *                    this argument, default settings follow those of
      *                    LisOption struct.
      */
-    EigenLinearSolver(EigenMatrix &A, const std::string& solver_name = "",
+    EigenLinearSolver(EigenMatrix &A, const std::string solver_name = "",
                       boost::property_tree::ptree const*const option = nullptr);
 
     ~EigenLinearSolver()

--- a/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
+++ b/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
@@ -27,7 +27,7 @@ namespace MathLib
 using boost::property_tree::ptree;
 
 EigenLisLinearSolver::EigenLisLinearSolver(EigenMatrix &A,
-                      const std::string& /*solver_name*/,
+                      const std::string /*solver_name*/,
                       ptree const*const option)
 : _A(A)
 {

--- a/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
+++ b/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
@@ -26,7 +26,9 @@ namespace MathLib
 
 using boost::property_tree::ptree;
 
-EigenLisLinearSolver::EigenLisLinearSolver(EigenMatrix &A, ptree const*const option)
+EigenLisLinearSolver::EigenLisLinearSolver(EigenMatrix &A,
+                      const std::string& /*solver_name*/,
+                      ptree const*const option)
 : _A(A)
 {
     if (option)

--- a/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.h
+++ b/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.h
@@ -30,12 +30,15 @@ class EigenLisLinearSolver final
 public:
     /**
      * Constructor
-     * @param A         Coefficient matrix object
-     * @param option    A pointer to a linear solver option. In case you omit
-     *                  this argument, default settings follow those of
-     *                  LisOption struct.
+     * @param A           Coefficient matrix object
+     * @param solver_name A name used as a prefix for command line options
+     *                    if there are such options available.
+     * @param option      A pointer to a linear solver option. In case you omit
+     *                    this argument, default settings follow those of
+     *                    LisOption struct.
      */
-    EigenLisLinearSolver(EigenMatrix &A, boost::property_tree::ptree const*const option = nullptr);
+    EigenLisLinearSolver(EigenMatrix &A, const std::string& solver_name = "",
+                         boost::property_tree::ptree const*const option = nullptr);
 
     /**
      * parse linear solvers configuration

--- a/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.h
+++ b/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.h
@@ -37,7 +37,7 @@ public:
      *                    this argument, default settings follow those of
      *                    LisOption struct.
      */
-    EigenLisLinearSolver(EigenMatrix &A, const std::string& solver_name = "",
+    EigenLisLinearSolver(EigenMatrix &A, const std::string solver_name = "",
                          boost::property_tree::ptree const*const option = nullptr);
 
     /**

--- a/MathLib/LinAlg/Lis/LisLinearSolver.cpp
+++ b/MathLib/LinAlg/Lis/LisLinearSolver.cpp
@@ -28,7 +28,9 @@ namespace MathLib
 
 using boost::property_tree::ptree;
 
-LisLinearSolver::LisLinearSolver(LisMatrix &A, ptree const*const option)
+LisLinearSolver::LisLinearSolver(LisMatrix &A,
+                    const std::string& /*solver_name*/,
+                    ptree const*const option)
 : _A(A)
 {
     if (option)

--- a/MathLib/LinAlg/Lis/LisLinearSolver.cpp
+++ b/MathLib/LinAlg/Lis/LisLinearSolver.cpp
@@ -29,7 +29,7 @@ namespace MathLib
 using boost::property_tree::ptree;
 
 LisLinearSolver::LisLinearSolver(LisMatrix &A,
-                    const std::string& /*solver_name*/,
+                    const std::string /*solver_name*/,
                     ptree const*const option)
 : _A(A)
 {

--- a/MathLib/LinAlg/Lis/LisLinearSolver.h
+++ b/MathLib/LinAlg/Lis/LisLinearSolver.h
@@ -44,7 +44,7 @@ public:
      *                    this argument, default settings follow those of
      *                    LisOption struct.
      */
-    LisLinearSolver(LisMatrix &A, const std::string& solver_name = "",
+    LisLinearSolver(LisMatrix &A, const std::string solver_name = "",
                     boost::property_tree::ptree const*const option = nullptr);
 
     virtual ~LisLinearSolver() {}

--- a/MathLib/LinAlg/Lis/LisLinearSolver.h
+++ b/MathLib/LinAlg/Lis/LisLinearSolver.h
@@ -16,6 +16,7 @@
 #define LISLINEARSOLVER_H_
 
 #include <vector>
+#include <string>
 #include <boost/property_tree/ptree.hpp>
 
 #include "lis.h"
@@ -36,12 +37,15 @@ class LisLinearSolver
 public:
     /**
      * Constructor
-     * @param A         Coefficient matrix object
-     * @param option    A pointer to a linear solver option. In case you omit
-     *                  this argument, default settings follow those of
-     *                  LisOption struct.
+     * @param A           Coefficient matrix object
+     * @param solver_name A name used as a prefix for command line options
+     *                    if there are such options available.
+     * @param option      A pointer to a linear solver option. In case you omit
+     *                    this argument, default settings follow those of
+     *                    LisOption struct.
      */
-    LisLinearSolver(LisMatrix &A, boost::property_tree::ptree const*const option = nullptr);
+    LisLinearSolver(LisMatrix &A, const std::string& solver_name = "",
+                    boost::property_tree::ptree const*const option = nullptr);
 
     virtual ~LisLinearSolver() {}
 

--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
@@ -14,12 +14,16 @@
                http://www.opengeosys.org/project/license
 */
 
+#include <boost/property_tree/ptree.hpp>
+
 #include "PETScLinearSolver.h"
 #include "BaseLib/RunTime.h"
 
 namespace MathLib
 {
-PETScLinearSolver::PETScLinearSolver(PETScMatrix &A, const std::string &prefix)
+PETScLinearSolver::PETScLinearSolver(PETScMatrix &A,
+                      const std::string &prefix,
+                      boost::property_tree::ptree const*const /*option*/)
     : _A(A), _elapsed_ctime(0.)
 {
     KSPCreate(PETSC_COMM_WORLD, &_solver);

--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
@@ -22,7 +22,7 @@
 namespace MathLib
 {
 PETScLinearSolver::PETScLinearSolver(PETScMatrix &A,
-                      const std::string &prefix,
+                      const std::string prefix,
                       boost::property_tree::ptree const*const /*option*/)
     : _A(A), _elapsed_ctime(0.)
 {

--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.h
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.h
@@ -18,10 +18,11 @@
 #define PETSCLINEARSOLVER_H_
 
 #include<string>
+#include <boost/property_tree/ptree_fwd.hpp>
+
+#include <petscksp.h>
 
 #include "logog/include/logog.hpp"
-
-#include "petscksp.h"
 
 #include "PETScMatrix.h"
 #include "PETScVector.h"
@@ -44,8 +45,11 @@ class PETScLinearSolver
             \param prefix  Name used to distinguish the options in the command
                            line for this solver. It can be the name of the PDE
                            that owns an instance of this class.
+            \param option  Not used here, just for the consistency of
+                           the linear solver interface.
         */
-        PETScLinearSolver(PETScMatrix &A, const std::string &prefix="");
+        PETScLinearSolver(PETScMatrix &A, const std::string &prefix="",
+                          boost::property_tree::ptree const*const option = nullptr);
 
         ~PETScLinearSolver()
         {

--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.h
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.h
@@ -48,7 +48,7 @@ class PETScLinearSolver
             \param option  Not used here, just for the consistency of
                            the linear solver interface.
         */
-        PETScLinearSolver(PETScMatrix &A, const std::string &prefix="",
+        PETScLinearSolver(PETScMatrix &A, const std::string prefix="",
                           boost::property_tree::ptree const*const option = nullptr);
 
         ~PETScLinearSolver()

--- a/MathLib/LinAlg/Solvers/GaussAlgorithm-impl.h
+++ b/MathLib/LinAlg/Solvers/GaussAlgorithm-impl.h
@@ -20,7 +20,7 @@ namespace MathLib {
 
 template <typename MAT_T, typename VEC_T>
 GaussAlgorithm<MAT_T, VEC_T>::GaussAlgorithm(MAT_T &A,
-		const std::string& /*solver_name*/,
+		const std::string /*solver_name*/,
 		boost::property_tree::ptree const* const) :
 		_mat(A), _n(_mat.getNRows()), _perm(new IDX_T[_n])
 {}

--- a/MathLib/LinAlg/Solvers/GaussAlgorithm-impl.h
+++ b/MathLib/LinAlg/Solvers/GaussAlgorithm-impl.h
@@ -20,6 +20,7 @@ namespace MathLib {
 
 template <typename MAT_T, typename VEC_T>
 GaussAlgorithm<MAT_T, VEC_T>::GaussAlgorithm(MAT_T &A,
+		const std::string& /*solver_name*/,
 		boost::property_tree::ptree const* const) :
 		_mat(A), _n(_mat.getNRows()), _perm(new IDX_T[_n])
 {}

--- a/MathLib/LinAlg/Solvers/GaussAlgorithm.h
+++ b/MathLib/LinAlg/Solvers/GaussAlgorithm.h
@@ -54,7 +54,7 @@ public:
 	 * of all solvers of systems of linear equations. For this reason the
 	 * second argument was introduced.
 	 */
-	GaussAlgorithm(MAT_T &A, const std::string& solver_name = "",
+	GaussAlgorithm(MAT_T &A, const std::string solver_name = "",
                    boost::property_tree::ptree const*const option = nullptr);
 	/**
 	 * destructor, deletes the permutation

--- a/MathLib/LinAlg/Solvers/GaussAlgorithm.h
+++ b/MathLib/LinAlg/Solvers/GaussAlgorithm.h
@@ -47,12 +47,15 @@ public:
 	 * in the strictly lower part and the factor U in the upper part.
 	 * The diagonal entries of L are all 1.0 and are not explicitly stored.
 	 * @attention The entries of the given matrix will be changed!
+	 * @param solver_name A name used as a prefix for command line options
+	 *                    if there are such options available.
 	 * @param option For some solvers the user can give parameters to the
 	 * algorithm. GaussAlgorithm has to fulfill the common interface
 	 * of all solvers of systems of linear equations. For this reason the
 	 * second argument was introduced.
 	 */
-	GaussAlgorithm(MAT_T &A, boost::property_tree::ptree const*const option = nullptr);
+	GaussAlgorithm(MAT_T &A, const std::string& solver_name = "",
+                   boost::property_tree::ptree const*const option = nullptr);
 	/**
 	 * destructor, deletes the permutation
 	 */

--- a/Tests/MathLib/TestLinearSolver.cpp
+++ b/Tests/MathLib/TestLinearSolver.cpp
@@ -126,7 +126,7 @@ void checkLinearSolverInterface(T_MATRIX &A, boost::property_tree::ptree &ls_opt
     MathLib::finalizeMatrixAssembly(A);
 
     // solve
-    T_LINEAR_SOVLER ls(A, &ls_option);
+    T_LINEAR_SOVLER ls(A, "dummy_name", &ls_option);
     ls.solve(rhs, x);
 
     ASSERT_ARRAY_NEAR(ex1.exH, x, ex1.dim_eqs, 1e-5);


### PR DESCRIPTION
Make solver interface unique by adding a string argument to the constructor of linear solver classes, which could be used as a prefix for command line options of linear solvers if they are available.
PS: removed the calling ``releaseEquationMemory()`` from main to avoid compilation error.  