### PR TITLE
Rework axis aligned bounding box

### DIFF
--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -108,9 +108,9 @@ public:
 	template <typename T>
 	bool containsPoint(T const & pnt) const
 	{
-		if (pnt[0] < _min_pnt[0] || _max_pnt[0] < pnt[0]) return false;
-		if (pnt[1] < _min_pnt[1] || _max_pnt[1] < pnt[1]) return false;
-		if (pnt[2] < _min_pnt[2] || _max_pnt[2] < pnt[2]) return false;
+		if (pnt[0] < _min_pnt[0] || _max_pnt[0] <= pnt[0]) return false;
+		if (pnt[1] < _min_pnt[1] || _max_pnt[1] <= pnt[1]) return false;
+		if (pnt[2] < _min_pnt[2] || _max_pnt[2] <= pnt[2]) return false;
 		return true;
 	}
 

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -29,7 +29,6 @@
 
 #include "MathLib/Point3d.h"
 #include "MathLib/MathTools.h"
-#include "Point.h"
 
 namespace GeoLib
 {
@@ -50,7 +49,7 @@ namespace GeoLib
  * @tparam PNT_TYPE a point type supporting accessing the coordinates via
  * operator[]
  */
-template <typename PNT_TYPE = GeoLib::Point>
+template <typename PNT_TYPE>
 class AABB
 {
 public:

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -34,12 +34,22 @@
 namespace GeoLib
 {
 /**
- *
- * \ingroup GeoLib
- *
  * \brief Class AABB is an axis aligned bounding box around a given
  * set of geometric points of (template) type PNT_TYPE.
- * */
+ *
+ * Let \f$P = \{p_k \in \mathbb{R}^3, \ k=1, \dotsc, n\}\f$ a set of 3d points.
+ * The bounding volume is described by its lower, left, front point \f$\ell\f$
+ * and the upper, right, back point \f$u\f$, i.e. the coordinates of \f$\ell\f$
+ * and \f$u\f$ are computed as follows \f$\ell_i = \min \limits_{p \in P}
+ * p_i\f$, \f$u_i = \max \limits_{p \in P} p_i\f$, respectively. The bounding
+ * box consists of half-open intervals \f$[\ell_x, u_x) \times [\ell_y, u_y)
+ * \times [\ell_z, u_z).\f$ The bounding box is enlarged up to the next
+ * available floating point number such that all input points are contained in
+ * the bounding box.
+ *
+ * @tparam PNT_TYPE a point type supporting accessing the coordinates via
+ * operator[]
+ */
 template <typename PNT_TYPE = GeoLib::Point>
 class AABB
 {

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -15,11 +15,14 @@
 #ifndef AABB_H_
 #define AABB_H_
 
-#include <limits>
+#include <bitset>
+#include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <cstdlib>
 #include <iterator>
-#include <cassert>
+#include <limits>
+#include <tuple>
 #include <vector>
 
 #include <logog/include/logog.hpp>
@@ -49,8 +52,9 @@ public:
 		assert(! ids.empty());
 		init(pnts[ids[0]]);
 		for (std::size_t i=1; i<ids.size(); ++i) {
-			update(*(pnts[ids[i]]));
+			updateWithoutEnlarge(*(pnts[ids[i]]));
 		}
+		enlarge();
 	}
 
 	/**
@@ -81,25 +85,41 @@ public:
 		init(*first);
 		InputIterator it(first);
 		while (it != last) {
-			update(*it);
+			updateWithoutEnlarge(*it);
 			it++;
 		}
+		enlarge();
 	}
 
-	bool update(PNT_TYPE const & pnt)
+	/// Checks if the bounding box has to be updated.
+	/// @return true if AABB is updated.
+	bool update(PNT_TYPE const & p)
 	{
-		bool updated(false);
+		// First component of the pair signals if the minimum point is changed
+		// Second component signals not only if the max point is changed.
+		// Furthermore it is signaled what coordinate (0,1,2) is changed.
+		std::pair<bool,std::bitset<3>> updated(0,0);
 		for (std::size_t k(0); k<3; k++) {
-			if (pnt[k] < _min_pnt[k]) {
-				_min_pnt[k] = pnt[k];
-				updated = true;
+			// if the minimum point is updated pair.first==true
+			if (p[k] < _min_pnt[k]) {
+				_min_pnt[k] = p[k];
+				updated.first = true;
 			}
-			if (_max_pnt[k] < pnt[k]) {
-				_max_pnt[k] = pnt[k];
-				updated = true;
+			// if the kth coordinate of the maximum point is updated
+			// pair.second[k]==true
+			if (p[k] >= _max_pnt[k]) {
+				_max_pnt[k] = p[k];
+				updated.second[k] = true;
 			}
 		}
-		return updated;
+
+		if (updated.second.any()) {
+			enlarge(updated.second);
+			return true;
+		} else if (updated.first) {
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -150,6 +170,19 @@ protected:
 		std::numeric_limits<double>::lowest(),
 		std::numeric_limits<double>::lowest()}}};
 private:
+	/// Enlarge the bounding box the smallest possible amount (modifying the
+	/// unit in the last place). Only the coordinates of the maximum point are
+	/// changed such that the half-open property will be preserved.
+	void enlarge(std::bitset<3> to_update = 7)
+	{
+		for (std::size_t k=0; k<3; ++k) {
+			if (to_update[k]) {
+				_max_pnt[k] = std::nextafter(_max_pnt[k],
+					std::numeric_limits<double>::max());
+			}
+		}
+	}
+
 	void init(PNT_TYPE const & pnt)
 	{
 		_min_pnt[0] = _max_pnt[0] = pnt[0];
@@ -160,9 +193,32 @@ private:
 	{
 		init(*pnt);
 	}
+
+	/// Private method that is used internally to update the min and max point
+	/// of the bounding box using point \f$p\f$ without enlarging the bounding
+	/// box. Using this method the bounding box of the initial point set is
+	/// enlarged only once.
+	/// @param p point that will possibly change the bounding box points
+	void  updateWithoutEnlarge(PNT_TYPE const & p)
+	{
+		for (std::size_t k(0); k<3; k++) {
+			if (p[k] < _min_pnt[k]) {
+				_min_pnt[k] = p[k];
+			}
+			if (p[k] >= _max_pnt[k]) {
+				_max_pnt[k] = p[k];
+			}
+		}
+	}
+
+	void updateWithoutEnlarge(PNT_TYPE const * pnt)
+	{
+		updateWithoutEnlarge(*pnt);
+	}
+
 	void update(PNT_TYPE const * pnt)
 	{
-		update (*pnt);
+		update(*pnt);
 	}
 };
 } // end namespace

--- a/MeshLib/CoordinateSystem.h
+++ b/MeshLib/CoordinateSystem.h
@@ -86,11 +86,14 @@ unsigned char CoordinateSystem::getCoordinateSystem(const GeoLib::AABB<T> &bbox)
 
     const MathLib::Vector3 pt_diff(bbox.getMinPoint(), bbox.getMaxPoint());
 
-    if (std::abs(pt_diff[0]) > .0)
+    // The axis aligned bounding box is a from the right half-open interval.
+    // Therefore, the difference between the particular coordinates of the
+    // points is modified by the unit in the last place towards zero.
+    if (std::nexttoward(std::abs(pt_diff[0]), 0.0) > .0)
         coords |= CoordinateSystemType::X;
-    if (std::abs(pt_diff[1]) > .0)
+    if (std::nexttoward(std::abs(pt_diff[1]), 0.0) > .0)
         coords |= CoordinateSystemType::Y;
-    if (std::abs(pt_diff[2]) > .0)
+    if (std::nexttoward(std::abs(pt_diff[2]), 0.0) > .0)
         coords |= CoordinateSystemType::Z;
 
     return coords;

--- a/Tests/GeoLib/TestAABB.cpp
+++ b/Tests/GeoLib/TestAABB.cpp
@@ -27,7 +27,7 @@
 TEST(GeoLibAABB, RandomNumberOfPointersToRandomPoints)
 {
 	/* initialize random seed: */
-	 srand ( static_cast<unsigned>(time(NULL)) );
+	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 100000);
 	 int box_size (rand());
 	 int half_box_size(box_size/2);
@@ -60,7 +60,7 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPoints)
 TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAList)
 {
 	/* initialize random seed: */
-	 srand ( static_cast<unsigned>(time(NULL)) );
+	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 1000000);
 	 int box_size (rand());
 	 int half_box_size(box_size/2);
