### PR TITLE
[GL] Algorithm for computing line segment intersections in the xy-plane

### DIFF
--- a/GeoLib/AnalyticalGeometry.h
+++ b/GeoLib/AnalyticalGeometry.h
@@ -299,6 +299,21 @@ bool parallel(MathLib::Vector3 v, MathLib::Vector3 w);
 bool lineSegmentIntersect (const GeoLib::Point& a, const GeoLib::Point& b,
         const GeoLib::Point& c, const GeoLib::Point& d, GeoLib::Point& s);
 
+/// A line segment is given by its two end-points. The function checks,
+/// if the two line segments (ab) and (cd) intersects. This method checks the
+/// intersection only in 2d.
+/// @param a first end-point of the first line segment
+/// @param b second end-point of the first line segment
+/// @param c first end-point of the second line segment
+/// @param d second end-point of the second line segment
+/// @return empty vector in case there isn't an intersection point, a vector
+/// containing one point if the line segments intersect in a single point, a
+/// vector containing two points describing the line segment the original line
+/// segments are interfering.
+std::vector<MathLib::Point3d>
+lineSegmentIntersect2d(MathLib::Point3d const& a, MathLib::Point3d const& b,
+	MathLib::Point3d const& c, MathLib::Point3d const& d);
+
 /**
  * Calculates the intersection points of a line PQ and a triangle ABC.
  * This method requires ABC to be counterclockwise and PQ to point downward.

--- a/GeoLib/LineSegment.h
+++ b/GeoLib/LineSegment.h
@@ -1,0 +1,40 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#ifndef LINESEGMENT_H_
+#define LINESEGMENT_H_
+
+#include <iostream>
+
+#include "Point.h"
+
+namespace GeoLib
+{
+
+struct LineSegment
+{
+	GeoLib::Point a;
+	GeoLib::Point b;
+};
+
+std::ostream& operator<< (std::ostream& os, LineSegment const& s)
+{
+	os << "{(" << s.a << "), (" << s.b << ")}";
+	return os;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         std::pair<GeoLib::LineSegment const&,
+                                   GeoLib::LineSegment const&> const& seg_pair)
+{
+	os << seg_pair.first << " x " << seg_pair.second;
+	return os;
+}
+
+}
+#endif

--- a/Tests/GeoLib/AutoCheckGenerators.h
+++ b/Tests/GeoLib/AutoCheckGenerators.h
@@ -1,0 +1,120 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *			Distributed under a Modified BSD License.
+ *			  See accompanying file LICENSE.txt or
+ *			  http://www.opengeosys.org/LICENSE.txt
+ */
+
+#ifndef TESTS_GEOLIB_AUTOCHECKGENERATORS_H_
+#define TESTS_GEOLIB_AUTOCHECKGENERATORS_H_
+
+#include <cmath>
+#include <random>
+
+#include "autocheck/autocheck.hpp"
+#include "MathLib/Point3d.h"
+#include "MathLib/Vector3.h"
+#include "GeoLib/LineSegment.h"
+
+namespace autocheck
+{
+
+// generates points on a circle in x-y plane
+template <typename Gen = generator<double>>
+struct RandomCirclePointGeneratorXY
+{
+	RandomCirclePointGeneratorXY(
+		MathLib::Point3d const& c = MathLib::Point3d{std::array<double, 3>{{0, 0, 0}}},
+		double r = 1.0)
+	    : center(c), radius(r)
+	{}
+
+	using result_type = MathLib::Point3d;
+
+	result_type operator()(std::size_t size = 0)
+	{
+		// generates uniformly distributed values in the interval [-4, 4]
+		auto const angle(generator(4));
+		return MathLib::Point3d{
+		    std::array<double, 3>{{center[0] + radius * std::cos(angle),
+		                           center[1] + radius * std::sin(angle), 0.0}}};
+	}
+
+	Gen generator;
+	MathLib::Point3d const center;
+	double const radius;
+};
+
+// reflect point p on the point c in x-y plane
+MathLib::Point3d reflect(MathLib::Point3d const& c, MathLib::Point3d const& p)
+{
+	return MathLib::Point3d(
+	    std::array<double, 3>{{2 * c[0] - p[0], 2 * c[1] - p[1], 0.0}});
+}
+
+// generates line segments that are special chords of a circle, i.e. the chords
+// include the circle centre point.
+template <typename Gen = RandomCirclePointGeneratorXY<generator<double>>>
+struct SymmSegmentGeneratorXY
+{
+	SymmSegmentGeneratorXY(
+	    Gen s,
+	    std::function<MathLib::Point3d(MathLib::Point3d const&)> f)
+	    : source(s), function(f)
+	{}
+
+	using result_type = GeoLib::LineSegment;
+
+	result_type operator()(std::size_t size = 0)
+	{
+		result_type rv;
+		rv.a = GeoLib::Point(source(), 0);
+		rv.b = GeoLib::Point(function(rv.a), 1);
+		return rv;
+	}
+
+	Gen source;
+	std::function<MathLib::Point3d(MathLib::Point3d const&)> function;
+};
+
+GeoLib::LineSegment translate(MathLib::Vector3 const& translation,
+                              GeoLib::LineSegment const& line_seg)
+{
+	GeoLib::LineSegment s;
+	s.a = line_seg.a;
+	for (std::size_t k(0); k<3; ++k)
+		s.a[k] += translation[k];
+	s.b = line_seg.b;
+	for (std::size_t k(0); k<3; ++k)
+		s.b[k] += translation[k];
+	return s;
+}
+
+template <typename Gen = SymmSegmentGeneratorXY<
+              RandomCirclePointGeneratorXY<generator<double>>>>
+struct PairSegmentGeneratorXY
+{
+	PairSegmentGeneratorXY(
+	    Gen s, std::function<GeoLib::LineSegment(GeoLib::LineSegment const&)> f)
+	    : segment_generator(s), function(f)
+	{
+	}
+
+	using result_type = std::pair<GeoLib::LineSegment, GeoLib::LineSegment>;
+
+	result_type operator()(std::size_t size = 0)
+	{
+		result_type rv;
+		rv.first = segment_generator();
+		rv.second = function(rv.first);
+		return rv;
+	}
+
+	Gen segment_generator;
+	std::function<GeoLib::LineSegment(GeoLib::LineSegment const&)> function;
+};
+
+}  // namespace autocheck
+
+#endif  // TESTS_GEOLIB_AUTOCHECKGENERATORS_H_

