### PR TITLE
Rewrite of LisOption

### DIFF
--- a/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
+++ b/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
@@ -30,32 +30,7 @@ EigenLisLinearSolver::EigenLisLinearSolver(EigenMatrix &A,
 : _A(A)
 {
     if (option)
-        setOption(*option);
-}
-
-void EigenLisLinearSolver::setOption(BaseLib::ConfigTree const& option)
-{
-    boost::optional<BaseLib::ConfigTree> ptSolver =
-        option.get_child("LinearSolver");
-    if (!ptSolver)
-        return;
-
-    boost::optional<std::string> solver_type = ptSolver->get_optional<std::string>("solver_type");
-    if (solver_type) {
-        _option.solver_type = _option.getSolverType(*solver_type);
-    }
-    boost::optional<std::string> precon_type = ptSolver->get_optional<std::string>("precon_type");
-    if (precon_type) {
-        _option.precon_type = _option.getPreconType(*precon_type);
-    }
-    boost::optional<double> error_tolerance = ptSolver->get_optional<double>("error_tolerance");
-    if (error_tolerance) {
-        _option.error_tolerance = *error_tolerance;
-    }
-    boost::optional<int> max_iteration_step = ptSolver->get_optional<int>("max_iteration_step");
-    if (max_iteration_step) {
-        _option.max_iterations = *max_iteration_step;
-    }
+        _option.addOptions(*option);
 }
 
 void EigenLisLinearSolver::solve(EigenVector &b_, EigenVector &x_)

--- a/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.h
+++ b/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.h
@@ -41,19 +41,9 @@ public:
                          BaseLib::ConfigTree const*const option = nullptr);
 
     /**
-     * parse linear solvers configuration
-     */
-    void setOption(BaseLib::ConfigTree const& option);
-
-    /**
      * copy linear solvers options
      */
     void setOption(const LisOption &option) { _option = option; }
-
-    /**
-     * get linear solver options
-     */
-    LisOption &getOption() { return _option; }
 
     /**
      * solve a given linear equations

--- a/MathLib/LinAlg/Lis/LisLinearSolver.cpp
+++ b/MathLib/LinAlg/Lis/LisLinearSolver.cpp
@@ -12,6 +12,10 @@
  *
  */
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 #include "LisLinearSolver.h"
 
 #include "logog/include/logog.hpp"
@@ -58,6 +62,9 @@ void LisLinearSolver::solve(LisVector &b, LisVector &x)
             checkLisError(ierr);
         }
     }
