### PR TITLE
Conversion tool + warning

### DIFF
--- a/Applications/Utils/OGSFileConverter/FileList.ui
+++ b/Applications/Utils/OGSFileConverter/FileList.ui
@@ -10,11 +10,22 @@
     <height>300</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="font">
+   <font>
+    <pointsize>8</pointsize>
+   </font>
+  </property>
   <property name="windowTitle">
    <string>FileList</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="5" column="1" colspan="2">
+   <item row="6" column="1" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -24,7 +35,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="2" column="2">
     <widget class="QPushButton" name="addButton">
      <property name="minimumSize">
       <size>
@@ -43,7 +54,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="3" column="2">
     <widget class="QPushButton" name="removeButton">
      <property name="minimumSize">
       <size>
@@ -62,7 +73,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
+   <item row="4" column="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -75,17 +86,17 @@
      </property>
     </spacer>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QLineEdit" name="outputDirEdit"/>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="saveLabel">
      <property name="text">
       <string>Save to:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="2">
+   <item row="5" column="2">
     <widget class="QPushButton" name="browseButton">
      <property name="minimumSize">
       <size>
@@ -104,13 +115,37 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" rowspan="3" colspan="2">
+   <item row="2" column="0" rowspan="3" colspan="2">
     <widget class="QListView" name="listView"/>
    </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="label">
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="addSourcesLabel">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
      <property name="text">
       <string>Add source files to convert:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="3">
+    <widget class="QLabel" name="warningLabel">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>1</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>1</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>.</string>
      </property>
     </widget>
    </item>

--- a/Applications/Utils/OGSFileConverter/FileListDialog.cpp
+++ b/Applications/Utils/OGSFileConverter/FileListDialog.cpp
@@ -18,12 +18,17 @@
 #include "StringTools.h"
 #include <QSettings>
 #include <QFileInfo>
+#include <QFont>
 #include <QLineEdit>
 
 FileListDialog::FileListDialog(FileType input, FileType output, QWidget* parent)
 : QDialog(parent), _output_dir(""), _input_file_type(input), _output_file_type(output)
 {
 	setupUi(this);
+
+	if (_input_file_type == FileType::VTU && _output_file_type == FileType::MSH)
+		displayWarningLabel();
+
 	this->listView->setModel(&_allFiles);
 }
 
@@ -97,3 +102,16 @@ const QString FileListDialog::getFileTypeString(FileType file_type) const
 	else if (file_type==FileType::MSH) return "GeoSys mesh files (*.msh)";
 	else return "All files (*.*)";
 }
+
+void FileListDialog::displayWarningLabel() const
+{
+	this->warningLabel->setFixedWidth(300);
+	this->warningLabel->setFixedHeight(40);
+	QFont font = this->warningLabel->font();
+	font.setPointSize(9);
+	font.setBold(true);
+	warningLabel->setFont(font);
+	this->warningLabel->setStyleSheet("QLabel { color : red; }");
+	this->warningLabel->setText("Warning: all scalar information except<br />MaterialIDs will be lost!");
+}
+

--- a/Applications/Utils/OGSFileConverter/FileListDialog.h
+++ b/Applications/Utils/OGSFileConverter/FileListDialog.h
@@ -40,6 +40,7 @@ public:
 
 private:
 	const QString getFileTypeString(FileType file_type) const;
+	void displayWarningLabel() const;
 
 	QStringListModel _allFiles;
 	QString _output_dir;

--- a/Applications/Utils/OGSFileConverter/FileListDialog.h
+++ b/Applications/Utils/OGSFileConverter/FileListDialog.h
@@ -27,19 +27,28 @@ enum class FileType {
 	MSH,	// ascii-meshes
 };
 
+/**
+ * A list of selected files selected for conversion incl. an output directory.
+ */
 class FileListDialog : public QDialog, private Ui_FileList
 {
 	Q_OBJECT
 
 public:
-	FileListDialog(FileType input, FileType output, QWidget* parent = NULL);
+	/// Constructor
+	FileListDialog(FileType input, FileType output, QWidget* parent = nullptr);
+	/// Destructor
 	~FileListDialog(void);
 
+	/// Returns list of all selected files
 	const QStringList getInputFileList() const { return _allFiles.stringList(); };
+	/// Returns selected output directory
 	const QString getOutputDir() const { return _output_dir; };
 
 private:
+	/// Returns a string for the given file type enum
 	const QString getFileTypeString(FileType file_type) const;
+	/// Display a warning for vtu- to msh-conversion
 	void displayWarningLabel() const;
 
 	QStringListModel _allFiles;

--- a/Applications/Utils/OGSFileConverter/OGSFileConverter.h
+++ b/Applications/Utils/OGSFileConverter/OGSFileConverter.h
@@ -18,15 +18,21 @@
 #include "ui_OGSFileConverter.h"
 #include <QDialog>
 
+/**
+ * A conversion tool for ogs5 and ogs6 files
+ */
 class OGSFileConverter : public QDialog, private Ui_OGSFileConverter
 {
 	Q_OBJECT
 
 public:
-	OGSFileConverter(QWidget* parent = 0);
+	/// Constructor
+	OGSFileConverter(QWidget* parent = nullptr);
+	/// Destructor
 	~OGSFileConverter(void);
 
 private:
+	/// Checks if a given file already exists
 	bool fileExists(const std::string &file_name) const;
 
 private slots:


### PR DESCRIPTION
Added a warning for vtu to msh conversion that all scalar data will be lost (except mat ids).
Geometry + mesh conversion work in both directions, bc's are still deactivated.