### PR TITLE
AddLayer properties

### DIFF
--- a/Applications/Utils/MeshEdit/AddTopLayer.cpp
+++ b/Applications/Utils/MeshEdit/AddTopLayer.cpp
@@ -18,14 +18,11 @@
 
 #include "BaseLib/FileTools.h"
 
-// FileIO
 #include "FileIO/readMeshFromFile.h"
-#include "FileIO/VtkIO/VtuInterface.h"
+#include "FileIO/writeMeshToFile.h"
 
-// MeshLib
 #include "MeshLib/Mesh.h"
 #include "MeshLib/MeshEditing/AddLayerToMesh.h"
-
 
 int main (int argc, char* argv[])
 {
@@ -69,8 +66,7 @@ int main (int argc, char* argv[])
 	}
 
 	INFO("Writing mesh \"%s\" ... ", mesh_out_arg.getValue().c_str());
-	FileIO::VtuInterface mesh_io(result.get(), vtkXMLWriter::Binary);
-	mesh_io.writeToFile(mesh_out_arg.getValue());
+	FileIO::writeMeshToFile(*result, mesh_out_arg.getValue());
 	INFO("done.");
 
 	return EXIT_SUCCESS;

--- a/Applications/Utils/MeshEdit/AddTopLayer.cpp
+++ b/Applications/Utils/MeshEdit/AddTopLayer.cpp
@@ -53,17 +53,25 @@ int main (int argc, char* argv[])
 	cmd.parse(argc, argv);
 
 	INFO("Reading mesh \"%s\" ... ", mesh_arg.getValue().c_str());
-	MeshLib::Mesh * subsfc_mesh(FileIO::readMeshFromFile(mesh_arg.getValue()));
+	auto subsfc_mesh = std::unique_ptr<MeshLib::Mesh>(
+	    FileIO::readMeshFromFile(mesh_arg.getValue()));
+	if (!subsfc_mesh) {
+		ERR("Error reading mesh \"%s\".", mesh_arg.getValue().c_str());
+		return EXIT_FAILURE;
+	}
 	INFO("done.");
 
-	std::unique_ptr<MeshLib::Mesh> result (MeshLib::addTopLayerToMesh(
-		*subsfc_mesh, layer_thickness_arg.getValue(), mesh_out_arg.getValue()
-	));
+	std::unique_ptr<MeshLib::Mesh> result(MeshLib::addTopLayerToMesh(
+	    *subsfc_mesh, layer_thickness_arg.getValue(), mesh_out_arg.getValue()));
+	if (!result) {
+		ERR("Failure while adding top layer.")
+		return EXIT_FAILURE;
+	}
 
 	INFO("Writing mesh \"%s\" ... ", mesh_out_arg.getValue().c_str());
 	FileIO::VtuInterface mesh_io(result.get(), vtkXMLWriter::Binary);
 	mesh_io.writeToFile(mesh_out_arg.getValue());
 	INFO("done.");
 
-	return 0;
+	return EXIT_SUCCESS;
 }

--- a/Applications/Utils/MeshEdit/AddTopLayer.cpp
+++ b/Applications/Utils/MeshEdit/AddTopLayer.cpp
@@ -14,11 +14,8 @@
 // TCLAP
 #include "tclap/CmdLine.h"
 
-// ThirdParty/logog
-#include "logog/include/logog.hpp"
+#include "Applications/ApplicationsLib/LogogSetup.h"
 
-// BaseLib
-#include "BaseLib/LogogSimpleFormatter.h"
 #include "BaseLib/FileTools.h"
 
 // FileIO
@@ -32,10 +29,7 @@
 
 int main (int argc, char* argv[])
 {
-	LOGOG_INITIALIZE();
-	logog::Cout* logog_cout (new logog::Cout);
-	BaseLib::LogogSimpleFormatter *custom_format (new BaseLib::LogogSimpleFormatter);
-	logog_cout->SetFormatter(*custom_format);
+	ApplicationsLib::LogogSetup logog_setup;
 
 	TCLAP::CmdLine cmd(
 		"Adds a top layer to an existing mesh",

--- a/MeshLib/MeshEditing/AddLayerToMesh.cpp
+++ b/MeshLib/MeshEditing/AddLayerToMesh.cpp
@@ -107,7 +107,6 @@ MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh, double thickness,
 	}
 
 	// *** insert new top layer elements into subsfc_mesh
-	std::size_t orig_size(subsfc_elements.size());
 	std::vector<MeshLib::Element*> const& sfc_elements(sfc_mesh->getElements());
 	std::size_t const n_sfc_elements(sfc_elements.size());
 	for (std::size_t k(0); k<n_sfc_elements; ++k)
@@ -115,23 +114,33 @@ MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh, double thickness,
 			extrudeElement(subsfc_nodes, *sfc_elements[k], subsfc_sfc_id_map)
 		);
 
