### PR TITLE
Lis performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,8 @@ option(OGS_NO_EXTERNAL_LIBS "Builds OGS without any external dependencies." OFF)
 # Linear solvers
 option(OGS_USE_LIS "Use Lis" OFF)
 
+option(OGS_USE_EIGENLIS "Use Lis solver together with Eigen sparse matrices" OFF)
+
 # Parallel computing: vector and matrix algebraic caculation, solvers
 option(OGS_USE_PETSC "Use PETSc routines" OFF)
 
@@ -145,6 +147,15 @@ if(OGS_USE_EIGEN)
 		add_definitions(-DEIGEN_NO_DEBUG)
 	endif()
 	include_directories (SYSTEM ${EIGEN3_INCLUDE_DIR})
+endif()
+
+if (OGS_USE_EIGENLIS)
+	if (OGS_USE_EIGEN AND OGS_USE_LIS)
+		add_definitions(-DOGS_USE_EIGENLIS)
+	else()
+		message(WARNING "The setting OGS_USE_EIGENLIS needs both OGS_USE_EIGEN"
+		        " and OGS_USE_LIS set in order to have some effect.")
+	endif()
 endif()
 
 add_subdirectory( Applications )

--- a/MathLib/LinAlg/Eigen/EigenMatrix.h
+++ b/MathLib/LinAlg/Eigen/EigenMatrix.h
@@ -71,7 +71,8 @@ public:
     /// dynamically allocates it.
     int setValue(IndexType row, IndexType col, double val)
     {
-        _mat.coeffRef(row, col) = val;
+        assert(row < (IndexType) getNRows() && col < (IndexType) getNCols());
+        if (val != 0.0) _mat.coeffRef(row, col) = val;
         return 0;
     }
 
@@ -79,7 +80,7 @@ public:
     /// inserted.
     int add(IndexType row, IndexType col, double val)
     {
-        _mat.coeffRef(row, col) += val;
+        if (val != 0.0) _mat.coeffRef(row, col) += val;
         return 0;
     }
 

