### PR TITLE
Move up linear solver

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -84,9 +84,6 @@ ProjectData::~ProjectData()
 {
 	delete _geoObjects;
 
-	for(ProcessLib::Process<GlobalSetupType>* p : _processes)
-		delete p;
-
 	for (MeshLib::Mesh* m : _mesh_vec)
 		delete m;
 }

--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -84,7 +84,7 @@ ProjectData::~ProjectData()
 {
 	delete _geoObjects;
 
-	for(ProcessLib::Process* p : _processes)
+	for(ProcessLib::Process<GlobalSetupType>* p : _processes)
 		delete p;
 
 	for (MeshLib::Mesh* m : _mesh_vec)

--- a/Applications/ApplicationsLib/ProjectData.h
+++ b/Applications/ApplicationsLib/ProjectData.h
@@ -110,24 +110,24 @@ public:
 
 	/// Iterator access for processes.
 	/// Provides read access to the process container.
-	std::vector<ProcessLib::Process*>::const_iterator
+	std::vector<ProcessLib::Process<GlobalSetupType>*>::const_iterator
 	processesBegin() const
 	{
 		return _processes.begin();
 	}
-	std::vector<ProcessLib::Process*>::iterator
+	std::vector<ProcessLib::Process<GlobalSetupType>*>::iterator
 	processesBegin()
 	{
 		return _processes.begin();
 	}
 
 	/// Iterator access for processes as in processesBegin().
-	std::vector<ProcessLib::Process*>::const_iterator
+	std::vector<ProcessLib::Process<GlobalSetupType>*>::const_iterator
 	processesEnd() const
 	{
 		return _processes.end();
 	}
-	std::vector<ProcessLib::Process*>::iterator
+	std::vector<ProcessLib::Process<GlobalSetupType>*>::iterator
 	processesEnd()
 	{
 		return _processes.end();
@@ -187,7 +187,7 @@ private:
 private:
 	GeoLib::GEOObjects *_geoObjects = new GeoLib::GEOObjects();
 	std::vector<MeshLib::Mesh*> _mesh_vec;
-	std::vector<ProcessLib::Process*> _processes;
+	std::vector<ProcessLib::Process<GlobalSetupType>*> _processes;
 	std::vector<ProcessLib::ProcessVariable> _process_variables;
 
 	/// Buffer for each process' config used in the process building function.

--- a/Applications/ApplicationsLib/ProjectData.h
+++ b/Applications/ApplicationsLib/ProjectData.h
@@ -97,7 +97,7 @@ public:
 				// TODO at the moment we have only one mesh, later there can be
 				// several meshes. Then we have to assign the referenced mesh
 				// here.
-				_processes.push_back(
+				_processes.emplace_back(
 					new ProcessLib::GroundwaterFlowProcess<GlobalSetupType>(
 						*_mesh_vec[0], _process_variables, _parameters, pc));
 			}
@@ -110,24 +110,26 @@ public:
 
 	/// Iterator access for processes.
 	/// Provides read access to the process container.
-	std::vector<ProcessLib::Process<GlobalSetupType>*>::const_iterator
+	std::vector<
+	    std::unique_ptr<ProcessLib::Process<GlobalSetupType>>>::const_iterator
 	processesBegin() const
 	{
 		return _processes.begin();
 	}
-	std::vector<ProcessLib::Process<GlobalSetupType>*>::iterator
+	std::vector<std::unique_ptr<ProcessLib::Process<GlobalSetupType>>>::iterator
 	processesBegin()
 	{
 		return _processes.begin();
 	}
 
 	/// Iterator access for processes as in processesBegin().
-	std::vector<ProcessLib::Process<GlobalSetupType>*>::const_iterator
+	std::vector<
+	    std::unique_ptr<ProcessLib::Process<GlobalSetupType>>>::const_iterator
 	processesEnd() const
 	{
 		return _processes.end();
 	}
-	std::vector<ProcessLib::Process<GlobalSetupType>*>::iterator
+	std::vector<std::unique_ptr<ProcessLib::Process<GlobalSetupType>>>::iterator
 	processesEnd()
 	{
 		return _processes.end();
@@ -187,7 +189,8 @@ private:
 private:
 	GeoLib::GEOObjects *_geoObjects = new GeoLib::GEOObjects();
 	std::vector<MeshLib::Mesh*> _mesh_vec;
-	std::vector<ProcessLib::Process<GlobalSetupType>*> _processes;
+	std::vector<std::unique_ptr<ProcessLib::Process<GlobalSetupType>>>
+	    _processes;
 	std::vector<ProcessLib::ProcessVariable> _process_variables;
 
 	/// Buffer for each process' config used in the process building function.

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -219,7 +219,7 @@ public:
     {
         DBUG("Initialize GroundwaterFlowProcess.");
 
-        setInitialConditions(*_hydraulic_head);
+        setInitialConditions(*_hydraulic_head, 0);
 
         if (this->_mesh.getDimension()==1)
             createLocalAssemblers<1>();
@@ -231,15 +231,17 @@ public:
             assert(false);
     }
 
-    void setInitialConditions(ProcessVariable const& variable)
+    void setInitialConditions(ProcessVariable const& variable,
+                              int const component_id)
     {
         std::size_t const n = this->_mesh.getNNodes();
         for (std::size_t i = 0; i < n; ++i)
         {
             MeshLib::Location const l(this->_mesh.getID(),
                                       MeshLib::MeshItemType::Node, i);
-            auto const global_index = // 0 is the component id.
-              std::abs(this->_local_to_global_index_map->getGlobalIndex(l, 0) );
+            auto const global_index =  // 0 is the component id.
+                std::abs(this->_local_to_global_index_map->getGlobalIndex(
+                    l, component_id));
             this->_x->set(
                 global_index,
                 variable.getInitialConditionValue(*this->_mesh.getNode(i)));

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -193,9 +193,7 @@ public:
                     *_mesh_subset_all_nodes);
         }
 
-        for (auto bc : _neumann_bcs)
-            bc->initialize(this->_global_setup, *(this->_A), *(this->_rhs),
-                           this->_mesh.getDimension());
+        Process<GlobalSetup>::initializeNeumannBcs(_neumann_bcs);
     }
 
     void initializeMeshSubsets(MeshLib::Mesh const& mesh) override

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -215,23 +215,9 @@ public:
         return "gw_";
     }
 
-    void initialize() override
+    void init() override
     {
         DBUG("Initialize GroundwaterFlowProcess.");
-
-        DBUG("Construct dof mappings.");
-        initializeMeshSubsets(this->_mesh);
-
-        this->_local_to_global_index_map.reset(
-            new AssemblerLib::LocalToGlobalIndexMap(this->_all_mesh_subsets, AssemblerLib::ComponentOrder::BY_COMPONENT));
-
-        DBUG("Compute sparsity pattern");
-        Process<GlobalSetup>::computeSparsityPattern(
-            *this->_local_to_global_index_map);
-
-        // create global vectors and linear solver
-        Process<GlobalSetup>::createLinearSolver(*this->_local_to_global_index_map,
-                                                 getLinearSolverName());
 
         setInitialConditions(*_hydraulic_head);
 

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -254,9 +254,9 @@ public:
         }
     }
 
