### PR TITLE
Move up process bcs

### DIFF
--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -48,8 +48,6 @@ namespace ProcessLib
 template<typename GlobalSetup>
 class GroundwaterFlowProcess : public Process<GlobalSetup>
 {
-    unsigned const _integration_order = 2;
-
 public:
     GroundwaterFlowProcess(MeshLib::Mesh& mesh,
             std::vector<ProcessVariable> const& variables,
@@ -151,7 +149,7 @@ public:
                 this->_mesh.getElements(),
                 _local_assemblers,
                 *_hydraulic_conductivity,
-                _integration_order);
+                this->_integration_order);
     }
 
     void initializeBoundaryConditions() override
@@ -174,7 +172,7 @@ public:
                     std::back_inserter(this->_neumann_bcs),
                     hydraulic_head_mesh_element_searcher,
                     this->_global_setup,
-                    _integration_order,
+                    this->_integration_order,
                     *this->_local_to_global_index_map,
                     0,
                     *_mesh_subset_all_nodes);

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -170,8 +170,6 @@ public:
     {
         DBUG("Initialize GroundwaterFlowProcess.");
 
-        Process<GlobalSetup>::setInitialConditions(*_hydraulic_head, 0);
-
         if (this->_mesh.getDimension()==1)
             createLocalAssemblers<1>();
         else if (this->_mesh.getDimension()==2)

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -78,7 +78,9 @@ public:
 
             DBUG("Associate hydraulic_head with process variable \'%s\'.",
                 name.c_str());
-            _hydraulic_head = const_cast<ProcessVariable*>(&*variable);
+            this->_process_variables.emplace_back(
+                const_cast<ProcessVariable*>(&*variable));
+            _hydraulic_head = this->_process_variables.back();
         }
 
         // Hydraulic conductivity parameter.

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -149,17 +149,6 @@ public:
                 this->_integration_order);
     }
 
-    void initializeMeshSubsets(MeshLib::Mesh const& mesh) override
-    {
-        // Create single component dof in every of the mesh's nodes.
-        this->_mesh_subset_all_nodes =
-            new MeshLib::MeshSubset(mesh, &mesh.getNodes());
-
-        // Collect the mesh subsets in a vector.
-        this->_all_mesh_subsets.push_back(
-            new MeshLib::MeshSubsets(this->_mesh_subset_all_nodes));
-    }
-
     std::string getLinearSolverName() const override
     {
         return "gw_";

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -150,33 +150,6 @@ public:
                 this->_integration_order);
     }
 
-    void initializeBoundaryConditions() override
-    {
-        MeshGeoToolsLib::MeshNodeSearcher& hydraulic_head_mesh_node_searcher =
-            MeshGeoToolsLib::MeshNodeSearcher::getMeshNodeSearcher(
-                _hydraulic_head->getMesh());
-
-        //
-        // Neumann boundary conditions.
-        //
-        {
-            // Find mesh nodes.
-            MeshGeoToolsLib::BoundaryElementsSearcher hydraulic_head_mesh_element_searcher(
-                _hydraulic_head->getMesh(), hydraulic_head_mesh_node_searcher);
-
-            // Create a neumann BC for the hydraulic head storing them in the
-            // _neumann_bcs vector.
-            _hydraulic_head->createNeumannBcs(
-                    std::back_inserter(this->_neumann_bcs),
-                    hydraulic_head_mesh_element_searcher,
-                    this->_global_setup,
-                    this->_integration_order,
-                    *this->_local_to_global_index_map,
-                    0,
-                    *this->_mesh_subset_all_nodes);
-        }
-    }
-
     void initializeMeshSubsets(MeshLib::Mesh const& mesh) override
     {
         // Create single component dof in every of the mesh's nodes.

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -75,7 +75,6 @@ public:
                 name.c_str());
             this->_process_variables.emplace_back(
                 const_cast<ProcessVariable*>(&*variable));
-            _hydraulic_head = this->_process_variables.back();
         }
 
         // Hydraulic conductivity parameter.