-	MeshLib::Properties subsfc_props (mesh.getProperties());
-	boost::optional<MeshLib::PropertyVector<int> &> opt_materials(
-		subsfc_props.getPropertyVector<int>("MaterialIDs")
+	auto new_mesh = new MeshLib::Mesh(name, subsfc_nodes, subsfc_elements);
+
+	boost::optional<MeshLib::PropertyVector<int> const&> opt_materials(
+		mesh.getProperties().getPropertyVector<int>("MaterialIDs")
 	);
-	if (!opt_materials) {
-		ERR("Can not set material properties for new layer");
-	} else {
-		MeshLib::PropertyVector<int> & materials(opt_materials.get());
-		unsigned layer_id(*(std::max_element(
-			materials.cbegin(), materials.cend()))+1);
-		while (orig_size<subsfc_elements.size()) {
-			materials.push_back(layer_id);
-			orig_size++;
+
+	if (opt_materials) {
+		boost::optional<PropertyVector<int> &> new_opt_materials(
+		new_mesh->getProperties().createNewPropertyVector<int>("MaterialIDs",
+			MeshLib::MeshItemType::Cell, 1));
+		if (!new_opt_materials) {
+			ERR("Can not set material properties for new layer");
+		} else {
+			unsigned new_layer_id(*(std::max_element(
+				opt_materials->cbegin(), opt_materials->cend()))+1);
+			std::copy(opt_materials->cbegin(), opt_materials->cend(),
+			          new_opt_materials->begin());
+			auto const n_new_props(subsfc_elements.size()-mesh.getNElements());
+			std::fill_n(new_opt_materials->end(), n_new_props, new_layer_id);
 		}
+	} else {
+		ERR(
+		    "Could not copy the property \"MaterialIDs\" since the original "
+		    "mesh does not contain such a property.");
 	}
 
-	return new MeshLib::Mesh(name, subsfc_nodes, subsfc_elements, subsfc_props);
+	return new_mesh;
 }
 
 } // namespace MeshLib

--- a/MeshLib/MeshEditing/AddLayerToMesh.cpp
+++ b/MeshLib/MeshEditing/AddLayerToMesh.cpp
@@ -42,7 +42,8 @@ MeshLib::Element* extrudeElement(std::vector<MeshLib::Node*> const& subsfc_nodes
 	{
 		new_nodes[j] = subsfc_nodes[sfc_elem.getNode(j)->getID()];
 		std::size_t new_idx = (nElemNodes==2) ? (3-j) : (nElemNodes+j);
-		new_nodes[new_idx] = subsfc_nodes[subsfc_sfc_id_map.at(sfc_elem.getNode(j)->getID())];
+		new_nodes[new_idx] =
+		    subsfc_nodes[subsfc_sfc_id_map.at(sfc_elem.getNode(j)->getID())];
 	}
 	
 	if (sfc_elem.getGeomType() == MeshLib::MeshElemType::LINE)
@@ -84,7 +85,8 @@ MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh, double thickness,
 	INFO("done.");
 
 	// *** add new surface nodes
-	std::vector<MeshLib::Node*> subsfc_nodes = MeshLib::copyNodeVector(mesh.getNodes());
+	std::vector<MeshLib::Node*> subsfc_nodes =
+	    MeshLib::copyNodeVector(mesh.getNodes());
 	std::vector<MeshLib::Element*> subsfc_elements =
 		MeshLib::copyElementVector(mesh.getElements(), subsfc_nodes);
 
@@ -100,9 +102,8 @@ MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh, double thickness,
 		std::size_t const sfc_id(k+n_subsfc_nodes);
 		subsfc_sfc_id_map.insert(std::make_pair(subsfc_id, sfc_id));
 		MeshLib::Node const& node (*sfc_nodes[k]);
-		subsfc_nodes.push_back(
-			new MeshLib::Node(node[0], node[1], node[2] - (flag * thickness), sfc_id)
-		);
+		subsfc_nodes.push_back(new MeshLib::Node(
+		    node[0], node[1], node[2] - (flag * thickness), sfc_id));
 	}
 
 	// *** insert new top layer elements into subsfc_mesh

--- a/MeshLib/MeshEditing/AddLayerToMesh.h
+++ b/MeshLib/MeshEditing/AddLayerToMesh.h
@@ -26,20 +26,20 @@ class Node;
 class Element;
 
 /// Adds a layer on top of the mesh
-MeshLib::Mesh* addTopLayerToMesh(MeshLib::Mesh const& mesh, 
-	double thickness, 
+MeshLib::Mesh* addTopLayerToMesh(MeshLib::Mesh const& mesh,
+	double thickness,
 	std::string const& name);
 
 /// Adds a layer at the bottom of the mesh
-MeshLib::Mesh* addBottomLayerToMesh(MeshLib::Mesh const& mesh, 
-	double thickness, 
+MeshLib::Mesh* addBottomLayerToMesh(MeshLib::Mesh const& mesh,
+	double thickness,
 	std::string const& name);
 
 /// Adds a layer to the mesh. If on_top is true, the layer is added on top,
 /// if it is false, the layer is added at the bottom.
-MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh, 
-	double thickness, 
-	std::string const& name, 
+MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh,
+	double thickness,
+	std::string const& name,
 	bool on_top);
 
 } // end namespace MeshLib


### PR DESCRIPTION
This PR fixes the bug from issue #968. The property vectors "MaterialIDs" is updated correctly. All other property vectors of the original mesh are removed from the new mesh. Furthermore a mem leaks is removed. The tool can output the new mesh in vtu or old mesh format.