### PR TITLE
ConfigTreeNew: Added support for XML attributes

### DIFF
--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -114,6 +114,7 @@ int main(int argc, char *argv[])
 		//          created inside this same scope!
 		using Conf = BaseLib::ConfigTreeNew;
 		Conf conf(project_config.get_child("OpenGeoSysProject"),
+				  project_arg.getValue(),
 		          Conf::onerror,
 		          nonfatal_arg.getValue() ? Conf::onwarning : Conf::onerror);
 

--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -16,8 +16,7 @@
 
 // BaseLib
 #include "BaseLib/BuildInfo.h"
-#include "BaseLib/ConfigTree.h"
-#include "BaseLib/ConfigTreeNew.h"
+#include "BaseLib/ConfigTreeUtil.h"
 #include "BaseLib/FileTools.h"
 
 #include "Applications/ApplicationsLib/LinearSolverLibrarySetup.h"
@@ -102,38 +101,25 @@ int main(int argc, char *argv[])
 	ApplicationsLib::LinearSolverLibrarySetup linear_solver_library_setup(
 	    argc, argv);
 
-	// Project's configuration
-	BaseLib::ConfigTree project_config =
-	    BaseLib::read_xml_config(project_arg.getValue());
+	auto project_config = BaseLib::makeConfigTree(
+	    project_arg.getValue(), !nonfatal_arg.getValue(), "OpenGeoSysProject");
 
-	std::unique_ptr<ProjectData> project;
-	{
-		// Nested scope in order to trigger config tree checks early.
-		// Caution: The top level config tree must not be saved inside
-		//          ProjectData and the boost::property_tree must not be
-		//          created inside this same scope!
-		using Conf = BaseLib::ConfigTreeNew;
-		Conf conf(project_config.get_child("OpenGeoSysProject"),
-				  project_arg.getValue(),
-		          Conf::onerror,
-		          nonfatal_arg.getValue() ? Conf::onwarning : Conf::onerror);
+	ProjectData project(*project_config, BaseLib::extractPath(project_arg.getValue()));
 
-		project.reset(new ProjectData(
-		              conf, BaseLib::extractPath(project_arg.getValue())));
-	}
+	project_config.checkAndInvalidate();
 
 	// Create processes.
-	project->buildProcesses<GlobalSetupType>();
+	project.buildProcesses<GlobalSetupType>();
 
 	INFO("Initialize processes.");
-	for (auto p_it = project->processesBegin(); p_it != project->processesEnd(); ++p_it)
+	for (auto p_it = project.processesBegin(); p_it != project.processesEnd(); ++p_it)
 	{
 		(*p_it)->initialize();
 	}
 
-	std::string const output_file_name(project->getOutputFilePrefix() + ".vtu");
+	std::string const output_file_name(project.getOutputFilePrefix() + ".vtu");
 
-	solveProcesses(*project);
+	solveProcesses(project);
 
 	return 0;
 }

--- a/BaseLib/ConfigTree.cpp
+++ b/BaseLib/ConfigTree.cpp
@@ -9,37 +9,7 @@
 
 #include "ConfigTree.h"
 
-#include <boost/property_tree/xml_parser.hpp>
-#include <boost/property_tree/json_parser.hpp>
-
-#include <logog/include/logog.hpp>
-
 // Explicitly instantiate the boost::property_tree::ptree which is a typedef to
 // the following basic_ptree.
 template class boost::property_tree::basic_ptree<std::string, std::string,
                                                  std::less<std::string>>;
-
-namespace BaseLib
-{
-
-ConfigTree read_xml_config(std::string const& path)
-{
-	ConfigTree ptree;
-	read_xml(path, ptree,
-	         boost::property_tree::xml_parser::no_comments |
-	             boost::property_tree::xml_parser::trim_whitespace);
-
-	DBUG("Project configuration from file \'%s\' read.",
-	     path.c_str());
-
-	return ptree;
-}
-
-std::string propertyTreeToString(ConfigTree const& tree)
-{
-	std::ostringstream ss;
-	boost::property_tree::write_json(ss, tree);
-	return ss.str();
-}
-
-}

--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -10,20 +10,9 @@
 #ifndef BASELIB_CONFIGTREE_H_
 #define BASELIB_CONFIGTREE_H_
 
-#include <string>
 #include <boost/property_tree/ptree.hpp>
 
 extern template class boost::property_tree::basic_ptree<
     std::string, std::string, std::less<std::string>>;
-
-namespace BaseLib
-{
-using ConfigTree = boost::property_tree::ptree;
-
-boost::property_tree::ptree read_xml_config(std::string const& path);
-
-/// Returns the JSON-representation of the given boost::property_tree.
-std::string propertyTreeToString(boost::property_tree::ptree const& tree);
-}
 
 #endif  // BASELIB_CONFIGTREE_H_

