### PR TITLE
Improvement in the usage of PETSc matrix and vector

### DIFF
--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -68,6 +68,12 @@ public:
     /// Returns total number of degrees of freedom.
     std::size_t dofSize() const;
 
+    /// Returns total number of local degrees of freedom for DDC.
+    std::size_t dofSizeLocal() const
+    {
+        return _mesh_component_map.getNLocalUnknowns();
+    }
+
     /// Returns total number of global degrees of freedom for DDC.
     std::size_t dofSizeGlobal() const
     {
@@ -92,6 +98,12 @@ public:
     std::vector<GlobalIndexType> getGlobalIndices(const MeshLib::Location &l) const
     {
         return _mesh_component_map.getGlobalIndices(l);
+    }
+
+    /// Get ghost indices, forwarded from MeshComponentMap.
+    std::vector<GlobalIndexType> getGhostIndices() const
+    {
+        return _mesh_component_map.getGhostIndices();
     }
 
 private:

--- a/AssemblerLib/MeshComponentMap.cpp
+++ b/AssemblerLib/MeshComponentMap.cpp
@@ -40,6 +40,7 @@ MeshComponentMap::MeshComponentMap(
     std::size_t comp_id = 0;
 
     _num_global_dof = 0;
+    _num_local_dof = 0;
     for (auto c = components.cbegin(); c != components.cend(); ++c)
     {
         assert (*c != nullptr);
@@ -57,8 +58,18 @@ MeshComponentMap::MeshComponentMap(
                 {
                     const GlobalIndexType global_id = static_cast<GlobalIndexType>(components.size()
                                                * mesh.getGlobalNodeID(j) + comp_id);
-                    const GlobalIndexType signed_global_id = mesh.isGhostNode( mesh.getNode(j)->getID() )
-                                                    ? -global_id : global_id;
+                    const bool is_ghost = mesh.isGhostNode( mesh.getNode(j)->getID() );
+                    GlobalIndexType signed_global_id
+                                          = is_ghost ? -global_id : global_id;
+                    if (is_ghost)
+                    {
+                        _ghosts_indices.push_back(-signed_global_id);
+                        if (signed_global_id == 0)
+                             signed_global_id = -9999;
+                    }
+                    else
+                        _num_local_dof++;
+                       
                     _dict.insert(Line(Location(mesh_id, MeshLib::MeshItemType::Node, j),
                                 comp_id, signed_global_id) );
                 }
@@ -77,8 +88,18 @@ MeshComponentMap::MeshComponentMap(
                 {
                     const GlobalIndexType global_id = static_cast<GlobalIndexType>(global_index_offset
                                                           + mesh.getGlobalNodeID(j) );
-                    const GlobalIndexType signed_global_id = mesh.isGhostNode( mesh.getNode(j)->getID() )
-                                                    ? -global_id : global_id;
+                    const bool is_ghost = mesh.isGhostNode( mesh.getNode(j)->getID() );
+                    GlobalIndexType signed_global_id
+                                        = is_ghost ? -global_id : global_id;
+                    if (is_ghost)
+                    {
+                        _ghosts_indices.push_back(-signed_global_id);
+                        if (signed_global_id == 0)
+                             signed_global_id = -9999;
+                    }
+                    else
+                        _num_local_dof++;
+
                     _dict.insert(Line(Location(mesh_id, MeshLib::MeshItemType::Node, j),
                                 comp_id, signed_global_id) );
                 }

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -126,10 +126,22 @@ public:
     std::vector<GlobalIndexType> getGlobalIndicesByComponent(
         const std::vector<Location>& ls) const;
 
-    /// Get the number of global unknowns.
+    /// Get the number of global unknowns (for DDC).
     std::size_t getNGlobalUnknowns() const
     {
         return _num_global_dof;
+    }
+
+    /// Get the number of local unknowns (for DDC).
+    std::size_t getNLocalUnknowns() const
+    {
+        return _num_local_dof;
+    }
+
+    /// Get ghost indices (for DDC).
+    std::vector<GlobalIndexType> getGhostIndices() const
+    {
+        return _ghosts_indices;
     }
 
     /// A value returned if no global index was found for the requested
@@ -166,15 +178,20 @@ private:
 
     void renumberByLocation(GlobalIndexType offset=0);
 
-private:
     detail::ComponentGlobalIndexDict _dict;
 
     /// Number of global unknowns.
     std::size_t _num_global_dof = 0;
 
+    /// Number of local unknowns.
+    std::size_t _num_local_dof  = 0;
+
     /// Number of components
     /// introduced mainly for error checking
     unsigned const _num_components;
+
+    /// Global ID for ghost entries
+    std::vector<GlobalIndexType> _ghosts_indices;
 };
 
 }   // namespace AssemblerLib

--- a/MathLib/LinAlg/Dense/DenseVector.h
+++ b/MathLib/LinAlg/Dense/DenseVector.h
@@ -75,6 +75,14 @@ public:
 		}
 	}
 
+	/// get entry values to an array
+	void getValues(T u[])
+	{
+		for (std::size_t i=0; i<this->size(); ++i) {
+			u[i] = (*this)[i];
+		}
+	}
+
 	/**
 	 * writes the matrix entries into a file
 	 * @param filename output file name

--- a/MathLib/LinAlg/Eigen/EigenVector.h
+++ b/MathLib/LinAlg/Eigen/EigenVector.h
@@ -86,6 +86,13 @@ public:
         }
     }
 
+    /// get entry values to an array
+    void getValues(double u[])
+    {
+        for (IndexType i=0; i<_vec.size(); i++)
+            u[i] = _vec[i];
+    }
+
 #ifndef NDEBUG
     /// printout this equation for debugging
     void write (const std::string &filename) const { std::ofstream os(filename); os << _vec; }

--- a/MathLib/LinAlg/Lis/LisVector.h
+++ b/MathLib/LinAlg/Lis/LisVector.h
@@ -107,6 +107,12 @@ public:
 		}
 	}
 
+	/// get entry values to an array
+	void getValues(LIS_SCALAR u[])
+	{
+		lis_vector_get_values(_vec, 0, size(), u);
+	}
+
 private:
 	LIS_VECTOR _vec;
 };

--- a/MathLib/LinAlg/PETSc/PETScMatrix.cpp
+++ b/MathLib/LinAlg/PETSc/PETScMatrix.cpp
@@ -24,13 +24,10 @@ PETScMatrix::PETScMatrix (const PetscInt nrows, const PETScMatrixOption &mat_opt
 {
     if(!mat_opt.is_global_size)
     {
+        _n_loc_rows = nrows;
+        _n_loc_cols = nrows;
         _nrows = PETSC_DECIDE;
         _ncols = PETSC_DECIDE;
-        _n_loc_rows = nrows;
-
-        // Make the matrix be square.
-        MPI_Allreduce(&_n_loc_rows, &_nrows, 1, MPI_INT, MPI_SUM, PETSC_COMM_WORLD);
-        _ncols = _nrows;
     }
 
     create(mat_opt.d_nz, mat_opt.o_nz);
@@ -57,6 +54,7 @@ void PETScMatrix::setRowsColumnsZero(std::vector<PetscInt> const& row_pos)
     const PetscScalar one = 1.0;
     const PetscInt nrows = static_cast<PetscInt> (row_pos.size());
 
+    MatSetOption(_A, MAT_NO_OFF_PROC_ZERO_ROWS, PETSC_TRUE); 
     if(nrows>0)
         MatZeroRows(_A, nrows, &row_pos[0], one, PETSC_NULL, PETSC_NULL);
     else

--- a/MathLib/LinAlg/PETSc/PETScVector.cpp
+++ b/MathLib/LinAlg/PETSc/PETScVector.cpp
@@ -36,14 +36,27 @@ PETScVector::PETScVector(const PetscInt vec_size, const bool is_global_size)
         // the size can be associated to specific memory allocation of a matrix
         VecCreateMPI(PETSC_COMM_WORLD, vec_size, PETSC_DECIDE, &_v);
     }
-    VecSetFromOptions(_v);
-    // VecSetUp(_v); // for petsc ver.>3.3
-    VecGetOwnershipRange(_v, &_start_rank, &_end_rank);
 
-    VecGetLocalSize(_v, &_size_loc);
-    VecGetSize(_v, &_size);
+    config();
+}
 
-    VecSetOption(_v, VEC_IGNORE_NEGATIVE_INDICES,PETSC_TRUE);
+PETScVector::PETScVector(const PetscInt vec_size,
+                         const std::vector<PetscInt>& ghost_ids,
+                         const bool is_global_size) : has_ghost_id(true)
+{
+    PetscInt nghosts = static_cast<PetscInt>( ghost_ids.size() );
+    if ( is_global_size )
+    {
+        VecCreateGhost(PETSC_COMM_WORLD, PETSC_DECIDE, vec_size, nghosts,
+                       &ghost_ids[0], &_v);
+    }
+    else
+    {
+        VecCreateGhost(PETSC_COMM_WORLD, vec_size, PETSC_DECIDE, nghosts,
+                       &ghost_ids[0], &_v);
+    }
+
+    config();
 }
 
 PETScVector::PETScVector(const PETScVector &existing_vec, const bool deep_copy)
@@ -61,6 +74,30 @@ PETScVector::PETScVector(const PETScVector &existing_vec, const bool deep_copy)
     }
 
     VecSetOption(_v, VEC_IGNORE_NEGATIVE_INDICES,PETSC_TRUE);
+}
+
+void PETScVector::config()
+{
+    VecSetFromOptions(_v);
+    // VecSetUp(_v); // for petsc ver.>3.3
+    VecGetOwnershipRange(_v, &_start_rank, &_end_rank);
+
+    VecGetLocalSize(_v, &_size_loc);
+    VecGetSize(_v, &_size);
+
+    VecSetOption(_v, VEC_IGNORE_NEGATIVE_INDICES,PETSC_TRUE);
+}
+
+void PETScVector::finalizeAssembly()
+{
+    VecAssemblyBegin(_v);
+    VecAssemblyEnd(_v);
+
+    if (has_ghost_id)
+    {
+        VecGhostUpdateBegin(_v,INSERT_VALUES,SCATTER_FORWARD);
+        VecGhostUpdateEnd(_v,INSERT_VALUES,SCATTER_FORWARD);
+    }
 }
 
 void PETScVector::gatherLocalVectors( PetscScalar local_array[],

--- a/MathLib/LinAlg/PETSc/PETScVector.h
+++ b/MathLib/LinAlg/PETSc/PETScVector.h
@@ -167,45 +167,16 @@ class PETScVector
         }
 
         /*!
-           Get local vector, i.e. entries in the same rank
-           \param loc_vec  Pointer to array where stores the local vector,
-                           memory allocation is not needed
-        */
-        PetscScalar *getLocalVector() const
-        {
-            PetscScalar *loc_array;
-            if (has_ghost_id)
-            {
-                VecGhostUpdateBegin(_v, INSERT_VALUES, SCATTER_FORWARD);
-                VecGhostUpdateEnd(_v, INSERT_VALUES, SCATTER_FORWARD);
-                VecGhostGetLocalForm(_v, &_v_loc);
-                VecGetArray(_v_loc, &loc_array);
-            }
-            else
-               VecGetArray(_v, &loc_array);
-            return loc_array;
-        }
-
-        /*!
-           Restore array after finish access local array
-           \param array  Pointer to the local array fetched by VecGetArray
-        */
-        void restoreArray(PetscScalar* array) const
-        {
-            if (has_ghost_id)
-            {
-                VecRestoreArray(_v_loc, &array);
-             //   VecGhostRestoreLocalForm(_v, &_v_loc);
-            }
-            else
-                VecRestoreArray(_v, &array);
-        }
-
-        /*!
            Get global vector
            \param u Array to store the global vector. Memory allocation is needed in advance
         */
         void getGlobalVector(PetscScalar u[]);
+
+         /*!
+           Get local entries including ghost ones to an array
+           \param u Array for the values of local entries.
+        */
+        void getValues(PetscScalar u[]);
 
         /// Get an entry value. This is an expensive operation,
         /// and it only get local value. Use it for only test purpose
@@ -299,6 +270,19 @@ class PETScVector
         */
         void gatherLocalVectors(PetscScalar local_array[],
                                 PetscScalar global_array[]);
+
+        /*!
+           Get local vector, i.e. entries in the same rank
+           \param loc_vec  Pointer to array where stores the local vector,
+                           memory allocation is not needed
+        */
+        PetscScalar* getLocalVector() const;
+
+        /*!
+           Restore array after finish access local array
+           \param array  Pointer to the local array fetched by VecGetArray
+        */
+        inline void restoreArray(PetscScalar* array) const;
 
         /// A funtion called by constructors to configure members
         void config();

--- a/MathLib/LinAlg/PETSc/PETScVector.h
+++ b/MathLib/LinAlg/PETSc/PETScVector.h
@@ -48,6 +48,16 @@ class PETScVector
         PETScVector(const PetscInt vec_size, const bool is_global_size = true);
 
         /*!
+            \brief Constructor
+            \param vec_size       The size of the vector, either global or local
+            \param ghost_ids      The global indices of ghost entries
+            \param is_global_size The flag of the type of vec_size, i.e. whether it is a global size
+                                  or local size. The default is true.
+        */
+        PETScVector(const PetscInt vec_size, const std::vector<PetscInt>& ghost_ids,
+                    const bool is_global_size = true);
+
+        /*!
              \brief Copy constructor
              \param existing_vec The vector to be copied
              \param deep_copy    The flag for a deep copy, which means to copy the values as well,
@@ -61,11 +71,7 @@ class PETScVector
         }
 
         /// Perform MPI collection of assembled entries in buffer
-        void finalizeAssembly()
-        {
-            VecAssemblyBegin(_v);
-            VecAssemblyEnd(_v);
-        }
+        void finalizeAssembly();
 
         /// Get the global size of the vector
         PetscInt size() const
@@ -167,6 +173,15 @@ class PETScVector
         }
 
         /*!
+           Restore array after finish access local array
+           \param array  Pointer to the local array fetched by VecGetArray
+        */
+        void restoreArray(PetscScalar* array) const
+        {
+            VecRestoreArray(_v, &array);         
+        }
+
+        /*!
            Get global vector
            \param u Array to store the global vector. Memory allocation is needed in advance
         */
@@ -249,6 +264,9 @@ class PETScVector
         /// Size of local entries
         PetscInt _size_loc;
 
+        /// Flag to indicate whether the vector is created with ghost entry indices
+        bool has_ghost_id = false;
+
         /*!
               \brief  Collect local vectors
               \param  local_array Local array
@@ -256,6 +274,9 @@ class PETScVector
         */
         void gatherLocalVectors(PetscScalar local_array[],
                                 PetscScalar global_array[]);
+
+        /// A funtion called by constructors to configure members
+        void config();
 
         friend void finalizeVectorAssembly(PETScVector &vec);
 };

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -192,18 +192,7 @@ public:
         assert(result && result->size() == this->_x->size());
 
         // Copy result
