### PR TITLE
Clang Jenkins workflow script with sanitizers

### DIFF
--- a/scripts/jenkins/clang-log-parser.rules
+++ b/scripts/jenkins/clang-log-parser.rules
@@ -1,0 +1,15 @@
+# Workflow stages used for grouping
+start /stage:/
+
+# CMake
+warning /CMake Warning/
+error /CMake Error/
+
+# CTest
+error \[*][*][*]Failed\
+
+# Clang
+
+# Clang sanitizer
+error /: runtime error:/
+error /==ERROR:/

--- a/scripts/jenkins/clang.groovy
+++ b/scripts/jenkins/clang.groovy
@@ -2,14 +2,9 @@ node('docker')
 {
 	// Checks out into subdirectory ogs
 	stage 'Checkout'
-	checkout([$class: 'GitSCM',
-		branches: [[name: '*/master']],
-		doGenerateSubmoduleConfigurations: false,
-		extensions:
-			[[$class: 'RelativeTargetDirectory', relativeTargetDir: 'ogs']],
-		submoduleCfg: [],
-		userRemoteConfigs:
-			[[url: 'https://github.com/ufz/ogs']]])
+	dir('ogs') {
+ 		checkout scm
+ 	}
 
 
 	// Multiple configurations are build in parallel

--- a/scripts/jenkins/clang.groovy
+++ b/scripts/jenkins/clang.groovy
@@ -27,6 +27,8 @@ node('docker')
 			sh '''cd build
 			      make ctest'''
 		}
+		step([$class: 'LogParserPublisher', failBuildOnError: true, unstableOnWarning: true,
+			projectRulePath: 'ogs/scripts/jenkins/clang-log-parser.rules', useProjectRule: true])
 	}
 
 	//linux_gui: {

--- a/scripts/jenkins/clang.groovy
+++ b/scripts/jenkins/clang.groovy
@@ -16,7 +16,7 @@ node('docker')
 	parallel linux: {
 		docker.image('ogs6/clang-ogs-base:latest').inside
 		{
-			build 'build', '-DOGS_ADDRESS_SANITIZER=ON -DOGS_UNDEFINED_BEHAVIOR_SANITIZER=ON', ''
+			build 'build', '-DOGS_ADDRESS_SANITIZER=ON -DOGS_UNDEFINED_BEHAVIOR_SANITIZER=ON -DBOOST_ROOT=$BOOST_ROOT', ''
 
 			stage 'Unit tests'
 			sh '''cd build

--- a/scripts/jenkins/clang.groovy
+++ b/scripts/jenkins/clang.groovy
@@ -17,7 +17,7 @@ node('docker')
 		docker.image('ogs6/clang-ogs-base:latest').inside
 		{
 			catchError {
-				build 'build', '-DOGS_ADDRESS_SANITIZER=ON -DOGS_UNDEFINED_BEHAVIOR_SANITIZER=ON -DBOOST_ROOT=/usr/src/boost_1_56_0', ''
+				build 'build', '-DOGS_ADDRESS_SANITIZER=ON -DOGS_UNDEFINED_BEHAVIOR_SANITIZER=ON', ''
 
 				stage 'Unit tests'
 				sh '''cd build

--- a/scripts/jenkins/clang.groovy
+++ b/scripts/jenkins/clang.groovy
@@ -1,0 +1,55 @@
+node('docker')
+{
+	// Checks out into subdirectory ogs
+	stage 'Checkout'
+	checkout([$class: 'GitSCM',
+		branches: [[name: '*/master']],
+		doGenerateSubmoduleConfigurations: false,
+		extensions:
+			[[$class: 'RelativeTargetDirectory', relativeTargetDir: 'ogs']],
+		submoduleCfg: [],
+		userRemoteConfigs:
+			[[url: 'https://github.com/ufz/ogs']]])
+
+
+	// Multiple configurations are build in parallel
+	parallel linux: {
+		docker.image('ogs6/clang-ogs-base:latest').inside
+		{
+			build 'build', '-DOGS_ADDRESS_SANITIZER=ON -DOGS_UNDEFINED_BEHAVIOR_SANITIZER=ON', ''
+
+			stage 'Unit tests'
+			sh '''cd build
+			      rm -rf tests/testrunner.xml
+			      bin/testrunner --gtest_output=xml:./tests/testrunner.xml'''
+
+			stage 'End-to-end tests'
+			sh '''cd build
+			      make ctest'''
+		}
+	}
+
+	//linux_gui: {
+	//	docker.image('ogs6/gcc-ogs-gui:latest').inside {
+	//		build 'build_gui', '-DOGS_BUILD_GUI=ON -DOGS_BUILD_TESTS=OFF -DOGS_BUILD_CLI=OFF', 'package'
+	//	}
+	//}
+
+	// end parallel
+
+	step([$class: 'JUnitResultArchiver',
+		testResults: 'build/tests/testrunner.xml,build_win/tests/testrunner.xml'])
+
+	archive 'build*/*.tar.gz,build_win*/*.zip'
+} // end node
+
+
+def build(buildDir, cmakeOptions, target) {
+	sh "rm -rf ${buildDir} && mkdir ${buildDir}"
+
+	stage 'Configure'
+	sh "cd ${buildDir} && cmake ../ogs ${cmakeOptions}"
+
+	stage 'Build'
+	sh "cd ${buildDir} && make -j 4 ${target}"
+}


### PR DESCRIPTION
Adds Jenkins scripts to compile with clang sanitizers enabled which are run in Docker containers.

Sanitizer errors are shown under *Parsed Console Output* in a run job, e.g. [here](https://svn.ufz.de:8443/job/OGS-6/job/Docker/job/clang-scm/54/parsed_console/).

Closes #954.