@@ -89,7 +89,7 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAList)
 TEST(GeoLibAABB, RandomNumberOfPointersToRandomPointsInAVector)
 {
 	/* initialize random seed: */
-	 srand ( static_cast<unsigned>(time(NULL)) );
+	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 100000);
 	 int box_size (rand());
 	 int half_box_size(box_size/2);
@@ -101,7 +101,7 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPointsInAVector)
 		 pnts.push_back(new GeoLib::Point(rand() % box_size - half_box_size, rand() % box_size - half_box_size, rand() % box_size - half_box_size));
 	 }
 
-	 // construct from list points a axis algined bounding box
+	 // construct from list points a axis aligned bounding box
 	 GeoLib::AABB<GeoLib::Point> aabb(pnts.begin(), pnts.end());
 
 	 MathLib::Point3d const& min_pnt(aabb.getMinPoint());
@@ -122,7 +122,7 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPointsInAVector)
 TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAVector)
 {
 	/* initialize random seed: */
-	 srand ( static_cast<unsigned>(time(NULL)) );
+	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 1000000);
 	 int box_size (rand());
 	 int half_box_size(box_size/2);
@@ -151,7 +151,7 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAVector)
 TEST(GeoLibAABB, RandomNumberOfPointsRandomBox)
 {
 	/* initialize random seed: */
-	 srand (static_cast<unsigned>(time(NULL)));
+	 srand (static_cast<unsigned>(time(nullptr)));
 	 int n (rand() % 1000000);
 	 int box_size_x (rand());
 	 int box_size_y (rand());

--- a/Tests/GeoLib/TestAABB.cpp
+++ b/Tests/GeoLib/TestAABB.cpp
@@ -30,8 +30,8 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPoints)
 	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 100000);
 	 int box_size (rand());
