### PR TITLE
Linear solver library setup

### DIFF
--- a/Applications/ApplicationsLib/LinearSolverLibrarySetup.h
+++ b/Applications/ApplicationsLib/LinearSolverLibrarySetup.h
@@ -1,0 +1,64 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef APPLICATIONSLIB_LINEARSOLVERLIBRARYSETUP_H_
+#define APPLICATIONSLIB_LINEARSOLVERLIBRARYSETUP_H_
+
+namespace ApplicationsLib
+{
+
+/// The LinearSolverLibrarySetup takes care of proper initialization and
+/// shutting down of an external linear solver library. The concrete
+/// implementation is chosen by the build system.
+/// An object of this class must be created at the begining of the scope where
+/// it is used. When the scope closes (or the object is destroyed explicitly)
+/// library shutting down functions are automatically called.
+/// The default implementation is empty providing polymorphic behaviour when
+/// using this class.
+
+#if defined(USE_PETSC)
+#include <petsc.h>
+#include <mpi.h>
+struct LinearSolverLibrarySetup final
+{
+	LinearSolverLibrarySetup(int argc, char* argv[])
+	{
+		MPI_Init(&argc, &argv);
+		char help[] = "ogs6 with PETSc \n";
+		PetscInitialize(&argc, &argv, nullptr, help);
+	}
+
+	~LinearSolverLibrarySetup()
+	{
+		PetscFinalize();
+		MPI_Finalize();
+	}
+};
+#elif defined(USE_LIS)
+#include <lis.h>
+struct LinearSolverLibrarySetup final
+{
+	LinearSolverLibrarySetup(int argc, char* argv[])
+	{
+		lis_initialize(&argc, &argv);
+	}
+
+	~LinearSolverLibrarySetup() { lis_finalize(); }
+};
+#else
+struct LinearSolverLibrarySetup final
+{
+	LinearSolverLibrarySetup(int /*argc*/, char* /*argv*/[]) {}
+	~LinearSolverLibrarySetup() {}
+};
+#endif
+
+}	// ApplicationsLib
+
+#endif  // APPLICATIONSLIB_LINEARSOLVERLIBRARYSETUP_H_

--- a/Applications/ApplicationsLib/LinearSolverLibrarySetup.h
+++ b/Applications/ApplicationsLib/LinearSolverLibrarySetup.h
@@ -10,9 +10,6 @@
 #ifndef APPLICATIONSLIB_LINEARSOLVERLIBRARYSETUP_H_
 #define APPLICATIONSLIB_LINEARSOLVERLIBRARYSETUP_H_
 
-namespace ApplicationsLib
-{
-
 /// The LinearSolverLibrarySetup takes care of proper initialization and
 /// shutting down of an external linear solver library. The concrete
 /// implementation is chosen by the build system.
@@ -25,6 +22,8 @@ namespace ApplicationsLib
 #if defined(USE_PETSC)
 #include <petsc.h>
 #include <mpi.h>
+namespace ApplicationsLib
+{
 struct LinearSolverLibrarySetup final
 {
 	LinearSolverLibrarySetup(int argc, char* argv[])
@@ -40,8 +39,11 @@ struct LinearSolverLibrarySetup final
 		MPI_Finalize();
 	}
 };
+}	// ApplicationsLib
 #elif defined(USE_LIS)
 #include <lis.h>
+namespace ApplicationsLib
+{
 struct LinearSolverLibrarySetup final
 {
 	LinearSolverLibrarySetup(int argc, char* argv[])
@@ -51,14 +53,17 @@ struct LinearSolverLibrarySetup final
 
 	~LinearSolverLibrarySetup() { lis_finalize(); }
 };
+}	// ApplicationsLib
 #else
+namespace ApplicationsLib
+{
 struct LinearSolverLibrarySetup final
 {
 	LinearSolverLibrarySetup(int /*argc*/, char* /*argv*/[]) {}
 	~LinearSolverLibrarySetup() {}
 };
+}	// ApplicationsLib
 #endif
 
