### PR TITLE
srqDist2d() and writeGeometryToFile()

### DIFF
--- a/FileIO/CMakeLists.txt
+++ b/FileIO/CMakeLists.txt
@@ -11,6 +11,8 @@ set(SOURCES
 	PetrelInterface.cpp
 	readMeshFromFile.h
 	readMeshFromFile.cpp
+	writeGeometryToFile.h
+	writeGeometryToFile.cpp
 	SHPInterface.h
 	SHPInterface.cpp
 	TetGenInterface.h

--- a/FileIO/writeGeometryToFile.cpp
+++ b/FileIO/writeGeometryToFile.cpp
@@ -1,0 +1,37 @@
+/**
+ *
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "writeGeometryToFile.h"
+
+#include "BaseLib/FileTools.h"
+
+#include "FileIO/XmlIO/Boost/BoostXmlGmlInterface.h"
+#include "FileIO/Legacy/OGSIOVer4.h"
+
+#include "GeoLib/GEOObjects.h"
+
+namespace FileIO
+{
+void writeGeometryToFile(std::string const& geo_name,
+	GeoLib::GEOObjects& geo_objs, std::string const& fname)
+{
+	std::string const extension(BaseLib::getFileExtension(fname));
+	if (extension == "gml" || extension == "GML") {
+		FileIO::BoostXmlGmlInterface xml(geo_objs);
+		xml.setNameForExport(geo_name);
+		xml.writeToFile(fname);
+	} else if (extension == "gli" || extension == "GLI") {
+		FileIO::Legacy::writeGLIFileV4(fname, geo_name, geo_objs);
+	} else {
+		ERR("Writing of geometry failed, since it was not possible to determine"
+			" the required format from file extension.");
+	}
+}
+}

--- a/FileIO/writeGeometryToFile.h
+++ b/FileIO/writeGeometryToFile.h
@@ -1,0 +1,32 @@
+/**
+ *
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef WRITEGEOMETRYTOFILE_H
+#define WRITEGEOMETRYTOFILE_H
+
+#include <string>
+
+namespace GeoLib
+{
+	class GEOObjects;
+}
+
+namespace FileIO
+{
+
+/// Write geometry given by the \c geo_objs object and specified by the name
+/// stored in param \c geo_name either to a gml or a gli file. If the extension
+/// given in the \c fname parameter is "gml" or "GML" a gml file is written. In
+/// case the extension is "gli" or "GLI" a gli file is written.
+void writeGeometryToFile(std::string const& geo_name,
+	GeoLib::GEOObjects& geo_objs, std::string const& fname);
+}
+
+#endif // WRITEGEOMETRYTOFILE_H

--- a/MathLib/Point3d.h
+++ b/MathLib/Point3d.h
@@ -50,6 +50,14 @@ double sqrDist(MathLib::Point3d const& p0, MathLib::Point3d const& p1)
 	return MathLib::scalarProduct<double,3>(v,v);
 }
 
+/// Computes the squared distance between the orthogonal projection of the two
+/// points \c p0 and \c p1 onto the \f$xy\f$-plane.
+inline
+double sqrDist2d(MathLib::Point3d const& p0, MathLib::Point3d const& p1)
+{
+	return (p0[0]-p1[0])*(p0[0]-p1[0]) + (p0[1]-p1[1])*(p0[1]-p1[1]);
+}
+
 } // end namespace MathLib
 
 #endif /* POINT3D_H_ */


### PR DESCRIPTION
- At the moment the 2-D (xy-plane) (squared) distance of of two nodes / points is accomplished by copying the nodes or points and setting the *z*-coordinate explicitely to zero. Then the usual 3-D `sqrDist()` is used. To omit the copies and setting zero of the *z*-coordinate this PR suggest a function `sqrDist2d()`.
- The second commit is a function `writeGeometryToFile()` that takes the file name extension for the decision which format the data will be written. This will be used in several simulation model preprocessing tools.