-    bool solve(const double /*delta_t*/) override
+    bool assemble(const double /*delta_t*/) override
     {
-        DBUG("Solve GroundwaterFlowProcess.");
+        DBUG("Assemble GroundwaterFlowProcess.");
 
         this->_A->setZero();
         MathLib::setMatrixSparsity(*this->_A, _sparsity_pattern);
@@ -272,8 +272,6 @@ public:
         MathLib::applyKnownSolution(*this->_A, *this->_rhs, *this->_x,
                                     _dirichlet_bc.global_ids,
                                     _dirichlet_bc.values);
-
-        this->_linear_solver->solve(*this->_rhs, *this->_x);
 
         return true;
     }

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -210,6 +210,11 @@ public:
         _all_mesh_subsets.push_back(new MeshLib::MeshSubsets(_mesh_subset_all_nodes));
     }
 
+    std::string getLinearSolverName() const override
+    {
+        return "gw_";
+    }
+
     void initialize() override
     {
         DBUG("Initialize GroundwaterFlowProcess.");
@@ -226,7 +231,7 @@ public:
 
         // create global vectors and linear solver
         Process<GlobalSetup>::createLinearSolver(*_local_to_global_index_map,
-                                                 "gw_");
+                                                 getLinearSolverName());
 
         setInitialConditions(*_hydraulic_head);
 

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -200,17 +200,22 @@ public:
                            this->_mesh.getDimension());
     }
 
