### PR TITLE
Rework reset properties in polygonal region

### DIFF
--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -205,6 +205,12 @@ int main (int argc, char* argv[])
 
 	// *** read mesh
 	MeshLib::Mesh * mesh(FileIO::readMeshFromFile(mesh_in.getValue()));
+	std::vector<std::string> property_names(
+		mesh->getProperties().getPropertyVectorNames());
+	INFO("Mesh contains %d property vectors:", property_names.size());
+	for (auto name : property_names) {
+		INFO("- %s", name.c_str());
+	}
 	std::string const& property_name(property_name_arg.getValue());
 
 	resetMeshElementProperty(*mesh, polygon, property_name, new_property_val);

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -213,6 +213,17 @@ int main (int argc, char* argv[])
 
 	{
 		char new_property_val(static_cast<char>(new_property_arg.getValue()));
+
+		// check if PropertyVector exists
+		boost::optional<MeshLib::PropertyVector<char> &> opt_pv(
+			mesh->getProperties().getPropertyVector<char>(property_name)
+		);
+		if (!opt_pv) {
+			opt_pv = mesh->getProperties().createNewPropertyVector<char>(
+				property_name, MeshLib::MeshItemType::Cell, 1);
+			opt_pv.get().resize(mesh->getElements().size());
+			INFO("Created PropertyVector with name \"%s\".", property_name.c_str());
+		}
 		resetMeshElementProperty(*mesh, polygon, property_name, new_property_val);
 	}
 

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -1,6 +1,12 @@
 /*
- * \date 2014-09-25
  * \brief Reset material properties in meshes in a polygonal region.
+ *
+ * \copyright
+ * Copyright (c) 2012-2015, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
  */
 
 #include <algorithm>

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -19,8 +19,7 @@
 // ThirdParty/logog
 #include "logog/include/logog.hpp"
 
-// BaseLib
-#include "BaseLib/LogogSimpleFormatter.h"
+#include "Applications/ApplicationsLib/LogogSetup.h"
 
 // FileIO
 #include "FileIO/readMeshFromFile.h"
