### PR TITLE
Added a matrix pool

### DIFF
--- a/Applications/ApplicationsLib/LinearSolverLibrarySetup.h
+++ b/Applications/ApplicationsLib/LinearSolverLibrarySetup.h
@@ -19,6 +19,8 @@
 /// The default implementation is empty providing polymorphic behaviour when
 /// using this class.
 
+#include "MathLib/LinAlg/GlobalMatrixProviders.h"
+
 #if defined(USE_PETSC)
 #include <petsc.h>
 #include <mpi.h>
@@ -35,6 +37,7 @@ struct LinearSolverLibrarySetup final
 
 	~LinearSolverLibrarySetup()
 	{
+		MathLib::cleanupGlobalMatrixProviders();
 		PetscFinalize();
 		MPI_Finalize();
 	}
@@ -51,7 +54,11 @@ struct LinearSolverLibrarySetup final
 		lis_initialize(&argc, &argv);
 	}
 
-	~LinearSolverLibrarySetup() { lis_finalize(); }
+	~LinearSolverLibrarySetup()
+	{
+		MathLib::cleanupGlobalMatrixProviders();
+		lis_finalize();
+	}
 };
 }	// ApplicationsLib
 #else
@@ -60,7 +67,10 @@ namespace ApplicationsLib
 struct LinearSolverLibrarySetup final
 {
 	LinearSolverLibrarySetup(int /*argc*/, char* /*argv*/[]) {}
-	~LinearSolverLibrarySetup() {}
+	~LinearSolverLibrarySetup()
+	{
+		MathLib::cleanupGlobalMatrixProviders();
+	}
 };
 }	// ApplicationsLib
 #endif

--- a/MathLib/LinAlg/BLAS.cpp
+++ b/MathLib/LinAlg/BLAS.cpp
@@ -9,6 +9,7 @@
 
 #include "BLAS.h"
 
+// TODO reorder BLAS function signatures?
 
 // Dense Eigen matrices and vectors ////////////////////////////////////////
 #ifdef OGS_USE_EIGEN

--- a/MathLib/LinAlg/Eigen/EigenMatrix.h
+++ b/MathLib/LinAlg/Eigen/EigenMatrix.h
@@ -35,9 +35,6 @@ public:
     using RawMatrixType = Eigen::SparseMatrix<double, Eigen::RowMajor>;
     using IndexType = RawMatrixType::Index;
 
-    // TODO: preliminary
-    EigenMatrix() {}
-
     // TODO The matrix constructor should take num_rows and num_cols as arguments
     //      that is left for a later refactoring.
     /**

--- a/MathLib/LinAlg/Eigen/EigenTools.h
+++ b/MathLib/LinAlg/Eigen/EigenTools.h
@@ -11,6 +11,7 @@
 #define EIGENTOOLS_H_
 
 #include <vector>
+#include <logog/include/logog.hpp>
 
 #include "EigenMatrix.h" // for EigenMatrix::IndexType
 
@@ -37,9 +38,11 @@ void applyKnownSolution(Eigen::MatrixXd &A, Eigen::VectorXd &b, Eigen::VectorXd 
 		const std::vector<Eigen::MatrixXd::Index> &_vec_knownX_id,
 		const std::vector<double> &_vec_knownX_x, double penalty_scaling = 1e+10)
 {
-	// TODO implement
 	(void) A; (void) b; (void) _vec_knownX_id; (void) _vec_knownX_x;
 	(void) penalty_scaling;
+
+	ERR("Method not implemented."); // TODO implement
+	std::abort();
 }
 
 } // MathLib

--- a/MathLib/LinAlg/GlobalMatrixProviders.cpp
+++ b/MathLib/LinAlg/GlobalMatrixProviders.cpp
@@ -1,0 +1,55 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include<memory>
+
+#include "ProcessLib/NumericsConfig.h"
+
+#include "GlobalMatrixProviders.h"
+#include "SimpleMatrixVectorProvider.h"
+
+
+// Initializes the static members of the structs in the header file
+// associated with this file.
+#define INITIALIZE_GLOBAL_MATRIX_VECTOR_PROVIDER(MAT, VEC, VARNAME) \
+    static std::unique_ptr<MathLib::SimpleMatrixVectorProvider<MAT, VEC>> VARNAME{ \
+        new MathLib::SimpleMatrixVectorProvider<MAT, VEC>}; \
+    \
+    namespace MathLib { \
+    template<> \
+    VectorProvider<VEC>& GlobalVectorProvider<VEC>::provider = *VARNAME; \
+    \
+    template<> \
+    MatrixProvider<MAT>& GlobalMatrixProvider<MAT>::provider = *VARNAME; \
+    }
+
+
+#ifdef OGS_USE_EIGEN
+
+INITIALIZE_GLOBAL_MATRIX_VECTOR_PROVIDER(Eigen::MatrixXd, Eigen::VectorXd,
+                                         eigenGlobalMatrixVectorProvider)
+
+#endif
+
+
+using GlobalMatrix = GlobalSetupType::MatrixType;
+using GlobalVector = GlobalSetupType::VectorType;
+
+INITIALIZE_GLOBAL_MATRIX_VECTOR_PROVIDER(GlobalMatrix, GlobalVector,
+                                         globalSetupGlobalMatrixVectorProvider)
+
+
+namespace MathLib
+{
+void cleanupGlobalMatrixProviders()
+{
+    eigenGlobalMatrixVectorProvider.reset();
+    globalSetupGlobalMatrixVectorProvider.reset();
+}
+}

--- a/MathLib/LinAlg/GlobalMatrixProviders.h
+++ b/MathLib/LinAlg/GlobalMatrixProviders.h
@@ -1,0 +1,34 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef MATHLIB_GLOBAL_MATRIX_PROVIDERS
+#define MATHLIB_GLOBAL_MATRIX_PROVIDERS
+
+#include "MatrixProviderUser.h"
+
+namespace MathLib
+{
+
+template<typename Vector>
+struct GlobalVectorProvider
+{
+    static VectorProvider<Vector>& provider;
+};
+
+template<typename Matrix>
+struct GlobalMatrixProvider
+{
+    static MatrixProvider<Matrix>& provider;
+};
+
+void cleanupGlobalMatrixProviders();
+
+} // MathLib
+
+#endif // MATHLIB_GLOBAL_MATRIX_PROVIDERS

--- a/MathLib/LinAlg/MatrixProviderUser.h
+++ b/MathLib/LinAlg/MatrixProviderUser.h
@@ -1,0 +1,131 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef MATHLIB_MATRIX_PROVIDER_USER_H
+#define MATHLIB_MATRIX_PROVIDER_USER_H
+
+#include <cstddef>
+
+namespace MathLib
+{
+
+struct MatrixSpecifications
+{
+    std::size_t const nrows;
+    std::size_t const ncols;
+};
+
+class MatrixSpecificationsProvider
+{
+public:
+    virtual MatrixSpecifications getMatrixSpecifications() const = 0;
+
+    virtual ~MatrixSpecificationsProvider() = default;
+};
+
+
+/*! Manages storage for vectors.
+ *
+ * This interface provides storage management semantics for vectors, which
+ * can be acquired at a certain point in time, be released later on and
+ * be acquired again etc.
+ *
+ * "Released" means that the caller indicates, that he currently does not need
+ * that \c Vector instance, i.e, Either it is not needed anymore for the entire
+ * program run, or it is temporarily not needed, but might be aquired again
+ * later on. Thereby the implementation of this interface can decide, whether
+ * the storage for the specific vector can be freed or reused in the meantime.
+ *
+ * All get-methods of this class come in two variants: One with an \c id argument,
+ * and one without. The latter makes it possible to temporarily release a vector
+ * during the program run and re-acquire it again. The former variant is intended
+ * as a short-cut that simplifies vector acquisition for callers that will use
+ * the same vector throughout all of their lifetime without releasing it
+ * intermediately.
+ *
+ * \attention
+ * The first time a vector is acquired by a method with \c id argument, the \c id
+ * has to be initialized with zero. The respective method then will set the \c id
+ * to the specific \c id of the returned vector.
+ */
+template<typename Vector>
+class VectorProvider
+{
+public:
+    using MSP = MatrixSpecificationsProvider;
+
+    //! Get an uninitialized vector.
+    virtual Vector& getVector() = 0;
+
+    //! Get an uninitialized vector with the given \c id.
+    virtual Vector& getVector(std::size_t& id) = 0;
+
+    //! Get a copy of \c x.
+    virtual Vector& getVector(Vector const& x) = 0;
+
+    //! Get a copy of \c x in the storage of the vector with the given \c id.
+    virtual Vector& getVector(Vector const& x, std::size_t& id) = 0;
+
+    //! Get a vector according to the given specifications.
+    virtual Vector& getVector(MSP const& msp) = 0;
+
+    //! Get a vector according to the given specifications in the storage
+    //! of the vector with the given \c id.
+    virtual Vector& getVector(MSP const& msp, std::size_t& id) = 0;
+
+    //! Release the given vector.
+    //!
+    //! \pre \c x must have been acquired before, i.e., you must not call this
+    //! method twice in a row in the same \c x!
+    virtual void releaseVector(Vector const& x) = 0;
+
+    virtual ~VectorProvider() = default;
+};
+
+/*! Manages storage for matrices.
+ *
+ * This the matrix-analog of VectorProvider. The same notes apply to this class.
+ */
+template<typename Matrix>
+class MatrixProvider
+{
+public:
+    using MSP = MatrixSpecificationsProvider;
+
+    //! Get an uninitialized matrix.
+    virtual Matrix& getMatrix() = 0;
+
+    //! Get an uninitialized matrix with the given \c id.
+    virtual Matrix& getMatrix(std::size_t& id) = 0;
+
+    //! Get a copy of \c A.
+    virtual Matrix& getMatrix(Matrix const& A) = 0;
+
+    //! Get a copy of \c A in the storage of the matrix with the given \c id.
+    virtual Matrix& getMatrix(Matrix const& A, std::size_t& id) = 0;
+
+    //! Get a matrix according to the given specifications.
+    virtual Matrix& getMatrix(MSP const& msp) = 0;
+
+    //! Get a matrix according to the given specifications in the storage
+    //! of the matrix with the given \c id.
+    virtual Matrix& getMatrix(MSP const& msp, std::size_t& id) = 0;
+
+    //! Release the given matrix.
+    //!
+    //! \pre \c A must have been acquired before, i.e., you must not call this
+    //! method twice in a row in the same \c A!
+    virtual void releaseMatrix(Matrix const& A) = 0;
+
+    virtual ~MatrixProvider() = default;
+};
+
+} // namespace MathLib
+
+#endif // MATHLIB_MATRIX_PROVIDER_USER_H

