### PR TITLE
Multiple nodal d.o.f.

### DIFF
--- a/AssemblerLib/LocalAssemblerBuilder.h
+++ b/AssemblerLib/LocalAssemblerBuilder.h
@@ -58,11 +58,9 @@ public:
     {
         assert(_local_to_global_index_map.size() > id);
 
-        LocalToGlobalIndexMap::RowColumnIndices const& indices =
-            _local_to_global_index_map[id];
+        auto const num_local_dof = _local_to_global_index_map.getNumElementDOF(id);
 
-        assert(indices.rows.size() >= indices.columns.size());
-        _builder(*item, item_data, indices.rows.size(),
+        _builder(*item, item_data, num_local_dof,
             std::forward<Args>(args)...);
     }
 

--- a/AssemblerLib/LocalToGlobalIndexMap.cpp
+++ b/AssemblerLib/LocalToGlobalIndexMap.cpp
@@ -17,6 +17,40 @@
 namespace AssemblerLib
 {
 
+
+
+template <typename ElementIterator>
+void
+LocalToGlobalIndexMap::findGlobalIndices(
+    ElementIterator first, ElementIterator last,
+    std::size_t const mesh_id,
+    const unsigned comp_id, const unsigned comp_id_write)
+{
+    _rows.resize(std::distance(first, last), _mesh_subsets.size());
+
+    // For each element find the global indices for node/element
+    // components.
+    std::size_t elem_id = 0;
+    for (ElementIterator e = first; e != last; ++e, ++elem_id)
+    {
+        std::size_t const nnodes = (*e)->getNNodes();
+
+        LineIndex indices;
+        indices.reserve(nnodes);
+
+        for (unsigned n = 0; n < nnodes; n++)
+        {
+            MeshLib::Location l(mesh_id,
+                                MeshLib::MeshItemType::Node,
+                                (*e)->getNode(n)->getID());
+            indices.push_back(_mesh_component_map.getGlobalIndex(l, comp_id));
+        }
+
+        _rows(elem_id, comp_id_write) = std::move(indices);
+    }
+}
+
+
 LocalToGlobalIndexMap::LocalToGlobalIndexMap(
     std::vector<MeshLib::MeshSubsets*> const& mesh_subsets,
     AssemblerLib::ComponentOrder const order)
@@ -24,48 +58,68 @@ LocalToGlobalIndexMap::LocalToGlobalIndexMap(
 {
     // For all MeshSubsets and each of their MeshSubset's and each element
     // of that MeshSubset save a line of global indices.
+
+    unsigned comp_id = 0;
     for (MeshLib::MeshSubsets const* const mss : _mesh_subsets)
     {
         for (MeshLib::MeshSubset const* const ms : *mss)
         {
             std::size_t const mesh_id = ms->getMeshID();
 
-            findGlobalIndices(ms->elementsBegin(), ms->elementsEnd(), mesh_id, order);
+            findGlobalIndices(ms->elementsBegin(), ms->elementsEnd(), mesh_id,
+                              comp_id, comp_id);
         }
+        ++comp_id;
     }
 }
 
 LocalToGlobalIndexMap::LocalToGlobalIndexMap(
-    std::vector<MeshLib::MeshSubsets*> const& mesh_subsets,
+    std::vector<MeshLib::MeshSubsets*>&& mesh_subsets,
+    std::vector<std::size_t> const& original_indices,
     std::vector<MeshLib::Element*> const& elements,
-    AssemblerLib::MeshComponentMap&& mesh_component_map,
-    AssemblerLib::ComponentOrder const order)
-    : _mesh_subsets(mesh_subsets), _mesh_component_map(std::move(mesh_component_map))
+    AssemblerLib::MeshComponentMap&& mesh_component_map)
+    : _mesh_subsets(std::move(mesh_subsets)),
+      _mesh_component_map(std::move(mesh_component_map))
 {
+    assert(original_indices.size() == _mesh_subsets.size());
     // For all MeshSubsets and each of their MeshSubset's and each element
     // of that MeshSubset save a line of global indices.
+
+    unsigned comp_id = 0;
     for (MeshLib::MeshSubsets const* const mss : _mesh_subsets)
     {
+        if (! mss) continue;
         for (MeshLib::MeshSubset const* const ms : *mss)
         {
             std::size_t const mesh_id = ms->getMeshID();
 
-            findGlobalIndices(elements.cbegin(), elements.cend(), mesh_id, order);
+            findGlobalIndices(elements.cbegin(), elements.cend(), mesh_id,
+                              original_indices[comp_id], comp_id);
         }
+        ++comp_id;
     }
 }
 
 LocalToGlobalIndexMap*
-LocalToGlobalIndexMap::deriveBoundaryConstrainedMap(
-    std::vector<MeshLib::MeshSubsets*> const& mesh_subsets,
-    std::vector<MeshLib::Element*> const& elements,
-    AssemblerLib::ComponentOrder const order) const
+LocalToGlobalIndexMap::deriveBoundaryConstrainedMap(std::vector<MeshLib::MeshSubsets*> const& mesh_subsets,
+    std::vector<MeshLib::Element*> const& elements) const
 {
     DBUG("Construct reduced local to global index map.");
 
-    return new LocalToGlobalIndexMap(mesh_subsets, elements,
-        _mesh_component_map.getSubset(mesh_subsets),
-        order);
+    std::vector<MeshLib::MeshSubsets*> subsets;
+    std::vector<std::size_t> orig_idcs;
+    unsigned i=0;
+    for (auto m : mesh_subsets)
+    {
+        if (m != nullptr) {
+            subsets.push_back(m);
+            orig_idcs.push_back(i);
+        }
+        ++i;
+    }
+
+    return new LocalToGlobalIndexMap(std::move(subsets), orig_idcs, elements,
+        _mesh_component_map.getSubset(mesh_subsets));
 }
 
 std::size_t
@@ -77,25 +131,27 @@ LocalToGlobalIndexMap::dofSize() const
 std::size_t
 LocalToGlobalIndexMap::size() const
 {
-    return _rows.size();
+    return _rows.rows();
 }
 
 LocalToGlobalIndexMap::RowColumnIndices
-LocalToGlobalIndexMap::operator[](std::size_t const mesh_item_id) const
+LocalToGlobalIndexMap::operator()(std::size_t const mesh_item_id, const unsigned component_id) const
 {
-    return RowColumnIndices(_rows[mesh_item_id], _columns[mesh_item_id]);
+    return RowColumnIndices(_rows(mesh_item_id, component_id),
+                            _columns(mesh_item_id, component_id));
 }
 
-LocalToGlobalIndexMap::LineIndex
-LocalToGlobalIndexMap::rowIndices(std::size_t const mesh_item_id) const
+std::size_t
+LocalToGlobalIndexMap::getNumElementDOF(std::size_t const mesh_item_id) const
 {
-    return _rows[mesh_item_id];
-}
+    std::size_t ndof = 0;
 
-LocalToGlobalIndexMap::LineIndex
-LocalToGlobalIndexMap::columnIndices(std::size_t const mesh_item_id) const
-{
-    return _columns[mesh_item_id];
+    for (unsigned c=0; c<_rows.cols(); ++c)
+    {
+        ndof += _rows(mesh_item_id, c).size();
+    }
+
+    return ndof;
 }
 
 #ifndef NDEBUG
@@ -106,18 +162,23 @@ std::ostream& operator<<(std::ostream& os, LocalToGlobalIndexMap const& map)
 
     os << "Rows of the local to global index map; " << map._rows.size()
         << " rows\n";
-    for (auto line : map._rows)
+    for (std::size_t e=0; e<map.size(); ++e)
     {
+        for (std::size_t c=0; c<map.getNumComponents(); ++c)
+        {
+            auto const& line = map._rows(e, c);
+
+            os << "c" << c << " { ";
+            std::copy(line.cbegin(), line.cend(),
+                std::ostream_iterator<std::size_t>(os, " "));
+            os << " }\n";
+        }
+
         if (lines_printed++ > max_lines)
         {
             os << "...\n";
             break;
         }
-
-        os << "{ ";
-        std::copy(line.cbegin(), line.cend(),
-            std::ostream_iterator<std::size_t>(os, " "));
-        os << " }\n";
     }
     lines_printed = 0;
 

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -116,8 +116,7 @@ private:
     /// a vector (\c LineIndex) of indices in the global stiffness matrix or vector
     Table _rows;
 
-    /// Vector alias to that contains for each element a vector of global column
-    /// indices in the global stiffness matrix
+    /// \see _rows
     Table const& _columns = _rows;
 
 #ifndef NDEBUG

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -46,7 +46,18 @@ public:
         ComponentOrder order);
 
     /// Creates a subset of the current mesh component map.
-    /// The order of components is the same as of the current map.
+    /// The components are those from \c components which are not nullptrs.
+    /// The order (BY_LOCATION/BY_COMPONENT) of components is the same as of the current map.
+    ///
+    /// \param components components that should remain in the created subset
+    ///
+    /// The size of parameter \c components must be equal to the number of components in this map,
+    /// if an element of \c components is \c nullptr, this component will not be included
+    /// in the subset.
+    ///
+    /// The number of components of the subset will equal the number of non-null pointers in
+    /// \c components.
+    ///
     MeshComponentMap getSubset(
         std::vector<MeshLib::MeshSubsets*> const& components) const;
 
@@ -142,8 +153,9 @@ public:
 
 private:
     /// Private constructor used by internally created mesh component maps.
-    MeshComponentMap(detail::ComponentGlobalIndexDict& dict)
-        : _dict(dict)
+    MeshComponentMap(detail::ComponentGlobalIndexDict& dict,
+                     unsigned const num_components)
+        : _dict(dict), _num_components(num_components)
     { }
 
     /// Looks up if a line is already stored in the dictionary.
@@ -159,6 +171,10 @@ private:
 
     /// Number of global unknowns.
     std::size_t _num_global_dof = 0;
+
+    /// Number of components
+    /// introduced mainly for error checking
+    unsigned const _num_components;
 };
 
 }   // namespace AssemblerLib