@@ -122,10 +121,7 @@ void resetMeshElementProperty(MeshLib::Mesh &mesh, GeoLib::Polygon const& polygo
 
 int main (int argc, char* argv[])
 {
-	LOGOG_INITIALIZE();
-	logog::Cout* logog_cout (new logog::Cout);
-	BaseLib::LogogSimpleFormatter *custom_format (new BaseLib::LogogSimpleFormatter);
-	logog_cout->SetFormatter(*custom_format);
+	ApplicationsLib::LogogSetup logog_setup;
 
 	TCLAP::CmdLine cmd("Sets the property id of an mesh element to a given new "
 		"id iff at least one node of the element is within a polygonal region "

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -123,12 +123,12 @@ int main (int argc, char* argv[])
 {
 	ApplicationsLib::LogogSetup logog_setup;
 
-	TCLAP::CmdLine cmd("Sets the property id of an mesh element to a given new "
-		"id iff at least one node of the element is within a polygonal region "
-		"that is given by a polygon read from a gml file.", ' ', "0.1");
+	TCLAP::CmdLine cmd("Sets the property value of a mesh element to a given new "
+		"value iff at least one node of the element is within a polygonal region "
+		"that is given by a polygon.", ' ', "0.1");
 	TCLAP::ValueArg<std::string> mesh_out("o", "mesh-output-file",
-		"the name of the file the mesh will be written to", true,
-		"", "file name");
+		"the name of the file the mesh will be written to, format depends on "
+		"the given file name extension", true, "", "file name");
 	cmd.add(mesh_out);
 	TCLAP::ValueArg<std::string> polygon_name_arg("p", "polygon-name",
 		"name of polygon in the geometry", true, "", "string");
@@ -143,7 +143,7 @@ int main (int argc, char* argv[])
 	TCLAP::ValueArg<std::string> property_name_arg("n", "property-name",
 		"name of property in the mesh", false, "MaterialIDs", "string");
 	cmd.add(property_name_arg);
-	TCLAP::ValueArg<std::string> mesh_in("i", "mesh-input-file",
+	TCLAP::ValueArg<std::string> mesh_in("m", "mesh-input-file",
 		"the name of the file containing the input mesh", true,
 		"", "file name");
 	cmd.add(mesh_in);

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -133,13 +133,19 @@ int main (int argc, char* argv[])
 	TCLAP::ValueArg<std::string> polygon_name_arg("p", "polygon-name",
 		"name of polygon in the geometry", true, "", "string");
 	cmd.add(polygon_name_arg);
-	TCLAP::ValueArg<std::string> geometry_fname("g", "geometry",
-		"the name of the file containing the input geometry", true,
+	TCLAP::ValueArg<std::string> geometry_fname("g", "geometry", "the name of "
+		"the file containing the input geometry (gli or gml format)", true,
 		"", "file name");
 	cmd.add(geometry_fname);
-	TCLAP::ValueArg<char> new_property_arg("v", "new-property-value",
-		"new property value", false, 'A', "number");
-	cmd.add(new_property_arg);
+	TCLAP::ValueArg<char> char_property_arg("c", "char-property-value",
+		"new property value (data type char)", false, 'A', "character");
+	cmd.add(char_property_arg);
+	TCLAP::ValueArg<int> int_property_arg("i", "int-property-value",
+		"new property value (data type int)", false, 0, "number");
+	cmd.add(int_property_arg);
+	TCLAP::ValueArg<bool> bool_property_arg("b", "bool-property-value",
+		"new property value (data type bool)", false, 0, "boolean value");
+	cmd.add(bool_property_arg);
 	TCLAP::ValueArg<std::string> property_name_arg("n", "property-name",
 		"name of property in the mesh", false, "MaterialIDs", "string");
 	cmd.add(property_name_arg);
@@ -199,8 +205,8 @@ int main (int argc, char* argv[])
 	}
 	std::string const& property_name(property_name_arg.getValue());
 
-	{
-		char new_property_val(static_cast<char>(new_property_arg.getValue()));
+	if (char_property_arg.isSet()) {
+		char new_property_val(char_property_arg.getValue());
 
 		// check if PropertyVector exists
 		boost::optional<MeshLib::PropertyVector<char> &> opt_pv(
@@ -215,14 +221,14 @@ int main (int argc, char* argv[])
 		resetMeshElementProperty(*mesh, polygon, property_name, new_property_val);
 	}
 
-	{
-		unsigned new_property_val(new_property_arg.getValue());
-		resetMeshElementProperty(*mesh, polygon, property_name, new_property_val);
+	if (int_property_arg.isSet()) {
+		int int_property_val(int_property_arg.getValue());
+		resetMeshElementProperty(*mesh, polygon, property_name, int_property_val);
 	}
 
-	{
-		bool new_property_val(static_cast<bool>(new_property_arg.getValue()));
-		resetMeshElementProperty(*mesh, polygon, property_name, new_property_val);
+	if (bool_property_arg.isSet()) {
+		bool bool_property_val(bool_property_arg.getValue());
+		resetMeshElementProperty(*mesh, polygon, property_name, bool_property_val);
 	}
 
 	FileIO::writeMeshToFile(*mesh, mesh_out.getValue());

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -199,8 +199,6 @@ int main (int argc, char* argv[])
 		return EXIT_FAILURE;
 	}
 
-	unsigned new_property_val(new_property_arg.getValue());
-
 	GeoLib::Polygon polygon(*(ply));
 
 	// *** read mesh
@@ -213,7 +211,20 @@ int main (int argc, char* argv[])
 	}
 	std::string const& property_name(property_name_arg.getValue());
 
-	resetMeshElementProperty(*mesh, polygon, property_name, new_property_val);
+	{
+		char new_property_val(static_cast<char>(new_property_arg.getValue()));
+		resetMeshElementProperty(*mesh, polygon, property_name, new_property_val);
+	}
+
+	{
+		unsigned new_property_val(new_property_arg.getValue());
+		resetMeshElementProperty(*mesh, polygon, property_name, new_property_val);
+	}
+
+	{
+		bool new_property_val(static_cast<bool>(new_property_arg.getValue()));
+		resetMeshElementProperty(*mesh, polygon, property_name, new_property_val);
+	}
 
 	FileIO::writeMeshToFile(*mesh, mesh_out.getValue());
 

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -130,27 +130,27 @@ int main (int argc, char* argv[])
 	TCLAP::CmdLine cmd("Sets the property id of an mesh element to a given new "
 		"id iff at least one node of the element is within a polygonal region "
 		"that is given by a polygon read from a gml file.", ' ', "0.1");
-	TCLAP::ValueArg<std::string> mesh_in("i", "mesh-input-file",
-		"the name of the file containing the input mesh", true,
-		"", "file name");
-	cmd.add(mesh_in);
 	TCLAP::ValueArg<std::string> mesh_out("o", "mesh-output-file",
 		"the name of the file the mesh will be written to", true,
 		"", "file name");
 	cmd.add(mesh_out);
+	TCLAP::ValueArg<std::string> polygon_name_arg("p", "polygon-name",
+		"name of polygon in the geometry", true, "", "string");
+	cmd.add(polygon_name_arg);
 	TCLAP::ValueArg<std::string> geometry_fname("g", "geometry",
 		"the name of the file containing the input geometry", true,
 		"", "file name");
 	cmd.add(geometry_fname);
-	TCLAP::ValueArg<std::string> polygon_name_arg("p", "polygon-name",
-		"name of polygon in the geometry", true, "", "string");
-	cmd.add(polygon_name_arg);
+	TCLAP::ValueArg<char> new_property_arg("v", "new-property-value",
+		"new property value", false, 'A', "number");
+	cmd.add(new_property_arg);
 	TCLAP::ValueArg<std::string> property_name_arg("n", "property-name",
 		"name of property in the mesh", false, "MaterialIDs", "string");
 	cmd.add(property_name_arg);
-	TCLAP::ValueArg<unsigned> new_property_arg("n", "new-property-value",
-		"new property value", false, 0, "number");
-	cmd.add(new_property_arg);
+	TCLAP::ValueArg<std::string> mesh_in("i", "mesh-input-file",
+		"the name of the file containing the input mesh", true,
+		"", "file name");
+	cmd.add(mesh_in);
 	cmd.parse(argc, argv);
 
 	// *** read geometry

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -153,9 +153,6 @@ int main (int argc, char* argv[])
 	cmd.add(new_property_arg);
 	cmd.parse(argc, argv);
 
-	// *** read mesh
-	MeshLib::Mesh * mesh(FileIO::readMeshFromFile(mesh_in.getValue()));
-
 	// *** read geometry
 	GeoLib::GEOObjects geometries;
 	{
@@ -164,7 +161,6 @@ int main (int argc, char* argv[])
 			INFO("Read geometry from file \"%s\".",
 				geometry_fname.getValue().c_str());
 		} else {
-			delete mesh;
 			return EXIT_FAILURE;
 		}
 	}
@@ -182,7 +178,6 @@ int main (int argc, char* argv[])
 	if (!plys) {
 		ERR("Could not get vector of polylines out of geometry \"%s\".",
 			geo_name.c_str());
-		delete mesh;
 		return EXIT_FAILURE;
 	}
 
@@ -192,7 +187,6 @@ int main (int argc, char* argv[])
 	);
 	if (! ply) {
 		ERR("Polyline \"%s\" not found.", polygon_name_arg.getValue().c_str());
-		delete mesh;
 		return EXIT_FAILURE;
 	}
 
@@ -202,7 +196,6 @@ int main (int argc, char* argv[])
 	{
 		ERR("Polyline \"%s\" is not closed, i.e. does not describe a\
 			region.", polygon_name_arg.getValue().c_str());
-		delete mesh;
 		return EXIT_FAILURE;
 	}
 
@@ -210,6 +203,9 @@ int main (int argc, char* argv[])
 
 	GeoLib::Polygon polygon(*(ply));
 
+	// *** read mesh
+	MeshLib::Mesh * mesh(FileIO::readMeshFromFile(mesh_in.getValue()));
+	std::string const& property_name(property_name_arg.getValue());
 
 	resetMeshElementProperty(*mesh, polygon, property_name, new_property_val);
 

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -24,7 +24,7 @@
 // FileIO
 #include "FileIO/readMeshFromFile.h"
 #include "FileIO/writeMeshToFile.h"
-#include "FileIO/XmlIO/Boost/BoostXmlGmlInterface.h"
+#include "FileIO/readGeometryFromFile.h"
 
 // GeoLib
 #include "GeoLib/GEOObjects.h"
@@ -151,15 +151,7 @@ int main (int argc, char* argv[])
 
 	// *** read geometry
 	GeoLib::GEOObjects geometries;
-	{
-		FileIO::BoostXmlGmlInterface xml_io(geometries);
-		if (xml_io.readFile(geometry_fname.getValue())) {
-			INFO("Read geometry from file \"%s\".",
-				geometry_fname.getValue().c_str());
-		} else {
-			return EXIT_FAILURE;
-		}
-	}
+	FileIO::readGeometryFromFile(geometry_fname.getValue(), geometries);
 
 	std::string geo_name;
 	{

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -89,9 +89,6 @@ template <typename PT>
 void resetMeshElementProperty(MeshLib::Mesh &mesh, GeoLib::Polygon const& polygon,
 	std::string const& property_name, PT new_property_value)
 {
-	std::vector<bool> outside(markNodesOutSideOfPolygon(mesh.getNodes(),
-		polygon));
-
 	boost::optional<MeshLib::PropertyVector<PT> &> opt_pv(
 		mesh.getProperties().getPropertyVector<PT>(property_name)
 	);
@@ -105,6 +102,9 @@ void resetMeshElementProperty(MeshLib::Mesh &mesh, GeoLib::Polygon const& polygo
 		ERR("Values of the PropertyVector are not assigned to cells.");
 		return;
 	}
+
+	std::vector<bool> outside(markNodesOutSideOfPolygon(mesh.getNodes(),
+		polygon));
 
 	for(std::size_t j(0); j<mesh.getElements().size(); ++j) {
 		bool elem_out(true);


### PR DESCRIPTION
- Tool can reset different property data types (int, boolean and character).
- Updated [documentation](http://docs.opengeosys.org/docs/tools/meshing/set-properties-in-polygonal-region)