### PR TITLE
Automated Jenkins job creation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,4 @@
+node('master') {
+	checkout scm
+	load 'scripts/jenkins/gcc.groovy'
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -69,16 +69,21 @@ endif()
 
 ADD_VTK_DEPENDENCY(testrunner)
 
-# Add make-target test which runs the testrunner
-# This should override CTest's predefined test-target but it does not
+# Add make-target tests which runs the testrunner
 if(DEFINED ENV{CI})
-	set(TESTRUNNER_ADDITIONAL_ARGUMENTS ${TESTRUNNER_ADDITIONAL_ARGUMENTS} --gtest_shuffle --gtest_repeat=3)
+	set(TESTRUNNER_ADDITIONAL_ARGUMENTS ${TESTRUNNER_ADDITIONAL_ARGUMENTS}
+		--gtest_shuffle --gtest_repeat=3)
 endif()
+set(TESTRUNNER_ADDITIONAL_ARGUMENTS ${TESTRUNNER_ADDITIONAL_ARGUMENTS}
+	--gtest_output=xml:./testrunner.xml)
+
+add_custom_target(tests-cleanup ${CMAKE_COMMAND} -E remove testrunner.xml)
+
 if(OGS_USE_PETSC)
 	set(TEST_FILTER_MPI --gtest_filter=-MPITest*:*Assembler*:*MeshSubsets*:*PointVec*:*InsertZeroPointsInGrid*:InSituMesh.MappedMeshSourceRoundtrip)
 	add_custom_target(tests
 		mpirun -np 1 $<TARGET_FILE:testrunner> ${TESTRUNNER_ADDITIONAL_ARGUMENTS} ${TEST_FILTER_MPI}
-		DEPENDS testrunner
+		DEPENDS testrunner tests-cleanup
 	)
 	add_custom_target(tests_mpi
 		mpirun -np 3 $<TARGET_FILE:testrunner> --gtest_filter=MPITest*
@@ -87,7 +92,7 @@ if(OGS_USE_PETSC)
 else()
 	add_custom_target(tests
 		$<TARGET_FILE:testrunner> ${TESTRUNNER_ADDITIONAL_ARGUMENTS}
-		DEPENDS testrunner
+		DEPENDS testrunner tests-cleanup
 	)
 endif()
 

--- a/scripts/cmake/test/Test.cmake
+++ b/scripts/cmake/test/Test.cmake
@@ -45,17 +45,23 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/scripts/cmake/test/Data.cmake)
 if(CMAKE_CONFIGURATION_TYPES)
 	set(CONFIG_PARAMETER --build-config "$<CONFIGURATION>")
 endif()
+add_custom_target(ctest-cleanup ${CMAKE_COMMAND} -E remove Tests/ctest.log)
 add_custom_target(
 	ctest -T Test
 	COMMAND ${CMAKE_CTEST_COMMAND}
-	--force-new-ctest-process --output-on-failure --exclude-regex LARGE
+	--force-new-ctest-process
+	--output-on-failure --output-log Tests/ctest.log
+	--exclude-regex LARGE
 	${CONFIG_PARAMETER} --parallel ${NUM_PROCESSORS} --test-action test
-	DEPENDS data ogs vtkdiff
+	DEPENDS data ogs vtkdiff ctest-cleanup
 )
+add_custom_target(ctest-large-cleanup ${CMAKE_COMMAND} -E remove Tests/ctest-large.log)
 add_custom_target(
 	ctest-large -T Test
 	COMMAND ${CMAKE_CTEST_COMMAND}
-	--force-new-ctest-process --output-on-failure --tests-regex LARGE
+	--force-new-ctest-process
+	--output-on-failure --output-log Tests/ctest-large.log
+	--tests-regex LARGE
 	${CONFIG_PARAMETER} --parallel ${NUM_PROCESSORS} --test-action test
-	DEPENDS data ogs vtkdiff
+	DEPENDS data ogs vtkdiff ctest-large-cleanup
 )

--- a/scripts/jenkins/clang-log-parser.rules
+++ b/scripts/jenkins/clang-log-parser.rules
@@ -6,9 +6,11 @@ warning /CMake Warning/
 error /CMake Error/
 
 # CTest
+warning \\[WARNING\]\
 error \[*][*][*]Failed\
 
 # Clang
+warning /: warning:/
 
 # Clang sanitizer
 error /: runtime error:/

--- a/scripts/jenkins/clang.groovy
+++ b/scripts/jenkins/clang.groovy
@@ -16,8 +16,7 @@ node('docker')
 
 				stage 'Unit tests'
 				sh '''cd build
-			          rm -rf tests/testrunner.xml
-			          bin/testrunner --gtest_output=xml:./tests/testrunner.xml'''
+			          make tests'''
 
 				stage 'End-to-end tests'
 				sh '''cd build

--- a/scripts/jenkins/gcc.groovy
+++ b/scripts/jenkins/gcc.groovy
@@ -20,8 +20,7 @@ node('docker')
 
 			stage 'Test'
 			sh '''cd build
-			      rm -rf tests/testrunner.xml
-			      bin/testrunner --gtest_output=xml:./tests/testrunner.xml'''
+			      make tests'''
 		}
 	},
 

--- a/scripts/jenkins/gcc.groovy
+++ b/scripts/jenkins/gcc.groovy
@@ -1,71 +1,40 @@
+defaultCMakeOptions = '-DOGS_LIB_BOOST=System -DOGS_LIB_VTK=System'
+
 node('docker')
 {
-	// Checks out into subdirectory ogs
 	stage 'Checkout'
-	checkout([$class: 'GitSCM',
-		branches: [[name: '*/master']],
-		doGenerateSubmoduleConfigurations: false,
-		extensions:
-			[[$class: 'RelativeTargetDirectory', relativeTargetDir: 'ogs']],
-		submoduleCfg: [],
-		userRemoteConfigs:
-			[[url: 'https://github.com/ufz/ogs']]])
+ 	dir('ogs') {
+  		checkout scm
+  	}
 
-
-	// Multiple configurations are build in parallel
-	parallel linux: {
-		docker.image('ogs6/gcc-ogs-cli:latest').inside
-		{
-			build 'build', '', 'package'
-
-			stage 'Test'
-			sh '''cd build
-			      make tests'''
-		}
-	},
-
-	linux_gui: {
-		docker.image('ogs6/gcc-ogs-gui:latest').inside {
-			build 'build_gui', '-DOGS_BUILD_GUI=ON -DOGS_BUILD_TESTS=OFF -DOGS_BUILD_CLI=OFF', 'package'
-		}
+	stage 'Build'
+	docker.image('ogs6/gcc-ogs-base:latest').inside {
+		build 'build', '', 'package tests ctest'
 	}
 
-//	windows: {
-//		docker.image('ogs6/mingw-ogs-gui:latest').inside
-//		{
-//			build 'build_win', '-DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE', 'package'
-//
-//			stage 'Test'
-//			sh '''cd build_win
-//						rm -rf tests/testrunner.xml
-//						wine bin/testrunner.exe --gtest_output=xml:./tests/testrunner.xml'''
-//		}
-//	},
-//
-//	windows_gui: {
-//		docker.image('ogs6/mingw-ogs-gui:latest').inside
-//		{
-//			build 'build_win_gui',
-//						'-DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE -DOGS_BUILD_GUI=ON -DOGS_BUILD_TESTS=OFF -DOGS_BUILD_CLI=OFF',
-//						'package'
-//		}
-//	}
+	publishTestReports 'build/Testing/**/*.xml', 'build/Tests/testrunner.xml'
 
-	// end parallel
-
-	step([$class: 'JUnitResultArchiver',
-		testResults: 'build/tests/testrunner.xml,build_win/tests/testrunner.xml'])
-
-	archive 'build*/*.tar.gz,build_win*/*.zip'
-} // end node
+	// archive 'build*/*.tar.gz'
+}
 
 
 def build(buildDir, cmakeOptions, target) {
 	sh "rm -rf ${buildDir} && mkdir ${buildDir}"
 
 	stage 'Configure'
-	sh "cd ${buildDir} && cmake ../ogs ${cmakeOptions}"
+	sh "cd ${buildDir} && cmake ../ogs ${defaultCMakeOptions} ${cmakeOptions}"
 
 	stage 'Build'
-	sh "cd ${buildDir} && make -j 2 ${target}"
+	sh "cd ${buildDir} && make -j 4 ${target}"
+}
+
+def publishTestReports(ctestPattern, gtestPattern) {
+	step([$class: 'XUnitPublisher', testTimeMargin: '3000', thresholdMode: 1,
+		thresholds: [
+			[$class: 'FailedThreshold', failureNewThreshold: '', failureThreshold: '', unstableNewThreshold: '', unstableThreshold: ''],
+			[$class: 'SkippedThreshold', failureNewThreshold: '', failureThreshold: '', unstableNewThreshold: '', unstableThreshold: '']],
+		tools: [
+			[$class: 'CTestType', deleteOutputFiles: true, failIfNotNew: true, pattern: "${ctestPattern}", skipNoTestFiles: false, stopProcessingIfError: true],
+			[$class: 'GoogleTestType', deleteOutputFiles: true, failIfNotNew: true, pattern: "${gtestPattern}", skipNoTestFiles: false, stopProcessingIfError: true]]
+	])
 }