--- a/MathLib/LinAlg/MatrixVectorTraits.cpp
+++ b/MathLib/LinAlg/MatrixVectorTraits.cpp
@@ -1,0 +1,163 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "MatrixVectorTraits.h"
+
+#ifdef OGS_USE_EIGEN
+
+namespace MathLib
+{
+
+std::unique_ptr<Eigen::MatrixXd>
+MatrixVectorTraits<Eigen::MatrixXd>::
+newInstance()
+{
+    return std::unique_ptr<Eigen::MatrixXd>(new Eigen::MatrixXd);
+}
+
+std::unique_ptr<Eigen::MatrixXd>
+MatrixVectorTraits<Eigen::MatrixXd>::
+newInstance(Eigen::MatrixXd const& A)
+{
+    return std::unique_ptr<Eigen::MatrixXd>(new Eigen::MatrixXd(A));
+}
+
+std::unique_ptr<Eigen::MatrixXd>
+MatrixVectorTraits<Eigen::MatrixXd>::
+newInstance(MatrixSpecifications const& spec)
+{
+    return std::unique_ptr<Eigen::MatrixXd>(new Eigen::MatrixXd(spec.nrows, spec.ncols));
+}
+
+std::unique_ptr<Eigen::VectorXd>
+MatrixVectorTraits<Eigen::VectorXd>::
+newInstance()
+{
+    return std::unique_ptr<Eigen::VectorXd>(new Eigen::VectorXd);
+}
+
+std::unique_ptr<Eigen::VectorXd>
+MatrixVectorTraits<Eigen::VectorXd>::
+newInstance(Eigen::VectorXd const& A)
+{
+    return std::unique_ptr<Eigen::VectorXd>(new Eigen::VectorXd(A));
+}
+
+std::unique_ptr<Eigen::VectorXd>
+MatrixVectorTraits<Eigen::VectorXd>::
+newInstance(MatrixSpecifications const& spec)
+{
+    return std::unique_ptr<Eigen::VectorXd>(new Eigen::VectorXd(spec.nrows));
+}
+
+} // namespace MathLib
+
+#endif // OGS_USE_EIGEN
+
+
+#ifdef USE_PETSC
+
+namespace MathLib
+{
+
+std::unique_ptr<PETScMatrix>
+MatrixVectorTraits<PETScMatrix>::
+newInstance()
+{
+    return std::unique_ptr<PETScMatrix>(new PETScMatrix(0, 0)); // TODO default constructor
+}
+
+std::unique_ptr<PETScMatrix>
+MatrixVectorTraits<PETScMatrix>::
+newInstance(PETScMatrix const& A)
+{
+    return std::unique_ptr<PETScMatrix>(new PETScMatrix(A));
+}
+
+std::unique_ptr<PETScMatrix>
+MatrixVectorTraits<PETScMatrix>::
+newInstance(MatrixSpecifications const& spec)
+{
+    return std::unique_ptr<PETScMatrix>(new PETScMatrix(spec.nrows)); // TODO sparsity pattern
+}
+
+std::unique_ptr<PETScVector>
+MatrixVectorTraits<PETScVector>::
+newInstance()
+{
+    return std::unique_ptr<PETScVector>(new PETScVector);
+}
+
+std::unique_ptr<PETScVector>
+MatrixVectorTraits<PETScVector>::
+newInstance(PETScVector const& x)
+{
+    return std::unique_ptr<PETScVector>(new PETScVector(x));
+}
+
+std::unique_ptr<PETScVector>
+MatrixVectorTraits<PETScVector>::
+newInstance(MatrixSpecifications const& spec)
+{
+    return std::unique_ptr<PETScVector>(new PETScVector(spec.nrows));
+}
+
+} // namespace MathLib
+
+
+#elif defined(OGS_USE_EIGEN)
+
+namespace MathLib
+{
+
+std::unique_ptr<EigenMatrix>
+MatrixVectorTraits<EigenMatrix>::
+newInstance()
+{
+    return std::unique_ptr<EigenMatrix>(new EigenMatrix(0, 0)); // TODO default constructor
+}
+
+std::unique_ptr<EigenMatrix>
+MatrixVectorTraits<EigenMatrix>::
+newInstance(EigenMatrix const& A)
+{
+    return std::unique_ptr<EigenMatrix>(new EigenMatrix(A));
+}
+
+std::unique_ptr<EigenMatrix>
+MatrixVectorTraits<EigenMatrix>::
+newInstance(MatrixSpecifications const& spec)
+{
+    return std::unique_ptr<EigenMatrix>(new EigenMatrix(spec.nrows)); // TODO sparsity pattern
+}
+
+std::unique_ptr<EigenVector>
+MatrixVectorTraits<EigenVector>::
+newInstance()
+{
+    return std::unique_ptr<EigenVector>(new EigenVector);
+}
+
+std::unique_ptr<EigenVector>
+MatrixVectorTraits<EigenVector>::
+newInstance(EigenVector const& x)
+{
+    return std::unique_ptr<EigenVector>(new EigenVector(x));
+}
+
+std::unique_ptr<EigenVector>
+MatrixVectorTraits<EigenVector>::
+newInstance(MatrixSpecifications const& spec)
+{
+    return std::unique_ptr<EigenVector>(new EigenVector(spec.nrows));
+}
+
+} // namespace MathLib
+
+#endif // defined(OGS_USE_EIGEN)