-}	// ApplicationsLib
 
 #endif  // APPLICATIONSLIB_LINEARSOLVERLIBRARYSETUP_H_

--- a/Applications/ApplicationsLib/LogogSetup.h
+++ b/Applications/ApplicationsLib/LogogSetup.h
@@ -1,0 +1,47 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef APPLICATIONSLIB_LOGOGSETUP_H_
+#define APPLICATIONSLIB_LOGOGSETUP_H_
+
+#include <logog/include/logog.hpp>
+
+#include "BaseLib/LogogSimpleFormatter.h"
+
+namespace ApplicationsLib
+{
+
+/// Initialization and shutting down of the logog library.
+class LogogSetup final
+{
+public:
+
+	LogogSetup()
+	{
+		LOGOG_INITIALIZE();
+		fmt = new BaseLib::LogogSimpleFormatter;
+		logog_cout = new logog::Cout;
+		logog_cout->SetFormatter(*fmt);
+	}
+
+	~LogogSetup()
+	{
+		delete fmt;
+		delete logog_cout;
+		LOGOG_SHUTDOWN();
+	}
+
+private:
+	BaseLib::LogogSimpleFormatter* fmt;
+	logog::Cout* logog_cout;
+};
+
+}	// ApplicationsLib
+
+#endif  // APPLICATIONSLIB_LOGOGSETUP_H_

--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -28,6 +28,7 @@
 #include "BaseLib/BuildInfo.h"
 #include "BaseLib/FileTools.h"
 
+#include "Applications/ApplicationsLib/LinearSolverLibrarySetup.h"
 #include "Applications/ApplicationsLib/LogogSetup.h"
 #include "Applications/ApplicationsLib/ProjectData.h"
 