+    void initializeMeshSubsets(MeshLib::Mesh const& mesh) override
+    {
+        // Create single component dof in every of the mesh's nodes.
+        _mesh_subset_all_nodes =
+            new MeshLib::MeshSubset(mesh, &mesh.getNodes());
+
+        // Collect the mesh subsets in a vector.
+        _all_mesh_subsets.push_back(new MeshLib::MeshSubsets(_mesh_subset_all_nodes));
+    }
+
     void initialize() override
     {
         DBUG("Initialize GroundwaterFlowProcess.");
 
         DBUG("Construct dof mappings.");
-        // Create single component dof in every of the mesh's nodes.
-        _mesh_subset_all_nodes =
-            new MeshLib::MeshSubset(this->_mesh, &this->_mesh.getNodes());
-
-        // Collect the mesh subsets in a vector.
-        _all_mesh_subsets.push_back(new MeshLib::MeshSubsets(_mesh_subset_all_nodes));
+        initializeMeshSubsets(this->_mesh);
 
         _local_to_global_index_map.reset(
             new AssemblerLib::LocalToGlobalIndexMap(_all_mesh_subsets, AssemblerLib::ComponentOrder::BY_COMPONENT));

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -20,7 +20,6 @@
 #include "logog/include/logog.hpp"
 
 #include "AssemblerLib/LocalAssemblerBuilder.h"
-#include "AssemblerLib/VectorMatrixAssembler.h"
 #include "AssemblerLib/LocalDataInitializer.h"
 
 #include "FileIO/VtkIO/VtuInterface.h"
@@ -159,10 +158,6 @@ public:
                 *_hydraulic_conductivity,
                 _integration_order);
 
-        DBUG("Create global assembler.");
-        _global_assembler.reset(new GlobalAssembler(
-            *(this->_A), *(this->_rhs), *this->_local_to_global_index_map));
-
         DBUG("Initialize boundary conditions.");
         MeshGeoToolsLib::MeshNodeSearcher& hydraulic_head_mesh_node_searcher =
             MeshGeoToolsLib::MeshNodeSearcher::getMeshNodeSearcher(
@@ -235,7 +230,8 @@ public:
         *this->_rhs = 0;   // This resets the whole vector.
 
         // Call global assembler for each local assembly item.
-        this->_global_setup.execute(*_global_assembler, _local_assemblers);
+        this->_global_setup.execute(*this->_global_assembler,
+                                    _local_assemblers);
 
         // Call global assembler for each Neumann boundary local assembler.
         for (auto bc : _neumann_bcs)
@@ -321,14 +317,6 @@ private:
         typename GlobalSetup::MatrixType, typename GlobalSetup::VectorType>;
 
     std::vector<LocalAssembler*> _local_assemblers;
-
-    using GlobalAssembler =
-        AssemblerLib::VectorMatrixAssembler<
-            typename GlobalSetup::MatrixType,
-            typename GlobalSetup::VectorType>;
-
-
-    std::unique_ptr<GlobalAssembler> _global_assembler;
 
     /// Global ids in the global matrix/vector where the dirichlet bc is
     /// imposed and their corresponding values.

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -22,12 +22,10 @@
 #include "AssemblerLib/LocalAssemblerBuilder.h"
 #include "AssemblerLib/VectorMatrixAssembler.h"
 #include "AssemblerLib/LocalDataInitializer.h"
-#include "AssemblerLib/ComputeSparsityPattern.h"
 
 #include "FileIO/VtkIO/VtuInterface.h"
 
 #include "MathLib/LinAlg/ApplyKnownSolution.h"
-#include "MathLib/LinAlg/SetMatrixSparsity.h"
 
 #include "MeshLib/MeshSubset.h"
 #include "MeshLib/MeshSubsets.h"
@@ -218,10 +216,8 @@ public:
             new AssemblerLib::LocalToGlobalIndexMap(_all_mesh_subsets, AssemblerLib::ComponentOrder::BY_COMPONENT));
 
         DBUG("Compute sparsity pattern");
