### PR TITLE
Transformed class template AABB -> class AABB

### DIFF
--- a/Applications/DataExplorer/DataView/ElementTreeModel.cpp
+++ b/Applications/DataExplorer/DataView/ElementTreeModel.cpp
@@ -144,7 +144,7 @@ void ElementTreeModel::setMesh(MeshLib::Mesh const*const mesh)
 	TreeItem* aabb_item = new TreeItem(bounding_box, _rootItem);
 	_rootItem->appendChild(aabb_item);
 
-	const GeoLib::AABB<MeshLib::Node> aabb (MeshLib::MeshInformation::getBoundingBox(*mesh));
+	const GeoLib::AABB aabb (MeshLib::MeshInformation::getBoundingBox(*mesh));
 	auto const& min = aabb.getMinPoint();
 	auto const& max = aabb.getMaxPoint();
 

--- a/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
@@ -80,7 +80,7 @@ void MeshElementRemovalDialog::accept()
 	if (this->boundingBoxCheckBox->isChecked())
 	{
 		std::vector<MeshLib::Node*> const& nodes (_project.getMesh(this->meshNameComboBox->currentText().toStdString())->getNodes());
-		GeoLib::AABB<MeshLib::Node> const aabb(nodes.begin(), nodes.end());
+		GeoLib::AABB const aabb(nodes.begin(), nodes.end());
 		auto minAABB = aabb.getMinPoint();
 		auto maxAABB = aabb.getMaxPoint();
 
@@ -94,7 +94,7 @@ void MeshElementRemovalDialog::accept()
 		std::vector<MathLib::Point3d> extent;
 		extent.push_back(minAABB);
 		extent.push_back(maxAABB);
-		const GeoLib::AABB<MathLib::Point3d> updated_aabb(extent.begin(), extent.end());
+		const GeoLib::AABB updated_aabb(extent.begin(), extent.end());
 		ex.searchByBoundingBox(updated_aabb);
 		anything_checked = true;
 	}
@@ -144,7 +144,7 @@ void MeshElementRemovalDialog::on_boundingBoxCheckBox_toggled(bool is_checked)
 	{
 		_aabbIndex = _currentIndex;
 		std::vector<MeshLib::Node*> const& nodes (_project.getMesh(this->meshNameComboBox->currentText().toStdString())->getNodes());
-		GeoLib::AABB<MeshLib::Node> aabb(nodes.begin(), nodes.end());
+		GeoLib::AABB aabb(nodes.begin(), nodes.end());
 		auto const& minAABB = aabb.getMinPoint();
 		auto const& maxAABB = aabb.getMaxPoint();
 		this->xMinEdit->setText(QString::number(minAABB[0], 'f'));

--- a/Applications/Utils/MeshEdit/MoveMesh.cpp
+++ b/Applications/Utils/MeshEdit/MoveMesh.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
 	if (fabs(x_arg.getValue()) < std::numeric_limits<double>::epsilon()
 		&& fabs(y_arg.getValue()) < std::numeric_limits<double>::epsilon()
 		&& fabs(z_arg.getValue()) < std::numeric_limits<double>::epsilon()) {
-		GeoLib::AABB<MeshLib::Node> aabb(mesh->getNodes().begin(), mesh->getNodes().end());
+		GeoLib::AABB aabb(mesh->getNodes().begin(), mesh->getNodes().end());
 		displacement[0] = -(aabb.getMaxPoint()[0] + aabb.getMinPoint()[0])/2.0;
 		displacement[1] = -(aabb.getMaxPoint()[1] + aabb.getMinPoint()[1])/2.0;
 		displacement[2] = -(aabb.getMaxPoint()[2] + aabb.getMinPoint()[2])/2.0;

--- a/Applications/Utils/MeshEdit/checkMesh.cpp
+++ b/Applications/Utils/MeshEdit/checkMesh.cpp
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
 	INFO ("Time for reading: %g s", run_time.elapsed());
 
 	// Geometric information
-	const GeoLib::AABB<MeshLib::Node> aabb(MeshLib::MeshInformation::getBoundingBox(*mesh));
+	const GeoLib::AABB aabb(MeshLib::MeshInformation::getBoundingBox(*mesh));
 	auto minPt(aabb.getMinPoint());
 	auto maxPt(aabb.getMaxPoint());
 	INFO("Node coordinates:");

--- a/Applications/Utils/MeshEdit/moveMeshNodes.cpp
+++ b/Applications/Utils/MeshEdit/moveMeshNodes.cpp
@@ -140,7 +140,7 @@ int main (int argc, char* argv[])
 		double offset (0.0); // additional offset for elevation (should be 0)
 		MeshLib::Mesh* ground_truth (FileIO::readMeshFromFile(value));
 		const std::vector<MeshLib::Node*> ground_truth_nodes (ground_truth->getNodes());
-		GeoLib::AABB<MeshLib::Node> bounding_box(ground_truth_nodes.begin(), ground_truth_nodes.end());
+		GeoLib::AABB bounding_box(ground_truth_nodes.begin(), ground_truth_nodes.end());
 		MathLib::Point3d const& min(bounding_box.getMinPoint());
 		MathLib::Point3d const& max(bounding_box.getMaxPoint());
 

--- a/Applications/Utils/MeshEdit/removeMeshElements.cpp
+++ b/Applications/Utils/MeshEdit/removeMeshElements.cpp
@@ -138,7 +138,7 @@ int main (int argc, char* argv[])
 			MathLib::Point3d(std::array<double,3>{{xLargeArg.getValue(),
 				yLargeArg.getValue(), zLargeArg.getValue()}})}});
 		const std::size_t n_removed_elements = ex.searchByBoundingBox(
-			GeoLib::AABB<MathLib::Point3d>(extent.begin(), extent.end()));
+			GeoLib::AABB(extent.begin(), extent.end()));
 		INFO("%d elements found.", n_removed_elements);
 	}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Release notes
-# 6.0.5
+# 6.0.5 (in preparation)
 
 ### Features:
+ - Axis aligned bounding box:
+   - Is now a from the right half-open interval.
+   - Removed template from class declaration.
 
 ### Infrastructure
 
@@ -10,7 +13,6 @@
 
 
 ### Fixes
-
 
 # 6.0.4
 

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -108,9 +108,9 @@ public:
 	template <typename T>
 	bool containsPoint(T const & pnt) const
 	{
-		if (pnt[0] < _min_pnt[0] || _max_pnt[0] < pnt[0]) return false;
-		if (pnt[1] < _min_pnt[1] || _max_pnt[1] < pnt[1]) return false;
-		if (pnt[2] < _min_pnt[2] || _max_pnt[2] < pnt[2]) return false;
+		if (pnt[0] < _min_pnt[0] || _max_pnt[0] <= pnt[0]) return false;
+		if (pnt[1] < _min_pnt[1] || _max_pnt[1] <= pnt[1]) return false;
+		if (pnt[2] < _min_pnt[2] || _max_pnt[2] <= pnt[2]) return false;
 		return true;
 	}
 

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -29,7 +29,6 @@
 
 #include "MathLib/Point3d.h"
 #include "MathLib/MathTools.h"
-#include "Point.h"
 
 namespace GeoLib
 {
@@ -50,7 +49,7 @@ namespace GeoLib
  * @tparam PNT_TYPE a point type supporting accessing the coordinates via
  * operator[]
  */
-template <typename PNT_TYPE = GeoLib::Point>
+template <typename PNT_TYPE>
 class AABB
 {
 public:

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -46,16 +46,16 @@ namespace GeoLib
  * available floating point number such that all input points are contained in
  * the bounding box.
  *
- * @tparam PNT_TYPE a point type supporting accessing the coordinates via
- * operator[]
  */
-template <typename PNT_TYPE>
 class AABB
 {
 public:
 	/**
 	 * construction of object, initialization the axis aligned bounding box
+	 * @tparam PNT_TYPE a point type supporting accessing the coordinates via
+	 * operator[]
 	 * */
+	template <typename PNT_TYPE>
 	AABB(std::vector<PNT_TYPE*> const& pnts, std::vector<std::size_t> const& ids)
 	{
 		assert(! ids.empty());
@@ -69,8 +69,8 @@ public:
 	/**
 	 * copy constructor.
 	 * @param src an axis aligned bounding box
-	 */
-	AABB(AABB<PNT_TYPE> const& src) :
+	 * */
+	AABB(AABB const& src) :
 		_min_pnt(src._min_pnt), _max_pnt(src._max_pnt)
 	{}
 
@@ -102,6 +102,7 @@ public:
 
 	/// Checks if the bounding box has to be updated.
 	/// @return true if AABB is updated.
+	template <typename PNT_TYPE>
 	bool update(PNT_TYPE const & p)
 	{
 		// First component of the pair signals if the minimum point is changed
@@ -164,7 +165,7 @@ public:
 	 * @return true if the other AABB is contained in the AABB
 	 * represented by this object
 	 */
-	bool containsAABB(AABB<PNT_TYPE> const& other_aabb) const
+	bool containsAABB(AABB const& other_aabb) const
 	{
 		return containsPoint(other_aabb.getMinPoint()) && containsPoint(other_aabb.getMaxPoint());
 	}
@@ -192,13 +193,16 @@ private:
 		}
 	}
 
+	template <typename PNT_TYPE>
 	void init(PNT_TYPE const & pnt)
 	{
 		_min_pnt[0] = _max_pnt[0] = pnt[0];
 		_min_pnt[1] = _max_pnt[1] = pnt[1];
 		_min_pnt[2] = _max_pnt[2] = pnt[2];
 	}
-	void init(PNT_TYPE const * pnt)
+
+	template <typename PNT_TYPE>
+	void init(PNT_TYPE * const & pnt)
 	{
 		init(*pnt);
 	}
@@ -208,6 +212,7 @@ private:
 	/// box. Using this method the bounding box of the initial point set is
 	/// enlarged only once.
 	/// @param p point that will possibly change the bounding box points
+	template <typename PNT_TYPE>
 	void  updateWithoutEnlarge(PNT_TYPE const & p)
 	{
 		for (std::size_t k(0); k<3; k++) {
@@ -220,11 +225,13 @@ private:
 		}
 	}
 
-	void updateWithoutEnlarge(PNT_TYPE const * pnt)
+	template <typename PNT_TYPE>
+	void updateWithoutEnlarge(PNT_TYPE * const & pnt)
 	{
 		updateWithoutEnlarge(*pnt);
 	}
 
+	template <typename PNT_TYPE>
 	void update(PNT_TYPE const * pnt)
 	{
 		update(*pnt);

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -34,12 +34,22 @@
 namespace GeoLib
 {
 /**
- *
- * \ingroup GeoLib
- *
  * \brief Class AABB is an axis aligned bounding box around a given
  * set of geometric points of (template) type PNT_TYPE.
- * */
+ *
+ * Let \f$P = \{p_k \in \mathbb{R}^3, \ k=1, \dotsc, n\}\f$ a set of 3d points.
+ * The bounding volume is described by its lower, left, front point \f$\ell\f$
+ * and the upper, right, back point \f$u\f$, i.e. the coordinates of \f$\ell\f$
+ * and \f$u\f$ are computed as follows \f$\ell_i = \min \limits_{p \in P}
+ * p_i\f$, \f$u_i = \max \limits_{p \in P} p_i\f$, respectively. The bounding
+ * box consists of half-open intervals \f$[\ell_x, u_x) \times [\ell_y, u_y)
+ * \times [\ell_z, u_z).\f$ The bounding box is enlarged up to the next
+ * available floating point number such that all input points are contained in
+ * the bounding box.
+ *
+ * @tparam PNT_TYPE a point type supporting accessing the coordinates via
+ * operator[]
+ */
 template <typename PNT_TYPE = GeoLib::Point>
 class AABB
 {

--- a/GeoLib/AABB.h
+++ b/GeoLib/AABB.h
@@ -15,11 +15,14 @@
 #ifndef AABB_H_
 #define AABB_H_
 
-#include <limits>
+#include <bitset>
+#include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <cstdlib>
 #include <iterator>
-#include <cassert>
+#include <limits>
+#include <tuple>
 #include <vector>
 
 #include <logog/include/logog.hpp>
@@ -49,8 +52,9 @@ public:
 		assert(! ids.empty());
 		init(pnts[ids[0]]);
 		for (std::size_t i=1; i<ids.size(); ++i) {
-			update(*(pnts[ids[i]]));
+			updateWithoutEnlarge(*(pnts[ids[i]]));
 		}
+		enlarge();
 	}
 
 	/**
@@ -81,25 +85,41 @@ public:
 		init(*first);
 		InputIterator it(first);
 		while (it != last) {
-			update(*it);
+			updateWithoutEnlarge(*it);
 			it++;
 		}
+		enlarge();
 	}
 
-	bool update(PNT_TYPE const & pnt)
+	/// Checks if the bounding box has to be updated.
+	/// @return true if AABB is updated.
+	bool update(PNT_TYPE const & p)
 	{
-		bool updated(false);
+		// First component of the pair signals if the minimum point is changed
+		// Second component signals not only if the max point is changed.
+		// Furthermore it is signaled what coordinate (0,1,2) is changed.
+		std::pair<bool,std::bitset<3>> updated(0,0);
 		for (std::size_t k(0); k<3; k++) {
-			if (pnt[k] < _min_pnt[k]) {
-				_min_pnt[k] = pnt[k];
-				updated = true;
+			// if the minimum point is updated pair.first==true
+			if (p[k] < _min_pnt[k]) {
+				_min_pnt[k] = p[k];
+				updated.first = true;
 			}
-			if (_max_pnt[k] < pnt[k]) {
-				_max_pnt[k] = pnt[k];
-				updated = true;
+			// if the kth coordinate of the maximum point is updated
+			// pair.second[k]==true
+			if (p[k] >= _max_pnt[k]) {
+				_max_pnt[k] = p[k];
+				updated.second[k] = true;
 			}
 		}
-		return updated;
+
+		if (updated.second.any()) {
+			enlarge(updated.second);
+			return true;
+		} else if (updated.first) {
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -150,6 +170,19 @@ protected:
 		std::numeric_limits<double>::lowest(),
 		std::numeric_limits<double>::lowest()}}};
 private:
+	/// Enlarge the bounding box the smallest possible amount (modifying the
+	/// unit in the last place). Only the coordinates of the maximum point are
+	/// changed such that the half-open property will be preserved.
+	void enlarge(std::bitset<3> to_update = 7)
+	{
+		for (std::size_t k=0; k<3; ++k) {
+			if (to_update[k]) {
+				_max_pnt[k] = std::nextafter(_max_pnt[k],
+					std::numeric_limits<double>::max());
+			}
+		}
+	}
+
 	void init(PNT_TYPE const & pnt)
 	{
 		_min_pnt[0] = _max_pnt[0] = pnt[0];
@@ -160,9 +193,32 @@ private:
 	{
 		init(*pnt);
 	}
+
+	/// Private method that is used internally to update the min and max point
+	/// of the bounding box using point \f$p\f$ without enlarging the bounding
+	/// box. Using this method the bounding box of the initial point set is
+	/// enlarged only once.
+	/// @param p point that will possibly change the bounding box points
+	void  updateWithoutEnlarge(PNT_TYPE const & p)
+	{
+		for (std::size_t k(0); k<3; k++) {
+			if (p[k] < _min_pnt[k]) {
+				_min_pnt[k] = p[k];
+			}
+			if (p[k] >= _max_pnt[k]) {
+				_max_pnt[k] = p[k];
+			}
+		}
+	}
+
+	void updateWithoutEnlarge(PNT_TYPE const * pnt)
+	{
+		updateWithoutEnlarge(*pnt);
+	}
+
 	void update(PNT_TYPE const * pnt)
 	{
-		update (*pnt);
+		update(*pnt);
 	}
 };
 } // end namespace

--- a/GeoLib/Grid.h
+++ b/GeoLib/Grid.h
@@ -32,7 +32,7 @@
 namespace GeoLib
 {
 template <typename POINT>
-class Grid : public GeoLib::AABB<POINT>
+class Grid : public GeoLib::AABB
 {
 public:
 	/**
@@ -179,7 +179,7 @@ template <typename POINT>
 template <typename InputIterator>
 Grid<POINT>::Grid(InputIterator first, InputIterator last,
 	std::size_t max_num_per_grid_cell)
-	: GeoLib::AABB<POINT>(first, last), _n_steps({{1,1,1}}),
+	: GeoLib::AABB(first, last), _n_steps({{1,1,1}}),
 		_step_sizes({{0.0,0.0,0.0}}), _inverse_step_sizes({{0.0,0.0,0.0}}),
 		_grid_cell_nodes_map(nullptr)
 {

--- a/GeoLib/PointVec.h
+++ b/GeoLib/PointVec.h
@@ -100,7 +100,7 @@ public:
 
 	const std::vector<std::size_t>& getIDMap () const { return _pnt_id_map; }
 
-	const GeoLib::AABB<GeoLib::Point>& getAABB () const;
+	const GeoLib::AABB& getAABB () const;
 
 	std::string const& getItemNameByID(std::size_t id) const;
 
@@ -136,7 +136,7 @@ private:
 	/// given point id.
 	std::vector<std::string> _id_to_name_map;
 
-	AABB<GeoLib::Point> _aabb;
+	AABB _aabb;
 	double _rel_eps;
 	std::unique_ptr<GeoLib::OctTree<GeoLib::Point, 16>> _oct_tree;
 };

--- a/GeoLib/Polygon.h
+++ b/GeoLib/Polygon.h
@@ -138,7 +138,7 @@ private:
 	void splitPolygonAtIntersection (std::list<Polygon*>::iterator polygon_it);
 	void splitPolygonAtPoint (std::list<Polygon*>::iterator polygon_it);
 	std::list<Polygon*> _simple_polygon_list;
-	AABB<GeoLib::Point> _aabb;
+	AABB _aabb;
 };
 
 /**

--- a/GeoLib/Surface.cpp
+++ b/GeoLib/Surface.cpp
@@ -58,7 +58,7 @@ void Surface::addTriangle(std::size_t pnt_a, std::size_t pnt_b, std::size_t pnt_
 		ids[0] = pnt_a;
 		ids[1] = pnt_b;
 		ids[2] = pnt_c;
-		_bounding_volume = new AABB<Point>(_sfc_pnts, ids);
+		_bounding_volume = new AABB(_sfc_pnts, ids);
 		if (_surface_grid == nullptr) {
 			_surface_grid = new SurfaceGrid(this);
 		}

--- a/GeoLib/Surface.h
+++ b/GeoLib/Surface.h
@@ -87,7 +87,7 @@ public:
 	 * method allows access to the internal axis aligned bounding box
 	 * @return axis aligned bounding box
 	 */
-	AABB<GeoLib::Point> const& getAABB () const { return *_bounding_volume; }
+	AABB const& getAABB () const { return *_bounding_volume; }
 
 protected:
 	/** a vector of pointers to Points */
@@ -95,7 +95,7 @@ protected:
 	/** position of pointers to the geometric points */
 	std::vector<Triangle*> _sfc_triangles;
 	/** bounding volume is an axis aligned bounding box */
-	AABB<GeoLib::Point> *_bounding_volume;
+	AABB *_bounding_volume;
 	/** a helper structure to accelerate the search */
 	SurfaceGrid * _surface_grid;
 };

--- a/GeoLib/SurfaceGrid.h
+++ b/GeoLib/SurfaceGrid.h
@@ -27,7 +27,7 @@ namespace GeoLib {
 class Triangle;
 class Surface;
 
-class SurfaceGrid : public AABB<GeoLib::Point> {
+class SurfaceGrid : public AABB {
 public:
 	explicit SurfaceGrid(GeoLib::Surface const*const sfc);
 	bool isPointInSurface(MathLib::Point3d const & pnt,

--- a/MeshGeoToolsLib/GeoMapper.cpp
+++ b/MeshGeoToolsLib/GeoMapper.cpp
@@ -110,7 +110,7 @@ void GeoMapper::mapData()
 	double min_val(0), max_val(0);
 	if (_surface_mesh)
 	{
-		GeoLib::AABB<MeshLib::Node> bounding_box(
+		GeoLib::AABB bounding_box(
 			_surface_mesh->getNodes().begin(), _surface_mesh->getNodes().end());
 		min_val = bounding_box.getMinPoint()[2];
 		max_val = bounding_box.getMaxPoint()[2];
@@ -217,7 +217,7 @@ void GeoMapper::advancedMapOnMesh(
 	const std::vector<GeoLib::Point*> *points (this->_geo_objects.getPointVec(this->_geo_name));
 	const std::vector<GeoLib::Polyline*> *org_lines (this->_geo_objects.getPolylineVec(this->_geo_name));
 
-	const GeoLib::AABB<GeoLib::Point> aabb(points->begin(), points->end());
+	const GeoLib::AABB aabb(points->begin(), points->end());
 	const double eps = sqrt(std::numeric_limits<float>::epsilon()) *
 		               sqrt( MathLib::sqrDist(aabb.getMinPoint(),aabb.getMaxPoint())) ;
 

--- a/MeshLib/CoordinateSystem.cpp
+++ b/MeshLib/CoordinateSystem.cpp
@@ -16,9 +16,8 @@ namespace MeshLib
 
 CoordinateSystem::CoordinateSystem(const Element &ele)
 {
-    const GeoLib::AABB<MeshLib::Node> aabb(ele.getNodes(),
-        ele.getNodes()+ele.getNNodes());
-    const CoordinateSystem bboxCoordSys(getCoordinateSystem(aabb));
+    GeoLib::AABB const aabb(ele.getNodes(), ele.getNodes() + ele.getNNodes());
+    CoordinateSystem const bboxCoordSys(getCoordinateSystem(aabb));
     if (bboxCoordSys.getDimension() >= ele.getDimension()) {
         _type = bboxCoordSys.getType();
     } else { // e.g. zero volume elements
@@ -29,6 +28,25 @@ CoordinateSystem::CoordinateSystem(const Element &ele)
         if (ele.getDimension()==3)
             _type |= CoordinateSystemType::Z;
     }
+}
+
+unsigned char CoordinateSystem::getCoordinateSystem(const GeoLib::AABB &bbox) const
+{
+    unsigned char coords = 0;
+
+    const MathLib::Vector3 pt_diff(bbox.getMinPoint(), bbox.getMaxPoint());
+
+    // The axis aligned bounding box is a from the right half-open interval.
+    // Therefore, the difference between the particular coordinates of the
+    // points is modified by the unit in the last place towards zero.
+    if (std::nexttoward(std::abs(pt_diff[0]), 0.0) > .0)
+        coords |= CoordinateSystemType::X;
+    if (std::nexttoward(std::abs(pt_diff[1]), 0.0) > .0)
+        coords |= CoordinateSystemType::Y;
+    if (std::nexttoward(std::abs(pt_diff[2]), 0.0) > .0)
+        coords |= CoordinateSystemType::Z;
+
+    return coords;
 }
 
 } // end

--- a/MeshLib/CoordinateSystem.h
+++ b/MeshLib/CoordinateSystem.h
@@ -86,11 +86,14 @@ unsigned char CoordinateSystem::getCoordinateSystem(const GeoLib::AABB<T> &bbox)
 
     const MathLib::Vector3 pt_diff(bbox.getMinPoint(), bbox.getMaxPoint());
 
-    if (std::abs(pt_diff[0]) > .0)
+    // The axis aligned bounding box is a from the right half-open interval.
+    // Therefore, the difference between the particular coordinates of the
+    // points is modified by the unit in the last place towards zero.
+    if (std::nexttoward(std::abs(pt_diff[0]), 0.0) > .0)
         coords |= CoordinateSystemType::X;
-    if (std::abs(pt_diff[1]) > .0)
+    if (std::nexttoward(std::abs(pt_diff[1]), 0.0) > .0)
         coords |= CoordinateSystemType::Y;
-    if (std::abs(pt_diff[2]) > .0)
+    if (std::nexttoward(std::abs(pt_diff[2]), 0.0) > .0)
         coords |= CoordinateSystemType::Z;
 
     return coords;

--- a/MeshLib/CoordinateSystem.h
+++ b/MeshLib/CoordinateSystem.h
@@ -47,8 +47,7 @@ public:
     explicit CoordinateSystem(const Element &ele);
 
     /// Decides a coordinate system from a bounding box
-    template <class T>
-    explicit CoordinateSystem(const GeoLib::AABB<T> &bbox) : _type(getCoordinateSystem(bbox)) {}
+    explicit CoordinateSystem(const GeoLib::AABB &bbox) : _type(getCoordinateSystem(bbox)) {}
 
     /// get this coordinate type
     unsigned char getType() const { return _type; }
@@ -73,31 +72,10 @@ public:
     bool hasZ() const { return (_type & CoordinateSystemType::type::Z) != 0; }
 
 private:
-    template <class T>
-    unsigned char getCoordinateSystem(const GeoLib::AABB<T> &bbox) const;
+    unsigned char getCoordinateSystem(const GeoLib::AABB &bbox) const;
 
     unsigned char _type;
 };
-
-template <class T>
-unsigned char CoordinateSystem::getCoordinateSystem(const GeoLib::AABB<T> &bbox) const
-{
-    unsigned char coords = 0;
-
-    const MathLib::Vector3 pt_diff(bbox.getMinPoint(), bbox.getMaxPoint());
-
-    // The axis aligned bounding box is a from the right half-open interval.
-    // Therefore, the difference between the particular coordinates of the
-    // points is modified by the unit in the last place towards zero.
-    if (std::nexttoward(std::abs(pt_diff[0]), 0.0) > .0)
-        coords |= CoordinateSystemType::X;
-    if (std::nexttoward(std::abs(pt_diff[1]), 0.0) > .0)
-        coords |= CoordinateSystemType::Y;
-    if (std::nexttoward(std::abs(pt_diff[2]), 0.0) > .0)
-        coords |= CoordinateSystemType::Z;
-
-    return coords;
-}
 
 } // MeshLib
 

--- a/MeshLib/MeshEditing/Mesh2MeshPropertyInterpolation.cpp
+++ b/MeshLib/MeshEditing/Mesh2MeshPropertyInterpolation.cpp
@@ -48,8 +48,8 @@ bool Mesh2MeshPropertyInterpolation::setPropertiesForMesh(Mesh *dest_mesh, std::
 		return false;
 	}
 
-	GeoLib::AABB<MeshLib::Node> src_aabb(_src_mesh->getNodes().begin(), _src_mesh->getNodes().end());
-	GeoLib::AABB<MeshLib::Node> dest_aabb(dest_mesh->getNodes().begin(), dest_mesh->getNodes().end());
+	GeoLib::AABB src_aabb(_src_mesh->getNodes().begin(), _src_mesh->getNodes().end());
+	GeoLib::AABB dest_aabb(dest_mesh->getNodes().begin(), dest_mesh->getNodes().end());
 	if (!src_aabb.containsAABB(dest_aabb)) {
 		ERR("MeshLib::Mesh2MeshPropertyInterpolation::setPropertiesForMesh() source mesh to small.");
 		ERR("src_aabb: %f, %f, %f | %f, %f, %f", src_aabb.getMinPoint()[0], src_aabb.getMinPoint()[1], src_aabb.getMinPoint()[2], src_aabb.getMaxPoint()[0], src_aabb.getMaxPoint()[1], src_aabb.getMaxPoint()[2]);
@@ -89,7 +89,7 @@ void Mesh2MeshPropertyInterpolation::interpolatePropertiesForMesh(Mesh *dest_mes
 	for (std::size_t k(0); k<n_dest_elements; k++)
 	{
 		// compute axis aligned bounding box around the current element
-		const GeoLib::AABB<MeshLib::Node> elem_aabb(dest_elements[k]->getNodes(), dest_elements[k]->getNodes()+dest_elements[k]->getNBaseNodes());
+		const GeoLib::AABB elem_aabb(dest_elements[k]->getNodes(), dest_elements[k]->getNodes()+dest_elements[k]->getNBaseNodes());
 
 		// request "interesting" nodes from grid
 		std::vector<std::vector<MeshLib::Node*> const*> nodes;

--- a/MeshLib/MeshInformation.cpp
+++ b/MeshLib/MeshInformation.cpp
@@ -37,10 +37,10 @@ const std::pair<int, int> MeshInformation::getValueBounds(const MeshLib::Mesh &m
 	return {*(mat_bounds.first), *(mat_bounds.second)};
 }
 
-const GeoLib::AABB<MeshLib::Node> MeshInformation::getBoundingBox(const MeshLib::Mesh &mesh)
+const GeoLib::AABB MeshInformation::getBoundingBox(const MeshLib::Mesh &mesh)
 {
 	const std::vector<MeshLib::Node*> &nodes (mesh.getNodes());
-	return GeoLib::AABB<MeshLib::Node>(nodes.begin(), nodes.end());
+	return GeoLib::AABB(nodes.begin(), nodes.end());
 }
 
 const std::array<unsigned, 7> MeshInformation::getNumberOfElementTypes(const MeshLib::Mesh &mesh)

--- a/MeshLib/MeshInformation.h
+++ b/MeshLib/MeshInformation.h
@@ -33,7 +33,7 @@ public:
 	static const std::pair<int, int> getValueBounds(const MeshLib::Mesh &mesh);
 
 	/// Returns the bounding box of the mesh.
-	static const GeoLib::AABB<MeshLib::Node> getBoundingBox(const MeshLib::Mesh &mesh);
+	static const GeoLib::AABB getBoundingBox(const MeshLib::Mesh &mesh);
 
 	/**
 	 * Returns an array with the number of elements of each type in the given mesh.

--- a/MeshLib/MeshSearch/ElementSearch.cpp
+++ b/MeshLib/MeshSearch/ElementSearch.cpp
@@ -74,7 +74,7 @@ std::size_t ElementSearch::searchByContent(double eps)
 }
 
 std::size_t ElementSearch::searchByBoundingBox(
-	GeoLib::AABB<MathLib::Point3d> const& aabb)
+	GeoLib::AABB const& aabb)
 {
 	auto matchedIDs = filter(_mesh.getElements(),
 		[&aabb](MeshLib::Element* e) {

--- a/MeshLib/MeshSearch/ElementSearch.h
+++ b/MeshLib/MeshSearch/ElementSearch.h
@@ -41,7 +41,7 @@ public:
 	std::size_t searchByContent(double eps = std::numeric_limits<double>::epsilon());
 
 	/// Marks all elements with at least one node outside the bounding box spanned by x1 and x2;
-	std::size_t searchByBoundingBox(GeoLib::AABB<MathLib::Point3d> const& aabb);
+	std::size_t searchByBoundingBox(GeoLib::AABB const& aabb);
 
 	/// Marks all elements connecting to any of the given nodes
 	std::size_t searchByNodeIDs(const std::vector<std::size_t> &node_ids);

--- a/Tests/GeoLib/TestAABB.cpp
+++ b/Tests/GeoLib/TestAABB.cpp
@@ -40,7 +40,7 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPoints)
 	 }
 
 	 // construct from list points a axis algined bounding box
-	 GeoLib::AABB<GeoLib::Point> aabb(pnts_list.begin(), pnts_list.end());
+	 GeoLib::AABB aabb(pnts_list.begin(), pnts_list.end());
 
 	 MathLib::Point3d const& min_pnt(aabb.getMinPoint());
 	 MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
@@ -76,7 +76,7 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAList)
 	 }
 
 	 // construct from list points a axis algined bounding box
-	 GeoLib::AABB<GeoLib::Point> aabb(pnts_list.begin(), pnts_list.end());
+	 GeoLib::AABB aabb(pnts_list.begin(), pnts_list.end());
 
 	 MathLib::Point3d const& min_pnt(aabb.getMinPoint());
 	 MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
@@ -108,7 +108,7 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPointsInAVector)
 	 }
 
 	 // construct from list points a axis aligned bounding box
-	 GeoLib::AABB<GeoLib::Point> aabb(pnts.begin(), pnts.end());
+	 GeoLib::AABB aabb(pnts.begin(), pnts.end());
 
 	 MathLib::Point3d const& min_pnt(aabb.getMinPoint());
 	 MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
@@ -144,7 +144,7 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAVector)
 	 }
 
 	 // construct from list points a axis algined bounding box
-	 GeoLib::AABB<GeoLib::Point> aabb(pnts.begin(), pnts.end());
+	 GeoLib::AABB aabb(pnts.begin(), pnts.end());
 
 	 MathLib::Point3d const& min_pnt(aabb.getMinPoint());
 	 MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
@@ -182,7 +182,7 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomBox)
 	 }
 
 	 // construct from list points a axis aligned bounding box
-	 GeoLib::AABB<GeoLib::Point> aabb(pnts.begin(), pnts.end());
+	 GeoLib::AABB aabb(pnts.begin(), pnts.end());
 
 	 MathLib::Point3d const& min_pnt(aabb.getMinPoint());
 	 MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
@@ -209,7 +209,7 @@ TEST(GeoLib, AABBAllPointsWithNegativeCoordinatesI)
 	std::vector<std::size_t> ids;
 	ids.push_back(0);
 	ids.push_back(1);
-	GeoLib::AABB<GeoLib::Point> aabb(pnts, ids);
+	GeoLib::AABB aabb(pnts, ids);
 
 	MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
 
@@ -229,7 +229,7 @@ TEST(GeoLib, AABBAllPointsWithNegativeCoordinatesII)
 	pnts.push_back(GeoLib::Point(-10, -10, -10));
 
 	// construct from points of the vector a axis aligned bounding box
-	GeoLib::AABB<GeoLib::Point> aabb(pnts.begin(), pnts.end());
+	GeoLib::AABB aabb(pnts.begin(), pnts.end());
 
 	MathLib::Point3d const& max_pnt(aabb.getMaxPoint());
 
@@ -254,7 +254,7 @@ TEST(GeoLib, AABBSinglePoint)
 	ASSERT_EQ(1u, pnts.size());
 
 	// construct from points of the vector a axis aligned bounding box
-	GeoLib::AABB<GeoLib::Point> aabb(pnts.begin(), pnts.end());
+	GeoLib::AABB aabb(pnts.begin(), pnts.end());
 
 	double const to_lowest(std::numeric_limits<double>::lowest());
 	double const to_max(std::numeric_limits<double>::max());

--- a/Tests/GeoLib/TestAABB.cpp
+++ b/Tests/GeoLib/TestAABB.cpp
@@ -27,7 +27,7 @@
 TEST(GeoLibAABB, RandomNumberOfPointersToRandomPoints)
 {
 	/* initialize random seed: */
-	 srand ( static_cast<unsigned>(time(NULL)) );
+	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 100000);
 	 int box_size (rand());
 	 int half_box_size(box_size/2);
@@ -60,7 +60,7 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPoints)
 TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAList)
 {
 	/* initialize random seed: */
-	 srand ( static_cast<unsigned>(time(NULL)) );
+	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 1000000);
 	 int box_size (rand());
 	 int half_box_size(box_size/2);
@@ -89,7 +89,7 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAList)
 TEST(GeoLibAABB, RandomNumberOfPointersToRandomPointsInAVector)
 {
 	/* initialize random seed: */
-	 srand ( static_cast<unsigned>(time(NULL)) );
+	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 100000);
 	 int box_size (rand());
 	 int half_box_size(box_size/2);
@@ -101,7 +101,7 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPointsInAVector)
 		 pnts.push_back(new GeoLib::Point(rand() % box_size - half_box_size, rand() % box_size - half_box_size, rand() % box_size - half_box_size));
 	 }
 
-	 // construct from list points a axis algined bounding box
+	 // construct from list points a axis aligned bounding box
 	 GeoLib::AABB<GeoLib::Point> aabb(pnts.begin(), pnts.end());
 
 	 MathLib::Point3d const& min_pnt(aabb.getMinPoint());
@@ -122,7 +122,7 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPointsInAVector)
 TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAVector)
 {
 	/* initialize random seed: */
-	 srand ( static_cast<unsigned>(time(NULL)) );
+	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 1000000);
 	 int box_size (rand());
 	 int half_box_size(box_size/2);
@@ -151,7 +151,7 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAVector)
 TEST(GeoLibAABB, RandomNumberOfPointsRandomBox)
 {
 	/* initialize random seed: */
-	 srand (static_cast<unsigned>(time(NULL)));
+	 srand (static_cast<unsigned>(time(nullptr)));
 	 int n (rand() % 1000000);
 	 int box_size_x (rand());
 	 int box_size_y (rand());

--- a/Tests/GeoLib/TestAABB.cpp
+++ b/Tests/GeoLib/TestAABB.cpp
@@ -30,8 +30,8 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPoints)
 	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 100000);
 	 int box_size (rand());
-	 int half_box_size(box_size/2);
-	 int minus_half_box_size(-half_box_size);
+	 double half_box_size(box_size/2);
+	 double minus_half_box_size(-half_box_size);
 
 	 // fill list with points
 	 std::list<GeoLib::Point*> pnts_list;
@@ -48,6 +48,9 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPoints)
 	 ASSERT_LE(minus_half_box_size, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[2]) << "coordinate 2 of min_pnt is smaller than " << minus_half_box_size;
