### PR TITLE
[AL] Rename getGlobalIndices<ORDER>() functions.

### DIFF
--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -146,10 +146,12 @@ LocalToGlobalIndexMap::findGlobalIndices(ElementIterator first, ElementIterator 
         switch (order)
         {
             case AssemblerLib::ComponentOrder::BY_LOCATION:
-                _rows.push_back(_mesh_component_map.getGlobalIndices<AssemblerLib::ComponentOrder::BY_LOCATION>(vec_items));
+                _rows.push_back(
+                    _mesh_component_map.getGlobalIndicesByLocation(vec_items));
                 break;
             case AssemblerLib::ComponentOrder::BY_COMPONENT:
-                _rows.push_back(_mesh_component_map.getGlobalIndices<AssemblerLib::ComponentOrder::BY_COMPONENT>(vec_items));
+                _rows.push_back(
+                    _mesh_component_map.getGlobalIndicesByComponent(vec_items));
                 break;
         }
     }

--- a/AssemblerLib/MeshComponentMap.cpp
+++ b/AssemblerLib/MeshComponentMap.cpp
@@ -132,10 +132,8 @@ std::vector<GlobalIndexType> MeshComponentMap::getGlobalIndices(const Location &
     return global_indices;
 }
 
-template <>
-std::vector<GlobalIndexType>
-MeshComponentMap::getGlobalIndices<ComponentOrder::BY_LOCATION>(
-    std::vector<Location> const &ls) const
+std::vector<GlobalIndexType> MeshComponentMap::getGlobalIndicesByLocation(
+    std::vector<Location> const& ls) const
 {
     // Create vector of global indices sorted by location containing all
     // locations given in ls parameter.
@@ -154,10 +152,8 @@ MeshComponentMap::getGlobalIndices<ComponentOrder::BY_LOCATION>(
     return global_indices;
 }
 
-template <>
-std::vector<GlobalIndexType>
-MeshComponentMap::getGlobalIndices<ComponentOrder::BY_COMPONENT>(
-    std::vector<Location> const &ls) const
+std::vector<GlobalIndexType> MeshComponentMap::getGlobalIndicesByComponent(
+    std::vector<Location> const& ls) const
 {
     // vector of (Component, global Index) pairs.
     typedef std::pair<std::size_t, GlobalIndexType> CIPair;

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -85,10 +85,8 @@ public:
     std::vector<GlobalIndexType> getGlobalIndices(const Location &l) const;
 
     /// Global indices for all components at all given locations \c ls ordered
-    /// as required by the template parameter ORDER.
+    /// by location. The return list is sorted first by location.
     ///
-    /// In case ORDER is ComponentOrder::BY_LOCATION the return list is sorted
-    /// first by location.
     /// | Location | ComponentID | GlobalIndex |
     /// | -------- | ----------- | ----------- |
     /// | l_1      | comp_id_1   | gi23        |
@@ -99,9 +97,11 @@ public:
     /// | l_2      | comp_id_m   | gi67        |
     /// | ...      |  ...        | ...         |
     /// | l_n      | comp_id_n   | gi78        |
-    ///
-    /// In case ORDER is ComponentOrder::BY_COMPONENT the return list is sorted
-    /// first by component ids.
+    std::vector<GlobalIndexType> getGlobalIndicesByLocation(
+        const std::vector<Location>& ls) const;
+
+    /// Global indices for all components at all given locations \c ls ordered
+    /// by component ids. The return list is sorted first by component ids.
     /// | Location | ComponentID | GlobalIndex |
     /// | -------- | ----------- | ----------- |
     /// | l_1      | comp_id_1   | gi23        |
@@ -112,8 +112,8 @@ public:
     /// | l_m      | comp_id_2   | gi78        |
     /// | ...      |  ...        | ...         |
     /// | l_n      | comp_id_n   | gi89        |
-    template <ComponentOrder ORDER>
-    std::vector<GlobalIndexType> getGlobalIndices(const std::vector<Location> &ls) const;
+    std::vector<GlobalIndexType> getGlobalIndicesByComponent(
+        const std::vector<Location>& ls) const;
 
     /// A value returned if no global index was found for the requested
     /// location/component. The value is implementation dependent.


### PR DESCRIPTION
This is independent part of the https://github.com/ufz/ogs/pull/580 PR.

Rename and documentation.