### PR TITLE
Multicomponent process variables and their output.

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -12,7 +12,7 @@ if(NOT OGS_USE_MPI)
 			EXECUTABLE_ARGS cube_${mesh_size}.prj
 			WRAPPER time
 			TESTER vtkdiff
-			DIFF_DATA cube_${mesh_size}_pcs_0_ts_1.vtu Linear_1_to_minus1 Result
+			DIFF_DATA cube_${mesh_size}_pcs_0_ts_1.vtu Linear_1_to_minus1 pressure
 			DATA cube_${mesh_size}.prj cube_1x1x1_hex_${mesh_size}.vtu cube_1x1x1.gml
 		)
 
@@ -23,7 +23,7 @@ if(NOT OGS_USE_MPI)
 			EXECUTABLE_ARGS cube_${mesh_size}_neumann.prj
 			WRAPPER time
 			TESTER vtkdiff
-			DIFF_DATA cube_${mesh_size}_neumann_pcs_0_ts_1.vtu D1_left_front_N1_right Result
+			DIFF_DATA cube_${mesh_size}_neumann_pcs_0_ts_1.vtu D1_left_front_N1_right pressure
 			DATA cube_${mesh_size}_neumann.prj cube_1x1x1_hex_${mesh_size}.vtu cube_1x1x1.gml
 		)
 	endforeach()
@@ -36,7 +36,7 @@ if(NOT OGS_USE_MPI)
 			EXECUTABLE_ARGS cube_${mesh_size}.prj
 			WRAPPER time
 			TESTER vtkdiff
-			DIFF_DATA cube_${mesh_size}_pcs_0_ts_1.vtu Linear_1_to_minus1 Result
+			DIFF_DATA cube_${mesh_size}_pcs_0_ts_1.vtu Linear_1_to_minus1 pressure
 			DATA cube_${mesh_size}.prj cube_1x1x1_hex_${mesh_size}.vtu cube_1x1x1.gml
 		)
 
@@ -47,7 +47,7 @@ if(NOT OGS_USE_MPI)
 			EXECUTABLE_ARGS cube_${mesh_size}_neumann.prj
 			WRAPPER time
 			TESTER vtkdiff
-			DIFF_DATA cube_${mesh_size}_neumann_pcs_0_ts_1.vtu D1_left_front_N1_right Result
+			DIFF_DATA cube_${mesh_size}_neumann_pcs_0_ts_1.vtu D1_left_front_N1_right pressure
 			DATA cube_${mesh_size}_neumann.prj cube_1x1x1_hex_${mesh_size}.vtu cube_1x1x1.gml
 		)
 	endforeach()
@@ -61,7 +61,7 @@ if(NOT OGS_USE_MPI)
 			EXECUTABLE_ARGS square_${mesh_size}.prj
 			WRAPPER time
 			TESTER vtkdiff
-			DIFF_DATA square_${mesh_size}_pcs_0_ts_1.vtu Linear_1_to_minus1 Result
+			DIFF_DATA square_${mesh_size}_pcs_0_ts_1.vtu Linear_1_to_minus1 pressure
 			DATA square_${mesh_size}.prj square_1x1_quad_${mesh_size}.vtu square_1x1.gml
 		)
 
@@ -72,7 +72,7 @@ if(NOT OGS_USE_MPI)
 			EXECUTABLE_ARGS square_${mesh_size}_neumann.prj
 			WRAPPER time
 			TESTER vtkdiff
-			DIFF_DATA square_${mesh_size}_neumann_pcs_0_ts_1.vtu D1_left_bottom_N1_right Result
+			DIFF_DATA square_${mesh_size}_neumann_pcs_0_ts_1.vtu D1_left_bottom_N1_right pressure
 			DATA square_${mesh_size}_neumann.prj square_1x1_quad_${mesh_size}.vtu square_1x1.gml
 		)
 	endforeach()
@@ -85,7 +85,7 @@ if(NOT OGS_USE_MPI)
 			EXECUTABLE_ARGS square_${mesh_size}.prj
 			WRAPPER time
 			TESTER vtkdiff
-			DIFF_DATA square_${mesh_size}_pcs_0_ts_1.vtu Linear_1_to_minus1 Result
+			DIFF_DATA square_${mesh_size}_pcs_0_ts_1.vtu Linear_1_to_minus1 pressure
 			DATA square_${mesh_size}.prj square_1x1_quad_${mesh_size}.vtu square_1x1.gml
 		)
 
@@ -96,7 +96,7 @@ if(NOT OGS_USE_MPI)
 			EXECUTABLE_ARGS square_${mesh_size}_neumann.prj
 			WRAPPER time
 			TESTER vtkdiff
-			DIFF_DATA square_${mesh_size}_neumann_pcs_0_ts_1.vtu D1_left_bottom_N1_right Result
+			DIFF_DATA square_${mesh_size}_neumann_pcs_0_ts_1.vtu D1_left_bottom_N1_right pressure
 			DATA square_${mesh_size}_neumann.prj square_1x1_quad_${mesh_size}.vtu square_1x1.gml
 		)
 	endforeach()
@@ -110,7 +110,7 @@ if(NOT OGS_USE_MPI)
 			EXECUTABLE_ARGS line_${mesh_size}.prj
 			WRAPPER time
 			TESTER vtkdiff
-			DIFF_DATA line_${mesh_size}_pcs_0_ts_1.vtu Linear_1_to_minus1 Result
+			DIFF_DATA line_${mesh_size}_pcs_0_ts_1.vtu Linear_1_to_minus1 pressure
 			DATA line_${mesh_size}.prj line_1_line_${mesh_size}.vtu line_1.gml
 		)
 