@@ -249,8 +248,6 @@ public:
     }
 
 private:
-    ProcessVariable* _hydraulic_head = nullptr;
-
     Parameter<double, MeshLib::Element const&> const* _hydraulic_conductivity = nullptr;
 
     using LocalAssembler = GroundwaterFlow::LocalAssemblerDataInterface<

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -25,7 +25,6 @@
 #include "FileIO/VtkIO/VtuInterface.h"
 
 #include "MeshLib/MeshSubset.h"
-#include "MeshGeoToolsLib/MeshNodeSearcher.h"
 
 #include "UniformDirichletBoundaryCondition.h"
 
@@ -157,16 +156,9 @@ public:
 
     void initializeBoundaryConditions() override
     {
-        DBUG("Initialize boundary conditions.");
         MeshGeoToolsLib::MeshNodeSearcher& hydraulic_head_mesh_node_searcher =
             MeshGeoToolsLib::MeshNodeSearcher::getMeshNodeSearcher(
                 _hydraulic_head->getMesh());
-
-        _hydraulic_head->initializeDirichletBCs(
-            std::back_inserter(this->_dirichlet_bcs),
-            hydraulic_head_mesh_node_searcher,
-            *this->_local_to_global_index_map,
-            0);
 
         //
         // Neumann boundary conditions.

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -11,25 +11,15 @@
 #define PROCESS_LIB_GROUNDWATERFLOWPROCESS_H_
 
 #include <cassert>
-#include <memory>
 
-#include <boost/algorithm/string/erase.hpp>
 #include <boost/optional.hpp>
-
-
-#include "logog/include/logog.hpp"
 
 #include "AssemblerLib/LocalAssemblerBuilder.h"
 #include "AssemblerLib/LocalDataInitializer.h"
 
 #include "FileIO/VtkIO/VtuInterface.h"
 
-#include "UniformDirichletBoundaryCondition.h"
-
 #include "GroundwaterFlowFEM.h"
-#include "NeumannBcAssembler.h"
-#include "NeumannBc.h"
-#include "DirichletBc.h"
 #include "Parameter.h"
 #include "Process.h"
 

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -24,8 +24,6 @@
 
 #include "FileIO/VtkIO/VtuInterface.h"
 
-#include "MeshLib/MeshSubset.h"
-
 #include "UniformDirichletBoundaryCondition.h"
 
 #include "GroundwaterFlowFEM.h"
@@ -175,19 +173,19 @@ public:
                     this->_integration_order,
                     *this->_local_to_global_index_map,
                     0,
-                    *_mesh_subset_all_nodes);
+                    *this->_mesh_subset_all_nodes);
         }
     }
 
     void initializeMeshSubsets(MeshLib::Mesh const& mesh) override
     {
         // Create single component dof in every of the mesh's nodes.
-        _mesh_subset_all_nodes =
+        this->_mesh_subset_all_nodes =
             new MeshLib::MeshSubset(mesh, &mesh.getNodes());
 
         // Collect the mesh subsets in a vector.
         this->_all_mesh_subsets.push_back(
-            new MeshLib::MeshSubsets(_mesh_subset_all_nodes));
+            new MeshLib::MeshSubsets(this->_mesh_subset_all_nodes));
     }
 
     std::string getLinearSolverName() const override
@@ -285,8 +283,6 @@ private:
     ProcessVariable* _hydraulic_head = nullptr;
 
     Parameter<double, MeshLib::Element const&> const* _hydraulic_conductivity = nullptr;
-
-    MeshLib::MeshSubset const* _mesh_subset_all_nodes = nullptr;
 
     using LocalAssembler = GroundwaterFlow::LocalAssemblerDataInterface<
         typename GlobalSetup::MatrixType, typename GlobalSetup::VectorType>;

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -166,10 +166,8 @@ public:
         return "gw_";
     }
 