--- a/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
+++ b/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
@@ -35,6 +35,8 @@ EigenLisLinearSolver::EigenLisLinearSolver(EigenMatrix &A,
 
 void EigenLisLinearSolver::solve(EigenVector &b_, EigenVector &x_)
 {
+    static_assert(EigenMatrix::RawMatrixType::IsRowMajor,
+                  "Sparse matrix is required to be in row major storage.");
     auto &A = _A.getRawMatrix();
     auto &b = b_.getRawVector();
     auto &x = x_.getRawVector();

--- a/MathLib/LinAlg/Lis/LisMatrix.cpp
+++ b/MathLib/LinAlg/Lis/LisMatrix.cpp
@@ -87,6 +87,7 @@ void LisMatrix::setZero()
 
 int LisMatrix::setValue(IndexType rowId, IndexType colId, double v)
 {
+    if (v == 0.0) return 0;
     lis_matrix_set_value(LIS_INS_VALUE, rowId, colId, v, _AA);
     if (rowId==colId)
         lis_vector_set_value(LIS_INS_VALUE, rowId, v, _diag);
@@ -96,6 +97,7 @@ int LisMatrix::setValue(IndexType rowId, IndexType colId, double v)
 
 int LisMatrix::add(IndexType rowId, IndexType colId, double v)
 {
+    if (v == 0.0) return 0;
     lis_matrix_set_value(LIS_ADD_VALUE, rowId, colId, v, _AA);
     if (rowId==colId)
         lis_vector_set_value(LIS_ADD_VALUE, rowId, v, _diag);

--- a/ProcessLib/NumericsConfig.h
+++ b/ProcessLib/NumericsConfig.h
@@ -23,7 +23,21 @@
 //
 // Global vector/matrix types and linear solver.
 //
-#if defined(USE_LIS)
+#if defined(OGS_USE_EIGENLIS)
+
+    #include "MathLib/LinAlg/Eigen/EigenMatrix.h"
+    #include "MathLib/LinAlg/Eigen/EigenVector.h"
+    #include "MathLib/LinAlg/EigenLis/EigenLisLinearSolver.h"
+
+    namespace detail
+    {
+    using GlobalVectorType = MathLib::EigenVector;
+    using GlobalMatrixType = MathLib::EigenMatrix;
+
+    using LinearSolverType = MathLib::EigenLisLinearSolver;
+    }
+
+#elif defined(USE_LIS)
 
     #include "MathLib/LinAlg/Lis/LisMatrix.h"
     #include "MathLib/LinAlg/Lis/LisVector.h"

--- a/Tests/MathLib/TestEigenCSR.cpp
+++ b/Tests/MathLib/TestEigenCSR.cpp
@@ -84,10 +84,11 @@ TEST(MathLibEigen, Eigen2CSR)
     // adapt entries of CSR matrix
     for (auto& v : values) v *= 4.0;
 
-    ASSERT_EQ(nnz, mat.nonZeros());
-    ASSERT_EQ(nnz, ja.size());
-
     mat.makeCompressed();
+
+    ASSERT_EQ(nnz, mat.nonZeros());
+    ASSERT_EQ(nnz, values.size());
+    ASSERT_EQ(nnz, ja.size());
 
     int* ptr = mat.outerIndexPtr();
     int* col = mat.innerIndexPtr();

--- a/Tests/MathLib/TestEigenCSR.cpp
+++ b/Tests/MathLib/TestEigenCSR.cpp
@@ -70,15 +70,12 @@ TEST(MathLibEigen, Eigen2CSR)
     }
 
     // change matrix
-    for (int repeat=0; repeat < 2; ++repeat) {
-        for (int row=0; row<nrows; ++row) {
-            for (int col = -1; col<=1; ++col) {
-                int cidx = row + col;
-                if (cidx < 0 || cidx >= ncols) continue;
+    for (int row=0; row<nrows; ++row) {
+        for (int col = -1; col<=1; ++col) {
+            int cidx = row + col;
+            if (cidx < 0 || cidx >= ncols) continue;
 
-                // doubles matrix entry
-                mat.coeffRef(row, cidx) += mat.coeff(row, cidx);
-            }
+            mat.coeffRef(row, cidx) = 4.0 * mat.coeff(row, cidx);
         }
     }
     // adapt entries of CSR matrix

--- a/Tests/MathLib/TestEigenCSR.cpp
+++ b/Tests/MathLib/TestEigenCSR.cpp
@@ -1,0 +1,105 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+#include <vector>
+#include <numeric>
+
+#include <Eigen/Sparse>
+
+
+/**
+ * This test case checks if the internal Eigen::SparseMatrix compressed storage format
+ * is a conventional CSR matrix. Currently this is the case, but it is not guaranteed
+ * for all time.
+ *
+ * Cf. section "Sparse matrix format" on page
+ * http://eigen.tuxfamily.org/dox/group__TutorialSparse.html
+ */
+TEST(MathLibEigen, Eigen2CSR)
+{
+    const int nrows = 16;
+    const int ncols = nrows;
+
+    Eigen::SparseMatrix<double, Eigen::RowMajor> mat(nrows, ncols);
+
+    // set up sparsity pattern
+    std::vector<int> pat(nrows);
+    for (std::size_t i=0; i<nrows; ++i)
+    {
+        if (i==0 || i==nrows-1) {
+            pat[i] = 2;
+        } else {
+            pat[i] = 3;
+        }
+    }
+
+    // CSR representation of the matrix
+    std::vector<double> values;
+    std::vector<int> ia(nrows+1); // row offsets
+    std::vector<int> ja;          // column indices
+
+    std::partial_sum(pat.begin(), pat.end(), ia.begin()+1);
+
+    const int nnz = ia.back();
+    values.reserve(nnz);
+    ja.reserve(nnz);
+
+    mat.reserve(pat);
+
+    // init matrix, build CSR matrix in parallel
+    for (int row=0; row<nrows; ++row) {
+        for (int col = -1; col<=1; ++col) {
+            int cidx = row + col;
+            if (cidx < 0 || cidx >= ncols) continue;
+
+            const double val = (col == 0) ? 2.0 : -1.0;
+            values.push_back(val);
+            mat.coeffRef(row, cidx) = val;
+            ja.push_back(cidx);
+        }
+    }
+
+    // change matrix
+    for (int repeat=0; repeat < 2; ++repeat) {
+        for (int row=0; row<nrows; ++row) {
+            for (int col = -1; col<=1; ++col) {
+                int cidx = row + col;
+                if (cidx < 0 || cidx >= ncols) continue;
+
+                // doubles matrix entry
+                mat.coeffRef(row, cidx) += mat.coeff(row, cidx);
+            }
+        }
+    }
+    // adapt entries of CSR matrix
+    for (auto& v : values) v *= 4.0;
+
+    ASSERT_EQ(nnz, mat.nonZeros());
+    ASSERT_EQ(nnz, ja.size());
+
+    mat.makeCompressed();
+
+    int* ptr = mat.outerIndexPtr();
+    int* col = mat.innerIndexPtr();
+    double* data = mat.valuePtr();
+
+    for (int r=0; r<(int) nrows; ++r) {
+        EXPECT_EQ(ia[r], ptr[r]);
+    }
+
+    for (int i=0; i<nnz; ++i) {
+        EXPECT_EQ(values[i], data[i]);
+        EXPECT_EQ(ja[i], col[i]);
+    }
+}
+


### PR DESCRIPTION
Changes of this PR are made for improving Lis performance.
Currently there is an issue with slow performance of Lis matrix assembly: Repeated invocation of `LisMatrix::add()` triggers many unnecessary checks in Lis. This PR makes using some workaround easier.
* There is the class `EigenLisLinearSolver` in master. This PR adds a CMake configuration option `OGS_USE_EigenLis` which makes ogs use this linear solver.
* EigenMatrix and LisMatrix now do not set values of 0.0 anymore. In the TES process I have many zeroes in local matrices. This filter speeds up the linear solvers quite a bit
* `applyKnownSolution()` for `EigenMatrix` has been updated to not degrade matrix condition by inserting 1.0 on the diagonal.
* A simple Test has been added to check if the internal storage of `Eigen::SparseMatrix` is a CSR matrix. Sure, this test is not perfect, though better than nothing, and it complements the test cases `TestLinearSolver.cpp` to simplify detection of possible errors that might arise if the Eigen project changes their internal matrix storage format.

All in all the changes from this PR saved very roughly 30% of runtime in my case.