--- a/AssemblerLib/VectorMatrixAssembler.h
+++ b/AssemblerLib/VectorMatrixAssembler.h
@@ -76,8 +76,8 @@ public:
 
         for (auto i : indices)
         {
-            if (_x)         localX.emplace_back((*_x)[i]);
-            if (_x_prev_ts) localX_pts.emplace_back((*_x_prev_ts)[i]);
+            if (_x)         localX.emplace_back(_x->get(i));
+            if (_x_prev_ts) localX_pts.emplace_back(_x_prev_ts->get(i));
         }
 
         LocalToGlobalIndexMap::RowColumnIndices const r_c_indices(

--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -159,4 +159,10 @@ MeshNodeSearcher::getMeshNodeSearcher(MeshLib::Mesh const& mesh)
 	return *_mesh_node_searchers[mesh_id];
 }
 
+std::size_t
+MeshNodeSearcher::getMeshId() const
+{
+	return _mesh.getID();
+}
+
 } // end namespace MeshGeoToolsLib

--- a/MeshGeoToolsLib/MeshNodeSearcher.h
+++ b/MeshGeoToolsLib/MeshNodeSearcher.h
@@ -125,6 +125,11 @@ public:
 	MeshNodesAlongSurface& getMeshNodesAlongSurface(GeoLib::Surface const& sfc);
 
 	/**
+	 * Get the mesh this searcher operates on.
+	 */
+	std::size_t getMeshId() const;
+
+	/**
 	 * Returns a (possibly new) mesh node searcher for the mesh.
 	 * A new one will be created, if it does not already exists.
 	 */