-        _sparsity_pattern = std::move(
-            AssemblerLib::computeSparsityPattern(
-                *_local_to_global_index_map, this->_mesh));
-
+        Process<GlobalSetup>::computeSparsityPattern(
+            *_local_to_global_index_map);
 
         // create global vectors and linear solver
         Process<GlobalSetup>::createLinearSolver(*_local_to_global_index_map,
@@ -258,8 +254,6 @@ public:
     {
         DBUG("Assemble GroundwaterFlowProcess.");
 
-        this->_A->setZero();
-        MathLib::setMatrixSparsity(*this->_A, _sparsity_pattern);
         *this->_rhs = 0;   // This resets the whole vector.
 
         // Call global assembler for each local assembly item.
@@ -372,8 +366,6 @@ private:
     } _dirichlet_bc;
 
     std::vector<NeumannBc<GlobalSetup>*> _neumann_bcs;
-
-    AssemblerLib::SparsityPattern _sparsity_pattern;
 };
 
 }   // namespace ProcessLib

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -28,7 +28,6 @@
 #include "MathLib/LinAlg/ApplyKnownSolution.h"
 
 #include "MeshLib/MeshSubset.h"
-#include "MeshLib/MeshSubsets.h"
 #include "MeshGeoToolsLib/MeshNodeSearcher.h"
 
 #include "UniformDirichletBoundaryCondition.h"
@@ -207,7 +206,8 @@ public:
             new MeshLib::MeshSubset(mesh, &mesh.getNodes());
 
         // Collect the mesh subsets in a vector.
-        _all_mesh_subsets.push_back(new MeshLib::MeshSubsets(_mesh_subset_all_nodes));
+        this->_all_mesh_subsets.push_back(
+            new MeshLib::MeshSubsets(_mesh_subset_all_nodes));
     }
 
     std::string getLinearSolverName() const override
@@ -223,7 +223,7 @@ public:
         initializeMeshSubsets(this->_mesh);
 
         _local_to_global_index_map.reset(
-            new AssemblerLib::LocalToGlobalIndexMap(_all_mesh_subsets, AssemblerLib::ComponentOrder::BY_COMPONENT));
+            new AssemblerLib::LocalToGlobalIndexMap(this->_all_mesh_subsets, AssemblerLib::ComponentOrder::BY_COMPONENT));
 
         DBUG("Compute sparsity pattern");
         Process<GlobalSetup>::computeSparsityPattern(
@@ -339,9 +339,6 @@ public:
         for (auto p : _local_assemblers)
             delete p;
 
-        for (auto p : _all_mesh_subsets)
-            delete p;
-
         delete _mesh_subset_all_nodes;
     }
 
@@ -351,7 +348,6 @@ private:
     Parameter<double, MeshLib::Element const&> const* _hydraulic_conductivity = nullptr;
 
     MeshLib::MeshSubset const* _mesh_subset_all_nodes = nullptr;
-    std::vector<MeshLib::MeshSubsets*> _all_mesh_subsets;
 
     using LocalAssembler = GroundwaterFlow::LocalAssemblerDataInterface<
         typename GlobalSetup::MatrixType, typename GlobalSetup::VectorType>;

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -13,8 +13,9 @@
 #include <cassert>
 #include <memory>
 
-#include <boost/optional.hpp>
 #include <boost/algorithm/string/erase.hpp>
+#include <boost/optional.hpp>
+
 
 #include "logog/include/logog.hpp"
 
@@ -130,14 +131,10 @@ public:
         }
 
         // Linear solver options
