### PR TITLE
Tools for Neumann boundary condition preparation

### DIFF
--- a/Applications/Utils/CMakeLists.txt
+++ b/Applications/Utils/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(FileConverter)
 add_subdirectory(GeoTools)
 add_subdirectory(MeshGeoTools)
 add_subdirectory(MeshEdit)
+add_subdirectory(ModelPreparation)
 add_subdirectory(SimpleMeshCreation)
 
 if(OGS_BUILD_GUI)

--- a/Applications/Utils/MeshEdit/CMakeLists.txt
+++ b/Applications/Utils/MeshEdit/CMakeLists.txt
@@ -80,6 +80,10 @@ add_executable(queryMesh queryMesh.cpp)
 target_link_libraries(queryMesh FileIO)
 set_target_properties(queryMesh PROPERTIES FOLDER Utilities)
 
+add_executable(ExtractSurface ExtractSurface.cpp)
+target_link_libraries(ExtractSurface FileIO MeshLib)
+set_target_properties(ExtractSurface PROPERTIES FOLDER Utilities)
+
 ####################
 ### Installation ###
 ####################
@@ -95,6 +99,7 @@ install(TARGETS
 	AddTopLayer
 	CreateBoundaryConditionsAlongPolylines
 	queryMesh
+	ExtractSurface
 	RUNTIME DESTINATION bin COMPONENT Utilities
 )
 if(QT4_FOUND)