--- a/ProcessLib/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlowFEM.h
@@ -34,7 +34,8 @@ public:
             Parameter<double, MeshLib::Element const&> const& hydraulic_conductivity,
             unsigned const integration_order) = 0;
 
-    virtual void assemble() = 0;
+    virtual void assemble(std::vector<double> const& local_x,
+                          std::vector<double> const& local_x_prev_ts) = 0;
 
     virtual void addToGlobal(GlobalMatrix& A, GlobalVector& rhs,
             AssemblerLib::LocalToGlobalIndexMap::RowColumnIndices const&) const = 0;
@@ -60,7 +61,7 @@ public:
               std::size_t const local_matrix_size,
               Parameter<double, MeshLib::Element const&> const&
                   hydraulic_conductivity,
-              unsigned const integration_order)
+              unsigned const integration_order) override
     {
         using FemType = NumLib::TemplateIsoparametric<
             ShapeFunction, ShapeMatricesType>;
@@ -89,7 +90,8 @@ public:
         _localRhs.reset(new NodalVectorType(local_matrix_size));
     }
 
-    void assemble()
+    void assemble(std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_x_prev_ts*/) override
     {
         _localA->setZero();
         _localRhs->setZero();
@@ -106,8 +108,10 @@ public:
         }
     }
 
-    void addToGlobal(GlobalMatrix& A, GlobalVector& rhs,
-            AssemblerLib::LocalToGlobalIndexMap::RowColumnIndices const& indices) const
+    void addToGlobal(
+        GlobalMatrix& A, GlobalVector& rhs,
+        AssemblerLib::LocalToGlobalIndexMap::RowColumnIndices const& indices)
+        const override
     {
         A.add(indices, *_localA);
         rhs.add(indices.rows, *_localRhs);

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -174,6 +174,7 @@ public:
 
         _hydraulic_head->initializeDirichletBCs(
                 hydraulic_head_mesh_node_searcher,
+                *_local_to_global_index_map, 0,
                 _dirichlet_bc.global_ids, _dirichlet_bc.values);
 
         //
@@ -192,6 +193,7 @@ public:
                     _global_setup,
                     _integration_order,
                     *_local_to_global_index_map,
+                    0,
                     *_mesh_subset_all_nodes);
         }
 