-	 int half_box_size(box_size/2);
-	 int minus_half_box_size(-half_box_size);
+	 double half_box_size(box_size/2);
+	 double minus_half_box_size(-half_box_size);
 
 	 // fill list with points
 	 std::list<GeoLib::Point*> pnts_list;
@@ -48,6 +48,9 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPoints)
 	 ASSERT_LE(minus_half_box_size, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[2]) << "coordinate 2 of min_pnt is smaller than " << minus_half_box_size;
+
+	// since the interval is half-open we have to move the upper bound also
+	 half_box_size = std::nexttoward(half_box_size, std::numeric_limits<double>::max());
 	 ASSERT_GE(half_box_size, max_pnt[0]) << "coordinate 0 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[1]) << "coordinate 1 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[2]) << "coordinate 2 of max_pnt is greater than " << half_box_size;
@@ -63,8 +66,8 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAList)
 	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 1000000);
 	 int box_size (rand());
-	 int half_box_size(box_size/2);
-	 int minus_half_box_size(-half_box_size);
+	 double half_box_size(box_size/2);
+	 double minus_half_box_size(-half_box_size);
 
 	 // fill list with points
 	 std::list<GeoLib::Point> pnts_list;
@@ -81,6 +84,9 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAList)
 	 ASSERT_LE(minus_half_box_size, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[2]) << "coordinate 2 of min_pnt is smaller than " << minus_half_box_size;
+
+	// since the interval is half-open we have to move the upper bound also
+	 half_box_size = std::nexttoward(half_box_size, std::numeric_limits<double>::max());
 	 ASSERT_GE(half_box_size, max_pnt[0]) << "coordinate 0 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[1]) << "coordinate 1 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[2]) << "coordinate 2 of max_pnt is greater than " << half_box_size;
@@ -92,8 +98,8 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPointsInAVector)
 	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 100000);
 	 int box_size (rand());
-	 int half_box_size(box_size/2);
-	 int minus_half_box_size(-half_box_size);
+	 double half_box_size(box_size/2);
+	 double minus_half_box_size(-half_box_size);
 
 	 // fill list with points
 	 std::vector<GeoLib::Point*> pnts;
@@ -110,6 +116,9 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPointsInAVector)
 	 ASSERT_LE(minus_half_box_size, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[2]) << "coordinate 2 of min_pnt is smaller than " << minus_half_box_size;