@@ -121,7 +121,7 @@ if(NOT OGS_USE_MPI)
 					EXECUTABLE_ARGS line_${mesh_size}_neumann.prj
 					WRAPPER time
 					TESTER vtkdiff
-					DIFF_DATA line_${mesh_size}_neumann_pcs_0_ts_1.vtu D1_left_N1_right Result
+					DIFF_DATA line_${mesh_size}_neumann_pcs_0_ts_1.vtu D1_left_N1_right pressure
 					DATA line_${mesh_size}_neumann.prj line_1_line_${mesh_size}.vtu line_1.gml
 				)
 		endforeach()

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -108,6 +108,16 @@ public:
         return _mesh_component_map.getGhostIndices();
     }
 
+    /// Computes the index in a local (for DDC) vector for a given location and
+    /// component; forwarded from MeshComponentMap.
+    GlobalIndexType getLocalIndex(MeshLib::Location const& l, std::size_t const comp_id,
+                                  std::size_t const range_begin,
+                                  std::size_t const range_end) const
+    {
+        return _mesh_component_map.getLocalIndex(l, comp_id, range_begin,
+                                                 range_end);
+    }
+
 private:
     /// Private constructor used by internally created local-to-global index
     /// maps. The mesh_component_map is passed as argument instead of being

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -145,6 +145,15 @@ public:
         return _ghosts_indices;
     }
 
+    /// Computes the index in a local (for DDC) vector for a given location and
+    /// component.
+    /// When domain decomposition is not used, it is equal to getGlobalIndex().
+    /// The range is needed to compute the offset for non-ghost locations and
+    /// also to map ghost locations.
+    GlobalIndexType getLocalIndex(Location const& l, std::size_t const comp_id,
+                                  std::size_t const range_begin,
+                                  std::size_t const range_end) const;
+
     /// A value returned if no global index was found for the requested
     /// location/component. The value is implementation dependent.
     static GlobalIndexType const nop;

--- a/InSituLib/VtkMappedPropertyVectorTemplate-impl.h
+++ b/InSituLib/VtkMappedPropertyVectorTemplate-impl.h
@@ -42,7 +42,7 @@ template <class Scalar> void VtkMappedPropertyVectorTemplate<Scalar>
 {
 	this->Initialize();
 	_propertyVector = &propertyVector;
-	this->NumberOfComponents = _propertyVector->getTupleSize();
+	this->NumberOfComponents = _propertyVector->getNumberOfComponents();
 	this->Size = this->NumberOfComponents *  _propertyVector->getNumberOfTuples();
 	this->MaxId = this->Size - 1;
 	this->Modified();

--- a/MeshLib/Properties-impl.h
+++ b/MeshLib/Properties-impl.h
@@ -15,7 +15,7 @@ template <typename T>
 boost::optional<PropertyVector<T> &>
 Properties::createNewPropertyVector(std::string const& name,
 	MeshItemType mesh_item_type,
-	std::size_t tuple_size)
+	std::size_t n_components)
 {
 	std::map<std::string, PropertyVectorBase*>::const_iterator it(
 		_properties.find(name)
@@ -28,7 +28,7 @@ Properties::createNewPropertyVector(std::string const& name,
 	auto entry_info(
 		_properties.insert(
 			std::make_pair(
-				name, new PropertyVector<T>(name, mesh_item_type, tuple_size)
+				name, new PropertyVector<T>(name, mesh_item_type, n_components)
 			)
 		)
 	);
@@ -44,7 +44,7 @@ Properties::createNewPropertyVector(std::string const& name,
 	std::size_t n_prop_groups,
 	std::vector<std::size_t> const& item2group_mapping,
 	MeshItemType mesh_item_type,
-	std::size_t tuple_size)
+	std::size_t n_components)
 {
 	// check if there is already a PropertyVector with the same name and
 	// mesh_item_type
@@ -71,7 +71,7 @@ Properties::createNewPropertyVector(std::string const& name,
 			std::pair<std::string, PropertyVectorBase*>(
 				name,
 				new PropertyVector<T>(n_prop_groups,
-					item2group_mapping, name, mesh_item_type, tuple_size)
+					item2group_mapping, name, mesh_item_type, n_components)
 			)
 		)
 	);

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -51,13 +51,14 @@ public:
 	/// @tparam T type of the property value
 	/// @param name the name of the property
 	/// @param mesh_item_type for instance node or element assigned properties
+	/// @param n_components number of components for each tuple
 	/// @return On success a reference to a PropertyVector packed into a
 	///   boost::optional else an empty boost::optional.
 	template <typename T>
 	boost::optional<PropertyVector<T> &>
 	createNewPropertyVector(std::string const& name,
 		MeshItemType mesh_item_type,
-		std::size_t tuple_size = 1);
+		std::size_t n_components = 1);
 
 	/// Method creates a PropertyVector if a PropertyVector with the same name
 	/// and the same type T was not already created before. In case there exists
@@ -73,6 +74,7 @@ public:
 	/// @param item2group_mapping the mapping between mesh item and the property
 	/// group
 	/// @param mesh_item_type for instance node or element assigned properties
+	/// @param n_components number of components for each tuple
 	/// @return On success a reference to a PropertyVector packed into a
 	///   boost::optional else an empty boost::optional.
 	template <typename T>
@@ -81,7 +83,7 @@ public:
 		std::size_t n_prop_groups,
 		std::vector<std::size_t> const& item2group_mapping,
 		MeshItemType mesh_item_type,