@@ -212,7 +214,7 @@ public:
         _all_mesh_subsets.push_back(new MeshLib::MeshSubsets(_mesh_subset_all_nodes));
 
         _local_to_global_index_map.reset(
-            new AssemblerLib::LocalToGlobalIndexMap(_all_mesh_subsets));
+            new AssemblerLib::LocalToGlobalIndexMap(_all_mesh_subsets, AssemblerLib::ComponentOrder::BY_COMPONENT));
 
 #ifdef USE_PETSC
         DBUG("Allocate global matrix, vectors, and linear solver.");

--- a/ProcessLib/NeumannBcAssembler.h
+++ b/ProcessLib/NeumannBcAssembler.h
@@ -30,7 +30,8 @@ public:
             std::function<double (MeshLib::Element const&)> const& value_lookup,
             unsigned const integration_order) = 0;
 
-    virtual void assemble() = 0;
+    virtual void assemble(std::vector<double> const& local_x,
+                          std::vector<double> const& local_x_prev_ts) = 0;
 
     virtual void addToGlobal(GlobalMatrix& A, GlobalVector& rhs,
             AssemblerLib::LocalToGlobalIndexMap::RowColumnIndices const&) const = 0;
@@ -57,7 +58,7 @@ public:
     init(MeshLib::Element const& e,
         std::size_t const local_matrix_size,
         std::function<double (MeshLib::Element const&)> const& value_lookup,
-        unsigned const integration_order)
+        unsigned const integration_order) override
     {
         using FemType = NumLib::TemplateIsoparametric<
             ShapeFunction, ShapeMatricesType>;
@@ -84,7 +85,8 @@ public:
     }
 
     void
-    assemble()
+    assemble(std::vector<double> const& /*local_x*/,
+             std::vector<double> const& /*local_x_prev_ts*/) override
     {
         _localA->setZero();
         _localRhs->setZero();
@@ -100,9 +102,10 @@ public:
         }
     }
 
