### PR TITLE
Element value

### DIFF
--- a/Applications/DataExplorer/DataView/ElementTreeModel.cpp
+++ b/Applications/DataExplorer/DataView/ElementTreeModel.cpp
@@ -163,11 +163,14 @@ void ElementTreeModel::setMesh(MeshLib::Mesh const*const mesh)
 	TreeItem* edge_item = new TreeItem(edges, _rootItem);
 	_rootItem->appendChild(edge_item);
 
-	const auto mat_bounds (MeshLib::MeshInformation::getValueBounds(*mesh));
-	QList<QVariant> materials;
-	materials << "MaterialIDs: " << "[" + QString::number(mat_bounds.first) + "," << QString::number(mat_bounds.second) + "]" << "";
-	TreeItem* mat_item = new TreeItem(materials, _rootItem);
-	_rootItem->appendChild(mat_item);
+	std::pair<int, int> const mat_bounds (MeshLib::MeshInformation::getValueBounds(*mesh));
+	if (mat_bounds.second != std::numeric_limits<int>::max())
+	{
+		QList<QVariant> materials;
+		materials << "MaterialIDs: " << "[" + QString::number(mat_bounds.first) + "," << QString::number(mat_bounds.second) + "]" << "";
+		TreeItem* mat_item = new TreeItem(materials, _rootItem);
+		_rootItem->appendChild(mat_item);
+	}
 
 	reset();
 