+
+	// since the interval is half-open we have to move the upper bound also
+	 half_box_size = std::nexttoward(half_box_size, std::numeric_limits<double>::max());
 	 ASSERT_GE(half_box_size, max_pnt[0]) << "coordinate 0 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[1]) << "coordinate 1 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[2]) << "coordinate 2 of max_pnt is greater than " << half_box_size;
@@ -63,8 +66,8 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAList)
 	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 1000000);
 	 int box_size (rand());
-	 int half_box_size(box_size/2);
-	 int minus_half_box_size(-half_box_size);
+	 double half_box_size(box_size/2);
+	 double minus_half_box_size(-half_box_size);
 
 	 // fill list with points
 	 std::list<GeoLib::Point> pnts_list;
@@ -81,6 +84,9 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAList)
 	 ASSERT_LE(minus_half_box_size, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[2]) << "coordinate 2 of min_pnt is smaller than " << minus_half_box_size;
+
+	// since the interval is half-open we have to move the upper bound also
+	 half_box_size = std::nexttoward(half_box_size, std::numeric_limits<double>::max());
 	 ASSERT_GE(half_box_size, max_pnt[0]) << "coordinate 0 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[1]) << "coordinate 1 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[2]) << "coordinate 2 of max_pnt is greater than " << half_box_size;
