### PR TITLE
[MGTL] Fix GeoMapper tri/line intersection memleak

### DIFF
--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -398,7 +398,10 @@ void rotatePointsToXZ(std::vector<GeoLib::Point*> &pnts)
 		(*(pnts[k]))[1] = 0.0; // should be -= d but there are numerical errors
 }
 
-GeoLib::Point* triangleLineIntersection(MathLib::Point3d const& a, MathLib::Point3d const& b, MathLib::Point3d const& c, MathLib::Point3d const& p, MathLib::Point3d const& q)
+std::unique_ptr<GeoLib::Point> triangleLineIntersection(
+    MathLib::Point3d const& a, MathLib::Point3d const& b,
+    MathLib::Point3d const& c, MathLib::Point3d const& p,
+    MathLib::Point3d const& q)
 {
 	const MathLib::Vector3 pq(p, q);
 	const MathLib::Vector3 pa(p, a);
@@ -416,7 +419,10 @@ GeoLib::Point* triangleLineIntersection(MathLib::Point3d const& a, MathLib::Poin
 	u*=denom;
 	v*=denom;
 	w*=denom;
-	return new GeoLib::Point(u*a[0]+v*b[0]+w*c[0],u*a[1]+v*b[1]+w*c[1],u*a[2]+v*b[2]+w*c[2]);
+	return std::unique_ptr<GeoLib::Point>{
+	    new GeoLib::Point(u * a[0] + v * b[0] + w * c[0],
+	                      u * a[1] + v * b[1] + w * c[1],
+	                      u * a[2] + v * b[2] + w * c[2])};
 }
 
 double scalarTriple(MathLib::Vector3 const& u, MathLib::Vector3 const& v, MathLib::Vector3 const& w)

--- a/GeoLib/AnalyticalGeometry.h
+++ b/GeoLib/AnalyticalGeometry.h
@@ -15,6 +15,8 @@
 #ifndef ANALYTICAL_GEOMETRY_H_
 #define ANALYTICAL_GEOMETRY_H_
 
+#include <memory>
+
 #include "MathLib/Vector3.h"
 #include "MathLib/LinAlg/Dense/DenseMatrix.h"
 
@@ -319,7 +321,10 @@ lineSegmentIntersect2d(MathLib::Point3d const& a, MathLib::Point3d const& b,
  * This method requires ABC to be counterclockwise and PQ to point downward.
  * @return Intersection point or nullptr if there is no intersection.
  */
-GeoLib::Point* triangleLineIntersection(MathLib::Point3d const& a, MathLib::Point3d const& b, MathLib::Point3d const& c, MathLib::Point3d const& p, MathLib::Point3d const& q);
+std::unique_ptr<GeoLib::Point> triangleLineIntersection(
+    MathLib::Point3d const& a, MathLib::Point3d const& b,
+    MathLib::Point3d const& c, MathLib::Point3d const& p,
+    MathLib::Point3d const& q);
 
 /// Calculates the scalar triple (u x v) . w
 double scalarTriple(MathLib::Vector3 const& u, MathLib::Vector3 const& v, MathLib::Vector3 const& w);

--- a/MeshGeoToolsLib/GeoMapper.cpp
+++ b/MeshGeoToolsLib/GeoMapper.cpp
@@ -201,7 +201,7 @@ double GeoMapper::getMeshElevation(
 	    _grid->getNearestPoint(MathLib::Point3d{{{x, y, 0}}});
 	const std::vector<MeshLib::Element*> elements(
 	    _surface_mesh->getNode(pnt->getID())->getElements());
-	GeoLib::Point* intersection(nullptr);
+	std::unique_ptr<GeoLib::Point> intersection;
 
 	for (auto const & element : elements)
 	{


### PR DESCRIPTION
Fix a memory leak detected by clang's address sanitizer in the testrunner.