-		std::size_t tuple_size = 1);
+		std::size_t n_components = 1);
 
 	/// Method to get a vector of property values.
 	template <typename T>

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -70,14 +70,15 @@ protected:
 	/// @brief The constructor taking meta information for the data.
 	/// @param property_name a string describing the property
 	/// @param mesh_item_type the values of the property are either assigned to
-	/// nodes or cells (see enumeration MeshItemType) (default:
-	/// MeshItemType::Cell)
-	/// @param n_components the number of elements of a tuple (default: 1)
+	/// nodes or cells (see enumeration MeshItemType)
+	/// @param n_components the number of components of a property
 	explicit PropertyVector(std::string const& property_name,
-		MeshItemType mesh_item_type = MeshItemType::Cell,
-		std::size_t n_components = 1)
-		: std::vector<PROP_VAL_TYPE>(), _n_components(n_components),
-		_mesh_item_type(mesh_item_type), _property_name(property_name)
+	                        MeshItemType mesh_item_type,
+	                        std::size_t n_components)
+	    : std::vector<PROP_VAL_TYPE>(),
+	      _n_components(n_components),
+	      _mesh_item_type(mesh_item_type),
+	      _property_name(property_name)
 	{}
 
 	/// @brief The constructor taking meta information for the data.
@@ -85,15 +86,15 @@ protected:
 	/// with several entries)
 	/// @param property_name a string describing the property
 	/// @param mesh_item_type the values of the property are either assigned to
-	/// nodes or cells (see enumeration MeshItemType) (default:
-	/// MeshItemType::Cell)
-	/// @param n_components the number of elements of a tuple (default: 1)
+	/// nodes or cells (see enumeration MeshItemType)
+	/// @param n_components the number of components of a property
 	PropertyVector(std::size_t n_property_values,
-		std::string const& property_name,
-		MeshItemType mesh_item_type = MeshItemType::Cell,
-		std::size_t n_components = 1)
-		: std::vector<PROP_VAL_TYPE>(n_property_values*n_components),
-		_mesh_item_type(mesh_item_type), _property_name(property_name)
+	               std::string const& property_name,
+	               MeshItemType mesh_item_type,
+	               std::size_t n_components)
+	    : std::vector<PROP_VAL_TYPE>(n_property_values * n_components),
+	      _mesh_item_type(mesh_item_type),
+	      _property_name(property_name)
 	{}
 
 	std::size_t const _n_components;
@@ -195,19 +196,18 @@ protected:
 	/// \f$[0, \text{n_prop_groups})\f$.
 	/// @param property_name a string describing the property
 	/// @param mesh_item_type the values of the property are either assigned to
-	/// nodes or cells (see enumeration MeshItemType) (default:
-	/// MeshItemType::Cell)
-	/// @param n_components the number of elements of a tuple (default: 1)
+	/// nodes or cells (see enumeration MeshItemType)
+	/// @param n_components the number of elements of a tuple
 	PropertyVector(std::size_t n_prop_groups,
-		std::vector<std::size_t> const& item2group_mapping,
-		std::string const& property_name,
-		MeshItemType mesh_item_type = MeshItemType::Cell,
-		std::size_t n_components = 1)
-		: std::vector<std::size_t>(item2group_mapping),
-		_n_components(n_components),
-		_mesh_item_type(mesh_item_type),
-		_property_name(property_name),
-		_values(n_prop_groups * n_components)
+	               std::vector<std::size_t> const& item2group_mapping,
+	               std::string const& property_name,
+	               MeshItemType mesh_item_type,
+	               std::size_t n_components)
+	    : std::vector<std::size_t>(item2group_mapping),
+	      _n_components(n_components),
+	      _mesh_item_type(mesh_item_type),
+	      _property_name(property_name),
+	      _values(n_prop_groups * n_components)
 	{}
 
 protected:

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -44,10 +44,10 @@ class PropertyVector : public std::vector<PROP_VAL_TYPE>,
 friend class Properties;
 
 public:
-	std::size_t getTupleSize() const { return _tuple_size; }
+	std::size_t getNumberOfComponents() const { return _n_components; }
 	std::size_t getNumberOfTuples() const
 	{
-		return std::vector<PROP_VAL_TYPE>::size() / _tuple_size;
+		return std::vector<PROP_VAL_TYPE>::size() / _n_components;
 	}
 	MeshItemType getMeshItemType() const { return _mesh_item_type; }
 	std::string const& getPropertyName() const { return _property_name; }
@@ -55,7 +55,7 @@ public:
 	PropertyVectorBase* clone(std::vector<std::size_t> const& exclude_positions) const
 	{
 		PropertyVector<PROP_VAL_TYPE> *t(new PropertyVector<PROP_VAL_TYPE>(_property_name,
-			_mesh_item_type, _tuple_size));
+			_mesh_item_type, _n_components));
 		BaseLib::excludeObjectCopy(*this, exclude_positions, *t);
 		return t;
 	}
@@ -72,11 +72,11 @@ protected:
 	/// @param mesh_item_type the values of the property are either assigned to
 	/// nodes or cells (see enumeration MeshItemType) (default:
 	/// MeshItemType::Cell)
-	/// @param tuple_size the number of elements of a tuple (default: 1)
+	/// @param n_components the number of elements of a tuple (default: 1)
 	explicit PropertyVector(std::string const& property_name,
 		MeshItemType mesh_item_type = MeshItemType::Cell,
-		std::size_t tuple_size = 1)
-		: std::vector<PROP_VAL_TYPE>(), _tuple_size(tuple_size),
+		std::size_t n_components = 1)
+		: std::vector<PROP_VAL_TYPE>(), _n_components(n_components),
 		_mesh_item_type(mesh_item_type), _property_name(property_name)
 	{}
 