@@ -92,8 +98,8 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPointsInAVector)
 	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 100000);
 	 int box_size (rand());
-	 int half_box_size(box_size/2);
-	 int minus_half_box_size(-half_box_size);
+	 double half_box_size(box_size/2);
+	 double minus_half_box_size(-half_box_size);
 
 	 // fill list with points
 	 std::vector<GeoLib::Point*> pnts;
@@ -110,6 +116,9 @@ TEST(GeoLibAABB, RandomNumberOfPointersToRandomPointsInAVector)
 	 ASSERT_LE(minus_half_box_size, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[2]) << "coordinate 2 of min_pnt is smaller than " << minus_half_box_size;
+
+	// since the interval is half-open we have to move the upper bound also
+	 half_box_size = std::nexttoward(half_box_size, std::numeric_limits<double>::max());
 	 ASSERT_GE(half_box_size, max_pnt[0]) << "coordinate 0 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[1]) << "coordinate 1 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[2]) << "coordinate 2 of max_pnt is greater than " << half_box_size;
@@ -125,8 +134,8 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAVector)
 	 srand ( static_cast<unsigned>(time(nullptr)) );
 	 int n (rand() % 1000000);
 	 int box_size (rand());
-	 int half_box_size(box_size/2);
-	 int minus_half_box_size(-half_box_size);
+	 double half_box_size(box_size/2);
+	 double minus_half_box_size(-half_box_size);
 
 	 // fill list with points
 	 std::list<GeoLib::Point> pnts;
