### PR TITLE
Improvement in the usage of PETSc matrix and vector

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -130,7 +130,7 @@ else()
 	AddTest(
 		NAME ParallelFEM_GroundWaterFlow2D
 		PATH EllipticPETSc
-		EXECUTABLE_ARGS quad_20x10_GroundWaterFlow.prj -- -gw_ksp_type bcgs -gw_pc_type bjacobi -gw_ksp_atol 1.e-10
+		EXECUTABLE_ARGS quad_20x10_GroundWaterFlow.prj -- -gw_ksp_type bcgs -gw_pc_type bjacobi -gw_ksp_rtol 1.e-10
 		WRAPPER mpirun
 		WRAPPER_ARGS -np 3
 		TESTER diff
@@ -143,7 +143,7 @@ else()
 	AddTest(
 		NAME ParallelFEM_GroundWaterFlow3D_DirichletBC
 		PATH EllipticPETSc
-		EXECUTABLE_ARGS cube_1e3.prj -- -gw_ksp_type bcgs -gw_pc_type bjacobi -gw_ksp_atol 1.e-10
+		EXECUTABLE_ARGS cube_1e3.prj -- -gw_ksp_type bcgs -gw_pc_type mg -gw_ksp_rtol 1.e-10
 		WRAPPER mpirun
 		WRAPPER_ARGS -np 3
 		TESTER diff
@@ -156,7 +156,7 @@ else()
 	AddTest(
 		NAME ParallelFEM_GroundWaterFlow3D_NeumannBC
 		PATH EllipticPETSc
-		EXECUTABLE_ARGS cube_1e3_neumann.prj -- -gw_ksp_type bcgs -gw_pc_type bjacobi -gw_ksp_atol 1.e-10
+		EXECUTABLE_ARGS cube_1e3_neumann.prj -- -gw_ksp_type gmres -gw_pc_type bjacobi -gw_ksp_rtol 1.e-10
 		WRAPPER mpirun
 		WRAPPER_ARGS -np 3
 		TESTER diff

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -103,7 +103,7 @@ public:
     }
 
     /// Get ghost indices, forwarded from MeshComponentMap.
-    std::vector<GlobalIndexType> getGhostIndices() const
+    std::vector<GlobalIndexType> const& getGhostIndices() const
     {
         return _mesh_component_map.getGhostIndices();
     }

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -68,7 +68,9 @@ public:
     /// Returns total number of degrees of freedom.
     std::size_t dofSize() const;
 
-    /// Returns total number of local degrees of freedom for DDC.
+    /// Returns total number of local degrees of freedom
+    /// of the present rank, which does not count the unknowns
+    /// associated with ghost nodes (for DDC with node-wise mesh partitioning).
     std::size_t dofSizeLocal() const
     {
         return _mesh_component_map.getNLocalUnknowns();

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -68,6 +68,12 @@ public:
     /// Returns total number of degrees of freedom.
     std::size_t dofSize() const;
 
+    /// Returns total number of local degrees of freedom for DDC.
+    std::size_t dofSizeLocal() const
+    {
+        return _mesh_component_map.getNLocalUnknowns();
+    }
+
     /// Returns total number of global degrees of freedom for DDC.
     std::size_t dofSizeGlobal() const
     {
@@ -92,6 +98,12 @@ public:
     std::vector<GlobalIndexType> getGlobalIndices(const MeshLib::Location &l) const
     {
         return _mesh_component_map.getGlobalIndices(l);
+    }
+
+    /// Get ghost indices, forwarded from MeshComponentMap.
+    std::vector<GlobalIndexType> getGhostIndices() const
+    {
+        return _mesh_component_map.getGhostIndices();
     }
 
 private:

--- a/AssemblerLib/MeshComponentMap.cpp
+++ b/AssemblerLib/MeshComponentMap.cpp
@@ -40,6 +40,7 @@ MeshComponentMap::MeshComponentMap(
     std::size_t comp_id = 0;
 
     _num_global_dof = 0;
+    _num_local_dof = 0;
     for (auto c = components.cbegin(); c != components.cend(); ++c)
     {
         assert (*c != nullptr);
@@ -57,8 +58,18 @@ MeshComponentMap::MeshComponentMap(
                 {
                     const GlobalIndexType global_id = static_cast<GlobalIndexType>(components.size()
                                                * mesh.getGlobalNodeID(j) + comp_id);
-                    const GlobalIndexType signed_global_id = mesh.isGhostNode( mesh.getNode(j)->getID() )
-                                                    ? -global_id : global_id;
+                    const bool is_ghost = mesh.isGhostNode( mesh.getNode(j)->getID() );
+                    GlobalIndexType signed_global_id
+                                          = is_ghost ? -global_id : global_id;
+                    if (is_ghost)
+                    {
+                        _ghosts_indices.push_back(-signed_global_id);
+                        if (signed_global_id == 0)
+                             signed_global_id = -9999;
+                    }
+                    else
+                        _num_local_dof++;
+                       
                     _dict.insert(Line(Location(mesh_id, MeshLib::MeshItemType::Node, j),
                                 comp_id, signed_global_id) );
                 }
@@ -77,8 +88,18 @@ MeshComponentMap::MeshComponentMap(
                 {
                     const GlobalIndexType global_id = static_cast<GlobalIndexType>(global_index_offset
                                                           + mesh.getGlobalNodeID(j) );
-                    const GlobalIndexType signed_global_id = mesh.isGhostNode( mesh.getNode(j)->getID() )
-                                                    ? -global_id : global_id;
+                    const bool is_ghost = mesh.isGhostNode( mesh.getNode(j)->getID() );
+                    GlobalIndexType signed_global_id
+                                        = is_ghost ? -global_id : global_id;
+                    if (is_ghost)
+                    {
+                        _ghosts_indices.push_back(-signed_global_id);
+                        if (signed_global_id == 0)
+                             signed_global_id = -9999;
+                    }
+                    else
+                        _num_local_dof++;
+
                     _dict.insert(Line(Location(mesh_id, MeshLib::MeshItemType::Node, j),
                                 comp_id, signed_global_id) );
                 }

--- a/AssemblerLib/MeshComponentMap.cpp
+++ b/AssemblerLib/MeshComponentMap.cpp
@@ -50,7 +50,6 @@ MeshComponentMap::MeshComponentMap(
     }
 
     // construct dict (and here we number global_index by component type)
-    std::size_t global_index_offset = 0;
     std::size_t cell_index = 0;
     std::size_t comp_id = 0;
     _num_global_dof = 0;
@@ -79,7 +78,8 @@ MeshComponentMap::MeshComponentMap(
                  }
                  else
                  {
-                     global_id = static_cast<GlobalIndexType>(global_index_offset
+                     // _num_global_dof is used as the global index offset
+                     global_id = static_cast<GlobalIndexType>(_num_global_dof
                                              + mesh.getGlobalNodeID(j) );
                  }
                  const bool is_ghost = mesh.isGhostNode( mesh.getNode(j)->getID() );
@@ -105,12 +105,6 @@ MeshComponentMap::MeshComponentMap(
              for (std::size_t j=0; j<mesh_subset.getNElements(); j++)
                  _dict.insert(Line(Location(mesh_id, MeshLib::MeshItemType::Cell, j),
                               comp_id, cell_index++));
-
-             if (order == ComponentOrder::BY_COMPONENT)
-             {
-                  // Include base nodes.
-                  global_index_offset += mesh.getNGlobalNodes();
-             }
 
              _num_global_dof += mesh.getNGlobalNodes();
         }

--- a/AssemblerLib/MeshComponentMap.cpp
+++ b/AssemblerLib/MeshComponentMap.cpp
@@ -35,16 +35,16 @@ MeshComponentMap::MeshComponentMap(
 
 {
     // get number of unknows
-    GlobalIndexType num_unknows = 0;
-    for (auto c = components.cbegin(); c != components.cend(); ++c)
+    GlobalIndexType num_unknowns = 0;
+    for (auto const c : components)
     {
-        assert (*c != nullptr);
-        for (unsigned mesh_subset_index = 0; mesh_subset_index < (*c)->size(); mesh_subset_index++)
+        assert (c != nullptr);
+        for (unsigned mesh_subset_index = 0; mesh_subset_index < c->size(); mesh_subset_index++)
         {
-            MeshLib::MeshSubset const& mesh_subset = (*c)->getMeshSubset(mesh_subset_index);
+            MeshLib::MeshSubset const& mesh_subset = c->getMeshSubset(mesh_subset_index);
            const MeshLib::NodePartitionedMesh &mesh
                    = static_cast<const MeshLib::NodePartitionedMesh&>(mesh_subset.getMesh());
-            num_unknows += mesh.getNGlobalNodes();
+            num_unknowns += mesh.getNGlobalNodes();
         }
     }
 
@@ -54,12 +54,12 @@ MeshComponentMap::MeshComponentMap(
     std::size_t comp_id = 0;
     _num_global_dof = 0;
     _num_local_dof = 0;
-    for (auto c = components.cbegin(); c != components.cend(); ++c)
+    for (auto const c : components)
     {
-        assert (*c != nullptr);
-        for (unsigned mesh_subset_index = 0; mesh_subset_index < (*c)->size(); mesh_subset_index++)
+        assert (c != nullptr);
+        for (unsigned mesh_subset_index = 0; mesh_subset_index < c->size(); mesh_subset_index++)
         {
-            MeshLib::MeshSubset const& mesh_subset = (*c)->getMeshSubset(mesh_subset_index);
+            MeshLib::MeshSubset const& mesh_subset = c->getMeshSubset(mesh_subset_index);
             std::size_t const mesh_id = mesh_subset.getMeshID();
             const MeshLib::NodePartitionedMesh &mesh
                    = static_cast<const MeshLib::NodePartitionedMesh&>(mesh_subset.getMesh());
@@ -79,7 +79,7 @@ MeshComponentMap::MeshComponentMap(
                         // If the ghost entry has an index of 0,
                         // its index is set to the negative value of unknowns.
                         if (global_id == 0)
-                             global_id = -num_unknows;
+                             global_id = -num_unknowns;
                     }
                     else
                         _num_local_dof++;
@@ -110,7 +110,7 @@ MeshComponentMap::MeshComponentMap(
                         // If the ghost entry has an index of 0,
                         // its index is set to the negative value of unknowns.
                         if (global_id == 0)
-                             global_id = -num_unknows;
+                             global_id = -num_unknowns;
                     }
                     else
                         _num_local_dof++;
@@ -142,12 +142,12 @@ MeshComponentMap::MeshComponentMap(
     // construct dict (and here we number global_index by component type)
     GlobalIndexType global_index = 0;
     std::size_t comp_id = 0;
-    for (auto c = components.cbegin(); c != components.cend(); ++c)
+    for (auto const c : components)
     {
-        assert (*c != nullptr);
-        for (std::size_t mesh_subset_index = 0; mesh_subset_index < (*c)->size(); mesh_subset_index++)
+        assert (c != nullptr);
+        for (std::size_t mesh_subset_index = 0; mesh_subset_index < c->size(); mesh_subset_index++)
         {
-            MeshLib::MeshSubset const& mesh_subset = (*c)->getMeshSubset(mesh_subset_index);
+            MeshLib::MeshSubset const& mesh_subset = c->getMeshSubset(mesh_subset_index);
             std::size_t const mesh_id = mesh_subset.getMeshID();
             // mesh items are ordered first by node, cell, ....
             for (std::size_t j=0; j<mesh_subset.getNNodes(); j++)

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -126,10 +126,22 @@ public:
     std::vector<GlobalIndexType> getGlobalIndicesByComponent(
         const std::vector<Location>& ls) const;
 
-    /// Get the number of global unknowns.
+    /// Get the number of global unknowns (for DDC).
     std::size_t getNGlobalUnknowns() const
     {
         return _num_global_dof;
+    }
+
+    /// Get the number of local unknowns (for DDC).
+    std::size_t getNLocalUnknowns() const
+    {
+        return _num_local_dof;
+    }
+
+    /// Get ghost indices (for DDC).
+    std::vector<GlobalIndexType> getGhostIndices() const
+    {
+        return _ghosts_indices;
     }
 
     /// A value returned if no global index was found for the requested
@@ -166,15 +178,20 @@ private:
 
     void renumberByLocation(GlobalIndexType offset=0);
 
-private:
     detail::ComponentGlobalIndexDict _dict;
 
     /// Number of global unknowns.
     std::size_t _num_global_dof = 0;
 
+    /// Number of local unknowns.
+    std::size_t _num_local_dof  = 0;
+
     /// Number of components
     /// introduced mainly for error checking
     unsigned const _num_components;
+
+    /// Global ID for ghost entries
+    std::vector<GlobalIndexType> _ghosts_indices;
 };
 
 }   // namespace AssemblerLib

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -140,7 +140,7 @@ public:
     }
 
     /// Get ghost indices (for DDC).
-    std::vector<GlobalIndexType> getGhostIndices() const
+    std::vector<GlobalIndexType> const& getGhostIndices() const
     {
         return _ghosts_indices;
     }

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -132,7 +132,8 @@ public:
         return _num_global_dof;
     }
 
-    /// Get the number of local unknowns (for DDC).
+    /// Get the number of local unknowns excluding those associated
+    /// with ghost nodes (for DDC with node-wise mesh partitioning).
     std::size_t getNLocalUnknowns() const
     {
         return _num_local_dof;
@@ -183,7 +184,8 @@ private:
     /// Number of global unknowns.
     std::size_t _num_global_dof = 0;
 
-    /// Number of local unknowns.
+    /// Number of local unknowns excluding those associated
+    /// with ghost nodes (for domain decomposition).
     std::size_t _num_local_dof  = 0;
 
     /// Number of components

--- a/MathLib/LinAlg/Dense/DenseVector.h
+++ b/MathLib/LinAlg/Dense/DenseVector.h
@@ -76,11 +76,10 @@ public:
 	}
 
 	/// get entry values to an array
-	void getValues(T u[])
+	void getValues(std::vector<double>& u)
 	{
-		for (std::size_t i=0; i<this->size(); ++i) {
-			u[i] = (*this)[i];
-		}
+		assert(u.size() == this->size());
+		std::copy(this->cbegin(), this->cend(), u.begin());
 	}
 
 	/**

--- a/MathLib/LinAlg/Dense/DenseVector.h
+++ b/MathLib/LinAlg/Dense/DenseVector.h
@@ -75,8 +75,8 @@ public:
 		}
 	}
 
-	/// get entry values to an array
-	void getValues(std::vector<double>& u)
+	/// Copy vector values.
+	void copyValues(std::vector<double>& u)
 	{
 		assert(u.size() == this->size());
 		std::copy(this->cbegin(), this->cend(), u.begin());

--- a/MathLib/LinAlg/Dense/DenseVector.h
+++ b/MathLib/LinAlg/Dense/DenseVector.h
@@ -75,6 +75,14 @@ public:
 		}
 	}
 
+	/// get entry values to an array
+	void getValues(T u[])
+	{
+		for (std::size_t i=0; i<this->size(); ++i) {
+			u[i] = (*this)[i];
+		}
+	}
+
 	/**
 	 * writes the matrix entries into a file
 	 * @param filename output file name

--- a/MathLib/LinAlg/Eigen/EigenVector.h
+++ b/MathLib/LinAlg/Eigen/EigenVector.h
@@ -87,10 +87,10 @@ public:
     }
 
     /// get entry values to an array
-    void getValues(double u[])
+    void getValues(std::vector<double>& u)
     {
-        for (IndexType i=0; i<_vec.size(); i++)
-            u[i] = _vec[i];
+        assert(u.size() == _vec.size());
+        copy_n(_vec.data(), _vec.size(), u.begin());
     }
 
 #ifndef NDEBUG

--- a/MathLib/LinAlg/Eigen/EigenVector.h
+++ b/MathLib/LinAlg/Eigen/EigenVector.h
@@ -86,8 +86,8 @@ public:
         }
     }
 
-    /// get entry values to an array
-    void getValues(std::vector<double>& u)
+    /// Copy vector values.
+    void copyValues(std::vector<double>& u)
     {
         assert(u.size() == _vec.size());
         copy_n(_vec.data(), _vec.size(), u.begin());

--- a/MathLib/LinAlg/Eigen/EigenVector.h
+++ b/MathLib/LinAlg/Eigen/EigenVector.h
@@ -86,6 +86,13 @@ public:
         }
     }
 
+    /// get entry values to an array
+    void getValues(double u[])
+    {
+        for (IndexType i=0; i<_vec.size(); i++)
+            u[i] = _vec[i];
+    }
+
 #ifndef NDEBUG
     /// printout this equation for debugging
     void write (const std::string &filename) const { std::ofstream os(filename); os << _vec; }

--- a/MathLib/LinAlg/Lis/LisVector.h
+++ b/MathLib/LinAlg/Lis/LisVector.h
@@ -108,9 +108,10 @@ public:
 	}
 
 	/// get entry values to an array
-	void getValues(LIS_SCALAR u[])
+	void getValues(std::vector<double>& u)
 	{
-		lis_vector_get_values(_vec, 0, size(), u);
+		assert(u.size() == size());
+		lis_vector_get_values(_vec, 0, size(), u.data());
 	}
 
 private:

--- a/MathLib/LinAlg/Lis/LisVector.h
+++ b/MathLib/LinAlg/Lis/LisVector.h
@@ -107,6 +107,12 @@ public:
 		}
 	}
 
+	/// get entry values to an array
+	void getValues(LIS_SCALAR u[])
+	{
+		lis_vector_get_values(_vec, 0, size(), u);
+	}
+
 private:
 	LIS_VECTOR _vec;
 };

--- a/MathLib/LinAlg/Lis/LisVector.h
+++ b/MathLib/LinAlg/Lis/LisVector.h
@@ -107,8 +107,8 @@ public:
 		}
 	}
 
-	/// get entry values to an array
-	void getValues(std::vector<double>& u)
+	/// Copy vector values.
+	void copyValues(std::vector<double>& u)
 	{
 		assert(u.size() == size());
 		lis_vector_get_values(_vec, 0, size(), u.data());

--- a/MathLib/LinAlg/PETSc/PETScMatrix.cpp
+++ b/MathLib/LinAlg/PETSc/PETScMatrix.cpp
@@ -24,13 +24,10 @@ PETScMatrix::PETScMatrix (const PetscInt nrows, const PETScMatrixOption &mat_opt
 {
     if(!mat_opt.is_global_size)
     {
+        _n_loc_rows = nrows;
+        _n_loc_cols = nrows;
         _nrows = PETSC_DECIDE;
         _ncols = PETSC_DECIDE;
-        _n_loc_rows = nrows;
-
-        // Make the matrix be square.
-        MPI_Allreduce(&_n_loc_rows, &_nrows, 1, MPI_INT, MPI_SUM, PETSC_COMM_WORLD);
-        _ncols = _nrows;
     }
 
     create(mat_opt.d_nz, mat_opt.o_nz);
@@ -57,6 +54,7 @@ void PETScMatrix::setRowsColumnsZero(std::vector<PetscInt> const& row_pos)
     const PetscScalar one = 1.0;
     const PetscInt nrows = static_cast<PetscInt> (row_pos.size());
 
+    MatSetOption(_A, MAT_NO_OFF_PROC_ZERO_ROWS, PETSC_TRUE); 
     if(nrows>0)
         MatZeroRows(_A, nrows, &row_pos[0], one, PETSC_NULL, PETSC_NULL);
     else

--- a/MathLib/LinAlg/PETSc/PETScMatrix.cpp
+++ b/MathLib/LinAlg/PETSc/PETScMatrix.cpp
@@ -54,6 +54,10 @@ void PETScMatrix::setRowsColumnsZero(std::vector<PetscInt> const& row_pos)
     const PetscScalar one = 1.0;
     const PetscInt nrows = static_cast<PetscInt> (row_pos.size());
 
+    // Each process will only zero its own rows.
+    // This avoids all reductions in the zero row routines
+    // and thus improves performance for very large process counts.
+    // See PETSc doc about MAT_NO_OFF_PROC_ZERO_ROWS.
     MatSetOption(_A, MAT_NO_OFF_PROC_ZERO_ROWS, PETSC_TRUE); 
     if(nrows>0)
         MatZeroRows(_A, nrows, &row_pos[0], one, PETSC_NULL, PETSC_NULL);

--- a/MathLib/LinAlg/PETSc/PETScMatrix.h
+++ b/MathLib/LinAlg/PETSc/PETScMatrix.h
@@ -170,7 +170,13 @@ class PETScMatrix
             std::vector<PetscInt> cols;
             cols.reserve(indices.columns.size());
             for (auto col : indices.columns)
-                cols.push_back(std::abs(col));
+            {
+                // Ghost entries, and its original index is 0.
+                if (col == -_ncols)
+                    cols.push_back(0);
+                else
+                    cols.push_back(std::abs(col));
+            }
 
             add(indices.rows, cols, sub_matrix);
         }

--- a/MathLib/LinAlg/PETSc/PETScVector.cpp
+++ b/MathLib/LinAlg/PETSc/PETScVector.cpp
@@ -21,6 +21,9 @@
 
 #include "PETScVector.h"
 
+#include <algorithm>
+#include <cassert>
+
 namespace MathLib
 {
 PETScVector::PETScVector(const PetscInt vec_size, const bool is_global_size)
@@ -150,13 +153,12 @@ void PETScVector::getGlobalVector(PetscScalar u[])
 #endif
 }
 
-void PETScVector::getValues(PetscScalar u[])
+void PETScVector::getValues(std::vector<double>& u)
 {
+    assert(u.size() == getLocalSize() + getGhostSize());
+
     double* loc_x = getLocalVector();
-    for (PetscInt i=0; i < getLocalSize() + getGhostSize(); i++)
-    {
-        u[i] = loc_x[i];
-    }
+    std::copy_n(loc_x, getLocalSize() + getGhostSize(), u.begin());
     restoreArray(loc_x);
 }
 

--- a/MathLib/LinAlg/PETSc/PETScVector.cpp
+++ b/MathLib/LinAlg/PETSc/PETScVector.cpp
@@ -36,14 +36,27 @@ PETScVector::PETScVector(const PetscInt vec_size, const bool is_global_size)
         // the size can be associated to specific memory allocation of a matrix
         VecCreateMPI(PETSC_COMM_WORLD, vec_size, PETSC_DECIDE, &_v);
     }
-    VecSetFromOptions(_v);
-    // VecSetUp(_v); // for petsc ver.>3.3
-    VecGetOwnershipRange(_v, &_start_rank, &_end_rank);
 
-    VecGetLocalSize(_v, &_size_loc);
-    VecGetSize(_v, &_size);
+    config();
+}
 
-    VecSetOption(_v, VEC_IGNORE_NEGATIVE_INDICES,PETSC_TRUE);
+PETScVector::PETScVector(const PetscInt vec_size,
+                         const std::vector<PetscInt>& ghost_ids,
+                         const bool is_global_size) : has_ghost_id(true)
+{
+    PetscInt nghosts = static_cast<PetscInt>( ghost_ids.size() );
+    if ( is_global_size )
+    {
+        VecCreateGhost(PETSC_COMM_WORLD, PETSC_DECIDE, vec_size, nghosts,
+                       &ghost_ids[0], &_v);
+    }
+    else
+    {
+        VecCreateGhost(PETSC_COMM_WORLD, vec_size, PETSC_DECIDE, nghosts,
+                       &ghost_ids[0], &_v);
+    }
+
+    config();
 }
 
 PETScVector::PETScVector(const PETScVector &existing_vec, const bool deep_copy)
@@ -61,6 +74,30 @@ PETScVector::PETScVector(const PETScVector &existing_vec, const bool deep_copy)
     }
 
     VecSetOption(_v, VEC_IGNORE_NEGATIVE_INDICES,PETSC_TRUE);
+}
+
+void PETScVector::config()
+{
+    VecSetFromOptions(_v);
+    // VecSetUp(_v); // for petsc ver.>3.3
+    VecGetOwnershipRange(_v, &_start_rank, &_end_rank);
+
+    VecGetLocalSize(_v, &_size_loc);
+    VecGetSize(_v, &_size);
+
+    VecSetOption(_v, VEC_IGNORE_NEGATIVE_INDICES,PETSC_TRUE);
+}
+
+void PETScVector::finalizeAssembly()
+{
+    VecAssemblyBegin(_v);
+    VecAssemblyEnd(_v);
+
+    if (has_ghost_id)
+    {
+        VecGhostUpdateBegin(_v,INSERT_VALUES,SCATTER_FORWARD);
+        VecGhostUpdateEnd(_v,INSERT_VALUES,SCATTER_FORWARD);
+    }
 }
 
 void PETScVector::gatherLocalVectors( PetscScalar local_array[],

--- a/MathLib/LinAlg/PETSc/PETScVector.cpp
+++ b/MathLib/LinAlg/PETSc/PETScVector.cpp
@@ -153,7 +153,7 @@ void PETScVector::getGlobalVector(PetscScalar u[])
 #endif
 }
 
-void PETScVector::getValues(std::vector<double>& u)
+void PETScVector::copyValues(std::vector<double>& u)
 {
     assert(u.size() == getLocalSize() + getGhostSize());
 

--- a/MathLib/LinAlg/PETSc/PETScVector.h
+++ b/MathLib/LinAlg/PETSc/PETScVector.h
@@ -167,45 +167,16 @@ class PETScVector
         }
 
         /*!
-           Get local vector, i.e. entries in the same rank
-           \param loc_vec  Pointer to array where stores the local vector,
-                           memory allocation is not needed
-        */
-        PetscScalar *getLocalVector() const
-        {
-            PetscScalar *loc_array;
-            if (has_ghost_id)
-            {
-                VecGhostUpdateBegin(_v, INSERT_VALUES, SCATTER_FORWARD);
-                VecGhostUpdateEnd(_v, INSERT_VALUES, SCATTER_FORWARD);
-                VecGhostGetLocalForm(_v, &_v_loc);
-                VecGetArray(_v_loc, &loc_array);
-            }
-            else
-               VecGetArray(_v, &loc_array);
-            return loc_array;
-        }
-
-        /*!
-           Restore array after finish access local array
-           \param array  Pointer to the local array fetched by VecGetArray
-        */
-        void restoreArray(PetscScalar* array) const
-        {
-            if (has_ghost_id)
-            {
-                VecRestoreArray(_v_loc, &array);
-             //   VecGhostRestoreLocalForm(_v, &_v_loc);
-            }
-            else
-                VecRestoreArray(_v, &array);
-        }
-
-        /*!
            Get global vector
            \param u Array to store the global vector. Memory allocation is needed in advance
         */
         void getGlobalVector(PetscScalar u[]);
+
+         /*!
+           Get local entries including ghost ones to an array
+           \param u Array for the values of local entries.
+        */
+        void getValues(PetscScalar u[]);
 
         /// Get an entry value. This is an expensive operation,
         /// and it only get local value. Use it for only test purpose
@@ -299,6 +270,19 @@ class PETScVector
         */
         void gatherLocalVectors(PetscScalar local_array[],
                                 PetscScalar global_array[]);
+
+        /*!
+           Get local vector, i.e. entries in the same rank
+           \param loc_vec  Pointer to array where stores the local vector,
+                           memory allocation is not needed
+        */
+        PetscScalar* getLocalVector() const;
+
+        /*!
+           Restore array after finish access local array
+           \param array  Pointer to the local array fetched by VecGetArray
+        */
+        inline void restoreArray(PetscScalar* array) const;
 
         /// A funtion called by constructors to configure members
         void config();

--- a/MathLib/LinAlg/PETSc/PETScVector.h
+++ b/MathLib/LinAlg/PETSc/PETScVector.h
@@ -177,11 +177,11 @@ class PETScVector
         */
         void getGlobalVector(PetscScalar u[]);
 
-         /*!
-           Get local entries including ghost ones to an array
-           \param u Array for the values of local entries.
+        /*!
+           Copy local entries including ghost ones to an array
+           \param u Preallocated vector for the values of local entries.
         */
-        void getValues(std::vector<double>& u);
+        void copyValues(std::vector<double>& u);
 
         /// Get an entry value. This is an expensive operation,
         /// and it only get local value. Use it for only test purpose

--- a/MathLib/LinAlg/PETSc/PETScVector.h
+++ b/MathLib/LinAlg/PETSc/PETScVector.h
@@ -42,8 +42,13 @@ class PETScVector
         /*!
             \brief Constructor
             \param vec_size       The size of the vector, either global or local
-            \param is_global_size The flag of the type of vec_size, i.e. whether it is a global size
+            \param is_global_size The flag of the type of vec_size, i.e.
+                                  whether it is a global size
                                   or local size. The default is true.
+                                  If is_global_size is true, the vector
+                                  is created by the global size, the local size
+                                  of the vector is determined by PETSc,
+                                  and vice versa is the same.
         */
         PETScVector(const PetscInt vec_size, const bool is_global_size = true);
 
@@ -261,7 +266,7 @@ class PETScVector
         PetscInt _size_ghosts = 0;
 
         /// Flag to indicate whether the vector is created with ghost entry indices
-        bool has_ghost_id = false;
+        bool _has_ghost_id = false;
 
         /*!
               \brief  Collect local vectors

--- a/MathLib/LinAlg/PETSc/PETScVector.h
+++ b/MathLib/LinAlg/PETSc/PETScVector.h
@@ -181,7 +181,7 @@ class PETScVector
            Get local entries including ghost ones to an array
            \param u Array for the values of local entries.
         */
-        void getValues(PetscScalar u[]);
+        void getValues(std::vector<double>& u);
 
         /// Get an entry value. This is an expensive operation,
         /// and it only get local value. Use it for only test purpose

--- a/MathLib/LinAlg/PETSc/PETScVector.h
+++ b/MathLib/LinAlg/PETSc/PETScVector.h
@@ -48,6 +48,16 @@ class PETScVector
         PETScVector(const PetscInt vec_size, const bool is_global_size = true);
 
         /*!
+            \brief Constructor
+            \param vec_size       The size of the vector, either global or local
+            \param ghost_ids      The global indices of ghost entries
+            \param is_global_size The flag of the type of vec_size, i.e. whether it is a global size
+                                  or local size. The default is true.
+        */
+        PETScVector(const PetscInt vec_size, const std::vector<PetscInt>& ghost_ids,
+                    const bool is_global_size = true);
+
+        /*!
              \brief Copy constructor
              \param existing_vec The vector to be copied
              \param deep_copy    The flag for a deep copy, which means to copy the values as well,
@@ -61,11 +71,7 @@ class PETScVector
         }
 
         /// Perform MPI collection of assembled entries in buffer
-        void finalizeAssembly()
-        {
-            VecAssemblyBegin(_v);
-            VecAssemblyEnd(_v);
-        }
+        void finalizeAssembly();
 
         /// Get the global size of the vector
         PetscInt size() const
@@ -167,6 +173,15 @@ class PETScVector
         }
 
         /*!
+           Restore array after finish access local array
+           \param array  Pointer to the local array fetched by VecGetArray
+        */
+        void restoreArray(PetscScalar* array) const
+        {
+            VecRestoreArray(_v, &array);         
+        }
+
+        /*!
            Get global vector
            \param u Array to store the global vector. Memory allocation is needed in advance
         */
@@ -249,6 +264,9 @@ class PETScVector
         /// Size of local entries
         PetscInt _size_loc;
 
+        /// Flag to indicate whether the vector is created with ghost entry indices
+        bool has_ghost_id = false;
+
         /*!
               \brief  Collect local vectors
               \param  local_array Local array
@@ -256,6 +274,9 @@ class PETScVector
         */
         void gatherLocalVectors(PetscScalar local_array[],
                                 PetscScalar global_array[]);
+
+        /// A funtion called by constructors to configure members
+        void config();
 
         friend void finalizeVectorAssembly(PETScVector &vec);
 };

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -278,7 +278,7 @@ private:
 		assert(result && result->size() == _x->size());
 
 		// Copy result
-		_x->getValues(*result);
+		_x->copyValues(*result);
 
 		// Write output file
 		DBUG("Writing output to \'%s\'.", file_name.c_str());

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -268,24 +268,8 @@ private:
 		}
 		assert(result && result->size() == _x->size());
 
-#ifdef USE_PETSC
-		std::unique_ptr<double[]> u(new double[_x->size()]);
-		_x->getGlobalVector(u.get());  // get the global solution
-
-		std::size_t const n = _mesh.getNNodes();
-		for (std::size_t i = 0; i < n; ++i)
-		{
-			MeshLib::Location const l(_mesh.getID(),
-			                          MeshLib::MeshItemType::Node, i);
-			auto const global_index = std::abs(  // 0 is the component id.
-			    _local_to_global_index_map->getGlobalIndex(l, 0));
-			(*result)[i] = u[global_index];
-		}
-#else
 		// Copy result
-		for (std::size_t i = 0; i < _x->size(); ++i)
-			(*result)[i] = (*_x)[i];
-#endif
+		_x->getValues(&(*result)[0]);
 
 		// Write output file
 		DBUG("Writing output to \'%s\'.", file_name.c_str());

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -213,15 +213,23 @@ private:
 		    static_cast<const MeshLib::NodePartitionedMesh&>(_mesh);
 		mat_opt.d_nz = pmesh.getMaximumNConnectedNodesToNode();
 		mat_opt.o_nz = mat_opt.d_nz;
+		mat_opt.is_global_size = false;
 		const std::size_t num_unknowns =
-		    _local_to_global_index_map->dofSizeGlobal();
+		    _local_to_global_index_map->dofSizeLocal();
 		_A.reset(_global_setup.createMatrix(num_unknowns, mat_opt));
+		// In the following two lines, false is assigned to
+		// the argument of is_global_size, which indicates num_unknowns
+		// is local.
+		_x.reset( _global_setup.createVector(num_unknowns,
+		          _local_to_global_index_map->getGhostIndices(), false) );
+		_rhs.reset( _global_setup.createVector(num_unknowns,
+		            _local_to_global_index_map->getGhostIndices(), false) );
 #else
 		const std::size_t num_unknowns = _local_to_global_index_map->dofSize();
 		_A.reset(_global_setup.createMatrix(num_unknowns));
-#endif
 		_x.reset(_global_setup.createVector(num_unknowns));
 		_rhs.reset(_global_setup.createVector(num_unknowns));
+#endif
 		_linear_solver.reset(new typename GlobalSetup::LinearSolver(
 		    *_A, solver_name, _linear_solver_options.get()));
 		checkAndInvalidate(_linear_solver_options);

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -278,7 +278,7 @@ private:
 		assert(result && result->size() == _x->size());
 
 		// Copy result
-		_x->getValues(&(*result)[0]);
+		_x->getValues(*result);
 
 		// Write output file
 		DBUG("Writing output to \'%s\'.", file_name.c_str());

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -166,9 +166,18 @@ private:
 			                          MeshLib::MeshItemType::Node, i);
 			auto global_index = std::abs(
 			    _local_to_global_index_map->getGlobalIndex(l, component_id));
-			// Ghost entry and its original index is 0
+#ifdef USE_PETSC
+			// The global indices of the ghost entries of the global
+			// matrix or the global vectors need to be set as negative values
+			// for equation assembly, however the global indices start from zero.
+			// Therefore, any ghost entry with zero index is assigned an negative
+			// value of the vector size or the matrix dimension.
+			// To assign the initial value for the ghost entries,
+			// the negative indices of the ghost entries are restored to zero.
+			// checked hereby.
 			if ( global_index == _x->size() )
 			    global_index = 0;
+#endif
 			_x->set(global_index,
 			        variable.getInitialConditionValue(*_mesh.getNode(i)));
 		}

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -273,9 +273,14 @@ private:
 			result =
 			    _mesh.getProperties().template createNewPropertyVector<double>(
 			        property_name, MeshLib::MeshItemType::Node);
+#ifdef USE_PETSC
+			result->resize(_x->getLocalSize() + _x->getGhostSize());
+#else
 			result->resize(_x->size());
+#endif
 		}
-		assert(result && result->size() == _x->size());
+
+		assert(result);
 
 		// Copy result
 		_x->copyValues(*result);

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -164,8 +164,11 @@ private:
 		{
 			MeshLib::Location const l(_mesh.getID(),
 			                          MeshLib::MeshItemType::Node, i);
-			auto const global_index = std::abs(
+			auto global_index = std::abs(
 			    _local_to_global_index_map->getGlobalIndex(l, component_id));
+			// Ghost entry and its original index is 0
+			if ( global_index == _x->size() )
+			    global_index = 0;
 			_x->set(global_index,
 			        variable.getInitialConditionValue(*_mesh.getNode(i)));
 		}

--- a/Tests/MathLib/TestGlobalVectorInterface.cpp
+++ b/Tests/MathLib/TestGlobalVectorInterface.cpp
@@ -179,7 +179,7 @@ void checkGlobalVectorInterfacePETSc()
     // check local array
     std::vector<double> loc_v(  x_fixed_p.getLocalSize()
                               + x_fixed_p.getGhostSize() );
-    x_fixed_p.getValues(loc_v);
+    x_fixed_p.copyValues(loc_v);
     z[0] = 1.0;
     z[1] = 2.0;
 
@@ -253,7 +253,7 @@ void checkGlobalVectorInterfacePETSc()
 
     std::vector<double> loc_v1(  x_with_ghosts.getLocalSize()
                                + x_with_ghosts.getGhostSize() );
-    x_with_ghosts.getValues(loc_v1);
+    x_with_ghosts.copyValues(loc_v1);
     for (std::size_t i=0; i<expected.size(); i++)
     {
          ASSERT_EQ(expected[i], loc_v1[i]);

--- a/Tests/MathLib/TestGlobalVectorInterface.cpp
+++ b/Tests/MathLib/TestGlobalVectorInterface.cpp
@@ -177,12 +177,13 @@ void checkGlobalVectorInterfacePETSc()
     ASSERT_ARRAY_NEAR(z, x0, 6, 1e-10);
 
     // check local array
-    double *loc_v = x_fixed_p.getLocalVector();
+    std::vector<double> loc_v(  x_fixed_p.getLocalSize()
+                              + x_fixed_p.getGhostSize() );
+    x_fixed_p.getValues(&loc_v[0]);
     z[0] = 1.0;
     z[1] = 2.0;
 
     ASSERT_ARRAY_NEAR(z, loc_v, 2, 1e-10);
-    x_fixed_p.restoreArray(loc_v);
 
     // Deep copy
     MathLib::finalizeVectorAssembly(x_fixed_p);
@@ -249,12 +250,14 @@ void checkGlobalVectorInterfacePETSc()
     MathLib::finalizeVectorAssembly(x_with_ghosts);
 
     ASSERT_EQ(12u, x_with_ghosts.size());
-    loc_v = x_with_ghosts.getLocalVector();
+
+    std::vector<double> loc_v1(  x_with_ghosts.getLocalSize()
+                               + x_with_ghosts.getGhostSize() );
+    x_with_ghosts.getValues(&loc_v1[0]);                          
     for (std::size_t i=0; i<expected.size(); i++)
     {
-         ASSERT_NEAR(expected[i], loc_v[i], 1.e-10);
+         ASSERT_NEAR(expected[i], loc_v1[i], 1.e-10);
     }
-    x_with_ghosts.restoreArray(loc_v);
 }
 #endif
 

--- a/Tests/MathLib/TestGlobalVectorInterface.cpp
+++ b/Tests/MathLib/TestGlobalVectorInterface.cpp
@@ -73,16 +73,16 @@ void checkGlobalVectorInterface()
     ASSERT_EQ(1.0, y.get(3));
 }
 
-#ifdef USE_PETSC // or MPI
+#ifdef USE_PETSC
 template <class T_VECTOR>
-void checkGlobalVectorInterfaceMPI()
+void checkGlobalVectorInterfacePETSc()
 {
     int msize;
     MPI_Comm_size(PETSC_COMM_WORLD, &msize);
 
     ASSERT_EQ(3u, msize);
 
-    // -------------------------------------------------------------------
+    // -----------------------------------------------------------------
     // PETSc determined partitioning
     T_VECTOR x(16);
 
@@ -148,7 +148,7 @@ void checkGlobalVectorInterfaceMPI()
 
     ASSERT_ARRAY_NEAR(z, x0, 16, 1e-10);
 
-    // -------------------------------------------------------------------
+    // -----------------------------------------------------------------
     // User determined partitioning
     const bool is_global_size = false;
     T_VECTOR x_fixed_p(2, is_global_size);
@@ -182,11 +182,79 @@ void checkGlobalVectorInterfaceMPI()
     z[1] = 2.0;
 
     ASSERT_ARRAY_NEAR(z, loc_v, 2, 1e-10);
+    x_fixed_p.restoreArray(loc_v);
 
     // Deep copy
     MathLib::finalizeVectorAssembly(x_fixed_p);
     T_VECTOR x_deep_copied(x_fixed_p);
     ASSERT_NEAR(sqrt(3.0*5), x_deep_copied.getNorm(), 1.e-10);
+
+    // -----------------------------------------------------------------
+    // Vector with ghost entries
+    /*
+         Assume there is a vector distributed over three processes as
+          -- rank0 --    --- rank1 ---   -- rank2 --
+           0  1  2  3    4  5  6  7  8   9   10   11 
+         where the numbers are the global entry indices.
+         In each trunk of entries of a rank, there are ghost entries in
+         other ranks attached and their global entry indices are:
+         rank0: 6 8 10
+         rank1: 0 9
+         rank2: 3 5
+
+         Assuming the values of the entries are just their global indices,
+         we have local arrays as:
+         rank0: 0 1 2 3     6 8 10
+         rank1: 4 5 6 7 8   0 9
+         rank2: 9 10 11     3 5
+
+         The above ghost entry embeded vector is realized by the following
+         test.
+    */    
+    std::size_t local_vec_size = 4;
+    if (mrank == 1)
+        local_vec_size = 5;
+    else if (mrank == 2)
+        local_vec_size = 3;
+    std::vector<GlobalIndexType> non_ghost_ids(local_vec_size);
+    std::vector<double> non_ghost_vals(local_vec_size);
+    std::size_t nghosts = 3;
+    if (mrank)
+        nghosts = 2;    
+    std::vector<GlobalIndexType> ghost_ids(nghosts);
+    std::vector<double> expected;
+    switch (mrank)
+    {
+        case 0:
+            non_ghost_ids  = {0, 1, 2, 3};
+            non_ghost_vals = {0., 1., 2., 3.};
+            ghost_ids      = {6, 8, 10};
+            expected       = {0., 1., 2., 3., 6., 8., 10.};
+            break;
+        case 1:
+            non_ghost_ids  = {4, 5, 6, 7, 8};
+            non_ghost_vals = {4., 5., 6., 7., 8.};
+            ghost_ids      = {0, 9};
+            expected       = {4., 5., 6., 7., 8., 0., 9.};
+            break;
+        case 2:
+            non_ghost_ids  = {9, 10, 11};
+            non_ghost_vals = {9., 10., 11.};
+            ghost_ids      = {3, 5};
+            expected       = {9., 10., 11., 3., 5.};
+            break;
+    }
+    T_VECTOR x_with_ghosts(local_vec_size, ghost_ids, is_global_size);
+    x_with_ghosts.set(non_ghost_ids, non_ghost_vals);
+    MathLib::finalizeVectorAssembly(x_with_ghosts);
+
+    ASSERT_EQ(12u, x_with_ghosts.size());
+    loc_v = x_with_ghosts.getLocalVector();
+    for (std::size_t i=0; i<expected.size(); i++)
+    {
+         ASSERT_NEAR(expected[i], loc_v[i], 1.e-10);
+    }
+    x_with_ghosts.restoreArray(loc_v);
 }
 #endif
 
@@ -201,7 +269,7 @@ TEST(Math, CheckInterface_LisVector)
 #elif defined(USE_PETSC)
 TEST(MPITest_Math, CheckInterface_PETScVector)
 {
-    checkGlobalVectorInterfaceMPI<MathLib::PETScVector >();
+    checkGlobalVectorInterfacePETSc<MathLib::PETScVector >();
 }
 #elif defined(OGS_USE_EIGEN)
 TEST(Math, CheckInterface_EigenVector)

--- a/Tests/MathLib/TestGlobalVectorInterface.cpp
+++ b/Tests/MathLib/TestGlobalVectorInterface.cpp
@@ -179,7 +179,7 @@ void checkGlobalVectorInterfacePETSc()
     // check local array
     std::vector<double> loc_v(  x_fixed_p.getLocalSize()
                               + x_fixed_p.getGhostSize() );
-    x_fixed_p.getValues(&loc_v[0]);
+    x_fixed_p.getValues(loc_v);
     z[0] = 1.0;
     z[1] = 2.0;
 
@@ -253,7 +253,7 @@ void checkGlobalVectorInterfacePETSc()
 
     std::vector<double> loc_v1(  x_with_ghosts.getLocalSize()
                                + x_with_ghosts.getGhostSize() );
-    x_with_ghosts.getValues(loc_v1.data());
+    x_with_ghosts.getValues(loc_v1);
     for (std::size_t i=0; i<expected.size(); i++)
     {
          ASSERT_EQ(expected[i], loc_v1[i]);

--- a/Tests/MathLib/TestGlobalVectorInterface.cpp
+++ b/Tests/MathLib/TestGlobalVectorInterface.cpp
@@ -209,7 +209,7 @@ void checkGlobalVectorInterfacePETSc()
          rank1: 4 5 6 7 8   0 9
          rank2: 9 10 11     3 5
 
-         The above ghost entry embeded vector is realized by the following
+         The above ghost entry embedded vector is realized by the following
          test.
     */    
     std::size_t local_vec_size = 4;
@@ -253,10 +253,10 @@ void checkGlobalVectorInterfacePETSc()
 
     std::vector<double> loc_v1(  x_with_ghosts.getLocalSize()
                                + x_with_ghosts.getGhostSize() );
-    x_with_ghosts.getValues(&loc_v1[0]);                          
+    x_with_ghosts.getValues(loc_v1.data());
     for (std::size_t i=0; i<expected.size(); i++)
     {
-         ASSERT_NEAR(expected[i], loc_v1[i], 1.e-10);
+         ASSERT_EQ(expected[i], loc_v1[i]);
     }
 }
 #endif


### PR DESCRIPTION
- Create vector with ghost entries

     To save memory when the solution is fetched.
- Use local size to create vector and matrix

    To improve the computational and communication load balance in the global assembly and the linear solver.

(c.f. issue #965)