### PR TITLE
make ConfigTreeNew more robust against nullptr accesses

### DIFF
--- a/BaseLib/ConfigTreeNew.cpp
+++ b/BaseLib/ConfigTreeNew.cpp
@@ -246,4 +246,20 @@ ConfigTreeNew::checkAndInvalidate()
     _tree = nullptr;
 }
 
+
+void checkAndInvalidate(ConfigTreeNew &conf)
+{
+    conf.checkAndInvalidate();
+}
+
+void checkAndInvalidate(ConfigTreeNew* const conf)
+{
+    if (conf) conf->checkAndInvalidate();
+}
+
+void checkAndInvalidate(std::unique_ptr<ConfigTreeNew> const& conf)
+{
+    if (conf) conf->checkAndInvalidate();
+}
+
 }

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -15,9 +15,26 @@
 #include <map>
 
 #include <functional>
+#include <memory>
 
 namespace BaseLib
 {
+
+class ConfigTreeNew;
+
+/*! Check if \c conf has been read entirely and invalidate it.
+ *
+ * This method can savely be called on \c nullptr's.
+ *
+ * \see ConfigTreeNew::checkAndInvalidate()
+ */
+void checkAndInvalidate(ConfigTreeNew* const conf);
+
+//! \overload
+void checkAndInvalidate(std::unique_ptr<ConfigTreeNew> const& conf);
+
+//! \overload
+void checkAndInvalidate(ConfigTreeNew& conf);
 
 template<typename Iterator> class Range;
 
@@ -305,13 +322,6 @@ public:
      */
     void ignoreConfParamAll(std::string const& param) const;
 
-    /*! Checks if the top level of this tree has been read entirely (and not too often).
-     *
-     * Caution: This method also invalidates the instance, i.e., afterwards it can not
-     *          be read from the tree anymore!
-     */
-    void checkAndInvalidate();
-
     //! The destructor performs the check if all nodes at the current level of the tree
     //! have been read.
     ~ConfigTreeNew();
@@ -372,6 +382,13 @@ private:
     //! and the number of times it exists in the ConfigTree
     void markVisitedDecrement(std::string const& key) const;
 
+    /*! Checks if the top level of this tree has been read entirely (and not too often).
+     *
+     * Caution: This method also invalidates the instance, i.e., afterwards it can not
+     *          be read from the tree anymore!
+     */
+    void checkAndInvalidate();
+
     //! returns a short string at suitable for error/warning messages
     static std::string shortString(std::string const& s);
 
@@ -401,6 +418,10 @@ private:
 
     //! Set of allowed characters in a key name.
     static const std::string key_chars;
+
+    friend void checkAndInvalidate(ConfigTreeNew* const conf);
+    friend void checkAndInvalidate(ConfigTreeNew& conf);
+    friend void checkAndInvalidate(std::unique_ptr<ConfigTreeNew> const& conf);
 };
 
 }

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -150,7 +150,7 @@ private:
 		_rhs.reset(_global_setup.createVector(num_unknowns));
 		_linear_solver.reset(new typename GlobalSetup::LinearSolver(
 		    *_A, solver_name, _linear_solver_options.get()));
-		_linear_solver_options->checkAndInvalidate();
+		checkAndInvalidate(_linear_solver_options);
 	}
 
 	/// Computes and stores global matrix' sparsity pattern from given


### PR DESCRIPTION
When examining #971 it was found that there was—additionally to the tag issue—a nullptr dereference. This PR introduces a methods that can savely be run on nullptrs, avoiding such errors.

Note: the call in `Process.h` now uses argument dependent lookup.