@@ -143,6 +152,9 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomPointInAVector)
 	 ASSERT_LE(minus_half_box_size, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size;
 	 ASSERT_LE(minus_half_box_size, min_pnt[2]) << "coordinate 2 of min_pnt is smaller than " << minus_half_box_size;
+
+	// since the interval is half-open we have to move the upper bound also
+	 half_box_size = std::nexttoward(half_box_size, std::numeric_limits<double>::max());
 	 ASSERT_GE(half_box_size, max_pnt[0]) << "coordinate 0 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[1]) << "coordinate 1 of max_pnt is greater than " << half_box_size;
 	 ASSERT_GE(half_box_size, max_pnt[2]) << "coordinate 2 of max_pnt is greater than " << half_box_size;
@@ -156,9 +168,9 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomBox)
 	 int box_size_x (rand());
 	 int box_size_y (rand());
 	 int box_size_z (rand());
-	 int half_box_size_x(box_size_x/2);
-	 int half_box_size_y(box_size_y/2);
-	 int half_box_size_z(box_size_z/2);
+	 double half_box_size_x(box_size_x/2);
+	 double half_box_size_y(box_size_y/2);
+	 double half_box_size_z(box_size_z/2);
 	 int minus_half_box_size_x(-half_box_size_x);
 	 int minus_half_box_size_y(-half_box_size_y);
 	 int minus_half_box_size_z(-half_box_size_z);