@@ -82,15 +83,6 @@ int main(int argc, char *argv[])
 {
 	using ConfigTree = boost::property_tree::ptree;
 
-#ifdef USE_MPI
-	MPI_Init(&argc, &argv);
-#endif
-
-#ifdef USE_PETSC
-	char help[] = "ogs6 with PETSc \n";
-	PetscInitialize(&argc, &argv, nullptr, help);
-#endif
-
 	// Parse CLI arguments.
 	TCLAP::CmdLine cmd("OpenGeoSys-6 software.\n"
 			"Copyright (c) 2012-2015, OpenGeoSys Community "
@@ -112,10 +104,8 @@ int main(int argc, char *argv[])
 	cmd.parse(argc, argv);
 
 	ApplicationsLib::LogogSetup logog_setup;
-	
-#ifdef USE_LIS
-	lis_initialize(&argc, &argv);
-#endif
+	ApplicationsLib::LinearSolverLibrarySetup linear_solver_library_setup(
+	    argc, argv);
 
 	// Project's configuration
 	ConfigTree project_config;
@@ -144,17 +134,6 @@ int main(int argc, char *argv[])
 	std::string const output_file_name(project.getOutputFilePrefix() + ".vtu");
 
 	solveProcesses(project);
-
-#ifdef USE_PETSC
-	PetscFinalize();
-#endif
-#ifdef USE_MPI
-	MPI_Finalize();
-#endif
-
-#ifdef USE_LIS
-	lis_finalize();
-#endif
 
 	return 0;
 }

--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -21,17 +21,14 @@
 #include <petsc.h>
 #endif
 
-// ThirdParty/logog
-#include "logog/include/logog.hpp"
-
 // ThirdParty/tclap
 #include "tclap/CmdLine.h"
 
 // BaseLib
 #include "BaseLib/BuildInfo.h"
 #include "BaseLib/FileTools.h"
-#include "BaseLib/LogogSimpleFormatter.h"
 
+#include "Applications/ApplicationsLib/LogogSetup.h"
 #include "Applications/ApplicationsLib/ProjectData.h"
 
 #include "ProcessLib/NumericsConfig.h"
@@ -94,12 +91,6 @@ int main(int argc, char *argv[])
 	PetscInitialize(&argc, &argv, nullptr, help);
 #endif
 
-	// logog
-	LOGOG_INITIALIZE();
-	BaseLib::LogogSimpleFormatter *fmt(new BaseLib::LogogSimpleFormatter);
-	logog::Cout *logog_cout(new logog::Cout);
-	logog_cout->SetFormatter(*fmt);
-
 	// Parse CLI arguments.
 	TCLAP::CmdLine cmd("OpenGeoSys-6 software.\n"
 			"Copyright (c) 2012-2015, OpenGeoSys Community "
@@ -120,6 +111,8 @@ int main(int argc, char *argv[])
 	cmd.add(project_arg);
 	cmd.parse(argc, argv);
 
+	ApplicationsLib::LogogSetup logog_setup;
+	
 #ifdef USE_LIS
 	lis_initialize(&argc, &argv);
 #endif
@@ -155,14 +148,9 @@ int main(int argc, char *argv[])
 #ifdef USE_PETSC
 	PetscFinalize();
 #endif
-
 #ifdef USE_MPI
 	MPI_Finalize();
 #endif
-
-	delete fmt;
-	delete logog_cout;
-	LOGOG_SHUTDOWN();
 
 #ifdef USE_LIS
 	lis_finalize();

--- a/BaseLib/LogogSimpleFormatter.h
+++ b/BaseLib/LogogSimpleFormatter.h
@@ -15,23 +15,22 @@
 #ifndef LOGOGSIMPLEFORMATTER_H
 #define LOGOGSIMPLEFORMATTER_H
 
-// ** INCLUDES **
-#include "logog/include/logog.hpp"
+#include <logog/include/logog.hpp>
 
-namespace BaseLib {
+namespace BaseLib
+{
 /**
- * \brief LogogSimpleFormatter strips file name and line number from logog output.
+ * \brief LogogSimpleFormatter strips file name and line number from logog
+ * output.
  * See http://johnwbyrd.github.com/logog/customformatting.html for details.
  **/
 class LogogSimpleFormatter : public logog::FormatterMSVC
 {
-
-	virtual TOPIC_FLAGS GetTopicFlags( const logog::Topic &topic )
+	virtual TOPIC_FLAGS GetTopicFlags(const logog::Topic& topic)
 	{
-	return ( logog::Formatter::GetTopicFlags( topic ) &
-		~( TOPIC_FILE_NAME_FLAG | TOPIC_LINE_NUMBER_FLAG ));
+		return (logog::Formatter::GetTopicFlags(topic) &
+		        ~(TOPIC_FILE_NAME_FLAG | TOPIC_LINE_NUMBER_FLAG));
 	}
-
 };
 
 }  // namespace BaseLib

--- a/BaseLib/LogogSimpleFormatter.h
+++ b/BaseLib/LogogSimpleFormatter.h
@@ -34,6 +34,6 @@ class LogogSimpleFormatter : public logog::FormatterMSVC
 
 };
 
-#endif // LOGOGSIMPLEFORMATTER_H
+}  // namespace BaseLib
 
-} // namespace BaseLib
+#endif  // LOGOGSIMPLEFORMATTER_H


### PR DESCRIPTION
Move initialization of linear solver libraries into own class `LinearSolverLibrarySetup` (which is chosen by preprocessor for now and will be chosen by cmake soon)  with purpose of correct initialization and *shutdown* of the external libraries.
This resolves the issue of core dumps in the pFEM4 PR (https://github.com/ufz/ogs/pull/580) because of improper order of matrix/vectors/linear-solver destruction. No explicit `releaseEquationsMemory()` workaround is longer necessary.

Logog is set up same way too.

 - First fix some issues on logog first,
 - then move logog initialization to LogogSetup,
 - finally implement LinearSolverLibrarySetup for PETSc, LIS, and a default (which is empty).

This closes https://github.com/ufz/ogs/pull/851.