--- a/MeshLib/Elements/Element.cpp
+++ b/MeshLib/Elements/Element.cpp
@@ -23,11 +23,6 @@
 
 namespace MeshLib {
 
-Element::Element(unsigned value, std::size_t id)
-	: _nodes(nullptr), _id(id), _content(-1.0), _value(value), _neighbors(nullptr)
-{
-}
-
 Element::Element(std::size_t id)
 	: _nodes(nullptr), _id(id), _content(-1.0), _neighbors(nullptr)
 {
@@ -195,8 +190,8 @@ bool Element::isBoundaryElement() const
 #ifndef NDEBUG
 std::ostream& operator<<(std::ostream& os, Element const& e)
 {
-	os << "Element #" << e._id << " value " << e._value << " @ " << &e
-		<< " with " << e.getNNeighbors() << " neighbours\n";
+	os << "Element #" << e._id << " @ " << &e << " with " << e.getNNeighbors()
+	   << " neighbours\n";
 
 	unsigned const nnodes = e.getNNodes();
 	MeshLib::Node* const* const nodes = e.getNodes();

--- a/MeshLib/Elements/Element.h
+++ b/MeshLib/Elements/Element.h
@@ -89,7 +89,7 @@ public:
 	virtual const Element* getFace(unsigned i) const = 0;
 
 	/// Returns the ID of the element.
-	std::size_t getID() const { return _id; }
+	virtual std::size_t getID() const final { return _id; }
 
 	/// Get the number of edges for this element.
 	virtual unsigned getNEdges() const = 0;
@@ -203,7 +203,7 @@ protected:
 	explicit Element(std::size_t id);
 
 	/// Sets the element ID.
-	void setID(std::size_t id) { _id = id; }
+	virtual void setID(std::size_t id) final { _id = id; }
 
 	Node** _nodes;
 	std::size_t _id;

--- a/MeshLib/Elements/Element.h
+++ b/MeshLib/Elements/Element.h
@@ -89,7 +89,7 @@ public:
 	virtual const Element* getFace(unsigned i) const = 0;
 
 	/// Returns the ID of the element.
-	virtual std::size_t getID() const { return this->_id; }
+	std::size_t getID() const { return _id; }
 
 	/// Get the number of edges for this element.
 	virtual unsigned getNEdges() const = 0;
@@ -138,16 +138,6 @@ public:
 	 */
 	virtual CellType getCellType() const = 0;
 
-	/**
-	 * Get the value for this element. The value can be used to store a link
-	 * to external information (for instance an index of a field) like material groups.
-	 */
-	unsigned getValue() const { return _value; }
-
-	/**
-	 * Get the value for this element as a const reference.
-	 */
-	unsigned const& getValueReference() const { return _value; }
 
 	/**
 	 * Returns true if the element has zero length/area/volume.
@@ -172,12 +162,6 @@ public:
 	 * Tests if the element is geometrically valid.
 	 */
 	virtual ElementErrorCode validate() const = 0;
-
-	/**
-	 * Set the index value for external information.
-	 * @param value an unsigned value for linking with external information
-	 */
-	void setValue(unsigned value) { _value = value; }
 
 	/// Returns true if elem is a neighbour of this element and false otherwise.
 	bool hasNeighbor(Element* elem) const;
@@ -215,25 +199,17 @@ public:
 
 protected:
 	/// Constructor for a generic mesh element without an array of mesh nodes.
-	/// @param value  element value
-	/// @param id     element id
-	Element(unsigned value, std::size_t id);
-
-	/// Constructor for a generic mesh element without an array of mesh nodes.
 	/// @param id     element id
 	explicit Element(std::size_t id);
 
 	/// Sets the element ID.
-	virtual void setID(std::size_t id) { this->_id = id; }
+	void setID(std::size_t id) { _id = id; }
 
 	Node** _nodes;
 	std::size_t _id;
 	/// Content corresponds to length for 1D, area for 2D, and volume for 3D elements
 	double _content;
-	/**
-	 * this is an index for external additional information like materials
-	 */
-	unsigned _value;
+
 	Element** _neighbors;
 	/// Sets the neighbor over the face with \c face_id to the given \c
 	/// neighbor.

--- a/MeshLib/Elements/TemplateElement-impl.h
+++ b/MeshLib/Elements/TemplateElement-impl.h
@@ -13,31 +13,10 @@ namespace MeshLib
 {
 
 template <class ELEMENT_RULE>
-TemplateElement<ELEMENT_RULE>::TemplateElement(Node* nodes[n_all_nodes], unsigned value, std::size_t id)
-: Element(value, id)
-{
-	this->_nodes = nodes;
-	this->_neighbors = new Element*[getNNeighbors()];
-	std::fill(this->_neighbors, this->_neighbors + getNNeighbors(), nullptr);
-	this->_content = ELEMENT_RULE::computeVolume(this->_nodes);
-}
-
-template <class ELEMENT_RULE>
 TemplateElement<ELEMENT_RULE>::TemplateElement(Node* nodes[n_all_nodes], std::size_t id)
 : Element(id)
 {
 	this->_nodes = nodes;
-	this->_neighbors = new Element*[getNNeighbors()];
-	std::fill(this->_neighbors, this->_neighbors + getNNeighbors(), nullptr);
-	this->_content = ELEMENT_RULE::computeVolume(this->_nodes);
-}
-
-template <class ELEMENT_RULE>
-TemplateElement<ELEMENT_RULE>::TemplateElement(std::array<Node*, n_all_nodes> const& nodes, unsigned value, std::size_t id)
-: Element(value, id)
-{
-	this->_nodes = new Node*[n_all_nodes];
-	std::copy(nodes.begin(), nodes.end(), this->_nodes);
 	this->_neighbors = new Element*[getNNeighbors()];
 	std::fill(this->_neighbors, this->_neighbors + getNNeighbors(), nullptr);
 	this->_content = ELEMENT_RULE::computeVolume(this->_nodes);

--- a/MeshLib/Elements/TemplateElement.h
+++ b/MeshLib/Elements/TemplateElement.h
@@ -45,27 +45,9 @@ public:
 	 * Constructor with an array of mesh nodes.
 	 *
 	 * @param nodes  an array of pointers of mesh nodes which form this element
-	 * @param value  element value, e.g. material ID
-	 * @param id     element id
-	 */
-	TemplateElement(Node* nodes[n_all_nodes], unsigned value, std::size_t id);
-
-	/**
-	 * Constructor with an array of mesh nodes.
-	 *
-	 * @param nodes  an array of pointers of mesh nodes which form this element
 	 * @param id     element id
 	 */
 	TemplateElement(Node* nodes[n_all_nodes], std::size_t id = std::numeric_limits<std::size_t>::max());
-
-	/**
-	 * Constructor with an array of mesh nodes
-	 *
-	 * @param nodes  an array of pointers of mesh nodes which form this element
-	 * @param value  element value, e.g. material ID
-	 * @param id     element id
-	 */
-	TemplateElement(std::array<Node*, n_all_nodes> const& nodes, unsigned value, std::size_t id);
 
 	/**
 	 * Constructor with an array of mesh nodes

--- a/Tests/InSituLib/TestVtkMappedMeshSource.cpp
+++ b/Tests/InSituLib/TestVtkMappedMeshSource.cpp
@@ -97,9 +97,9 @@ class InSituMesh : public ::testing::Test
 		std::string const material_ids_name("MaterialIDs");
 		boost::optional<MeshLib::PropertyVector<int> &> material_id_properties(
 			mesh->getProperties().createNewPropertyVector<int>(material_ids_name,
-				MeshLib::MeshItemType::Node)
+				MeshLib::MeshItemType::Cell)
 		);
-		(*material_id_properties).resize(mesh->getNNodes());
+		(*material_id_properties).resize(mesh->getNElements());
 		std::iota((*material_id_properties).begin(), (*material_id_properties).end(), 1);
 	}
 


### PR DESCRIPTION
The remains of the original "algprops" PR https://github.com/ufz/ogs/pull/897.

The `value` is finally removed from the `Element` class.
A changelog entry would be good.

Closes https://github.com/ufz/ogs/pull/897