### PR TITLE
Move boost::ptree type instantiations in single TU

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -40,7 +40,7 @@ void readGeometry(std::string const& fname, GeoLib::GEOObjects & geo_objects)
 
 }
 
-ProjectData::ProjectData(ConfigTree const& project_config,
+ProjectData::ProjectData(BaseLib::ConfigTree const& project_config,
 	std::string const& path)
 {
 	// geometry
@@ -174,7 +174,7 @@ bool ProjectData::isMeshNameUniqueAndProvideUniqueName(std::string &name) const
 }
 
 void ProjectData::parseProcessVariables(
-	ConfigTree const& process_variables_config)
+	BaseLib::ConfigTree const& process_variables_config)
 {
 	DBUG("Parse process variables:")
 	if (_geoObjects == nullptr) {
@@ -194,13 +194,13 @@ void ProjectData::parseProcessVariables(
 	_process_variables.reserve(process_variables_config.size());
 
 	for (auto it : process_variables_config) {
-		ConfigTree const& var_config = it.second;
+		BaseLib::ConfigTree const& var_config = it.second;
 		// TODO Extend to referenced meshes.
 		_process_variables.emplace_back(var_config,*_mesh_vec[0],*_geoObjects);
 	}
 }
 
-void ProjectData::parseParameters(ConfigTree const& parameters_config)
+void ProjectData::parseParameters(BaseLib::ConfigTree const& parameters_config)
 {
 	using namespace ProcessLib;
 
@@ -210,7 +210,7 @@ void ProjectData::parseParameters(ConfigTree const& parameters_config)
 		// Skip non-parameter section.
 		if (pc_it.first != "parameter")
 			continue;
-		ConfigTree const& parameter_config = pc_it.second;
+		BaseLib::ConfigTree const& parameter_config = pc_it.second;
 
 		auto name = parameter_config.get_optional<std::string>("name");
 		if (!name)
@@ -249,11 +249,11 @@ void ProjectData::parseParameters(ConfigTree const& parameters_config)
 	}
 }
 
-void ProjectData::parseProcesses(ConfigTree const& processes_config)
+void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config)
 {
 	DBUG("Reading processes:");
 	for (auto pc_it : processes_config) {
-		ConfigTree const& process_config = pc_it.second;
+		BaseLib::ConfigTree const& process_config = pc_it.second;
 
 		// Check if the process type is specified.
 		if (!process_config.get_optional<std::string>("type")) {
@@ -265,7 +265,7 @@ void ProjectData::parseProcesses(ConfigTree const& processes_config)
 	}
 }
 
-void ProjectData::parseOutput(ConfigTree const& output_config,
+void ProjectData::parseOutput(BaseLib::ConfigTree const& output_config,
 	std::string const& path)
 {
 	DBUG("Parse output configuration:");
@@ -280,7 +280,7 @@ void ProjectData::parseOutput(ConfigTree const& output_config,
 	_output_file_prefix = path + *file;
 }
 
-void ProjectData::parseTimeStepping(ConfigTree const& timestepping_config)
+void ProjectData::parseTimeStepping(BaseLib::ConfigTree const& timestepping_config)
 {
 	using namespace ProcessLib;
 

--- a/Applications/ApplicationsLib/ProjectData.h
+++ b/Applications/ApplicationsLib/ProjectData.h
@@ -14,7 +14,8 @@
 #define PROJECTDATA_H_
 
 #include <memory>
-#include <boost/property_tree/ptree.hpp>
+
+#include "BaseLib/ConfigTree.h"
 
 #include "GeoLib/GEOObjects.h"
 
@@ -36,7 +37,6 @@ namespace MeshLib {
  */
 class ProjectData
 {
-using ConfigTree = boost::property_tree::ptree;
 public:
 	/// The empty constructor used in the gui, for example, when the project's
 	/// configuration is not loaded yet.
@@ -45,7 +45,8 @@ public:
 	/// Constructs project data by parsing provided configuration.
 	/// The additional  path is used to find files referenced in the
 	/// configuration.
-	ProjectData(ConfigTree const& config_tree, std::string const& path);
+	ProjectData(BaseLib::ConfigTree const& config_tree,
+	            std::string const& path);
 
 	ProjectData(ProjectData&) = delete;
 	virtual ~ProjectData();
@@ -166,22 +167,22 @@ private:
 	/// Parses the process variables configuration and creates new variables for
 	/// each variable entry passing the corresponding subtree to the process
 	/// variable constructor.
-	void parseProcessVariables(ConfigTree const& process_variables_config);
+	void parseProcessVariables(BaseLib::ConfigTree const& process_variables_config);
 
 	/// Parses the parameters configuration and saves them in a list.
 	/// Checks if a parameter has name tag.
-	void parseParameters(ConfigTree const& parameters_config);
+	void parseParameters(BaseLib::ConfigTree const& parameters_config);
 
 	/// Parses the processes configuration and creates new processes for each
 	/// process entry passing the corresponding subtree to the process
 	/// constructor.
-	void parseProcesses(ConfigTree const& process_config);
+	void parseProcesses(BaseLib::ConfigTree const& process_config);
 
 	/// Parses the output configuration.
 	/// Parses the file tag and sets output file prefix.
-	void parseOutput(ConfigTree const& output_config, std::string const& path);
+	void parseOutput(BaseLib::ConfigTree const& output_config, std::string const& path);
 
-	void parseTimeStepping(ConfigTree const& timestepping_config);
+	void parseTimeStepping(BaseLib::ConfigTree const& timestepping_config);
 
 private:
 	GeoLib::GEOObjects *_geoObjects = new GeoLib::GEOObjects();
@@ -190,7 +191,7 @@ private:
 	std::vector<ProcessLib::ProcessVariable> _process_variables;
 
 	/// Buffer for each process' config used in the process building function.
-	std::vector<ConfigTree> _process_configs;
+	std::vector<BaseLib::ConfigTree> _process_configs;
 
 	/// Buffer for each parameter config passed to the process.
 	std::vector<std::unique_ptr<ProcessLib::ParameterBase>> _parameters;

--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -10,7 +10,6 @@
  *
  */
 
-#include <boost/property_tree/ptree.hpp>
 
 #ifdef USE_MPI
 #include <mpi.h>
@@ -25,8 +24,8 @@
 
 // BaseLib
 #include "BaseLib/BuildInfo.h"
-#include "BaseLib/FileTools.h"
 #include "BaseLib/ConfigTree.h"
+#include "BaseLib/FileTools.h"
 
 #include "Applications/ApplicationsLib/LinearSolverLibrarySetup.h"
 #include "Applications/ApplicationsLib/LogogSetup.h"
@@ -81,8 +80,6 @@ void solveProcesses(ProjectData &project)
 
 int main(int argc, char *argv[])
 {
-	using ConfigTree = boost::property_tree::ptree;
-
 	// Parse CLI arguments.
 	TCLAP::CmdLine cmd("OpenGeoSys-6 software.\n"
 			"Copyright (c) 2012-2015, OpenGeoSys Community "
@@ -108,9 +105,8 @@ int main(int argc, char *argv[])
 	    argc, argv);
 
 	// Project's configuration
-	ConfigTree project_config =
+	BaseLib::ConfigTree project_config =
 	    BaseLib::read_xml_config(project_arg.getValue());
-
 
 	project_config = project_config.get_child("OpenGeoSysProject");
 

--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -11,7 +11,6 @@
  */
 
 #include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/xml_parser.hpp>
 
 #ifdef USE_MPI
 #include <mpi.h>
@@ -27,6 +26,7 @@
 // BaseLib
 #include "BaseLib/BuildInfo.h"
 #include "BaseLib/FileTools.h"
+#include "BaseLib/ConfigTree.h"
 
 #include "Applications/ApplicationsLib/LinearSolverLibrarySetup.h"
 #include "Applications/ApplicationsLib/LogogSetup.h"
@@ -108,13 +108,8 @@ int main(int argc, char *argv[])
 	    argc, argv);
 
 	// Project's configuration
-	ConfigTree project_config;
-
-	read_xml(project_arg.getValue(), project_config,
-			boost::property_tree::xml_parser::no_comments
-			 | boost::property_tree::xml_parser::trim_whitespace);
-	DBUG("Project configuration from file \'%s\' read.",
-		project_arg.getValue().c_str());
+	ConfigTree project_config =
+	    BaseLib::read_xml_config(project_arg.getValue());
 
 
 	project_config = project_config.get_child("OpenGeoSysProject");

--- a/BaseLib/ConfigTree.cpp
+++ b/BaseLib/ConfigTree.cpp
@@ -11,11 +11,13 @@
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
+#include <boost/property_tree/json_parser.hpp>
 
 #include <logog/include/logog.hpp>
 
 namespace BaseLib
 {
+
 boost::property_tree::ptree read_xml_config(boost::filesystem::path const& path)
 {
 	boost::property_tree::ptree ptree;
@@ -28,4 +30,12 @@ boost::property_tree::ptree read_xml_config(boost::filesystem::path const& path)
 
 	return ptree;
 }
+
+std::string propertyTreeToString(boost::property_tree::ptree const& tree)
+{
+	std::ostringstream ss;
+	boost::property_tree::write_json(ss, tree);
+	return ss.str();
+}
+
 }

--- a/BaseLib/ConfigTree.cpp
+++ b/BaseLib/ConfigTree.cpp
@@ -9,7 +9,6 @@
 
 #include "ConfigTree.h"
 
-#include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
@@ -18,9 +17,9 @@
 namespace BaseLib
 {
 
-boost::property_tree::ptree read_xml_config(boost::filesystem::path const& path)
+ConfigTree read_xml_config(boost::filesystem::path const& path)
 {
-	boost::property_tree::ptree ptree;
+	ConfigTree ptree;
 	read_xml(path.string(), ptree,
 	         boost::property_tree::xml_parser::no_comments |
 	             boost::property_tree::xml_parser::trim_whitespace);
@@ -31,7 +30,7 @@ boost::property_tree::ptree read_xml_config(boost::filesystem::path const& path)
 	return ptree;
 }
 
-std::string propertyTreeToString(boost::property_tree::ptree const& tree)
+std::string propertyTreeToString(ConfigTree const& tree)
 {
 	std::ostringstream ss;
 	boost::property_tree::write_json(ss, tree);

--- a/BaseLib/ConfigTree.cpp
+++ b/BaseLib/ConfigTree.cpp
@@ -1,0 +1,31 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "ConfigTree.h"
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+
+#include <logog/include/logog.hpp>
+
+namespace BaseLib
+{
+boost::property_tree::ptree read_xml_config(boost::filesystem::path const& path)
+{
+	boost::property_tree::ptree ptree;
+	read_xml(path.string(), ptree,
+	         boost::property_tree::xml_parser::no_comments |
+	             boost::property_tree::xml_parser::trim_whitespace);
+
+	DBUG("Project configuration from file \'%s\' read.",
+	     path.string().c_str());
+
+	return ptree;
+}
+}

--- a/BaseLib/ConfigTree.cpp
+++ b/BaseLib/ConfigTree.cpp
@@ -14,6 +14,11 @@
 
 #include <logog/include/logog.hpp>
 
+// Explicitly instantiate the boost::property_tree::ptree which is a typedef to
+// the following basic_ptree.
+template class boost::property_tree::basic_ptree<std::string, std::string,
+                                                 std::less<std::string>>;
+
 namespace BaseLib
 {
 

--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -1,0 +1,23 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef BASELIB_CONFIGTREE_H_
+#define BASELIB_CONFIGTREE_H_
+
+#include <boost/property_tree/ptree_fwd.hpp>
+#include <boost/filesystem.hpp>
+
+namespace BaseLib
+{
+
+boost::property_tree::ptree read_xml_config(
+    boost::filesystem::path const& path);
+}
+
+#endif  // BASELIB_CONFIGTREE_H_

--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -18,6 +18,9 @@ namespace BaseLib
 
 boost::property_tree::ptree read_xml_config(
     boost::filesystem::path const& path);
+
+/// Returns the JSON-representation of the given boost::property_tree.
+std::string propertyTreeToString(boost::property_tree::ptree const& tree);
 }
 
 #endif  // BASELIB_CONFIGTREE_H_

--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -15,6 +15,7 @@
 
 namespace BaseLib
 {
+using ConfigTree = boost::property_tree::ptree;
 
 boost::property_tree::ptree read_xml_config(
     boost::filesystem::path const& path);

--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -10,7 +10,7 @@
 #ifndef BASELIB_CONFIGTREE_H_
 #define BASELIB_CONFIGTREE_H_
 
-#include <boost/property_tree/ptree_fwd.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include <boost/filesystem.hpp>
 
 namespace BaseLib

--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -10,8 +10,12 @@
 #ifndef BASELIB_CONFIGTREE_H_
 #define BASELIB_CONFIGTREE_H_
 
+#include <string>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/filesystem.hpp>
+
+extern template class boost::property_tree::basic_ptree<
+    std::string, std::string, std::less<std::string>>;
 
 namespace BaseLib
 {

--- a/BaseLib/StringTools.cpp
+++ b/BaseLib/StringTools.cpp
@@ -20,7 +20,6 @@
 
 #include "logog/include/logog.hpp"
 
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/algorithm/string/replace.hpp>
 
 namespace BaseLib
@@ -70,13 +69,6 @@ std::string padLeft(std::string const& str, int maxlen, char ch)
 {
 	std::stringstream ss(str);
 	ss << std::right << std::setw(maxlen) << std::setfill(ch) << str;
-	return ss.str();
-}
-
-std::string propertyTreeToString(boost::property_tree::ptree const& tree)
-{
-	std::ostringstream ss;
-	boost::property_tree::write_json(ss, tree);
 	return ss.str();
 }
 

--- a/BaseLib/StringTools.h
+++ b/BaseLib/StringTools.h
@@ -15,7 +15,6 @@
 #ifndef STRINGTOOLS_H
 #define STRINGTOOLS_H
 
-#include <boost/property_tree/ptree.hpp>
 
 #include <string>
 #include <list>
@@ -70,11 +69,6 @@ void simplify(std::string &str);
  * Returns the string which is right aligned with padding on the left.
  */
 std::string padLeft(std::string const& str, int maxlen, char ch=' ');
-
-/**
- * Returns the JSON-representation of the given boost::property_tree.
- */
-std::string propertyTreeToString(boost::property_tree::ptree const& tree);
 
 } // end namespace BaseLib
 

--- a/FileIO/XmlIO/Boost/BoostXmlGmlInterface.cpp
+++ b/FileIO/XmlIO/Boost/BoostXmlGmlInterface.cpp
@@ -62,15 +62,14 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
 	GeoLib::GEOObjects* geo_objects (&_geo_objects);
 
 	// build DOM tree
-	using boost::property_tree::ptree;
-	ptree doc;
+    BaseLib::ConfigTree doc;
 	read_xml(in, doc, boost::property_tree::xml_parser::no_comments);
 
 	if (!isGmlFile(doc))
 		return false;
 
-	ptree const & root_node = doc.get_child("OpenGeoSysGLI");
-	BOOST_FOREACH( ptree::value_type const & node, root_node )
+    BaseLib::ConfigTree const & root_node = doc.get_child("OpenGeoSysGLI");
+	BOOST_FOREACH( BaseLib::ConfigTree::value_type const & node, root_node )
 	{
 		if (node.first.compare("name") == 0)
 		{
@@ -115,12 +114,11 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
 	return true;
 }
 
-void BoostXmlGmlInterface::readPoints(boost::property_tree::ptree const & pointsRoot,
+void BoostXmlGmlInterface::readPoints(BaseLib::ConfigTree const& pointsRoot,
 	                                  std::vector<GeoLib::Point*>* points,
 	                                  std::map<std::string, std::size_t>* &pnt_names )
 {
-	using boost::property_tree::ptree;
-	BOOST_FOREACH( ptree::value_type const & point, pointsRoot )
+	BOOST_FOREACH( BaseLib::ConfigTree::value_type const & point, pointsRoot )
 	{
 		if (point.first.compare("point") != 0)
 			continue;
@@ -154,14 +152,13 @@ void BoostXmlGmlInterface::readPoints(boost::property_tree::ptree const & points
 }
 
 
-void BoostXmlGmlInterface::readPolylines(boost::property_tree::ptree const& polylinesRoot,
+void BoostXmlGmlInterface::readPolylines(BaseLib::ConfigTree const&  polylinesRoot,
 	                                     std::vector<GeoLib::Polyline*>* polylines,
 	                                     std::vector<GeoLib::Point*>* points,
 	                                     const std::vector<std::size_t> &pnt_id_map,
 	                                     std::map<std::string, std::size_t>* &ply_names )
 {
-	using boost::property_tree::ptree;
-	BOOST_FOREACH( ptree::value_type const & polyline, polylinesRoot )
+	BOOST_FOREACH( BaseLib::ConfigTree::value_type const & polyline, polylinesRoot )
 	{
 		if (polyline.first.compare("polyline") != 0)
 			continue;
@@ -190,7 +187,7 @@ void BoostXmlGmlInterface::readPolylines(boost::property_tree::ptree const& poly
 				}
 			}
 
-			BOOST_FOREACH( ptree::value_type const & pnt, polyline.second )
+			BOOST_FOREACH( BaseLib::ConfigTree::value_type const & pnt, polyline.second )
 			{
 				if (pnt.first.compare("pnt") == 0)
 					polylines->back()->addPoint(pnt_id_map[_idx_map[std::atoi(pnt.second.data().c_str())]]);
@@ -206,14 +203,13 @@ void BoostXmlGmlInterface::readPolylines(boost::property_tree::ptree const& poly
 	}
 }
 
-void BoostXmlGmlInterface::readSurfaces(boost::property_tree::ptree const& surfacesRoot,
+void BoostXmlGmlInterface::readSurfaces(BaseLib::ConfigTree const&  surfacesRoot,
 	                                    std::vector<GeoLib::Surface*>* surfaces,
 	                                    std::vector<GeoLib::Point*>* points,
 	                                    const std::vector<std::size_t> &pnt_id_map,
 	                                    std::map<std::string, std::size_t>* &sfc_names )
 {
-	using boost::property_tree::ptree;
-	BOOST_FOREACH( ptree::value_type const & surface, surfacesRoot )
+	BOOST_FOREACH( BaseLib::ConfigTree::value_type const & surface, surfacesRoot )
 	{
 		if (surface.first.compare("surface") != 0)
 			continue;
@@ -231,7 +227,7 @@ void BoostXmlGmlInterface::readSurfaces(boost::property_tree::ptree const& surfa
 		if (!s_name.empty())
 			sfc_names->insert(std::pair<std::string, std::size_t>(s_name, surfaces->size()-1));
 
-		BOOST_FOREACH( ptree::value_type const & element, surface.second )
+		BOOST_FOREACH( BaseLib::ConfigTree::value_type const & element, surface.second )
 		{
 			if (element.first.compare("element") != 0)
 				continue;
@@ -260,7 +256,7 @@ void BoostXmlGmlInterface::readSurfaces(boost::property_tree::ptree const& surfa
 	}
 }
 
-bool BoostXmlGmlInterface::isGmlFile(const boost::property_tree::ptree &root) const
+bool BoostXmlGmlInterface::isGmlFile(BaseLib::ConfigTree const& root) const
 {
 	if (!root.get_child_optional("OpenGeoSysGLI"))
 	{
@@ -297,20 +293,19 @@ bool BoostXmlGmlInterface::write()
 	}
 
 	// create a property tree for writing it to file
-	using boost::property_tree::ptree;
-	ptree pt;
+    BaseLib::ConfigTree pt;
 
 	// put header in property tree
 	pt.put("<xmlattr>.xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
 	pt.put("<xmlattr>.xsi:noNamespaceSchemaLocation",
 		"http://www.opengeosys.org/images/xsd/OpenGeoSysGLI.xsd");
 	pt.put("<xmlattr>.xmlns:ogs", "http://www.opengeosys.net");
-	ptree &geometry_set = pt.add("OpenGeoSysGLI", "");
+    BaseLib::ConfigTree &geometry_set = pt.add("OpenGeoSysGLI", "");
 
 	geometry_set.add("name", _exportName);
-	ptree & pnts_tag = geometry_set.add("points", "");
+    BaseLib::ConfigTree & pnts_tag = geometry_set.add("points", "");
 	for (std::size_t k(0); k<pnts->size(); k++) {
-		ptree &pnt_tag = pnts_tag.add("point", "");
+        BaseLib::ConfigTree &pnt_tag = pnts_tag.add("point", "");
 		pnt_tag.put("<xmlattr>.id", k);
 		pnt_tag.put("<xmlattr>.x", (*((*pnts)[k]))[0]);
 		pnt_tag.put("<xmlattr>.y", (*((*pnts)[k]))[1]);

--- a/FileIO/XmlIO/Boost/BoostXmlGmlInterface.h
+++ b/FileIO/XmlIO/Boost/BoostXmlGmlInterface.h
@@ -19,8 +19,8 @@
 #include <string>
 #include <vector>
 
-#include <boost/property_tree/ptree_fwd.hpp>
 
+#include "BaseLib/ConfigTree.h"
 #include "../XMLInterface.h"
 
 namespace GeoLib
@@ -50,26 +50,26 @@ protected:
 
 private:
 	/// Reads GeoLib::Point-objects from an xml-file
-	void readPoints    ( boost::property_tree::ptree const& pointsRoot,
+	void readPoints    ( BaseLib::ConfigTree const& pointsRoot,
 	                     std::vector<GeoLib::Point*>* points,
 	                     std::map<std::string, std::size_t>* &pnt_names );
 
 	/// Reads GeoLib::Polyline-objects from an xml-file
-	void readPolylines ( boost::property_tree::ptree const& polylinesRoot,
+	void readPolylines ( BaseLib::ConfigTree const& polylinesRoot,
 	                     std::vector<GeoLib::Polyline*>* polylines,
 	                     std::vector<GeoLib::Point*>* points,
 	                     const std::vector<std::size_t> &pnt_id_map,
 	                     std::map<std::string, std::size_t>* &ply_names );
 
 	/// Reads GeoLib::Surface-objects from an xml-file
-	void readSurfaces  ( boost::property_tree::ptree const& surfacesRoot,
+	void readSurfaces  ( BaseLib::ConfigTree const& surfacesRoot,
 	                     std::vector<GeoLib::Surface*>* surfaces,
 	                     std::vector<GeoLib::Point*>* points,
 	                     const std::vector<std::size_t> &pnt_id_map,
 	                     std::map<std::string, std::size_t>* &sfc_names );
 
 	/// Check if the root node really specifies an GML file
-	bool isGmlFile( boost::property_tree::ptree const& root) const;
+	bool isGmlFile( BaseLib::ConfigTree const& root) const;
 
 	std::map<std::size_t, std::size_t> _idx_map;
 	GeoLib::GEOObjects &_geo_objects;

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -9,17 +9,15 @@
 
 #include "EigenLinearSolver.h"
 
-#include <boost/property_tree/ptree.hpp>
 #include <logog/include/logog.hpp>
 
+#include "BaseLib/ConfigTree.h"
 #include "EigenVector.h"
 #include "EigenMatrix.h"
 #include "EigenTools.h"
 
 namespace MathLib
 {
-
-using boost::property_tree::ptree;
 
 namespace details
 {
@@ -97,7 +95,7 @@ private:
 
 EigenLinearSolver::EigenLinearSolver(EigenMatrix &A,
                             const std::string /*solver_name*/,
-                            ptree const*const option)
+                            BaseLib::ConfigTree const*const option)
 {
     if (option)
         setOption(*option);
@@ -116,9 +114,10 @@ EigenLinearSolver::EigenLinearSolver(EigenMatrix &A,
     }
 }
 
-void EigenLinearSolver::setOption(const ptree &option)
+void EigenLinearSolver::setOption(BaseLib::ConfigTree const& option)
 {
-    boost::optional<ptree> ptSolver = option.get_child("LinearSolver");
+    boost::optional<BaseLib::ConfigTree> ptSolver =
+        option.get_child("LinearSolver");
     if (!ptSolver)
         return;
 

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.h
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.h
@@ -12,8 +12,8 @@
 
 #include <vector>
 
-#include <boost/property_tree/ptree_fwd.hpp>
 
+#include "BaseLib/ConfigTree.h"
 #include "EigenVector.h"
 #include "EigenOption.h"
 
@@ -35,7 +35,7 @@ public:
      *                    LisOption struct.
      */
     EigenLinearSolver(EigenMatrix &A, const std::string solver_name = "",
-                      boost::property_tree::ptree const*const option = nullptr);
+                      BaseLib::ConfigTree const*const option = nullptr);
 
     ~EigenLinearSolver()
     {
@@ -45,7 +45,7 @@ public:
     /**
      * parse linear solvers configuration
      */
-    void setOption(const boost::property_tree::ptree &option);
+    void setOption(BaseLib::ConfigTree const& option);
 
     /**
      * copy linear solvers options

--- a/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
+++ b/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
@@ -9,12 +9,12 @@
 
 #include "EigenLisLinearSolver.h"
 
-#include <boost/property_tree/ptree.hpp>
 #ifdef _OPENMP
 #include <omp.h>
 #endif
 #include <logog/include/logog.hpp>
 
+#include "BaseLib/ConfigTree.h"
 #include "MathLib/LinAlg/Eigen/EigenMatrix.h"
 #include "MathLib/LinAlg/Eigen/EigenVector.h"
 #include "MathLib/LinAlg/Lis/LisMatrix.h"
@@ -24,20 +24,19 @@
 namespace MathLib
 {
 
-using boost::property_tree::ptree;
-
 EigenLisLinearSolver::EigenLisLinearSolver(EigenMatrix &A,
                       const std::string /*solver_name*/,
-                      ptree const*const option)
+                      BaseLib::ConfigTree const*const option)
 : _A(A)
 {
     if (option)
         setOption(*option);
 }
 
-void EigenLisLinearSolver::setOption(const ptree &option)
+void EigenLisLinearSolver::setOption(BaseLib::ConfigTree const& option)
 {
-    boost::optional<ptree> ptSolver = option.get_child("LinearSolver");
+    boost::optional<BaseLib::ConfigTree> ptSolver =
+        option.get_child("LinearSolver");
     if (!ptSolver)
         return;
 

--- a/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.h
+++ b/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.h
@@ -12,9 +12,9 @@
 
 #include <vector>
 
-#include <boost/property_tree/ptree_fwd.hpp>
 #include <lis.h>
 
+#include "BaseLib/ConfigTree.h"
 #include "MathLib/LinAlg/Lis/LisOption.h"
 
 namespace MathLib
@@ -38,12 +38,12 @@ public:
      *                    LisOption struct.
      */
     EigenLisLinearSolver(EigenMatrix &A, const std::string solver_name = "",
-                         boost::property_tree::ptree const*const option = nullptr);
+                         BaseLib::ConfigTree const*const option = nullptr);
 
     /**
      * parse linear solvers configuration
      */
-    void setOption(const boost::property_tree::ptree &option);
+    void setOption(BaseLib::ConfigTree const& option);
 
     /**
      * copy linear solvers options

--- a/MathLib/LinAlg/Lis/LisLinearSolver.cpp
+++ b/MathLib/LinAlg/Lis/LisLinearSolver.cpp
@@ -26,20 +26,19 @@
 namespace MathLib
 {
 
-using boost::property_tree::ptree;
-
 LisLinearSolver::LisLinearSolver(LisMatrix &A,
                     const std::string /*solver_name*/,
-                    ptree const*const option)
+                    BaseLib::ConfigTree const*const option)
 : _A(A)
 {
     if (option)
         setOption(*option);
 }
 
-void LisLinearSolver::setOption(const ptree &option)
+void LisLinearSolver::setOption(BaseLib::ConfigTree const& option)
 {
-    boost::optional<ptree> ptSolver = option.get_child("LinearSolver");
+    boost::optional<BaseLib::ConfigTree> ptSolver =
+        option.get_child("LinearSolver");
     if (!ptSolver)
         return;
 

--- a/MathLib/LinAlg/Lis/LisLinearSolver.h
+++ b/MathLib/LinAlg/Lis/LisLinearSolver.h
@@ -17,9 +17,9 @@
 
 #include <vector>
 #include <string>
-#include <boost/property_tree/ptree.hpp>
 
 #include "lis.h"
+#include "BaseLib/ConfigTree.h"
 
 #include "LisOption.h"
 #include "LisVector.h"
@@ -45,7 +45,7 @@ public:
      *                    LisOption struct.
      */
     LisLinearSolver(LisMatrix &A, const std::string solver_name = "",
-                    boost::property_tree::ptree const*const option = nullptr);
+                    BaseLib::ConfigTree const*const option = nullptr);
 
     virtual ~LisLinearSolver() {}
 
@@ -53,7 +53,7 @@ public:
      * configure linear solvers
      * @param option
      */
-    void setOption(const boost::property_tree::ptree &option);
+    void setOption(BaseLib::ConfigTree const& option);
 
     /**
      * configure linear solvers

--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
@@ -14,7 +14,6 @@
                http://www.opengeosys.org/project/license
 */
 
-#include <boost/property_tree/ptree.hpp>
 
 #include "PETScLinearSolver.h"
 #include "BaseLib/RunTime.h"
@@ -23,7 +22,7 @@ namespace MathLib
 {
 PETScLinearSolver::PETScLinearSolver(PETScMatrix &A,
                       const std::string prefix,
-                      boost::property_tree::ptree const*const /*option*/)
+                      BaseLib::ConfigTree const*const /*option*/)
     : _A(A), _elapsed_ctime(0.)
 {
     KSPCreate(PETSC_COMM_WORLD, &_solver);

--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.h
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.h
@@ -18,11 +18,12 @@
 #define PETSCLINEARSOLVER_H_
 
 #include<string>
-#include <boost/property_tree/ptree_fwd.hpp>
 
 #include <petscksp.h>
 
 #include "logog/include/logog.hpp"
+
+#include "BaseLib/ConfigTree.h"
 
 #include "PETScMatrix.h"
 #include "PETScVector.h"
@@ -49,7 +50,7 @@ class PETScLinearSolver
                            the linear solver interface.
         */
         PETScLinearSolver(PETScMatrix &A, const std::string prefix="",
-                          boost::property_tree::ptree const*const option = nullptr);
+                          BaseLib::ConfigTree const*const option = nullptr);
 
         ~PETScLinearSolver()
         {

--- a/MathLib/LinAlg/Solvers/GaussAlgorithm-impl.h
+++ b/MathLib/LinAlg/Solvers/GaussAlgorithm-impl.h
@@ -21,7 +21,7 @@ namespace MathLib {
 template <typename MAT_T, typename VEC_T>
 GaussAlgorithm<MAT_T, VEC_T>::GaussAlgorithm(MAT_T &A,
 		const std::string /*solver_name*/,
-		boost::property_tree::ptree const* const) :
+		BaseLib::ConfigTree const* const) :
 		_mat(A), _n(_mat.getNRows()), _perm(new IDX_T[_n])
 {}
 

--- a/MathLib/LinAlg/Solvers/GaussAlgorithm.h
+++ b/MathLib/LinAlg/Solvers/GaussAlgorithm.h
@@ -17,8 +17,8 @@
 
 #include <cstddef>
 
-#include <boost/property_tree/ptree.hpp>
 
+#include "BaseLib/ConfigTree.h"
 #include "../Dense/DenseMatrix.h"
 #include "TriangularSolve.h"
 
@@ -55,7 +55,7 @@ public:
 	 * second argument was introduced.
 	 */
 	GaussAlgorithm(MAT_T &A, const std::string solver_name = "",
-                   boost::property_tree::ptree const*const option = nullptr);
+                   BaseLib::ConfigTree const*const option = nullptr);
 	/**
 	 * destructor, deletes the permutation
 	 */

--- a/NumLib/TimeStepping/Algorithms/FixedTimeStepping.cpp
+++ b/NumLib/TimeStepping/Algorithms/FixedTimeStepping.cpp
@@ -17,6 +17,7 @@
 #include <limits>
 #include <cassert>
 
+#include "BaseLib/ConfigTree.h"
 #include "logog/include/logog.hpp"
 
 namespace NumLib
@@ -31,7 +32,7 @@ FixedTimeStepping::FixedTimeStepping(double t0, double tn, double dt)
 {}
 
 FixedTimeStepping*
-FixedTimeStepping::newInstance(const ConfigTree &config)
+FixedTimeStepping::newInstance(BaseLib::ConfigTree const& config)
 {
     assert(config.get<std::string>("type") == "FixedTimeStepping");
 

--- a/NumLib/TimeStepping/Algorithms/FixedTimeStepping.h
+++ b/NumLib/TimeStepping/Algorithms/FixedTimeStepping.h
@@ -13,8 +13,8 @@
 #define FIXEDTIMESTEPPING_H_
 
 #include <vector>
-#include <boost/property_tree/ptree.hpp>
 
+#include "BaseLib/ConfigTree.h"
 #include "ITimeStepAlgorithm.h"
 
 namespace NumLib
@@ -27,7 +27,6 @@ namespace NumLib
  */
 class FixedTimeStepping : public ITimeStepAlgorithm
 {
-    using ConfigTree = boost::property_tree::ptree;
 public:
 
     /**
@@ -65,7 +64,7 @@ public:
      *
      * Currently this function only covers uniform timestep size.
      */
-    static FixedTimeStepping* newInstance(ConfigTree const& config);
+    static FixedTimeStepping* newInstance(BaseLib::ConfigTree const& config);
 
     virtual ~FixedTimeStepping() {}
 

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -14,10 +14,10 @@
 #include <memory>
 
 #include <boost/optional.hpp>
-#include <boost/property_tree/ptree.hpp>
 #include <boost/algorithm/string/erase.hpp>
 
 #include "logog/include/logog.hpp"
+#include "BaseLib/ConfigTree.h"
 
 #ifdef USE_PETSC
 #include "MeshLib/NodePartitionedMesh.h"
@@ -61,15 +61,13 @@ namespace ProcessLib
 template<typename GlobalSetup>
 class GroundwaterFlowProcess : public Process
 {
-    using ConfigTree = boost::property_tree::ptree;
-
     unsigned const _integration_order = 2;
 
 public:
     GroundwaterFlowProcess(MeshLib::Mesh& mesh,
             std::vector<ProcessVariable> const& variables,
             std::vector<std::unique_ptr<ParameterBase>> const& parameters,
-            ConfigTree const& config)
+            BaseLib::ConfigTree const& config)
         : Process(mesh)
     {
         DBUG("Create GroundwaterFlowProcess.");

--- a/ProcessLib/InitialCondition.cpp
+++ b/ProcessLib/InitialCondition.cpp
@@ -9,7 +9,6 @@
 
 #include "InitialCondition.h"
 
-#include <boost/property_tree/ptree.hpp>
 #include <boost/optional.hpp>
 #include <logog/include/logog.hpp>
 
@@ -19,10 +18,8 @@
 
 namespace ProcessLib
 {
-using ConfigTree = boost::property_tree::ptree;
-
 std::unique_ptr<InitialCondition> createUniformInitialCondition(
-    ConfigTree const& config)
+    BaseLib::ConfigTree const& config)
 {
 	auto value = config.get_optional<double>("value");
 	if (!value)
@@ -37,7 +34,7 @@ std::unique_ptr<InitialCondition> createUniformInitialCondition(
 }
 
 std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
-    ConfigTree const& config, MeshLib::Mesh const& mesh)
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh)
 {
 	auto field_name = config.get_optional<std::string>("field_name");
 	if (!field_name)

--- a/ProcessLib/InitialCondition.h
+++ b/ProcessLib/InitialCondition.h
@@ -11,7 +11,7 @@
 #define PROCESS_LIB_INITIAL_CONDITION_H_
 
 #include <cassert>
-#include <boost/property_tree/ptree_fwd.hpp>
+#include "BaseLib/ConfigTree.h"
 #include "MeshLib/Node.h"
 #include "MeshLib/PropertyVector.h"
 
@@ -52,7 +52,7 @@ private:
 
 /// Construct a UniformInitialCondition from configuration.
 std::unique_ptr<InitialCondition> createUniformInitialCondition(
-    boost::property_tree::ptree const& config);
+    BaseLib::ConfigTree const& config);
 
 /// Distribution of values given by a mesh property defined on nodes.
 class MeshPropertyInitialCondition : public InitialCondition
@@ -76,7 +76,7 @@ private:
 
 /// Construct a MeshPropertyInitialCondition from configuration.
 std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
-    boost::property_tree::ptree const& config, MeshLib::Mesh const& mesh);
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh);
 
 }  // namespace ProcessLib
 

--- a/ProcessLib/NeumannBcConfig.h
+++ b/ProcessLib/NeumannBcConfig.h
@@ -10,9 +10,9 @@
 #ifndef PROCESS_LIB_NEUMANN_BC_CONFIG_H_
 #define PROCESS_LIB_NEUMANN_BC_CONFIG_H_
 
-#include <boost/property_tree/ptree.hpp>
 #include "logog/include/logog.hpp"
 
+#include "BaseLib/ConfigTree.h"
 #include "MathLib/ConstantFunction.h"
 #include "MeshGeoToolsLib/BoundaryElementsSearcher.h"
 #include "MeshLib/Elements/Element.h"
@@ -42,10 +42,9 @@ protected:
 /// Configuration of a Neumann type boundary condition read from input file.
 class NeumannBcConfig : public BoundaryConditionConfig
 {
-    using ConfigTree = boost::property_tree::ptree;
 public:
     NeumannBcConfig(GeoLib::GeoObject const* const geometry,
-            ConfigTree const& config)
+            BaseLib::ConfigTree const& config)
         : BoundaryConditionConfig(geometry)
     {
         DBUG("Constructing NeumannBcConfig from config.");

--- a/ProcessLib/Parameter.cpp
+++ b/ProcessLib/Parameter.cpp
@@ -9,7 +9,6 @@
 
 #include "Parameter.h"
 
-#include <boost/property_tree/ptree.hpp>
 #include <boost/optional.hpp>
 #include <logog/include/logog.hpp>
 
@@ -17,9 +16,8 @@
 
 namespace ProcessLib
 {
-using ConfigTree = boost::property_tree::ptree;
-
-std::unique_ptr<ParameterBase> createConstParameter(ConfigTree const config)
+std::unique_ptr<ParameterBase> createConstParameter(
+    BaseLib::ConfigTree const config)
 {
 	auto value = config.get_optional<double>("value");
 	if (!value)
@@ -33,7 +31,7 @@ std::unique_ptr<ParameterBase> createConstParameter(ConfigTree const config)
 }
 
 std::unique_ptr<ParameterBase> createMeshPropertyParameter(
-    ConfigTree const config, MeshLib::Mesh const& mesh)
+    BaseLib::ConfigTree const config, MeshLib::Mesh const& mesh)
 {
 	auto field_name = config.get_optional<std::string>("field_name");
 	if (!field_name)

--- a/ProcessLib/Parameter.h
+++ b/ProcessLib/Parameter.h
@@ -13,9 +13,9 @@
 #include <memory>
 
 #include <logog/include/logog.hpp>
-#include <boost/property_tree/ptree_fwd.hpp>
 #include <boost/optional.hpp>
 
+#include "BaseLib/ConfigTree.h"
 #include "MeshLib/Elements/Element.h"
 
 namespace MeshLib
@@ -66,8 +66,8 @@ private:
 	ReturnType _value;
 };
 
-using ConfigTree = boost::property_tree::ptree;
-std::unique_ptr<ParameterBase> createConstParameter(ConfigTree const config);
+std::unique_ptr<ParameterBase> createConstParameter(
+    BaseLib::ConfigTree const config);
 
 /// A parameter represented by a mesh property vector.
 template <typename ReturnType>
@@ -89,7 +89,7 @@ private:
 };
 
 std::unique_ptr<ParameterBase> createMeshPropertyParameter(
-    ConfigTree const config, MeshLib::Mesh const& mesh);
+    BaseLib::ConfigTree const config, MeshLib::Mesh const& mesh);
 
 }  // namespace ProcessLib
 

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -9,7 +9,6 @@
 
 #include "ProcessVariable.h"
 
-#include <boost/property_tree/ptree.hpp>
 #include "logog/include/logog.hpp"
 
 #include "GeoLib/GEOObjects.h"
@@ -20,7 +19,7 @@
 
 namespace ProcessLib
 {
-ProcessVariable::ProcessVariable(ConfigTree const& config,
+ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
                                  MeshLib::Mesh const& mesh,
                                  GeoLib::GEOObjects const& geometries)
     : _name(config.get<std::string>("name")), _mesh(mesh)
@@ -59,7 +58,7 @@ ProcessVariable::ProcessVariable(ConfigTree const& config,
 
 		for (auto const& bc_iterator : bcs_config->second)
 		{
-			ConfigTree const& bc_config = bc_iterator.second;
+			BaseLib::ConfigTree const& bc_config = bc_iterator.second;
 
 			// Find corresponding GeoObject
 			std::string const geometrical_set_name =

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -10,7 +10,6 @@
 #ifndef PROCESS_LIB_PROCESS_VARIABLE_H_
 #define PROCESS_LIB_PROCESS_VARIABLE_H_
 
-#include <boost/property_tree/ptree.hpp>
 
 #include "InitialCondition.h"
 #include "UniformDirichletBoundaryCondition.h"
@@ -46,10 +45,8 @@ namespace ProcessLib
 /// and boundary conditions.
 class ProcessVariable
 {
-	using ConfigTree = boost::property_tree::ptree;
-
 public:
-	ProcessVariable(ConfigTree const& config, MeshLib::Mesh const& mesh,
+	ProcessVariable(BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh,
 	                GeoLib::GEOObjects const& geometries);
 
 	ProcessVariable(ProcessVariable&&);

--- a/ProcessLib/UniformDirichletBoundaryCondition.h
+++ b/ProcessLib/UniformDirichletBoundaryCondition.h
@@ -13,9 +13,9 @@
 #include <algorithm>
 #include <vector>
 
-#include <boost/property_tree/ptree.hpp>
 #include "logog/include/logog.hpp"
 
+#include "BaseLib/ConfigTree.h"
 #include "MeshGeoToolsLib/MeshNodeSearcher.h"
 
 namespace GeoLib
@@ -32,10 +32,9 @@ namespace ProcessLib
 /// not present defaults to zero.
 class UniformDirichletBoundaryCondition
 {
-    using ConfigTree = boost::property_tree::ptree;
 public:
     UniformDirichletBoundaryCondition(GeoLib::GeoObject const* const geometry,
-            ConfigTree const& config)
+                                      BaseLib::ConfigTree const& config)
         : _geometry(geometry)
     {
         DBUG("Constructing UniformDirichletBoundaryCondition from config.");

--- a/Tests/MathLib/TestLinearSolver.cpp
+++ b/Tests/MathLib/TestLinearSolver.cpp
@@ -14,7 +14,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <boost/property_tree/ptree.hpp>
 
 #include "MathLib/LinAlg/Dense/DenseVector.h"
 #include "MathLib/LinAlg/Dense/DenseMatrix.h"
@@ -100,7 +99,7 @@ struct Example1
 };
 
 template <class T_MATRIX, class T_VECTOR, class T_LINEAR_SOVLER>
-void checkLinearSolverInterface(T_MATRIX &A, boost::property_tree::ptree &ls_option)
+void checkLinearSolverInterface(T_MATRIX &A, BaseLib::ConfigTree& ls_option)
 {
     Example1 ex1;
 


### PR DESCRIPTION
TU = translation unit.

This moves an expensive read_xml() instantiation in the first step from ogs.cpp into an own TU BaseLib/ConfigTree.cpp and reduces the compilation time for ogs.cpp from 6.80s (100%) to 5.84s (85%).
The compile time for the whole project increases slightly from 210.7s to 212.6s.

In the second step an explicit template instantiation of the boost::property_tree::ptree is added to ConfigTree.cpp avoiding multiple instantiations. This reduces the compile time for ogs.cpp to 5.46s (80%) and the whole project compilation time to 204.2s. (~3% faster)

The advantage of this all is that when actively working on processes the recompilation of the simulator is faster.