### PR TITLE
Switch behaviour for CMAKE_BUILD_TYPE in CMake gui

### DIFF
--- a/scripts/cmake/CMakeSetup.cmake
+++ b/scripts/cmake/CMakeSetup.cmake
@@ -21,6 +21,12 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 	set(OGS_BUILD_CLI OFF CACHE BOOL "" FORCE)
 endif()
 
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+	message(STATUS "Setting build type to 'Debug' as none was specified.")
+	set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build." FORCE)
+	set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 # Get the hostname
 site_name(HOSTNAME)
 


### PR DESCRIPTION
You can toggle through possible values for CMAKE_BUILD_TYPE with ENTER
in ccmake and by popup-menu in cmake-gui.