-    void init() override
+    void createLocalAssemblers() override
     {
-        DBUG("Initialize GroundwaterFlowProcess.");
-
         if (this->_mesh.getDimension()==1)
             createLocalAssemblers<1>();
         else if (this->_mesh.getDimension()==2)

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -49,7 +49,7 @@ public:
 	}
 
 	/// Process specific initialization called by initialize().
-	virtual void init() = 0;
+	virtual void createLocalAssemblers() = 0;
 	virtual bool assemble(const double delta_t) = 0;
 
 	virtual std::string getLinearSolverName() const = 0;
@@ -86,7 +86,7 @@ public:
 		_global_assembler.reset(
 		    new GlobalAssembler(*_A, *_rhs, *_local_to_global_index_map));
 
-		init();  // Execute proces specific initialization.
+		createLocalAssemblers();
 
 		for (auto const& pv : _process_variables)
 		{

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -10,7 +10,11 @@
 #ifndef PROCESS_LIB_PROCESS_H_
 #define PROCESS_LIB_PROCESS_H_
 
+#include <memory>
 #include <string>
+
+#include <logog/include/logog.hpp>
+
 
 #include "AssemblerLib/ComputeSparsityPattern.h"
 #include "AssemblerLib/LocalToGlobalIndexMap.h"
@@ -27,7 +31,11 @@
 #include "MathLib/LinAlg/PETSc/PETScMatrixOption.h"
 #endif
 
+#include "DirichletBc.h"
+#include "NeumannBc.h"
+#include "NeumannBcAssembler.h"
 #include "ProcessVariable.h"
+#include "UniformDirichletBoundaryCondition.h"
 
 namespace MeshLib
 {

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -18,6 +18,7 @@
 #include "BaseLib/ConfigTreeNew.h"
 #include "MathLib/LinAlg/ApplyKnownSolution.h"
 #include "MathLib/LinAlg/SetMatrixSparsity.h"
+#include "MeshGeoToolsLib/MeshNodeSearcher.h"
 #include "MeshLib/MeshSubsets.h"
 
 #ifdef USE_PETSC
@@ -87,6 +88,13 @@ public:
 
 		init();  // Execute proces specific initialization.
 
+		for (auto const& pv : _process_variables)
+		{
+			DBUG("Initialize boundary conditions.");
+			createDirichletBcs(*pv, 0);  // 0 is the component id
+
+		}
+
 		initializeBoundaryConditions();
 
 		for (auto& bc : _neumann_bcs)
@@ -136,6 +144,19 @@ protected:
 			_x->set(global_index,
 			        variable.getInitialConditionValue(*_mesh.getNode(i)));
 		}
+	}
+
+	void createDirichletBcs(ProcessVariable& variable,
+	                        int const component_id)
+	{
+		MeshGeoToolsLib::MeshNodeSearcher& mesh_node_searcher =
+		    MeshGeoToolsLib::MeshNodeSearcher::getMeshNodeSearcher(
+		        variable.getMesh());
+
+		variable.initializeDirichletBCs(std::back_inserter(_dirichlet_bcs),
+		                                 mesh_node_searcher,
+		                                 *_local_to_global_index_map,
+		                                 component_id);
 	}
 
 private:

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -90,6 +90,9 @@ public:
 
 		for (auto const& pv : _process_variables)
 		{
+			DBUG("Set initial conditions.");
+			setInitialConditions(*pv, 0);  // 0 is the component id
+
 			DBUG("Initialize boundary conditions.");
 			createDirichletBcs(*pv, 0);  // 0 is the component id
 

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -19,6 +19,7 @@
 #include "MathLib/LinAlg/ApplyKnownSolution.h"
 #include "MathLib/LinAlg/SetMatrixSparsity.h"
 #include "MeshGeoToolsLib/MeshNodeSearcher.h"
+#include "MeshLib/MeshSubset.h"
 #include "MeshLib/MeshSubsets.h"
 
 #ifdef USE_PETSC
@@ -44,6 +45,7 @@ public:
 	{
 		for (auto p : _all_mesh_subsets)
 			delete p;
+		delete _mesh_subset_all_nodes;
 	}
 
 	/// Process specific initialization called by initialize().
@@ -196,6 +198,7 @@ protected:
 	unsigned const _integration_order = 2;
 
 	MeshLib::Mesh& _mesh;
+	MeshLib::MeshSubset const* _mesh_subset_all_nodes = nullptr;
 	std::vector<MeshLib::MeshSubsets*> _all_mesh_subsets;
 
 	GlobalSetup _global_setup;

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -131,6 +131,7 @@ protected:
 			std::move(config)));
 	}
 