-#ifdef USE_PETSC
-        double* loc_x = this->_x->getLocalVector();
-        for (std::size_t i=0; i < this->_x->getLocalSize()
-                                + this->_x->getGhostSize(); i++)
-        {
-            (*result)[i] = loc_x[i];
-        }
-        this->_x->restoreArray(loc_x);
-#else
-        for (std::size_t i = 0; i < this->_x->size(); ++i)
-            (*result)[i] = (*this->_x)[i];
-#endif
+        this->_x->getValues(&(*result)[0]);
 
         // Write output file
         FileIO::VtuInterface vtu_interface(&this->_mesh, vtkXMLWriter::Binary, true);

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -193,12 +193,13 @@ public:
 
         // Copy result
 #ifdef USE_PETSC
-        double* loc_x = _x->getLocalVector();
-        for (std::size_t i=0; i<_x->getLocalSize() + _x->getGhostSize(); i++)
+        double* loc_x = this->_x->getLocalVector();
+        for (std::size_t i=0; i < this->_x->getLocalSize()
+                                + this->_x->getGhostSize(); i++)
         {
             (*result)[i] = loc_x[i];
         }
-        _x->restoreArray(loc_x);
+        this->_x->restoreArray(loc_x);
 #else
         for (std::size_t i = 0; i < this->_x->size(); ++i)
             (*result)[i] = (*this->_x)[i];

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -209,15 +209,23 @@ private:
 		    static_cast<const MeshLib::NodePartitionedMesh&>(_mesh);
 		mat_opt.d_nz = pmesh.getMaximumNConnectedNodesToNode();
 		mat_opt.o_nz = mat_opt.d_nz;