@@ -87,16 +87,16 @@ protected:
 	/// @param mesh_item_type the values of the property are either assigned to
 	/// nodes or cells (see enumeration MeshItemType) (default:
 	/// MeshItemType::Cell)
-	/// @param tuple_size the number of elements of a tuple (default: 1)
+	/// @param n_components the number of elements of a tuple (default: 1)
 	PropertyVector(std::size_t n_property_values,
 		std::string const& property_name,
 		MeshItemType mesh_item_type = MeshItemType::Cell,
-		std::size_t tuple_size = 1)
-		: std::vector<PROP_VAL_TYPE>(n_property_values*tuple_size),
+		std::size_t n_components = 1)
+		: std::vector<PROP_VAL_TYPE>(n_property_values*n_components),
 		_mesh_item_type(mesh_item_type), _property_name(property_name)
 	{}
 
-	std::size_t const _tuple_size;
+	std::size_t const _n_components;
 	MeshItemType const _mesh_item_type;
 	std::string const _property_name;
 };
@@ -140,7 +140,7 @@ public:
 		_values[group_id] = new T(value);
 	}
 
-	std::size_t getTupleSize() const { return _tuple_size; }
+	std::size_t getNumberOfComponents() const { return _n_components; }
 	std::size_t getNumberOfTuples() const
 	{
 		return std::vector<std::size_t>::size();
@@ -148,7 +148,7 @@ public:
 	/// Method returns the number of tuples times the number of tuple components.
 	std::size_t size() const
 	{
-		return _tuple_size * std::vector<std::size_t>::size();
+		return _n_components * std::vector<std::size_t>::size();
 	}
 	MeshItemType getMeshItemType() const { return _mesh_item_type; }
 	std::string const& getPropertyName() const { return _property_name; }
@@ -158,9 +158,9 @@ public:
 		// create new PropertyVector with modified mapping
 		PropertyVector<T*> *t(new PropertyVector<T*>
 			(
-				_values.size()/_tuple_size,
+				_values.size()/_n_components,
 				BaseLib::excludeObjectCopy(*this, exclude_positions),
-				_property_name, _mesh_item_type, _tuple_size
+				_property_name, _mesh_item_type, _n_components
 			)
 		);
 		// copy pointers to property values
@@ -197,21 +197,21 @@ protected:
 	/// @param mesh_item_type the values of the property are either assigned to
 	/// nodes or cells (see enumeration MeshItemType) (default:
 	/// MeshItemType::Cell)
-	/// @param tuple_size the number of elements of a tuple (default: 1)
+	/// @param n_components the number of elements of a tuple (default: 1)
 	PropertyVector(std::size_t n_prop_groups,
 		std::vector<std::size_t> const& item2group_mapping,
 		std::string const& property_name,
 		MeshItemType mesh_item_type = MeshItemType::Cell,
-		std::size_t tuple_size = 1)
+		std::size_t n_components = 1)
 		: std::vector<std::size_t>(item2group_mapping),
-		_tuple_size(tuple_size),
+		_n_components(n_components),
 		_mesh_item_type(mesh_item_type),
 		_property_name(property_name),
-		_values(n_prop_groups * tuple_size)
+		_values(n_prop_groups * n_components)
 	{}
 
 protected:
-	std::size_t const _tuple_size;
+	std::size_t const _n_components;
 	MeshItemType const _mesh_item_type;
 	std::string const _property_name;
 

--- a/ProcessLib/InitialCondition.cpp
+++ b/ProcessLib/InitialCondition.cpp
@@ -21,7 +21,7 @@
 namespace ProcessLib
 {
 std::unique_ptr<InitialCondition> createUniformInitialCondition(
-    BaseLib::ConfigTree const& config, int const tuple_size)
+    BaseLib::ConfigTree const& config, int const n_components)
 {
 	config.checkConfParam("type", "Uniform");
 
@@ -35,7 +35,7 @@ std::unique_ptr<InitialCondition> createUniformInitialCondition(
 std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
     BaseLib::ConfigTree const& config,
     MeshLib::Mesh const& mesh,
-    int const tuple_size)
+    int const n_components)
 {
 	auto field_name = config.getConfParam<std::string>("field_name");
 	DBUG("Using field_name %s", field_name.c_str());
@@ -55,11 +55,11 @@ std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
 		std::abort();
 	}
 
-	if (property->getTupleSize() != tuple_size)
+	if (property->getNumberOfComponents() != n_components)
 	{
-		ERR("The required property %s has different tuples size %d, "
+		ERR("The required property %s has different number of components %d, "
 		    "expected %d.",
-		    field_name.c_str(), property->getTupleSize(), tuple_size);
+		    field_name.c_str(), property->getNumberOfComponents(), n_components);
 		std::abort();
 	}
 	return std::unique_ptr<InitialCondition>(

--- a/ProcessLib/InitialCondition.cpp
+++ b/ProcessLib/InitialCondition.cpp
@@ -21,7 +21,7 @@
 namespace ProcessLib
 {
 std::unique_ptr<InitialCondition> createUniformInitialCondition(
-    BaseLib::ConfigTree const& config)
+    BaseLib::ConfigTree const& config, int const tuple_size)
 {
 	config.checkConfParam("type", "Uniform");
 
@@ -33,7 +33,9 @@ std::unique_ptr<InitialCondition> createUniformInitialCondition(
 }
 
 std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh)
+    BaseLib::ConfigTree const& config,
+    MeshLib::Mesh const& mesh,
+    int const tuple_size)
 {
 	auto field_name = config.getConfParam<std::string>("field_name");
 	DBUG("Using field_name %s", field_name.c_str());
@@ -53,6 +55,13 @@ std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
 		std::abort();
 	}
 