--- a/BaseLib/ConfigTreeNew-impl.h
+++ b/BaseLib/ConfigTreeNew-impl.h
@@ -144,10 +144,11 @@ ConfigTreeNew::
 getConfAttribute(std::string const& attr) const
 {
     checkUniqueAttr(attr);
-    markVisited<T>(attr, true);
+    auto& ct = markVisited<T>(attr, true, true);
 
     if (auto attrs = _tree->get_child_optional("<xmlattr>")) {
         if (auto a = attrs->get_child_optional(attr)) {
+            ++ct.count; // count only if attribute has been found
             if (auto v = a->get_value_optional<T>()) {
                 return *v;
             } else {
@@ -156,7 +157,7 @@ getConfAttribute(std::string const& attr) const
                       + "' not convertible to the desired type.");
             }
         } else {
-            error("No XML attribute named \"" + attr + "\"");
+            error("Did not find XML attribute with name \"" + attr + "\"");
         }
     } else {
         error("This parameter has no XML attributes");

--- a/BaseLib/ConfigTreeNew-impl.h
+++ b/BaseLib/ConfigTreeNew-impl.h
@@ -9,8 +9,6 @@
 
 #include "ConfigTreeNew.h"
 
-#include <logog/include/logog.hpp>
-
 namespace BaseLib
 {
 
@@ -123,7 +121,6 @@ T
 ConfigTreeNew::
 getValue() const
 {
-    // TODO test this
     if (_have_read_data) {
         error("The data of this subtree has already been read.");
     }

--- a/BaseLib/ConfigTreeNew-impl.h
+++ b/BaseLib/ConfigTreeNew-impl.h
@@ -71,7 +71,7 @@ ConfigTreeNew::
 getConfParamList(std::string const& param) const
 {
     checkUnique(param);
-    markVisited<T>(param, true);
+    markVisited<T>(param, false, true);
 
     auto p = _tree->equal_range(param);
     return Range<ValueIterator<T> >(
@@ -144,7 +144,7 @@ ConfigTreeNew::
 getAttribute(std::string const& attr) const
 {
     checkUniqueAttr(attr);
-    markVisited(attr, true);
+    markVisited<T>(attr, true);
 
     if (auto attrs = _tree->get_child_optional("<xmlattr>")) {
         if (auto a = attrs->get_child_optional(attr)) {
@@ -166,11 +166,13 @@ getAttribute(std::string const& attr) const
 template<typename T>
 ConfigTreeNew::CountType&
 ConfigTreeNew::
-markVisited(std::string const& key, bool const peek_only) const
+markVisited(std::string const& key, bool const is_attr,
+            bool const peek_only) const
 {
     auto const type = std::type_index(typeid(T));
 
-    auto p = _visited_params.emplace(key, CountType{peek_only ? 0 : 1, type});
+    auto p = _visited_params.emplace(std::make_pair(is_attr, key),
+                                     CountType{peek_only ? 0 : 1, type});
 
     if (!p.second) { // no insertion happened
         auto& v = p.first->second;

--- a/BaseLib/ConfigTreeNew-impl.h
+++ b/BaseLib/ConfigTreeNew-impl.h
@@ -71,7 +71,7 @@ ConfigTreeNew::
 getConfParamList(std::string const& param) const
 {
     checkUnique(param);
-    markVisited<T>(param, false, true);
+    markVisited<T>(param, Attr::TAG, true);
 
     auto p = _tree->equal_range(param);
     return Range<ValueIterator<T> >(
@@ -155,7 +155,7 @@ ConfigTreeNew::
 getConfAttributeOptional(std::string const& attr) const
 {
     checkUniqueAttr(attr);
-    auto& ct = markVisited<T>(attr, true, true);
+    auto& ct = markVisited<T>(attr, Attr::ATTR, true);
 
     if (auto attrs = _tree->get_child_optional("<xmlattr>")) {
         if (auto a = attrs->get_child_optional(attr)) {
@@ -176,7 +176,7 @@ getConfAttributeOptional(std::string const& attr) const
 template<typename T>
 ConfigTreeNew::CountType&
 ConfigTreeNew::
-markVisited(std::string const& key, bool const is_attr,
+markVisited(std::string const& key, Attr const is_attr,
             bool const peek_only) const
 {
     auto const type = std::type_index(typeid(T));

--- a/BaseLib/ConfigTreeNew-impl.h
+++ b/BaseLib/ConfigTreeNew-impl.h
@@ -141,7 +141,7 @@ getValue() const
 template<typename T>
 T
 ConfigTreeNew::
-getAttribute(std::string const& attr) const
+getConfAttribute(std::string const& attr) const
 {
     checkUniqueAttr(attr);
     markVisited<T>(attr, true);

--- a/BaseLib/ConfigTreeNew-impl.h
+++ b/BaseLib/ConfigTreeNew-impl.h
@@ -143,6 +143,17 @@ T
 ConfigTreeNew::
 getConfAttribute(std::string const& attr) const
 {
+    if (auto a = getConfAttributeOptional<T>(attr))
+        return *a;
+
+    error("Did not find XML attribute with name \"" + attr + "\".");
+}
+
+template<typename T>
+boost::optional<T>
+ConfigTreeNew::
+getConfAttributeOptional(std::string const& attr) const
+{
     checkUniqueAttr(attr);
     auto& ct = markVisited<T>(attr, true, true);
 
@@ -150,18 +161,16 @@ getConfAttribute(std::string const& attr) const
         if (auto a = attrs->get_child_optional(attr)) {
             ++ct.count; // count only if attribute has been found
             if (auto v = a->get_value_optional<T>()) {
-                return *v;
+                return v;
             } else {
                 error("Value for XML attribute \"" + attr + "\" `"
                       + shortString(a->data())
                       + "' not convertible to the desired type.");
             }
-        } else {
-            error("Did not find XML attribute with name \"" + attr + "\"");
         }
-    } else {
-        error("This parameter has no XML attributes");
     }
+
+    return boost::none;
 }
 
 template<typename T>

--- a/BaseLib/ConfigTreeNew-impl.h
+++ b/BaseLib/ConfigTreeNew-impl.h
@@ -35,11 +35,10 @@ T
 ConfigTreeNew::
 getConfParam(std::string const& param) const
 {
-    auto p = getConfParamOptional<T>(param);
-    if (p) return *p;
+    if (auto p = getConfParamOptional<T>(param))
+        return *p;
 
     error("Key <" + param + "> has not been found");
-    return T();
 }
 
 template<typename T>
@@ -47,8 +46,9 @@ T
 ConfigTreeNew::
 getConfParam(std::string const& param, T const& default_value) const
 {
-    auto p = getConfParamOptional<T>(param);
-    if (p) return *p;
+    if (auto p = getConfParamOptional<T>(param))
+        return *p;
+
     return default_value;
 }
 
@@ -58,20 +58,9 @@ ConfigTreeNew::
 getConfParamOptional(std::string const& param) const
 {
     checkUnique(param);
-    auto p = _tree->get_child_optional(param);
 
-    bool peek_only = p == boost::none;
-    markVisited<T>(param, peek_only);
-
-    if (p) {
-        auto v = p->get_value_optional<T>();
-        if (v) {
-            return v;
-        } else {
-            error("Value for key <" + param + "> `" + shortString(p->data())
-                  + "' not convertible to the desired type.");
-        }
-    }
+    if (auto p = getConfSubtreeOptional(param))
+        return p->getValue<T>();
 
     return boost::none;
 }
@@ -97,20 +86,16 @@ peekConfParam(std::string const& param) const
 {
     checkKeyname(param);
 
-    auto p =_tree->get_child_optional(param);
-
-    if (!p) {
-        error("Key <" + param + "> has not been found");
-    } else {
+    if (auto p =_tree->get_child_optional(param)) {
         try {
             return p->get_value<T>();
         } catch (boost::property_tree::ptree_bad_data) {
             error("Value for key <" + param + "> `" + shortString(p->data())
                   + "' not convertible to the desired type.");
         }
+    } else {
+        error("Key <" + param + "> has not been found");
     }
-
-    return T();
 }
 
 template<typename T>
@@ -133,11 +118,55 @@ checkConfParam(std::string const& param, Ch const* value) const
     }
 }
 
+template<typename T>
+T
+ConfigTreeNew::
+getValue() const
+{
+    // TODO test this
+    if (_have_read_data) {
+        error("The data of this subtree has already been read.");
+    }
+
+    _have_read_data = true;
+
+    if (auto v = _tree->get_value_optional<T>()) {
+        return *v;
+    } else {
+        error("Value `" + shortString(_tree->data())
+              + "' is not convertible to the desired type.");
+    }
+}
+
+template<typename T>
+T
+ConfigTreeNew::
+getAttribute(std::string const& attr) const
+{
+    checkUniqueAttr(attr);
+    markVisited(attr, true);
+
+    if (auto attrs = _tree->get_child_optional("<xmlattr>")) {
+        if (auto a = attrs->get_child_optional(attr)) {
+            if (auto v = a->get_value_optional<T>()) {
+                return *v;
+            } else {
+                error("Value for XML attribute \"" + attr + "\" `"
+                      + shortString(a->data())
+                      + "' not convertible to the desired type.");
+            }
+        } else {
+            error("No XML attribute named \"" + attr + "\"");
+        }
+    } else {
+        error("This parameter has no XML attributes");
+    }
+}
 
 template<typename T>
 ConfigTreeNew::CountType&
 ConfigTreeNew::
-markVisited(std::string const& key, bool peek_only) const
+markVisited(std::string const& key, bool const peek_only) const
 {
     auto const type = std::type_index(typeid(T));
 

--- a/BaseLib/ConfigTreeNew.cpp
+++ b/BaseLib/ConfigTreeNew.cpp
@@ -7,6 +7,7 @@
  *
  */
 
+#include <logog/include/logog.hpp>
 #include "ConfigTreeNew.h"
 
 namespace BaseLib

--- a/BaseLib/ConfigTreeNew.cpp
+++ b/BaseLib/ConfigTreeNew.cpp
@@ -298,10 +298,10 @@ ConfigTreeNew::checkAndInvalidate()
 
     for (auto const& p : _visited_params)
     {
-        auto const& tag   = std::get<1>(p.first);
+        auto const& tag   = p.first.second;
         auto const& count = p.second.count;
 
-        if (std::get<0>(p.first)) { // tag
+        if (p.first.first) { // tag
             if (count > 0) {
                 warning("XML attribute \"" + tag + "\" has been read " + std::to_string(count)
                         + " time(s) more than it was present in the configuration tree.");

--- a/BaseLib/ConfigTreeNew.cpp
+++ b/BaseLib/ConfigTreeNew.cpp
@@ -350,7 +350,7 @@ ConfigTreeNew::checkAndInvalidate()
         auto const& tag   = p.first.second;
         auto const& count = p.second.count;
 
-        if (p.first.first) { // tag
+        if (p.first.first) { // XML attribute
             if (count > 0) {
                 warning("XML attribute \"" + tag + "\" has been read " + std::to_string(count)
                         + " time(s) more than it was present in the configuration tree.");
@@ -358,7 +358,7 @@ ConfigTreeNew::checkAndInvalidate()
                 warning("XML attribute \"" + tag + "\" has been read " + std::to_string(-count)
                         + " time(s) less than it was present in the configuration tree.");
             }
-        } else { // XML attribute
+        } else { // tag
             if (count > 0) {
                 warning("Key <" + tag + "> has been read " + std::to_string(count)
                         + " time(s) more than it was present in the configuration tree.");

--- a/BaseLib/ConfigTreeNew.cpp
+++ b/BaseLib/ConfigTreeNew.cpp
@@ -275,18 +275,14 @@ ConfigTreeNew::checkAndInvalidate()
 
     // iterate over children
     for (auto const& p : *_tree) {
-        DBUG("-- %s <%s> ", _path.c_str(), p.first.c_str());
         if (p.first != "<xmlattr>") // attributes are handled below
             markVisitedDecrement(false, p.first);
-        DBUG("tag %s", p.first.c_str());
     }
 
     // iterate over attributes
     if (auto attrs = _tree->get_child_optional("<xmlattr>")) {
-        DBUG("has attributes");
         for (auto const& p : *attrs) {
             markVisitedDecrement(true, p.first);
-            DBUG("attr %s", p.first.c_str());
         }
     }
 

--- a/BaseLib/ConfigTreeNew.cpp
+++ b/BaseLib/ConfigTreeNew.cpp
@@ -85,6 +85,16 @@ getConfParam(std::string const& root) const
     return ct;
 }
 
+boost::optional<ConfigTreeNew>
+ConfigTreeNew::
+getConfParamOptional(std::string const& root) const
+{
+    auto ct = getConfSubtreeOptional(root);
+    if (ct && hasChildren(*ct))
+        error("Requested parameter <" + root + "> actually is a subtree.");
+    return ct;
+}
+
 ConfigTreeNew
 ConfigTreeNew::
 getConfSubtree(std::string const& root) const

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -146,8 +146,20 @@ public:
     class ParameterIterator : public SubtreeIterator
     {
     public:
-        // Inherit the constructor
+#if defined(_MSC_VER) && _MSC_VER < 1900
+        // 1900 == MSCV 14.0 == Visual Studio 2015
+        // according to this post: http://stackoverflow.com/a/70630
+        // This table: http://en.cppreference.com/w/cpp/compiler_support
+        // says that since MSVC 14.0 inheriting of constructors is supported.
+        //! Inherit the constructor
+        ParameterIterator(Iterator it, std::string const& root,
+                          ConfigTreeNew const& parent)
+            : SubtreeIterator(it, root, parent)
+        {}
+#else
+        //! Inherit the constructor
         using SubtreeIterator::SubtreeIterator;
+#endif
 
         ConfigTreeNew operator*() {
             auto st = SubtreeIterator::operator*();
@@ -497,7 +509,16 @@ private:
      * a custom error callback that breaks out of the normal control flow---e.g., by throwing
      * an exception---must be provided.
      */
-    [[noreturn]] void error(std::string const& message) const;
+#if defined(_MSC_VER) && _MSC_VER < 1900
+    // 1900 == MSCV 14.0 == Visual Studio 2015
+    // according to this post: http://stackoverflow.com/a/70630
+    // This table: http://en.cppreference.com/w/cpp/compiler_support
+    // says that since MSVC 14.0 attributes are supported.
+    __declspec(noreturn)
+#else
+    [[noreturn]]
+#endif
+    void error(std::string const& message) const;
 
     //! Called for printing warning messages. Will call the warning callback.
     //! This method only acts as a helper method.

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -156,12 +156,12 @@ public:
                 // TODO what about attributes?
             }
 
-            // TODO maybe better make complete ConfigTree
+            // TODO ____ maybe better make complete ConfigTree _____
             if (auto v = _it->second.get_value_optional<ValueType>())
                 return *v;
 
             // TODO: change error method
-            // TODO test
+            // TODO test, message: not convertible
             _parent.error("Could not get value out of key " + _tagname + ".");
         }
 

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -213,6 +213,11 @@ public:
     //! used anymore!
     ConfigTreeNew& operator=(ConfigTreeNew &&);
 
+    /*! \name Methods for directly accessing parameter values
+     *
+     */
+    //!\{
+
     /*! Get parameter \c param of type \c T from the configuration tree.
      *
      * \return the value looked for or a default constructed value \c T() in the case of
@@ -254,6 +259,13 @@ public:
     template<typename T> Range<ValueIterator<T> >
     getConfParamList(std::string const& param) const;
 
+    //!\}
+
+    /*! \name Methods for accessing parameters that have attributes
+     *
+     */
+    //!\{
+
     //! TODO doc
     ConfigTreeNew
     getConfParam(std::string const& param) const;
@@ -273,6 +285,14 @@ public:
     //! TODO doc
     template<typename T> T
     getConfAttribute(std::string const& attr) const;
+
+    //!\}
+
+    /*! \name Methods for peeking and checking parameters
+     *
+     * To be used in builder/factory functions
+     */
+    //!\{
 
     /*! Peek at a parameter \c param of type \c T from the configuration tree.
      *
@@ -294,6 +314,13 @@ public:
     //! Make checkConfParam() work for string literals.
     template<typename Ch> void
     checkConfParam(std::string const& param, Ch const* value) const;
+
+    //!\}
+
+    /*! \name Methods for accessing subtrees
+     *
+     */
+    //!\{
 
     /*! Get the subtree rooted at \c root
      *
@@ -320,6 +347,13 @@ public:
     Range<SubtreeIterator>
     getConfSubtreeList(std::string const& root) const;
 
+    //!\}
+
+    /*! \name Methods for ignoring parameters
+     *
+     */
+    //!\{
+
     /*! Tell this instance to ignore parameter \c param.
      *
      * This method is used to avoid warning messages.
@@ -335,6 +369,8 @@ public:
      * \pre \c root must not have been read before from this ConfigTree.
      */
     void ignoreConfParamAll(std::string const& param) const;
+
+    //!\}
 
     //! The destructor performs the check if all nodes at the current level of the tree
     //! have been read.

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -200,6 +200,7 @@ public:
      * Creates a new instance wrapping the given Boost Property Tree.
      *
      * \param tree the Boost Property Tree to be wrapped
+     * \param filename the file from which the \c tree has been read
      * \param error_cb callback function to be called on error.
      * \param warning_cb callback function to be called on warning.
      *
@@ -278,8 +279,12 @@ public:
     /*! \name Methods for accessing parameters that have attributes
      *
      * The <tt>getConfParam...()</tt> methods in this group---note: they do not have template
-     * parameters---check that the queried parameters do not have any children (apart from XML attributes).
-     * If they do, error() is called.
+     * parameters---check that the queried parameters do not have any children (apart from XML
+     * attributes); if they do, error() is called.
+     *
+     * The support for parameters with attributes is limited in the sense that there are no
+     * <tt>get...List()</tt> methods in this group and that it is not possible to explicitly
+     * ignore attibutes. However, such functionality can easily be added on demand.
      */
     //!\{
 

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -172,7 +172,8 @@ public:
     //! Type of the function objects used as callbacks.
     //! The first argument denotes the path in the tree at which an event (warning/error)
     //! occured, the second argument is the associated message
-    using Callback = std::function<void(const std::string& path,
+    using Callback = std::function<void(const std::string& filename,
+                                        const std::string& path,
                                         const std::string& message)>;
 
     /*!
@@ -194,6 +195,7 @@ public:
      * i.e., warnings will also result in program abortion!
      */
     explicit ConfigTreeNew(PTree const& tree,
+                           std::string const& filename,
                            Callback const& error_cb = onerror,
                            Callback const& warning_cb = onerror);
 
@@ -340,11 +342,13 @@ public:
 
     //! Default error callback function
     //! Will print an error message and call std::abort()
-    static void onerror(std::string const& path, std::string const& message);
+    static void onerror(std::string const& filename, std::string const& path,
+                        std::string const& message);
 
     //! Default warning callback function
     //! Will print a warning message
-    static void onwarning(std::string const& path, std::string const& message);
+    static void onwarning(std::string const& filename, std::string const& path,
+                          std::string const& message);
 
 private:
     struct CountType
@@ -417,7 +421,8 @@ private:
     //! A path printed in error/warning messages.
     std::string _path;
 
-    //! \todo add file name
+    //! TODO doc
+    std::string _filename;
 
     using KeyType = std::pair<bool, std::string>;
 

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -283,7 +283,7 @@ public:
 
     //! TODO doc
     template<typename T> T
-    getAttribute(std::string const& attr) const;
+    getConfAttribute(std::string const& attr) const;
 
     /*! Peek at a parameter \c param of type \c T from the configuration tree.
      *

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -147,7 +147,7 @@ public:
             // tell the _parent instance that a setting now has been parsed.
             if (_has_incremented) {
                 _has_incremented = false;
-                _parent.markVisited<ValueType>(_tagname, false);
+                _parent.markVisited<ValueType>(_tagname, false, false);
             }
             return ConfigTreeNew(_it->second, _parent, _tagname).getValue<ValueType>();
         }
@@ -384,7 +384,7 @@ private:
      */
     template<typename T>
     CountType& markVisited(std::string const& key, bool const is_attr,
-                           bool peek_only = false) const;
+                           bool peek_only) const;
 
     /*! Keeps track of the key \c key and its value type ConfigTree.
      *
@@ -392,7 +392,7 @@ private:
      *
      * \c param peek_only if true, do not change the read-count of the given key.
      */
-    CountType& markVisited(std::string const& key, bool const peek_only = false) const;
+    CountType& markVisited(std::string const& key, bool const peek_only) const;
 
     //! Used in the destructor to compute the difference between number of reads of a parameter
     //! and the number of times it exists in the ConfigTree

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -149,20 +149,7 @@ public:
                 _has_incremented = false;
                 _parent.markVisited<ValueType>(_tagname, false);
             }
-
-            if (_it->second.begin() != _it->second.end()) {
-                // TODO test
-                _parent.error("Configuration at key " + _tagname + " has subitems.");
-                // TODO what about attributes?
-            }
-
-            // TODO ____ maybe better make complete ConfigTree _____
-            if (auto v = _it->second.get_value_optional<ValueType>())
-                return *v;
-
-            // TODO: change error method
-            // TODO test, message: not convertible
-            _parent.error("Could not get value out of key " + _tagname + ".");
+            return ConfigTreeNew(_it->second, _parent, _tagname).getValue<ValueType>();
         }
 
         bool operator==(ValueIterator<ValueType> const& other) const {

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -220,11 +220,16 @@ public:
         ConfigTreeNew const& _parent;
     };
 
+    //! The tree being wrapped by this class.
     using PTree = boost::property_tree::ptree;
 
-    //! Type of the function objects used as callbacks.
-    //! The first argument denotes the path in the tree at which an event (warning/error)
-    //! occured, the second argument is the associated message
+    /*! Type of the function objects used as callbacks.
+     *
+     * Arguments of the callback:
+     * \arg \c filename the file being from which this ConfigTree has been read.
+     * \arg \c path     the path in the tree where the message was generated.
+     * \arg \c message  the message to be printed.
+     */
     using Callback = std::function<void(const std::string& filename,
                                         const std::string& path,
                                         const std::string& message)>;
@@ -581,7 +586,8 @@ private:
     //! The path of the file from which this tree has been read.
     std::string _filename;
 
-    //! A pair (is attribute, tag/attribute name)
+    //! A pair (is attribute, tag/attribute name).
+    //! The first entry is true for an XML attribute and false for a tag.
     using KeyType = std::pair<bool, std::string>;
 
     //! A map KeyType -> (count, type) keeping track which parameters have been read

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -116,7 +116,7 @@ public:
             // tell the _parent instance that a subtree now has been parsed.
             if (_has_incremented) {
                 _has_incremented = false;
-                _parent.markVisited(_tagname, false, false);
+                _parent.markVisited(_tagname, Attr::TAG, false);
             }
             return ConfigTreeNew(_it->second, _parent, _tagname);
         }
@@ -200,7 +200,7 @@ public:
             // tell the _parent instance that a setting now has been parsed.
             if (_has_incremented) {
                 _has_incremented = false;
-                _parent.markVisited<ValueType>(_tagname, false, false);
+                _parent.markVisited<ValueType>(_tagname, Attr::TAG, false);
             }
             return ConfigTreeNew(_it->second, _parent, _tagname).getValue<ValueType>();
         }
@@ -503,6 +503,12 @@ private:
         std::type_index type;
     };
 
+    //! Used to indicate if dealing with XML tags or XML attributes
+    enum class Attr : bool
+    {
+        TAG = false, ATTR = true
+    };
+
     //! Used for wrapping a subtree
     explicit ConfigTreeNew(PTree const& tree, ConfigTreeNew const& parent, std::string const& root);
 
@@ -548,7 +554,7 @@ private:
      * \c param peek_only if true, do not change the read-count of the given key.
      */
     template<typename T>
-    CountType& markVisited(std::string const& key, bool const is_attr,
+    CountType& markVisited(std::string const& key, Attr const is_attr,
                            bool peek_only) const;
 
     /*! Keeps track of the key \c key and its value type ConfigTree.
@@ -557,12 +563,12 @@ private:
      *
      * \c param peek_only if true, do not change the read-count of the given key.
      */
-    CountType& markVisited(std::string const& key, bool const is_attr,
+    CountType& markVisited(std::string const& key, Attr const is_attr,
                            bool const peek_only) const;
 
     //! Used in the destructor to compute the difference between number of reads of a parameter
     //! and the number of times it exists in the ConfigTree
-    void markVisitedDecrement(bool const is_attr, std::string const& key) const;
+    void markVisitedDecrement(Attr const is_attr, std::string const& key) const;
 
     //! Checks if this tree has any children.
     bool hasChildren() const;
@@ -587,8 +593,7 @@ private:
     std::string _filename;
 
     //! A pair (is attribute, tag/attribute name).
-    //! The first entry is true for an XML attribute and false for a tag.
-    using KeyType = std::pair<bool, std::string>;
+    using KeyType = std::pair<Attr, std::string>;
 
     //! A map KeyType -> (count, type) keeping track which parameters have been read
     //! how often and which datatype they have.

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -396,7 +396,8 @@ private:
      * \c param peek_only if true, do not change the read-count of the given key.
      */
     template<typename T>
-    CountType& markVisited(std::string const& key, bool peek_only = false) const;
+    CountType& markVisited(std::string const& key, bool const is_attr,
+                           bool peek_only = false) const;
 
     /*! Keeps track of the key \c key and its value type ConfigTree.
      *
@@ -408,7 +409,7 @@ private:
 
     //! Used in the destructor to compute the difference between number of reads of a parameter
     //! and the number of times it exists in the ConfigTree
-    void markVisitedDecrement(std::string const& key) const;
+    void markVisitedDecrement(bool const is_attr, std::string const& key) const;
 
     //! TODO doc
     bool hasChildren(ConfigTreeNew const& ct) const;
@@ -431,6 +432,8 @@ private:
 
     //! \todo add file name
 
+    using KeyType = std::pair<bool, std::string>;
+
     //! A map key -> (count, type) keeping track which parameters have been read how often
     //! and which datatype they have.
     //!
@@ -438,7 +441,7 @@ private:
     //! Therefore it has to be mutable in order to be able to read from
     //! constant instances, e.g., those passed as constant references to
     //! temporaries.
-    mutable std::map<std::string, CountType> _visited_params;
+    mutable std::map<KeyType, CountType> _visited_params;
 
     //! \todo doc
     mutable bool _have_read_data = false;

--- a/BaseLib/ConfigTreeNew.h
+++ b/BaseLib/ConfigTreeNew.h
@@ -152,8 +152,8 @@ public:
         // This table: http://en.cppreference.com/w/cpp/compiler_support
         // says that since MSVC 14.0 inheriting of constructors is supported.
         //! Inherit the constructor
-        ParameterIterator(Iterator it, std::string const& root,
-                          ConfigTreeNew const& parent)
+        explicit ParameterIterator(Iterator it, std::string const& root,
+                                   ConfigTreeNew const& parent)
             : SubtreeIterator(it, root, parent)
         {}
 #else

--- a/BaseLib/ConfigTreeUtil.cpp
+++ b/BaseLib/ConfigTreeUtil.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <boost/property_tree/xml_parser.hpp>
+#include <logog/include/logog.hpp>
 
 #include "ConfigTreeUtil.h"
 

--- a/BaseLib/ConfigTreeUtil.cpp
+++ b/BaseLib/ConfigTreeUtil.cpp
@@ -1,0 +1,74 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include <boost/property_tree/xml_parser.hpp>
+
+#include "ConfigTreeUtil.h"
+
+namespace BaseLib
+{
+
+ConfigTreeTopLevel::ConfigTreeTopLevel(
+        const std::string& filepath,
+        const bool be_ruthless,
+        ConfigTreeNew::PTree&& ptree)
+    : _ptree(std::move(ptree))
+    , _ctree(_ptree, filepath,
+             be_ruthless ? ConfigTreeNew::onerror : ConfigTreeNew::onwarning)
+{
+}
+
+ConfigTreeNew const&
+ConfigTreeTopLevel::operator*() const
+{
+    return _ctree;
+}
+
+ConfigTreeNew const*
+ConfigTreeTopLevel::operator->() const
+{
+    return &_ctree;
+}
+
+void
+ConfigTreeTopLevel::checkAndInvalidate()
+{
+    ::BaseLib::checkAndInvalidate(_ctree);
+}
+
+ConfigTreeTopLevel
+makeConfigTree(const std::string& filepath, const bool be_ruthless,
+               const std::string& toplevel_tag)
+{
+    ConfigTreeNew::PTree ptree;
+
+    // note: Trimming whitespace and ignoring comments is crucial in order
+    //       for our configuration tree implementation to work!
+    try {
+        read_xml(filepath, ptree,
+                 boost::property_tree::xml_parser::no_comments |
+                 boost::property_tree::xml_parser::trim_whitespace);
+    } catch (boost::property_tree::xml_parser_error e) {
+        ERR("Error while parsing XML file `%s' at line %lu: %s.",
+            e.filename().c_str(), e.line(), e.message().c_str());
+        std::abort();
+    }
+
+    DBUG("Project configuration from file \'%s\' read.", filepath.c_str());
+
+    if (auto child = std::move(ptree.get_child_optional(toplevel_tag))) {
+        return ConfigTreeTopLevel(filepath, be_ruthless, std::move(*child));
+    } else {
+        ERR("Tag <%s> has not been found in file `%s'.",
+            toplevel_tag.c_str(), filepath.c_str());
+        std::abort();
+    }
+}
+
+}

--- a/BaseLib/ConfigTreeUtil.h
+++ b/BaseLib/ConfigTreeUtil.h
@@ -1,0 +1,93 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef BASELIB_CONFIGTREEUTIL
+#define BASELIB_CONFIGTREEUTIL
+
+#include "ConfigTreeNew.h"
+
+namespace BaseLib
+{
+
+/*! Manages a ConfigTree and the <tt>boost::property_tree</tt> it depends on.
+ *
+ * The whole purpose of this class is making the management of said dependency easy.
+ */
+class ConfigTreeTopLevel final
+{
+public:
+    /*! Construct a new instance from the given data.
+     *
+     * \param filepath stored for use in error/warning messages
+     * \param be_ruthless if true, then warnings will raise errors, .i.e. lead to program abortion,
+     *                    else warnings will only warn
+     * \param ptree the underlying ptree of the created ConfigTree
+     */
+    explicit ConfigTreeTopLevel(std::string const& filepath,
+                                bool const be_ruthless,
+                                ConfigTreeNew::PTree&& ptree);
+
+    /*! Access the contained ConfigTree.
+     *
+     * The non-const version of this method has not been implemented in order to prevent invalidating
+     * the \c _ctree when it is passed around. In order to check and invalidate \c _ctree use the provided
+     * member function.
+     */
+    ConfigTreeNew const& operator*() const;
+
+    /*! Access the contained ConfigTree.
+     *
+     * The non-const version of this method has not been implemented in order to prevent invalidating
+     * the \c _ctree when it is passed around. In order to check and invalidate \c _ctree use the provided
+     * member function.
+     */
+    ConfigTreeNew const* operator->() const;
+
+    /*! Check if the contained ConfigTree has been processed entirely.
+     *
+     * This only checks the top level, as usual with ConfigTree instances.
+     *
+     * \post Afterwards the contained ConfigTree instance must not be used anymore!
+     */
+    void checkAndInvalidate();
+
+private:
+    ConfigTreeNew::PTree const _ptree; //!< <tt>boost::property_tree</tt> that underlies \c _ctree
+    ConfigTreeNew              _ctree; //!< ConfigTree depending on \c _ptree
+};
+
+/*! Create a ConfigTree from an XML file.
+ *
+ * \param filepath     see ConfigTreeTopLevel::ConfigTreeTopLevel()
+ * \param be_ruthless  see ConfigTreeTopLevel::ConfigTreeTopLevel()
+ * \param toplevel_tag name of the outermost tag in the XML file. The returned ConfigTree is rooted
+ *                     one level below that tag.
+ *
+ * The parameter \c toplevel_tag is provided for compatibility with our existing configuration
+ * files whose toplevel tags are written in camel case, which conflicts with the naming rules of
+ * ConfigTree. Via that parameter the naming rules do not apply to the toplevel tag.
+ *
+ * Unfortunately the XML parser shipped with <tt>boost::property_tree</tt> does not fully support
+ * the XML standard. Additionally there might be encoding issues. From their docs:
+ *
+ * > Please note that RapidXML does not understand the encoding specification. If you pass it a
+ * > character buffer, it assumes the data is already correctly encoded; if you pass it a filename,
+ * > it will read the file using the character conversion of the locale you give it (or the global
+ * > locale if you give it none). This means that, in order to parse a UTF-8-encoded XML file into
+ * > a wptree, you have to supply an alternate locale, either directly or by replacing the global one.
+ *
+ * \see http://www.boost.org/doc/libs/1_60_0/doc/html/property_tree/parsers.html
+ */
+ConfigTreeTopLevel
+makeConfigTree(std::string const& filepath, bool const be_ruthless,
+               std::string const& toplevel_tag);
+
+}
+
+#endif

--- a/FileIO/XmlIO/Boost/BoostXmlGmlInterface.cpp
+++ b/FileIO/XmlIO/Boost/BoostXmlGmlInterface.cpp
@@ -25,6 +25,7 @@
 
 #include <logog/include/logog.hpp>
 
+#include "BaseLib/ConfigTreeUtil.h"
 #include "BaseLib/StringTools.h"
 #include "GeoLib/GEOObjects.h"
 #include "GeoLib/Point.h"
@@ -42,14 +43,10 @@ BoostXmlGmlInterface::BoostXmlGmlInterface(GeoLib::GEOObjects& geo_objs) :
 
 bool BoostXmlGmlInterface::readFile(const std::string &fname)
 {
-	std::ifstream in(fname.c_str());
-	if (!in)
-	{
-		ERR("BoostXmlGmlInterface::readFile(): Can't open xml-file %s.", fname.c_str());
-		return false;
-	}
-
-	std::string geo_name("[NN]");
+	auto doc = BaseLib::makeConfigTree(fname, true, "OpenGeoSysGLI");
+	doc->ignoreConfAttribute("xmlns:xsi");
+	doc->ignoreConfAttribute("xsi:noNamespaceSchemaLocation");
+	doc->ignoreConfAttribute("xmlns:ogs");
 
 	auto points = std::unique_ptr<std::vector<GeoLib::Point*>>(
 	    new std::vector<GeoLib::Point*>);
@@ -60,51 +57,42 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
 
 	std::map<std::string, std::size_t>* pnt_names = new std::map<std::string, std::size_t>;
 	std::map<std::string, std::size_t>* ply_names = new std::map<std::string, std::size_t>;
-	std::map<std::string, std::size_t>* sfc_names  = new std::map<std::string, std::size_t>;
+	std::map<std::string, std::size_t>* sfc_names = new std::map<std::string, std::size_t>;
 
-	GeoLib::GEOObjects* geo_objects (&_geo_objects);
+	// GeoLib::GEOObjects* geo_objects (&_geo_objects);
 
-	// build DOM tree
-    BaseLib::ConfigTree doc;
-	read_xml(in, doc, boost::property_tree::xml_parser::no_comments);
+    auto geo_name = doc->getConfParam<std::string>("name");
+    if (geo_name.empty())
+    {
+        ERR("BoostXmlGmlInterface::readFile(): <name> tag is empty.")
+        std::abort();
+    }
 
-	if (!isGmlFile(doc))
-		return false;
-
-    BaseLib::ConfigTree const & root_node = doc.get_child("OpenGeoSysGLI");
-	BOOST_FOREACH( BaseLib::ConfigTree::value_type const & node, root_node )
-	{
-		if (node.first.compare("name") == 0)
-		{
-			if (node.second.data().empty())
-			{
-				ERR("BoostXmlGmlInterface::readFile(): <name>-tag is empty.")
-				return false;
-			}
-			geo_name = node.second.data();
-		}
-		else if (node.first.compare("points") == 0)
-		{
-			readPoints(node.second, points.get(), pnt_names);
-			geo_objects->addPointVec(std::move(points), geo_name, pnt_names);
-		}
-		else if (node.first.compare("polylines") == 0)
-			readPolylines(node.second,
-			              polylines.get(),
-			              geo_objects->getPointVec(geo_name),
-			              geo_objects->getPointVecObj(geo_name)->getIDMap(),
-			              ply_names);
-		else if (node.first.compare("surfaces") == 0)
-			readSurfaces(node.second,
-			             surfaces.get(),
-			             geo_objects->getPointVec(geo_name),
-			             geo_objects->getPointVecObj(geo_name)->getIDMap(),
-			             sfc_names);
-	}
+    for (auto st : doc->getConfSubtreeList("points"))
+    {
+        readPoints(st, points.get(), pnt_names);
+        _geo_objects.addPointVec(std::move(points), geo_name, pnt_names);
+    }
+    for (auto st : doc->getConfSubtreeList("polylines"))
+    {
+        readPolylines(st,
+                      polylines.get(),
+                      _geo_objects.getPointVec(geo_name),
+                      _geo_objects.getPointVecObj(geo_name)->getIDMap(),
+                      ply_names);
+    }
+    for (auto st : doc->getConfSubtreeList("surfaces"))
+    {
+        readSurfaces(st,
+                     surfaces.get(),
+                     _geo_objects.getPointVec(geo_name),
+                     _geo_objects.getPointVecObj(geo_name)->getIDMap(),
+                     sfc_names);
+    }
 
 	if (!polylines->empty())
 	{
-		geo_objects->addPolylineVec(std::move(polylines), geo_name, ply_names);
+		_geo_objects.addPolylineVec(std::move(polylines), geo_name, ply_names);
 	}
 	else
 	{
@@ -113,7 +101,7 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
 
 	if (!surfaces->empty())
 	{
-		geo_objects->addSurfaceVec(std::move(surfaces), geo_name, sfc_names);
+		_geo_objects.addSurfaceVec(std::move(surfaces), geo_name, sfc_names);
 	}
 	else
 	{
@@ -123,32 +111,29 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
 	return true;
 }
 
-void BoostXmlGmlInterface::readPoints(BaseLib::ConfigTree const& pointsRoot,
+void BoostXmlGmlInterface::readPoints(BaseLib::ConfigTreeNew const& pointsRoot,
 	                                  std::vector<GeoLib::Point*>* points,
 	                                  std::map<std::string, std::size_t>* &pnt_names )
 {
-	BOOST_FOREACH( BaseLib::ConfigTree::value_type const & point, pointsRoot )
+	for (auto const pt : pointsRoot.getConfParamList("point"))
 	{
-		if (point.first.compare("point") != 0)
-			continue;
+		auto const p_id = pt.getConfAttribute<std::size_t>("id");
+		auto const p_x  = pt.getConfAttribute<double>("x");
+		auto const p_y  = pt.getConfAttribute<double>("y");
+		auto const p_z  = pt.getConfAttribute<double>("z");
 
-		unsigned p_id = static_cast<unsigned>(point.second.get("<xmlattr>.id", std::numeric_limits<unsigned>::max()));
-		double   p_x  = static_cast<double>  (point.second.get("<xmlattr>.x",  std::numeric_limits<double>::max()));
-		double   p_y  = static_cast<double>  (point.second.get("<xmlattr>.y",  std::numeric_limits<double>::max()));
-		double   p_z  = static_cast<double>  (point.second.get("<xmlattr>.z",  std::numeric_limits<double>::max()));
-		std::string p_name = point.second.get("<xmlattr>.name", "");
+		auto const p_name = pt.getConfAttributeOptional<std::string>("name");
 
-		if ( p_id == std::numeric_limits<unsigned>::max() || p_x == std::numeric_limits<double>::max() ||
-		     p_y  == std::numeric_limits<double>::max()   || p_z == std::numeric_limits<double>::max() )
-			WARN("BoostXmlGmlInterface::readPoints(): Skipping point, attribute missing in <point> tag:\n%s",
-				BaseLib::propertyTreeToString(point.second).c_str())
-		else
-		{
-			_idx_map.insert (std::pair<std::size_t, std::size_t>(p_id, points->size()));
-			GeoLib::Point* p = new GeoLib::Point(p_x, p_y, p_z, p_id);
-			if (!p_name.empty())
-				pnt_names->insert( std::pair<std::string, std::size_t>(p_name, points->size()) );
-			points->push_back(p);
+		auto const p_size = points->size();
+		_idx_map[p_id] = p_size; // TODO: unique ids?
+		points->push_back(new GeoLib::Point(p_x, p_y, p_z, p_id));
+
+		if (p_name) {
+			if (p_name->empty()) {
+				ERR("Empty point name found in geometry file.");
+				std::abort();
+			}
+			(*pnt_names)[*p_name] = p_size; // TODO: unique names?
 		}
 	}
 
@@ -161,45 +146,43 @@ void BoostXmlGmlInterface::readPoints(BaseLib::ConfigTree const& pointsRoot,
 }
 
 void BoostXmlGmlInterface::readPolylines(
-    BaseLib::ConfigTree const& polylinesRoot,
+    BaseLib::ConfigTreeNew const& polylinesRoot,
     std::vector<GeoLib::Polyline*>* polylines,
     std::vector<GeoLib::Point*> const* points,
     const std::vector<std::size_t>& pnt_id_map,
     std::map<std::string, std::size_t>*& ply_names)
 {
-	BOOST_FOREACH( BaseLib::ConfigTree::value_type const & polyline, polylinesRoot )
+	for (auto const pl : polylinesRoot.getConfSubtreeList("polyline"))
 	{
-		if (polyline.first.compare("polyline") != 0)
-			continue;
+		auto const id = pl.getConfAttribute<std::size_t>("id");
+		(void) id; // id not used
 
-		if (static_cast<unsigned>(polyline.second.get("<xmlattr>.id", std::numeric_limits<unsigned>::max()) == std::numeric_limits<unsigned>::max()))
-			WARN("BoostXmlGmlInterface::readPolylines(): Skipping polyline, attribute \"id\" missing in <polyline> tag:\n%s",
-				BaseLib::propertyTreeToString(polyline.second).c_str())
-		else
-		{
-			polylines->push_back(new GeoLib::Polyline(*points));
+		polylines->push_back(new GeoLib::Polyline(*points));
 
-			std::string const p_name = polyline.second.get("<xmlattr>.name", "");
-			if (!p_name.empty()) {
-				std::map<std::string, std::size_t>::const_iterator it(
-					ply_names->find(p_name)
-				);
-				if (it == ply_names->end()) {
-					ply_names->insert(std::pair<std::string,std::size_t>(
-						p_name, polylines->size()-1)
-					);
-				} else {
-					WARN("Polyline \"%s\" exists already. The polyline will "
-						"be inserted without a name.\n%s",
-						p_name.c_str(),
-						BaseLib::propertyTreeToString(polyline.second).c_str());
-				}
+		auto const p_name = pl.getConfAttributeOptional<std::string>("name");
+		if (p_name) {
+			if (p_name->empty()) {
+				ERR("Empty polyline name found in geometry file.");
+				std::abort();
 			}
 
-			BOOST_FOREACH( BaseLib::ConfigTree::value_type const & pnt, polyline.second )
-			{
-				if (pnt.first.compare("pnt") == 0)
-					polylines->back()->addPoint(pnt_id_map[_idx_map[std::atoi(pnt.second.data().c_str())]]);
+			// TODO change
+			// auto const inserted = ply_names->insert(std::make_pair(p_name, polylines->size()-1));
+			auto const it = ply_names->find(*p_name);
+			if (it == ply_names->end()) {
+				ply_names->insert(std::pair<std::string,std::size_t>(
+					*p_name, polylines->size()-1)
+				);
+
+			} else {
+				WARN("Polyline \"%s\" exists already. The polyline will "
+					"be inserted without a name.\n%s",
+					p_name->c_str(), ""
+					/*BaseLib::propertyTreeToString(polyline.second).c_str()*/);
+			}
+
+			for (auto const pt : pl.getConfParamList<std::size_t>("pnt")) {
+				polylines->back()->addPoint(pnt_id_map[_idx_map[pt]]);
 			}
 		}
 	}
@@ -213,46 +196,35 @@ void BoostXmlGmlInterface::readPolylines(
 }
 
 void BoostXmlGmlInterface::readSurfaces(
-    BaseLib::ConfigTree const&  surfacesRoot,
+    BaseLib::ConfigTreeNew const&  surfacesRoot,
     std::vector<GeoLib::Surface*>* surfaces,
     std::vector<GeoLib::Point*> const* points,
     const std::vector<std::size_t>& pnt_id_map,
     std::map<std::string, std::size_t>*& sfc_names)
 {
-	BOOST_FOREACH( BaseLib::ConfigTree::value_type const & surface, surfacesRoot )
+	for (auto const& sfc : surfacesRoot.getConfSubtreeList("surface"))
 	{
-		if (surface.first.compare("surface") != 0)
-			continue;
-
-		if (static_cast<unsigned>(surface.second.get("<xmlattr>.id", std::numeric_limits<unsigned>::max()) == std::numeric_limits<unsigned>::max()))
-		{
-			WARN("BoostXmlGmlInterface::readSurfaces(): Skipping surface, attribute \"id\" missing in <surface> tag:\n%s",
-				BaseLib::propertyTreeToString(surface.second).c_str())
-			continue;
-		}
-
+		auto const id = sfc.getConfAttribute<std::size_t>("id");
+		(void) id; // id not used
 		surfaces->push_back(new GeoLib::Surface(*points));
 
-		std::string s_name = surface.second.get("<xmlattr>.name", "");
-		if (!s_name.empty())
-			sfc_names->insert(std::pair<std::string, std::size_t>(s_name, surfaces->size()-1));
+		auto const s_name = sfc.getConfAttributeOptional<std::string>("name");
+		if (s_name) {
+			if (s_name->empty()) {
+				ERR("Empty surface name found in geometry file.");
+				std::abort();
+			}
 
-		BOOST_FOREACH( BaseLib::ConfigTree::value_type const & element, surface.second )
-		{
-			if (element.first.compare("element") != 0)
-				continue;
+			(*sfc_names)[*s_name] = surfaces->size()-1; // TODO unique names
 
-			unsigned p1_attr = static_cast<unsigned>(element.second.get("<xmlattr>.p1", std::numeric_limits<unsigned>::max()));
-			unsigned p2_attr = static_cast<unsigned>(element.second.get("<xmlattr>.p2", std::numeric_limits<unsigned>::max()));
-			unsigned p3_attr = static_cast<unsigned>(element.second.get("<xmlattr>.p3", std::numeric_limits<unsigned>::max()));
+			for (auto const& element : sfc.getConfParamList("element")) {
+				auto const p1_attr = element.getConfAttribute<std::size_t>("p1");
+				auto const p2_attr = element.getConfAttribute<std::size_t>("p2");
+				auto const p3_attr = element.getConfAttribute<std::size_t>("p3");
 
-			if (p1_attr == std::numeric_limits<unsigned>::max() || p2_attr == std::numeric_limits<unsigned>::max() || p3_attr == std::numeric_limits<unsigned>::max())
-				WARN("BoostXmlGmlInterface::readSurfaces(): Skipping triangle, attribute missing in <element> tag:\n%s",
-					BaseLib::propertyTreeToString(element.second).c_str())
-			{
-				std::size_t p1 = pnt_id_map[_idx_map[p1_attr]];
-				std::size_t p2 = pnt_id_map[_idx_map[p2_attr]];
-				std::size_t p3 = pnt_id_map[_idx_map[p3_attr]];
+				auto const p1 = pnt_id_map[_idx_map[p1_attr]];
+				auto const p2 = pnt_id_map[_idx_map[p2_attr]];
+				auto const p3 = pnt_id_map[_idx_map[p3_attr]];
 				surfaces->back()->addTriangle(p1,p2,p3);
 			}
 		}
@@ -264,16 +236,6 @@ void BoostXmlGmlInterface::readSurfaces(
 		delete sfc_names;
 		sfc_names = nullptr;
 	}
-}
-
-bool BoostXmlGmlInterface::isGmlFile(BaseLib::ConfigTree const& root) const
-{
-	if (!root.get_child_optional("OpenGeoSysGLI"))
-	{
-		ERR("BoostXmlGmlInterface::isGmlFile(): Not a GML file.");
-		return false;
-	}
-	return true;
 }
 
 bool BoostXmlGmlInterface::write()
@@ -303,19 +265,19 @@ bool BoostXmlGmlInterface::write()
 	}
 
 	// create a property tree for writing it to file
-	BaseLib::ConfigTree pt;
+	boost::property_tree::ptree pt;
 
 	// put header in property tree
 	pt.put("<xmlattr>.xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
 	pt.put("<xmlattr>.xsi:noNamespaceSchemaLocation",
 		"http://www.opengeosys.org/images/xsd/OpenGeoSysGLI.xsd");
 	pt.put("<xmlattr>.xmlns:ogs", "http://www.opengeosys.net");
-	BaseLib::ConfigTree &geometry_set = pt.add("OpenGeoSysGLI", "");
+	auto& geometry_set = pt.add("OpenGeoSysGLI", "");
 
 	geometry_set.add("name", _exportName);
-	BaseLib::ConfigTree & pnts_tag = geometry_set.add("points", "");
+	auto& pnts_tag = geometry_set.add("points", "");
 	for (std::size_t k(0); k<pnts->size(); k++) {
-		BaseLib::ConfigTree &pnt_tag = pnts_tag.add("point", "");
+		auto& pnt_tag = pnts_tag.add("point", "");
 		pnt_tag.put("<xmlattr>.id", k);
 		pnt_tag.put("<xmlattr>.x", (*((*pnts)[k]))[0]);
 		pnt_tag.put("<xmlattr>.y", (*((*pnts)[k]))[1]);
@@ -338,7 +300,7 @@ bool BoostXmlGmlInterface::write()
 }
 
 void BoostXmlGmlInterface::addSurfacesToPropertyTree(
-	BaseLib::ConfigTree & geometry_set)
+	boost::property_tree::ptree & geometry_set)
 {
 	GeoLib::SurfaceVec const*const sfc_vec(_geo_objects.getSurfaceVecObj(_exportName));
 	if (!sfc_vec) {
@@ -357,17 +319,17 @@ void BoostXmlGmlInterface::addSurfacesToPropertyTree(
 		return;
 	}
 
-	BaseLib::ConfigTree & surfaces_tag = geometry_set.add("surfaces", "");
+	auto& surfaces_tag = geometry_set.add("surfaces", "");
 	for (std::size_t i=0; i<surfaces->size(); ++i) {
 		GeoLib::Surface const*const surface((*surfaces)[i]);
 		std::string sfc_name("");
 		sfc_vec->getNameOfElement(surface, sfc_name);
-		BaseLib::ConfigTree &surface_tag = surfaces_tag.add("surface", "");
+		auto& surface_tag = surfaces_tag.add("surface", "");
 		surface_tag.put("<xmlattr>.id", i);
 		if (!sfc_name.empty())
 			surface_tag.put("<xmlattr>.name", sfc_name);
 		for (std::size_t j=0; j<surface->getNTriangles(); ++j) {
-			BaseLib::ConfigTree &element_tag = surface_tag.add("element", "");
+			auto& element_tag = surface_tag.add("element", "");
 			element_tag.put("<xmlattr>.p1", (*(*surface)[j])[0]);
 			element_tag.put("<xmlattr>.p2", (*(*surface)[j])[1]);
 			element_tag.put("<xmlattr>.p3", (*(*surface)[j])[2]);
@@ -376,7 +338,7 @@ void BoostXmlGmlInterface::addSurfacesToPropertyTree(
 }
 
 void BoostXmlGmlInterface::addPolylinesToPropertyTree(
-	BaseLib::ConfigTree & geometry_set)
+	boost::property_tree::ptree & geometry_set)
 {
 	GeoLib::PolylineVec const*const vec(_geo_objects.getPolylineVecObj(_exportName));
 	if (!vec) {
@@ -395,12 +357,12 @@ void BoostXmlGmlInterface::addPolylinesToPropertyTree(
 		return;
 	}
 
-	BaseLib::ConfigTree & polylines_tag = geometry_set.add("polylines", "");
+	auto& polylines_tag = geometry_set.add("polylines", "");
 	for (std::size_t i=0; i<polylines->size(); ++i) {
 		GeoLib::Polyline const*const polyline((*polylines)[i]);
 		std::string ply_name("");
 		vec->getNameOfElement(polyline, ply_name);
-		BaseLib::ConfigTree &polyline_tag = polylines_tag.add("polyline", "");
+		auto& polyline_tag = polylines_tag.add("polyline", "");
 		polyline_tag.put("<xmlattr>.id", i);
 		if (!ply_name.empty())
 			polyline_tag.put("<xmlattr>.name", ply_name);

--- a/FileIO/XmlIO/Boost/BoostXmlGmlInterface.h
+++ b/FileIO/XmlIO/Boost/BoostXmlGmlInterface.h
@@ -51,22 +51,22 @@ protected:
 private:
 	/// Reads GeoLib::Point-objects from an xml-file
 	void readPoints    ( BaseLib::ConfigTreeNew const& pointsRoot,
-	                     std::vector<GeoLib::Point*>* points,
-	                     std::map<std::string, std::size_t>* &pnt_names );
+	                     std::vector<GeoLib::Point*>& points,
+	                     std::map<std::string, std::size_t>& pnt_names);
 
 	/// Reads GeoLib::Polyline-objects from an xml-file
 	void readPolylines ( BaseLib::ConfigTreeNew const& polylinesRoot,
-	                   std::vector<GeoLib::Polyline*>* polylines,
-	                   std::vector<GeoLib::Point*> const* points,
+	                   std::vector<GeoLib::Polyline*>& polylines,
+	                   std::vector<GeoLib::Point*> const& points,
 	                   const std::vector<std::size_t>& pnt_id_map,
-	                   std::map<std::string, std::size_t>*& ply_names);
+	                   std::map<std::string, std::size_t>& ply_names);
 
 	/// Reads GeoLib::Surface-objects from an xml-file
 	void readSurfaces  ( BaseLib::ConfigTreeNew const& surfacesRoot,
-	                  std::vector<GeoLib::Surface*>* surfaces,
-	                  std::vector<GeoLib::Point*> const* points,
+	                  std::vector<GeoLib::Surface*>& surfaces,
+	                  std::vector<GeoLib::Point*> const& points,
 	                  const std::vector<std::size_t>& pnt_id_map,
-	                  std::map<std::string, std::size_t>*& sfc_names);
+	                  std::map<std::string, std::size_t>& sfc_names);
 
 	void addSurfacesToPropertyTree(BaseLib::ConfigTreeNew::PTree & pt);
 	void addPolylinesToPropertyTree(BaseLib::ConfigTreeNew::PTree & geometry_set);

--- a/FileIO/XmlIO/Boost/BoostXmlGmlInterface.h
+++ b/FileIO/XmlIO/Boost/BoostXmlGmlInterface.h
@@ -20,7 +20,7 @@
 #include <vector>
 
 
-#include "BaseLib/ConfigTree.h"
+#include "BaseLib/ConfigTreeNew.h"
 #include "../XMLInterface.h"
 
 namespace GeoLib
@@ -50,29 +50,26 @@ protected:
 
 private:
 	/// Reads GeoLib::Point-objects from an xml-file
-	void readPoints    ( BaseLib::ConfigTree const& pointsRoot,
+	void readPoints    ( BaseLib::ConfigTreeNew const& pointsRoot,
 	                     std::vector<GeoLib::Point*>* points,
 	                     std::map<std::string, std::size_t>* &pnt_names );
 
 	/// Reads GeoLib::Polyline-objects from an xml-file
-	void readPolylines ( BaseLib::ConfigTree const& polylinesRoot,
+	void readPolylines ( BaseLib::ConfigTreeNew const& polylinesRoot,
 	                   std::vector<GeoLib::Polyline*>* polylines,
 	                   std::vector<GeoLib::Point*> const* points,
 	                   const std::vector<std::size_t>& pnt_id_map,
 	                   std::map<std::string, std::size_t>*& ply_names);
 
 	/// Reads GeoLib::Surface-objects from an xml-file
-	void readSurfaces  ( BaseLib::ConfigTree const& surfacesRoot,
+	void readSurfaces  ( BaseLib::ConfigTreeNew const& surfacesRoot,
 	                  std::vector<GeoLib::Surface*>* surfaces,
 	                  std::vector<GeoLib::Point*> const* points,
 	                  const std::vector<std::size_t>& pnt_id_map,
 	                  std::map<std::string, std::size_t>*& sfc_names);
 
-	void addSurfacesToPropertyTree(BaseLib::ConfigTree & pt);
-	void addPolylinesToPropertyTree(BaseLib::ConfigTree & geometry_set);
-
-	/// Check if the root node really specifies an GML file
-	bool isGmlFile( BaseLib::ConfigTree const& root) const;
+	void addSurfacesToPropertyTree(BaseLib::ConfigTreeNew::PTree & pt);
+	void addPolylinesToPropertyTree(BaseLib::ConfigTreeNew::PTree & geometry_set);
 
 	std::map<std::size_t, std::size_t> _idx_map;
 	GeoLib::GEOObjects &_geo_objects;

--- a/FileIO/XmlIO/Boost/BoostXmlGmlInterface.h
+++ b/FileIO/XmlIO/Boost/BoostXmlGmlInterface.h
@@ -21,7 +21,7 @@
 
 
 #include "BaseLib/ConfigTreeNew.h"
-#include "../XMLInterface.h"
+#include "FileIO/XmlIO/XMLInterface.h"
 
 namespace GeoLib
 {

--- a/Tests/AssemblerLib/TestSerialLinearSolver.cpp
+++ b/Tests/AssemblerLib/TestSerialLinearSolver.cpp
@@ -136,7 +136,7 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
         t_root.put_child("eigen", t_solver);
     }
     t_root.put("lis", "-i cg -p none -tol 1e-16 -maxiter 1000");
-    BaseLib::ConfigTreeNew conf(t_root);
+    BaseLib::ConfigTreeNew conf(t_root, "");
 
     GlobalSetup::LinearSolver ls(*A, "solver_name", &conf);
     ls.solve(*rhs, *x);

--- a/Tests/BaseLib/TestConfigTree.cpp
+++ b/Tests/BaseLib/TestConfigTree.cpp
@@ -15,7 +15,7 @@
 
 #include "BaseLib/ConfigTreeNew.h"
 
-#define DO_EXPECT(cbs, error, warning) do  { \
+#define EXPECT_ERR_WARN(cbs, error, warning) do  { \
         if (error)   EXPECT_TRUE((cbs).get_error());   else EXPECT_FALSE((cbs).get_error()); \
         if (warning) EXPECT_TRUE((cbs).get_warning()); else EXPECT_FALSE((cbs).get_warning()); \
         (cbs).reset(); \
@@ -33,7 +33,8 @@ class Callbacks
 {
 public:
     BaseLib::ConfigTreeNew::Callback
-    get_error_cb() {
+    get_error_cb()
+    {
         return [this](std::string const& path, std::string const& message)
         {
             (void) path; (void) message;
@@ -44,7 +45,8 @@ public:
     }
 
     BaseLib::ConfigTreeNew::Callback
-    get_warning_cb() {
+    get_warning_cb()
+    {
         return [this](std::string const& path, std::string const& message)
         {
             (void) path; (void) message;
@@ -73,7 +75,7 @@ TEST(BaseLibConfigTree, ConfigTreeEmpty)
         (void) conf;
     } // ConfigTree destroyed here
 
-    DO_EXPECT(cbs, false, false);
+    EXPECT_ERR_WARN(cbs, false, false);
 }
 
 
@@ -86,89 +88,163 @@ TEST(BaseLibConfigTree, ConfigTreeGet)
             "<sub>"
             "  <float>6.1</float>"
             "  <float2>0.1</float2>"
+            "  <bool1>false</bool1>"
+            "  <bool2>false</bool2>"
+            "  <bool3/>"
             "  <ignored/>"
             "  <ignored2/>"
             "  <ignored2/>"
             "</sub>"
-            "<x>Y</x>";
+            "<x>Y</x>"
+            "<z attr=\"0.5\">32.0</z>";
 
     boost::property_tree::ptree ptree;
     std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree);
+    read_xml(xml_str, ptree,
+             boost::property_tree::xml_parser::no_comments |
+	             boost::property_tree::xml_parser::trim_whitespace);
 
     Callbacks cbs;
     {
         BaseLib::ConfigTreeNew conf(ptree, cbs.get_error_cb(), cbs.get_warning_cb());
 
         EXPECT_EQ(5.6e-4, conf.getConfParam<double>("double")); // read certain types
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
         EXPECT_TRUE(conf.getConfParam<bool>("bool"));
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
         EXPECT_EQ(5, conf.getConfParam<int>("int"));
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
 
         EXPECT_EQ(8, conf.getConfParam<int>("intx", 8)); // reading with default value
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
 
+
+        // Testing subtree
         {
             auto sub = conf.getConfSubtree("sub");
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
 
             EXPECT_EQ(6.1f, sub.getConfParam<float>("float"));
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
 
             if (auto f2 = sub.getConfParamOptional<float>("float2")) { // read optional value
                 EXPECT_EQ(0.1f, *f2);
-                DO_EXPECT(cbs, false, false);
             }
+            EXPECT_ERR_WARN(cbs, false, false);
 
             auto f3 = sub.getConfParamOptional<float>("float3"); // optional value not existent
             ASSERT_FALSE(f3);
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
+
+
+            // Testing the getConfParam...() (non-template) / getValue() combination
+
+            auto bool1 = sub.getConfParam("bool1");
+            EXPECT_ERR_WARN(cbs, false, false);
+            EXPECT_FALSE(bool1.getValue<bool>());
+            EXPECT_ERR_WARN(cbs, false, false);
+            RUN_SAFE(bool1.getValue<bool>()); // getting data twice
+            EXPECT_ERR_WARN(cbs, true, false);
+
+            if (auto bool2 = sub.getConfParamOptional("bool2")) {
+                EXPECT_ERR_WARN(cbs, false, false);
+                EXPECT_FALSE(bool2->getValue<bool>());
+            }
+            EXPECT_ERR_WARN(cbs, false, false);
+
+            if (auto bool3 = sub.getConfParamOptional("bool3")) {
+                EXPECT_ERR_WARN(cbs, false, false);
+                RUN_SAFE(bool3->getValue<bool>());
+                EXPECT_ERR_WARN(cbs, true, false); // error because of no data
+            }
+            EXPECT_ERR_WARN(cbs, false, false);
+
+            EXPECT_FALSE(sub.getConfParamOptional("bool4")); // optional value not existent
+            EXPECT_ERR_WARN(cbs, false, false);
+
+
+            // Testing ignore
 
             sub.ignoreConfParam("ignored");
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
             sub.ignoreConfParamAll("ignored2");
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
             sub.ignoreConfParamAll("ignored4"); // I can ignore nonexistent stuff
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
 
             // I can not ignore stuff that I already read
             // this also makes sure that the subtree inherits the callbacks properly
             RUN_SAFE(sub.ignoreConfParam("float"));
-            DO_EXPECT(cbs, true, false);
+            EXPECT_ERR_WARN(cbs, true, false);
         }
         for (int i : {0, 1, 2}) {
             (void) i;
             EXPECT_EQ("Y", conf.peekConfParam<std::string>("x"));
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
         }
         conf.checkConfParam<std::string>("x", "Y");
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
+
+
+        // Testing attributes
+        {
+            auto z = conf.getConfParam("z");
+            EXPECT_ERR_WARN(cbs, false, false);
+            EXPECT_EQ(0.5, z.getConfAttribute<double>("attr"));
+            EXPECT_ERR_WARN(cbs, false, false);
+            RUN_SAFE(z.getConfAttribute<double>("attr")); // getting attr twice
+            EXPECT_ERR_WARN(cbs, true, false);
+            RUN_SAFE(z.getConfAttribute<double>("not_an_attr")); // nonexistent attribute
+            EXPECT_ERR_WARN(cbs, true, false);
+            EXPECT_EQ(32.0, z.getValue<double>());
+            EXPECT_ERR_WARN(cbs, false, false);
+        }
+        EXPECT_ERR_WARN(cbs, false, false);
     } // ConfigTree destroyed here
-    DO_EXPECT(cbs, false, false);
+    EXPECT_ERR_WARN(cbs, false, false);
 }
 
 
-TEST(BaseLibConfigTree, ConfigTreeIncompleteParse)
+TEST(BaseLibConfigTree, IncompleteParse)
 {
     const char xml[] =
             "<double>5.6</double>"
-            "<bool>true</bool>"
+            "<not_read>true</not_read>"
+            "<tag>this data won't be read</tag>"
+            "<pt x=\"0.5\">1</pt>"
+            "<pt2 x=\"0.5\" y=\"1.0\" z=\"2.0\" />"
             ;
 
     boost::property_tree::ptree ptree;
     std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree);
+    read_xml(xml_str, ptree,
+             boost::property_tree::xml_parser::no_comments |
+                 boost::property_tree::xml_parser::trim_whitespace);
 
     Callbacks cbs;
     {
         BaseLib::ConfigTreeNew conf(ptree, cbs.get_error_cb(), cbs.get_warning_cb());
 
-        EXPECT_EQ(5.6, conf.getConfParam<double>("double")); // read certain types
-        DO_EXPECT(cbs, false, false);
+        EXPECT_EQ(5.6, conf.getConfParam<double>("double"));
+        EXPECT_ERR_WARN(cbs, false, false);
+
+        conf.getConfSubtree("tag");
+        EXPECT_ERR_WARN(cbs, false, true); // data of <tag> has not been read
+
+        EXPECT_EQ(1, conf.getConfParam<int>("pt"));
+        EXPECT_ERR_WARN(cbs, false, true); // attribute "x" has not been read
+
+        {
+            auto pt2 = conf.getConfParam("pt2");
+            EXPECT_EQ(0.5, pt2.getConfAttribute<double>("x"));
+            EXPECT_ERR_WARN(cbs, false, false);
+            EXPECT_EQ(1.0, pt2.getConfAttribute<double>("y"));
+            EXPECT_ERR_WARN(cbs, false, false);
+        }
+        EXPECT_ERR_WARN(cbs, false, true); // attribute "z" not read
+
     } // ConfigTree destroyed here
-    DO_EXPECT(cbs, false, true); // expect warning because I didn't read everything
+    EXPECT_ERR_WARN(cbs, false, true); // expect warning because I didn't read everything
 }
 
 
@@ -184,34 +260,38 @@ TEST(BaseLibConfigTree, ConfigTreeCheckRange)
 
     boost::property_tree::ptree ptree;
     std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree);
+    read_xml(xml_str, ptree,
+             boost::property_tree::xml_parser::no_comments |
+	             boost::property_tree::xml_parser::trim_whitespace);
 
     Callbacks cbs;
     {
         BaseLib::ConfigTreeNew conf(ptree, cbs.get_error_cb(), cbs.get_warning_cb());
 
         {
+            // check that std::distance can be computed twice in a row
             auto list = conf.getConfSubtreeList("val");
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_EQ(3, std::distance(list.begin(), list.end()));
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_EQ(3, std::distance(list.begin(), list.end()));
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
         }
 
         {
+            // check that std::distance can be computed twice in a row
             auto list = conf.getConfParamList<int>("int");
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_EQ(3, std::distance(list.begin(), list.end()));
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_EQ(3, std::distance(list.begin(), list.end()));
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
         }
 
     } // ConfigTree destroyed here
 
     // there will be warnings because I don't process the list entries
-    DO_EXPECT(cbs, false, true);
+    EXPECT_ERR_WARN(cbs, false, true);
 }
 
 
@@ -224,7 +304,9 @@ TEST(BaseLibConfigTree, ConfigTreeGetSubtreeList)
 
     boost::property_tree::ptree ptree;
     std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree);
+    read_xml(xml_str, ptree,
+             boost::property_tree::xml_parser::no_comments |
+	             boost::property_tree::xml_parser::trim_whitespace);
 
     Callbacks cbs;
     {
@@ -234,11 +316,11 @@ TEST(BaseLibConfigTree, ConfigTreeGetSubtreeList)
         for (auto ct : conf.getConfSubtreeList("val"))
         {
             EXPECT_EQ(i, ct.getConfParam<int>("int"));
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
             ++i;
         }
     } // ConfigTree destroyed here
-    DO_EXPECT(cbs, false, false);
+    EXPECT_ERR_WARN(cbs, false, false);
 }
 
 
@@ -261,11 +343,11 @@ TEST(BaseLibConfigTree, ConfigTreeGetValueList)
         for (auto i : conf.getConfParamList<int>("int"))
         {
             EXPECT_EQ(n, i);
-            DO_EXPECT(cbs, false, false);
+            EXPECT_ERR_WARN(cbs, false, false);
             ++n;
         }
     } // ConfigTree destroyed here
-    DO_EXPECT(cbs, false, false);
+    EXPECT_ERR_WARN(cbs, false, false);
 }
 
 
@@ -282,52 +364,54 @@ TEST(BaseLibConfigTree, ConfigTreeNoConversion)
 
     boost::property_tree::ptree ptree;
     std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree);
+    read_xml(xml_str, ptree,
+             boost::property_tree::xml_parser::no_comments |
+	             boost::property_tree::xml_parser::trim_whitespace);
 
     Callbacks cbs;
     {
         BaseLib::ConfigTreeNew conf(ptree, cbs.get_error_cb(), cbs.get_warning_cb());
 
         RUN_SAFE(conf.getConfParam<int>("int"));
-        DO_EXPECT(cbs, true, false);
+        EXPECT_ERR_WARN(cbs, true, false);
         RUN_SAFE(conf.ignoreConfParam("int")); // after failure I also cannot ignore something
-        DO_EXPECT(cbs, true, false);
+        EXPECT_ERR_WARN(cbs, true, false);
 
         RUN_SAFE(conf.getConfParam<double>("double"));
-        DO_EXPECT(cbs, true, false);
+        EXPECT_ERR_WARN(cbs, true, false);
 
         // peek value existent but not convertible
         RUN_SAFE(conf.peekConfParam<double>("non_double"));
-        DO_EXPECT(cbs, true, false);
+        EXPECT_ERR_WARN(cbs, true, false);
 
         // optional value existent but not convertible
         RUN_SAFE(
             auto d = conf.getConfParamOptional<double>("non_double");
             ASSERT_FALSE(d);
         );
-        DO_EXPECT(cbs, true, false);
+        EXPECT_ERR_WARN(cbs, true, false);
 
         // assert that I can only ignore something once
         RUN_SAFE(conf.ignoreConfParam("ign"));
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
         RUN_SAFE(conf.ignoreConfParam("ign"));
-        DO_EXPECT(cbs, true, false);
+        EXPECT_ERR_WARN(cbs, true, false);
         RUN_SAFE(conf.ignoreConfParamAll("ign2"));
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
         RUN_SAFE(conf.ignoreConfParamAll("ign2"));
-        DO_EXPECT(cbs, true, false);
+        EXPECT_ERR_WARN(cbs, true, false);
 
         // assert that I cannot read a parameter twice
         RUN_SAFE(conf.getConfParam<bool>("bool"));
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
         RUN_SAFE(conf.getConfParam<bool>("bool"));
-        DO_EXPECT(cbs, true, false);
+        EXPECT_ERR_WARN(cbs, true, false);
 
     } // ConfigTree destroyed here
 
     // There will bewarnings because I don't succeed in reading every setting,
     // and furthermore I read some setting too often.
-    DO_EXPECT(cbs, false, false);
+    EXPECT_ERR_WARN(cbs, false, false);
 }
 
 
@@ -337,39 +421,49 @@ TEST(BaseLibConfigTree, BadKeynames)
 
     boost::property_tree::ptree ptree;
     std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree);
+    read_xml(xml_str, ptree,
+             boost::property_tree::xml_parser::no_comments |
+	             boost::property_tree::xml_parser::trim_whitespace);
 
     Callbacks cbs;
     {
         BaseLib::ConfigTreeNew conf(ptree, cbs.get_error_cb(), cbs.get_warning_cb());
 
-        for (std::string tag : { "<", "Z", ".", "$", "0", "", "/" })
+        for (auto tag : { "<", "Z", ".", "$", "0", "", "/", "_", "a__" })
         {
             RUN_SAFE(conf.getConfParam<int>(tag));
-            DO_EXPECT(cbs, true, false);
+            EXPECT_ERR_WARN(cbs, true, false);
             RUN_SAFE(conf.getConfParam<int>(tag, 500));
-            DO_EXPECT(cbs, true, false);
+            EXPECT_ERR_WARN(cbs, true, false);
             RUN_SAFE(conf.getConfParamOptional<int>(tag));
-            DO_EXPECT(cbs, true, false);
+            EXPECT_ERR_WARN(cbs, true, false);
             RUN_SAFE(conf.getConfParamList<int>(tag));
+            EXPECT_ERR_WARN(cbs, true, false);
 
-            DO_EXPECT(cbs, true, false);
+            RUN_SAFE(conf.getConfParam(tag));
+            EXPECT_ERR_WARN(cbs, true, false);
+            RUN_SAFE(conf.getConfParamOptional(tag));
+            EXPECT_ERR_WARN(cbs, true, false);
+
             RUN_SAFE(conf.peekConfParam<int>(tag));
-            DO_EXPECT(cbs, true, false);
+            EXPECT_ERR_WARN(cbs, true, false);
             RUN_SAFE(conf.checkConfParam<int>(tag, 500));
+            EXPECT_ERR_WARN(cbs, true, false);
 
-            DO_EXPECT(cbs, true, false);
             RUN_SAFE(conf.getConfSubtree(tag));
-            DO_EXPECT(cbs, true, false);
+            EXPECT_ERR_WARN(cbs, true, false);
             RUN_SAFE(conf.getConfSubtreeOptional(tag));
-            DO_EXPECT(cbs, true, false);
+            EXPECT_ERR_WARN(cbs, true, false);
             RUN_SAFE(conf.getConfSubtreeList(tag));
-            DO_EXPECT(cbs, true, false);
+            EXPECT_ERR_WARN(cbs, true, false);
+
+            RUN_SAFE(conf.getConfAttribute<int>(tag));
+            EXPECT_ERR_WARN(cbs, true, false);
         }
 
     } // ConfigTree destroyed here
 
-    DO_EXPECT(cbs, false, false);
+    EXPECT_ERR_WARN(cbs, false, false);
 }
 
 // String literals are somewhat special for template classes
@@ -381,22 +475,25 @@ TEST(BaseLibConfigTree, ConfigTreeStringLiterals)
 
     boost::property_tree::ptree ptree;
     std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree);
+    read_xml(xml_str, ptree,
+             boost::property_tree::xml_parser::no_comments |
+	             boost::property_tree::xml_parser::trim_whitespace);
 
     Callbacks cbs;
     {
         BaseLib::ConfigTreeNew conf(ptree, cbs.get_error_cb(), cbs.get_warning_cb());
 
         EXPECT_EQ("test", conf.getConfParam<std::string>("s", "XX"));
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
 
+        // <n> not present in the XML, so return the default value
         EXPECT_EQ("XX",   conf.getConfParam<std::string>("n", "XX"));
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
 
         conf.checkConfParam("t", "Test");
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
     } // ConfigTree destroyed here
-    DO_EXPECT(cbs, false, false);
+    EXPECT_ERR_WARN(cbs, false, false);
 }
 
 // String literals are somewhat special for template classes
@@ -408,24 +505,26 @@ TEST(BaseLibConfigTree, ConfigTreeMoveConstruct)
 
     boost::property_tree::ptree ptree;
     std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree);
+    read_xml(xml_str, ptree,
+             boost::property_tree::xml_parser::no_comments |
+	             boost::property_tree::xml_parser::trim_whitespace);
 
     Callbacks cbs;
     {
         BaseLib::ConfigTreeNew conf(ptree, cbs.get_error_cb(), cbs.get_warning_cb());
 
         EXPECT_EQ("test", conf.getConfParam<std::string>("s", "XX"));
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
 
         BaseLib::ConfigTreeNew conf2(std::move(conf));
 
         EXPECT_EQ("XX",   conf2.getConfParam<std::string>("n", "XX"));
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
 
         conf2.checkConfParam("t", "Test");
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
     } // ConfigTree destroyed here
-    DO_EXPECT(cbs, false, false);
+    EXPECT_ERR_WARN(cbs, false, false);
 }
 
 // String literals are somewhat special for template classes
@@ -437,27 +536,53 @@ TEST(BaseLibConfigTree, ConfigTreeMoveAssign)
 
     boost::property_tree::ptree ptree;
     std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree);
+    read_xml(xml_str, ptree,
+             boost::property_tree::xml_parser::no_comments |
+	             boost::property_tree::xml_parser::trim_whitespace);
 
     Callbacks cbs;
     {
         BaseLib::ConfigTreeNew conf(ptree, cbs.get_error_cb(), cbs.get_warning_cb());
 
         EXPECT_EQ("test", conf.getConfParam<std::string>("s", "XX"));
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
 
         BaseLib::ConfigTreeNew conf2(ptree, cbs.get_error_cb(), cbs.get_warning_cb());
         conf2 = std::move(conf);
         // Expect warning because config tree has not been traversed
         // entirely before.
-        DO_EXPECT(cbs, false, true);
+        EXPECT_ERR_WARN(cbs, false, true);
 
         EXPECT_EQ("XX",   conf2.getConfParam<std::string>("n", "XX"));
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
 
         conf2.checkConfParam("t", "Test");
-        DO_EXPECT(cbs, false, false);
+        EXPECT_ERR_WARN(cbs, false, false);
     } // ConfigTree destroyed here
-    DO_EXPECT(cbs, false, false);
+    EXPECT_ERR_WARN(cbs, false, false);
+}
+
+
+TEST(BLT, TEST)
+{
+    const char xml[] =
+            "<s>test</s>"
+            "<t>Test</t>"
+            "<z/>";
+
+    // boost::property_tree::basic_ptree<std::string, char*, std::less<std::string>> ptree;
+    // boost::property_tree::basic_ptree<std::string, boost::optional<std::string>, std::less<std::string>> ptree;
+    boost::property_tree::ptree ptree;
+    std::istringstream xml_str(xml);
+    read_xml(xml_str, ptree,
+             boost::property_tree::xml_parser::no_comments |
+	             boost::property_tree::xml_parser::trim_whitespace);
+    WARN("value: <%s>", ptree.get_child("z").get_value<std::string>().c_str());
+
+    auto opt = ptree.get_child("z").get_value_optional<std::string>();
+    WARN("has value? -> %s", opt ? "true" : "false");
+
+    auto dat = ptree.get_child("z").data();
+    WARN("value: <%s>", dat.c_str());
 }
 

--- a/Tests/BaseLib/TestConfigTree.cpp
+++ b/Tests/BaseLib/TestConfigTree.cpp
@@ -15,12 +15,14 @@
 
 #include "BaseLib/ConfigTreeNew.h"
 
+// make useful line numbers appear in the output of gtest
 #define EXPECT_ERR_WARN(cbs, error, warning) do  { \
         if (error)   EXPECT_TRUE((cbs).get_error());   else EXPECT_FALSE((cbs).get_error()); \
         if (warning) EXPECT_TRUE((cbs).get_warning()); else EXPECT_FALSE((cbs).get_warning()); \
         (cbs).reset(); \
     } while(false)
 
+// catch exception thrown by the error callback
 #define RUN_SAFE(expr) do { \
         try { expr; } catch(Exc) {} \
     } while (false)
@@ -65,7 +67,19 @@ private:
 };
 
 
-TEST(BaseLibConfigTree, ConfigTreeEmpty)
+boost::property_tree::ptree
+readXml(const char xml[])
+{
+    boost::property_tree::ptree ptree;
+    std::istringstream xml_str(xml);
+    read_xml(xml_str, ptree,
+             boost::property_tree::xml_parser::no_comments |
+             boost::property_tree::xml_parser::trim_whitespace);
+    return ptree;
+}
+
+
+TEST(BaseLibConfigTree, Empty)
 {
     boost::property_tree::ptree ptree;
     Callbacks cbs;
@@ -79,7 +93,7 @@ TEST(BaseLibConfigTree, ConfigTreeEmpty)
 }
 
 
-TEST(BaseLibConfigTree, ConfigTreeGet)
+TEST(BaseLibConfigTree, Get)
 {
     const char xml[] =
             "<double>5.6e-4</double>"
@@ -97,12 +111,7 @@ TEST(BaseLibConfigTree, ConfigTreeGet)
             "</sub>"
             "<x>Y</x>"
             "<z attr=\"0.5\">32.0</z>";
-
-    boost::property_tree::ptree ptree;
-    std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree,
-             boost::property_tree::xml_parser::no_comments |
-	             boost::property_tree::xml_parser::trim_whitespace);
+    auto const ptree = readXml(xml);
 
     Callbacks cbs;
     {
@@ -214,12 +223,7 @@ TEST(BaseLibConfigTree, IncompleteParse)
             "<pt x=\"0.5\">1</pt>"
             "<pt2 x=\"0.5\" y=\"1.0\" z=\"2.0\" />"
             ;
-
-    boost::property_tree::ptree ptree;
-    std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree,
-             boost::property_tree::xml_parser::no_comments |
-                 boost::property_tree::xml_parser::trim_whitespace);
+    auto const ptree = readXml(xml);
 
     Callbacks cbs;
     {
@@ -248,7 +252,7 @@ TEST(BaseLibConfigTree, IncompleteParse)
 }
 
 
-TEST(BaseLibConfigTree, ConfigTreeCheckRange)
+TEST(BaseLibConfigTree, CheckRange)
 {
     const char xml[] =
             "<val><int>0</int></val>"
@@ -257,12 +261,7 @@ TEST(BaseLibConfigTree, ConfigTreeCheckRange)
             "<int>0</int>"
             "<int>1</int>"
             "<int>2</int>";
-
-    boost::property_tree::ptree ptree;
-    std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree,
-             boost::property_tree::xml_parser::no_comments |
-	             boost::property_tree::xml_parser::trim_whitespace);
+    auto const ptree = readXml(xml);
 
     Callbacks cbs;
     {
@@ -295,18 +294,13 @@ TEST(BaseLibConfigTree, ConfigTreeCheckRange)
 }
 
 
-TEST(BaseLibConfigTree, ConfigTreeGetSubtreeList)
+TEST(BaseLibConfigTree, GetSubtreeList)
 {
     const char xml[] =
             "<val><int>0</int></val>"
             "<val><int>1</int></val>"
             "<val><int>2</int></val>";
-
-    boost::property_tree::ptree ptree;
-    std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree,
-             boost::property_tree::xml_parser::no_comments |
-	             boost::property_tree::xml_parser::trim_whitespace);
+    auto const ptree = readXml(xml);
 
     Callbacks cbs;
     {
@@ -324,16 +318,13 @@ TEST(BaseLibConfigTree, ConfigTreeGetSubtreeList)
 }
 
 
-TEST(BaseLibConfigTree, ConfigTreeGetValueList)
+TEST(BaseLibConfigTree, GetValueList)
 {
     const char xml[] =
             "<int>0</int>"
             "<int>1</int>"
             "<int>2</int>";
-
-    boost::property_tree::ptree ptree;
-    std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree);
+    auto const ptree = readXml(xml);
 
     Callbacks cbs;
     {
@@ -351,7 +342,7 @@ TEST(BaseLibConfigTree, ConfigTreeGetValueList)
 }
 
 
-TEST(BaseLibConfigTree, ConfigTreeNoConversion)
+TEST(BaseLibConfigTree, NoConversion)
 {
     const char xml[] =
             "<int>5.6</int>"         // not convertible to int
@@ -361,12 +352,7 @@ TEST(BaseLibConfigTree, ConfigTreeNoConversion)
             "<ign/>"
             "<ign2/><ign2/><ign2/>"
             ;
-
-    boost::property_tree::ptree ptree;
-    std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree,
-             boost::property_tree::xml_parser::no_comments |
-	             boost::property_tree::xml_parser::trim_whitespace);
+    auto const ptree = readXml(xml);
 
     Callbacks cbs;
     {
@@ -418,12 +404,7 @@ TEST(BaseLibConfigTree, ConfigTreeNoConversion)
 TEST(BaseLibConfigTree, BadKeynames)
 {
     const char xml[] = "";
-
-    boost::property_tree::ptree ptree;
-    std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree,
-             boost::property_tree::xml_parser::no_comments |
-	             boost::property_tree::xml_parser::trim_whitespace);
+    auto const ptree = readXml(xml);
 
     Callbacks cbs;
     {
@@ -467,17 +448,12 @@ TEST(BaseLibConfigTree, BadKeynames)
 }
 
 // String literals are somewhat special for template classes
-TEST(BaseLibConfigTree, ConfigTreeStringLiterals)
+TEST(BaseLibConfigTree, StringLiterals)
 {
     const char xml[] =
             "<s>test</s>"
             "<t>Test</t>";
-
-    boost::property_tree::ptree ptree;
-    std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree,
-             boost::property_tree::xml_parser::no_comments |
-	             boost::property_tree::xml_parser::trim_whitespace);
+    auto const ptree = readXml(xml);
 
     Callbacks cbs;
     {
@@ -497,17 +473,12 @@ TEST(BaseLibConfigTree, ConfigTreeStringLiterals)
 }
 
 // String literals are somewhat special for template classes
-TEST(BaseLibConfigTree, ConfigTreeMoveConstruct)
+TEST(BaseLibConfigTree, MoveConstruct)
 {
     const char xml[] =
             "<s>test</s>"
             "<t>Test</t>";
-
-    boost::property_tree::ptree ptree;
-    std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree,
-             boost::property_tree::xml_parser::no_comments |
-	             boost::property_tree::xml_parser::trim_whitespace);
+    auto const ptree = readXml(xml);
 
     Callbacks cbs;
     {
@@ -528,17 +499,12 @@ TEST(BaseLibConfigTree, ConfigTreeMoveConstruct)
 }
 
 // String literals are somewhat special for template classes
-TEST(BaseLibConfigTree, ConfigTreeMoveAssign)
+TEST(BaseLibConfigTree, MoveAssign)
 {
     const char xml[] =
             "<s>test</s>"
             "<t>Test</t>";
-
-    boost::property_tree::ptree ptree;
-    std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree,
-             boost::property_tree::xml_parser::no_comments |
-	             boost::property_tree::xml_parser::trim_whitespace);
+    auto const ptree = readXml(xml);
 
     Callbacks cbs;
     {

--- a/Tests/BaseLib/TestConfigTree.cpp
+++ b/Tests/BaseLib/TestConfigTree.cpp
@@ -561,28 +561,3 @@ TEST(BaseLibConfigTree, ConfigTreeMoveAssign)
     } // ConfigTree destroyed here
     EXPECT_ERR_WARN(cbs, false, false);
 }
-
-
-TEST(BLT, TEST)
-{
-    const char xml[] =
-            "<s>test</s>"
-            "<t>Test</t>"
-            "<z/>";
-
-    // boost::property_tree::basic_ptree<std::string, char*, std::less<std::string>> ptree;
-    // boost::property_tree::basic_ptree<std::string, boost::optional<std::string>, std::less<std::string>> ptree;
-    boost::property_tree::ptree ptree;
-    std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree,
-             boost::property_tree::xml_parser::no_comments |
-	             boost::property_tree::xml_parser::trim_whitespace);
-    WARN("value: <%s>", ptree.get_child("z").get_value<std::string>().c_str());
-
-    auto opt = ptree.get_child("z").get_value_optional<std::string>();
-    WARN("has value? -> %s", opt ? "true" : "false");
-
-    auto dat = ptree.get_child("z").data();
-    WARN("value: <%s>", dat.c_str());
-}
-

--- a/Tests/MathLib/TestLinearSolver.cpp
+++ b/Tests/MathLib/TestLinearSolver.cpp
@@ -204,7 +204,7 @@ void checkLinearSolverInterface(T_MATRIX& A, T_VECTOR& b,
 TEST(MathLib, CheckInterface_GaussAlgorithm)
 {
     boost::property_tree::ptree t_root;
-    BaseLib::ConfigTreeNew conf(t_root);
+    BaseLib::ConfigTreeNew conf(t_root, "");
 
     using Example = Example1<std::size_t>;
 
@@ -226,7 +226,7 @@ TEST(Math, CheckInterface_Eigen)
     t_solver.put("error_tolerance", 1e-15);
     t_solver.put("max_iteration_step", 1000);
     t_root.put_child("eigen", t_solver);
-    BaseLib::ConfigTreeNew conf(t_root);
+    BaseLib::ConfigTreeNew conf(t_root, "");
 
     using IntType = MathLib::EigenMatrix::IndexType;
 
@@ -243,7 +243,7 @@ TEST(Math, CheckInterface_EigenLis)
     boost::property_tree::ptree t_root;
     boost::property_tree::ptree t_solver;
     t_root.put("lis", "-i cg -p none -tol 1e-15 -maxiter 1000");
-    BaseLib::ConfigTreeNew conf(t_root);
+    BaseLib::ConfigTreeNew conf(t_root, "");
 
     using IntType = MathLib::LisMatrix::IndexType;
 
@@ -260,7 +260,7 @@ TEST(Math, CheckInterface_Lis)
     boost::property_tree::ptree t_root;
     boost::property_tree::ptree t_solver;
     t_root.put("lis", "-i cg -p none -tol 1e-15 -maxiter 1000");
-    BaseLib::ConfigTreeNew conf(t_root);
+    BaseLib::ConfigTreeNew conf(t_root, "");
 
     using IntType = MathLib::LisMatrix::IndexType;
 
@@ -294,7 +294,7 @@ TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_basic)
     checkLinearSolverInterface<MathLib::PETScMatrix,
                                MathLib::PETScVector,
                                MathLib::PETScLinearSolver>(
-        A, b, "ptest1_", BaseLib::ConfigTreeNew(t_root));
+        A, b, "ptest1_", BaseLib::ConfigTreeNew(t_root, ""));
 }
 
 TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_chebyshev_sor)
@@ -320,7 +320,7 @@ TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_chebyshev_sor)
     checkLinearSolverInterface<MathLib::PETScMatrix,
                                MathLib::PETScVector,
                                MathLib::PETScLinearSolver>(
-        A, b, "ptest2_", BaseLib::ConfigTreeNew(t_root));
+        A, b, "ptest2_", BaseLib::ConfigTreeNew(t_root, ""));
 }
 
 TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_gmres_amg)
@@ -348,7 +348,7 @@ TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_gmres_amg)
     checkLinearSolverInterface<MathLib::PETScMatrix,
                                MathLib::PETScVector,
                                MathLib::PETScLinearSolver>(
-        A, b, "ptest3_", BaseLib::ConfigTreeNew(t_root));
+        A, b, "ptest3_", BaseLib::ConfigTreeNew(t_root, ""));
 }
 
 #endif


### PR DESCRIPTION
Said support is necessary in order to be able to process our geometry files with ConfigTreeNew.

This PR actually does many things:
* adds support for XML attributes in `ConfigTreeNew`
* along with that adds `getValue()` methods to access data from XML nodes,
* adds `_filename` member to `ConfigTreeNew` that will be printed in error messages,
* contains some cleanup of `ConfigTreeNew`, and extends its documentation
* adds some functionality to conveniently read an XML file into a `ConfigTreeNew`.

Furthermore, in order to demonstate the handiness of the introduced changes:
* parsing of GML files now happens through `ConfigTreeNew`.
* Therefore the old `ConfigTree` typdefs and functions are not needed anymore and have been removed

The tests for `ConfigTreeNew` have been extended to cover most of the added functionality. However, not everything is tested yet. I want to complete the tests later on, not in this PR.

Sorry for the long PR, but the only thing that can be separated from it easily are the changes in `BoostXmlGmlInterface`. If you think, that it is too much work for you to review it, I'd suggest to make an Q&A session with you about it rather than having to disassemble all of my commits. Unfortunately reviewing commit-wise will not be an option, I'm afraid.

### Suggested order of review (to make it easier for you)
First packet (reading tree from file):
1. Applications/CLI/ogs.cpp
2. BaseLib/ConfigTreeUtil.h
3. BaseLib/ConfigTreeUtil.cpp
Second packet (ConfigTreeNew):
4. BaseLib/ConfigTreeNew.h
5. BaseLib/ConfigTreeNew.cpp
6. BaseLib/ConfigTreeNew-impl.h
Third packet (Tests):
7. Tests/BaseLib/TestConfigTree.cpp
8. Tests/AssemblerLib/TestSerialLinearSolver.cpp (few changes)
9. Tests/MathLib/TestLinearSolver.cpp (few changes)
Fourth packet (GML parsing):
10. FileIO/XmlIO/Boost/BoostXmlGmlInterface.h
11. FileIO/XmlIO/Boost/BoostXmlGmlInterface.cpp
12. BaseLib/ConfigTree.h (only deletions)
13. BaseLib/ConfigTree.cpp (only deletions)

OK, maybe there should have been four PRs. ^^