+
+	// since the interval is half-open we have to move the upper bound also
+	 half_box_size = std::nexttoward(half_box_size, std::numeric_limits<double>::max());
 	 ASSERT_GE(half_box_size, max_pnt[0]) << "coordinate 0 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[1]) << "coordinate 1 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[2]) << "coordinate 2 of max_pnt is greater than " << half_box_size;
@@ -125,8 +134,8 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAVector)
 	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 1000000);
 	 int box_size (rand());
-	 int half_box_size(box_size/2);
-	 int minus_half_box_size(-half_box_size);
+	 double half_box_size(box_size/2);
+	 double minus_half_box_size(-half_box_size);
 
 	 // fill list with points
 	 std::list<GeoLib::Point> pnts;
@@ -143,6 +152,9 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAVector)
 	 ASSERT_LE(minus_half_box_size, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[2]) << "coordinate 2 of min_pnt is smaller than " << minus_half_box_size;
+
+	// since the interval is half-open we have to move the upper bound also
+	 half_box_size = std::nexttoward(half_box_size, std::numeric_limits<double>::max());
 	 ASSERT_GE(half_box_size, max_pnt[0]) << "coordinate 0 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[1]) << "coordinate 1 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[2]) << "coordinate 2 of max_pnt is greater than " << half_box_size;
@@ -156,9 +168,9 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomBox)
 	 int box_size_x (rand());
 	 int box_size_y (rand());
 	 int box_size_z (rand());
-	 int half_box_size_x(box_size_x/2);
-	 int half_box_size_y(box_size_y/2);
-	 int half_box_size_z(box_size_z/2);
+	 double half_box_size_x(box_size_x/2);
+	 double half_box_size_y(box_size_y/2);
+	 double half_box_size_z(box_size_z/2);
 	 int minus_half_box_size_x(-half_box_size_x);
 	 int minus_half_box_size_y(-half_box_size_y);
 	 int minus_half_box_size_z(-half_box_size_z);
@@ -178,6 +190,11 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomBox)
 	 ASSERT_LE(minus_half_box_size_x, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size_x;
 	 ASSERT_LE(minus_half_box_size_y, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size_y;
 	 ASSERT_LE(minus_half_box_size_z, min_pnt[2]) << "coordinate 2 of min_pnt is smaller than " << minus_half_box_size_z;
+
+	// since the interval is half-open we have to move the upper bound also
+	 half_box_size_x = std::nexttoward(half_box_size_x, std::numeric_limits<double>::max());
+	 half_box_size_y = std::nexttoward(half_box_size_y, std::numeric_limits<double>::max());
+	 half_box_size_z = std::nexttoward(half_box_size_z, std::numeric_limits<double>::max());
 	 ASSERT_GE(half_box_size_x, max_pnt[0]) << "coordinate 0 of max_pnt is greater than " << half_box_size_x;
 	 ASSERT_GE(half_box_size_y, max_pnt[1]) << "coordinate 1 of max_pnt is greater than " << half_box_size_y;
 	 ASSERT_GE(half_box_size_z, max_pnt[2]) << "coordinate 2 of max_pnt is greater than " << half_box_size_z;
@@ -221,6 +238,9 @@ TEST(GeoLib, AABBAllPointsWithNegativeCoordinatesII)
 	ASSERT_NEAR(-1.0, max_pnt[2], std::numeric_limits<double>::epsilon());
 }
 
+// This test creates an AABB containing a single point.
+// This point is moved in every space direction to the next possible double value.
+// It is checked that the AABB contains the point iff it has not been moved.
 TEST(GeoLib, AABBSinglePoint)
 {
 	std::random_device rd;


### PR DESCRIPTION
Until now, it was always necessary to enlarge the axis aligned bounding box (AABB) to assure that all points of the point set that defined the AABB are located inside this AABB. AABB should implement a from the right half-open interval. Unfortunately the implementation was not consistent.

The PR changes this behaviour. The AABB will enlarged a very small amount (unit in the last place) by default. The method `containsPoint()` is implemented such that "min <= p < max".

The doxygen documentation for the class template is not generated. If somebody has a hint ...

ToDo
 - [x] fix documentation