+	if (property->getTupleSize() != tuple_size)
+	{
+		ERR("The required property %s has different tuples size %d, "
+		    "expected %d.",
+		    field_name.c_str(), property->getTupleSize(), tuple_size);
+		std::abort();
+	}
 	return std::unique_ptr<InitialCondition>(
 	    new MeshPropertyInitialCondition(*property));
 }

--- a/ProcessLib/InitialCondition.h
+++ b/ProcessLib/InitialCondition.h
@@ -35,7 +35,7 @@ class InitialCondition
 {
 public:
 	virtual ~InitialCondition() = default;
-	virtual double getValue(MeshLib::Node const&) const = 0;
+	virtual double getValue(MeshLib::Node const&, int const) const = 0;
 };
 
 /// Uniform value initial condition
@@ -45,8 +45,8 @@ public:
 	UniformInitialCondition(double const value) : _value(value)
 	{
 	}
-
-	virtual double getValue(MeshLib::Node const&) const override
+	virtual double getValue(MeshLib::Node const&,
+	                        int const /* tuple_size */) const override
 	{
 		return _value;
 	}
@@ -56,8 +56,10 @@ private:
 };
 
 /// Construct a UniformInitialCondition from configuration.
+/// The initial condition will expect a correct tuple size in the configuration,
+/// which should be the same as in the corresponding process variable.
 std::unique_ptr<InitialCondition> createUniformInitialCondition(
-    BaseLib::ConfigTree const& config);
+    BaseLib::ConfigTree const& config, int const tuple_size);
 
 /// Distribution of values given by a mesh property defined on nodes.
 class MeshPropertyInitialCondition : public InitialCondition
@@ -70,9 +72,11 @@ public:
 		assert(_property.getMeshItemType() == MeshLib::MeshItemType::Node);
 	}
 
-	virtual double getValue(MeshLib::Node const& n) const override
+	virtual double getValue(MeshLib::Node const& n,
+	                        int const component_id) const override
 	{
-		return _property[n.getID()];
+		return _property[n.getID() * _property.getNumberOfComponents() +
+		                 component_id];
 	}
 
 private:
@@ -80,8 +84,11 @@ private:
 };
 
 /// Construct a MeshPropertyInitialCondition from configuration.
+/// The initial condition will expect a correct tuple size in the configuration,
+/// which should be the same as in the corresponding process variable.
 std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh);
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh,
+    int const tuple_size);
 
 }  // namespace ProcessLib
 

--- a/ProcessLib/InitialCondition.h
+++ b/ProcessLib/InitialCondition.h
@@ -35,7 +35,7 @@ class InitialCondition
 {
 public:
 	virtual ~InitialCondition() = default;
-	virtual double getValue(MeshLib::Node const&, int const) const = 0;
+	virtual double getValue(MeshLib::Node const&, int const component_id) const = 0;
 };
 
 /// Uniform value initial condition
@@ -45,8 +45,10 @@ public:
 	UniformInitialCondition(double const value) : _value(value)
 	{
 	}
+	/// Returns a value for given node and component.
+	/// \todo The component_id is to be implemented.
 	virtual double getValue(MeshLib::Node const&,
-	                        int const /* tuple_size */) const override
+	                        int const /* component_id */) const override
 	{
 		return _value;
 	}
@@ -56,10 +58,11 @@ private:
 };
 
 /// Construct a UniformInitialCondition from configuration.
-/// The initial condition will expect a correct tuple size in the configuration,
-/// which should be the same as in the corresponding process variable.
+/// The initial condition will expect a correct number of components in the
+/// configuration, which should be the same as in the corresponding process
+/// variable.
 std::unique_ptr<InitialCondition> createUniformInitialCondition(
-    BaseLib::ConfigTree const& config, int const tuple_size);
+    BaseLib::ConfigTree const& config, int const n_components);
 
 /// Distribution of values given by a mesh property defined on nodes.
 class MeshPropertyInitialCondition : public InitialCondition
@@ -84,11 +87,12 @@ private:
 };
 
 /// Construct a MeshPropertyInitialCondition from configuration.
-/// The initial condition will expect a correct tuple size in the configuration,
-/// which should be the same as in the corresponding process variable.
+/// The initial condition will expect a correct number of components in the
+/// configuration, which should be the same as in the corresponding process
+/// variable.
 std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
     BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh,
-    int const tuple_size);
+    int const n_components);
 
 }  // namespace ProcessLib
 

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -179,7 +179,8 @@ private:
 			    global_index = 0;
 #endif
 			_x->set(global_index,
-			        variable.getInitialConditionValue(*_mesh.getNode(i)));
+			        variable.getInitialConditionValue(*_mesh.getNode(i),
+			                                          component_id));
 		}
 	}
 

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -272,31 +272,11 @@ private:
 		_x->copyValues(x_copy);
 
 		std::size_t const n = _mesh.getNNodes();