--- a/scripts/jenkins/gcc.groovy
+++ b/scripts/jenkins/gcc.groovy
@@ -15,7 +15,8 @@ node('docker')
 	publishTestReports 'build/Testing/**/*.xml', 'build/Tests/testrunner.xml',
 		'ogs/scripts/jenkins/clang-log-parser.rules'
 
-	// archive 'build*/*.tar.gz'
+	if (env.BRANCH_NAME == 'master')
+		archive 'build*/*.tar.gz'
 }
 
 


### PR DESCRIPTION
This PR adds functionality to automatically create Jenkins jobs for a given git repository and then automatically build all branches when pushed (i.e. pull request testing before submitting the pull request). The only thing to be done is to mark a repo to be tested (see [my repo](https://svn.ufz.de:8443/job/OGS-6/job/Docker/job/bilke/) and the [ufz repo](https://svn.ufz.de:8443/job/OGS-6/job/Docker/job/bufz/)).

For the moment these tests will be run in addition to other tests as I am using the [Jenkins Pipeline](https://github.com/jenkinsci/workflow-plugin)-functionality which still misses some features. Also the tests are a little bit slow because they are run on an old machine.

Starting point is the `Jenkinsfile` which loads the `gcc.groovy` where the actual job config is given:

- builds inside a docker container
- runs testrunner and ctest
- publishes test results
- scans console output for error and warnings