### PR TITLE
Check for time binary

### DIFF
--- a/scripts/cmake/test/Test.cmake
+++ b/scripts/cmake/test/Test.cmake
@@ -1,8 +1,7 @@
 # Find tools and data
 find_program(DIFF_TOOL_PATH diff)
 find_program(NUMDIFF_TOOL_PATH numdiff)
-# find_program(TIME_TOOL_PATH time) # TODO: does not work Travis
-set(TIME_TOOL_PATH time)
+find_program(TIME_TOOL_PATH time)
 find_program(GREP_TOOL_PATH grep)
 find_program(BASH_TOOL_PATH bash)
 find_program(VALGRIND_TOOL_PATH valgrind)


### PR DESCRIPTION
The check was there but disabled because it did not work in the past on Travis. But now it works. If `time` is not found there is CMake warning that corresponding are disabled.

Closes #1044.