-		for (ProcessVariable const& pv : _process_variables)
+		for (ProcessVariable& pv : _process_variables)
 		{
-			std::string const property_name = pv.getName();
-			// Get or create a property vector for results.
-			boost::optional<MeshLib::PropertyVector<double>&> result;
-			if (_mesh.getProperties().hasPropertyVector(property_name))
-			{
-				result =
-				    _mesh.getProperties().template getPropertyVector<double>(
-				        property_name);
-			}
-			else
-			{
-				result = _mesh.getProperties()
-				             .template createNewPropertyVector<double>(
-				                 property_name, MeshLib::MeshItemType::Node);
-			}
-
-			assert(result);
+			auto& output_data = pv.getOrCreateMeshProperty();
 
 			int const n_components = pv.getTupleSize();
-			// result's resize function is from std::vector not accounting the
-			// tuple size.
-			result->resize(x_copy.size() * n_components);
-
 			for (std::size_t i = 0; i < n; ++i)
 			{
 				MeshLib::Location const l(_mesh.getID(),

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -260,31 +260,61 @@ private:
 	{
 		DBUG("Process output.");
 
-		std::string const property_name = "Result";
-
-		// Get or create a property vector for results.
-		boost::optional<MeshLib::PropertyVector<double>&> result;
-		if (_mesh.getProperties().hasPropertyVector(property_name))
-		{
-			result = _mesh.getProperties().template getPropertyVector<double>(
-			    property_name);
-		}
-		else
-		{
-			result =
-			    _mesh.getProperties().template createNewPropertyVector<double>(
-			        property_name, MeshLib::MeshItemType::Node);
-#ifdef USE_PETSC
-			result->resize(_x->getLocalSize() + _x->getGhostSize());
-#else
-			result->resize(_x->size());
-#endif
-		}
-
-		assert(result);
-
 		// Copy result
-		_x->copyValues(*result);
+#ifdef USE_PETSC
+		// TODO It is also possible directly to copy the data for single process
+		// variable to a mesh property. It needs a vector of global indices and
+		// some PETSc magic to do so.
+		std::vector<double> x_copy(_x->getLocalSize() + _x->getGhostSize());
+#else
+		std::vector<double> x_copy(_x->size());
+#endif
+		_x->copyValues(x_copy);
+
+		std::size_t const n = _mesh.getNNodes();
+		for (ProcessVariable const& pv : _process_variables)
+		{
+			std::string const property_name = pv.getName();
+			// Get or create a property vector for results.
+			boost::optional<MeshLib::PropertyVector<double>&> result;
+			if (_mesh.getProperties().hasPropertyVector(property_name))
+			{
+				result =
+				    _mesh.getProperties().template getPropertyVector<double>(
+				        property_name);
+			}
+			else
+			{
+				result = _mesh.getProperties()
+				             .template createNewPropertyVector<double>(
+				                 property_name, MeshLib::MeshItemType::Node);
+			}
+
+			assert(result);
+
+			int const n_components = pv.getTupleSize();
+			// result's resize function is from std::vector not accounting the
+			// tuple size.
+			result->resize(x_copy.size() * n_components);
+
+			for (std::size_t i = 0; i < n; ++i)
+			{
+				MeshLib::Location const l(_mesh.getID(),
+				                          MeshLib::MeshItemType::Node, i);
+				// TODO extend component ids to multiple process variables.
+				for (int component_id = 0; component_id < n_components;
+				     ++component_id)
+				{
+					auto const index =
+					    _local_to_global_index_map->getLocalIndex(
+					        l, component_id, _x->getRangeBegin(),
+					        _x->getRangeEnd());
+
+					output_data[node_id * n_components + component_id] =
+					    x_copy[index];
+				}
+			}
+		}
 
 		// Write output file
 		DBUG("Writing output to \'%s\'.", file_name.c_str());

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -271,16 +271,16 @@ private:
 #endif
 		_x->copyValues(x_copy);
 
-		std::size_t const n = _mesh.getNNodes();
+		std::size_t const n_nodes = _mesh.getNNodes();
 		for (ProcessVariable& pv : _process_variables)
 		{
 			auto& output_data = pv.getOrCreateMeshProperty();
 
-			int const n_components = pv.getTupleSize();
-			for (std::size_t i = 0; i < n; ++i)
+			int const n_components = pv.getNumberOfComponents();
+			for (std::size_t node_id = 0; node_id < n_nodes; ++node_id)
 			{
 				MeshLib::Location const l(_mesh.getID(),
-				                          MeshLib::MeshItemType::Node, i);
+				                          MeshLib::MeshItemType::Node, node_id);
 				// TODO extend component ids to multiple process variables.
 				for (int component_id = 0; component_id < n_components;
 				     ++component_id)

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -159,11 +159,11 @@ private:
 	void setInitialConditions(ProcessVariable const& variable,
 	                          int const component_id)
 	{
-		std::size_t const n = _mesh.getNNodes();
-		for (std::size_t i = 0; i < n; ++i)
+		std::size_t const n_nodes = _mesh.getNNodes();
+		for (std::size_t node_id = 0; node_id < n_nodes; ++node_id)
 		{
 			MeshLib::Location const l(_mesh.getID(),
-			                          MeshLib::MeshItemType::Node, i);
+			                          MeshLib::MeshItemType::Node, node_id);
 			auto global_index = std::abs(
 			    _local_to_global_index_map->getGlobalIndex(l, component_id));
 #ifdef USE_PETSC
@@ -179,7 +179,7 @@ private:
 			    global_index = 0;
 #endif
 			_x->set(global_index,
-			        variable.getInitialConditionValue(*_mesh.getNode(i),
+			        variable.getInitialConditionValue(*_mesh.getNode(node_id),
 			                                          component_id));
 		}
 	}

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -21,8 +21,9 @@ namespace ProcessLib
 ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
                                  MeshLib::Mesh const& mesh,
                                  GeoLib::GEOObjects const& geometries)
-    : _name(config.getConfParam<std::string>("name"))
-    , _mesh(mesh)
+    : _name(config.getConfParam<std::string>("name")),
+      _mesh(mesh),
+      _tuple_size(config.getConfParam<int>("components"))
 {
 	DBUG("Constructing process variable %s", this->_name.c_str());
 
@@ -33,12 +34,12 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
 		if (type == "Uniform")
 		{
 			_initial_condition =
-			    createUniformInitialCondition(*ic_config);
+			    createUniformInitialCondition(*ic_config, _tuple_size);
 		}
 		else if (type == "MeshProperty")
 		{
 			_initial_condition =
-			    createMeshPropertyInitialCondition(*ic_config, _mesh);
+			    createMeshPropertyInitialCondition(*ic_config, _mesh, _tuple_size);
 		}
 		else
 		{

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -114,4 +114,24 @@ MeshLib::Mesh const& ProcessVariable::getMesh() const
 	return _mesh;
 }
 
+MeshLib::PropertyVector<double>& ProcessVariable::getOrCreateMeshProperty()
+{
+	boost::optional<MeshLib::PropertyVector<double>&> result;
+	if (_mesh.getProperties().hasPropertyVector(_name))
+	{
+		result =
+		    _mesh.getProperties().template getPropertyVector<double>(_name);
+		assert(result);
+		assert(result->size() == _mesh.getNNodes() * _tuple_size);
+	}
+	else
+	{
+		result = _mesh.getProperties().template createNewPropertyVector<double>(
+		    _name, MeshLib::MeshItemType::Node);
+		assert(result);
+		result->resize(_mesh.getNNodes() * _tuple_size);
+	}
+	return *result;
+}
+
 }  // namespace ProcessLib

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -23,7 +23,7 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
                                  GeoLib::GEOObjects const& geometries)
     : _name(config.getConfParam<std::string>("name")),
       _mesh(mesh),
-      _tuple_size(config.getConfParam<int>("components"))
+      _n_components(config.getConfParam<int>("components"))
 {
 	DBUG("Constructing process variable %s", this->_name.c_str());
 
@@ -34,12 +34,12 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
 		if (type == "Uniform")
 		{
 			_initial_condition =
-			    createUniformInitialCondition(*ic_config, _tuple_size);
+			    createUniformInitialCondition(*ic_config, _n_components);
 		}
 		else if (type == "MeshProperty")
 		{
 			_initial_condition =
-			    createMeshPropertyInitialCondition(*ic_config, _mesh, _tuple_size);
+			    createMeshPropertyInitialCondition(*ic_config, _mesh, _n_components);
 		}
 		else
 		{
@@ -122,14 +122,14 @@ MeshLib::PropertyVector<double>& ProcessVariable::getOrCreateMeshProperty()
 		result =
 		    _mesh.getProperties().template getPropertyVector<double>(_name);
 		assert(result);
-		assert(result->size() == _mesh.getNNodes() * _tuple_size);
+		assert(result->size() == _mesh.getNNodes() * _n_components);
 	}
 	else
 	{
 		result = _mesh.getProperties().template createNewPropertyVector<double>(
 		    _name, MeshLib::MeshItemType::Node);
 		assert(result);
-		result->resize(_mesh.getNNodes() * _tuple_size);
+		result->resize(_mesh.getNNodes() * _n_components);
 	}
 	return *result;
 }

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -19,7 +19,7 @@
 namespace ProcessLib
 {
 ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
-                                 MeshLib::Mesh const& mesh,
+                                 MeshLib::Mesh& mesh,
                                  GeoLib::GEOObjects const& geometries)
     : _name(config.getConfParam<std::string>("name")),
       _mesh(mesh),

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -57,8 +57,8 @@ public:
 	/// Returns a mesh on which the process variable is defined.
 	MeshLib::Mesh const& getMesh() const;
 
-	/// Returns the tuple size of the process variable.
-	int getTupleSize() const { return _tuple_size; }
+	/// Returns the number of components of the process variable.
+	int getNumberOfComponents() const { return _n_components; }
 
 	template <typename OutputIterator>
 	void initializeDirichletBCs(
@@ -97,13 +97,14 @@ public:
 	}
 
 	// Get or create a property vector for results.
-	// The returned mesh property size is number of mesh nodes times tuple size.
+	// The returned mesh property size is number of mesh nodes times number of
+	// components.
 	MeshLib::PropertyVector<double>& getOrCreateMeshProperty();
 
 private:
 	std::string const _name;
 	MeshLib::Mesh& _mesh;
-	int _tuple_size;
+	int _n_components;
 	std::unique_ptr<InitialCondition> _initial_condition;
 	std::vector<std::unique_ptr<UniformDirichletBoundaryCondition>>
 	    _dirichlet_bc_configs;

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -47,7 +47,7 @@ namespace ProcessLib
 class ProcessVariable
 {
 public:
-	ProcessVariable(BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh,
+	ProcessVariable(BaseLib::ConfigTree const& config, MeshLib::Mesh& mesh,
 	                GeoLib::GEOObjects const& geometries);
 
 	ProcessVariable(ProcessVariable&&);
@@ -98,7 +98,7 @@ public:
 
 private:
 	std::string const _name;
-	MeshLib::Mesh const& _mesh;
+	MeshLib::Mesh& _mesh;
 	int _tuple_size;
 	std::unique_ptr<InitialCondition> _initial_condition;
 	std::vector<std::unique_ptr<UniformDirichletBoundaryCondition>>

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -57,6 +57,9 @@ public:
 	/// Returns a mesh on which the process variable is defined.
 	MeshLib::Mesh const& getMesh() const;
 
+	/// Returns the tuple size of the process variable.
+	int getTupleSize() const { return _tuple_size; }
+
 	template <typename OutputIterator>
 	void initializeDirichletBCs(
 	    OutputIterator output_bcs,
@@ -87,14 +90,16 @@ public:
 		}
 	}
 
-	double getInitialConditionValue(MeshLib::Node const& n) const
+	double getInitialConditionValue(MeshLib::Node const& n,
+	                                int const component_id) const
 	{
-		return _initial_condition->getValue(n);
+		return _initial_condition->getValue(n, component_id);
 	}
 
 private:
 	std::string const _name;
 	MeshLib::Mesh const& _mesh;
+	int _tuple_size;
 	std::unique_ptr<InitialCondition> _initial_condition;
 	std::vector<std::unique_ptr<UniformDirichletBoundaryCondition>>
 	    _dirichlet_bc_configs;

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -96,6 +96,10 @@ public:
 		return _initial_condition->getValue(n, component_id);
 	}
 
+	// Get or create a property vector for results.
+	// The returned mesh property size is number of mesh nodes times tuple size.
+	MeshLib::PropertyVector<double>& getOrCreateMeshProperty();
+
 private:
 	std::string const _name;
 	MeshLib::Mesh& _mesh;

--- a/Tests/InSituLib/TestVtkMappedMeshSource.cpp
+++ b/Tests/InSituLib/TestVtkMappedMeshSource.cpp
@@ -264,7 +264,7 @@ TEST_F(InSituMesh, MappedMeshSourceRoundtrip)
 			// Check some properties on equality
 			auto doubleProps = meshProperties.getPropertyVector<double>("PointDoubleProperty");
 			auto newDoubleProps = newMeshProperties.getPropertyVector<double>("PointDoubleProperty");
-			ASSERT_EQ((*newDoubleProps).getTupleSize(), (*doubleProps).getTupleSize());
+			ASSERT_EQ((*newDoubleProps).getNumberOfComponents(), (*doubleProps).getNumberOfComponents());
 			ASSERT_EQ((*newDoubleProps).getNumberOfTuples(), (*doubleProps).getNumberOfTuples());
 			ASSERT_EQ((*newDoubleProps).size(), (*doubleProps).size());
 			for(std::size_t i = 0; i < (*doubleProps).size(); i++)
@@ -273,7 +273,7 @@ TEST_F(InSituMesh, MappedMeshSourceRoundtrip)
 			auto unsignedProps = meshProperties.getPropertyVector<unsigned>("CellUnsignedProperty");
 			auto newUnsignedIds = newMeshProperties.getPropertyVector<unsigned>("CellUnsignedProperty");
 
-			ASSERT_EQ((*newUnsignedIds).getTupleSize(), (*unsignedProps).getTupleSize());
+			ASSERT_EQ((*newUnsignedIds).getNumberOfComponents(), (*unsignedProps).getNumberOfComponents());
 			ASSERT_EQ((*newUnsignedIds).getNumberOfTuples(), (*unsignedProps).getNumberOfTuples());
 			ASSERT_EQ((*newUnsignedIds).size(), (*unsignedProps).size());
 			for(std::size_t i = 0; i < (*unsignedProps).size(); i++)
@@ -281,7 +281,7 @@ TEST_F(InSituMesh, MappedMeshSourceRoundtrip)
 
 			auto materialIds = meshProperties.getPropertyVector<int>("MaterialIDs");
 			auto newMaterialIds = newMeshProperties.getPropertyVector<int>("MaterialIDs");
-			ASSERT_EQ((*newMaterialIds).getTupleSize(), (*materialIds).getTupleSize());
+			ASSERT_EQ((*newMaterialIds).getNumberOfComponents(), (*materialIds).getNumberOfComponents());
 			ASSERT_EQ((*newMaterialIds).getNumberOfTuples(), (*materialIds).getNumberOfTuples());
 			ASSERT_EQ((*newMaterialIds).size(), (*materialIds).size());
 			for(std::size_t i = 0; i < (*materialIds).size(); i++)

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -49,7 +49,7 @@ TEST_F(MeshLibProperties, PropertyVectorTestMetaData)
 
 	ASSERT_EQ(0u, (*p).getPropertyName().compare(prop_name));
 	ASSERT_EQ(MeshLib::MeshItemType::Cell, (*p).getMeshItemType());
-	ASSERT_EQ(1u, (*p).getTupleSize());
+	ASSERT_EQ(1u, (*p).getNumberOfComponents());
 	ASSERT_EQ(0u, (*p).size());
 }
 
@@ -476,7 +476,7 @@ TEST_F(MeshLibProperties, AddDoublePropertiesTupleSize2)
 
 	ASSERT_EQ(0u, pv.getPropertyName().compare(prop_name));
 	ASSERT_EQ(MeshLib::MeshItemType::Cell, pv.getMeshItemType());
-	ASSERT_EQ(2u, pv.getTupleSize());
+	ASSERT_EQ(2u, pv.getNumberOfComponents());
 	ASSERT_EQ(0u, pv.getNumberOfTuples());
 	ASSERT_EQ(0u, pv.size());
 
@@ -487,7 +487,7 @@ TEST_F(MeshLibProperties, AddDoublePropertiesTupleSize2)
 	}
 	// check the number of tuples
 	ASSERT_EQ(number_of_tuples, pv.getNumberOfTuples());
-	ASSERT_EQ(pv.getNumberOfTuples()*pv.getTupleSize(), pv.size());
+	ASSERT_EQ(pv.getNumberOfTuples()*pv.getNumberOfComponents(), pv.size());
 	// check the values
 	for (std::size_t k(0); k<number_of_tuples; k++) {
 		ASSERT_EQ(static_cast<double>(k), pv[2*k]);


### PR DESCRIPTION
Process variable is now aware of its number of components. This is reflected in the tests by new `<components>` tag: [Tests data PR](https://github.com/ufz/ogs-data/pull/3/files).

Creation of the mesh property for each process variable is now handled by the process variable itself.

And finally the output is now generalized to all process variables of a process and is independent of number of components.