--- a/Tests/GeoLib/TestLineSegmentIntersect2d.cpp
+++ b/Tests/GeoLib/TestLineSegmentIntersect2d.cpp
@@ -1,0 +1,137 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include "gtest/gtest.h"
+#include <array>
+#include <ctime>
+#include <functional>
+#include <memory>
+#include <random>
+
+#include "Tests/GeoLib/AutoCheckGenerators.h"
+
+#include "MathLib/Point3d.h"
+#include "GeoLib/AnalyticalGeometry.h"
+
+namespace ac = autocheck;
+
+class LineSegmentIntersect2dTest : public testing::Test
+{
+public:
+	using PointGenerator = ac::RandomCirclePointGeneratorXY<ac::generator<double>>;
+	using SymmSegmentGenerator = ac::SymmSegmentGeneratorXY<PointGenerator>;
+	using PairSegmentGenerator = ac::PairSegmentGeneratorXY<SymmSegmentGenerator>;
+
+	PointGenerator point_generator1 = PointGenerator(
+	    MathLib::Point3d(std::array<double, 3>{{0.0, 0.0, 0.0}}), 1.0);
+	SymmSegmentGenerator segment_generator1 = SymmSegmentGenerator{point_generator1,
+		std::bind(ac::reflect, point_generator1.center, std::placeholders::_1)};
+
+	PointGenerator point_generator2 = PointGenerator(
+	    MathLib::Point3d(std::array<double, 3>{{2.0, 0.0, 0.0}}), 1.0);
+	SymmSegmentGenerator segment_generator2 = SymmSegmentGenerator{point_generator2,
+		std::bind(ac::reflect, point_generator2.center, std::placeholders::_1)};
+
+	MathLib::Vector3 const translation_vector1 = {2,2,0};
+	PairSegmentGenerator pair_segment_generator1 = PairSegmentGenerator{
+	    segment_generator1,
+	    std::bind(ac::translate, translation_vector1, std::placeholders::_1)};
+
+	MathLib::Vector3 const translation_vector2 = {0,0,0};
+	PairSegmentGenerator pair_segment_generator2 = PairSegmentGenerator{
+	    segment_generator1,
+	    std::bind(ac::translate, translation_vector2, std::placeholders::_1)};
+
+	ac::gtest_reporter gtest_reporter;
+};
+
+// Test the intersection of intersecting line segments. Line segments are chords
+// of the same circle that both contains the center of the circle. As a
+// consequence the center of the circle is the intersection point.
+TEST_F(LineSegmentIntersect2dTest, RandomSegmentOrientationIntersecting)
+{
+	auto intersect =
+	    [](GeoLib::LineSegment const& s0, GeoLib::LineSegment const& s1)
+	{
+		auto ipnts = GeoLib::lineSegmentIntersect2d(s0.a, s0.b, s1.a, s1.b);
+		if (ipnts.size() == 1) {
+			MathLib::Point3d const center{std::array<double, 3>{
+			    {(s0.a[0] + s0.b[0]) / 2, (s0.a[1] + s0.b[1]) / 2, 0.0}}};
+			const double sqr_dist(MathLib::sqrDist(ipnts[0], center));
+			if (sqr_dist < std::numeric_limits<double>::epsilon())
+				return true;
+			else
+				return false;
+		}
+		return ipnts.size() == 2;
+	};
+
+	ac::check<GeoLib::LineSegment, GeoLib::LineSegment>(
+	    intersect, 1000,
+	    ac::make_arbitrary(segment_generator1, segment_generator1),
+	    gtest_reporter);
+}
+
+// Test the intersection of non-intersecting line segments. Line segments are
+// chords of non-intersecting circles.
+TEST_F(LineSegmentIntersect2dTest, RandomSegmentOrientationNonIntersecting)
+{
+	auto intersect =
+	    [](GeoLib::LineSegment const& s0, GeoLib::LineSegment const& s1)
+	{
+		auto ipnts = GeoLib::lineSegmentIntersect2d(s0.a, s0.b, s1.a, s1.b);
+		return ipnts.empty();
+	};
+
+	// generate non-intersecting segments
+	ac::check<GeoLib::LineSegment, GeoLib::LineSegment>(
+	    intersect, 1000,
+	    ac::make_arbitrary(segment_generator1, segment_generator2),
+	    gtest_reporter);
+}
+
+// Test the intersection of non-intersecting, parallel line segments. The second
+// line segment is created by translating the first line segment.
+TEST_F(LineSegmentIntersect2dTest, ParallelNonIntersectingSegmentOrientation)
+{
+	auto intersect = [](
+	    std::pair<GeoLib::LineSegment const&, GeoLib::LineSegment const&> const&
+	        segment_pair)
+	{
+		auto ipnts = GeoLib::lineSegmentIntersect2d(
+		    segment_pair.first.a, segment_pair.first.b, segment_pair.second.a,
+		    segment_pair.second.b);
+		return ipnts.empty();
+	};
+
+	// generate non-intersecting segments
+	ac::check<std::pair<GeoLib::LineSegment, GeoLib::LineSegment>>(
+	    intersect, 1000,
+	    ac::make_arbitrary(pair_segment_generator1),
+	    gtest_reporter);
+}
+
+// Test the intersection of parallel, interfering line segments.
+TEST_F(LineSegmentIntersect2dTest, ParallelIntersectingSegmentOrientation)
+{
+	auto intersect = [](
+	    std::pair<GeoLib::LineSegment const&, GeoLib::LineSegment const&> const&
+	        segment_pair)
+	{
+		auto ipnts = GeoLib::lineSegmentIntersect2d(
+		    segment_pair.first.a, segment_pair.first.b, segment_pair.second.a,
+		    segment_pair.second.b);
+		return ipnts.size() == 2;
+	};
+
+	// generate non-intersecting segments
+	ac::check<std::pair<GeoLib::LineSegment, GeoLib::LineSegment>>(
+	    intersect, 1000,
+	    ac::make_arbitrary(pair_segment_generator2),
+	    gtest_reporter);
+}


### PR DESCRIPTION
This PR not only contains the algorithm itself, there are also 
- some new point and line segment generators used within the 
- tests of the algorithm.

The lineSegmentIntersection2d algorithm is an important to fix the GeoMapper, see issue #944.