### PR TITLE
Use unique_ptr in TemplateVec for data.

### DIFF
--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -545,11 +545,14 @@ void MainWindow::loadFile(ImportFileType::type t, const QString &fileName)
 	{
 		if (fi.suffix().toLower() == "txt") // GMS borehole files
 		{
-			std::vector<GeoLib::Point*>* boreholes = new std::vector<GeoLib::Point*>();
+			auto boreholes = std::unique_ptr<std::vector<GeoLib::Point*>>(
+			    new std::vector<GeoLib::Point*>());
 			std::string name = fi.baseName().toStdString();
 
-			if (GMSInterface::readBoreholesFromGMS(boreholes, fileName.toStdString()))
-				_project.getGEOObjects()->addStationVec(boreholes, name);
+			if (GMSInterface::readBoreholesFromGMS(boreholes.get(),
+			                                       fileName.toStdString()))
+				_project.getGEOObjects()->addStationVec(std::move(boreholes),
+				                                        name);
 			else
 				OGSError::box("Error reading GMS file.");
 		}

--- a/Applications/Utils/FileConverter/ConvertSHPToGLI.cpp
+++ b/Applications/Utils/FileConverter/ConvertSHPToGLI.cpp
@@ -50,7 +50,7 @@ void convertPoints (DBFHandle dbf_handle,
 	int n_records (DBFGetRecordCount (dbf_handle));
 	INFO("Reading %d records.", n_records);
 
-	std::vector<GeoLib::Point*>* points (new std::vector<GeoLib::Point*>);
+	auto points = std::unique_ptr<std::vector<GeoLib::Point*>>(new std::vector<GeoLib::Point*>);
 	points->reserve (n_records);
 
 	std::string name;
@@ -83,9 +83,9 @@ void convertPoints (DBFHandle dbf_handle,
 
 	GeoLib::GEOObjects geo_objs;
 	if (station)
-		geo_objs.addStationVec(points, points_group_name);
+		geo_objs.addStationVec(std::move(points), points_group_name);
 	else
-		geo_objs.addPointVec(points, points_group_name);
+		geo_objs.addPointVec(std::move(points), points_group_name);
 
 	if (station) {
 		FileIO::XmlStnInterface xml (geo_objs);

--- a/Applications/Utils/FileConverter/TIN2VTK.cpp
+++ b/Applications/Utils/FileConverter/TIN2VTK.cpp
@@ -56,8 +56,9 @@ int main (int argc, char* argv[])
 
 	INFO("reading the TIN file...");
 	const std::string tinFileName(inArg.getValue());
-	std::vector<GeoLib::Point*> *pnt_vec(new std::vector<GeoLib::Point*>);
-	GeoLib::PointVec point_vec("SurfacePoints", pnt_vec);
+	auto pnt_vec = std::unique_ptr<std::vector<GeoLib::Point*>>(
+	    new std::vector<GeoLib::Point*>);
+	GeoLib::PointVec point_vec("SurfacePoints", std::move(pnt_vec));
 	std::unique_ptr<GeoLib::Surface> sfc(FileIO::TINInterface::readTIN(tinFileName, point_vec));
 	if (!sfc)
 		return 1;

--- a/Applications/Utils/GeoTools/TriangulatePolyline.cpp
+++ b/Applications/Utils/GeoTools/TriangulatePolyline.cpp
@@ -100,13 +100,14 @@ int main(int argc, char *argv[])
 
 	// create surface
 	INFO ("Triangulating surface...");
-	std::vector<GeoLib::Surface*> *new_sfc = new std::vector<GeoLib::Surface*>;
+	auto new_sfc = std::unique_ptr<std::vector<GeoLib::Surface*>>(
+	    new std::vector<GeoLib::Surface*>);
 	new_sfc->push_back(GeoLib::Surface::createSurface(*line));
 
 	GeoLib::SurfaceVec* sfc_vec (geo_objects.getSurfaceVecObj(geo_names[0]));
 	if (sfc_vec == nullptr)
 	{
-		geo_objects.addSurfaceVec(new_sfc, geo_names[0]);
+		geo_objects.addSurfaceVec(std::move(new_sfc), geo_names[0]);
 		sfc_vec = geo_objects.getSurfaceVecObj(geo_names[0]);
 	}
 	else

--- a/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
+++ b/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
@@ -47,7 +47,8 @@ void convertMeshNodesToGeometry(std::vector<MeshLib::Node*> const& nodes,
 	GeoLib::GEOObjects & geometry_sets)
 {
 	// copy data
-	std::vector<GeoLib::Point*> * pnts(new std::vector<GeoLib::Point*>);
+	auto pnts = std::unique_ptr<std::vector<GeoLib::Point*>>(
+	    new std::vector<GeoLib::Point*>);
 	std::map<std::string, std::size_t>* pnt_names(
 		new std::map<std::string, std::size_t>);
 	std::size_t cnt(0);
@@ -59,7 +60,7 @@ void convertMeshNodesToGeometry(std::vector<MeshLib::Node*> const& nodes,
 	}
 
 	// create data structures for geometry
-	geometry_sets.addPointVec(pnts, geo_name, pnt_names);
+	geometry_sets.addPointVec(std::move(pnts), geo_name, pnt_names);
 }
 
 void writeBCsAndGML(GeoLib::GEOObjects & geometry_sets,
@@ -230,7 +231,8 @@ int main (int argc, char* argv[])
 	);
 
 	double const eps (std::numeric_limits<double>::epsilon());
-	std::vector<GeoLib::Point*> *surface_pnts (new std::vector<GeoLib::Point*>);
+	auto surface_pnts = std::unique_ptr<std::vector<GeoLib::Point*>>(
+	    new std::vector<GeoLib::Point*>);
 	std::map<std::string, std::size_t> *name_id_map(
 		new std::map<std::string, std::size_t>
 	);
@@ -259,7 +261,7 @@ int main (int argc, char* argv[])
 	}
 
 	std::string surface_name(BaseLib::dropFileExtension(mesh_arg.getValue())+"-MeshNodesAlongPolylines");
-	geometry_sets.addPointVec(surface_pnts, surface_name, name_id_map, 1e-6);
+	geometry_sets.addPointVec(std::move(surface_pnts), surface_name, name_id_map, 1e-6);
 
 	// write the BCs and the merged geometry set to file
 	writeBCsAndGML(geometry_sets, surface_name, vis_arg.getValue());

--- a/FileIO/FEFLOWInterface.cpp
+++ b/FileIO/FEFLOWInterface.cpp
@@ -176,11 +176,15 @@ MeshLib::Mesh* FEFLOWInterface::readFEFLOWFile(const std::string &filename)
 		}
 	}
 
-	std::string project_name(BaseLib::extractBaseNameWithoutExtension(filename));
+	std::string project_name(
+	    BaseLib::extractBaseNameWithoutExtension(filename));
 	if (_geoObjects && points)
-		_geoObjects->addPointVec(points, project_name);
+		_geoObjects->addPointVec(
+		    std::unique_ptr<std::vector<GeoLib::Point*>>(points), project_name);
 	if (_geoObjects && lines)
-		_geoObjects->addPolylineVec(lines, project_name);
+		_geoObjects->addPolylineVec(
+		    std::unique_ptr<std::vector<GeoLib::Polyline*>>(lines),
+		    project_name);
 
 	auto mesh = new MeshLib::Mesh(project_name, vec_nodes, vec_elements);
 	boost::optional<MeshLib::PropertyVector<int> &> opt_material_ids(

--- a/FileIO/GmshIO/GMSHPolygonTree.cpp
+++ b/FileIO/GmshIO/GMSHPolygonTree.cpp
@@ -274,18 +274,20 @@ void GMSHPolygonTree::writeAdditionalPointData(std::size_t & pnt_id_offset, std:
 
 #ifndef NDEBUG
 	if (dynamic_cast<GMSHAdaptiveMeshDensity*>(_mesh_density_strategy)) {
-		std::vector<GeoLib::Point*> * pnts(new std::vector<GeoLib::Point*>);
-		std::vector<GeoLib::Polyline*> *plys(new std::vector<GeoLib::Polyline*>);
+		auto pnts = std::unique_ptr<std::vector<GeoLib::Point*>>(
+		    new std::vector<GeoLib::Point*>);
+		auto plys = std::unique_ptr<std::vector<GeoLib::Polyline*>>(
+		    new std::vector<GeoLib::Polyline*>);
 		dynamic_cast<GMSHAdaptiveMeshDensity*>(_mesh_density_strategy)->getQuadTreeGeometry(*pnts, *plys);
 		std::string quad_tree_geo("QuadTree");
-		_geo_objs.addPointVec(pnts, quad_tree_geo);
+		_geo_objs.addPointVec(std::move(pnts), quad_tree_geo);
 		std::vector<std::size_t> const& id_map ((_geo_objs.getPointVecObj(quad_tree_geo))->getIDMap());
 		for (std::size_t k(0); k<plys->size(); k++) {
 			for (std::size_t j(0); j<(*plys)[k]->getNumberOfPoints(); j++) {
 				((*plys)[k])->setPointID(j, id_map[((*plys)[k])->getPointID(j)]);
 			}
 		}
-		_geo_objs.addPolylineVec(plys, quad_tree_geo);
+		_geo_objs.addPolylineVec(std::move(plys), quad_tree_geo);
 	}
 #endif
 

--- a/FileIO/PetrelInterface.cpp
+++ b/FileIO/PetrelInterface.cpp
@@ -65,9 +65,16 @@ PetrelInterface::PetrelInterface(std::list<std::string> &sfc_fnames,
 	}
 
 	// store data in GEOObject
-	geo_obj->addPointVec(pnt_vec, _unique_name);
-	if (well_vec->size() > 0) geo_obj->addStationVec(well_vec, _unique_name);
-	if (ply_vec->size() > 0) geo_obj->addPolylineVec(ply_vec, _unique_name);
+	geo_obj->addPointVec(std::unique_ptr<std::vector<GeoLib::Point*>>(pnt_vec),
+	                     _unique_name);
+	if (well_vec->size() > 0)
+		geo_obj->addStationVec(
+		    std::unique_ptr<std::vector<GeoLib::Point*>>(well_vec),
+		    _unique_name);
+	if (ply_vec->size() > 0)
+		geo_obj->addPolylineVec(
+		    std::unique_ptr<std::vector<GeoLib::Polyline*>>(ply_vec),
+		    _unique_name);
 }
 
 PetrelInterface::~PetrelInterface()

--- a/FileIO/SHPInterface.cpp
+++ b/FileIO/SHPInterface.cpp
@@ -72,7 +72,8 @@ void SHPInterface::readSHPFile(const std::string &filename, OGSType choice, cons
 void SHPInterface::readPoints(const SHPHandle &hSHP, int numberOfElements, std::string listName)
 {
 	if (numberOfElements > 0) {
-		std::vector<GeoLib::Point*>* points = new std::vector<GeoLib::Point*>();
+		auto points = std::unique_ptr<std::vector<GeoLib::Point*>>(
+		    new std::vector<GeoLib::Point*>);
 		SHPObject* hSHPObject;
 
 		for (int i = 0; i < numberOfElements; i++) {
@@ -84,7 +85,7 @@ void SHPInterface::readPoints(const SHPHandle &hSHP, int numberOfElements, std::
 			points->push_back(pnt);
 		}
 
-		_geoObjects->addPointVec(points, listName);
+		_geoObjects->addPointVec(std::move(points), listName);
 		SHPDestroyObject(hSHPObject); // de-allocate SHPObject
 	}
 }
@@ -92,7 +93,8 @@ void SHPInterface::readPoints(const SHPHandle &hSHP, int numberOfElements, std::
 void SHPInterface::readStations(const SHPHandle &hSHP, int numberOfElements, std::string listName)
 {
 	if (numberOfElements > 0) {
-		std::vector<GeoLib::Point*>* stations(new std::vector<GeoLib::Point*>);
+		auto stations = std::unique_ptr<std::vector<GeoLib::Point*>>(
+		    new std::vector<GeoLib::Point*>);
 		stations->reserve(numberOfElements);
 		SHPObject* hSHPObject;
 
@@ -105,7 +107,7 @@ void SHPInterface::readStations(const SHPHandle &hSHP, int numberOfElements, std
 			stations->push_back(stn);
 		}
 
-		_geoObjects->addStationVec(stations, listName);
+		_geoObjects->addStationVec(std::move(stations), listName);
 		SHPDestroyObject(hSHPObject); // de-allocate SHPObject
 	}
 }
@@ -114,8 +116,10 @@ void SHPInterface::readPolylines(const SHPHandle &hSHP, int numberOfElements, st
 {
 	if (numberOfElements <= 0)
 		return;
-	std::vector<GeoLib::Point*>* pnts = new std::vector<GeoLib::Point*>();
-	std::vector<GeoLib::Polyline*>* lines = new std::vector<GeoLib::Polyline*>();
+	auto pnts = std::unique_ptr<std::vector<GeoLib::Point*>>(
+	    new std::vector<GeoLib::Point*>);
+	auto lines = std::unique_ptr<std::vector<GeoLib::Polyline*>>(
+	    new std::vector<GeoLib::Polyline*>);
 
 	std::size_t pnt_id(0);
 	// for each polyline
@@ -139,7 +143,7 @@ void SHPInterface::readPolylines(const SHPHandle &hSHP, int numberOfElements, st
 		SHPDestroyObject(hSHPObject); // de-allocate SHPObject
 	}
 
-	_geoObjects->addPointVec(pnts, listName);
+	_geoObjects->addPointVec(std::move(pnts), listName);
 	GeoLib::PointVec const& points(*(_geoObjects->getPointVecObj(listName)));
 	std::vector<std::size_t> const& pnt_id_map(points.getIDMap());
 
@@ -166,7 +170,7 @@ void SHPInterface::readPolylines(const SHPHandle &hSHP, int numberOfElements, st
 		}
 		SHPDestroyObject(hSHPObject); // de-allocate SHPObject
 	}
-	_geoObjects->addPolylineVec(lines, listName);
+	_geoObjects->addPolylineVec(std::move(lines), listName);
 }
 
 void SHPInterface::readPolygons(const SHPHandle &hSHP, int numberOfElements, const std::string &listName)
@@ -174,7 +178,8 @@ void SHPInterface::readPolygons(const SHPHandle &hSHP, int numberOfElements, con
 	this->readPolylines(hSHP, numberOfElements, listName);
 
 	const std::vector<GeoLib::Polyline*>* polylines(_geoObjects->getPolylineVec(listName));
-	std::vector<GeoLib::Surface*>* sfc_vec(new std::vector<GeoLib::Surface*>);
+	auto sfc_vec = std::unique_ptr<std::vector<GeoLib::Surface*>>(
+	    new std::vector<GeoLib::Surface*>);
 
 	for (std::vector<GeoLib::Polyline*>::const_iterator poly_it(polylines->begin()); poly_it
 	                != polylines->end(); ++poly_it) {
@@ -187,7 +192,7 @@ void SHPInterface::readPolygons(const SHPHandle &hSHP, int numberOfElements, con
 	}
 
 	if (!sfc_vec->empty())
-		_geoObjects->addSurfaceVec(sfc_vec, listName);
+		_geoObjects->addSurfaceVec(std::move(sfc_vec), listName);
 }
 
 bool SHPInterface::write2dMeshToSHP(const std::string &file_name, const MeshLib::Mesh &mesh)

--- a/FileIO/XmlIO/Boost/BoostXmlGmlInterface.cpp
+++ b/FileIO/XmlIO/Boost/BoostXmlGmlInterface.cpp
@@ -151,12 +151,12 @@ void BoostXmlGmlInterface::readPoints(BaseLib::ConfigTree const& pointsRoot,
 	}
 }
 
-
-void BoostXmlGmlInterface::readPolylines(BaseLib::ConfigTree const&  polylinesRoot,
-	                                     std::vector<GeoLib::Polyline*>* polylines,
-	                                     std::vector<GeoLib::Point*>* points,
-	                                     const std::vector<std::size_t> &pnt_id_map,
-	                                     std::map<std::string, std::size_t>* &ply_names )
+void BoostXmlGmlInterface::readPolylines(
+    BaseLib::ConfigTree const& polylinesRoot,
+    std::vector<GeoLib::Polyline*>* polylines,
+    std::vector<GeoLib::Point*> const* points,
+    const std::vector<std::size_t>& pnt_id_map,
+    std::map<std::string, std::size_t>*& ply_names)
 {
 	BOOST_FOREACH( BaseLib::ConfigTree::value_type const & polyline, polylinesRoot )
 	{
@@ -203,11 +203,12 @@ void BoostXmlGmlInterface::readPolylines(BaseLib::ConfigTree const&  polylinesRo
 	}
 }
 
-void BoostXmlGmlInterface::readSurfaces(BaseLib::ConfigTree const&  surfacesRoot,
-	                                    std::vector<GeoLib::Surface*>* surfaces,
-	                                    std::vector<GeoLib::Point*>* points,
-	                                    const std::vector<std::size_t> &pnt_id_map,
-	                                    std::map<std::string, std::size_t>* &sfc_names )
+void BoostXmlGmlInterface::readSurfaces(
+    BaseLib::ConfigTree const&  surfacesRoot,
+    std::vector<GeoLib::Surface*>* surfaces,
+    std::vector<GeoLib::Point*> const* points,
+    const std::vector<std::size_t>& pnt_id_map,
+    std::map<std::string, std::size_t>*& sfc_names)
 {
 	BOOST_FOREACH( BaseLib::ConfigTree::value_type const & surface, surfacesRoot )
 	{

--- a/FileIO/XmlIO/Boost/BoostXmlGmlInterface.h
+++ b/FileIO/XmlIO/Boost/BoostXmlGmlInterface.h
@@ -56,17 +56,17 @@ private:
 
 	/// Reads GeoLib::Polyline-objects from an xml-file
 	void readPolylines ( BaseLib::ConfigTree const& polylinesRoot,
-	                     std::vector<GeoLib::Polyline*>* polylines,
-	                     std::vector<GeoLib::Point*>* points,
-	                     const std::vector<std::size_t> &pnt_id_map,
-	                     std::map<std::string, std::size_t>* &ply_names );
+	                   std::vector<GeoLib::Polyline*>* polylines,
+	                   std::vector<GeoLib::Point*> const* points,
+	                   const std::vector<std::size_t>& pnt_id_map,
+	                   std::map<std::string, std::size_t>*& ply_names);
 
 	/// Reads GeoLib::Surface-objects from an xml-file
 	void readSurfaces  ( BaseLib::ConfigTree const& surfacesRoot,
-	                     std::vector<GeoLib::Surface*>* surfaces,
-	                     std::vector<GeoLib::Point*>* points,
-	                     const std::vector<std::size_t> &pnt_id_map,
-	                     std::map<std::string, std::size_t>* &sfc_names );
+	                  std::vector<GeoLib::Surface*>* surfaces,
+	                  std::vector<GeoLib::Point*> const* points,
+	                  const std::vector<std::size_t>& pnt_id_map,
+	                  std::map<std::string, std::size_t>*& sfc_names);
 
 	/// Check if the root node really specifies an GML file
 	bool isGmlFile( BaseLib::ConfigTree const& root) const;

--- a/FileIO/XmlIO/Qt/XmlGmlInterface.h
+++ b/FileIO/XmlIO/Qt/XmlGmlInterface.h
@@ -52,31 +52,33 @@ private:
 	/// Reads GeoLib::Polyline-objects from an xml-file
 	void readPolylines ( const QDomNode &polylinesRoot,
 	                     std::vector<GeoLib::Polyline*>* polylines,
-	                     std::vector<GeoLib::Point*>* points,
+	                     std::vector<GeoLib::Point*> const& points,
 	                     const std::vector<std::size_t> &pnt_id_map,
 	                     std::map<std::string, std::size_t>* &ply_names );
 
 	/// Reads GeoLib::Surface-objects from an xml-file
 	void readSurfaces  ( const QDomNode &surfacesRoot,
 	                     std::vector<GeoLib::Surface*>* surfaces,
-	                     std::vector<GeoLib::Point*>* points,
+	                     std::vector<GeoLib::Point*> const& points,
 	                     const std::vector<std::size_t> &pnt_id_map,
 	                     std::map<std::string, std::size_t>* &sfc_names );
 
 	/// Deletes all geometry data structures
-	void deleteGeometry(std::vector<GeoLib::Point*>* points,
-	                    std::vector<GeoLib::Polyline*>* polylines,
-	                    std::vector<GeoLib::Surface*>* surfaces,
-	                    std::map<std::string, std::size_t>* pnt_names,
-	                    std::map<std::string, std::size_t>* ply_names,
-	                    std::map<std::string, std::size_t>* sfc_names) const;
+	void deleteGeometry(
+	    std::unique_ptr<std::vector<GeoLib::Point*>> points,
+	    std::unique_ptr<std::vector<GeoLib::Polyline*>> polylines,
+	    std::unique_ptr<std::vector<GeoLib::Surface*>> surfaces,
+	    std::map<std::string, std::size_t>* pnt_names,
+	    std::map<std::string, std::size_t>* ply_names,
+	    std::map<std::string, std::size_t>* sfc_names) const;
 
 	/// Cleans up polylines-vector as well as its content if necessary
-	void deletePolylines(std::vector<GeoLib::Polyline*>* polylines,
-	                     std::map<std::string, std::size_t>* ply_names) const;
+	void deletePolylines(
+	    std::unique_ptr<std::vector<GeoLib::Polyline*>> polylines,
+	    std::map<std::string, std::size_t>* ply_names) const;
 
 	/// Cleans up surfaces-vector as well as its content if necessary
-	void deleteSurfaces(std::vector<GeoLib::Surface*>* surfaces,
+	void deleteSurfaces(std::unique_ptr<std::vector<GeoLib::Surface*>> surfaces,
 	                    std::map<std::string, std::size_t>* sfc_names) const;
 
 	GeoLib::GEOObjects& _geo_objs;

--- a/FileIO/XmlIO/Qt/XmlStnInterface.cpp
+++ b/FileIO/XmlIO/Qt/XmlStnInterface.cpp
@@ -54,7 +54,8 @@ int XmlStnInterface::readFile(const QString &fileName)
 	{
 		// read all the station lists
 		QDomNodeList stationList = lists.at(i).childNodes();
-		std::vector<GeoLib::Point*>* stations = new std::vector<GeoLib::Point*>;
+		auto stations = std::unique_ptr<std::vector<GeoLib::Point*>>(
+		    new std::vector<GeoLib::Point*>);
 		std::string stnName("[NN]");
 
 		for (int j = 0; j < stationList.count(); j++)
@@ -64,15 +65,13 @@ int XmlStnInterface::readFile(const QString &fileName)
 			if (station_type.compare("name") == 0)
 				stnName = station_node.toElement().text().toStdString();
 			else if (station_type.compare("stations") == 0)
-				readStations(station_node, stations, fileName.toStdString());
+				readStations(station_node, stations.get(), fileName.toStdString());
 			else if (station_type.compare("boreholes") == 0)
-				readStations(station_node, stations, fileName.toStdString());
+				readStations(station_node, stations.get(), fileName.toStdString());
 		}
 
 		if (!stations->empty())
-			_geo_objs.addStationVec(stations, stnName);
-		else
-			delete stations;
+			_geo_objs.addStationVec(std::move(stations), stnName);
 	}
 
 	return 1;
@@ -349,7 +348,8 @@ int XmlStnInterface::rapidReadFile(const std::string &fileName)
 	for (rapidxml::xml_node<>* station_list = doc.first_node()->first_node(); station_list;
 	     station_list = station_list->next_sibling())
 	{
-		std::vector<GeoLib::Point*>* stations = new std::vector<GeoLib::Point*>;
+		auto stations = std::unique_ptr<std::vector<GeoLib::Point*>>(
+		    new std::vector<GeoLib::Point*>);
 		std::string stnName("[NN]");
 
 		stnName = station_list->first_node("name")->value();
@@ -358,15 +358,13 @@ int XmlStnInterface::rapidReadFile(const std::string &fileName)
 		{
 			std::string b(list_item->name());
 			if (b.compare("stations") == 0)
-				this->rapidReadStations(list_item, stations, fileName);
+				this->rapidReadStations(list_item, stations.get(), fileName);
 			if (b.compare("boreholes") == 0)
-				this->rapidReadStations(list_item, stations, fileName);
+				this->rapidReadStations(list_item, stations.get(), fileName);
 		}
 
 		if (!stations->empty())
-			_geo_objs.addStationVec(stations, stnName);
-		else
-			delete stations;
+			_geo_objs.addStationVec(std::move(stations), stnName);
 	}
 
 	doc.clear();

--- a/GeoLib/GEOObjects.h
+++ b/GeoLib/GEOObjects.h
@@ -295,6 +295,22 @@ public:
 	    [](std::string const&)
 	{
 	};
+
+	std::function<void(std::string const&)> addSurfaceVecCallback =
+	    [](std::string const&)
+	{
+	};
+
+	std::function<void(std::string const&)> appendSurfaceVecCallback =
+	    [](std::string const&)
+	{
+	};
+
+	std::function<void(std::string const&)> removeSurfaceVecCallback =
+	    [](std::string const&)
+	{
+	};
+
 private:
 	/**
 	 * Method merges points from different geometries into one geometry. This

--- a/GeoLib/GEOObjects.h
+++ b/GeoLib/GEOObjects.h
@@ -86,7 +86,7 @@ public:
 	 * @param pnt_names vector of the names corresponding to the points
 	 * @param eps relative tolerance value for testing of point uniqueness
 	 */
-	void addPointVec(std::vector<Point*>* points,
+	void addPointVec(std::unique_ptr<std::vector<Point*>> points,
 	                 std::string& name,
 	                 std::map<std::string, std::size_t>* pnt_names = nullptr,
 	                 double eps = sqrt(std::numeric_limits<double>::epsilon()));
@@ -117,7 +117,8 @@ public:
 	bool removePointVec(const std::string &name);
 
 	/// Adds a vector of stations with the given name and colour to GEOObjects.
-	void addStationVec(std::vector<Point*>* stations, std::string &name);
+	void addStationVec(
+	    std::unique_ptr<std::vector<Point *>> stations, std::string &name);
 
 	/// Returns the station vector with the given name.
 	const std::vector<GeoLib::Point*>* getStationVec(
@@ -136,7 +137,7 @@ public:
 	 * @param name The geometry to which the given Polyline objects should be added.
 	 * @param ply_names map of names and ids that are corresponding to the polylines
 	 */
-	void addPolylineVec(std::vector<Polyline*>* lines,
+	void addPolylineVec(std::unique_ptr<std::vector<Polyline*>> lines,
 	                            const std::string &name,
 	                            std::map<std::string,std::size_t>* ply_names = nullptr);
 
@@ -178,7 +179,7 @@ public:
 	bool removePolylineVec(const std::string &name);
 
 	/** Adds a vector of surfaces with the given name to GEOObjects. */
-	void addSurfaceVec(std::vector<Surface*>* surfaces,
+	void addSurfaceVec(std::unique_ptr<std::vector<Surface*>> surfaces,
 	                           const std::string &name,
 	                           std::map<std::string, std::size_t>* sfc_names = nullptr);
 

--- a/GeoLib/GEOObjects.h
+++ b/GeoLib/GEOObjects.h
@@ -281,6 +281,20 @@ public:
 
 	std::unique_ptr<Callbacks> _callbacks{new Callbacks};
 
+	std::function<void(std::string const&)> addPolylineVecCallback =
+	    [](std::string const&)
+	{
+	};
+
+	std::function<void(std::string const&)> appendPolylineVecCallback =
+	    [](std::string const&)
+	{
+	};
+
+	std::function<void(std::string const&)> removePolylineVecCallback =
+	    [](std::string const&)
+	{
+	};
 private:
 	/**
 	 * Method merges points from different geometries into one geometry. This

--- a/GeoLib/Grid.h
+++ b/GeoLib/Grid.h
@@ -305,7 +305,8 @@ void Grid<POINT>::createGridGeometry(GeoLib::GEOObjects* geo_obj) const
 				grid_names.push_back(name);
 
 				{
-					std::vector<GeoLib::Point*>* points (new std::vector<GeoLib::Point*>);
+					auto points = std::unique_ptr<std::vector<GeoLib::Point*>>(
+					    new std::vector<GeoLib::Point*>);
 					points->push_back(new GeoLib::Point(llf[0]+i*dx, llf[1]+j*dy, llf[2]+k*dz));
 					points->push_back(new GeoLib::Point(llf[0]+i*dx, llf[1]+(j+1)*dy, llf[2]+k*dz));
 					points->push_back(new GeoLib::Point(llf[0]+(i+1)*dx, llf[1]+(j+1)*dy, llf[2]+k*dz));
@@ -314,11 +315,12 @@ void Grid<POINT>::createGridGeometry(GeoLib::GEOObjects* geo_obj) const
 					points->push_back(new GeoLib::Point(llf[0]+i*dx, llf[1]+(j+1)*dy, llf[2]+(k+1)*dz));
 					points->push_back(new GeoLib::Point(llf[0]+(i+1)*dx, llf[1]+(j+1)*dy, llf[2]+(k+1)*dz));
 					points->push_back(new GeoLib::Point(llf[0]+(i+1)*dx, llf[1]+j*dy, llf[2]+(k+1)*dz));
-					geo_obj->addPointVec(points, grid_names.back(), nullptr);
+					geo_obj->addPointVec(std::move(points), grid_names.back(),
+					                     nullptr);
 				}
 
-				std::vector<GeoLib::Polyline*>* plys (
-				        new std::vector<GeoLib::Polyline*>);
+				auto plys = std::unique_ptr<std::vector<GeoLib::Polyline*>>(
+				    new std::vector<GeoLib::Polyline*>);
 				auto const& points = *geo_obj->getPointVec(grid_names.back());
 				GeoLib::Polyline* ply0 (new GeoLib::Polyline(points));
 
@@ -353,7 +355,7 @@ void Grid<POINT>::createGridGeometry(GeoLib::GEOObjects* geo_obj) const
 				ply5->addPoint(7);
 				plys->push_back(ply5);
 
-				geo_obj->addPolylineVec(plys, grid_names.back(),
+				geo_obj->addPolylineVec(std::move(plys), grid_names.back(),
 					nullptr);
 			}
 		}

--- a/GeoLib/PointVec.cpp
+++ b/GeoLib/PointVec.cpp
@@ -22,12 +22,13 @@
 
 namespace GeoLib
 {
-PointVec::PointVec(const std::string& name, std::vector<Point*>* points,
+PointVec::PointVec(const std::string& name,
+                   std::unique_ptr<std::vector<Point*>> points,
                    std::map<std::string, std::size_t>* name_id_map,
                    PointType type, double rel_eps)
-    : TemplateVec<Point>(name, points, name_id_map),
+    : TemplateVec<Point>(name, std::move(points), name_id_map),
       _type(type),
-      _aabb(points->begin(), points->end()),
+      _aabb(_data_vec->begin(), _data_vec->end()),
       _rel_eps(rel_eps * std::sqrt(MathLib::sqrDist(_aabb.getMinPoint(),
                                                     _aabb.getMaxPoint()))),
       _oct_tree(OctTree<GeoLib::Point, 16>::createOctTree(

--- a/GeoLib/PointVec.h
+++ b/GeoLib/PointVec.h
@@ -69,7 +69,7 @@ public:
 	 * real tolerance \f$tol\f$. Two points \f$p_0, p_1 \f$ are identical iff
 	 * \f$|p_1 - p_0| \le tol.\f$
 	 */
-	PointVec (const std::string& name, std::vector<Point*>* points,
+	PointVec (const std::string& name, std::unique_ptr<std::vector<Point*>> points,
 	          std::map<std::string, std::size_t>* name_id_map = nullptr,
 	          PointType type = PointVec::PointType::POINT, double rel_eps = std::numeric_limits<double>::epsilon());
 

--- a/GeoLib/TemplateVec.h
+++ b/GeoLib/TemplateVec.h
@@ -19,8 +19,9 @@
 #include <algorithm>
 #include <cstdlib>
 #include <map>
-#include <vector>
+#include <memory>
 #include <string>
+#include <vector>
 
 #include <logog/include/logog.hpp>
 
@@ -53,9 +54,9 @@ public:
 	 * of the element and the value for std::size_t stands for an index in
 	 * the data_vec.
 	 */
-	TemplateVec (const std::string &name, std::vector<T*>* data_vec,
+	TemplateVec (const std::string &name, std::unique_ptr<std::vector<T*>> data_vec,
 	             NameIdMap* elem_name_map = nullptr) :
-		_name(name), _data_vec(data_vec), _name_id_map (elem_name_map)
+		_name(name), _data_vec(std::move(data_vec)), _name_id_map (elem_name_map)
 	{
 		if (_data_vec == nullptr)
 		{
@@ -73,7 +74,6 @@ public:
 	virtual ~TemplateVec ()
 	{
 		for (std::size_t k(0); k < size(); k++) delete (*_data_vec)[k];
-		delete _data_vec;
 		delete _name_id_map;
 	}
 
@@ -102,7 +102,7 @@ public:
 	 * get a pointer to a standard vector containing the data elements
 	 * @return the data elements
 	 */
-	const std::vector<T*>* getVector () const { return _data_vec; }
+	const std::vector<T*>* getVector () const { return _data_vec.get(); }
 
 	/**
 	 * search the vector of names for the ID of the geometric element with the given name
@@ -230,7 +230,7 @@ protected:
 	/**
 	 * pointer to a vector of data elements
 	 */
-	std::vector <T*>* _data_vec;
+	std::unique_ptr<std::vector <T*>> _data_vec;
 	/**
 	 * store names associated with the element ids
 	 */

--- a/MeshLib/convertMeshToGeo.cpp
+++ b/MeshLib/convertMeshToGeo.cpp
@@ -39,20 +39,21 @@ bool convertMeshToGeo(const MeshLib::Mesh &mesh, GeoLib::GEOObjects &geo_objects
 	// nodes to points conversion
 	std::string mesh_name(mesh.getName());
 	{
-		std::vector<GeoLib::Point*>* points = new std::vector<GeoLib::Point*>;
+		auto points = std::unique_ptr<std::vector<GeoLib::Point*>>(
+			new std::vector<GeoLib::Point*>);
 		points->reserve(mesh.getNNodes());
 
 		for (auto node_ptr : mesh.getNodes())
 			points->push_back(new GeoLib::Point(*node_ptr, node_ptr->getID()));
 
-		geo_objects.addPointVec(points, mesh_name, nullptr, eps);
+		geo_objects.addPointVec(std::move(points), mesh_name, nullptr, eps);
 	}
 	const std::vector<std::size_t> id_map (geo_objects.getPointVecObj(mesh_name)->getIDMap());
 
 	// elements to surface triangles conversion
 	const std::pair<unsigned, unsigned> bounds (MeshInformation::getValueBounds(mesh));
 	const unsigned nMatGroups(bounds.second-bounds.first+1);
-	std::vector<GeoLib::Surface*> *sfcs = new std::vector<GeoLib::Surface*>;
+	auto sfcs = std::unique_ptr<std::vector<GeoLib::Surface*>>(new std::vector<GeoLib::Surface*>);
 	sfcs->reserve(nMatGroups);
 	auto const& points = *geo_objects.getPointVec(mesh_name);
 	for (unsigned i=0; i<nMatGroups; ++i)
@@ -78,7 +79,7 @@ bool convertMeshToGeo(const MeshLib::Mesh &mesh, GeoLib::GEOObjects &geo_objects
 	auto sfcs_end = std::remove(sfcs->begin(), sfcs->end(), nullptr);
 	sfcs->erase(sfcs_end, sfcs->end());
 
-	geo_objects.addSurfaceVec(sfcs, mesh_name);
+	geo_objects.addSurfaceVec(std::move(sfcs), mesh_name);
 	return true;
 }
 

--- a/Tests/FileIO/TestXmlGmlReader.cpp
+++ b/Tests/FileIO/TestXmlGmlReader.cpp
@@ -32,9 +32,12 @@ TEST(FileIO, XmlGmlWriterReaderTest)
 
 	//setup test data
 	std::string geo_name("TestData");
-	std::vector<GeoLib::Point*> *points = new std::vector<GeoLib::Point*>(10);
-	std::vector<GeoLib::Polyline*> *lines = new std::vector<GeoLib::Polyline*>(5);
-	std::vector<GeoLib::Surface*> *sfcs = new std::vector<GeoLib::Surface*>(2);
+	auto points = std::unique_ptr<std::vector<GeoLib::Point*>>(
+	    new std::vector<GeoLib::Point*>(10));
+	auto lines = std::unique_ptr<std::vector<GeoLib::Polyline*>>(
+	    new std::vector<GeoLib::Polyline*>(5));
+	auto sfcs = std::unique_ptr<std::vector<GeoLib::Surface*>>(
+	    new std::vector<GeoLib::Surface*>(2));
 	std::map<std::string, std::size_t>* ply_names = new std::map<std::string, std::size_t>;
 
 	(*points)[0] = new GeoLib::Point(1,1,0);
@@ -47,7 +50,7 @@ TEST(FileIO, XmlGmlWriterReaderTest)
 	(*points)[7] = new GeoLib::Point(3,1,0);
 	(*points)[8] = new GeoLib::Point(3,2,0);
 	(*points)[9] = new GeoLib::Point(3,3,0);
-	geo_objects.addPointVec(points, geo_name);
+	geo_objects.addPointVec(std::move(points), geo_name);
 	const std::vector<std::size_t> pnt_id_map (geo_objects.getPointVecObj(geo_name)->getIDMap());
 
 	(*lines)[0] = new GeoLib::Polyline(*points);
@@ -63,7 +66,7 @@ TEST(FileIO, XmlGmlWriterReaderTest)
 	(*lines)[4] = new GeoLib::Polyline(*points);
 	(*lines)[4]->addPoint(pnt_id_map[7]); (*lines)[4]->addPoint(pnt_id_map[8]); (*lines)[4]->addPoint(pnt_id_map[9]);
 	ply_names->insert(std::pair<std::string, std::size_t>("right", 4));
-	geo_objects.addPolylineVec(lines, geo_name, ply_names);
+	geo_objects.addPolylineVec(std::move(lines), geo_name, ply_names);
 
 	(*sfcs)[0] = new GeoLib::Surface(*points);
 	(*sfcs)[0]->addTriangle(pnt_id_map[1],pnt_id_map[4],pnt_id_map[2]);
@@ -73,7 +76,7 @@ TEST(FileIO, XmlGmlWriterReaderTest)
 	(*sfcs)[1] = new GeoLib::Surface(*points);
 	(*sfcs)[1]->addTriangle(pnt_id_map[4],pnt_id_map[7],pnt_id_map[9]);
 	(*sfcs)[1]->addTriangle(pnt_id_map[4],pnt_id_map[9],pnt_id_map[6]);
-	geo_objects.addSurfaceVec(sfcs, geo_name);
+	geo_objects.addSurfaceVec(std::move(sfcs), geo_name);
 
 	FileIO::XmlGmlInterface xml(geo_objects);
 	xml.setNameForExport(geo_name);

--- a/Tests/FileIO/TestXmlGmlReader.cpp
+++ b/Tests/FileIO/TestXmlGmlReader.cpp
@@ -32,51 +32,69 @@ TEST(FileIO, XmlGmlWriterReaderTest)
 
 	//setup test data
 	std::string geo_name("TestData");
-	auto points = std::unique_ptr<std::vector<GeoLib::Point*>>(
-	    new std::vector<GeoLib::Point*>(10));
-	auto lines = std::unique_ptr<std::vector<GeoLib::Polyline*>>(
-	    new std::vector<GeoLib::Polyline*>(5));
-	auto sfcs = std::unique_ptr<std::vector<GeoLib::Surface*>>(
-	    new std::vector<GeoLib::Surface*>(2));
-	std::map<std::string, std::size_t>* ply_names = new std::map<std::string, std::size_t>;
 
-	(*points)[0] = new GeoLib::Point(1,1,0);
-	(*points)[1] = new GeoLib::Point(1,1,0);
-	(*points)[2] = new GeoLib::Point(1,2,0);
-	(*points)[3] = new GeoLib::Point(1,3,0);
-	(*points)[4] = new GeoLib::Point(2,1,0);
-	(*points)[5] = new GeoLib::Point(2,2,0);
-	(*points)[6] = new GeoLib::Point(2,3,0);
-	(*points)[7] = new GeoLib::Point(3,1,0);
-	(*points)[8] = new GeoLib::Point(3,2,0);
-	(*points)[9] = new GeoLib::Point(3,3,0);
-	geo_objects.addPointVec(std::move(points), geo_name);
+	{   // Create points.
+		auto points = std::unique_ptr<std::vector<GeoLib::Point*>>(
+		    new std::vector<GeoLib::Point*>(10));
+
+		(*points)[0] = new GeoLib::Point(1, 1, 0);
+		(*points)[1] = new GeoLib::Point(1, 1, 0);
+		(*points)[2] = new GeoLib::Point(1, 2, 0);
+		(*points)[3] = new GeoLib::Point(1, 3, 0);
+		(*points)[4] = new GeoLib::Point(2, 1, 0);
+		(*points)[5] = new GeoLib::Point(2, 2, 0);
+		(*points)[6] = new GeoLib::Point(2, 3, 0);
+		(*points)[7] = new GeoLib::Point(3, 1, 0);
+		(*points)[8] = new GeoLib::Point(3, 2, 0);
+		(*points)[9] = new GeoLib::Point(3, 3, 0);
+		geo_objects.addPointVec(std::move(points), geo_name);
+	}
+	auto const points = geo_objects.getPointVec(geo_name);
+
 	const std::vector<std::size_t> pnt_id_map (geo_objects.getPointVecObj(geo_name)->getIDMap());
 
-	(*lines)[0] = new GeoLib::Polyline(*points);
-	(*lines)[0]->addPoint(pnt_id_map[0]); (*lines)[0]->addPoint(pnt_id_map[2]); (*lines)[0]->addPoint(pnt_id_map[3]);
-	ply_names->insert(std::pair<std::string, std::size_t>("left", 0));
-	(*lines)[1] = new GeoLib::Polyline(*points);
-	(*lines)[1]->addPoint(pnt_id_map[4]); (*lines)[1]->addPoint(pnt_id_map[5]); (*lines)[1]->addPoint(pnt_id_map[6]);
-	ply_names->insert(std::pair<std::string, std::size_t>("center", 1));
-	(*lines)[2] = new GeoLib::Polyline(*points);
-	(*lines)[2]->addPoint(pnt_id_map[1]); (*lines)[2]->addPoint(pnt_id_map[4]);
-	(*lines)[3] = new GeoLib::Polyline(*points);
-	(*lines)[3]->addPoint(pnt_id_map[4]); (*lines)[3]->addPoint(pnt_id_map[7]);
-	(*lines)[4] = new GeoLib::Polyline(*points);
-	(*lines)[4]->addPoint(pnt_id_map[7]); (*lines)[4]->addPoint(pnt_id_map[8]); (*lines)[4]->addPoint(pnt_id_map[9]);
-	ply_names->insert(std::pair<std::string, std::size_t>("right", 4));
-	geo_objects.addPolylineVec(std::move(lines), geo_name, ply_names);
+	{   // Create polylines.
+		auto lines = std::unique_ptr<std::vector<GeoLib::Polyline*>>(
+		    new std::vector<GeoLib::Polyline*>(5));
+		std::map<std::string, std::size_t>* ply_names =
+		    new std::map<std::string, std::size_t>;
+		(*lines)[0] = new GeoLib::Polyline(*points);
+		(*lines)[0]->addPoint(pnt_id_map[0]);
+		(*lines)[0]->addPoint(pnt_id_map[2]);
+		(*lines)[0]->addPoint(pnt_id_map[3]);
+		ply_names->insert(std::pair<std::string, std::size_t>("left", 0));
+		(*lines)[1] = new GeoLib::Polyline(*points);
+		(*lines)[1]->addPoint(pnt_id_map[4]);
+		(*lines)[1]->addPoint(pnt_id_map[5]);
+		(*lines)[1]->addPoint(pnt_id_map[6]);
+		ply_names->insert(std::pair<std::string, std::size_t>("center", 1));
+		(*lines)[2] = new GeoLib::Polyline(*points);
+		(*lines)[2]->addPoint(pnt_id_map[1]);
+		(*lines)[2]->addPoint(pnt_id_map[4]);
+		(*lines)[3] = new GeoLib::Polyline(*points);
+		(*lines)[3]->addPoint(pnt_id_map[4]);
+		(*lines)[3]->addPoint(pnt_id_map[7]);
+		(*lines)[4] = new GeoLib::Polyline(*points);
+		(*lines)[4]->addPoint(pnt_id_map[7]);
+		(*lines)[4]->addPoint(pnt_id_map[8]);
+		(*lines)[4]->addPoint(pnt_id_map[9]);
+		ply_names->insert(std::pair<std::string, std::size_t>("right", 4));
+		geo_objects.addPolylineVec(std::move(lines), geo_name, ply_names);
+	}
 
-	(*sfcs)[0] = new GeoLib::Surface(*points);
-	(*sfcs)[0]->addTriangle(pnt_id_map[1],pnt_id_map[4],pnt_id_map[2]);
-	(*sfcs)[0]->addTriangle(pnt_id_map[2],pnt_id_map[4],pnt_id_map[5]);
-	(*sfcs)[0]->addTriangle(pnt_id_map[2],pnt_id_map[5],pnt_id_map[3]);
-	(*sfcs)[0]->addTriangle(pnt_id_map[3],pnt_id_map[5],pnt_id_map[6]);
-	(*sfcs)[1] = new GeoLib::Surface(*points);
-	(*sfcs)[1]->addTriangle(pnt_id_map[4],pnt_id_map[7],pnt_id_map[9]);
-	(*sfcs)[1]->addTriangle(pnt_id_map[4],pnt_id_map[9],pnt_id_map[6]);
-	geo_objects.addSurfaceVec(std::move(sfcs), geo_name);
+	{   // Create surfaces.
+		auto sfcs = std::unique_ptr<std::vector<GeoLib::Surface*>>(
+		    new std::vector<GeoLib::Surface*>(2));
+		(*sfcs)[0] = new GeoLib::Surface(*points);
+		(*sfcs)[0]->addTriangle(pnt_id_map[1], pnt_id_map[4], pnt_id_map[2]);
+		(*sfcs)[0]->addTriangle(pnt_id_map[2], pnt_id_map[4], pnt_id_map[5]);
+		(*sfcs)[0]->addTriangle(pnt_id_map[2], pnt_id_map[5], pnt_id_map[3]);
+		(*sfcs)[0]->addTriangle(pnt_id_map[3], pnt_id_map[5], pnt_id_map[6]);
+		(*sfcs)[1] = new GeoLib::Surface(*points);
+		(*sfcs)[1]->addTriangle(pnt_id_map[4], pnt_id_map[7], pnt_id_map[9]);
+		(*sfcs)[1]->addTriangle(pnt_id_map[4], pnt_id_map[9], pnt_id_map[6]);
+		geo_objects.addSurfaceVec(std::move(sfcs), geo_name);
+	}
 
 	FileIO::XmlGmlInterface xml(geo_objects);
 	xml.setNameForExport(geo_name);

--- a/Tests/GeoLib/TestComputeAndInsertAllIntersectionPoints.cpp
+++ b/Tests/GeoLib/TestComputeAndInsertAllIntersectionPoints.cpp
@@ -21,35 +21,39 @@
 
 TEST(GeoLib, TestComputeAndInsertAllIntersectionPoints)
 {
-	// *** insert points in vector
-	std::vector<GeoLib::Point*> *pnts(new std::vector<GeoLib::Point*>);
-	pnts->push_back(new GeoLib::Point(0.0,0.0,0.0,0));
-	pnts->push_back(new GeoLib::Point(11.0,0.0,0.0,1));
-
-	pnts->push_back(new GeoLib::Point(0.0,1.0,0.0,2));
-	pnts->push_back(new GeoLib::Point(1.0,-1.0,0.0,3));
-	pnts->push_back(new GeoLib::Point(2.0, 1.0,0.0,4));
-	pnts->push_back(new GeoLib::Point(3.0,-1.0,0.0,5));
-	pnts->push_back(new GeoLib::Point(4.0, 1.0,0.0,6));
-	pnts->push_back(new GeoLib::Point(5.0,-1.0,0.0,7));
-	pnts->push_back(new GeoLib::Point(6.0, 1.0,0.0,8));
-	pnts->push_back(new GeoLib::Point(7.0,-1.0,0.0,9));
-	pnts->push_back(new GeoLib::Point(8.0, 1.0,0.0,10));
-	pnts->push_back(new GeoLib::Point(9.0,-1.0,0.0,11));
-	pnts->push_back(new GeoLib::Point(10.0, 1.0,0.0,12));
-	pnts->push_back(new GeoLib::Point(11.0,-1.0,0.0,13));
-
-
 	GeoLib::GEOObjects geo_objs;
 	std::string geo_name("TestGeometry");
-	geo_objs.addPointVec(pnts, geo_name);
+
+	{
+		// *** insert points in vector
+		auto pnts = std::unique_ptr<std::vector<GeoLib::Point*>>(
+		    new std::vector<GeoLib::Point*>);
+		pnts->push_back(new GeoLib::Point(0.0,0.0,0.0,0));
+		pnts->push_back(new GeoLib::Point(11.0,0.0,0.0,1));
+
+		pnts->push_back(new GeoLib::Point(0.0,1.0,0.0,2));
+		pnts->push_back(new GeoLib::Point(1.0,-1.0,0.0,3));
+		pnts->push_back(new GeoLib::Point(2.0, 1.0,0.0,4));
+		pnts->push_back(new GeoLib::Point(3.0,-1.0,0.0,5));
+		pnts->push_back(new GeoLib::Point(4.0, 1.0,0.0,6));
+		pnts->push_back(new GeoLib::Point(5.0,-1.0,0.0,7));
+		pnts->push_back(new GeoLib::Point(6.0, 1.0,0.0,8));
+		pnts->push_back(new GeoLib::Point(7.0,-1.0,0.0,9));
+		pnts->push_back(new GeoLib::Point(8.0, 1.0,0.0,10));
+		pnts->push_back(new GeoLib::Point(9.0,-1.0,0.0,11));
+		pnts->push_back(new GeoLib::Point(10.0, 1.0,0.0,12));
+		pnts->push_back(new GeoLib::Point(11.0,-1.0,0.0,13));
+
+		geo_objs.addPointVec(std::move(pnts), geo_name);
+	}
 
 	// *** create polylines
-	GeoLib::Polyline* ply0(new GeoLib::Polyline(*pnts));
+	auto& pnts = *geo_objs.getPointVec(geo_name);
+	GeoLib::Polyline* ply0(new GeoLib::Polyline(pnts));
 	ply0->addPoint(0);
 	ply0->addPoint(1);
-	GeoLib::Polyline* ply1(new GeoLib::Polyline(*pnts));
-	for (std::size_t k(2); k<pnts->size(); ++k)
+	GeoLib::Polyline* ply1(new GeoLib::Polyline(pnts));
+	for (std::size_t k(2); k<pnts.size(); ++k)
 		ply1->addPoint(k);
 	std::vector<GeoLib::Polyline*>* plys(new std::vector<GeoLib::Polyline*>);
 	plys->push_back(ply0);

--- a/Tests/GeoLib/TestGEOObjectsMerge.cpp
+++ b/Tests/GeoLib/TestGEOObjectsMerge.cpp
@@ -21,7 +21,8 @@
 
 void createSetOfTestPointsAndAssociatedNames(GeoLib::GEOObjects & geo_objs, std::string &name, GeoLib::Point const& shift)
 {
-	std::vector<GeoLib::Point*> *pnts(new std::vector<GeoLib::Point*>);
+	auto pnts = std::unique_ptr<std::vector<GeoLib::Point*>>(
+	    new std::vector<GeoLib::Point*>);
 	std::map<std::string, std::size_t>* pnt_name_map(new std::map< std::string, std::size_t>);
 
 	const std::size_t pnts_per_edge(8);
@@ -41,7 +42,7 @@ void createSetOfTestPointsAndAssociatedNames(GeoLib::GEOObjects & geo_objs, std:
 		}
 	}
 
-	geo_objs.addPointVec(pnts, name, pnt_name_map);
+	geo_objs.addPointVec(std::move(pnts), name, pnt_name_map);
 }
 
 TEST(GeoLib, GEOObjectsMergePoints)
@@ -107,7 +108,8 @@ TEST(GeoLib, GEOObjectsMergePointsAndPolylines)
 	std::vector<std::string> names;
 
 	// *** insert points to vector
-	std::vector<GeoLib::Point*> *pnts(new std::vector<GeoLib::Point*>);
+	auto pnts = std::unique_ptr<std::vector<GeoLib::Point*>>(
+	    new std::vector<GeoLib::Point*>);
 	pnts->reserve(4);
 	pnts->push_back(new GeoLib::Point(0.0,0.0,0.0));
 	pnts->push_back(new GeoLib::Point(1.0,0.0,0.0));
@@ -115,7 +117,7 @@ TEST(GeoLib, GEOObjectsMergePointsAndPolylines)
 	pnts->push_back(new GeoLib::Point(0.0,1.0,0.0));
 
 	std::string geometry_0("GeometryWithPntsAndPolyline");
-	geo_objs.addPointVec(pnts, geometry_0, nullptr, std::numeric_limits<double>::epsilon());
+	geo_objs.addPointVec(std::move(pnts), geometry_0, nullptr, std::numeric_limits<double>::epsilon());
 
 	// *** insert polyline
 	GeoLib::Polyline* ply(new GeoLib::Polyline(*geo_objs.getPointVec(geometry_0)));
@@ -124,9 +126,10 @@ TEST(GeoLib, GEOObjectsMergePointsAndPolylines)
 	ply->addPoint(2);
 	ply->addPoint(3);
 	ply->addPoint(0);
-	std::vector<GeoLib::Polyline*> *plys(new std::vector<GeoLib::Polyline*>);
+	auto plys = std::unique_ptr<std::vector<GeoLib::Polyline*>>(
+	    new std::vector<GeoLib::Polyline*>);
 	plys->push_back(ply);
-	geo_objs.addPolylineVec(plys, geometry_0, nullptr);
+	geo_objs.addPolylineVec(std::move(plys), geometry_0, nullptr);
 	names.push_back(geometry_0);
 
 	// *** insert set of points number
@@ -151,7 +154,8 @@ TEST(GeoLib, GEOObjectsMergePolylinesWithNames)
 	std::vector<std::string> names;
 
 	// *** insert first set of points to vector (for first polyline)
-	std::vector<GeoLib::Point*> *pnts_0(new std::vector<GeoLib::Point*>);
+	auto pnts_0 = std::unique_ptr<std::vector<GeoLib::Point*>>(
+	    new std::vector<GeoLib::Point*>);
 	pnts_0->reserve(4);
 	pnts_0->push_back(new GeoLib::Point(0.0,0.0,0.0));
 	pnts_0->push_back(new GeoLib::Point(1.0,0.0,0.0));
@@ -159,7 +163,10 @@ TEST(GeoLib, GEOObjectsMergePolylinesWithNames)
 	pnts_0->push_back(new GeoLib::Point(0.0,1.0,0.0));
 
 	std::string geometry_0("Geometry0");
-	geo_objs.addPointVec(pnts_0, geometry_0, nullptr, std::numeric_limits<double>::epsilon());
+	geo_objs.addPointVec(std::move(pnts_0),
+	                     geometry_0,
+	                     nullptr,
+	                     std::numeric_limits<double>::epsilon());
 
 	// *** insert a named polyline into geometry
 	GeoLib::Polyline* ply_00(new GeoLib::Polyline(*geo_objs.getPointVec(geometry_0)));
@@ -168,14 +175,16 @@ TEST(GeoLib, GEOObjectsMergePolylinesWithNames)
 	ply_00->addPoint(2);
 	ply_00->addPoint(3);
 	ply_00->addPoint(0);
-	std::vector<GeoLib::Polyline*> *plys_0(new std::vector<GeoLib::Polyline*>);
+	auto plys_0 = std::unique_ptr<std::vector<GeoLib::Polyline*>>(
+	    new std::vector<GeoLib::Polyline*>);
 	plys_0->push_back(ply_00);
 	std::map<std::string, std::size_t> *names_map_0(new std::map<std::string, std::size_t>);
 	names_map_0->insert(std::pair<std::string, std::size_t>("Polyline0FromGeometry0", 0));
-	geo_objs.addPolylineVec(plys_0, geometry_0, names_map_0);
+	geo_objs.addPolylineVec(std::move(plys_0), geometry_0, names_map_0);
 	names.push_back(geometry_0);
 
-	std::vector<GeoLib::Point*> *pnts_1(new std::vector<GeoLib::Point*>);
+	auto pnts_1 = std::unique_ptr<std::vector<GeoLib::Point*>>(
+	    new std::vector<GeoLib::Point*>);
 	pnts_1->reserve(4);
 	pnts_1->push_back(new GeoLib::Point(0.0,0.0,0.0));
 	pnts_1->push_back(new GeoLib::Point(1.0,0.0,0.0));
@@ -183,7 +192,10 @@ TEST(GeoLib, GEOObjectsMergePolylinesWithNames)
 	pnts_1->push_back(new GeoLib::Point(0.0,1.0,0.0));
 
 	std::string geometry_1("Geometry1");
-	geo_objs.addPointVec(pnts_1, geometry_1, nullptr, std::numeric_limits<double>::epsilon());
+	geo_objs.addPointVec(std::move(pnts_1),
+	                     geometry_1,
+	                     nullptr,
+	                     std::numeric_limits<double>::epsilon());
 
 	// *** insert a named polyline into geometry
 	GeoLib::Polyline* ply_10(new GeoLib::Polyline(*geo_objs.getPointVec(geometry_1)));
@@ -192,13 +204,14 @@ TEST(GeoLib, GEOObjectsMergePolylinesWithNames)
 	GeoLib::Polyline* ply_11(new GeoLib::Polyline(*geo_objs.getPointVec(geometry_1)));
 	ply_11->addPoint(2);
 	ply_11->addPoint(3);
-	std::vector<GeoLib::Polyline*> *plys_1(new std::vector<GeoLib::Polyline*>);
+	auto plys_1 = std::unique_ptr<std::vector<GeoLib::Polyline*>>(
+	    new std::vector<GeoLib::Polyline*>);
 	plys_1->push_back(ply_10);
 	plys_1->push_back(ply_11);
 	std::map<std::string, std::size_t> *names_map_1(new std::map<std::string, std::size_t>);
 	names_map_1->insert(std::pair<std::string, std::size_t>("Polyline0FromGeometry1", 0));
 	names_map_1->insert(std::pair<std::string, std::size_t>("Polyline1FromGeometry1", 1));
-	geo_objs.addPolylineVec(plys_1, geometry_1, names_map_1);
+	geo_objs.addPolylineVec(std::move(plys_1), geometry_1, names_map_1);
 	names.push_back(geometry_1);
 
 	// *** merge geometries

--- a/Tests/GeoLib/TestPointVec.cpp
+++ b/Tests/GeoLib/TestPointVec.cpp
@@ -20,49 +20,46 @@ public:
 	PointVecTest()
 		: gen(std::random_device() ()), name("JustAName")
 	{
-		ps_ptr = new VectorOfPoints;
 	}
 
 protected:
 	// Generates n new points according to given random number distribution,
 	// which is uniform distribution in [-1, 1]^3.
 	void
-	generateRandomPoints(std::size_t const n = 1000)
+	generateRandomPoints(VectorOfPoints& ps, std::size_t const n = 1000)
 	{
 		std::uniform_real_distribution<double> rnd(-1, 1);
-		std::generate_n(std::back_inserter(*ps_ptr), n,
+		std::generate_n(std::back_inserter(ps), n,
 			[&]() {
-				return new GeoLib::Point(rnd(gen), rnd(gen), rnd(gen), ps_ptr->size());
+				return new GeoLib::Point(rnd(gen), rnd(gen), rnd(gen), ps.size());
 			});
 	}
 
 protected:
 	std::mt19937 gen;
 	const std::string name;
-
-	VectorOfPoints* ps_ptr;
 };
 
 // Testing nullptr input vector.
 TEST_F(PointVecTest, TestPointVecCtorNullptr)
 {
 	ASSERT_DEATH(GeoLib::PointVec(name, nullptr), "");
-	delete ps_ptr;
 }
 
 // Testing empty input vector.
 TEST_F(PointVecTest, TestPointVecCtorEmpty)
 {
-	ASSERT_DEATH(GeoLib::PointVec(name, ps_ptr), "");
-	delete ps_ptr;
+	auto ps_ptr = std::unique_ptr<VectorOfPoints>(new VectorOfPoints);
+	ASSERT_DEATH(GeoLib::PointVec(name, std::move(ps_ptr)), "");
 }
 
 // Testing input vector with single point.
 TEST_F(PointVecTest, TestPointVecCtorSinglePoint)
 {
+	auto ps_ptr = std::unique_ptr<VectorOfPoints>(new VectorOfPoints);
 	ps_ptr->push_back(new GeoLib::Point(0,0,0,0));
 	GeoLib::PointVec* point_vec = nullptr;
-	point_vec = new GeoLib::PointVec(name, ps_ptr);
+	point_vec = new GeoLib::PointVec(name, std::move(ps_ptr));
 	ASSERT_EQ(std::size_t(1), point_vec->size());
 
 	delete point_vec;
@@ -71,11 +68,12 @@ TEST_F(PointVecTest, TestPointVecCtorSinglePoint)
 // Testing input vector with two different points.
 TEST_F(PointVecTest, TestPointVecCtorTwoDiffPoints)
 {
+	auto ps_ptr = std::unique_ptr<VectorOfPoints>(new VectorOfPoints);
 	ps_ptr->push_back(new GeoLib::Point(0,0,0,0));
 	ps_ptr->push_back(new GeoLib::Point(1,0,0,1));
 
 	GeoLib::PointVec* point_vec = nullptr;
-	point_vec = new GeoLib::PointVec(name, ps_ptr);
+	point_vec = new GeoLib::PointVec(name, std::move(ps_ptr));
 	ASSERT_EQ(std::size_t(2), point_vec->size());
 
 	delete point_vec;
@@ -84,11 +82,12 @@ TEST_F(PointVecTest, TestPointVecCtorTwoDiffPoints)
 // Testing input vector with two equal points.
 TEST_F(PointVecTest, TestPointVecCtorTwoEqualPoints)
 {
+	auto ps_ptr = std::unique_ptr<VectorOfPoints>(new VectorOfPoints);
 	ps_ptr->push_back(new GeoLib::Point(0,0,0,0));
 	ps_ptr->push_back(new GeoLib::Point(0,0,0,1));
 
 	GeoLib::PointVec* point_vec = nullptr;
-	point_vec = new GeoLib::PointVec(name, ps_ptr);
+	point_vec = new GeoLib::PointVec(name, std::move(ps_ptr));
 	ASSERT_EQ(std::size_t(1), point_vec->size());
 
 	delete point_vec;
@@ -97,11 +96,12 @@ TEST_F(PointVecTest, TestPointVecCtorTwoEqualPoints)
 // Testing input vector with single point.
 TEST_F(PointVecTest, TestPointVecPushBack)
 {
+	auto ps_ptr = std::unique_ptr<VectorOfPoints>(new VectorOfPoints);
 	ps_ptr->push_back(new GeoLib::Point(0,0,0,0));
 	ps_ptr->push_back(new GeoLib::Point(1,0,0,1));
 	ps_ptr->push_back(new GeoLib::Point(0,1,0,2));
 	ps_ptr->push_back(new GeoLib::Point(0,0,1,3));
-	GeoLib::PointVec point_vec(name, ps_ptr);
+	GeoLib::PointVec point_vec(name, std::move(ps_ptr));
 
 	ASSERT_EQ(std::size_t(0), point_vec.getIDMap()[0]);
 	ASSERT_EQ(std::size_t(1), point_vec.getIDMap()[1]);
@@ -185,19 +185,21 @@ TEST_F(PointVecTest, TestPointVecPushBack)
 // Testing random input points.
 TEST_F(PointVecTest, TestPointVecCtorRandomPoints)
 {
-	generateRandomPoints(10000);
+	auto ps_ptr = std::unique_ptr<VectorOfPoints>(new VectorOfPoints);
+	generateRandomPoints(*ps_ptr, 10000);
 
 	GeoLib::PointVec* point_vec = nullptr;
-	point_vec = new GeoLib::PointVec(name, ps_ptr);
+	point_vec = new GeoLib::PointVec(name, std::move(ps_ptr));
 
 	delete point_vec;
 }
 TEST_F(PointVecTest, TestPointVecCtorRandomPointsLargeEps)
 {
-	generateRandomPoints(10000);
+	auto ps_ptr = std::unique_ptr<VectorOfPoints>(new VectorOfPoints);
+	generateRandomPoints(*ps_ptr, 10000);
 
 	GeoLib::PointVec* point_vec = nullptr;
-	point_vec = new GeoLib::PointVec(name, ps_ptr,
+	point_vec = new GeoLib::PointVec(name, std::move(ps_ptr),
 					nullptr, GeoLib::PointVec::PointType::POINT, 1e-2);
 
 	delete point_vec;

--- a/Tests/NumLib/TestDistribution.cpp
+++ b/Tests/NumLib/TestDistribution.cpp
@@ -37,13 +37,15 @@ public:
 		_ply0(nullptr)
 	{
 		// create geometry
-		std::vector<GeoLib::Point*>* pnts (new std::vector<GeoLib::Point*>);
+		auto pnts = std::unique_ptr<std::vector<GeoLib::Point*>>(
+		    new std::vector<GeoLib::Point*>);
 		pnts->push_back(new GeoLib::Point(0.0, 0.0, 0.0));
 		pnts->push_back(new GeoLib::Point(_geometric_size, 0.0, 0.0));
 		pnts->push_back(new GeoLib::Point(_geometric_size, _geometric_size, 0.0));
 		pnts->push_back(new GeoLib::Point(0.0, _geometric_size, 0.0));
 
-		std::vector<GeoLib::Polyline*>* plys (new std::vector<GeoLib::Polyline*>);
+		auto plys = std::unique_ptr<std::vector<GeoLib::Polyline*>>(
+		    new std::vector<GeoLib::Polyline*>);
 		_ply0 = new GeoLib::Polyline(*pnts);
 		_ply0->addPoint(0);
 		_ply0->addPoint(1);
@@ -57,13 +59,14 @@ public:
 		ply1->addPoint(0);
 		plys->push_back(ply1);
 
-		std::vector<GeoLib::Surface*>* sfcs (new std::vector<GeoLib::Surface*>);
+		auto sfcs = std::unique_ptr<std::vector<GeoLib::Surface*>>(
+		    new std::vector<GeoLib::Surface*>);
 		_sfc1 = GeoLib::Surface::createSurface(*ply1);
 		sfcs->push_back(_sfc1);
 
-		_geo_objs.addPointVec(pnts,_project_name);
-		_geo_objs.addPolylineVec(plys, _project_name);
-		_geo_objs.addSurfaceVec(sfcs, _project_name);
+		_geo_objs.addPointVec(std::move(pnts), _project_name);
+		_geo_objs.addPolylineVec(std::move(plys), _project_name);
+		_geo_objs.addSurfaceVec(std::move(sfcs), _project_name);
 	}
 
 protected:
@@ -88,7 +91,8 @@ public:
 		_ply0(nullptr)
 	{
 		// create geometry
-		std::vector<GeoLib::Point*>* pnts (new std::vector<GeoLib::Point*>);
+		auto pnts = std::unique_ptr<std::vector<GeoLib::Point*>>(
+		    new std::vector<GeoLib::Point*>);
 		pnts->push_back(new GeoLib::Point(0.0, 0.0, 0.0));
 		pnts->push_back(new GeoLib::Point(_geometric_size, 0.0, 0.0));
 		pnts->push_back(new GeoLib::Point(_geometric_size, _geometric_size, 0.0));
@@ -98,7 +102,8 @@ public:
 		pnts->push_back(new GeoLib::Point(_geometric_size, _geometric_size, _geometric_size));
 		pnts->push_back(new GeoLib::Point(0.0, _geometric_size, _geometric_size));
 
-		std::vector<GeoLib::Polyline*>* plys (new std::vector<GeoLib::Polyline*>);
+		auto plys = std::unique_ptr<std::vector<GeoLib::Polyline*>>(
+		    new std::vector<GeoLib::Polyline*>);
 		_ply0 = new GeoLib::Polyline(*pnts); // vertical polyline
 		_ply0->addPoint(0);
 		_ply0->addPoint(4);
@@ -111,13 +116,14 @@ public:
 		ply1->addPoint(0);
 		plys->push_back(ply1);
 
-		std::vector<GeoLib::Surface*>* sfcs (new std::vector<GeoLib::Surface*>);
+		auto sfcs = std::unique_ptr<std::vector<GeoLib::Surface*>>(
+		    new std::vector<GeoLib::Surface*>);
 		_sfc1 = GeoLib::Surface::createSurface(*ply1);
 		sfcs->push_back(_sfc1);
 
-		_geo_objs.addPointVec(pnts,_project_name);
-		_geo_objs.addPolylineVec(plys, _project_name);
-		_geo_objs.addSurfaceVec(sfcs, _project_name);
+		_geo_objs.addPointVec(std::move(pnts) ,_project_name);
+		_geo_objs.addPolylineVec(std::move(plys), _project_name);
+		_geo_objs.addSurfaceVec(std::move(sfcs), _project_name);
 	}
 
 protected:


### PR DESCRIPTION
Follow up of https://github.com/ufz/ogs/pull/866 *Separate GEOObjects and GEOModels.*
This improves (and actually fixes few memory leaks) memory management.
Especially use of unique_ptr indicates ownership of the data, whereas raw memory pointer are just pointers and are not allowed to be released or reset.

Main change is only in `TemplateVec` class; all other changes just required changes to keep the code correct.
The bulk of changes follow the same pattern:
 - replace `std::vector<Point*>* points` with `std::unique_ptr<std::vector<Point*>>`
 - move in the call of e.g. `geo_objects.addPointVec(std::move(points), ...)`
 - the points pointer is no longer usable (ownership transferred to `geo_objects`) and if needed is fetched by `auto points = geo_objects.getPointVec(name)`.