-        {
-            auto const par = config.get_child_optional("linear_solver");
-
-            if (par)
-            {
-                this->_linear_solver_options.reset(new BaseLib::ConfigTree(*par));
-            }
-        }
+        if (auto const& linear_solver_options =
+                config.get_child_optional("linear_solver"))
+            Process<GlobalSetup>::setLinearSolverOptions(
+                *linear_solver_options);
     }
 
     template <unsigned GlobalDim>

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -37,7 +37,6 @@
 #include "NeumannBc.h"
 #include "Parameter.h"
 #include "Process.h"
-#include "ProcessVariable.h"
 
 namespace MeshLib
 {
@@ -219,7 +218,7 @@ public:
     {
         DBUG("Initialize GroundwaterFlowProcess.");
 
-        setInitialConditions(*_hydraulic_head, 0);
+        Process<GlobalSetup>::setInitialConditions(*_hydraulic_head, 0);
 
         if (this->_mesh.getDimension()==1)
             createLocalAssemblers<1>();
@@ -229,23 +228,6 @@ public:
             createLocalAssemblers<3>();
         else
             assert(false);
-    }
-
-    void setInitialConditions(ProcessVariable const& variable,
-                              int const component_id)
-    {
-        std::size_t const n = this->_mesh.getNNodes();
-        for (std::size_t i = 0; i < n; ++i)
-        {
-            MeshLib::Location const l(this->_mesh.getID(),
-                                      MeshLib::MeshItemType::Node, i);
-            auto const global_index =  // 0 is the component id.
-                std::abs(this->_local_to_global_index_map->getGlobalIndex(
-                    l, component_id));
-            this->_x->set(
-                global_index,
-                variable.getInitialConditionValue(*this->_mesh.getNode(i)));
-        }
     }
 
     bool assemble(const double /*delta_t*/) override

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -12,6 +12,8 @@
 
 #include <string>
 
+#include "BaseLib/ConfigTree.h"
+
 namespace MeshLib
 {
     class Mesh;
@@ -20,6 +22,7 @@ namespace MeshLib
 namespace ProcessLib
 {
 
+template<typename GlobalSetup>
 class Process
 {
 public:
@@ -39,6 +42,15 @@ public:
 
 protected:
     MeshLib::Mesh& _mesh;
+
+    GlobalSetup _global_setup;
+
+    std::unique_ptr<BaseLib::ConfigTree> _linear_solver_options;
+    std::unique_ptr<typename GlobalSetup::LinearSolver> _linear_solver;
+
+    std::unique_ptr<typename GlobalSetup::MatrixType> _A;
+    std::unique_ptr<typename GlobalSetup::VectorType> _rhs;
+    std::unique_ptr<typename GlobalSetup::VectorType> _x;
 };
 
 }   // namespace ProcessLib

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -38,6 +38,14 @@ public:
 	                          const unsigned timestep) = 0;
 
 protected:
+	/// Set linear solver options; called by the derived process which is
+	/// parsing the configuration.
+	void setLinearSolverOptions(const BaseLib::ConfigTree& config)
+	{
+		_linear_solver_options.reset(new BaseLib::ConfigTree(config));
+	}
+
+protected:
 	MeshLib::Mesh& _mesh;
 
 	GlobalSetup _global_setup;

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "AssemblerLib/ComputeSparsityPattern.h"
+#include "AssemblerLib/VectorMatrixAssembler.h"
 #include "AssemblerLib/LocalToGlobalIndexMap.h"
 #include "BaseLib/ConfigTree.h"
 #include "MathLib/LinAlg/SetMatrixSparsity.h"
@@ -76,6 +77,10 @@ public:
 
 		// create global vectors and linear solver
 		createLinearSolver(getLinearSolverName());
+
+		DBUG("Create global assembler.");
+		_global_assembler.reset(
+		    new GlobalAssembler(*_A, *_rhs, *_local_to_global_index_map));
 
 		init();  // Execute proces specific initialization.
 	}
@@ -159,6 +164,12 @@ protected:
 	std::vector<MeshLib::MeshSubsets*> _all_mesh_subsets;
 
 	GlobalSetup _global_setup;