+		mat_opt.is_global_size = false;
 		const std::size_t num_unknowns =
-		    _local_to_global_index_map->dofSizeGlobal();
+		    _local_to_global_index_map->dofSizeLocal();
 		_A.reset(_global_setup.createMatrix(num_unknowns, mat_opt));
+		// In the following two lines, false is assigned to
+		// the argument of is_global_size, which indicates num_unknowns
+		// is local.
+		_x.reset( _global_setup.createVector(num_unknowns,
+		          _local_to_global_index_map->getGhostIndices(), false) );
+		_rhs.reset( _global_setup.createVector(num_unknowns,
+		            _local_to_global_index_map->getGhostIndices(), false) );
 #else
 		const std::size_t num_unknowns = _local_to_global_index_map->dofSize();
 		_A.reset(_global_setup.createMatrix(num_unknowns));
-#endif
 		_x.reset(_global_setup.createVector(num_unknowns));
 		_rhs.reset(_global_setup.createVector(num_unknowns));
+#endif
 		_linear_solver.reset(new typename GlobalSetup::LinearSolver(
 		    *_A, solver_name, _linear_solver_options.get()));
 		checkAndInvalidate(_linear_solver_options);

--- a/Tests/MathLib/TestGlobalVectorInterface.cpp
+++ b/Tests/MathLib/TestGlobalVectorInterface.cpp
@@ -177,12 +177,13 @@ void checkGlobalVectorInterfacePETSc()
     ASSERT_ARRAY_NEAR(z, x0, 6, 1e-10);
 
     // check local array
