### PR TITLE
Set log level at runtime

### DIFF
--- a/Applications/ApplicationsLib/LogogSetup.h
+++ b/Applications/ApplicationsLib/LogogSetup.h
@@ -12,6 +12,9 @@
 
 #include <logog/include/logog.hpp>
 
+#include <map>
+#include <memory>
+
 #include "BaseLib/LogogSimpleFormatter.h"
 
 namespace ApplicationsLib
@@ -25,21 +28,28 @@ public:
 	LogogSetup()
 	{
 		LOGOG_INITIALIZE();
-		fmt = new BaseLib::LogogSimpleFormatter;
-		logog_cout = new logog::Cout;
-		logog_cout->SetFormatter(*fmt);
+		logog_cout = std::unique_ptr<logog::Cout>(new logog::Cout);
+		SetFormatter(std::unique_ptr<BaseLib::LogogSimpleFormatter>
+			(new BaseLib::LogogSimpleFormatter));
 	}
 
 	~LogogSetup()
 	{
-		delete fmt;
-		delete logog_cout;
+		// Objects have to be deleted before shutdown
+		fmt.reset(nullptr);
+		logog_cout.reset(nullptr);
 		LOGOG_SHUTDOWN();
 	}
 
+	void SetFormatter(std::unique_ptr<logog::Formatter> formatter)
+	{
+		fmt = std::move(formatter);
+		logog_cout->SetFormatter(*fmt);
+	}
+
 private:
-	BaseLib::LogogSimpleFormatter* fmt;
-	logog::Cout* logog_cout;
+	std::unique_ptr<logog::Formatter> fmt;
+	std::unique_ptr<logog::Cout> logog_cout;
 };
 
 }	// ApplicationsLib

--- a/Applications/ApplicationsLib/LogogSetup.h
+++ b/Applications/ApplicationsLib/LogogSetup.h
@@ -47,6 +47,37 @@ public:
 		logog_cout->SetFormatter(*fmt);
 	}
 
+	void SetLevel(LOGOG_LEVEL_TYPE level)
+	{
+		logog::SetDefaultLevel(level);
+	}
+
+	void SetLevel(std::string const & level)
+	{
+		std::map<std::string, LOGOG_LEVEL_TYPE> foo =
+		{
+			{ "none", LOGOG_LEVEL_NONE },
+			{ "emergency", LOGOG_LEVEL_EMERGENCY },
+			{ "alert", LOGOG_LEVEL_ALERT},
+			{ "critical", LOGOG_LEVEL_CRITICAL },
+			{ "error", LOGOG_LEVEL_ERROR },
+			{ "warn", LOGOG_LEVEL_WARN },
+			{ "info", LOGOG_LEVEL_INFO },
+			{ "debug", LOGOG_LEVEL_DEBUG },
+			{ "all", LOGOG_LEVEL_ALL }
+		};
+
+
+		//LOGOG_LEVEL_TYPE level_type;
+		if(foo.find(level) != foo.end())
+			SetLevel(foo[level]);
+		else
+		{
+			ERR("%s is not a valid log level! Setting log level to all.", level.c_str());
+			SetLevel(LOGOG_LEVEL_ALL);
+		}
+	}
+
 private:
 	std::unique_ptr<logog::Formatter> fmt;
 	std::unique_ptr<logog::Cout> logog_cout;

--- a/Applications/ApplicationsLib/LogogSetup.h
+++ b/Applications/ApplicationsLib/LogogSetup.h
@@ -41,7 +41,7 @@ public:
 		LOGOG_SHUTDOWN();
 	}
 
-	void SetFormatter(std::unique_ptr<logog::Formatter> formatter)
+	void SetFormatter(std::unique_ptr<logog::Formatter>&& formatter)
 	{
 		fmt = std::move(formatter);
 		logog_cout->SetFormatter(*fmt);
@@ -73,8 +73,8 @@ public:
 			SetLevel(foo[level]);
 		else
 		{
-			ERR("%s is not a valid log level! Setting log level to all.", level.c_str());
-			SetLevel(LOGOG_LEVEL_ALL);
+			ERR("%s is not a valid log level! Aborting.", level.c_str());
+			std::abort();
 		}
 	}
 