--- a/MathLib/LinAlg/MatrixVectorTraits.h
+++ b/MathLib/LinAlg/MatrixVectorTraits.h
@@ -1,0 +1,72 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef MATHLIB_MATRIX_VECTOR_TRAITS_H
+#define MATHLIB_MATRIX_VECTOR_TRAITS_H
+
+#include<memory>
+
+#include "MatrixProviderUser.h"
+
+namespace MathLib
+{
+template<typename Matrix>
+struct MatrixVectorTraits;
+}
+
+#define SPECIALIZE_MATRIX_VECTOR_TRAITS(MATVEC, IDX) \
+    template<> struct MatrixVectorTraits<MATVEC> { \
+        using Index = IDX; \
+        static std::unique_ptr<MATVEC> newInstance(); \
+        static std::unique_ptr<MATVEC> newInstance(MATVEC const& A); \
+        static std::unique_ptr<MATVEC> newInstance(MatrixSpecifications const& spec); \
+    };
+
+
+#ifdef OGS_USE_EIGEN
+
+#include<Eigen/Core>
+
+namespace MathLib
+{
+SPECIALIZE_MATRIX_VECTOR_TRAITS(Eigen::MatrixXd, Eigen::MatrixXd::Index);
+SPECIALIZE_MATRIX_VECTOR_TRAITS(Eigen::VectorXd, Eigen::VectorXd::Index);
+}
+
+#endif
+
+
+#ifdef USE_PETSC
+
+#include "MathLib/LinAlg/PETSc/PETScMatrix.h"
+#include "MathLib/LinAlg/PETSc/PETScVector.h"
+
+namespace MathLib
+{
+SPECIALIZE_MATRIX_VECTOR_TRAITS(PETScMatrix, PETScMatrix::IndexType);
+SPECIALIZE_MATRIX_VECTOR_TRAITS(PETScVector, PETScVector::IndexType);
+}
+
+
+#elif defined(OGS_USE_EIGEN)
+
+#include "MathLib/LinAlg/Eigen/EigenMatrix.h"
+#include "MathLib/LinAlg/Eigen/EigenVector.h"
+
+namespace MathLib
+{
+SPECIALIZE_MATRIX_VECTOR_TRAITS(EigenMatrix, EigenMatrix::IndexType);
+SPECIALIZE_MATRIX_VECTOR_TRAITS(EigenVector, EigenVector::IndexType);
+}
+
+#endif
+
+#undef SPECIALIZE_MATRIX_VECTOR_TRAITS
+
+#endif // MATHLIB_MATRIX_VECTOR_TRAITS_H