@@ -178,6 +190,11 @@ TEST(GeoLibAABB, RandomNumberOfPointsRandomBox)
 	 ASSERT_LE(minus_half_box_size_x, min_pnt[0]) << "coordinate 0 of min_pnt is smaller than " << minus_half_box_size_x;
 	 ASSERT_LE(minus_half_box_size_y, min_pnt[1]) << "coordinate 1 of min_pnt is smaller than " << minus_half_box_size_y;
 	 ASSERT_LE(minus_half_box_size_z, min_pnt[2]) << "coordinate 2 of min_pnt is smaller than " << minus_half_box_size_z;
+
+	// since the interval is half-open we have to move the upper bound also
+	 half_box_size_x = std::nexttoward(half_box_size_x, std::numeric_limits<double>::max());
+	 half_box_size_y = std::nexttoward(half_box_size_y, std::numeric_limits<double>::max());
+	 half_box_size_z = std::nexttoward(half_box_size_z, std::numeric_limits<double>::max());
 	 ASSERT_GE(half_box_size_x, max_pnt[0]) << "coordinate 0 of max_pnt is greater than " << half_box_size_x;
 	 ASSERT_GE(half_box_size_y, max_pnt[1]) << "coordinate 1 of max_pnt is greater than " << half_box_size_y;
 	 ASSERT_GE(half_box_size_z, max_pnt[2]) << "coordinate 2 of max_pnt is greater than " << half_box_size_z;