-    double *loc_v = x_fixed_p.getLocalVector();
+    std::vector<double> loc_v(  x_fixed_p.getLocalSize()
+                              + x_fixed_p.getGhostSize() );
+    x_fixed_p.getValues(&loc_v[0]);
     z[0] = 1.0;
     z[1] = 2.0;
 
     ASSERT_ARRAY_NEAR(z, loc_v, 2, 1e-10);
-    x_fixed_p.restoreArray(loc_v);
 
     // Deep copy
     MathLib::finalizeVectorAssembly(x_fixed_p);
@@ -249,12 +250,14 @@ void checkGlobalVectorInterfacePETSc()
     MathLib::finalizeVectorAssembly(x_with_ghosts);
 
     ASSERT_EQ(12u, x_with_ghosts.size());
-    loc_v = x_with_ghosts.getLocalVector();
+
+    std::vector<double> loc_v1(  x_with_ghosts.getLocalSize()
+                               + x_with_ghosts.getGhostSize() );
+    x_with_ghosts.getValues(&loc_v1[0]);                          
     for (std::size_t i=0; i<expected.size(); i++)
     {
-         ASSERT_NEAR(expected[i], loc_v[i], 1.e-10);
+         ASSERT_NEAR(expected[i], loc_v1[i], 1.e-10);
     }