+#ifdef _OPENMP
+    INFO("-> number of threads: %i", (int) omp_get_max_threads());
+#endif
     {
         int precon;
         ierr = lis_solver_get_precon(solver, &precon);

--- a/MathLib/LinAlg/Lis/LisLinearSolver.cpp
+++ b/MathLib/LinAlg/Lis/LisLinearSolver.cpp
@@ -14,11 +14,6 @@
 
 #include "LisLinearSolver.h"
 
-#include <string>
-#include <sstream>
-#ifdef _OPENMP
-#include <omp.h>
-#endif
 #include "logog/include/logog.hpp"
 
 #include "LisCheck.h"
@@ -32,35 +27,12 @@ LisLinearSolver::LisLinearSolver(LisMatrix &A,
 : _A(A)
 {
     if (option)
-        setOption(*option);
-}
+    {
+        _option.addOptions(*option);
 
-void LisLinearSolver::setOption(BaseLib::ConfigTree const& option)
-{
-    boost::optional<BaseLib::ConfigTree> ptSolver =
-        option.get_child("LinearSolver");
-    if (!ptSolver)
-        return;
-
-    boost::optional<std::string> solver_type = ptSolver->get_optional<std::string>("solver_type");
-    if (solver_type) {
-        _option.solver_type = _option.getSolverType(*solver_type);
-    }
-    boost::optional<std::string> precon_type = ptSolver->get_optional<std::string>("precon_type");
-    if (precon_type) {
-        _option.precon_type = _option.getPreconType(*precon_type);
-    }
-    boost::optional<std::string> matrix_type = ptSolver->get_optional<std::string>("matrix_type");
-    if (matrix_type) {
-        _option.matrix_type = _option.getMatrixType(*matrix_type);
-    }
-    boost::optional<double> error_tolerance = ptSolver->get_optional<double>("error_tolerance");
-    if (error_tolerance) {
-        _option.error_tolerance = *error_tolerance;
-    }
-    boost::optional<int> max_iteration_step = ptSolver->get_optional<int>("max_iteration_step");
-    if (max_iteration_step) {
-        _option.max_iterations = *max_iteration_step;
+#ifndef NDEBUG
+        _option.printInfo();
+#endif
     }
 }
 
@@ -70,62 +42,64 @@ void LisLinearSolver::solve(LisVector &b, LisVector &x)
 
     INFO("------------------------------------------------------------------");
     INFO("*** LIS solver computation");
-#ifdef _OPENMP
-    INFO("-> max number of threads = %d", omp_get_num_procs());
-    INFO("-> number of threads = %d", omp_get_max_threads());
-#endif
-
-    // configure option
-    std::string solver_options;
-    if (_option.solver_precon_arg.empty()) {
-        std::stringstream ss;
-        ss << "-i " << static_cast<int>(_option.solver_type);
-        ss << " -p " << static_cast<int>(_option.precon_type);
-        if (!_option.extra_arg.empty())
-            ss << " " << _option.extra_arg;
-        solver_options = ss.str();
-    } else {
-        solver_options = _option.solver_precon_arg;
-    }
-    std::string tol_option;
-    {
-        std::stringstream ss;
-        ss << "-tol " << _option.error_tolerance;
-        ss << " -maxiter " << _option.max_iterations;
-        ss << " -initx_zeros 0"; //0: use given x as initial guess, 1: x0=0
-#ifdef _OPENMP
-        const int nthreads = omp_get_max_threads();
-        ss << " -omp_num_threads " << nthreads;
-#endif
-        tol_option = ss.str();
-    }
 
     // Create solver
     LIS_SOLVER solver;
     int ierr = lis_solver_create(&solver);
     checkLisError(ierr);
-    ierr = lis_solver_set_option(const_cast<char*>(solver_options.c_str()), solver);
-    checkLisError(ierr);
-    ierr = lis_solver_set_option(const_cast<char*>(tol_option.c_str()), solver);
-    checkLisError(ierr);
-    ierr = lis_solver_set_option(const_cast<char*>("-print mem"), solver);
-    checkLisError(ierr);
-    ierr = lis_solver_set_optionC(solver);
-    checkLisError(ierr);
+
+    {
+        std::string opt;
+        for (auto const& it : _option.settings)
+        {
+            opt = it.first + " " + it.second;
+
+            ierr = lis_solver_set_option(const_cast<char*>(opt.c_str()), solver);
+            checkLisError(ierr);
+        }
+    }
+    {
+        int precon;
+        ierr = lis_solver_get_precon(solver, &precon);
+        INFO("-> precon: %i", precon);
+    }
+    {
+        int slv;
+        ierr = lis_solver_get_solver(solver, &slv);
+        INFO("-> solver: %i", slv);
+    }
 
     // solve
     INFO("-> solve");
     ierr = lis_solve(_A.getRawMatrix(), b.getRawVector(), x.getRawVector(), solver);
     checkLisError(ierr);
 
-    int iter = 0;
-    double resid = 0.0;
-    ierr = lis_solver_get_iter(solver, &iter);
-    checkLisError(ierr);
-    ierr = lis_solver_get_residualnorm(solver, &resid);
-    checkLisError(ierr);
-    INFO("\t iteration: %d/%ld\n", iter, _option.max_iterations);
-    INFO("\t residual: %e\n", resid);
+    {
+        int iter = 0;
+        ierr = lis_solver_get_iter(solver, &iter);
+        checkLisError(ierr);
+
+        std::string max_iter = _option.settings["-maxiter"];
+        if (max_iter.empty()) max_iter = "--";
+        INFO("-> iteration: %d/%s", iter, max_iter.c_str());
+    }
+    {
+        double resid = 0.0;
+        ierr = lis_solver_get_residualnorm(solver, &resid);
+        checkLisError(ierr);
+        INFO("-> residual: %g", resid);
+    }
+    {
+        double time, itime, ptime, p_ctime, p_itime;
+        ierr = lis_solver_get_timeex(solver, &time, &itime,
+                                     &ptime, &p_ctime, &p_itime);
+        checkLisError(ierr);
+        INFO("-> time total           (s): %g", time);
+        INFO("-> time iterations      (s): %g", itime);
+        INFO("-> time preconditioning (s): %g", ptime);
+        INFO("-> time precond. create (s): %g", p_ctime);
+        INFO("-> time precond. iter   (s): %g", p_itime);
+    }
 
     // Clear solver
     ierr = lis_solver_destroy(solver);

--- a/MathLib/LinAlg/Lis/LisLinearSolver.h
+++ b/MathLib/LinAlg/Lis/LisLinearSolver.h
@@ -32,7 +32,7 @@ namespace MathLib
  * \brief Linear solver using Lis (http://www.ssisc.org/lis/)
  *
  */
-class LisLinearSolver
+class LisLinearSolver final
 {
 public:
     /**
@@ -47,25 +47,11 @@ public:
     LisLinearSolver(LisMatrix &A, const std::string solver_name = "",
                     BaseLib::ConfigTree const*const option = nullptr);
 
-    virtual ~LisLinearSolver() {}
-
-    /**
-     * configure linear solvers
-     * @param option
-     */
-    void setOption(BaseLib::ConfigTree const& option);
-
     /**
      * configure linear solvers
      * @param option
      */
     void setOption(const LisOption &option) { _option = option; }
-
-    /**
-     * get linear solver options
-     * @return
-     */
-    LisOption &getOption() { return _option; }
 
     /**
      * solve a given linear equations

--- a/MathLib/LinAlg/Lis/LisOption.cpp
+++ b/MathLib/LinAlg/Lis/LisOption.cpp
@@ -14,89 +14,54 @@
 
 #include "LisOption.h"
 
+#include "logog/include/logog.hpp"
+
 namespace MathLib
 {
 
-LisOption::LisOption()
+void LisOption::addOptions(const BaseLib::ConfigTree & options)
 {
-    solver_type = SolverType::CG;
-    precon_type = PreconType::NONE;
-    matrix_type = MatrixType::CRS;
-    max_iterations = 1e6;
-    error_tolerance = 1.e-16;
+    auto const range = options.equal_range("lis_option");
+    for (auto it=range.first; it!=range.second; ++it)
+    {
+        auto key = it->second.get_optional<Key>("option");
+        auto val = it->second.get_optional<Value>("value");
+
+        if (key && val) {
+            settings[*key] = *val;
+        }
+    }
+
+    auto solver_type = options.get_optional<std::string>("solver_type");
+    if (solver_type) {
+        settings["-i"] = *solver_type;
+    }
+    auto precon_type = options.get_optional<std::string>("precon_type");
+    if (precon_type) {
+        settings["-p"] = *precon_type;
+    }
+    auto error_tolerance = options.get_optional<std::string>("error_tolerance");
+    if (error_tolerance) {
+        settings["-tol"] = *error_tolerance;
+    }
+    auto max_iteration_step = options.get_optional<std::string>("max_iteration_step");
+    if (max_iteration_step) {
+        settings["-maxiter"] = *max_iteration_step;
+    }
 }
 
-LisOption::SolverType LisOption::getSolverType(const std::string &solver_name)
+void LisOption::printInfo() const
 {
-#define RETURN_SOLVER_ENUM_IF_SAME_STRING(str, TypeName) \
-    if (#TypeName==str) return SolverType::TypeName;
+    if (settings.empty()) {
+        INFO("Lis options: none set.");
+    } else {
+        INFO("Lis options:");
 
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, CG);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, BiCG);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, CGS);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, BiCGSTAB);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, BiCGSTABl);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, GPBiCG);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, TFQMR);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, Orthomin);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, GMRES);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, Jacobi);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, GaussSeidel);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, SOR);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, BiCGSafe);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, CR);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, BiCR);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, CRS);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, BiCRSTAB);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, GPBiCR);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, BiCRSafe);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, FGMRESm);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, IDRs);
-    RETURN_SOLVER_ENUM_IF_SAME_STRING(solver_name, MINRES);
-
-    return SolverType::INVALID;
-#undef RETURN_SOLVER_ENUM_IF_SAME_STRING
-}
-
-LisOption::PreconType LisOption::getPreconType(const std::string &precon_name)
-{
-#define RETURN_PRECOM_ENUM_IF_SAME_STRING(str, TypeName) \
-    if (#TypeName==str) return PreconType::TypeName;
-
-    RETURN_PRECOM_ENUM_IF_SAME_STRING(precon_name, NONE);
-    RETURN_PRECOM_ENUM_IF_SAME_STRING(precon_name, JACOBI);
-    RETURN_PRECOM_ENUM_IF_SAME_STRING(precon_name, ILU);
-    RETURN_PRECOM_ENUM_IF_SAME_STRING(precon_name, SSOR);
-    RETURN_PRECOM_ENUM_IF_SAME_STRING(precon_name, Hybrid);
-    RETURN_PRECOM_ENUM_IF_SAME_STRING(precon_name, IplusS);
-    RETURN_PRECOM_ENUM_IF_SAME_STRING(precon_name, SAINV);
-    RETURN_PRECOM_ENUM_IF_SAME_STRING(precon_name, SAAMG);
-    RETURN_PRECOM_ENUM_IF_SAME_STRING(precon_name, CroutILU);
-    RETURN_PRECOM_ENUM_IF_SAME_STRING(precon_name, ILUT);
-
-    return PreconType::NONE;
-#undef RETURN_PRECOM_ENUM_IF_SAME_STRING
-}
-
-LisOption::MatrixType LisOption::getMatrixType(const std::string &matrix_name)
-{
-#define RETURN_MATRIX_ENUM_IF_SAME_STRING(str, TypeName) \
-    if (#TypeName==str) return MatrixType::TypeName;
-
-    RETURN_MATRIX_ENUM_IF_SAME_STRING(matrix_name, CRS);
-    RETURN_MATRIX_ENUM_IF_SAME_STRING(matrix_name, CCS);
-    RETURN_MATRIX_ENUM_IF_SAME_STRING(matrix_name, MSR);
-    RETURN_MATRIX_ENUM_IF_SAME_STRING(matrix_name, DIA);
-    RETURN_MATRIX_ENUM_IF_SAME_STRING(matrix_name, ELL);
-    RETURN_MATRIX_ENUM_IF_SAME_STRING(matrix_name, JDS);
-    RETURN_MATRIX_ENUM_IF_SAME_STRING(matrix_name, BSR);
-    RETURN_MATRIX_ENUM_IF_SAME_STRING(matrix_name, BSC);
-    RETURN_MATRIX_ENUM_IF_SAME_STRING(matrix_name, VBR);
-    RETURN_MATRIX_ENUM_IF_SAME_STRING(matrix_name, COO);
-    RETURN_MATRIX_ENUM_IF_SAME_STRING(matrix_name, DNS);
-
-    return MatrixType::CRS;
-#undef RETURN_MATRIX_ENUM_IF_SAME_STRING
+        for (auto const& it : settings) {
+            INFO("-> %s %s ", it.first.c_str(), it.second.c_str());
+        }
+        INFO("");
+    }
 }
 
 } //MathLib

--- a/MathLib/LinAlg/Lis/LisOption.h
+++ b/MathLib/LinAlg/Lis/LisOption.h
@@ -16,6 +16,9 @@
 #define LIS_OPTION_H_
 
 #include <string>
+#include <map>
+
+#include "BaseLib/ConfigTree.h"
 
 namespace MathLib
 {
@@ -25,120 +28,55 @@ namespace MathLib
  */
 struct LisOption
 {
-    /// Solver type
-    enum class SolverType : int
+    using Key = std::string;
+    using Value = std::string;
+
+    std::map<Key, Value> settings;
+
+    LisOption()
     {
-        INVALID = 0,
-        CG = 1,
-        BiCG = 2,
-        CGS = 3,
-        BiCGSTAB = 4,
-        BiCGSTABl = 5,
-        GPBiCG = 6,
-        TFQMR = 7,
-        Orthomin = 8,
-        GMRES = 9,
-        Jacobi = 10,
-        GaussSeidel = 11,
-        SOR = 12,
-        BiCGSafe = 13,
-        CR = 14,
-        BiCR = 15,
-        CRS = 16,
-        BiCRSTAB = 17,
-        GPBiCR = 18,
-        BiCRSafe = 19,
-        FGMRESm = 20,
-        IDRs = 21,
-        MINRES = 22
-    };
-
-    /// Preconditioner type
-    enum class PreconType : int
-    {
-        NONE = 0,
-        JACOBI = 1,
-        ILU = 2,
-        SSOR = 3,
-        Hybrid = 4,
-        IplusS = 5,
-        SAINV = 6,
-        SAAMG = 7,
-        CroutILU = 8,
-        ILUT = 9
-    };
-
-    /// Matrix type
-    enum class MatrixType : int
-    {
-        CRS = 1,
-        CCS = 2,
-        MSR = 3,
-        DIA = 4,
-        ELL = 5,
-        JDS = 6,
-        BSR = 7,
-        BSC = 8,
-        VBR = 9,
-        COO = 10,
-        DNS = 11
-    };
-
-    /// Linear solver type
-    SolverType solver_type;
-    /// Preconditioner type
-    PreconType precon_type;
-    /// Matrix type
-    MatrixType matrix_type;
-    /// Maximum iteration count
-    long max_iterations;
-    /// Error tolerance
-    double error_tolerance;
-    /// Extra option
-    std::string extra_arg;
-    /// Arguments for solver and preconditioner. This variable is always preferred
-    /// to other variables.
-    std::string solver_precon_arg;
+        // by default do not zero out the solution vector
+        settings["-initxzeros"] = "0";
+    }
 
     /**
-     * Constructor
+     * Adds options from a \c ConfigTree.
      *
-     * Default options are CG, no preconditioner, iteration count 500 and
-     * tolerance 1e-10. Default matrix storage type is CRS.
-     */
-    LisOption();
-
-    /// Destructor
-    ~LisOption() {}
-
-    /**
-     * return a linear solver type from the solver name
+     * Options are stored as strings as obtained from the ConfigTree.
+     * In particular it will not be checked by this method if options are valid.
      *
-     * @param solver_name
-     * @return a linear solver type
-     *      If there is no solver type matched with the given name, INVALID
-     *      is returned.
-     */
-    static SolverType getSolverType(const std::string &solver_name);
-
-    /**
-     * return a preconditioner type from the name
+     * It is only guaranteed that each given option will be passed only once to Lis.
      *
-     * @param precon_name
-     * @return a preconditioner type
-     *      If there is no preconditioner type matched with the given name, NONE
-     *      is returned.
+     * The \c ConfigTree section must have the layout as shown in the
+     * following example:
+     *
+     * \code{.xml}
+     * <linear_solver>
+     *   <solver_type>         gmres </solver_type>
+     *   <precon_type>           ilu </precon_type>
+     *   <error_tolerance>   1.0e-10 </error_tolerance>
+     *   <max_iteration_step>    200 </max_iteration_step>
+     *
+     *   <lis_option><option> -ilu_fill </option><value>   3 </value></lis_option>
+     *   <lis_option><option>    -print </option><value> mem </value></lis_option>
+     * </linear_solver>
+     * \endcode
+     *
+     * The first four tags are special in the sense that those options
+     * will take precedence even if there is an equivalent Lis option specified.
+     *
+     * Any possible Lis option can be supplied by a line like
+     *
+     * \code{.xml}
+     *   <lis_option><option> -ilu_fill </option><value>   3 </value></lis_option>
+     * \endcode
+     *
+     * For possible values, please refer to the Lis User Guide:
+     * http://www.ssisc.org/lis/lis-ug-en.pdf
      */
-    static PreconType getPreconType(const std::string &precon_name);
+    void addOptions(BaseLib::ConfigTree const& options);
 
-    /**
-     * return a matrix type
-     * @param matrix_name
-     * @return
-     *      If there is no matrix type matched with the given name, CRS
-     *      is returned.
-     */
-    static MatrixType getMatrixType(const std::string &matrix_name);
+    void printInfo() const;
 };
 
 }

--- a/MathLib/LinAlg/Lis/LisOption.h
+++ b/MathLib/LinAlg/Lis/LisOption.h
@@ -77,6 +77,23 @@ struct LisOption
     void addOptions(BaseLib::ConfigTree const& options);
 
     void printInfo() const;
+
+
+    /// Matrix type
+    enum class MatrixType : int
+    {
+        CRS = 1,
+        CCS = 2,
+        MSR = 3,
+        DIA = 4,
+        ELL = 5,
+        JDS = 6,
+        BSR = 7,
+        BSC = 8,
+        VBR = 9,
+        COO = 10,
+        DNS = 11
+    };
 };
 
 }

--- a/MathLib/LinAlg/Lis/LisOption.h
+++ b/MathLib/LinAlg/Lis/LisOption.h
@@ -73,6 +73,10 @@ struct LisOption
      *
      * For possible values, please refer to the Lis User Guide:
      * http://www.ssisc.org/lis/lis-ug-en.pdf
+     *
+     * Note: Option -omp_num_threads cannot be used with this class since Lis
+     * currently (version 1.5.57) only sets the number of threads in
+     * \c lis_initialize(). Refer to the Lis source code for details.
      */
     void addOptions(BaseLib::ConfigTree const& options);
 


### PR DESCRIPTION
I largely rewrote the class `LisOption`. Now any Lis option can be given in the input file. The new implementation `LisOption` just stores options. `LisLinearSolver` then passes them through to Lis.

I simplified setting of options: There are no longer any conditions that decide what will happen. I also removed unused methods, members and enums.