+private:
 	/// Sets the initial condition values in the solution vector x for a given
 	/// process variable and component.
 	void setInitialConditions(ProcessVariable const& variable,
@@ -181,7 +182,6 @@ protected:
 		                          *_mesh_subset_all_nodes);
 	}
 
-private:
 	/// Creates global matrix, rhs and solution vectors, and the linear solver.
 	void createLinearSolver(std::string const& solver_name)
 	{

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -197,6 +197,9 @@ protected:
 
 	std::vector<DirichletBc<GlobalIndexType>> _dirichlet_bcs;
 	std::vector<std::unique_ptr<NeumannBc<GlobalSetup>>> _neumann_bcs;
+
+    /// Variables used by this process.
+	std::vector<ProcessVariable*> _process_variables;
 };
 
 }  // namespace ProcessLib

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -60,15 +60,12 @@ public:
 	virtual void postTimestep(std::string const& file_name,
 	                          const unsigned timestep) = 0;
 
-	/// Creates mesh subsets, i.e. components, for given mesh.
-	virtual void initializeMeshSubsets(MeshLib::Mesh const& mesh) = 0;
-
 	void initialize()
 	{
 		DBUG("Initialize process.");
 
 		DBUG("Construct dof mappings.");
-		initializeMeshSubsets(_mesh);
+		initializeMeshSubsets();
 
 		_local_to_global_index_map.reset(
 		    new AssemblerLib::LocalToGlobalIndexMap(
@@ -132,6 +129,18 @@ protected:
 	}
 
 private:
+	/// Creates mesh subsets, i.e. components, for given mesh.
+	void initializeMeshSubsets()
+	{
+		// Create single component dof in every of the mesh's nodes.
+		_mesh_subset_all_nodes =
+		    new MeshLib::MeshSubset(_mesh, &_mesh.getNodes());
+
+		// Collect the mesh subsets in a vector.
+		_all_mesh_subsets.push_back(
+		    new MeshLib::MeshSubsets(_mesh_subset_all_nodes));
+	}
+
 	/// Sets the initial condition values in the solution vector x for a given
 	/// process variable and component.
 	void setInitialConditions(ProcessVariable const& variable,

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -193,6 +193,8 @@ private:
 	}
 
 protected:
+	unsigned const _integration_order = 2;
+
 	MeshLib::Mesh& _mesh;
 	std::vector<MeshLib::MeshSubsets*> _all_mesh_subsets;
 

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -81,8 +81,9 @@ public:
 		for (auto& config : _neumann_bc_configs)
 		{
 			config->initialize(searcher);
-			bcs++ = new NeumannBc<GlobalSetup>(*config,
-			                                   std::forward<Args>(args)...);
+			bcs++ = std::unique_ptr<NeumannBc<GlobalSetup>>{
+			    new NeumannBc<GlobalSetup>(*config,
+			                               std::forward<Args>(args)...)};
 		}
 	}
 


### PR DESCRIPTION
Second chunk of moves from GroundwaterFlowProcess up into the Process class.
As the result the GWFP now has only the local assemblers and the hydraulic conductivity members.

Initial and both types of boundary conditions were directly moved. To generalize the initialization the Process class has a new member _process_variables pointing to the used set of process variables (defined in ProjectData).

Initialization of the mesh subsets (components) was finally moved up.

Next steps are:
 - move up post() for output
 - extend the Process class to handle multiple components. (For now at the corresponding places there is a 0 passed around.)