+
+	using GlobalAssembler =
+	    AssemblerLib::VectorMatrixAssembler<typename GlobalSetup::MatrixType,
+	                                        typename GlobalSetup::VectorType>;
+
+	std::unique_ptr<GlobalAssembler> _global_assembler;
 
 	std::unique_ptr<AssemblerLib::LocalToGlobalIndexMap>
 	    _local_to_global_index_map;

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -16,43 +16,40 @@
 
 namespace MeshLib
 {
-    class Mesh;
+class Mesh;
 }
 
 namespace ProcessLib
 {
-
-template<typename GlobalSetup>
+template <typename GlobalSetup>
 class Process
 {
 public:
-    Process(MeshLib::Mesh& mesh)
-        : _mesh(mesh)
-    { }
+	Process(MeshLib::Mesh& mesh) : _mesh(mesh) {}
+	virtual ~Process() = default;
 
-    virtual ~Process() = default;
+	virtual void initialize() = 0;
+	virtual bool solve(const double delta_t) = 0;
 
-    virtual void initialize() = 0;
-    virtual bool solve(const double delta_t) = 0;
-
-    /// Postprocessing after solve().
-    /// The file_name is indicating the name of possible output file.
-    virtual void post(std::string const& file_name) = 0;
-    virtual void postTimestep(std::string const& file_name, const unsigned timestep) = 0;
+	/// Postprocessing after solve().
+	/// The file_name is indicating the name of possible output file.
+	virtual void post(std::string const& file_name) = 0;
+	virtual void postTimestep(std::string const& file_name,
+	                          const unsigned timestep) = 0;
 
 protected:
-    MeshLib::Mesh& _mesh;
+	MeshLib::Mesh& _mesh;
 
-    GlobalSetup _global_setup;
+	GlobalSetup _global_setup;
 
-    std::unique_ptr<BaseLib::ConfigTree> _linear_solver_options;
-    std::unique_ptr<typename GlobalSetup::LinearSolver> _linear_solver;
+	std::unique_ptr<BaseLib::ConfigTree> _linear_solver_options;
+	std::unique_ptr<typename GlobalSetup::LinearSolver> _linear_solver;
 
-    std::unique_ptr<typename GlobalSetup::MatrixType> _A;
-    std::unique_ptr<typename GlobalSetup::VectorType> _rhs;
-    std::unique_ptr<typename GlobalSetup::VectorType> _x;
+	std::unique_ptr<typename GlobalSetup::MatrixType> _A;
+	std::unique_ptr<typename GlobalSetup::VectorType> _rhs;
+	std::unique_ptr<typename GlobalSetup::VectorType> _x;
 };
 
-}   // namespace ProcessLib
+}  // namespace ProcessLib
 
 #endif  // PROCESS_LIB_PROCESS_H_

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -23,6 +23,8 @@
 #include "MathLib/LinAlg/PETSc/PETScMatrixOption.h"
 #endif
 
