### PR TITLE
Replace wget by curl

### DIFF
--- a/scripts/travis/cmake.sh
+++ b/scripts/travis/cmake.sh
@@ -2,9 +2,10 @@
 set -e
 # check to see if cmake folder is empty
 if [ ! -d "$HOME/cmake-3.1.1-Linux-x86_64/bin" ]; then
+	CMAKE_TAR="cmake-3.1.1-Linux-x86_64.tar.gz"
 	cd $HOME
-	wget http://www.cmake.org/files/v3.1/cmake-3.1.1-Linux-x86_64.tar.gz;
-	tar -xzvf cmake-3.1.1-Linux-x86_64.tar.gz;
+	curl -L -o $CMAKE_TAR http://www.cmake.org/files/v3.1/$CMAKE_TAR;
+	tar -xzvf $CMAKE_TAR;
 else
 	echo 'Using cached cmake directory.';
 fi


### PR DESCRIPTION
Old wget on Travis (Ubuntu 12.04) has some bugs checking certificates, see e.g.:

https://github.com/haskell/cabal/issues/1796