### PR TITLE
ConfigTree -- Follow-Up PR

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.h
+++ b/Applications/ApplicationsLib/ProjectData.h
@@ -107,6 +107,10 @@ public:
 				ERR("Unknown process type: %s\n", type.c_str());
 			}
 		}
+
+		// process configs are not needed anymore, so clear the storage
+		// in order to trigger config tree checks
+		_process_configs.clear();
 	}
 
 	/// Iterator access for processes.

--- a/Applications/ApplicationsLib/ProjectData.h
+++ b/Applications/ApplicationsLib/ProjectData.h
@@ -15,7 +15,7 @@
 
 #include <memory>
 
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 
 #include "GeoLib/GEOObjects.h"
 
@@ -45,7 +45,7 @@ public:
 	/// Constructs project data by parsing provided configuration.
 	/// The additional  path is used to find files referenced in the
 	/// configuration.
-	ProjectData(BaseLib::ConfigTree const& config_tree,
+	ProjectData(BaseLib::ConfigTreeNew const& config_tree,
 	            std::string const& path);
 
 	ProjectData(ProjectData&) = delete;
@@ -89,9 +89,10 @@ public:
 	template <typename GlobalSetupType>
 	void buildProcesses()
 	{
-		for (auto pc : _process_configs)
+		for (auto const& pc : _process_configs)
 		{
-			if (pc.get<std::string>("type") == "GROUNDWATER_FLOW") {
+			auto const type = pc.peekConfParam<std::string>("type");
+			if (type == "GROUNDWATER_FLOW") {
 				// The existence check of the in the configuration referenced
 				// process variables is checked in the physical process.
 				// TODO at the moment we have only one mesh, later there can be
@@ -103,7 +104,7 @@ public:
 			}
 			else
 			{
-				WARN("Unknown process type: %s\n", pc.get<std::string>("type").c_str());
+				ERR("Unknown process type: %s\n", type.c_str());
 			}
 		}
 	}
@@ -169,22 +170,22 @@ private:
 	/// Parses the process variables configuration and creates new variables for
 	/// each variable entry passing the corresponding subtree to the process
 	/// variable constructor.
-	void parseProcessVariables(BaseLib::ConfigTreeNew& process_variables_config);
+	void parseProcessVariables(BaseLib::ConfigTreeNew const& process_variables_config);
 
 	/// Parses the parameters configuration and saves them in a list.
 	/// Checks if a parameter has name tag.
-	void parseParameters(BaseLib::ConfigTree const& parameters_config);
+	void parseParameters(BaseLib::ConfigTreeNew const& parameters_config);
 
 	/// Parses the processes configuration and creates new processes for each
 	/// process entry passing the corresponding subtree to the process
 	/// constructor.
-	void parseProcesses(BaseLib::ConfigTree const& process_config);
+	void parseProcesses(BaseLib::ConfigTreeNew const& process_config);
 
 	/// Parses the output configuration.
 	/// Parses the file tag and sets output file prefix.
-	void parseOutput(BaseLib::ConfigTree const& output_config, std::string const& path);
+	void parseOutput(BaseLib::ConfigTreeNew const& output_config, std::string const& path);
 
-	void parseTimeStepping(BaseLib::ConfigTree const& timestepping_config);
+	void parseTimeStepping(BaseLib::ConfigTreeNew const& timestepping_config);
 
 private:
 	GeoLib::GEOObjects *_geoObjects = new GeoLib::GEOObjects();
@@ -194,7 +195,7 @@ private:
 	std::vector<ProcessLib::ProcessVariable> _process_variables;
 
 	/// Buffer for each process' config used in the process building function.
-	std::vector<BaseLib::ConfigTree> _process_configs;
+	std::vector<BaseLib::ConfigTreeNew> _process_configs;
 
 	/// Buffer for each parameter config passed to the process.
 	std::vector<std::unique_ptr<ProcessLib::ParameterBase>> _parameters;

--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -17,6 +17,7 @@
 // BaseLib
 #include "BaseLib/BuildInfo.h"
 #include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 #include "BaseLib/FileTools.h"
 
 #include "Applications/ApplicationsLib/LinearSolverLibrarySetup.h"
@@ -100,10 +101,8 @@ int main(int argc, char *argv[])
 	BaseLib::ConfigTree project_config =
 	    BaseLib::read_xml_config(project_arg.getValue());
 
-	project_config = project_config.get_child("OpenGeoSysProject");
-
-	ProjectData project(project_config,
-			BaseLib::extractPath(project_arg.getValue()));
+	BaseLib::ConfigTreeNew conf(project_config.get_child("OpenGeoSysProject"));
+	ProjectData project(conf, BaseLib::extractPath(project_arg.getValue()));
 
 	// Create processes.
 	project.buildProcesses<GlobalSetupType>();

--- a/BaseLib/ConfigTreeNew-impl.h
+++ b/BaseLib/ConfigTreeNew-impl.h
@@ -33,7 +33,7 @@ private:
 template<typename T>
 T
 ConfigTreeNew::
-getConfParam(std::string const& param)
+getConfParam(std::string const& param) const
 {
     auto p = getConfParamOptional<T>(param);
     if (p) return *p;
@@ -45,7 +45,7 @@ getConfParam(std::string const& param)
 template<typename T>
 T
 ConfigTreeNew::
-getConfParam(std::string const& param, T const& default_value)
+getConfParam(std::string const& param, T const& default_value) const
 {
     auto p = getConfParamOptional<T>(param);
     if (p) return *p;
@@ -55,7 +55,7 @@ getConfParam(std::string const& param, T const& default_value)
 template<typename T>
 boost::optional<T>
 ConfigTreeNew::
-getConfParamOptional(std::string const& param)
+getConfParamOptional(std::string const& param) const
 {
     checkUnique(param);
     auto p = _tree->get_child_optional(param);
@@ -79,7 +79,7 @@ getConfParamOptional(std::string const& param)
 template<typename T>
 Range<ConfigTreeNew::ValueIterator<T> >
 ConfigTreeNew::
-getConfParamList(std::string const& param)
+getConfParamList(std::string const& param) const
 {
     checkUnique(param);
     markVisited<T>(param, true);
@@ -93,7 +93,7 @@ getConfParamList(std::string const& param)
 template<typename T>
 T
 ConfigTreeNew::
-peekConfParam(std::string const& param)
+peekConfParam(std::string const& param) const
 {
     checkKeyname(param);
 
@@ -116,7 +116,7 @@ peekConfParam(std::string const& param)
 template<typename T>
 void
 ConfigTreeNew::
-checkConfParam(std::string const& param, T const& value)
+checkConfParam(std::string const& param, T const& value) const
 {
     if (getConfParam<T>(param) != value) {
         error("The value of key <" + param + "> is not the expected one.");
@@ -126,7 +126,7 @@ checkConfParam(std::string const& param, T const& value)
 template<typename Ch>
 void
 ConfigTreeNew::
-checkConfParam(std::string const& param, Ch const* value)
+checkConfParam(std::string const& param, Ch const* value) const
 {
     if (getConfParam<std::string>(param) != value) {
         error("The value of key <" + param + "> is not the expected one.");
@@ -137,7 +137,7 @@ checkConfParam(std::string const& param, Ch const* value)
 template<typename T>
 ConfigTreeNew::CountType&
 ConfigTreeNew::
-markVisited(std::string const& key, bool peek_only)
+markVisited(std::string const& key, bool peek_only) const
 {
     auto const type = std::type_index(typeid(T));
 

--- a/BaseLib/ConfigTreeNew.cpp
+++ b/BaseLib/ConfigTreeNew.cpp
@@ -54,37 +54,21 @@ ConfigTreeNew(ConfigTreeNew && other)
 
 ConfigTreeNew::~ConfigTreeNew()
 {
-    if (!_tree) return;
-
-    for (auto const& p : *_tree)
-    {
-        markVisitedDecrement(p.first);
-    }
-
-    for (auto const& p : _visited_params)
-    {
-        if (p.second.count > 0) {
-            warning("Key <" + p.first + "> has been read " + std::to_string(p.second.count)
-                    + " time(s) more than it was present in the configuration tree.");
-        } else if (p.second.count < 0) {
-            warning("Key <" + p.first + "> has been read " + std::to_string(-p.second.count)
-                    + " time(s) less than it was present in the configuration tree.");
-        }
-    }
+    checkFullyRead();
 }
 
 ConfigTreeNew&
 ConfigTreeNew::
 operator=(ConfigTreeNew&& other)
 {
-    _tree = other._tree;
-    other._tree = nullptr;
-    _path = other._path;
-    _visited_params = std::move(other._visited_params);
+    checkFullyRead();
 
-    // TODO Caution: That might be a very nontrivial operation (copying a std::function).
-    _onerror = other._onerror;
-    _onwarning = other._onwarning;
+    _tree           = other._tree;
+    other._tree     = nullptr;
+    _path           = std::move(other._path);
+    _visited_params = std::move(other._visited_params);
+    _onerror        = std::move(other._onerror);
+    _onwarning      = std::move(other._onwarning);
 
     return *this;
 }
@@ -233,6 +217,28 @@ markVisitedDecrement(std::string const& key) const
     if (!p.second) { // no insertion happened
         auto& v = p.first->second;
         --v.count;
+    }
+}
+
+void
+ConfigTreeNew::checkFullyRead() const
+{
+    if (!_tree) return;
+
+    for (auto const& p : *_tree)
+    {
+        markVisitedDecrement(p.first);
+    }
+
+    for (auto const& p : _visited_params)
+    {
+        if (p.second.count > 0) {
+            warning("Key <" + p.first + "> has been read " + std::to_string(p.second.count)
+                    + " time(s) more than it was present in the configuration tree.");
+        } else if (p.second.count < 0) {
+            warning("Key <" + p.first + "> has been read " + std::to_string(-p.second.count)
+                    + " time(s) less than it was present in the configuration tree.");
+        }
     }
 }
 

--- a/BaseLib/ConfigTreeNew.cpp
+++ b/BaseLib/ConfigTreeNew.cpp
@@ -73,9 +73,25 @@ ConfigTreeNew::~ConfigTreeNew()
 	}
 }
 
+ConfigTreeNew&
+ConfigTreeNew::
+operator=(ConfigTreeNew&& other)
+{
+	_tree = other._tree;
+	other._tree = nullptr;
+	_path = other._path;
+	_visited_params = std::move(other._visited_params);
+
+	// TODO Caution: That might be a very nontrivial operation (copying a std::function).
+	_onerror = other._onerror;
+	_onwarning = other._onwarning;
+
+	return *this;
+}
+
 ConfigTreeNew
 ConfigTreeNew::
-getConfSubtree(std::string const& root)
+getConfSubtree(std::string const& root) const
 {
     if (auto t = getConfSubtreeOptional(root)) {
         return std::move(*t);
@@ -87,7 +103,7 @@ getConfSubtree(std::string const& root)
 
 boost::optional<ConfigTreeNew>
 ConfigTreeNew::
-getConfSubtreeOptional(std::string const& root)
+getConfSubtreeOptional(std::string const& root) const
 {
     checkUnique(root);
     auto subtree = _tree->get_child_optional(root);
@@ -104,7 +120,7 @@ getConfSubtreeOptional(std::string const& root)
 
 Range<ConfigTreeNew::SubtreeIterator>
 ConfigTreeNew::
-getConfSubtreeList(std::string const& root)
+getConfSubtreeList(std::string const& root) const
 {
     checkUnique(root);
     markVisited(root, true);
@@ -116,7 +132,7 @@ getConfSubtreeList(std::string const& root)
                 SubtreeIterator(p.second, root, *this));
 }
 
-void ConfigTreeNew::ignoreConfParam(const std::string &param)
+void ConfigTreeNew::ignoreConfParam(const std::string &param) const
 {
     checkUnique(param);
     // if not found, peek only
@@ -124,7 +140,7 @@ void ConfigTreeNew::ignoreConfParam(const std::string &param)
     markVisited(param, peek_only);
 }
 
-void ConfigTreeNew::ignoreConfParamAll(const std::string &param)
+void ConfigTreeNew::ignoreConfParamAll(const std::string &param) const
 {
     checkUnique(param);
     auto& ct = markVisited(param, true);
@@ -136,12 +152,12 @@ void ConfigTreeNew::ignoreConfParamAll(const std::string &param)
 }
 
 
-void ConfigTreeNew::error(const std::string& message)
+void ConfigTreeNew::error(const std::string& message) const
 {
 	_onerror(_path, message);
 }
 
-void ConfigTreeNew::warning(const std::string& message)
+void ConfigTreeNew::warning(const std::string& message) const
 {
 	_onwarning(_path, message);
 }
@@ -168,7 +184,7 @@ std::string ConfigTreeNew::shortString(const std::string &s)
 }
 
 
-void ConfigTreeNew::checkKeyname(std::string const& key)
+void ConfigTreeNew::checkKeyname(std::string const& key) const
 {
 	if (key.empty()) {
 		error("Search for empty key.");
@@ -180,7 +196,7 @@ void ConfigTreeNew::checkKeyname(std::string const& key)
 }
 
 std::string ConfigTreeNew::
-joinPaths( const std::string &p1, const std::string &p2)
+joinPaths( const std::string &p1, const std::string &p2) const
 {
 	if (p2.empty()) {
 		error("Second path to be joined is empty.");
@@ -191,7 +207,7 @@ joinPaths( const std::string &p1, const std::string &p2)
 	return p1 + pathseparator + p2;
 }
 
-void ConfigTreeNew::checkUnique(const std::string &key)
+void ConfigTreeNew::checkUnique(const std::string &key) const
 {
 	checkKeyname(key);
 
@@ -202,14 +218,14 @@ void ConfigTreeNew::checkUnique(const std::string &key)
 
 ConfigTreeNew::CountType&
 ConfigTreeNew::
-markVisited(std::string const& key, bool peek_only)
+markVisited(std::string const& key, bool peek_only) const
 {
     return markVisited<ConfigTreeNew>(key, peek_only);
 }
 
 void
 ConfigTreeNew::
-markVisitedDecrement(std::string const& key)
+markVisitedDecrement(std::string const& key) const
 {
     auto const type = std::type_index(typeid(nullptr));
 

--- a/BaseLib/ConfigTreeNew.cpp
+++ b/BaseLib/ConfigTreeNew.cpp
@@ -43,50 +43,50 @@ ConfigTreeNew(PTree const& tree, ConfigTreeNew const& parent,
 
 ConfigTreeNew::
 ConfigTreeNew(ConfigTreeNew && other)
-	: _tree(other._tree)
-	, _path(other._path)
-	, _visited_params(std::move(other._visited_params))
-	, _onerror(other._onerror)
-	, _onwarning(other._onwarning)
+    : _tree(other._tree)
+    , _path(other._path)
+    , _visited_params(std::move(other._visited_params))
+    , _onerror(other._onerror)
+    , _onwarning(other._onwarning)
 {
-	other._tree = nullptr;
+    other._tree = nullptr;
 }
 
 ConfigTreeNew::~ConfigTreeNew()
 {
-	if (!_tree) return;
+    if (!_tree) return;
 
-	for (auto const& p : *_tree)
-	{
-		markVisitedDecrement(p.first);
-	}
+    for (auto const& p : *_tree)
+    {
+        markVisitedDecrement(p.first);
+    }
 
-	for (auto const& p : _visited_params)
-	{
-		if (p.second.count > 0) {
-			warning("Key <" + p.first + "> has been read " + std::to_string(p.second.count)
-					+ " time(s) more than it was present in the configuration tree.");
-		} else if (p.second.count < 0) {
-			warning("Key <" + p.first + "> has been read " + std::to_string(-p.second.count)
-					+ " time(s) less than it was present in the configuration tree.");
-		}
-	}
+    for (auto const& p : _visited_params)
+    {
+        if (p.second.count > 0) {
+            warning("Key <" + p.first + "> has been read " + std::to_string(p.second.count)
+                    + " time(s) more than it was present in the configuration tree.");
+        } else if (p.second.count < 0) {
+            warning("Key <" + p.first + "> has been read " + std::to_string(-p.second.count)
+                    + " time(s) less than it was present in the configuration tree.");
+        }
+    }
 }
 
 ConfigTreeNew&
 ConfigTreeNew::
 operator=(ConfigTreeNew&& other)
 {
-	_tree = other._tree;
-	other._tree = nullptr;
-	_path = other._path;
-	_visited_params = std::move(other._visited_params);
+    _tree = other._tree;
+    other._tree = nullptr;
+    _path = other._path;
+    _visited_params = std::move(other._visited_params);
 
-	// TODO Caution: That might be a very nontrivial operation (copying a std::function).
-	_onerror = other._onerror;
-	_onwarning = other._onwarning;
+    // TODO Caution: That might be a very nontrivial operation (copying a std::function).
+    _onerror = other._onerror;
+    _onwarning = other._onwarning;
 
-	return *this;
+    return *this;
 }
 
 ConfigTreeNew
@@ -154,12 +154,12 @@ void ConfigTreeNew::ignoreConfParamAll(const std::string &param) const
 
 void ConfigTreeNew::error(const std::string& message) const
 {
-	_onerror(_path, message);
+    _onerror(_path, message);
 }
 
 void ConfigTreeNew::warning(const std::string& message) const
 {
-	_onwarning(_path, message);
+    _onwarning(_path, message);
 }
 
 
@@ -186,34 +186,34 @@ std::string ConfigTreeNew::shortString(const std::string &s)
 
 void ConfigTreeNew::checkKeyname(std::string const& key) const
 {
-	if (key.empty()) {
-		error("Search for empty key.");
-	} else if (key_chars_start.find(key.front()) == std::string::npos) {
-		error("Key <" + key + "> starts with an illegal character.");
-	} else if (key.find_first_not_of(key_chars, 1) != std::string::npos) {
-		error("Key <" + key + "> contains illegal characters.");
-	}
+    if (key.empty()) {
+        error("Search for empty key.");
+    } else if (key_chars_start.find(key.front()) == std::string::npos) {
+        error("Key <" + key + "> starts with an illegal character.");
+    } else if (key.find_first_not_of(key_chars, 1) != std::string::npos) {
+        error("Key <" + key + "> contains illegal characters.");
+    }
 }
 
 std::string ConfigTreeNew::
 joinPaths( const std::string &p1, const std::string &p2) const
 {
-	if (p2.empty()) {
-		error("Second path to be joined is empty.");
-	}
+    if (p2.empty()) {
+        error("Second path to be joined is empty.");
+    }
 
-	if (p1.empty()) return p2;
+    if (p1.empty()) return p2;
 
-	return p1 + pathseparator + p2;
+    return p1 + pathseparator + p2;
 }
 
 void ConfigTreeNew::checkUnique(const std::string &key) const
 {
-	checkKeyname(key);
+    checkKeyname(key);
 
-	if (_visited_params.find(key) != _visited_params.end()) {
-		error("Key <" + key + "> has already been processed.");
-	}
+    if (_visited_params.find(key) != _visited_params.end()) {
+        error("Key <" + key + "> has already been processed.");
+    }
 }
 
 ConfigTreeNew::CountType&

--- a/BaseLib/ConfigTreeNew.cpp
+++ b/BaseLib/ConfigTreeNew.cpp
@@ -110,8 +110,7 @@ getConfSubtreeOptional(std::string const& root) const
 
     if (subtree) {
         markVisited(root);
-        return boost::optional<ConfigTreeNew>(std::move(
-                ConfigTreeNew(*subtree, *this, root)));
+        return ConfigTreeNew(*subtree, *this, root);
     } else {
         markVisited(root, true);
         return boost::optional<ConfigTreeNew>();

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -192,8 +192,6 @@ public:
     //! used anymore!
     ConfigTreeNew(ConfigTreeNew && other);
 
-    ConfigTreeNew() = delete;
-
     //! copying is not compatible with the semantics of this class
     ConfigTreeNew& operator=(ConfigTreeNew const&) = delete;
 
@@ -364,6 +362,10 @@ private:
     //! and the number of times it exists in the ConfigTree
     void markVisitedDecrement(std::string const& key) const;
 
+    //! Helper method that checks if the top level of this tree has
+    //! been red entirely (and not too often).
+    void checkFullyRead() const;
+
     //! returns a short string at suitable for error/warning messages
     static std::string shortString(std::string const& s);
 
@@ -375,6 +377,11 @@ private:
 
     //! A map key -> (count, type) keeping track which parameters have been read how often
     //! and which datatype they have.
+    //!
+    //! This member will be written to when reading from the config tree.
+    //! Therefore it has to be mutable in order to be able to read from
+    //! constant instances, e.g., those passed as constant references to
+    //! temporaries.
     mutable std::map<std::string, CountType> _visited_params;
 
     Callback _onerror;

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -62,7 +62,7 @@ public:
         using Iterator = boost::property_tree::ptree::const_assoc_iterator;
 
         explicit SubtreeIterator(Iterator it, std::string const& root,
-                                 ConfigTreeNew& parent)
+                                 ConfigTreeNew const& parent)
             : _it(it), _root(root), _parent(parent)
         {}
 
@@ -94,7 +94,7 @@ public:
         bool _has_incremented = true;
         Iterator _it;
         std::string const _root;
-        ConfigTreeNew& _parent;
+        ConfigTreeNew const& _parent;
     };
 
 
@@ -112,7 +112,7 @@ public:
         using Iterator = boost::property_tree::ptree::const_assoc_iterator;
 
         explicit ValueIterator(Iterator it, std::string const& root,
-                               ConfigTreeNew& parent)
+                               ConfigTreeNew const& parent)
             : _it(it), _root(root), _parent(parent)
         {}
 
@@ -156,7 +156,7 @@ public:
         bool _has_incremented = true;
         Iterator _it;
         std::string const _root;
-        ConfigTreeNew& _parent;
+        ConfigTreeNew const& _parent;
     };
 
     using PTree = boost::property_tree::ptree;
@@ -194,8 +194,12 @@ public:
 
     ConfigTreeNew() = delete;
 
-    void operator=(ConfigTreeNew const&) = delete;
-    void operator=(ConfigTreeNew &&) = delete;
+    //! copying is not compatible with the semantics of this class
+    ConfigTreeNew& operator=(ConfigTreeNew const&) = delete;
+
+    //! After being moved from, \c other is in an undefined state and must not be
+    //! used anymore!
+    ConfigTreeNew& operator=(ConfigTreeNew &&);
 
     /*! Get parameter \c param of type \c T from the configuration tree.
      *
@@ -206,7 +210,7 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> T
-    getConfParam(std::string const& param);
+    getConfParam(std::string const& param) const;
 
     /*! Get parameter \c param of type \c T from the configuration tree or the \c default_value.
      *
@@ -216,7 +220,7 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> T
-    getConfParam(std::string const& param, T const& default_value);
+    getConfParam(std::string const& param, T const& default_value) const;
 
     /*! Get parameter \c param of type \c T from the configuration tree if present
      *
@@ -227,7 +231,7 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> boost::optional<T>
-    getConfParamOptional(std::string const& param);
+    getConfParamOptional(std::string const& param) const;
 
     /*! Returns all parameters with the name \c param from the current level of the tree.
      *
@@ -236,7 +240,7 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> Range<ValueIterator<T> >
-    getConfParamList(std::string const& param);
+    getConfParamList(std::string const& param) const;
 
     /*! Peek at a parameter \c param of type \c T from the configuration tree.
      *
@@ -246,18 +250,18 @@ public:
      * Return value and error behaviour are the same as for getConfParam(std::string const&).
      */
     template<typename T> T
-    peekConfParam(std::string const& param);
+    peekConfParam(std::string const& param) const;
 
     /*! Assert that \c param has the given \c value.
      *
      * Convenience method combining getConfParam(std::string const&) with a check.
      */
     template<typename T> void
-    checkConfParam(std::string const& param, T const& value);
+    checkConfParam(std::string const& param, T const& value) const;
 
     //! Make checkConfParam() work for string literals.
     template<typename Ch> void
-    checkConfParam(std::string const& param, Ch const* value);
+    checkConfParam(std::string const& param, Ch const* value) const;
 
     /*! Get the subtree rooted at \c root
      *
@@ -266,14 +270,14 @@ public:
      * \pre \c root must not have been read before from this ConfigTree.
      */
     ConfigTreeNew
-    getConfSubtree(std::string const& root);
+    getConfSubtree(std::string const& root) const;
 
     /*! Get the subtree rooted at \c root if present
      *
      * \pre \c root must not have been read before from this ConfigTree.
      */
     boost::optional<ConfigTreeNew>
-    getConfSubtreeOptional(std::string const& root);
+    getConfSubtreeOptional(std::string const& root) const;
 
     /*! Get all subtrees that have a root \c root from the current level of the tree.
      *
@@ -282,7 +286,7 @@ public:
      * \pre \c root must not have been read before from this ConfigTree.
      */
     Range<SubtreeIterator>
-    getConfSubtreeList(std::string const& root);
+    getConfSubtreeList(std::string const& root) const;
 
     /*! Tell this instance to ignore parameter \c param.
      *
@@ -290,7 +294,7 @@ public:
      *
      * \pre \c root must not have been read before from this ConfigTree.
      */
-    void ignoreConfParam(std::string const& param);
+    void ignoreConfParam(std::string const& param) const;
 
     /*! Tell this instance to ignore all parameters \c param on the current level of the tree.
      *
@@ -298,11 +302,19 @@ public:
      *
      * \pre \c root must not have been read before from this ConfigTree.
      */
-    void ignoreConfParamAll(std::string const& param);
+    void ignoreConfParamAll(std::string const& param) const;
 
     //! The destructor performs the check if all nodes at the current level of the tree
     //! have been read.
     ~ConfigTreeNew();
+
+    //! Default error callback function
+    //! Will print an error message and call std::abort()
+    static void onerror(std::string const& path, std::string const& message);
+
+    //! Default warning callback function
+    //! Will print a warning message
+    static void onwarning(std::string const& path, std::string const& message);
 
 private:
     struct CountType
@@ -316,20 +328,20 @@ private:
 
     //! Called if an error occurs. Will call the error callback.
     //! This method only acts as a helper method.
-    void error(std::string const& message);
+    void error(std::string const& message) const;
 
     //! Called for printing warning messages. Will call the warning callback.
     //! This method only acts as a helper method.
-    void warning(std::string const& message);
+    void warning(std::string const& message) const;
 
     //! Checks if \c key complies with the rules [a-z0-9_].
-    void checkKeyname(std::string const& key);
+    void checkKeyname(std::string const& key) const;
 
     //! Used to generate the path of a subtree.
-    std::string joinPaths(std::string const& p1, std::string const& p2);
+    std::string joinPaths(std::string const& p1, std::string const& p2) const;
 
     //! Asserts that the \c key has not been read yet.
-    void checkUnique(std::string const& key);
+    void checkUnique(std::string const& key) const;
 
     /*! Keeps track of the key \c key and its value type \c T.
      *
@@ -338,7 +350,7 @@ private:
      * \c param peek_only if true, do not change the read-count of the given key.
      */
     template<typename T>
-    CountType& markVisited(std::string const& key, bool peek_only = false);
+    CountType& markVisited(std::string const& key, bool peek_only = false) const;
 
     /*! Keeps track of the key \c key and its value type ConfigTree.
      *
@@ -346,19 +358,11 @@ private:
      *
      * \c param peek_only if true, do not change the read-count of the given key.
      */
-    CountType& markVisited(std::string const& key, bool peek_only = false);
+    CountType& markVisited(std::string const& key, bool peek_only = false) const;
 
     //! Used in the destructor to compute the difference between number of reads of a parameter
     //! and the number of times it exists in the ConfigTree
-    void markVisitedDecrement(std::string const& key);
-
-    //! Default error callback function
-    //! Will print an error message and call std::abort()
-    static void onerror(std::string const& path, std::string const& message);
-
-    //! Default warning callback function
-    //! Will print a warning message
-    static void onwarning(std::string const& path, std::string const& message);
+    void markVisitedDecrement(std::string const& key) const;
 
     //! returns a short string at suitable for error/warning messages
     static std::string shortString(std::string const& s);
@@ -367,14 +371,14 @@ private:
     boost::property_tree::ptree const* _tree;
 
     //! A path printed in error/warning messages.
-    std::string const _path;
+    std::string _path;
 
     //! A map key -> (count, type) keeping track which parameters have been read how often
     //! and which datatype they have.
-    std::map<std::string, CountType> _visited_params;
+    mutable std::map<std::string, CountType> _visited_params;
 
-    const Callback _onerror;
-    const Callback _onwarning;
+    Callback _onerror;
+    Callback _onwarning;
 
     //! Character separating two path components.
     static const char pathseparator;

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -11,10 +11,12 @@
 
 #include <logog/include/logog.hpp>
 
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 #include "EigenVector.h"
 #include "EigenMatrix.h"
 #include "EigenTools.h"
+
+#include "MathLib/LinAlg/LinearSolverOptions.h"
 
 namespace MathLib
 {
@@ -95,7 +97,7 @@ private:
 
 EigenLinearSolver::EigenLinearSolver(EigenMatrix &A,
                             const std::string /*solver_name*/,
-                            BaseLib::ConfigTree const*const option)
+                            const BaseLib::ConfigTreeNew* const option)
 {
     if (option)
         setOption(*option);
@@ -114,26 +116,23 @@ EigenLinearSolver::EigenLinearSolver(EigenMatrix &A,
     }
 }
 
-void EigenLinearSolver::setOption(BaseLib::ConfigTree const& option)
+void EigenLinearSolver::setOption(BaseLib::ConfigTreeNew const& option)
 {
-    auto const ptSolver = option.get_child_optional("eigen");
+    ignoreOtherLinearSolvers(option, "eigen");
+    auto const ptSolver = option.getConfSubtreeOptional("eigen");
     if (!ptSolver)
         return;
 
-    boost::optional<std::string> solver_type = ptSolver->get_optional<std::string>("solver_type");
-    if (solver_type) {
+    if (auto solver_type = ptSolver->getConfParamOptional<std::string>("solver_type")) {
         _option.solver_type = _option.getSolverType(*solver_type);
     }
-    boost::optional<std::string> precon_type = ptSolver->get_optional<std::string>("precon_type");
-    if (precon_type) {
+    if (auto precon_type = ptSolver->getConfParamOptional<std::string>("precon_type")) {
         _option.precon_type = _option.getPreconType(*precon_type);
     }
-    boost::optional<double> error_tolerance = ptSolver->get_optional<double>("error_tolerance");
-    if (error_tolerance) {
+    if (auto error_tolerance = ptSolver->getConfParamOptional<double>("error_tolerance")) {
         _option.error_tolerance = *error_tolerance;
     }
-    boost::optional<int> max_iteration_step = ptSolver->get_optional<int>("max_iteration_step");
-    if (max_iteration_step) {
+    if (auto max_iteration_step = ptSolver->getConfParamOptional<int>("max_iteration_step")) {
         _option.max_iterations = *max_iteration_step;
     }
 }

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.h
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.h
@@ -13,7 +13,7 @@
 #include <vector>
 
 
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 #include "EigenVector.h"
 #include "EigenOption.h"
 
@@ -35,7 +35,7 @@ public:
      *                    LisOption struct.
      */
     EigenLinearSolver(EigenMatrix &A, const std::string solver_name = "",
-                      BaseLib::ConfigTree const*const option = nullptr);
+                      BaseLib::ConfigTreeNew const*const option = nullptr);
 
     ~EigenLinearSolver()
     {
@@ -45,7 +45,7 @@ public:
     /**
      * parse linear solvers configuration
      */
-    void setOption(BaseLib::ConfigTree const& option);
+    void setOption(const BaseLib::ConfigTreeNew& option);
 
     /**
      * copy linear solvers options

--- a/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
+++ b/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
@@ -14,7 +14,7 @@
 #endif
 #include <logog/include/logog.hpp>
 
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 #include "MathLib/LinAlg/Eigen/EigenMatrix.h"
 #include "MathLib/LinAlg/Eigen/EigenVector.h"
 #include "MathLib/LinAlg/Lis/LisMatrix.h"
@@ -26,7 +26,7 @@ namespace MathLib
 EigenLisLinearSolver::EigenLisLinearSolver(
     EigenMatrix& A,
     const std::string /*solver_name*/,
-    BaseLib::ConfigTree const* const option)
+    BaseLib::ConfigTreeNew const* const option)
     : _A(A), _lis_option(option)
 {
 }

--- a/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.h
+++ b/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.h
@@ -14,7 +14,7 @@
 
 #include <lis.h>
 
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 #include "MathLib/LinAlg/Lis/LisOption.h"
 
 namespace MathLib
@@ -38,7 +38,7 @@ public:
      *                    LisOption struct.
      */
     EigenLisLinearSolver(EigenMatrix &A, const std::string solver_name = "",
-                         BaseLib::ConfigTree const*const option = nullptr);
+                         BaseLib::ConfigTreeNew const*const option = nullptr);
 
     /**
      * copy linear solvers options

--- a/MathLib/LinAlg/LinearSolverOptions.cpp
+++ b/MathLib/LinAlg/LinearSolverOptions.cpp
@@ -1,0 +1,25 @@
+#include "LinearSolverOptions.h"
+
+#include <set>
+
+//! Configuration tag names of all known linear solvers for their
+//! configuration in the project file.
+//! Add your tag name here when you add a new solver.
+static
+std::set<std::string>
+known_linear_solvers { "eigen", "lis", "petsc" };
+
+namespace MathLib
+{
+
+
+void
+ignoreOtherLinearSolvers(const BaseLib::ConfigTreeNew &config,
+                         const std::string &solver_name)
+{
+    for (auto const& s : known_linear_solvers) {
+        if (s!=solver_name) config.ignoreConfParam(s);
+    }
+}
+
+}

--- a/MathLib/LinAlg/LinearSolverOptions.h
+++ b/MathLib/LinAlg/LinearSolverOptions.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "BaseLib/ConfigTreeNew.h"
+
+namespace MathLib
+{
+
+/*! Ignore linear solver settings not needed for the selected one.
+ *
+ * The project files support specifying linear solver options for all
+ * known solver libraries (currently PETSC, LIS, Eigen) even though for
+ * a specific build only one of those settings is used.
+ * That clearly conflicts with the requirement of the config tree that
+ * each setting present in the project file must be read exactly once.
+ *
+ * The purpose of this function is to explicitly ignore all the settings
+ * that are not relevant for the currently used linear solver
+ *
+ * \param config The config tree snippet for the linear solver.
+ * \param solver_name The tag under which the relevant configuration is found.
+ *                    All other configurations will be ignored.
+ *
+ * This function is currently used in the option parsing code of our
+ * \c EigenLinearSolver, \c LisOption and \c PETScLinearSolver
+ */
+void ignoreOtherLinearSolvers(BaseLib::ConfigTreeNew const& config,
+                              std::string const& solver_name);
+
+}

--- a/MathLib/LinAlg/Lis/LisLinearSolver.cpp
+++ b/MathLib/LinAlg/Lis/LisLinearSolver.cpp
@@ -27,7 +27,7 @@ namespace MathLib
 
 LisLinearSolver::LisLinearSolver(LisMatrix &A,
                     const std::string /*solver_name*/,
-                    BaseLib::ConfigTree const*const option)
+                    const BaseLib::ConfigTreeNew* const option)
 : _A(A), _lis_option(option)
 {
 }

--- a/MathLib/LinAlg/Lis/LisLinearSolver.h
+++ b/MathLib/LinAlg/Lis/LisLinearSolver.h
@@ -20,7 +20,7 @@
 
 #include <lis.h>
 
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 
 #include "LisOption.h"
 #include "LisVector.h"
@@ -46,7 +46,7 @@ public:
      *                    LisOption struct.
      */
     LisLinearSolver(LisMatrix &A, const std::string solver_name = "",
-                    BaseLib::ConfigTree const*const option = nullptr);
+                    BaseLib::ConfigTreeNew const*const option = nullptr);
 
     /**
      * configure linear solvers

--- a/MathLib/LinAlg/Lis/LisOption.h
+++ b/MathLib/LinAlg/Lis/LisOption.h
@@ -17,11 +17,11 @@
 
 #include <string>
 #include <map>
-#include <boost/algorithm/string.hpp>
 
 #include <logog/include/logog.hpp>
 
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
+#include "MathLib/LinAlg/LinearSolverOptions.h"
 
 namespace MathLib
 {
@@ -40,12 +40,14 @@ namespace MathLib
  */
 struct LisOption
 {
-	LisOption(BaseLib::ConfigTree const* const options)
+	LisOption(BaseLib::ConfigTreeNew const* const options)
 	{
 		if (options)
 		{
-			_option_string += " " + options->get<std::string>("lis", "");
-			boost::algorithm::trim_right(_option_string);
+			ignoreOtherLinearSolvers(*options, "lis");
+			if (auto s = options->getConfParamOptional<std::string>("lis")) {
+				if (!s->empty()) _option_string += " " + *s;
+			}
 		}
 #ifndef NDEBUG
 		INFO("Lis options: \"%s\"", _option_string.c_str());

--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
@@ -17,18 +17,20 @@
 
 #include "PETScLinearSolver.h"
 #include "BaseLib/RunTime.h"
+#include "MathLib/LinAlg/LinearSolverOptions.h"
 
 namespace MathLib
 {
 PETScLinearSolver::PETScLinearSolver(PETScMatrix& A,
                                      const std::string prefix,
-                                     BaseLib::ConfigTree const* const option)
+                                     BaseLib::ConfigTreeNew const* const option)
     : _A(A), _elapsed_ctime(0.)
 {
     // Insert options into petsc database if any.
     if (option)
     {
-        std::string const petsc_options = option->get<std::string>("petsc", "");
+        ignoreOtherLinearSolvers(*option, "petsc");
+        std::string const petsc_options = option->getConfParam<std::string>("petsc", "");
         PetscOptionsInsertString(petsc_options.c_str());
     }
 

--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.h
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.h
@@ -23,7 +23,7 @@
 
 #include "logog/include/logog.hpp"
 
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 
 #include "PETScMatrix.h"
 #include "PETScVector.h"
@@ -50,7 +50,7 @@ class PETScLinearSolver
                            petsc options database.
         */
         PETScLinearSolver(PETScMatrix& A, const std::string prefix = "",
-                          BaseLib::ConfigTree const* const option = nullptr);
+                          BaseLib::ConfigTreeNew const* const option = nullptr);
 
         ~PETScLinearSolver()
         {

--- a/MathLib/LinAlg/Solvers/GaussAlgorithm-impl.h
+++ b/MathLib/LinAlg/Solvers/GaussAlgorithm-impl.h
@@ -21,7 +21,7 @@ namespace MathLib {
 template <typename MAT_T, typename VEC_T>
 GaussAlgorithm<MAT_T, VEC_T>::GaussAlgorithm(MAT_T &A,
 		const std::string /*solver_name*/,
-		BaseLib::ConfigTree const* const) :
+		BaseLib::ConfigTreeNew const* const) :
 		_mat(A), _n(_mat.getNRows()), _perm(new IDX_T[_n])
 {}
 

--- a/MathLib/LinAlg/Solvers/GaussAlgorithm.h
+++ b/MathLib/LinAlg/Solvers/GaussAlgorithm.h
@@ -18,7 +18,7 @@
 #include <cstddef>
 
 
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 #include "../Dense/DenseMatrix.h"
 #include "TriangularSolve.h"
 
@@ -55,7 +55,7 @@ public:
 	 * second argument was introduced.
 	 */
 	GaussAlgorithm(MAT_T &A, const std::string solver_name = "",
-                   BaseLib::ConfigTree const*const option = nullptr);
+                   BaseLib::ConfigTreeNew const*const option = nullptr);
 	/**
 	 * destructor, deletes the permutation
 	 */

--- a/NumLib/TimeStepping/Algorithms/FixedTimeStepping.cpp
+++ b/NumLib/TimeStepping/Algorithms/FixedTimeStepping.cpp
@@ -17,7 +17,7 @@
 #include <limits>
 #include <cassert>
 
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 #include "logog/include/logog.hpp"
 
 namespace NumLib
@@ -32,31 +32,15 @@ FixedTimeStepping::FixedTimeStepping(double t0, double tn, double dt)
 {}
 
 FixedTimeStepping*
-FixedTimeStepping::newInstance(BaseLib::ConfigTree const& config)
+FixedTimeStepping::newInstance(BaseLib::ConfigTreeNew const& config)
 {
-    assert(config.get<std::string>("type") == "FixedTimeStepping");
+    config.checkConfParam("type", "FixedTimeStepping");
 
-    auto const t_initial = config.get_optional<double>("t_initial");
-    auto const t_end     = config.get_optional<double>("t_end");
-    auto const dt        = config.get_optional<double>("dt");
+    auto const t_initial = config.getConfParam<double>("t_initial");
+    auto const t_end     = config.getConfParam<double>("t_end");
+    auto const dt        = config.getConfParam<double>("dt");
 
-    if (!t_initial)
-    {
-        ERR("could not find required parameter t_initial.");
-        return nullptr;
-    }
-    if (!t_end)
-    {
-        ERR("could not find required parameter t_end.");
-        return nullptr;
-    }
-    if (!dt)
-    {
-        ERR("could not find required parameter dt.");
-        return nullptr;
-    }
-
-    return new FixedTimeStepping(*t_initial, *t_end, *dt);
+    return new FixedTimeStepping(t_initial, t_end, dt);
 }
 
 const TimeStep FixedTimeStepping::getTimeStep() const

--- a/NumLib/TimeStepping/Algorithms/FixedTimeStepping.h
+++ b/NumLib/TimeStepping/Algorithms/FixedTimeStepping.h
@@ -14,7 +14,7 @@
 
 #include <vector>
 
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 #include "ITimeStepAlgorithm.h"
 
 namespace NumLib
@@ -64,7 +64,7 @@ public:
      *
      * Currently this function only covers uniform timestep size.
      */
-    static FixedTimeStepping* newInstance(BaseLib::ConfigTree const& config);
+    static FixedTimeStepping* newInstance(BaseLib::ConfigTreeNew const& config);
 
     virtual ~FixedTimeStepping() {}
 

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -56,7 +56,7 @@ public:
     GroundwaterFlowProcess(MeshLib::Mesh& mesh,
             std::vector<ProcessVariable> const& variables,
             std::vector<std::unique_ptr<ParameterBase>> const& parameters,
-            BaseLib::ConfigTree const& config)
+            BaseLib::ConfigTreeNew const& config)
         : Process<GlobalSetup>(mesh)
     {
         DBUG("Create GroundwaterFlowProcess.");
@@ -64,7 +64,7 @@ public:
         // Process variable.
         {
             // Find the corresponding process variable.
-            std::string const name = config.get<std::string>("process_variable");
+            std::string const name = config.getConfParam<std::string>("process_variable");
 
             auto variable = std::find_if(variables.cbegin(), variables.cend(),
                     [&name](ProcessVariable const& v) {
@@ -83,14 +83,7 @@ public:
         // Hydraulic conductivity parameter.
         {
             // find hydraulic_conductivity in process config
-            boost::optional<std::string> const name =
-                config.get_optional<std::string>("hydraulic_conductivity");
-            if (!name)
-            {
-                ERR("Could not find required tag hydraulic_conductivity in "
-                    "the process config.");
-                std::abort();
-            }
+            auto const name = config.getConfParam<std::string>("hydraulic_conductivity");
 
             // find corresponding parameter by name
             auto const parameter =
@@ -104,7 +97,7 @@ public:
             {
                 ERR("Could not find required parameter config for \'%s\' "
                     "among read parameters.",
-                    name->c_str());
+                    name.c_str());
                 std::abort();
             }
 
@@ -120,10 +113,10 @@ public:
         }
 
         // Linear solver options
-        if (auto const& linear_solver_options =
-                config.get_child_optional("linear_solver"))
+        if (auto linear_solver_options =
+                config.getConfSubtreeOptional("linear_solver"))
             Process<GlobalSetup>::setLinearSolverOptions(
-                *linear_solver_options);
+                std::move(*linear_solver_options));
     }
 
     template <unsigned GlobalDim>

--- a/ProcessLib/InitialCondition.cpp
+++ b/ProcessLib/InitialCondition.cpp
@@ -21,7 +21,7 @@
 namespace ProcessLib
 {
 std::unique_ptr<InitialCondition> createUniformInitialCondition(
-    BaseLib::ConfigTreeNew& config)
+    BaseLib::ConfigTreeNew const& config)
 {
 	config.checkConfParam("type", "Uniform");
 
@@ -33,7 +33,7 @@ std::unique_ptr<InitialCondition> createUniformInitialCondition(
 }
 
 std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
-    BaseLib::ConfigTreeNew& config, MeshLib::Mesh const& mesh)
+    BaseLib::ConfigTreeNew const& config, MeshLib::Mesh const& mesh)
 {
 	auto field_name = config.getConfParam<std::string>("field_name");
 	DBUG("Using field_name %s", field_name.c_str());

--- a/ProcessLib/InitialCondition.h
+++ b/ProcessLib/InitialCondition.h
@@ -11,7 +11,7 @@
 #define PROCESS_LIB_INITIAL_CONDITION_H_
 
 #include <cassert>
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 #include "MeshLib/Node.h"
 #include "MeshLib/PropertyVector.h"
 
@@ -57,7 +57,7 @@ private:
 
 /// Construct a UniformInitialCondition from configuration.
 std::unique_ptr<InitialCondition> createUniformInitialCondition(
-    BaseLib::ConfigTreeNew& config);
+    BaseLib::ConfigTreeNew const& config);
 
 /// Distribution of values given by a mesh property defined on nodes.
 class MeshPropertyInitialCondition : public InitialCondition
@@ -81,7 +81,7 @@ private:
 
 /// Construct a MeshPropertyInitialCondition from configuration.
 std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
-    BaseLib::ConfigTreeNew& config, MeshLib::Mesh const& mesh);
+    BaseLib::ConfigTreeNew const& config, MeshLib::Mesh const& mesh);
 
 }  // namespace ProcessLib
 

--- a/ProcessLib/NeumannBcConfig.h
+++ b/ProcessLib/NeumannBcConfig.h
@@ -44,7 +44,7 @@ class NeumannBcConfig : public BoundaryConditionConfig
 {
 public:
     NeumannBcConfig(GeoLib::GeoObject const* const geometry,
-            BaseLib::ConfigTreeNew& config)
+            BaseLib::ConfigTreeNew const& config)
         : BoundaryConditionConfig(geometry)
     {
         DBUG("Constructing NeumannBcConfig from config.");

--- a/ProcessLib/Parameter.cpp
+++ b/ProcessLib/Parameter.cpp
@@ -17,42 +17,34 @@
 namespace ProcessLib
 {
 std::unique_ptr<ParameterBase> createConstParameter(
-    BaseLib::ConfigTree const config)
+    BaseLib::ConfigTreeNew const& config)
 {
-	auto value = config.get_optional<double>("value");
-	if (!value)
-	{
-		ERR("Could not find required parameter value.");
-		std::abort();
-	}
-	DBUG("Using value %g", *value);
+	config.checkConfParam("type", "Constant");
+	auto value = config.getConfParam<double>("value");
+	DBUG("Using value %g", value);
 
-	return std::unique_ptr<ParameterBase>(new ConstParameter<double>(*value));
+	return std::unique_ptr<ParameterBase>(new ConstParameter<double>(value));
 }
 
 std::unique_ptr<ParameterBase> createMeshPropertyParameter(
-    BaseLib::ConfigTree const config, MeshLib::Mesh const& mesh)
+    BaseLib::ConfigTreeNew const& config, MeshLib::Mesh const& mesh)
 {
-	auto field_name = config.get_optional<std::string>("field_name");
-	if (!field_name)
-	{
-		ERR("Could not find required parameter field_name.");
-		std::abort();
-	}
-	DBUG("Using field_name %s", field_name->c_str());
+	config.checkConfParam("type", "MeshProperty");
+	auto field_name = config.getConfParam<std::string>("field_name");
+	DBUG("Using field_name %s", field_name.c_str());
 
-	if (!mesh.getProperties().hasPropertyVector(*field_name))
+	if (!mesh.getProperties().hasPropertyVector(field_name))
 	{
 		ERR("The required property %s does not exists in the mesh.",
-		    field_name->c_str());
+		    field_name.c_str());
 		std::abort();
 	}
 	auto const& property =
-	    mesh.getProperties().template getPropertyVector<double>(*field_name);
+	    mesh.getProperties().template getPropertyVector<double>(field_name);
 	if (!property)
 	{
 		ERR("The required property %s is not of the requested type.",
-		    field_name->c_str());
+		    field_name.c_str());
 		std::abort();
 	}
 

--- a/ProcessLib/Parameter.h
+++ b/ProcessLib/Parameter.h
@@ -15,7 +15,7 @@
 #include <logog/include/logog.hpp>
 #include <boost/optional.hpp>
 
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 #include "MeshLib/Elements/Element.h"
 
 namespace MeshLib
@@ -66,8 +66,7 @@ private:
 	ReturnType _value;
 };
 
-std::unique_ptr<ParameterBase> createConstParameter(
-    BaseLib::ConfigTree const config);
+std::unique_ptr<ParameterBase> createConstParameter(BaseLib::ConfigTreeNew const& config);
 
 /// A parameter represented by a mesh property vector.
 template <typename ReturnType>
@@ -88,8 +87,7 @@ private:
 	MeshLib::PropertyVector<ReturnType> const& _property;
 };
 
-std::unique_ptr<ParameterBase> createMeshPropertyParameter(
-    BaseLib::ConfigTree const config, MeshLib::Mesh const& mesh);
+std::unique_ptr<ParameterBase> createMeshPropertyParameter(BaseLib::ConfigTreeNew const& config, MeshLib::Mesh const& mesh);
 
 }  // namespace ProcessLib
 

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -15,7 +15,7 @@
 #include "AssemblerLib/ComputeSparsityPattern.h"
 #include "AssemblerLib/VectorMatrixAssembler.h"
 #include "AssemblerLib/LocalToGlobalIndexMap.h"
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 #include "MathLib/LinAlg/SetMatrixSparsity.h"
 #include "MeshLib/MeshSubsets.h"
 
@@ -105,9 +105,10 @@ public:
 protected:
 	/// Set linear solver options; called by the derived process which is
 	/// parsing the configuration.
-	void setLinearSolverOptions(const BaseLib::ConfigTree& config)
+	void setLinearSolverOptions(BaseLib::ConfigTreeNew&& config)
 	{
-		_linear_solver_options.reset(new BaseLib::ConfigTree(config));
+		_linear_solver_options.reset(new BaseLib::ConfigTreeNew(
+			std::move(config)));
 	}
 
 	/// Sets the initial condition values in the solution vector x for a given
@@ -174,7 +175,7 @@ protected:
 	std::unique_ptr<AssemblerLib::LocalToGlobalIndexMap>
 	    _local_to_global_index_map;
 
-	std::unique_ptr<BaseLib::ConfigTree> _linear_solver_options;
+	std::unique_ptr<BaseLib::ConfigTreeNew> _linear_solver_options;
 	std::unique_ptr<typename GlobalSetup::LinearSolver> _linear_solver;
 
 	std::unique_ptr<typename GlobalSetup::MatrixType> _A;

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -18,7 +18,7 @@
 
 namespace ProcessLib
 {
-ProcessVariable::ProcessVariable(BaseLib::ConfigTreeNew& config,
+ProcessVariable::ProcessVariable(BaseLib::ConfigTreeNew const& config,
                                  MeshLib::Mesh const& mesh,
                                  GeoLib::GEOObjects const& geometries)
     : _name(config.getConfParam<std::string>("name"))

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -46,7 +46,7 @@ namespace ProcessLib
 class ProcessVariable
 {
 public:
-	ProcessVariable(BaseLib::ConfigTreeNew& config, MeshLib::Mesh const& mesh,
+	ProcessVariable(BaseLib::ConfigTreeNew const& config, MeshLib::Mesh const& mesh,
 	                GeoLib::GEOObjects const& geometries);
 
 	ProcessVariable(ProcessVariable&&);

--- a/ProcessLib/UniformDirichletBoundaryCondition.h
+++ b/ProcessLib/UniformDirichletBoundaryCondition.h
@@ -37,7 +37,7 @@ class UniformDirichletBoundaryCondition
 {
 public:
     UniformDirichletBoundaryCondition(GeoLib::GeoObject const* const geometry,
-                                      BaseLib::ConfigTreeNew& config)
+                                      BaseLib::ConfigTreeNew const& config)
         : _geometry(geometry)
     {
         DBUG("Constructing UniformDirichletBoundaryCondition from config.");

--- a/Tests/AssemblerLib/TestSerialLinearSolver.cpp
+++ b/Tests/AssemblerLib/TestSerialLinearSolver.cpp
@@ -19,7 +19,6 @@
 #include "AssemblerLib/VectorMatrixAssembler.h"
 #include "AssemblerLib/LocalAssemblerBuilder.h"
 
-
 #include "MathLib/LinAlg/ApplyKnownSolution.h"
 #include "MathLib/LinAlg/Solvers/GaussAlgorithm.h"
 #include "MathLib/LinAlg/FinalizeMatrixAssembly.h"
@@ -137,8 +136,9 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
         t_root.put_child("eigen", t_solver);
     }
     t_root.put("lis", "-i cg -p none -tol 1e-16 -maxiter 1000");
+    BaseLib::ConfigTreeNew conf(t_root);
 
-    GlobalSetup::LinearSolver ls(*A, "solver_name", &t_root);
+    GlobalSetup::LinearSolver ls(*A, "solver_name", &conf);
     ls.solve(*rhs, *x);
 
     // copy solution to double vector

--- a/Tests/BaseLib/TestConfigTree.cpp
+++ b/Tests/BaseLib/TestConfigTree.cpp
@@ -400,7 +400,7 @@ TEST(BaseLibConfigTree, ConfigTreeStringLiterals)
 }
 
 // String literals are somewhat special for template classes
-TEST(BaseLibConfigTree, ConfigTreeMove)
+TEST(BaseLibConfigTree, ConfigTreeMoveConstruct)
 {
     const char xml[] =
             "<s>test</s>"
@@ -418,6 +418,39 @@ TEST(BaseLibConfigTree, ConfigTreeMove)
         DO_EXPECT(cbs, false, false);
 
         BaseLib::ConfigTreeNew conf2(std::move(conf));
+
+        EXPECT_EQ("XX",   conf2.getConfParam<std::string>("n", "XX"));
+        DO_EXPECT(cbs, false, false);
+
+        conf2.checkConfParam("t", "Test");
+        DO_EXPECT(cbs, false, false);
+    } // ConfigTree destroyed here
+    DO_EXPECT(cbs, false, false);
+}
+
+// String literals are somewhat special for template classes
+TEST(BaseLibConfigTree, ConfigTreeMoveAssign)
+{
+    const char xml[] =
+            "<s>test</s>"
+            "<t>Test</t>";
+
+    boost::property_tree::ptree ptree;
+    std::istringstream xml_str(xml);
+    read_xml(xml_str, ptree);
+
+    Callbacks cbs;
+    {
+        BaseLib::ConfigTreeNew conf(ptree, cbs.get_error_cb(), cbs.get_warning_cb());
+
+        EXPECT_EQ("test", conf.getConfParam<std::string>("s", "XX"));
+        DO_EXPECT(cbs, false, false);
+
+        BaseLib::ConfigTreeNew conf2(ptree, cbs.get_error_cb(), cbs.get_warning_cb());
+        conf2 = std::move(conf);
+        // Expect warning because config tree has not been traversed
+        // entirely before.
+        DO_EXPECT(cbs, false, true);
 
         EXPECT_EQ("XX",   conf2.getConfParam<std::string>("n", "XX"));
         DO_EXPECT(cbs, false, false);

--- a/Tests/MathLib/TestLinearSolver.cpp
+++ b/Tests/MathLib/TestLinearSolver.cpp
@@ -99,7 +99,7 @@ template<typename IntType> struct Example1
 };
 
 template <class T_MATRIX, class T_VECTOR, class T_LINEAR_SOVLER, typename IntType>
-void checkLinearSolverInterface(T_MATRIX &A, BaseLib::ConfigTree& ls_option)
+void checkLinearSolverInterface(T_MATRIX &A, BaseLib::ConfigTreeNew const& ls_option)
 {
     Example1<IntType> ex1;
 
@@ -136,7 +136,7 @@ void checkLinearSolverInterface(T_MATRIX &A, BaseLib::ConfigTree& ls_option)
 template <class T_MATRIX, class T_VECTOR, class T_LINEAR_SOVLER>
 void checkLinearSolverInterface(T_MATRIX& A, T_VECTOR& b,
                                 const std::string& prefix_name,
-                                BaseLib::ConfigTree& ls_option)
+                                BaseLib::ConfigTreeNew const& ls_option)
 {
     int mrank;
     MPI_Comm_rank(PETSC_COMM_WORLD, &mrank);
@@ -206,6 +206,7 @@ TEST(MathLib, CheckInterface_GaussAlgorithm)
     boost::property_tree::ptree t_root;
     boost::property_tree::ptree t_solver;
     t_root.put_child("ogs", t_solver);
+    BaseLib::ConfigTreeNew conf(t_root);
 
     using Example = Example1<std::size_t>;
 
@@ -213,7 +214,7 @@ TEST(MathLib, CheckInterface_GaussAlgorithm)
     MathLib::GlobalDenseMatrix<double> A(Example::dim_eqs, Example::dim_eqs);
     checkLinearSolverInterface<MathLib::GlobalDenseMatrix<double>,
                                MathLib::DenseVector<double>, LinearSolverType, std::size_t>(
-        A, t_root);
+        A, conf);
 }
 
 #ifdef OGS_USE_EIGEN
@@ -227,12 +228,13 @@ TEST(Math, CheckInterface_Eigen)
     t_solver.put("error_tolerance", 1e-15);
     t_solver.put("max_iteration_step", 1000);
     t_root.put_child("eigen", t_solver);
+    BaseLib::ConfigTreeNew conf(t_root);
 
     using IntType = MathLib::EigenMatrix::IndexType;
 
     MathLib::EigenMatrix A(Example1<IntType>::dim_eqs);
     checkLinearSolverInterface<MathLib::EigenMatrix, MathLib::EigenVector,
-                               MathLib::EigenLinearSolver, IntType>(A, t_root);
+                               MathLib::EigenLinearSolver, IntType>(A, conf);
 }
 #endif
 
@@ -243,12 +245,13 @@ TEST(Math, CheckInterface_EigenLis)
     boost::property_tree::ptree t_root;
     boost::property_tree::ptree t_solver;
     t_root.put("lis", "-i cg -p none -tol 1e-15 -maxiter 1000");
+    BaseLib::ConfigTreeNew conf(t_root);
 
     using IntType = MathLib::LisMatrix::IndexType;
 
     MathLib::EigenMatrix A(Example1<IntType>::dim_eqs);
     checkLinearSolverInterface<MathLib::EigenMatrix, MathLib::EigenVector,
-                               MathLib::EigenLisLinearSolver, IntType>(A, t_root);
+                               MathLib::EigenLisLinearSolver, IntType>(A, conf);
 }
 #endif
 
@@ -259,12 +262,13 @@ TEST(Math, CheckInterface_Lis)
     boost::property_tree::ptree t_root;
     boost::property_tree::ptree t_solver;
     t_root.put("lis", "-i cg -p none -tol 1e-15 -maxiter 1000");
+    BaseLib::ConfigTreeNew conf(t_root);
 
     using IntType = MathLib::LisMatrix::IndexType;
 
     MathLib::LisMatrix A(Example1<IntType>::dim_eqs);
     checkLinearSolverInterface<MathLib::LisMatrix, MathLib::LisVector,
-                               MathLib::LisLinearSolver, IntType>(A, t_root);
+                               MathLib::LisLinearSolver, IntType>(A, conf);
 }
 #endif
 
@@ -292,7 +296,7 @@ TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_basic)
     checkLinearSolverInterface<MathLib::PETScMatrix,
                                MathLib::PETScVector,
                                MathLib::PETScLinearSolver>(
-        A, b, "ptest1_", t_root);
+        A, b, "ptest1_", BaseLib::ConfigTreeNew(t_root));
 }
 
 TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_chebyshev_sor)