+#include "ProcessVariable.h"
+
 namespace MeshLib
 {
 class Mesh;
@@ -126,6 +128,24 @@ protected:
 	{
 		_sparsity_pattern = std::move(AssemblerLib::computeSparsityPattern(
 		    *_local_to_global_index_map, _mesh));
+	}
+
+
+	/// Sets the initial condition values in the solution vector x for a given
+	/// process variable and component.
+	void setInitialConditions(ProcessVariable const& variable,
+	                          int const component_id)
+	{
+		std::size_t const n = _mesh.getNNodes();
+		for (std::size_t i = 0; i < n; ++i)
+		{
+			MeshLib::Location const l(_mesh.getID(),
+			                          MeshLib::MeshItemType::Node, i);
+			auto const global_index = std::abs(
+			    _local_to_global_index_map->getGlobalIndex(l, component_id));
+			_x->set(global_index,
+			        variable.getInitialConditionValue(*_mesh.getNode(i)));
+		}
 	}
 
 protected:

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -35,13 +35,21 @@ public:
 	virtual ~Process() = default;
 
 	virtual void initialize() = 0;
-	virtual bool solve(const double delta_t) = 0;
+	virtual bool assemble(const double delta_t) = 0;
 
 	/// Postprocessing after solve().
 	/// The file_name is indicating the name of possible output file.
 	virtual void post(std::string const& file_name) = 0;
 	virtual void postTimestep(std::string const& file_name,
 	                          const unsigned timestep) = 0;
+
+	bool solve(const double delta_t)
+	{
+		bool const result = assemble(delta_t);
+
+		_linear_solver->solve(*_rhs, *_x);
+		return result;
+	}
 
 protected:
 	/// Set linear solver options; called by the derived process which is

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -114,6 +114,9 @@ protected:
 
 	GlobalSetup _global_setup;
 
+	std::unique_ptr<AssemblerLib::LocalToGlobalIndexMap>
+	    _local_to_global_index_map;
+
 	std::unique_ptr<BaseLib::ConfigTree> _linear_solver_options;
 	std::unique_ptr<typename GlobalSetup::LinearSolver> _linear_solver;
 

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -110,6 +110,24 @@ protected:
 		_linear_solver_options.reset(new BaseLib::ConfigTree(config));
 	}
 