@@ -221,6 +238,9 @@ TEST(GeoLib, AABBAllPointsWithNegativeCoordinatesII)
 	ASSERT_NEAR(-1.0, max_pnt[2], std::numeric_limits<double>::epsilon());
 }
 
+// This test creates an AABB containing a single point.
+// This point is moved in every space direction to the next possible double value.
+// It is checked that the AABB contains the point iff it has not been moved.
 TEST(GeoLib, AABBSinglePoint)
 {
 	std::random_device rd;

--- a/Tests/GeoLib/TestOctTree.cpp
+++ b/Tests/GeoLib/TestOctTree.cpp
@@ -257,7 +257,7 @@ TEST_F(GeoLibOctTree, TestWithAlternatingPoints3d)
 	ps_ptr.push_back(new GeoLib::Point(6*small_displacement,0,0,5));
 	ps_ptr.push_back(new GeoLib::Point(5*small_displacement,1,0,6));
 
-	GeoLib::AABB<GeoLib::Point> const aabb(ps_ptr.cbegin(), ps_ptr.cend());
+	GeoLib::AABB const aabb(ps_ptr.cbegin(), ps_ptr.cend());
 	MathLib::Point3d min(aabb.getMinPoint());
 	MathLib::Point3d max(aabb.getMaxPoint());
 	std::unique_ptr<GeoLib::OctTree<GeoLib::Point, 8>> oct_tree(
@@ -308,7 +308,7 @@ TEST_F(GeoLibOctTree, TestSmallDistanceDifferentLeaves)
 	}
 
 	// create OctTree
-	GeoLib::AABB<GeoLib::Point> const aabb(ps_ptr.cbegin(), ps_ptr.cend());
+	GeoLib::AABB const aabb(ps_ptr.cbegin(), ps_ptr.cend());
 	MathLib::Point3d min(aabb.getMinPoint());
 	MathLib::Point3d max(aabb.getMaxPoint());
 	std::unique_ptr<GeoLib::OctTree<GeoLib::Point, 2>> oct_tree(
@@ -339,7 +339,7 @@ TEST_F(GeoLibOctTree, TestOctTreeWithTwoEqualPoints)
 	ps_ptr.push_back(new GeoLib::Point(0,0,0,1));
 	double const eps(0.0);
 
-	GeoLib::AABB<GeoLib::Point> aabb(ps_ptr.begin(), ps_ptr.end());
+	GeoLib::AABB aabb(ps_ptr.begin(), ps_ptr.end());
 	std::unique_ptr<GeoLib::OctTree<GeoLib::Point, 2>> oct_tree(
 		GeoLib::OctTree<GeoLib::Point, 2>::createOctTree(
 			aabb.getMinPoint(), aabb.getMaxPoint(), eps));
@@ -357,7 +357,7 @@ TEST_F(GeoLibOctTree, TestOctTreeWithTwoEqualPointsOne)
 	ps_ptr.push_back(new GeoLib::Point(1,1,1,1));
 	double const eps(0.0);
 
-	GeoLib::AABB<GeoLib::Point> aabb(ps_ptr.begin(), ps_ptr.end());
+	GeoLib::AABB aabb(ps_ptr.begin(), ps_ptr.end());
 	std::unique_ptr<GeoLib::OctTree<GeoLib::Point, 2>> oct_tree(
 		GeoLib::OctTree<GeoLib::Point, 2>::createOctTree(
 			aabb.getMinPoint(), aabb.getMaxPoint(), eps));
@@ -375,7 +375,7 @@ TEST_F(GeoLibOctTree, TestOctTreeOnCubicDomain)
 	ps_ptr.push_back(new GeoLib::Point(1,1,1,1));
 	double const eps(0.0);
 
-	GeoLib::AABB<GeoLib::Point> aabb(ps_ptr.begin(), ps_ptr.end());
+	GeoLib::AABB aabb(ps_ptr.begin(), ps_ptr.end());
 	std::unique_ptr<GeoLib::OctTree<GeoLib::Point, 2>> oct_tree(
 		GeoLib::OctTree<GeoLib::Point, 2>::createOctTree(
 			aabb.getMinPoint(), aabb.getMaxPoint(), eps));


### PR DESCRIPTION
Removing the template stuff makes 
- AABB more flexible and
- easier to use.

This PR is based on the PR #911 and must not be merged before PR #911.

**Update 2016-01-05**
All changes from PR #911 are included now in the PR.