--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -79,7 +79,8 @@ int main(int argc, char *argv[])
 			"(http://www.opengeosys.org) "
 			"Distributed under a Modified BSD License. "
 			"See accompanying file LICENSE.txt or "
-			"http://www.opengeosys.org/project/license",
+			"http://www.opengeosys.org/project/license\n"
+			"version: " + BaseLib::BuildInfo::git_describe,
 		' ',
 		BaseLib::BuildInfo::git_describe);
 

--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -100,6 +100,14 @@ int main(int argc, char *argv[])
 		"output directory");
 	cmd.add(outdir_arg);
 
+	TCLAP::ValueArg<std::string> log_level_arg(
+		"l", "log-level",
+		"the verbosity of logging messages: none, error, warn, info, debug, all",
+		false,
+		"all",
+		"log level");
+	cmd.add(log_level_arg);
+
 	TCLAP::SwitchArg nonfatal_arg("",
 		"config-warnings-nonfatal",
 		"warnings from parsing the configuration file will not trigger program abortion");
@@ -108,6 +116,7 @@ int main(int argc, char *argv[])
 	cmd.parse(argc, argv);
 
 	ApplicationsLib::LogogSetup logog_setup;
+	logog_setup.SetLevel(log_level_arg.getValue());
 	ApplicationsLib::LinearSolverLibrarySetup linear_solver_library_setup(
 	    argc, argv);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - New configuration tree parser
    - Checks configuration parameters more strictly, automatically prints error/warning messages.
    - Requires Boost >= 1.56 because of boost::optional with move semantics.
+ - Command line argument `-l` for OGS cli and testrunner to specify verbosity of logging, #1056
 
 ### Infrastructure
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -73,6 +73,7 @@ if(DEFINED ENV{CI})
 		--gtest_shuffle --gtest_repeat=3)
 endif()
 set(TESTRUNNER_ADDITIONAL_ARGUMENTS ${TESTRUNNER_ADDITIONAL_ARGUMENTS}
+	-l warn
 	--gtest_output=xml:./testrunner.xml)
 
 add_custom_target(tests-cleanup ${CMAKE_COMMAND} -E remove testrunner.xml)

--- a/Tests/testrunner.cpp
+++ b/Tests/testrunner.cpp
@@ -30,6 +30,7 @@
 #endif
 
 #include "Applications/ApplicationsLib/LogogSetup.h"
+#include "BaseLib/BuildInfo.h"
 #include "BaseLib/TemplateLogogFormatterSuppressedGCC.h"
 #ifdef OGS_BUILD_GUI
 #include <QApplication>
@@ -38,6 +39,15 @@
 /// Implementation of the googletest testrunner
 int main(int argc, char* argv[])
 {
+    std::string logLevel("all");
+    for (int i = 1; i < argc; i++)
+    {
+        if(i + 1 == argc)
+            break;
+        if(std::strcmp(argv[i], "-l") == 0)
+            logLevel = argv[i + 1];
+    }
+
     setlocale(LC_ALL, "C");
 #ifdef OGS_BUILD_GUI
     QApplication app(argc, argv, false);
@@ -51,6 +61,7 @@ int main(int argc, char* argv[])
         <TOPIC_LEVEL_FLAG | TOPIC_FILE_NAME_FLAG | TOPIC_LINE_NUMBER_FLAG> >
             (new BaseLib::TemplateLogogFormatterSuppressedGCC
             <TOPIC_LEVEL_FLAG | TOPIC_FILE_NAME_FLAG | TOPIC_LINE_NUMBER_FLAG>()));
+    logog_setup.SetLevel(logLevel);
 
 
 #ifdef USE_PETSC


### PR DESCRIPTION
- Added `-l` command line arguments to OGS cli and the testrunner. Possible values: `none`, `error`, `warn`, `info`, `debug`, `all`.
- `make tests` log-level is now `warn` (this suppresses verbose logging in [recent Jenkins builds](https://svn.ufz.de:8443/job/OGS-6/job/Tests_Linux/511/consoleFull)).