--- a/MathLib/LinAlg/SimpleMatrixVectorProvider-impl.h
+++ b/MathLib/LinAlg/SimpleMatrixVectorProvider-impl.h
@@ -1,0 +1,281 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include <cassert>
+#include <logog/include/logog.hpp>
+
+#include "BLAS.h"
+#include "MatrixVectorTraits.h"
+#include "SimpleMatrixVectorProvider.h"
+
+namespace detail
+{
+
+template<typename MatVec>
+MatVec*
+transfer(std::map<std::size_t, MatVec*>& from_unused,
+         std::map<MatVec*, std::size_t>& to_used,
+         typename std::map<std::size_t, MatVec*>::iterator it)
+{
+    auto const id = it->first;
+    auto& ptr = it->second;
+
+    auto res = to_used.emplace(ptr, id);
+    assert(res.second && "Emplacement failed.");
+    from_unused.erase(it);
+    return res.first->first;
+}
+
+template<typename MatVec>
+void
+transfer(std::map<MatVec*, std::size_t>& from_used,
+         std::map<std::size_t, MatVec*>& to_unused,
+         typename std::map<MatVec*, std::size_t>::iterator it)
+{
+    auto& ptr = it->first;
+    auto const id = it->second;
+
+    auto res = to_unused.emplace(id, ptr);
+    assert(res.second && "Emplacement failed.");
+    (void) res; // res unused if NDEBUG
+    from_used.erase(it);
+}
+
+} // detail
+
+
+namespace MathLib
+{
+
+template<typename Matrix, typename Vector>
+template<bool do_search, typename MatVec, typename... Args>
+std::pair<MatVec*, bool>
+SimpleMatrixVectorProvider<Matrix, Vector>::
+get_(std::size_t& id,
+     std::map<std::size_t, MatVec*>& unused_map,
+     std::map<MatVec*, std::size_t>& used_map,
+     Args&&... args)
+{
+    if (id >= _next_id) {
+        ERR("An obviously uninitialized id argument has been passed."
+            " This might not be a serious error for the current implementation,"
+            " but it might become one in the future."
+            " Hence, I will abort now.");
+        std::abort();
+    }
+
+    if (do_search)
+    {
+        auto it = unused_map.find(id);
+        if (it != unused_map.end()) // unused matrix/vector found
+            return { ::detail::transfer(unused_map, used_map, it), false };
+    }
+
+    // not searched or not found, so create a new one
+    id = _next_id++;
+    auto res = used_map.emplace(
+        MatrixVectorTraits<MatVec>::newInstance(std::forward<Args>(args)...).release(),
+        id);
+    assert(res.second && "Emplacement failed.");
+    return { res.first->first, true };
+}
+
+template<typename Matrix, typename Vector>
+template<bool do_search, typename... Args>
+std::pair<Matrix*, bool>
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getMatrix_(std::size_t& id, Args&&... args)
+{
+    return get_<do_search>(id, _unused_matrices, _used_matrices, std::forward<Args>(args)...);
+}
+
+
+template<typename Matrix, typename Vector>
+Matrix&
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getMatrix()
+{
+    std::size_t id = 0u;
+    return *getMatrix_<false>(id).first;
+}
+
+template<typename Matrix, typename Vector>
+Matrix&
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getMatrix(std::size_t& id)
+{
+    return *getMatrix_<true>(id).first;
+}
+
+template<typename Matrix, typename Vector>
+Matrix&
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getMatrix(MatrixSpecificationsProvider const& msp)
+{
+    std::size_t id = 0u;
+    auto const& mat_spec = msp.getMatrixSpecifications();
+    return *getMatrix_<false>(id, mat_spec).first;
+    // TODO assert that the returned object always is of the right size
+}
+
+template<typename Matrix, typename Vector>
+Matrix&
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getMatrix(MatrixSpecificationsProvider const& msp, std::size_t& id)
+{
+    auto const& mat_spec = msp.getMatrixSpecifications();
+    return *getMatrix_<true>(id, mat_spec).first;
+    // TODO assert that the returned object always is of the right size
+}
+
+template<typename Matrix, typename Vector>
+Matrix&
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getMatrix(Matrix const& A)
+{
+    std::size_t id = 0u;
+    auto const& res = getMatrix_<false>(id, A);
+    if (!res.second) // no new object has been created
+        BLAS::copy(A, *res.first);
+    return *res.first;
+}
+
+template<typename Matrix, typename Vector>
+Matrix&
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getMatrix(Matrix const& A, std::size_t& id)
+{
+    auto const& res = getMatrix_<true>(id, A);
+    if (!res.second) // no new object has been created
+        BLAS::copy(A, *res.first);
+    return *res.first;
+}
+
+template<typename Matrix, typename Vector>
+void
+SimpleMatrixVectorProvider<Matrix, Vector>::
+releaseMatrix(Matrix const& A)
+{
+    auto it = _used_matrices.find(const_cast<Matrix*>(&A));
+    if (it == _used_matrices.end()) {
+        ERR("The given matrix has not been found. Cannot release it. Aborting.");
+        std::abort();
+    } else {
+        ::detail::transfer(_used_matrices, _unused_matrices, it);
+    }
+}
+
+template<typename Matrix, typename Vector>
+template<bool do_search, typename... Args>
+std::pair<Vector*, bool>
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getVector_(std::size_t& id, Args&&... args)
+{
+    return get_<do_search>(id, _unused_vectors, _used_vectors, std::forward<Args>(args)...);
+}
+
+
+template<typename Matrix, typename Vector>
+Vector&
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getVector()
+{
+    std::size_t id = 0u;
+    return *getVector_<false>(id).first;
+}
+
+template<typename Matrix, typename Vector>
+Vector&
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getVector(std::size_t& id)
+{
+    return *getVector_<true>(id).first;
+}
+
+template<typename Matrix, typename Vector>
+Vector&
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getVector(MatrixSpecificationsProvider const& msp)
+{
+    std::size_t id = 0u;
+    auto const& mat_spec = msp.getMatrixSpecifications();
+    return *getVector_<false>(id, mat_spec).first;
+    // TODO assert that the returned object always is of the right size
+}
+
+template<typename Matrix, typename Vector>
+Vector&
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getVector(MatrixSpecificationsProvider const& msp, std::size_t& id)
+{
+    auto const& mat_spec = msp.getMatrixSpecifications();
+    return *getVector_<true>(id, mat_spec).first;
+    // TODO assert that the returned object always is of the right size
+}
+
+template<typename Matrix, typename Vector>
+Vector&
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getVector(Vector const& x)
+{
+    std::size_t id = 0u;
+    auto const& res = getVector_<false>(id, x);
+    if (!res.second) // no new object has been created
+        BLAS::copy(x, *res.first);
+    return *res.first;
+}
+
+template<typename Matrix, typename Vector>
+Vector&
+SimpleMatrixVectorProvider<Matrix, Vector>::
+getVector(Vector const& x, std::size_t& id)
+{
+    auto const& res = getVector_<true>(id, x);
+    if (!res.second) // no new object has been created
+        BLAS::copy(x, *res.first);
+    return *res.first;
+}
+
+template<typename Matrix, typename Vector>
+void
+SimpleMatrixVectorProvider<Matrix, Vector>::
+releaseVector(Vector const& x)
+{
+    auto it = _used_vectors.find(const_cast<Vector*>(&x));
+    if (it == _used_vectors.end()) {
+        ERR("The given vector has not been found. Cannot release it. Aborting.");
+        std::abort();
+    } else {
+        ::detail::transfer(_used_vectors, _unused_vectors, it);
+    }
+}
+
+template<typename Matrix, typename Vector>
+SimpleMatrixVectorProvider<Matrix, Vector>::
+~SimpleMatrixVectorProvider()
+{
+    if ((!_used_matrices.empty()) || (!_used_vectors.empty())) {
+        WARN("There are still some matrices and vectors in use."
+             " This might be an indicator of a possible waste of memory.");
+    }
+
+    for (auto& id_ptr : _unused_matrices)
+        delete id_ptr.second;
+
+    for (auto& ptr_id : _used_matrices)
+        delete ptr_id.first;
+
+    for (auto& id_ptr : _unused_vectors)
+        delete id_ptr.second;
+
+    for (auto& ptr_id : _used_vectors)
+        delete ptr_id.first;
+}
+
+} // MathLib

--- a/MathLib/LinAlg/SimpleMatrixVectorProvider.h
+++ b/MathLib/LinAlg/SimpleMatrixVectorProvider.h
@@ -1,0 +1,97 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef MATHLIB_SIMPLE_MATRIX_PROVIDER_H
+#define MATHLIB_SIMPLE_MATRIX_PROVIDER_H
+
+#include<map>
+#include<memory>
+
+#include "MatrixProviderUser.h"
+
+namespace MathLib
+{
+
+/*! Manages storage for matrices and vectors.
+ *
+ * This is a simple implementation of the MatrixProvider and VectorProvider interfaces.
+ *
+ * It is simple insofar it does not reuse released matrices/vectors, but keeps them in
+ * memory until they are acquired again by the user.
+ */
+template<typename Matrix, typename Vector>
+class SimpleMatrixVectorProvider final
+        : public MatrixProvider<Matrix>
+        , public VectorProvider<Vector>
+{
+public:
+    SimpleMatrixVectorProvider() = default;
+
+    // no copies
+    SimpleMatrixVectorProvider(SimpleMatrixVectorProvider const&) = delete;
+    SimpleMatrixVectorProvider& operator=(SimpleMatrixVectorProvider const&) = delete;
+
+    using MSP = MatrixSpecificationsProvider;
+
+    Vector& getVector() override;
+    Vector& getVector(std::size_t& id) override;
+
+    Vector& getVector(Vector const& x) override;
+    Vector& getVector(Vector const& x, std::size_t& id) override;
+
+    Vector& getVector(MSP const& msp) override;
+    Vector& getVector(MSP const& msp, std::size_t& id) override;
+
+    void releaseVector(Vector const& x) override;
+
+    Matrix& getMatrix() override;
+    Matrix& getMatrix(std::size_t& id) override;
+
+    Matrix& getMatrix(Matrix const& A) override;
+    Matrix& getMatrix(Matrix const& A, std::size_t& id) override;
+
+    Matrix& getMatrix(MSP const& msp) override;
+    Matrix& getMatrix(MSP const& msp, std::size_t& id) override;
+
+    void releaseMatrix(Matrix const& A) override;
+
+    ~SimpleMatrixVectorProvider();
+
+private:
+    template<bool do_search, typename... Args>
+    std::pair<Matrix*, bool> getMatrix_(std::size_t& id, Args&&... args);
+
+    template<bool do_search, typename... Args>
+    std::pair<Vector*, bool> getVector_(std::size_t& id, Args&&... args);
+
+    // returns a pair with the pointer to the matrix/vector and
+    // a boolean indicating if a new object has been built (then true else false)
+    template<bool do_search, typename MatVec, typename... Args>
+    std::pair<MatVec*, bool>
+    get_(std::size_t& id,
+         std::map<std::size_t, MatVec*>& unused_map,
+         std::map<MatVec*, std::size_t>& used_map,
+         Args&&... args);
+
+    std::size_t _next_id = 1;
+
+    std::map<std::size_t, Matrix*> _unused_matrices;
+    std::map<Matrix*, std::size_t> _used_matrices;
+
+    std::map<std::size_t, Vector*> _unused_vectors;
+    std::map<Vector*, std::size_t> _used_vectors;
+};
+
+
+
+} // namespace MathLib
+
+#include "SimpleMatrixVectorProvider-impl.h"
+
+#endif // MATHLIB_SIMPLE_MATRIX_PROVIDER_H

