### PR TITLE
[MeshLib] Add char and bool properties to VtkMeshConverter.

### DIFF
--- a/InSituLib/VtkMappedMeshSource.cpp
+++ b/InSituLib/VtkMappedMeshSource.cpp
@@ -98,6 +98,9 @@ int VtkMappedMeshSource::RequestData(vtkInformation *,
 		if (addProperty<unsigned>(*output, properties, *name))
 			continue;
 
+		if (addProperty<char>(*output, properties, *name))
+			continue;
+
 		DBUG ("Mesh property \"%s\" with unknown data type.", *name->c_str());
 	}
 	return 1;

--- a/MeshLib/MeshGenerators/VtkMeshConverter.cpp
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.cpp
@@ -22,6 +22,8 @@
 #include <vtkImageData.h>
 #include <vtkPointData.h>
 #include <vtkSmartPointer.h>
+#include <vtkBitArray.h>
+#include <vtkCharArray.h>
 #include <vtkUnsignedCharArray.h>
 #include <vtkDoubleArray.h>
 #include <vtkIntArray.h>
@@ -439,6 +441,18 @@ void VtkMeshConverter::convertArray(vtkDataArray &array, MeshLib::Properties &pr
 	if (vtkIntArray::SafeDownCast(&array))
 	{
 		VtkMeshConverter::convertTypedArray<int>(array, properties, type);
+		return;
+	}
+
+	if (vtkBitArray::SafeDownCast(&array))
+	{
+		VtkMeshConverter::convertTypedArray<bool>(array, properties, type);
+		return;
+	}
+
+	if (vtkCharArray::SafeDownCast(&array))
+	{
+		VtkMeshConverter::convertTypedArray<char>(array, properties, type);
 		return;
 	}
 

--- a/MeshLib/MeshGenerators/VtkMeshConverter.h
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.h
@@ -101,7 +101,7 @@ private:
 			(properties.createNewPropertyVector<T>(array_name, type, nComponents));
 		if (!vec)
 		{
-			WARN("vtkFloatArray %s could not be converted to PropertyVector.", array_name);
+			WARN("Array %s could not be converted to PropertyVector.", array_name);
 			return;
 		}
 		vec->reserve(nTuples*nComponents);


### PR DESCRIPTION
This PR deals with the conversion of `vtkCharArray` and `vtkBitArray` to `PropertyVector`. These conversion is needed for a tool (PR in preparation).