+	/// Sets the initial condition values in the solution vector x for a given
+	/// process variable and component.
+	void setInitialConditions(ProcessVariable const& variable,
+	                          int const component_id)
+	{
+		std::size_t const n = _mesh.getNNodes();
+		for (std::size_t i = 0; i < n; ++i)
+		{
+			MeshLib::Location const l(_mesh.getID(),
+			                          MeshLib::MeshItemType::Node, i);
+			auto const global_index = std::abs(
+			    _local_to_global_index_map->getGlobalIndex(l, component_id));
+			_x->set(global_index,
+			        variable.getInitialConditionValue(*_mesh.getNode(i)));
+		}
+	}
+
+private:
 	/// Creates global matrix, rhs and solution vectors, and the linear solver.
 	void createLinearSolver(std::string const& solver_name)
 	{
@@ -139,24 +157,6 @@ protected:
 	{
 		_sparsity_pattern = std::move(AssemblerLib::computeSparsityPattern(
 		    *_local_to_global_index_map, _mesh));
-	}
-
-
-	/// Sets the initial condition values in the solution vector x for a given
-	/// process variable and component.
-	void setInitialConditions(ProcessVariable const& variable,
-	                          int const component_id)
-	{
-		std::size_t const n = _mesh.getNNodes();
-		for (std::size_t i = 0; i < n; ++i)
-		{
-			MeshLib::Location const l(_mesh.getID(),
-			                          MeshLib::MeshItemType::Node, i);
-			auto const global_index = std::abs(
-			    _local_to_global_index_map->getGlobalIndex(l, component_id));
-			_x->set(global_index,
-			        variable.getInitialConditionValue(*_mesh.getNode(i)));
-		}
 	}
 
 protected:

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -12,7 +12,13 @@
 
 #include <string>
 
+#include "AssemblerLib/LocalToGlobalIndexMap.h"
 #include "BaseLib/ConfigTree.h"
+
+#ifdef USE_PETSC
+#include "MeshLib/NodePartitionedMesh.h"
+#include "MathLib/LinAlg/PETSc/PETScMatrixOption.h"
+#endif
 
 namespace MeshLib
 {
@@ -44,6 +50,32 @@ protected:
 	{
 		_linear_solver_options.reset(new BaseLib::ConfigTree(config));
 	}
+
+	/// Creates global matrix, rhs and solution vectors, and the linear solver.
+	void createLinearSolver(
+	    AssemblerLib::LocalToGlobalIndexMap const& local_to_global_index_map,
+	    std::string const solver_name)
+	{
+		DBUG("Allocate global matrix, vectors, and linear solver.");
+#ifdef USE_PETSC
+		MathLib::PETScMatrixOption mat_opt;
+		const MeshLib::NodePartitionedMesh& pmesh =
+		    static_cast<const MeshLib::NodePartitionedMesh&>(_mesh);
+		mat_opt.d_nz = pmesh.getMaximumNConnectedNodesToNode();
+		mat_opt.o_nz = mat_opt.d_nz;
+		const std::size_t num_unknowns =
+		    local_to_global_index_map.dofSizeGlobal();
+		_A.reset(_global_setup.createMatrix(num_unknowns, mat_opt));
+#else
+		const std::size_t num_unknowns = local_to_global_index_map.dofSize();
+		_A.reset(_global_setup.createMatrix(num_unknowns));
+#endif
+		_x.reset(_global_setup.createVector(num_unknowns));
+		_rhs.reset(_global_setup.createVector(num_unknowns));
+		_linear_solver.reset(new typename GlobalSetup::LinearSolver(
+		    *_A, solver_name, _linear_solver_options.get()));
+	}
+
 
 protected:
 	MeshLib::Mesh& _mesh;

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -45,6 +45,9 @@ public:
 	virtual void postTimestep(std::string const& file_name,
 	                          const unsigned timestep) = 0;
 
+	/// Creates mesh subsets, i.e. components, for given mesh.
+	virtual void initializeMeshSubsets(MeshLib::Mesh const& mesh) = 0;
+
 	bool solve(const double delta_t)
 	{
 		_A->setZero();

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -39,6 +39,8 @@ public:
 	virtual void initialize() = 0;
 	virtual bool assemble(const double delta_t) = 0;
 
+	virtual std::string getLinearSolverName() const = 0;
+
 	/// Postprocessing after solve().
 	/// The file_name is indicating the name of possible output file.
 	virtual void post(std::string const& file_name) = 0;

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -16,6 +16,7 @@
 #include "AssemblerLib/LocalToGlobalIndexMap.h"
 #include "BaseLib/ConfigTree.h"
 #include "MathLib/LinAlg/SetMatrixSparsity.h"
+#include "MeshLib/MeshSubsets.h"
 
 #ifdef USE_PETSC
 #include "MeshLib/NodePartitionedMesh.h"
@@ -34,7 +35,11 @@ class Process
 {
 public:
 	Process(MeshLib::Mesh& mesh) : _mesh(mesh) {}
-	virtual ~Process() = default;
+	virtual ~Process()
+	{
+		for (auto p : _all_mesh_subsets)
+			delete p;
+	}
 
 	virtual void initialize() = 0;
 	virtual bool assemble(const double delta_t) = 0;
@@ -105,6 +110,7 @@ protected:
 
 protected:
 	MeshLib::Mesh& _mesh;
+	std::vector<MeshLib::MeshSubsets*> _all_mesh_subsets;
 
 	GlobalSetup _global_setup;
 

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -80,6 +80,12 @@ public:
 		init();  // Execute proces specific initialization.
 	}
 
+	void initializeNeumannBcs(std::vector<NeumannBc<GlobalSetup>*> const& bcs)
+	{
+		for (auto bc : bcs)
+			bc->initialize(_global_setup, *_A, *_rhs, _mesh.getDimension());
+	}
+
 	bool solve(const double delta_t)
 	{
 		_A->setZero();


### PR DESCRIPTION
This is one step (of many following) to separate process specific functionality (like for the GroundwaterFlowProcess) from common parts of all monolithic processes. This is required for introduction of non-linear solver loop which will control the linear solver solve calls.

In this PR there is no functionality change nor their is any (but unavoidable) generalization, for example to handle multiple DOF per node. It's just moving some of the GroundwaterFlowProcess variables up into the Process class. Following the variables there are some functions.

Major changes in functions are:
 - Process::solve() is split into two parts: GroundwaterFlowProcess::assemble() followed common linear solver solve call.
 - Process::initialize() is split into two parts: Common process initialization and specific GroundwaterFlowProcess::init() part.

There is one thing I like to point out: because the GroundwaterFlow class is derived from a template Process<GlobalSetup> `this` pointer is used to access Process<GlobalSetup>'s protected variables; I'll reduce their numbers in following PRs when more interfaces will be introduced.


_Update:_ I'v just seen that diff for the review look like a mess, so maybe commit-wise review is easier...