--- a/MathLib/LinAlg/Solvers/GaussAlgorithm.h
+++ b/MathLib/LinAlg/Solvers/GaussAlgorithm.h
@@ -49,9 +49,10 @@ public:
 	 * of all solvers of systems of linear equations. For this reason the
 	 * second argument was introduced.
 	 */
-	GaussAlgorithm(const std::string /*solver_name*/ = "",
-	               BaseLib::ConfigTree const*const /*option*/ = nullptr)
+	GaussAlgorithm(const std::string solver_name = "",
+	               BaseLib::ConfigTree const*const option = nullptr)
 	{
+		(void) solver_name; (void) option; // silence both compiler and doxygen warnings.
 	}
 
 	/**

--- a/MathLib/LinAlg/UnifiedMatrixSetters.cpp
+++ b/MathLib/LinAlg/UnifiedMatrixSetters.cpp
@@ -1,0 +1,179 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include <cassert>
+#include "UnifiedMatrixSetters.h"
+
+#ifdef OGS_USE_EIGEN
+
+// Dense Eigen matrix/vector //////////////////////////////////////////
+
+namespace MathLib
+{
+
+void setMatrix(Eigen::MatrixXd& m,
+               Eigen::MatrixXd::Index const rows, Eigen::MatrixXd::Index const cols,
+               std::initializer_list<double> values)
+{
+    using IndexType = Eigen::MatrixXd::Index;
+    assert((IndexType) values.size() == rows*cols);
+
+    auto it = values.begin();
+    for (IndexType r=0; r<rows; ++r) {
+        for (IndexType c=0; c<cols; ++c) {
+            m(r, c) = *(it++);
+        }
+    }
+}
+
+void setMatrix(Eigen::MatrixXd& m, Eigen::MatrixXd const& tmp)
+{
+    m = tmp;
+}
+
+void addToMatrix(Eigen::MatrixXd& m,
+                 Eigen::MatrixXd::Index const rows, Eigen::MatrixXd::Index const cols,
+                 std::initializer_list<double> values)
+{
+    using IndexType = Eigen::MatrixXd::Index;
+    assert((IndexType) values.size() == rows*cols);
+
+    auto it = values.begin();
+    for (IndexType r=0; r<rows; ++r) {
+        for (IndexType c=0; c<cols; ++c) {
+            m(r, c) += *(it++);
+        }
+    }
+}
+
+double norm(Eigen::VectorXd const& x) { return x.norm(); }
+
+void setVector(Eigen::VectorXd& v, std::initializer_list<double> values)
+{
+    assert((std::size_t) v.size() == values.size());
+    auto it = values.begin();
+    for (std::size_t i=0; i<values.size(); ++i) v[i] = *(it++);
+}
+
+} // namespace MathLib
+
+#endif // OGS_USE_EIGEN
+
+
+#ifdef USE_PETSC
+
+// Global PETScMatrix/PETScVector //////////////////////////////////////////
+
+#include "MathLib/LinAlg/PETSc/PETScVector.h"
+
+namespace MathLib
+{
+
+double norm(PETScVector const& x)
+{
+    return x.getNorm();
+}
+
+void setVector(PETScVector& v,
+               std::initializer_list<double> values)
+{
+    (void) v; (void) values;
+    // TODO implement
+}
+
+
+void setMatrix(PETScMatrix& m,
+               PETScMatrix::IndexType const rows,
+               PETScMatrix::IndexType const cols,
+               std::initializer_list<double> values)
+{
+    (void) m; (void) rows; (void) cols; (void) values;
+    // TODO implement
+}
+
+void setMatrix(PETScMatrix& m, Eigen::MatrixXd const& tmp)
+{
+
+    (void) m; (void) tmp;
+    // TODO implement
+}
+
+void addToMatrix(PETScMatrix& m,
+                 PETScMatrix::IndexType const rows,
+                 PETScMatrix::IndexType const cols,
+                 std::initializer_list<double> values)
+{
+    (void) m; (void) rows; (void) cols; (void) values;
+    // TODO implement
+}
+
+} // namespace MathLib
+
+
+#elif defined(OGS_USE_EIGEN)
+
+// Sparse global EigenMatrix/EigenVector //////////////////////////////////////////
+
+#include "MathLib/LinAlg/Eigen/EigenVector.h"
+
+namespace MathLib
+{
+
+void setVector(EigenVector& v,
+                      std::initializer_list<double> values)
+{
+    setVector(v.getRawVector(), values);
+}
+
+void setMatrix(EigenMatrix& m,
+               EigenMatrix::IndexType const rows,
+               EigenMatrix::IndexType const cols,
+               std::initializer_list<double> values)
+{
+    using IndexType = EigenMatrix::IndexType;
+    assert((IndexType) values.size() == rows*cols);
+    Eigen::MatrixXd tmp(rows, cols);
+
+    auto it = values.begin();
+    for (IndexType r=0; r<rows; ++r) {
+        for (IndexType c=0; c<cols; ++c) {
+            tmp(r, c) = *(it++);
+        }
+    }
+
+    m.getRawMatrix() = tmp.sparseView();
+}
+
+void setMatrix(EigenMatrix& m, Eigen::MatrixXd const& tmp)
+{
+    m.getRawMatrix() = tmp.sparseView();
+}
+
+void addToMatrix(EigenMatrix& m,
+                 EigenMatrix::IndexType const rows,
+                 EigenMatrix::IndexType const cols,
+                 std::initializer_list<double> values)
+{
+    using IndexType = EigenMatrix::IndexType;
+    assert((IndexType) values.size() == rows*cols);
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> tmp(rows, cols);
+
+    auto it = values.begin();
+    for (IndexType r=0; r<rows; ++r) {
+        for (IndexType c=0; c<cols; ++c) {
+            tmp(r, c) = *(it++);
+        }
+    }
+
+    m.getRawMatrix() += tmp.sparseView();
+}
+
+} // namespace MathLib
+
+#endif // OGS_USE_EIGEN

--- a/MathLib/LinAlg/UnifiedMatrixSetters.h
+++ b/MathLib/LinAlg/UnifiedMatrixSetters.h
@@ -7,66 +7,39 @@
  *
  */
 
