### PR TITLE
Avoid warning/error/debug messages in SurfaceGrid

### DIFF
--- a/GeoLib/Surface.cpp
+++ b/GeoLib/Surface.cpp
@@ -40,8 +40,6 @@ Surface::~Surface ()
 {
 	for (std::size_t k(0); k < _sfc_triangles.size(); k++)
 		delete _sfc_triangles[k];
-	delete _bounding_volume;
-	delete _surface_grid;
 }
 
 void Surface::addTriangle(std::size_t pnt_a, std::size_t pnt_b, std::size_t pnt_c)
@@ -53,15 +51,15 @@ void Surface::addTriangle(std::size_t pnt_a, std::size_t pnt_b, std::size_t pnt_
 		return;
 
 	// Adding a new triangle invalides the surface grid.
-	if (_surface_grid)
-		delete _surface_grid;
+	_surface_grid.reset();
+
 	_sfc_triangles.push_back(new Triangle(_sfc_pnts, pnt_a, pnt_b, pnt_c));
 	if (!_bounding_volume) {
 		std::vector<std::size_t> ids(3);
 		ids[0] = pnt_a;
 		ids[1] = pnt_b;
 		ids[2] = pnt_c;
-		_bounding_volume = new AABB(_sfc_pnts, ids);
+		_bounding_volume.reset(new AABB(_sfc_pnts, ids));
 	} else {
 		_bounding_volume->update(*_sfc_pnts[pnt_a]);
 		_bounding_volume->update(*_sfc_pnts[pnt_b]);
@@ -132,7 +130,7 @@ bool Surface::isPntInSfc(MathLib::Point3d const& pnt) const
 {
 	// Mutable _surface_grid is constructed if method is called the first time.
 	if (_surface_grid == nullptr) {
-		_surface_grid = new SurfaceGrid(this);
+		_surface_grid.reset(new SurfaceGrid(this));
 	}
 	return _surface_grid->isPointInSurface(
 		pnt, std::numeric_limits<double>::epsilon());

--- a/GeoLib/Surface.h
+++ b/GeoLib/Surface.h
@@ -96,8 +96,11 @@ protected:
 	std::vector<Triangle*> _sfc_triangles;
 	/** bounding volume is an axis aligned bounding box */
 	AABB *_bounding_volume;
-	/** a helper structure to accelerate the search */
-	SurfaceGrid * _surface_grid;
+	/// The surface grid is a helper data structure to accelerate the point
+	/// search. The method addTriangle() invalidates/resets the surface grid.
+	/// A valid surface grid is created in case the const method isPntInSfc() is
+	/// called and a valid surface grid is not existing.
+	mutable SurfaceGrid* _surface_grid;
 };
 
 }

--- a/GeoLib/Surface.h
+++ b/GeoLib/Surface.h
@@ -16,6 +16,7 @@
 #define SURFACE_H_
 
 #include <vector>
+#include <memory>
 
 #include "GeoObject.h"
 #include "Point.h"
@@ -95,12 +96,12 @@ protected:
 	/** position of pointers to the geometric points */
 	std::vector<Triangle*> _sfc_triangles;
 	/** bounding volume is an axis aligned bounding box */
-	AABB *_bounding_volume;
+	std::unique_ptr<AABB> _bounding_volume;
 	/// The surface grid is a helper data structure to accelerate the point
 	/// search. The method addTriangle() invalidates/resets the surface grid.
 	/// A valid surface grid is created in case the const method isPntInSfc() is
 	/// called and a valid surface grid is not existing.
-	mutable SurfaceGrid* _surface_grid;
+	mutable std::unique_ptr<SurfaceGrid> _surface_grid;
 };
 
 }

--- a/GeoLib/SurfaceGrid.cpp
+++ b/GeoLib/SurfaceGrid.cpp
@@ -120,10 +120,11 @@ void SurfaceGrid::sortTrianglesInGridCells(Surface const*const sfc)
 			Point const& p0(*((*sfc)[l]->getPoint(0)));
 			Point const& p1(*((*sfc)[l]->getPoint(1)));
 			Point const& p2(*((*sfc)[l]->getPoint(2)));
-			DBUG("Sorting triangle %d [(%f,%f,%f), (%f,%f,%f), (%f,%f,%f) into "
+			ERR("Sorting triangle %d [(%f,%f,%f), (%f,%f,%f), (%f,%f,%f) into "
 				"grid.",
 				l, p0[0], p0[1], p0[2], p1[0], p1[1], p1[2], p2[0], p2[1], p2[2]
 			);
+			std::abort();
 		}
 	}
 }

--- a/GeoLib/SurfaceGrid.h
+++ b/GeoLib/SurfaceGrid.h
@@ -34,7 +34,6 @@ public:
 		double eps = std::numeric_limits<double>::epsilon()) const;
 
 private:
-	friend GeoLib::Surface;
 	void sortTrianglesInGridCells(GeoLib::Surface const*const surface);
 	bool sortTriangleInGridCells(GeoLib::Triangle const*const triangle);
 	boost::optional<std::array<std::size_t,3>>


### PR DESCRIPTION
The construction of the class `SurfaceGrid` within the `Surface` is moved to the method `isPntInSfc()`. This avoids the repeatedly update of the surface grid and the warning/error/debug messages connected to the update. Since `SurfaceGrid` does not need the `Surface` as friend class a better encapsulation is realized.

**Update** In a run time test the new impl. took only ~77 % of the time the previous code needed.