--- a/Applications/Utils/MeshEdit/ExtractSurface.cpp
+++ b/Applications/Utils/MeshEdit/ExtractSurface.cpp
@@ -1,0 +1,80 @@
+/**
+ * @brief Extracts the surface from the given mesh.
+ *
+ * @copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tclap/CmdLine.h"
+
+#include "Applications/ApplicationsLib/LogogSetup.h"
+
+#include "BaseLib/StringTools.h"
+#include "BaseLib/FileTools.h"
+
+#include "FileIO/readMeshFromFile.h"
+#include "FileIO/writeMeshToFile.h"
+
+#include "MathLib/Vector3.h"
+
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshSurfaceExtraction.h"
+
+int main (int argc, char* argv[])
+{
+	ApplicationsLib::LogogSetup logog_setup;
+
+	TCLAP::CmdLine cmd("Tool extracts the surface of the given mesh.", ' ',
+	                   "0.1");
+	TCLAP::ValueArg<std::string> mesh_in(
+	    "i", "mesh-input-file",
+	    "the name of the file containing the input mesh", true, "",
+	    "file name of input mesh");
+	cmd.add(mesh_in);
+	TCLAP::ValueArg<std::string> mesh_out(
+	    "o", "mesh-output-file",
+	    "the name of the file the surface mesh should be written to", false, "",
+	    "file name of output mesh");
+	cmd.add(mesh_out);
+	TCLAP::ValueArg<double> x("x", "x-component", "x component of the normal",
+	                          false, 0, "floating point value");
+	cmd.add(x);
+	TCLAP::ValueArg<double> y("y", "y-component", "y component of the normal",
+	                          false, 0, "floating point value");
+	cmd.add(y);
+	TCLAP::ValueArg<double> z("z", "z-component", "z component of the normal",
+	                          false, -1.0, "floating point value");
+	cmd.add(z);
+	TCLAP::ValueArg<double> angle_arg(
+	    "a", "angle", "angle between given normal and element normal", false,
+	    90, "floating point value");
+	cmd.add(angle_arg);
+
+	cmd.parse(argc, argv);
+
+	std::unique_ptr<MeshLib::Mesh const> mesh(
+	    FileIO::readMeshFromFile(mesh_in.getValue()));
+	INFO("Mesh read: %u nodes, %u elements.", mesh->getNNodes(), mesh->getNElements());
+
+	// extract surface
+	MathLib::Vector3 const dir(x.getValue(), y.getValue(), z.getValue());
+	double const angle(angle_arg.getValue());
+	std::unique_ptr<MeshLib::Mesh> surface_mesh(
+	    MeshLib::MeshSurfaceExtraction::getMeshSurface(
+	        *mesh, dir, angle, "OriginalSubsurfaceNodeIDs"));
+
+	std::string out_fname(mesh_out.getValue());
+	if (out_fname.empty())
+		out_fname = BaseLib::dropFileExtension(mesh_in.getValue()) + "_sfc.vtu";
+	FileIO::writeMeshToFile(*surface_mesh, out_fname);
+
+	return EXIT_SUCCESS;
+}

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -224,6 +224,18 @@ int main (int argc, char* argv[])
 
 	if (int_property_arg.isSet()) {
 		int int_property_val(int_property_arg.getValue());
+
+		// check if PropertyVector exists
+		boost::optional<MeshLib::PropertyVector<int> &> opt_pv(
+			mesh->getProperties().getPropertyVector<int>(property_name)
+		);
+		if (!opt_pv) {
+			opt_pv = mesh->getProperties().createNewPropertyVector<int>(
+				property_name, MeshLib::MeshItemType::Cell, 1);
+			opt_pv.get().resize(mesh->getElements().size());
+			INFO("Created PropertyVector with name \"%s\".", property_name.c_str());
+		}
+
 		resetMeshElementProperty(*mesh, polygon, property_name, int_property_val);
 	}
 

--- a/Applications/Utils/ModelPreparation/CMakeLists.txt
+++ b/Applications/Utils/ModelPreparation/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(ComputeNodeAreasFromSurfaceMesh ComputeNodeAreasFromSurfaceMesh.cpp)
+set_target_properties(ComputeNodeAreasFromSurfaceMesh PROPERTIES FOLDER Utils)
+target_link_libraries(ComputeNodeAreasFromSurfaceMesh
+	FileIO
+	MeshLib
+	MathLib
+	${OGS_VTK_REQUIRED_LIBS}
+)
+

--- a/Applications/Utils/ModelPreparation/ComputeNodeAreasFromSurfaceMesh.cpp
+++ b/Applications/Utils/ModelPreparation/ComputeNodeAreasFromSurfaceMesh.cpp
@@ -1,0 +1,124 @@
+/**
+ * @brief Computes the areas associated nodes of the surface mesh.
+ *
+ * @copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tclap/CmdLine.h"
+
+#include "Applications/ApplicationsLib/LogogSetup.h"
+
+#include "BaseLib/FileTools.h"
+
+#include "FileIO/readMeshFromFile.h"
+#include "FileIO/readGeometryFromFile.h"
+
+#include "MeshLib/Mesh.h"
+#include "MeshLib/Node.h"
+#include "MeshLib/MeshSurfaceExtraction.h"
+
+static
+void writeToFile(std::string const& id_area_fname, std::string const& csv_fname,
+	std::vector<std::pair<std::size_t, double>> const& ids_and_areas,
+	std::vector<MeshLib::Node*> const& mesh_nodes)
+{
+	std::ofstream ids_and_area_out(id_area_fname);
+	if (!ids_and_area_out) {
+		ERR("Unable to open the file \"%s\" - aborting.", id_area_fname.c_str());
+		std::abort();
+	}
+	std::ofstream csv_out(csv_fname);
+	if (!csv_out) {
+		ERR("Unable to open the file \"%s\" - aborting.", csv_fname.c_str());
+		std::abort();
+	}
+
+	ids_and_area_out << std::numeric_limits<double>::digits10;
+	csv_out << std::numeric_limits<double>::digits10;
+
+	csv_out << "ID x y z area node_id\n"; // CSV header
+	for (std::size_t k(0); k<ids_and_areas.size(); k++) {
+		ids_and_area_out << ids_and_areas[k].first << " "
+		                 << ids_and_areas[k].second << "\n";
+		csv_out << k << " " << *(mesh_nodes[k]) << ids_and_areas[k].second
+		        << " " << ids_and_areas[k].first << "\n";
+	}
+	ids_and_area_out << "\n";
+	csv_out << "\n";
+}
+
+int main (int argc, char* argv[])
+{
+	ApplicationsLib::LogogSetup logog_setup;
+
+	TCLAP::CmdLine cmd("The tool computes the area per node of the surface mesh"
+		" and writes the information as txt and csv data.", ' ', "0.1");
+	TCLAP::ValueArg<std::string> mesh_in("i", "mesh-input-file",
+		"the name of the file containing the input mesh", true,
+		"", "file name of input mesh");
+	cmd.add(mesh_in);
+	TCLAP::ValueArg<std::string> id_prop_name("", "id-prop-name",
+		"the name of the property containing the id information", false,
+		"OriginalSubsurfaceNodeIDs", "property name");
+	cmd.add(id_prop_name);
+	TCLAP::ValueArg<std::string> out_base_fname("p", "output-base-name",
+		"the path and base file name the output will be written to", false,
+		"", "file name of input mesh");
+	cmd.add(out_base_fname);
+
+	cmd.parse(argc, argv);
+
+	std::unique_ptr<MeshLib::Mesh> surface_mesh(
+	    FileIO::readMeshFromFile(mesh_in.getValue()));
+	INFO("Mesh read: %u nodes, %u elements.", surface_mesh->getNNodes(),
+	     surface_mesh->getNElements());
+	// ToDo check if mesh is read correct and if the mesh is a surface mesh
+
+	// check if a node property containing the subsurface ids is available
+	boost::optional<MeshLib::PropertyVector<int> const&> orig_node_ids(
+	    surface_mesh->getProperties().getPropertyVector<int>(
+	        id_prop_name.getValue()));
+	// if the node property is not available generate it
+	if (!orig_node_ids) {
+		boost::optional<MeshLib::PropertyVector<int>&> node_ids(
+		    surface_mesh->getProperties().createNewPropertyVector<int>(
+		        id_prop_name.getValue(), MeshLib::MeshItemType::Node, 1));
+		if (!node_ids) {
+			ERR("Fatal error: could not create property.");
+			return EXIT_FAILURE;
+		}
+		node_ids->resize(surface_mesh->getNNodes());
+		std::iota(node_ids->begin(), node_ids->end(), 0);
+		orig_node_ids = node_ids;
+	}
+
+	std::vector<double> areas(
+	    MeshLib::MeshSurfaceExtraction::getSurfaceAreaForNodes(*surface_mesh));
+
+	// pack area and node id together
+	std::vector<std::pair<std::size_t, double>> ids_and_areas;
+	std::transform(orig_node_ids->cbegin(), orig_node_ids->cend(),
+	               areas.cbegin(), std::back_inserter(ids_and_areas),
+	               std::make_pair<std::size_t const&, double const&>);
+
+	// generate file names for output
+	std::string path(out_base_fname.getValue());
+	if (path.empty())
+		path = BaseLib::dropFileExtension(mesh_in.getValue());
+	std::string const id_and_area_fname(path+".txt");
+	std::string const csv_fname(path+".csv");
+
+	writeToFile(id_and_area_fname, csv_fname, ids_and_areas,
+	            surface_mesh->getNodes());
+
+	return EXIT_SUCCESS;
+}

--- a/InSituLib/VtkMappedMeshSource.cpp
+++ b/InSituLib/VtkMappedMeshSource.cpp
@@ -96,6 +96,7 @@ int VtkMappedMeshSource::RequestData(vtkInformation *,
 		if (addProperty<double>(properties, *name)) continue;
 		if (addProperty<int>(properties, *name)) continue;
 		if (addProperty<unsigned>(properties, *name)) continue;
+		if (addProperty<std::size_t>(properties, *name)) continue;
 		if (addProperty<char>(properties, *name)) continue;
 
 		DBUG ("Mesh property \"%s\" with unknown data type.", *name->c_str());

--- a/MeshLib/MeshGenerators/VtkMeshConverter.cpp
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.cpp
@@ -25,6 +25,7 @@
 #include <vtkBitArray.h>
 #include <vtkCharArray.h>
 #include <vtkUnsignedCharArray.h>
+#include <vtkUnsignedLongArray.h>
 #include <vtkDoubleArray.h>
 #include <vtkIntArray.h>
 
@@ -228,6 +229,12 @@ void VtkMeshConverter::convertArray(vtkDataArray &array, MeshLib::Properties &pr
 	if (vtkCharArray::SafeDownCast(&array))
 	{
 		VtkMeshConverter::convertTypedArray<char>(array, properties, type);
+		return;
+	}
+
+	if (vtkUnsignedLongArray::SafeDownCast(&array))
+	{
+		VtkMeshConverter::convertTypedArray<unsigned long>(array, properties, type);
 		return;
 	}
 


### PR DESCRIPTION
This PR consists of two new simple tools
 - ExtractSurface
 - ComputeNodeAreasFromSurfaceMesh
and some additional functionality to the already existing tool ResetPropertyInPolygonalRegion.

The tools can be used in a workflow setting Neumann boundary conditions for different regions of the top surface (for instance groundwater recharge):
 1. Extract top surface (ExtractSurface)
 2. Mark the surface elements in the region the Neumann conditions should be set: ResetPropertyInPolygonalRegion
 3. Remove those parts of the surface mesh the Neumann condition shouldn't be set to deploying the tool removeMeshElements which results in a surface patch
 4. For OGS-5 modelling use the surface patch to generate Neumann condition using the tool ComputeNodeAreasFromSurfaceMesh

Using this workflow the bug described in issue #992 should be corrected.
Fixes #992.