+// TODO merge that with MatrixVectorTraits?
+
 #ifndef MATHLIB_UNIFIED_MATRIX_SETTERS_H
 #define MATHLIB_UNIFIED_MATRIX_SETTERS_H
 
 #include <initializer_list>
-#include <cassert>
 
+#ifdef OGS_USE_EIGEN
 
 // Dense Eigen matrix/vector //////////////////////////////////////////
-// always enabled
 
-#include <Eigen/LU>
+#include <Eigen/Core>
 
 namespace MathLib
 {
 
-inline void setMatrix(Eigen::MatrixXd& m,
-                      Eigen::MatrixXd::Index const rows, Eigen::MatrixXd::Index const cols,
-                      std::initializer_list<double> values)
-{
-    using IndexType = Eigen::MatrixXd::Index;
-    assert((IndexType) values.size() == rows*cols);
+void setMatrix(Eigen::MatrixXd& m,
+               Eigen::MatrixXd::Index const rows, Eigen::MatrixXd::Index const cols,
+               std::initializer_list<double> values);
 
-    auto it = values.begin();
-    for (IndexType r=0; r<rows; ++r) {
-        for (IndexType c=0; c<cols; ++c) {
-            m(r, c) = *(it++);
-        }
-    }
-}
+void setMatrix(Eigen::MatrixXd& m, Eigen::MatrixXd const& tmp);
 
-inline void setMatrix(Eigen::MatrixXd& m, Eigen::MatrixXd const& tmp)
-{
-    m = tmp;
-}
+void addToMatrix(Eigen::MatrixXd& m,
+                 Eigen::MatrixXd::Index const rows, Eigen::MatrixXd::Index const cols,
+                 std::initializer_list<double> values);
 
-inline void addToMatrix(Eigen::MatrixXd& m,
-                        Eigen::MatrixXd::Index const rows, Eigen::MatrixXd::Index const cols,
-                        std::initializer_list<double> values)
-{
-    using IndexType = Eigen::MatrixXd::Index;
-    assert((IndexType) values.size() == rows*cols);
+double norm(Eigen::VectorXd const& x);
 
-    auto it = values.begin();
-    for (IndexType r=0; r<rows; ++r) {
-        for (IndexType c=0; c<cols; ++c) {
-            m(r, c) += *(it++);
-        }
-    }
-}
-
-inline double norm(Eigen::VectorXd const& x) { return x.norm(); }
-
-inline void setVector(Eigen::VectorXd& v, std::initializer_list<double> values)
-{
-    assert((std::size_t) v.size() == values.size());
-    auto it = values.begin();
-    for (std::size_t i=0; i<values.size(); ++i) v[i] = *(it++);
-}
+void setVector(Eigen::VectorXd& v, std::initializer_list<double> values);
 
 } // namespace MathLib
+
+#endif // OGS_USE_EIGEN
 
 
 #ifdef USE_PETSC
@@ -74,48 +47,29 @@ inline void setVector(Eigen::VectorXd& v, std::initializer_list<double> values)
 // Global PETScMatrix/PETScVector //////////////////////////////////////////
 
 #include "MathLib/LinAlg/PETSc/PETScMatrix.h"
-#include "MathLib/LinAlg/PETSc/PETScVector.h"
 
 namespace MathLib
 {
 
-inline double norm(MathLib::PETScVector const& x)
-{
-    return x.getNorm();
-}
+class PETScVector;
 
-inline void setVector(MathLib::PETScVector& v,
-                      std::initializer_list<double> values)
-{
-    (void) v; (void) values;
-    // TODO implement
-}
+double norm(PETScVector const& x);
+
+void setVector(PETScVector& v,
+                      std::initializer_list<double> values);
 
 
-inline void setMatrix(MathLib::PETScMatrix& m,
-                      MathLib::PETScMatrix::IndexType const rows,
-                      MathLib::PETScMatrix::IndexType const cols,
-                      std::initializer_list<double> values)
-{
-    (void) m; (void) rows; (void) cols; (void) values;
-    // TODO implement
-}
+void setMatrix(PETScMatrix& m,
+               PETScMatrix::IndexType const rows,
+               PETScMatrix::IndexType const cols,
+               std::initializer_list<double> values);
 
-inline void setMatrix(MathLib::PETScMatrix& m, Eigen::MatrixXd const& tmp)
-{
+void setMatrix(PETScMatrix& m, Eigen::MatrixXd const& tmp);
 
-    (void) m; (void) tmp;
-    // TODO implement
-}
-
-inline void addToMatrix(MathLib::PETScMatrix& m,
-                        MathLib::PETScMatrix::IndexType const rows,
-                        MathLib::PETScMatrix::IndexType const cols,
-                        std::initializer_list<double> values)
-{
-    (void) m; (void) rows; (void) cols; (void) values;
-    // TODO implement
-}
+void addToMatrix(PETScMatrix& m,
+                 PETScMatrix::IndexType const rows,
+                 PETScMatrix::IndexType const cols,
+                 std::initializer_list<double> values);
 
 } // namespace MathLib
 