-    void
-    addToGlobal(GlobalMatrix& A, GlobalVector& rhs,
-            AssemblerLib::LocalToGlobalIndexMap::RowColumnIndices const& indices) const
+    void addToGlobal(
+        GlobalMatrix& A, GlobalVector& rhs,
+        AssemblerLib::LocalToGlobalIndexMap::RowColumnIndices const& indices)
+        const override
     {
         A.add(indices, *_localA);
         rhs.add(indices.rows, *_localRhs);

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -115,10 +115,13 @@ MeshLib::Mesh const& ProcessVariable::getMesh() const
 
 void ProcessVariable::initializeDirichletBCs(
     MeshGeoToolsLib::MeshNodeSearcher& searcher,
+    AssemblerLib::LocalToGlobalIndexMap const& dof_table,
+    const unsigned nodal_dof_idx,
     std::vector<std::size_t>& global_ids, std::vector<double>& values)
 {
-	for (auto& bc : _dirichlet_bcs)
-		bc->initialize(searcher, global_ids, values);
+    for (auto& bc : _dirichlet_bcs)
+        bc->initialize(searcher, dof_table, nodal_dof_idx,
+                       global_ids, values);
 }
 
 }  // namespace ProcessLib

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -57,8 +57,9 @@ public:
 	MeshLib::Mesh const& getMesh() const;
 
 	void initializeDirichletBCs(MeshGeoToolsLib::MeshNodeSearcher& searcher,
-	                            std::vector<std::size_t>& global_ids,
-	                            std::vector<double>& values);
+	        const AssemblerLib::LocalToGlobalIndexMap& dof_table,
+	        const unsigned nodal_dof_idx,
+	        std::vector<std::size_t>& global_ids, std::vector<double>& values);
 
 	template <typename OutputIterator, typename GlobalSetup, typename... Args>
 	void createNeumannBcs(OutputIterator bcs,

--- a/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
@@ -129,8 +129,8 @@ public:
 
 	std::unique_ptr<const MeshLib::Mesh> mesh;
 	std::unique_ptr<const MeL::MeshSubset> mesh_items_all_nodes;
-    std::vector<MeL::MeshSubsets*> components_boundary;
-    std::vector<MeL::MeshSubsets*> components;
+	std::vector<MeL::MeshSubsets*> components_boundary;
+	std::vector<MeL::MeshSubsets*> components;
 
 	GeoLib::GEOObjects geo_objs;
 

--- a/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
@@ -181,23 +181,18 @@ void AssemblerLibLocalToGlobalIndexMapMultiDOFTest::test(
 	// check mesh elements
 	for (unsigned e=0; e<dof_map->size(); ++e)
 	{
+		auto const element_nodes_size = mesh->getElement(e)->getNNodes();
+		auto const ptr_element_nodes = mesh->getElement(e)->getNodes();
+
 		for (unsigned c=0; c<dof_map->getNumComponents(); ++c)
 		{
 			auto const& global_idcs = (*dof_map)(e, c).rows;
+			ASSERT_EQ(element_nodes_size, global_idcs.size());
 
-			ASSERT_EQ(4, global_idcs.size()); // quad element with four nodes
-
-			for (unsigned n=0; n<4; ++n) // boundary of quad is line with two nodes
+			for (unsigned n = 0; n < element_nodes_size; ++n)
 			{
-				unsigned node = e/4*(mesh_subdivs+1) + e%4; // first node of the quad
-				switch (n)
-				{
-				case 0: break;
-				case 1: node += 1; break;
-				case 2: node += 1 + (mesh_subdivs+1); break;
-				case 3: node +=     (mesh_subdivs+1); break;
-				}
-				auto const glob_idx = compute_global_index(node, c);
+				auto const node_id = ptr_element_nodes[n]->getID();
+				auto const glob_idx = compute_global_index(node_id, c);
 				EXPECT_EQ(glob_idx, global_idcs[n]);
 			}
 		}

--- a/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
@@ -172,11 +172,11 @@ void AssemblerLibLocalToGlobalIndexMapMultiDOFTest::test(
 {
 	initComponents(num_components, selected_component, ComponentOrder);
 
-	ASSERT_TRUE(dof_map->getNumComponents() == num_components);
-	ASSERT_TRUE(dof_map->size() == mesh->getNElements());
+	ASSERT_EQ(dof_map->getNumComponents(), num_components);
+	ASSERT_EQ(dof_map->size(), mesh->getNElements());
 
-	ASSERT_TRUE(dof_map_boundary->getNumComponents() == 1);
-	ASSERT_TRUE(dof_map_boundary->size() == boundary_elements.size());
+	ASSERT_EQ(dof_map_boundary->getNumComponents(), 1);
+	ASSERT_EQ(dof_map_boundary->size(), boundary_elements.size());
 
 	// check mesh elements
 	for (unsigned e=0; e<dof_map->size(); ++e)
@@ -225,15 +225,15 @@ void AssemblerLibLocalToGlobalIndexMapMultiDOFTest::test(
 
 void assert_equal(AL::LocalToGlobalIndexMap const& dof1, AL::LocalToGlobalIndexMap const& dof2)
 {
-	ASSERT_TRUE(dof1.size() == dof2.size());
-	ASSERT_TRUE(dof1.getNumComponents() == dof2.getNumComponents());
+	ASSERT_EQ(dof1.size(), dof2.size());
+	ASSERT_EQ(dof1.getNumComponents(), dof2.getNumComponents());
 
 	for (unsigned e=0; e<dof1.size(); ++e)
 	{
 		for (unsigned c=0; c<dof1.getNumComponents(); ++c)
 		{
-			EXPECT_TRUE(dof1(e, c).rows == dof2(e, c).rows);
-			EXPECT_TRUE(dof1(e, c).columns == dof2(e, c).columns);
+			EXPECT_EQ(dof1(e, c).rows, dof2(e, c).rows);
+			EXPECT_EQ(dof1(e, c).columns, dof2(e, c).columns);
 		}
 	}
 }

--- a/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
@@ -1,0 +1,290 @@
+/*
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "AssemblerLib/LocalAssemblerBuilder.h"
+#include "AssemblerLib/VectorMatrixAssembler.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Location.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshSubsets.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
+#include "MeshLib/MeshSearch/NodeSearch.h"
+#include "GeoLib/Polyline.h"
+#include "GeoLib/GEOObjects.h"
+
+#include "MeshGeoToolsLib/MeshNodeSearcher.h"
+#include "MeshGeoToolsLib/BoundaryElementsSearcher.h"
+
+#include <iostream>
+
+namespace AL = AssemblerLib;
+namespace MeL = MeshLib;
+namespace MGTL = MeshGeoToolsLib;
+
+class AssemblerLibLocalToGlobalIndexMapMultiDOFTest : public ::testing::Test
+{
+public:
+	static const std::size_t mesh_subdivs = 4;
+	AssemblerLibLocalToGlobalIndexMapMultiDOFTest()
+	{
+		mesh.reset(MeL::MeshGenerator::generateRegularQuadMesh(2.0, mesh_subdivs));
+		mesh_items_all_nodes.reset(new MeL::MeshSubset(*mesh, &mesh->getNodes()));
+
+		std::vector<GeoLib::Point*>* ply_pnts = new std::vector<GeoLib::Point*>;
+		ply_pnts->push_back(new GeoLib::Point(0.0, 0.0, 0.0));
+		ply_pnts->push_back(new GeoLib::Point(1.0, 0.0, 0.0));
+
+		std::string geometry_0("GeometryWithPntsAndPolyline");
+		geo_objs.addPointVec(ply_pnts, geometry_0, nullptr);
+
+		auto ply = new GeoLib::Polyline(*geo_objs.getPointVec(geometry_0));
+
+		ply->addPoint(0);
+		ply->addPoint(1);
+
+		std::vector<GeoLib::Polyline*>* plys = new std::vector<GeoLib::Polyline*>;
+		plys->push_back(ply);
+
+		geo_objs.addPolylineVec(plys, geometry_0, nullptr);
+
+		MGTL::MeshNodeSearcher& searcher_nodes = MGTL::MeshNodeSearcher::getMeshNodeSearcher(*mesh);
+		MGTL::BoundaryElementsSearcher searcher_elements(*mesh, searcher_nodes);
+
+		auto elems = searcher_elements.getBoundaryElements(*ply);
+
+		// deep copy because the searcher destroys the elements.
+		std::transform(elems.cbegin(), elems.cend(),
+					   std::back_inserter(boundary_elements),
+					   std::mem_fn(&MeL::Element::clone));
+
+		std::vector<MeL::Node*> nodes = MeL::getUniqueNodes(boundary_elements);
+
+		mesh_items_boundary.reset(
+		    mesh_items_all_nodes->getIntersectionByNodes(nodes));
+	}
+
+	virtual ~AssemblerLibLocalToGlobalIndexMapMultiDOFTest()
+	{
+		for (auto p : components_boundary)
+			delete p;
+		for (auto p : components)
+			delete p;
+		for (auto p : boundary_elements)
+			delete p;
+	}
+
+	void clear()
+	{
+		for (auto* mss : components) {
+			delete mss;
+		}
+
+		components.clear();
+
+		for (auto* mss : components_boundary) {
+			delete mss;
+		}
+
+		components_boundary.clear();
+	}
+
+	void initComponents(const unsigned num_components, const unsigned selected_component,
+						const AL::ComponentOrder order)
+	{
+		assert(selected_component < num_components);
+
+		clear();
+
+		for (unsigned i=0; i<num_components; ++i)
+		{
+			components.push_back(new MeL::MeshSubsets(
+			    mesh_items_all_nodes.get()));
+		}
+		dof_map.reset(new AL::LocalToGlobalIndexMap(components, order));
+
+		components_boundary.resize(num_components, nullptr);
+		components_boundary[selected_component] =
+		    new MeL::MeshSubsets(mesh_items_boundary.get());
+
+		dof_map_boundary.reset(
+				dof_map->deriveBoundaryConstrainedMap(components_boundary, boundary_elements)
+				);
+	}
+
+	template <AL::ComponentOrder order>
+	void test(const unsigned num_components, const unsigned selected_component,
+	          std::function<std::size_t(std::size_t, std::size_t)> const
+	              compute_global_index);
+
+	std::unique_ptr<const MeshLib::Mesh> mesh;
+	std::unique_ptr<const MeL::MeshSubset> mesh_items_all_nodes;
+    std::vector<MeL::MeshSubsets*> components_boundary;
+    std::vector<MeL::MeshSubsets*> components;
+
+	GeoLib::GEOObjects geo_objs;
+
+	std::unique_ptr<AL::LocalToGlobalIndexMap> dof_map;
+	std::unique_ptr<AL::LocalToGlobalIndexMap> dof_map_boundary;
+
+	std::unique_ptr<MeL::MeshSubset const> mesh_items_boundary;
+	std::vector<MeL::Element*> boundary_elements;
+};
+
+
+struct ComputeGlobalIndexByComponent
+{
+	std::size_t num_nodes;
+
+	std::size_t operator()(std::size_t const node,
+	                       std::size_t const component) const
+	{
+		return node + component * num_nodes;
+	}
+};
+
+struct ComputeGlobalIndexByLocation
+{
+	std::size_t num_components;
+
+	std::size_t operator()(std::size_t const node,
+	                       std::size_t const component) const
+	{
+		return node * num_components + component;
+	}
+};
+
+
+template <AL::ComponentOrder ComponentOrder>
+void AssemblerLibLocalToGlobalIndexMapMultiDOFTest::test(
+    const unsigned num_components,
+    const unsigned selected_component,
+    std::function<std::size_t(std::size_t, std::size_t)> const
+        compute_global_index)
+{
+	initComponents(num_components, selected_component, ComponentOrder);
+
+	ASSERT_TRUE(dof_map->getNumComponents() == num_components);
+	ASSERT_TRUE(dof_map->size() == mesh->getNElements());
+
+	ASSERT_TRUE(dof_map_boundary->getNumComponents() == 1);
+	ASSERT_TRUE(dof_map_boundary->size() == boundary_elements.size());
+
+	// check mesh elements
+	for (unsigned e=0; e<dof_map->size(); ++e)
+	{
+		for (unsigned c=0; c<dof_map->getNumComponents(); ++c)
+		{
+			auto const& global_idcs = (*dof_map)(e, c).rows;
+
+			ASSERT_EQ(4, global_idcs.size()); // quad element with four nodes
+
+			for (unsigned n=0; n<4; ++n) // boundary of quad is line with two nodes
+			{
+				unsigned node = e/4*(mesh_subdivs+1) + e%4; // first node of the quad
+				switch (n)
+				{
+				case 0: break;
+				case 1: node += 1; break;
+				case 2: node += 1 + (mesh_subdivs+1); break;
+				case 3: node +=     (mesh_subdivs+1); break;
+				}
+				auto const glob_idx = compute_global_index(node, c);
+				EXPECT_EQ(glob_idx, global_idcs[n]);
+			}
+		}
+	}
+
+	// check boundary elements
+	for (unsigned e=0; e<dof_map_boundary->size(); ++e)
+	{
+		ASSERT_EQ(1, dof_map_boundary->getNumComponents());
+
+		for (unsigned c=0; c<1; ++c)
+		{
+			auto const& global_idcs = (*dof_map_boundary)(e, c).rows;
+
+			ASSERT_EQ(2, global_idcs.size()); // boundary of quad is line with two nodes
+
+			for (unsigned n=0; n<2; ++n) // boundary of quad is line with two nodes
+			{
+				auto const node = e + n;
+				auto const glob_idx =
+				    compute_global_index(node, selected_component);
+				EXPECT_EQ(glob_idx, global_idcs[n]);
+			}
+		}
+	}
+}
+
+
+
+
+void assert_equal(AL::LocalToGlobalIndexMap const& dof1, AL::LocalToGlobalIndexMap const& dof2)
+{
+	ASSERT_TRUE(dof1.size() == dof2.size());
+	ASSERT_TRUE(dof1.getNumComponents() == dof2.getNumComponents());
+
+	for (unsigned e=0; e<dof1.size(); ++e)
+	{
+		for (unsigned c=0; c<dof1.getNumComponents(); ++c)
+		{
+			EXPECT_TRUE(dof1(e, c).rows == dof2(e, c).rows);
+			EXPECT_TRUE(dof1(e, c).columns == dof2(e, c).columns);
+		}
+	}
+}
+
+
+TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, Test1Comp)
+{
+	unsigned const num_components = 1;
+
+	test<AL::ComponentOrder::BY_LOCATION>(
+	    num_components, 0, ComputeGlobalIndexByComponent{num_components});
+
+	auto dof_map_bc = std::move(dof_map);
+	auto dof_map_boundary_bc = std::move(dof_map_boundary);
+
+	test<AL::ComponentOrder::BY_COMPONENT>(
+	    num_components, 0,
+	    ComputeGlobalIndexByComponent{(mesh_subdivs + 1) * (mesh_subdivs + 1)});
+
+	assert_equal(*dof_map, *dof_map_bc);
+	assert_equal(*dof_map_boundary, *dof_map_boundary_bc);
+}
+
+TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, Test_2Comp_0thSel_ByComp)
+{
+	test<AL::ComponentOrder::BY_COMPONENT>(
+	    2, 0,
+	    ComputeGlobalIndexByComponent{(mesh_subdivs + 1) * (mesh_subdivs + 1)});
+}
+
+TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, Test_2Comp_0thSel_ByLoc)
+{
+	test<AL::ComponentOrder::BY_LOCATION>(2, 0,
+	                                      ComputeGlobalIndexByLocation{2});
+}
+
+TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, Test_2Comp_1stSel_ByComp)
+{
+	test<AL::ComponentOrder::BY_COMPONENT>(
+	    2, 1,
+	    ComputeGlobalIndexByComponent{(mesh_subdivs + 1) * (mesh_subdivs + 1)});
+}
+
+TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, Test_2Comp_1stSel_ByLoc)
+{
+	test<AL::ComponentOrder::BY_LOCATION>(2, 1,
+	                                      ComputeGlobalIndexByLocation{2});
+}
+

--- a/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
@@ -39,22 +39,24 @@ public:
 		mesh.reset(MeL::MeshGenerator::generateRegularQuadMesh(2.0, mesh_subdivs));
 		mesh_items_all_nodes.reset(new MeL::MeshSubset(*mesh, &mesh->getNodes()));
 
-		std::vector<GeoLib::Point*>* ply_pnts = new std::vector<GeoLib::Point*>;
+		std::unique_ptr<std::vector<GeoLib::Point*>> ply_pnts(
+					new std::vector<GeoLib::Point*>);
 		ply_pnts->push_back(new GeoLib::Point(0.0, 0.0, 0.0));
 		ply_pnts->push_back(new GeoLib::Point(1.0, 0.0, 0.0));
 
 		std::string geometry_0("GeometryWithPntsAndPolyline");
-		geo_objs.addPointVec(ply_pnts, geometry_0, nullptr);
+		geo_objs.addPointVec(std::move(ply_pnts), geometry_0, nullptr);
 
 		auto ply = new GeoLib::Polyline(*geo_objs.getPointVec(geometry_0));
 
 		ply->addPoint(0);
 		ply->addPoint(1);
 
-		std::vector<GeoLib::Polyline*>* plys = new std::vector<GeoLib::Polyline*>;
+		std::unique_ptr<std::vector<GeoLib::Polyline*>> plys(
+					new std::vector<GeoLib::Polyline*>);
 		plys->push_back(ply);
 
-		geo_objs.addPolylineVec(plys, geometry_0, nullptr);
+		geo_objs.addPolylineVec(std::move(plys), geometry_0, nullptr);
 
 		MGTL::MeshNodeSearcher& searcher_nodes = MGTL::MeshNodeSearcher::getMeshNodeSearcher(*mesh);
 		MGTL::BoundaryElementsSearcher searcher_elements(*mesh, searcher_nodes);

--- a/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
@@ -257,29 +257,19 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, Test1Comp)
 	assert_equal(*dof_map_boundary, *dof_map_boundary_bc);
 }
 
-TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, Test_2Comp_0thSel_ByComp)
+TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, TestMultiCompByComponent)
 {
-	test<AL::ComponentOrder::BY_COMPONENT>(
-	    2, 0,
-	    ComputeGlobalIndexByComponent{(mesh_subdivs + 1) * (mesh_subdivs + 1)});
+	unsigned const num_components = 5;
+	for (auto c = 0; c < num_components; ++c)
+		test<AL::ComponentOrder::BY_COMPONENT>(
+		    num_components, c, ComputeGlobalIndexByComponent{
+		                           (mesh_subdivs + 1) * (mesh_subdivs + 1)});
 }
 
-TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, Test_2Comp_0thSel_ByLoc)
+TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, TestMultiCompByLocation)
 {
-	test<AL::ComponentOrder::BY_LOCATION>(2, 0,
-	                                      ComputeGlobalIndexByLocation{2});
+	unsigned const num_components = 5;
+	for (auto c = 0; c < num_components; ++c)
+		test<AL::ComponentOrder::BY_LOCATION>(
+		    num_components, c, ComputeGlobalIndexByLocation{num_components});
 }
-
-TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, Test_2Comp_1stSel_ByComp)
-{
-	test<AL::ComponentOrder::BY_COMPONENT>(
-	    2, 1,
-	    ComputeGlobalIndexByComponent{(mesh_subdivs + 1) * (mesh_subdivs + 1)});
-}
-
-TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, Test_2Comp_1stSel_ByLoc)
-{
-	test<AL::ComponentOrder::BY_LOCATION>(2, 1,
-	                                      ComputeGlobalIndexByLocation{2});
-}
-

--- a/Tests/AssemblerLib/SteadyDiffusion2DExample1.h
+++ b/Tests/AssemblerLib/SteadyDiffusion2DExample1.h
@@ -42,7 +42,8 @@ struct SteadyDiffusion2DExample1
 			_localRhs = &localRhs;
 		}
 
-		void assemble()
+		void assemble(std::vector<double> const& /*local_x*/,
+					  std::vector<double> const& /*local_x_prev_ts*/)
 		{
 			// The local contributions are computed here, usually, but for this
 			// particular test all contributions are equal for all elements and are

--- a/Tests/AssemblerLib/TestSerialLinearSolver.cpp
+++ b/Tests/AssemblerLib/TestSerialLinearSolver.cpp
@@ -62,7 +62,7 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
     vec_comp_dis.push_back(
         new MeshLib::MeshSubsets(&mesh_items_all_nodes));
     AssemblerLib::LocalToGlobalIndexMap local_to_global_index_map(
-            vec_comp_dis);
+            vec_comp_dis, AssemblerLib::ComponentOrder::BY_COMPONENT);
 
     //--------------------------------------------------------------------------
     // Construct a linear system


### PR DESCRIPTION
This PR is a reincarnation of #821.

It allows for using multiple degrees of freedom per node.

Changes are:
* VectorMatrixAssembler computes local nodal values for each degree of freedom and passes them on to the local assembler.
* Thus, local assemblers have to accept parameters: `assemble(x, xold)`
* MeshComponentMap stores number of components and global matrix order (by location vs. by component)
* some methods now have component id and dof_table as additional input parameters.
* dof table now saves global indices in a matrix indexed by mesh element and component id

TODOs (will not be handled in this PR):
* VectorMatrixAssembler passes all local nodal values in a single vector. In the future that might be changed to passing each component separately.
* using `LocalToGlobalIndexMap::deriveBoundaryConstrainedMap()` on a derived dof table is allowed only if certain conditions hold (see doc in source file). Yet, that might be a rather rare case to use.