-    x_with_ghosts.restoreArray(loc_v);
 }
 #endif
 

--- a/Tests/MathLib/TestGlobalVectorInterface.cpp
+++ b/Tests/MathLib/TestGlobalVectorInterface.cpp
@@ -73,16 +73,16 @@ void checkGlobalVectorInterface()
     ASSERT_EQ(1.0, y.get(3));
 }
 
-#ifdef USE_PETSC // or MPI
+#ifdef USE_PETSC
 template <class T_VECTOR>
-void checkGlobalVectorInterfaceMPI()
+void checkGlobalVectorInterfacePETSc()
 {
     int msize;
     MPI_Comm_size(PETSC_COMM_WORLD, &msize);
 
     ASSERT_EQ(3u, msize);
 
-    // -------------------------------------------------------------------
+    // -----------------------------------------------------------------
     // PETSc determined partitioning
     T_VECTOR x(16);
 
@@ -148,7 +148,7 @@ void checkGlobalVectorInterfaceMPI()
 
     ASSERT_ARRAY_NEAR(z, x0, 16, 1e-10);
 
-    // -------------------------------------------------------------------
+    // -----------------------------------------------------------------
     // User determined partitioning
     const bool is_global_size = false;
     T_VECTOR x_fixed_p(2, is_global_size);
@@ -182,11 +182,79 @@ void checkGlobalVectorInterfaceMPI()
     z[1] = 2.0;
 
     ASSERT_ARRAY_NEAR(z, loc_v, 2, 1e-10);
+    x_fixed_p.restoreArray(loc_v);
 
     // Deep copy
     MathLib::finalizeVectorAssembly(x_fixed_p);
     T_VECTOR x_deep_copied(x_fixed_p);
     ASSERT_NEAR(sqrt(3.0*5), x_deep_copied.getNorm(), 1.e-10);
+
+    // -----------------------------------------------------------------
+    // Vector with ghost entries
+    /*
+         Assume there is a vector distributed over three processes as
+          -- rank0 --    --- rank1 ---   -- rank2 --
+           0  1  2  3    4  5  6  7  8   9   10   11 
+         where the numbers are the global entry indices.
+         In each trunk of entries of a rank, there are ghost entries in
+         other ranks attached and their global entry indices are:
+         rank0: 6 8 10
+         rank1: 0 9
+         rank2: 3 5
+
+         Assuming the values of the entries are just their global indices,
+         we have local arrays as:
+         rank0: 0 1 2 3     6 8 10
+         rank1: 4 5 6 7 8   0 9
+         rank2: 9 10 11     3 5
+
+         The above ghost entry embeded vector is realized by the following
+         test.
+    */    
+    std::size_t local_vec_size = 4;
+    if (mrank == 1)
+        local_vec_size = 5;
+    else if (mrank == 2)
+        local_vec_size = 3;
+    std::vector<GlobalIndexType> non_ghost_ids(local_vec_size);
+    std::vector<double> non_ghost_vals(local_vec_size);
+    std::size_t nghosts = 3;
+    if (mrank)
+        nghosts = 2;    
+    std::vector<GlobalIndexType> ghost_ids(nghosts);
+    std::vector<double> expected;
+    switch (mrank)
+    {
+        case 0:
+            non_ghost_ids  = {0, 1, 2, 3};
+            non_ghost_vals = {0., 1., 2., 3.};
+            ghost_ids      = {6, 8, 10};
+            expected       = {0., 1., 2., 3., 6., 8., 10.};
+            break;
+        case 1:
+            non_ghost_ids  = {4, 5, 6, 7, 8};
+            non_ghost_vals = {4., 5., 6., 7., 8.};
+            ghost_ids      = {0, 9};
+            expected       = {4., 5., 6., 7., 8., 0., 9.};
+            break;
+        case 2:
+            non_ghost_ids  = {9, 10, 11};
+            non_ghost_vals = {9., 10., 11.};
+            ghost_ids      = {3, 5};
+            expected       = {9., 10., 11., 3., 5.};
+            break;
+    }
+    T_VECTOR x_with_ghosts(local_vec_size, ghost_ids, is_global_size);
+    x_with_ghosts.set(non_ghost_ids, non_ghost_vals);
+    MathLib::finalizeVectorAssembly(x_with_ghosts);
+
+    ASSERT_EQ(12u, x_with_ghosts.size());
+    loc_v = x_with_ghosts.getLocalVector();
+    for (std::size_t i=0; i<expected.size(); i++)
+    {
+         ASSERT_NEAR(expected[i], loc_v[i], 1.e-10);
+    }
+    x_with_ghosts.restoreArray(loc_v);
 }
 #endif
 
@@ -201,7 +269,7 @@ TEST(Math, CheckInterface_LisVector)
 #elif defined(USE_PETSC)
 TEST(MPITest_Math, CheckInterface_PETScVector)
 {
-    checkGlobalVectorInterfaceMPI<MathLib::PETScVector >();
+    checkGlobalVectorInterfacePETSc<MathLib::PETScVector >();
 }
 #elif defined(OGS_USE_EIGEN)
 TEST(Math, CheckInterface_EigenVector)


### PR DESCRIPTION
- Create vector with ghost entries

     To save memory when the solution is fetched.
- Use local size to create vector and matrix

    To improve the computational and communication load balance in the global assembly and the linear solver.

(c.f. issue #965)