@@ -124,61 +78,27 @@ inline void addToMatrix(MathLib::PETScMatrix& m,
 
 // Sparse global EigenMatrix/EigenVector //////////////////////////////////////////
 
-#include "MathLib/LinAlg/Eigen/EigenVector.h"
 #include "MathLib/LinAlg/Eigen/EigenMatrix.h"
-#include "MathLib/LinAlg/Eigen/EigenLinearSolver.h"
 
 namespace MathLib
 {
 
-inline void setVector(MathLib::EigenVector& v,
-                      std::initializer_list<double> values)
-{
-    setVector(v.getRawVector(), values);
-}
+class EigenVector;
 
-inline void setMatrix(MathLib::EigenMatrix& m,
-                      MathLib::EigenMatrix::IndexType const rows,
-                      MathLib::EigenMatrix::IndexType const cols,
-                      std::initializer_list<double> values)
-{
-    using IndexType = MathLib::EigenMatrix::IndexType;
-    assert((IndexType) values.size() == rows*cols);
-    Eigen::MatrixXd tmp(rows, cols);
+void setVector(EigenVector& v,
+                      std::initializer_list<double> values);
 
-    auto it = values.begin();
-    for (IndexType r=0; r<rows; ++r) {
-        for (IndexType c=0; c<cols; ++c) {
-            tmp(r, c) = *(it++);
-        }
-    }
+void setMatrix(EigenMatrix& m,
+               EigenMatrix::IndexType const rows,
+               EigenMatrix::IndexType const cols,
+               std::initializer_list<double> values);
 
-    m.getRawMatrix() = tmp.sparseView();
-}
+void setMatrix(EigenMatrix& m, Eigen::MatrixXd const& tmp);
 
-inline void setMatrix(MathLib::EigenMatrix& m, Eigen::MatrixXd const& tmp)
-{
-    m.getRawMatrix() = tmp.sparseView();
-}
-
-inline void addToMatrix(MathLib::EigenMatrix& m,
-                        MathLib::EigenMatrix::IndexType const rows,
-                        MathLib::EigenMatrix::IndexType const cols,
-                        std::initializer_list<double> values)
-{
-    using IndexType = MathLib::EigenMatrix::IndexType;
-    assert((IndexType) values.size() == rows*cols);
-    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> tmp(rows, cols);
-
-    auto it = values.begin();
-    for (IndexType r=0; r<rows; ++r) {
-        for (IndexType c=0; c<cols; ++c) {
-            tmp(r, c) = *(it++);
-        }
-    }
-
-    m.getRawMatrix() += tmp.sparseView();
-}
+void addToMatrix(EigenMatrix& m,
+                 EigenMatrix::IndexType const rows,
+                 EigenMatrix::IndexType const cols,
+                 std::initializer_list<double> values);
 
 } // namespace MathLib
 

--- a/NumLib/ODESolver/EquationSystem.h
+++ b/NumLib/ODESolver/EquationSystem.h
@@ -10,6 +10,8 @@
 #ifndef NUMLIB_EQUATIONSYSTEM_H
 #define NUMLIB_EQUATIONSYSTEM_H
 
+#include "MathLib/LinAlg/MatrixProviderUser.h"
+
 namespace NumLib
 {
 
@@ -18,11 +20,9 @@ namespace NumLib
 
 //! Collection of basic methods every equation system must provide.
 class EquationSystem
+        : public MathLib::MatrixSpecificationsProvider
 {
 public:
-    //! Return the number of equations.
-    virtual std::size_t getNumEquations() const = 0;
-
     /*! Check whether this is actually a linear equation system.
      *
      * \remark

--- a/NumLib/ODESolver/NonlinearSolver-impl.h
+++ b/NumLib/ODESolver/NonlinearSolver-impl.h
@@ -14,6 +14,7 @@
 
 #include "BaseLib/ConfigTree.h"
 #include "MathLib/LinAlg/BLAS.h"
+#include "MathLib/LinAlg/GlobalMatrixProviders.h"
 
 #include "NonlinearSolver.h"
 
@@ -38,36 +39,40 @@ solve(Vector &x)
     namespace BLAS = MathLib::BLAS;
     auto& sys = *_equation_system;
 
+    auto& A     = MathLib::GlobalMatrixProvider<Matrix>::provider.getMatrix(_A_id);
+    auto& rhs   = MathLib::GlobalVectorProvider<Vector>::provider.getVector(_rhs_id);
+    auto& x_new = MathLib::GlobalVectorProvider<Vector>::provider.getVector(_x_new_id);
+
     bool success = false;
 
-    BLAS::copy(x, _x_new); // set initial guess, TODO save the copy
+    BLAS::copy(x, x_new); // set initial guess, TODO save the copy
 
     for (unsigned iteration=1; iteration<_maxiter; ++iteration)
     {
-        sys.assembleMatricesPicard(_x_new);
-        sys.getA(_A);
-        sys.getRhs(_rhs);
+        sys.assembleMatricesPicard(x_new);
+        sys.getA(A);
+        sys.getRhs(rhs);
 
         // Here _x_new has to be used and it has to be equal to x!
-        sys.applyKnownSolutionsPicard(_A, _rhs, _x_new);
+        sys.applyKnownSolutionsPicard(A, rhs, x_new);
 
         // std::cout << "A:\n" << Eigen::MatrixXd(A) << "\n";
         // std::cout << "rhs:\n" << rhs << "\n\n";
 
-        if (!_linear_solver.solve(_A, _rhs, _x_new)) {
+        if (!_linear_solver.solve(A, rhs, x_new)) {
             ERR("The linear solver failed.");
-            x = _x_new;
+            x = x_new;
             success = false;
             break;
         }
 
         // x is used as delta_x in order to compute the error.
-        BLAS::aypx(x, -1.0, _x_new); // x = _x_new - x
+        BLAS::aypx(x, -1.0, x_new); // x = _x_new - x
         auto const error = BLAS::norm2(x);
         // INFO("  picard iteration %u error: %e", iteration, error);
 
         // Update x s.t. in the next iteration we will compute the right delta x
-        x = _x_new;
+        x = x_new;
 
         if (error < _tol) {
             success = true;
@@ -80,6 +85,10 @@ solve(Vector &x)
             break;
         }
     }
+
+    MathLib::GlobalMatrixProvider<Matrix>::provider.releaseMatrix(A);
+    MathLib::GlobalVectorProvider<Vector>::provider.releaseVector(rhs);
+    MathLib::GlobalVectorProvider<Vector>::provider.releaseVector(x_new);
 
     return success;
 }
@@ -104,35 +113,42 @@ solve(Vector &x)
     namespace BLAS = MathLib::BLAS;
     auto& sys = *_equation_system;
 
+    auto& res =
+            MathLib::GlobalVectorProvider<Vector>::provider.getVector(_res_id);
+    auto& minus_delta_x =
+            MathLib::GlobalVectorProvider<Vector>::provider.getVector(_minus_delta_x_id);
+    auto& J =
+            MathLib::GlobalMatrixProvider<Matrix>::provider.getMatrix(_J_id);
+
     bool success = false;
 
     // TODO be more efficient
     // init _minus_delta_x to the right size and 0.0
-    BLAS::copy(x, _minus_delta_x);
-    _minus_delta_x.setZero();
+    BLAS::copy(x, minus_delta_x);
+    minus_delta_x.setZero();
 
     for (unsigned iteration=1; iteration<_maxiter; ++iteration)
     {
         sys.assembleResidualNewton(x);
-        sys.getResidual(x, _res);
+        sys.getResidual(x, res);
 
         // std::cout << "  res:\n" << res << std::endl;
 
         // TODO streamline that, make consistent with Picard.
-        if (BLAS::norm2(_res) < _tol) {
+        if (BLAS::norm2(res) < _tol) {
             success = true;
             break;
         }
 
         sys.assembleJacobian(x);
-        sys.getJacobian(_J);
-        sys.applyKnownSolutionsNewton(_J, _res, _minus_delta_x);
+        sys.getJacobian(J);
+        sys.applyKnownSolutionsNewton(J, res, minus_delta_x);
 
         // std::cout << "  J:\n" << Eigen::MatrixXd(J) << std::endl;
 
-        if (!_linear_solver.solve(_J, _res, _minus_delta_x)) {
+        if (!_linear_solver.solve(J, res, minus_delta_x)) {
             ERR("The linear solver failed.");
-            BLAS::axpy(x, -_alpha, _minus_delta_x);
+            BLAS::axpy(x, -_alpha, minus_delta_x);
             success = false;
             break;
         }
@@ -140,7 +156,7 @@ solve(Vector &x)
         // auto const dx_norm = _minus_delta_x.norm();
         // INFO("  newton iteration %u, norm of delta x: %e", iteration, dx_norm);
 
-        BLAS::axpy(x, -_alpha, _minus_delta_x);
+        BLAS::axpy(x, -_alpha, minus_delta_x);
 
         if (sys.isLinear()) {
             // INFO("  newton linear system. not looping");
@@ -148,6 +164,10 @@ solve(Vector &x)
             break;
         }
     }
+
+    MathLib::GlobalMatrixProvider<Matrix>::provider.releaseMatrix(J);
+    MathLib::GlobalVectorProvider<Vector>::provider.releaseVector(res);
+    MathLib::GlobalVectorProvider<Vector>::provider.releaseVector(minus_delta_x);
 
     return success;
 }

--- a/NumLib/ODESolver/NonlinearSolver.h
+++ b/NumLib/ODESolver/NonlinearSolver.h
@@ -117,11 +117,11 @@ private:
     const double _tol;       //!< tolerance of the solver
     const unsigned _maxiter; //!< maximum number of iterations
 
-    Vector _res;             //!< The residual.
-    Matrix _J;               //!< The Jacobian of the residual.
-    Vector _minus_delta_x;   //!< The Newton-Raphson method solves the linearized equation
-                             //!< \f$ J \cdot (-\Delta x) = r \f$ repeatedly.
     double const _alpha = 1; //!< Damping factor. \todo Add constructor parameter.
+
+    std::size_t _res_id = 0u;           //!< ID of the residual vector.
+    std::size_t _J_id = 0u;             //!< ID of the Jacobian matrix.
+    std::size_t _minus_delta_x_id = 0u; //!< ID of the \f$ -\Delta x\f$ vector.
 };
 
 
@@ -167,20 +167,20 @@ private:
     const double _tol;       //!< tolerance of the solver
     const unsigned _maxiter; //!< maximum number of iterations
 
-    Matrix _A;     //!< \c Matrix describing the linearized system.
-    Vector _rhs;   //!< \c Vector describing the linearized system.
-    Vector _x_new; //!< \c Vector to store solutions of \f$ A \cdot x = \mathit{rhs} \f$.
+    std::size_t _A_id = 0u;     //!< ID of the \f$ A \f$ matrix.
+    std::size_t _rhs_id = 0u;   //!< ID of the right-hand side vector.
+    std::size_t _x_new_id = 0u; //!< ID of the vector storing the solution of the linearized equation.
 };
+
 
 /*! Creates a new nonlinear solver from the given configuration.
  *
- * \param linear_solver the linear solver that will be used by the nonlinear
- *        solver
+ * \param linear_solver the linear solver that will be used by the nonlinear solver
  * \param config configuration settings
  *
- * \return a pair <tt>(nl_slv, tag)</tt> where \c nl_slv is the generated
- *         nonlinear solver instance and the \c tag indicates if it uses the
- *         Picard or Newton-Raphson method
+ * \return a pair <tt>(nl_slv, tag)</tt> where \c nl_slv is the generated nonlinear
+ *         solver instance and the \c tag indicates if it uses the Picard
+ *         or Newton-Raphson method
  */
 template<typename Matrix, typename Vector>
 std::pair<

--- a/NumLib/ODESolver/ODESystem.h
+++ b/NumLib/ODESolver/ODESystem.h
@@ -10,6 +10,8 @@
 #ifndef NUMLIB_ODESYSTEM_H
 #define NUMLIB_ODESYSTEM_H
 
+#include "MathLib/LinAlg/MatrixVectorTraits.h"
+
 #include "Types.h"
 #include "EquationSystem.h"
 
@@ -61,7 +63,7 @@ public:
     virtual void assemble(const double t, Vector const& x,
                           Matrix& M, Matrix& K, Vector& b) = 0;
 
-    using Index = typename MatrixTraits<Matrix>::Index;
+    using Index = typename MathLib::MatrixVectorTraits<Matrix>::Index;
 
     virtual std::vector<ProcessLib::DirichletBc<Index> > const* getKnownSolutions() const
     {

--- a/NumLib/ODESolver/Types.h
+++ b/NumLib/ODESolver/Types.h
@@ -37,64 +37,6 @@ enum class ODESystemTag : char
 
 //! @}
 
-
-// TODO move MatrixTraits to NumericsConfig.h?
-template<typename Matrix>
-struct MatrixTraits
-/*
-{
-    using Index = int;
-}
-// */
-;
-
 } // namespace NumLib
-
-
-
-#ifdef OGS_USE_EIGEN
-
-#include<Eigen/Core>
-
-namespace NumLib
-{
-template<>
-struct MatrixTraits<Eigen::MatrixXd>
-{
-    using Index = Eigen::MatrixXd::Index;
-};
-}
-
-#endif
-
-
-#ifdef USE_PETSC
-
-namespace MathLib { class PETScMatrix; }
-
-namespace NumLib
-{
-template<>
-struct MatrixTraits<MathLib::PETScMatrix>
-{
-    using Index = MathLib::PETScMatrix::IndexType;
-};
-}
-
-#elif defined(OGS_USE_EIGEN)
-
-namespace MathLib { class EigenMatrix; }
-
-namespace NumLib
-{
-template<>
-struct MatrixTraits<MathLib::EigenMatrix>
-{
-    using Index = MathLib::EigenMatrix::IndexType;
-};
-}
-
-#endif
-
 
 #endif // NUMLIB_TYPES_H

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -126,12 +126,17 @@ public:
 		}
 	}
 
+	MathLib::MatrixSpecifications getMatrixSpecifications() const override final
+	{
+		return { _local_to_global_index_map->dofSize(), _local_to_global_index_map->dofSize() };
+	}
+
+#if 0
 	std::size_t getNumEquations() const override final
 	{
 		return _local_to_global_index_map->dofSize();
 
 #ifdef USE_PETSC
-#if 0
 		// TODO for PETSc the method and the interface maybe have to be extended
 		// this is the old code moved here from th deleted createLinearSolver() method.
 
@@ -152,8 +157,8 @@ public:
 		_rhs.reset( _global_setup.createVector(num_unknowns,
 		            _local_to_global_index_map->getGhostIndices(), false) );
 #endif
-#endif
 	}
+#endif
 
 	void assemble(const double t, GlobalVector const& x,
 	              GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) override final

--- a/Tests/NumLib/ODEs.h
+++ b/Tests/NumLib/ODEs.h
@@ -53,9 +53,9 @@ public:
             BLAS::axpy(Jac, dx_dx, K);
     }
 