@@ -318,7 +322,7 @@ TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_chebyshev_sor)
     checkLinearSolverInterface<MathLib::PETScMatrix,
                                MathLib::PETScVector,
                                MathLib::PETScLinearSolver>(
-        A, b, "ptest2_", t_root);
+        A, b, "ptest2_", BaseLib::ConfigTreeNew(t_root));
 }
 
 TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_gmres_amg)
@@ -346,7 +350,7 @@ TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_gmres_amg)
     checkLinearSolverInterface<MathLib::PETScMatrix,
                                MathLib::PETScVector,
                                MathLib::PETScLinearSolver>(
-        A, b, "ptest3_", t_root);
+        A, b, "ptest3_", BaseLib::ConfigTreeNew(t_root));
 }
 
 #endif

--- a/Tests/MathLib/TestLinearSolver.cpp
+++ b/Tests/MathLib/TestLinearSolver.cpp
@@ -204,8 +204,6 @@ void checkLinearSolverInterface(T_MATRIX& A, T_VECTOR& b,
 TEST(MathLib, CheckInterface_GaussAlgorithm)
 {
     boost::property_tree::ptree t_root;
-    boost::property_tree::ptree t_solver;
-    t_root.put_child("ogs", t_solver);
     BaseLib::ConfigTreeNew conf(t_root);
 
     using Example = Example1<std::size_t>;


### PR DESCRIPTION
This PR completes the transition to the new ConfigTree for project files.

Changes:
* make a member `mutable` and all methods `const` in order to be able to pass temporary instances directly to function calls
* change parsing of the project file completely to the new ConfigTree
* addresses two comments by @endJunction from #912

TODO (subsequent PR):
* remove the old ConfigTree code
* rename the new ConfigTree