-    std::size_t getNumEquations() const override
+    MathLib::MatrixSpecifications getMatrixSpecifications() const override
     {
-        return N;
+        return { N, N };
     }
 
     bool isLinear() const override
@@ -126,9 +126,9 @@ public:
             BLAS::axpy(Jac, dx_dx, K);
     }
 
-    std::size_t getNumEquations() const override
+    MathLib::MatrixSpecifications getMatrixSpecifications() const override
     {
-        return N;
+        return { N, N };
     }
 
     bool isLinear() const override
@@ -262,9 +262,9 @@ public:
         // INFO("Det J: %e <<<", J.determinant());
     }
 
-    std::size_t getNumEquations() const override
+    MathLib::MatrixSpecifications getMatrixSpecifications() const override
     {
-        return N;
+        return { N, N };
     }
 
     bool isLinear() const override


### PR DESCRIPTION
This matrix pool will make it possible to use global matrices and vectors in different processes. Furthermore, this PR adds builders for global matrices, which abstract away, e.g., the differences between PETSc and Eigen matrix creation. However, for PETSc there will be a follow-up PR.

Maybe we should discuss this PR as we did with #1040 and #1050.

Note: This is a follow-up PR of #1050!

To do:
* [x] add docu (for the members "matrix id")
* [x]  '(minor) cleanup
* [x] cpp file for UnifiedMatrixSetters
* [x] ~~discuss disabled unit tests put them to a separate PR~~ EDIT: this applies to #1060 
* [x] fix #1067 – fixed in ba4cc25c, @endJunction please have a look.
* [x] initialize matrix id members
* [x] make matrix and vector providers global objects, not members.