### PR TITLE
Fix ODE solver lib with PETSc

### DIFF
--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
@@ -269,6 +269,7 @@ setInitialConditions(ProjectData& project,
 
         auto& x0 = *_process_solutions[pcs_idx];
         pcs.setInitialConditions(x0);
+        MathLib::BLAS::finalizeAssembly(x0);
 
         time_disc.setInitialState(t0, x0); // push IC
 

--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -130,7 +130,7 @@ else()
 	AddTest(
 		NAME ParallelFEM_GroundWaterFlow2D
 		PATH EllipticPETSc
-		EXECUTABLE_ARGS quad_20x10_GroundWaterFlow.prj -- -gw_ksp_type bcgs -gw_pc_type bjacobi -gw_ksp_rtol 1.e-10
+		EXECUTABLE_ARGS quad_20x10_GroundWaterFlow.prj
 		WRAPPER mpirun
 		WRAPPER_ARGS -np 3
 		TESTER diff
@@ -143,7 +143,7 @@ else()
 	AddTest(
 		NAME ParallelFEM_GroundWaterFlow3D_DirichletBC
 		PATH EllipticPETSc
-		EXECUTABLE_ARGS cube_1e3.prj -- -gw_ksp_type bcgs -gw_pc_type mg -gw_ksp_rtol 1.e-10
+		EXECUTABLE_ARGS cube_1e3.prj
 		WRAPPER mpirun
 		WRAPPER_ARGS -np 3
 		TESTER diff
@@ -156,7 +156,7 @@ else()
 	AddTest(
 		NAME ParallelFEM_GroundWaterFlow3D_NeumannBC
 		PATH EllipticPETSc
-		EXECUTABLE_ARGS cube_1e3_neumann.prj -- -gw_ksp_type gmres -gw_pc_type bjacobi -gw_ksp_rtol 1.e-10
+		EXECUTABLE_ARGS cube_1e3_neumann.prj
 		WRAPPER mpirun
 		WRAPPER_ARGS -np 3
 		TESTER diff

--- a/MathLib/LinAlg/BLAS.cpp
+++ b/MathLib/LinAlg/BLAS.cpp
@@ -50,28 +50,28 @@ void copy(PETScVector const& x, PETScVector& y)
 
 void scale(PETScVector& x, double const a)
 {
-    VecScale(x.getRawVector(), a);
+    VecScale(*x.getRawVector(), a);
 }
 
 // y = a*y + X
 void aypx(PETScVector& y, double const a, PETScVector const& x)
 {
     // TODO check sizes
-    VecAYPX(y.getRawVector(), a, x.getRawVector());
+    VecAYPX(*y.getRawVector(), a, *x.getRawVector());
 }
 
 // y = a*x + y
 void axpy(PETScVector& y, double const a, PETScVector const& x)
 {
     // TODO check sizes
-    VecAXPY(y.getRawVector(), a, x.getRawVector());
+    VecAXPY(*y.getRawVector(), a, *x.getRawVector());
 }
 
-// y = a*x + y
+// y = a*x + b*y
 void axpby(PETScVector& y, double const a, double const b, PETScVector const& x)
 {
     // TODO check sizes
-    VecAXPBY(y.getRawVector(), a, b, x.getRawVector());
+    VecAXPBY(*y.getRawVector(), a, b, *x.getRawVector());
 }
 
 // Explicit specialization
@@ -122,7 +122,8 @@ void matMult(PETScMatrix const& A, PETScVector const& x, PETScVector& y)
 {
     // TODO check sizes
     assert(&x != &y);
-    MatMult(A.getRawMatrix(), x.getRawVector(), y.getRawVector());
+    if (!y.getRawVector()) y.shallowCopy(x);
+    MatMult(A.getRawMatrix(), *x.getRawVector(), *y.getRawVector());
 }
 
 // v3 = A*v1 + v2
@@ -131,7 +132,18 @@ void matMultAdd(PETScMatrix const& A, PETScVector const& v1,
 {
     // TODO check sizes
     assert(&v1 != &v3);
-    MatMultAdd(A.getRawMatrix(), v1.getRawVector(), v2.getRawVector(), v3.getRawVector());
+    if (!v3.getRawVector()) v3.shallowCopy(v1);
+    MatMultAdd(A.getRawMatrix(), *v1.getRawVector(), *v2.getRawVector(), *v3.getRawVector());
+}
+
+void finalizeAssembly(PETScMatrix& A)
+{
+    A.finalizeAssembly(MAT_FINAL_ASSEMBLY);
+}
+
+void finalizeAssembly(PETScVector& x)
+{
+    x.finalizeAssembly();
 }
 
 }} // namespaces

--- a/MathLib/LinAlg/BLAS.h
+++ b/MathLib/LinAlg/BLAS.h
@@ -70,6 +70,11 @@ void axpby(MatrixOrVector& y, double const a, double const b, MatrixOrVector con
 template<typename MatrixOrVector>
 double norm2(MatrixOrVector const& x);
 
+template<typename Matrix>
+void finalizeAssembly(Matrix& /*A*/)
+{
+    // By default do nothing.
+}
 
 // Matrix and Vector
 
@@ -152,8 +157,10 @@ void matMult(PETScMatrix const& A, PETScVector const& x, PETScVector& y);
 void matMultAdd(PETScMatrix const& A, PETScVector const& v1,
                        PETScVector const& v2, PETScVector& v3);
 
-}} // namespaces
+void finalizeAssembly(PETScMatrix& A);
+void finalizeAssembly(PETScVector& x);
 
+}} // namespaces
 
 
 // Sparse global EigenMatrix/EigenVector //////////////////////////////////////////

--- a/MathLib/LinAlg/MatrixProviderUser.h
+++ b/MathLib/LinAlg/MatrixProviderUser.h
@@ -12,13 +12,26 @@
 
 #include <cstddef>
 
+#include "AssemblerLib/ComputeSparsityPattern.h"
+
 namespace MathLib
 {
 
 struct MatrixSpecifications
 {
+    MatrixSpecifications(std::size_t const nrows_, std::size_t const ncols_,
+                         AssemblerLib::SparsityPattern const*const sparsity_pattern_,
+                         AssemblerLib::LocalToGlobalIndexMap const*const dof_table_,
+                         MeshLib::Mesh const*const mesh_)
+        : nrows(nrows_), ncols(ncols_), sparsity_pattern(sparsity_pattern_)
+        , dof_table(dof_table_), mesh(mesh_)
+    {}
+
     std::size_t const nrows;
     std::size_t const ncols;
+    AssemblerLib::SparsityPattern const*const sparsity_pattern;
+    AssemblerLib::LocalToGlobalIndexMap const*const dof_table;
+    MeshLib::Mesh const*const mesh;
 };
 
 class MatrixSpecificationsProvider

--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.h
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.h
@@ -84,7 +84,7 @@ class PETScLinearSolver
         KSP _solver; ///< Solver type.
         PC _pc;      ///< Preconditioner type.
 
-        double _elapsed_ctime; ///< Clock time
+        double _elapsed_ctime = 0.0; ///< Clock time
 };
 
 } // end namespace

--- a/MathLib/LinAlg/PETSc/PETScMatrix.cpp
+++ b/MathLib/LinAlg/PETSc/PETScMatrix.cpp
@@ -48,6 +48,41 @@ PETScMatrix::PETScMatrix (const PetscInt nrows, const PetscInt ncols, const PETS
     create(mat_opt.d_nz, mat_opt.o_nz);
 }
 
+PETScMatrix::PETScMatrix(const PETScMatrix &A)
+    : _A(new PETSc_Mat)
+    , _nrows(A._nrows)
+    , _ncols(A._ncols)
+    , _n_loc_rows(A._n_loc_rows)
+    , _n_loc_cols(A._n_loc_cols)
+    , _start_rank(A._start_rank)
+    , _end_rank(A._end_rank)
+{
+    _A.reset(new PETSc_Mat);
+    MatConvert(*A._A, MATSAME, MAT_INITIAL_MATRIX, _A.get());
+}
+
+PETScMatrix&
+PETScMatrix::operator=(PETScMatrix const& A)
+{
+    _nrows = A._nrows;
+    _ncols = A._ncols;
+    _n_loc_rows = A._n_loc_rows;
+    _n_loc_cols = A._n_loc_cols;
+    _start_rank = A._start_rank;
+    _end_rank = A._end_rank;
+
+    if (_A) {
+        // TODO this is the slowest option for copying
+        MatCopy(*A._A, *_A, DIFFERENT_NONZERO_PATTERN);
+    } else {
+        destroy();
+        _A.reset(new PETSc_Mat);
+        MatConvert(*A._A, MATSAME, MAT_INITIAL_MATRIX, _A.get());
+    }
+
+    return *this;
+}
+
 void PETScMatrix::setRowsColumnsZero(std::vector<PetscInt> const& row_pos)
 {
     // Each rank (compute core) processes only the rows that belong to the rank itself.
@@ -58,11 +93,11 @@ void PETScMatrix::setRowsColumnsZero(std::vector<PetscInt> const& row_pos)
     // This avoids all reductions in the zero row routines
     // and thus improves performance for very large process counts.
     // See PETSc doc about MAT_NO_OFF_PROC_ZERO_ROWS.
-    MatSetOption(_A, MAT_NO_OFF_PROC_ZERO_ROWS, PETSC_TRUE); 
+    MatSetOption(*_A, MAT_NO_OFF_PROC_ZERO_ROWS, PETSC_TRUE);
     if(nrows>0)
-        MatZeroRows(_A, nrows, &row_pos[0], one, PETSC_NULL, PETSC_NULL);
+        MatZeroRows(*_A, nrows, &row_pos[0], one, PETSC_NULL, PETSC_NULL);
     else
-        MatZeroRows(_A, 0, PETSC_NULL, one, PETSC_NULL, PETSC_NULL);
+        MatZeroRows(*_A, 0, PETSC_NULL, one, PETSC_NULL, PETSC_NULL);
 }
 
 void PETScMatrix::viewer(const std::string &file_name, const PetscViewerFormat vw_format)
@@ -73,13 +108,13 @@ void PETScMatrix::viewer(const std::string &file_name, const PetscViewerFormat v
 
     finalizeAssembly();
 
-    PetscObjectSetName((PetscObject)_A,"Stiffness_matrix");
-    MatView(_A,viewer);
+    PetscObjectSetName((PetscObject)*_A,"Stiffness_matrix");
+    MatView(*_A,viewer);
 
 // This preprocessor is only for debugging, e.g. dump the matrix and exit the program.
 //#define EXIT_TEST
 #ifdef EXIT_TEST
-    MatDestroy(&_A);
+    MatDestroy(_A);
     PetscFinalize();
     exit(0);
 #endif
@@ -88,20 +123,22 @@ void PETScMatrix::viewer(const std::string &file_name, const PetscViewerFormat v
 
 void PETScMatrix::create(const PetscInt d_nz, const PetscInt o_nz)
 {
-    MatCreate(PETSC_COMM_WORLD, &_A);
-    MatSetSizes(_A, _n_loc_rows, _n_loc_cols, _nrows, _ncols);
+    _A.reset(new PETSc_Mat);
 
-    MatSetFromOptions(_A);
+    MatCreate(PETSC_COMM_WORLD, _A.get());
+    MatSetSizes(*_A, _n_loc_rows, _n_loc_cols, _nrows, _ncols);
 
-    MatSetType(_A, MATMPIAIJ);
-    MatSeqAIJSetPreallocation(_A, d_nz, PETSC_NULL);
-    MatMPIAIJSetPreallocation(_A, d_nz, PETSC_NULL, o_nz, PETSC_NULL);
-    // If pre-allocation does not work one can use MatSetUp(_A), which is much
+    MatSetFromOptions(*_A);
+
+    MatSetType(*_A, MATMPIAIJ);
+    MatSeqAIJSetPreallocation(*_A, d_nz, PETSC_NULL);
+    MatMPIAIJSetPreallocation(*_A, d_nz, PETSC_NULL, o_nz, PETSC_NULL);
+    // If pre-allocation does not work one can use MatSetUp(*_A), which is much
     // slower.
 
-    MatGetOwnershipRange(_A, &_start_rank, &_end_rank);
-    MatGetSize(_A, &_nrows,  &_ncols);
-    MatGetLocalSize(_A, &_n_loc_rows, &_n_loc_cols);
+    MatGetOwnershipRange(*_A, &_start_rank, &_end_rank);
+    MatGetSize(*_A, &_nrows,  &_ncols);
+    MatGetLocalSize(*_A, &_n_loc_rows, &_n_loc_cols);
 }
 
 bool finalizeMatrixAssembly(PETScMatrix &mat, const MatAssemblyType asm_type)

--- a/MathLib/LinAlg/PETSc/PETScMatrix.h
+++ b/MathLib/LinAlg/PETSc/PETScMatrix.h
@@ -15,6 +15,7 @@
 #ifndef PETSCMATRIX_H_
 #define PETSCMATRIX_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -37,10 +38,7 @@ class PETScMatrix
         using IndexType = PetscInt;
 
     public:
-        // TODO preliminary
-        PETScMatrix() {
-            // TODO implement
-        }
+        PETScMatrix() {}
 
         /*!
           \brief        Constructor for a square matrix partitioning with more options
@@ -60,8 +58,12 @@ class PETScMatrix
 
         ~PETScMatrix()
         {
-            MatDestroy(&_A);
+            destroy();
         }
+
+        PETScMatrix(PETScMatrix const& A);
+
+        PETScMatrix& operator=(PETScMatrix const& A);
 
         /*!
            \brief          Perform MPI collection of assembled entries in buffer
@@ -70,8 +72,8 @@ class PETScMatrix
         */
         void finalizeAssembly(const MatAssemblyType asm_type = MAT_FINAL_ASSEMBLY)
         {
-            MatAssemblyBegin(_A, asm_type);
-            MatAssemblyEnd(_A, asm_type);
+            MatAssemblyBegin(*_A, asm_type);
+            MatAssemblyEnd(*_A, asm_type);
         }
 
         /// Get the number of rows.
@@ -114,20 +116,24 @@ class PETScMatrix
         /// Get matrix reference.
         PETSc_Mat &getRawMatrix()
         {
-            return _A;
+            return *_A;
         }
-        // TODO preliminary
-        // this method is dangerous insofar you can do arbitrary things also
-        // with a const PETSc matrix.
+
+        /*! Get a matrix reference.
+         *
+         * \warning
+         * This method is dangerous insofar as you can do arbitrary things also
+         * with a const PETSc matrix.
+         */
         PETSc_Mat const& getRawMatrix() const
         {
-            return _A;
+            return *_A;
         }
 
         /// Set all entries to zero.
         void setZero()
         {
-            MatZeroEntries(_A);
+            MatZeroEntries(*_A);
         }
 
         /*
@@ -149,7 +155,7 @@ class PETScMatrix
         */
         void multiply(const PETScVector &vec, PETScVector &vec_r)
         {
-            MatMult(_A, vec.getData(), vec_r.getData() );
+            MatMult(*_A, vec.getData(), vec_r.getData() );
         }
 
         /*!
@@ -160,7 +166,7 @@ class PETScMatrix
         */
         void set(const PetscInt i, const PetscInt j, const PetscScalar value)
         {
-            MatSetValue(_A, i, j, value, INSERT_VALUES);
+            MatSetValue(*_A, i, j, value, INSERT_VALUES);
         }
 
         /*!
@@ -171,7 +177,7 @@ class PETScMatrix
         */
         void add(const PetscInt i, const PetscInt j, const PetscScalar value)
         {
-            MatSetValue(_A, i, j, value, ADD_VALUES);
+            MatSetValue(*_A, i, j, value, ADD_VALUES);
         }
 
         /// Add sub-matrix at positions given by \c indices.
@@ -231,8 +237,10 @@ class PETScMatrix
                     const PetscViewerFormat vw_format = PETSC_VIEWER_ASCII_MATLAB );
 
     private:
+        void destroy() { if (_A) MatDestroy(_A.get()); _A.reset(nullptr); }
+
         /// PETSc matrix
-        PETSc_Mat _A;
+        std::unique_ptr<PETSc_Mat> _A;
 
         /// Number of the global rows
         PetscInt _nrows;
@@ -278,7 +286,7 @@ void PETScMatrix::add(std::vector<PetscInt> const& row_pos,
     const PetscInt nrows = static_cast<PetscInt> (row_pos.size());
     const PetscInt ncols = static_cast<PetscInt> (col_pos.size());
 
-    MatSetValues(_A, nrows, &row_pos[0], ncols, &col_pos[0], &sub_mat(0,0), ADD_VALUES);
+    MatSetValues(*_A, nrows, &row_pos[0], ncols, &col_pos[0], &sub_mat(0,0), ADD_VALUES);
 };
 
 /*!

--- a/MathLib/LinAlg/UnifiedMatrixSetters.h
+++ b/MathLib/LinAlg/UnifiedMatrixSetters.h
@@ -24,13 +24,11 @@ namespace MathLib
 {
 
 void setMatrix(Eigen::MatrixXd& m,
-               Eigen::MatrixXd::Index const rows, Eigen::MatrixXd::Index const cols,
                std::initializer_list<double> values);
 
 void setMatrix(Eigen::MatrixXd& m, Eigen::MatrixXd const& tmp);
 
 void addToMatrix(Eigen::MatrixXd& m,
-                 Eigen::MatrixXd::Index const rows, Eigen::MatrixXd::Index const cols,
                  std::initializer_list<double> values);
 
 double norm(Eigen::VectorXd const& x);
@@ -46,30 +44,24 @@ void setVector(Eigen::VectorXd& v, std::initializer_list<double> values);
 
 // Global PETScMatrix/PETScVector //////////////////////////////////////////
 
-#include "MathLib/LinAlg/PETSc/PETScMatrix.h"
-
 namespace MathLib
 {
 
 class PETScVector;
+class PETScMatrix;
 
 double norm(PETScVector const& x);
 
 void setVector(PETScVector& v,
-                      std::initializer_list<double> values);
-
-
-void setMatrix(PETScMatrix& m,
-               PETScMatrix::IndexType const rows,
-               PETScMatrix::IndexType const cols,
                std::initializer_list<double> values);
 
 void setMatrix(PETScMatrix& m, Eigen::MatrixXd const& tmp);
 
 void addToMatrix(PETScMatrix& m,
-                 PETScMatrix::IndexType const rows,
-                 PETScMatrix::IndexType const cols,
                  std::initializer_list<double> values);
+
+void setMatrix(PETScMatrix& m,
+               std::initializer_list<double> values);
 
 } // namespace MathLib
 
@@ -78,26 +70,21 @@ void addToMatrix(PETScMatrix& m,
 
 // Sparse global EigenMatrix/EigenVector //////////////////////////////////////////
 
-#include "MathLib/LinAlg/Eigen/EigenMatrix.h"
-
 namespace MathLib
 {
 
 class EigenVector;
+class EigenMatrix;
 
 void setVector(EigenVector& v,
-                      std::initializer_list<double> values);
+               std::initializer_list<double> values);
 
 void setMatrix(EigenMatrix& m,
-               EigenMatrix::IndexType const rows,
-               EigenMatrix::IndexType const cols,
                std::initializer_list<double> values);
 
 void setMatrix(EigenMatrix& m, Eigen::MatrixXd const& tmp);
 
 void addToMatrix(EigenMatrix& m,
-                 EigenMatrix::IndexType const rows,
-                 EigenMatrix::IndexType const cols,
                  std::initializer_list<double> values);
 
 } // namespace MathLib

--- a/MeshLib/NodePartitionedMesh.h
+++ b/MeshLib/NodePartitionedMesh.h
@@ -120,6 +120,7 @@ class NodePartitionedMesh : public Mesh
             return _n_nghost_elem;
         }
 
+        // TODO I guess that is a simplified version of computeSparsityPattern()
         /// Get the maximum number of connected nodes to node.
         std::size_t getMaximumNConnectedNodesToNode() const
         {

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.h
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.h
@@ -117,6 +117,8 @@ public:
 
     void assembleResidualNewton(const Vector &x_new_timestep) override
     {
+        namespace BLAS = MathLib::BLAS;
+
         auto const  t      = _time_disc.getCurrentTime();
         auto const& x_curr = _time_disc.getCurrentX(x_new_timestep);
 
@@ -125,6 +127,10 @@ public:
         _b->setZero();
 
         _ode.assemble(t, x_curr, *_M, *_K, *_b);
+
+        BLAS::finalizeAssembly(*_M);
+        BLAS::finalizeAssembly(*_K);
+        BLAS::finalizeAssembly(*_b);
     }
 
     void assembleJacobian(const Vector &x_new_timestep) override
@@ -144,6 +150,8 @@ public:
         _ode.assembleJacobian(t, x_curr, xdot,
                               dxdot_dx, *_M, dx_dx, *_K,
                               *_Jac);
+
+        MathLib::BLAS::finalizeAssembly(*_Jac);
 
         MathLib::GlobalVectorProvider<Vector>::provider.releaseVector(xdot);
     }
@@ -264,6 +272,8 @@ public:
 
     void assembleMatricesPicard(const Vector &x_new_timestep) override
     {
+        namespace BLAS = MathLib::BLAS;
+
         auto const  t      = _time_disc.getCurrentTime();
         auto const& x_curr = _time_disc.getCurrentX(x_new_timestep);
 
@@ -272,6 +282,10 @@ public:
         _b->setZero();
 
         _ode.assemble(t, x_curr, *_M, *_K, *_b);
+
+        BLAS::finalizeAssembly(*_M);
+        BLAS::finalizeAssembly(*_K);
+        BLAS::finalizeAssembly(*_b);
     }
 
     void getA(Matrix& A) const override

--- a/Tests/BaseLib/TestConfigTree.cpp
+++ b/Tests/BaseLib/TestConfigTree.cpp
@@ -14,6 +14,7 @@
 #include <sstream>
 
 #include "BaseLib/ConfigTree.h"
+#include "Tests/TestTools.h"
 
 // make useful line numbers appear in the output of gtest
 #define EXPECT_ERR_WARN(cbs, error, warning) do  { \
@@ -72,18 +73,6 @@ private:
     bool _error = false;
     bool _warning = false;
 };
-
-
-boost::property_tree::ptree
-readXml(const char xml[])
-{
-    boost::property_tree::ptree ptree;
-    std::istringstream xml_str(xml);
-    read_xml(xml_str, ptree,
-             boost::property_tree::xml_parser::no_comments |
-             boost::property_tree::xml_parser::trim_whitespace);
-    return ptree;
-}
 
 BaseLib::ConfigTree
 makeConfigTree(boost::property_tree::ptree const& ptree, Callbacks& cbs)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -24,7 +24,7 @@ if(OGS_USE_PETSC OR OGS_USE_MPI)
 	list(REMOVE_ITEM TEST_SOURCES AssemblerLib/TestSerialLinearSolver.cpp)
 endif()
 
-add_executable(testrunner testrunner.cpp ${TEST_SOURCES})
+add_executable(testrunner ${TEST_SOURCES})
 set_target_properties(testrunner PROPERTIES FOLDER Testing)
 
 target_link_libraries(testrunner

--- a/Tests/MathLib/TestLinearSolver.cpp
+++ b/Tests/MathLib/TestLinearSolver.cpp
@@ -43,7 +43,7 @@
 #include "MathLib/LinAlg/PETSc/PETScLinearSolver.h"
 #endif
 
-#include "../TestTools.h"
+#include "Tests/TestTools.h"
 
 namespace
 {
@@ -288,19 +288,24 @@ TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_basic)
     const bool is_global_size = false;
     MathLib::PETScVector b(2, is_global_size);
 
-    boost::property_tree::ptree t_root;
-    t_root.put("petsc",
-                 "-ptest1_ksp_type bcgs "
-                 "-ptest1_ksp_rtol 1.e-8 "
-                 "-ptest1_ksp_atol 1.e-50 "
-                 "-ptest1_ksp_max_it 1000 "
-                 "-ptest1_pc_type bjacobi");
+    const char xml[] =
+            "<petsc>"
+            "  <parameters>"
+            "    -ptest1_ksp_type bcgs "
+            "    -ptest1_ksp_rtol 1.e-8 "
+            "    -ptest1_ksp_atol 1.e-50 "
+            "    -ptest1_ksp_max_it 1000 "
+            "    -ptest1_pc_type bjacobi"
+            "  </parameters>"
+            "  <prefix>ptest1</prefix>"
+            "</petsc>";
+    auto const ptree = readXml(xml);
 
     checkLinearSolverInterface<MathLib::PETScMatrix,
                                MathLib::PETScVector,
                                MathLib::PETScLinearSolver>(
-        A, b, "ptest1_",
-        BaseLib::ConfigTree(t_root, "", BaseLib::ConfigTree::onerror,
+        A, b, "",
+        BaseLib::ConfigTree(ptree, "", BaseLib::ConfigTree::onerror,
                             BaseLib::ConfigTree::onwarning)
     );
 }
@@ -317,19 +322,24 @@ TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_chebyshev_sor)
     const bool is_global_size = false;
     MathLib::PETScVector b(2, is_global_size);
 
-    boost::property_tree::ptree t_root;
-    t_root.put("petsc",
-                 "-ptest2_ksp_type chebyshev "
-                 "-ptest2_ksp_rtol 1.e-8 "
-                 "-ptest2_ksp_atol 1.e-50"
-                 "-ptest2_ksp_max_it 1000 "
-                 "-ptest2_pc_type sor");
+    const char xml[] =
+            "<petsc>"
+            "  <parameters>"
+            "    -ptest2_ksp_type chebyshev "
+            "    -ptest2_ksp_rtol 1.e-8 "
+            "    -ptest2_ksp_atol 1.e-50"
+            "    -ptest2_ksp_max_it 1000 "
+            "    -ptest2_pc_type sor"
+            "  </parameters>"
+            "  <prefix>ptest2</prefix>"
+            "</petsc>";
+    auto const ptree = readXml(xml);
 
     checkLinearSolverInterface<MathLib::PETScMatrix,
                                MathLib::PETScVector,
                                MathLib::PETScLinearSolver>(
-        A, b, "ptest2_",
-        BaseLib::ConfigTree(t_root, "", BaseLib::ConfigTree::onerror,
+        A, b, "",
+        BaseLib::ConfigTree(ptree, "", BaseLib::ConfigTree::onerror,
                             BaseLib::ConfigTree::onwarning)
     );
 }
@@ -346,21 +356,26 @@ TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_gmres_amg)
     const bool is_global_size = false;
     MathLib::PETScVector b(2, is_global_size);
 
-    boost::property_tree::ptree t_root;
-    t_root.put("petsc",
-                 "-ptest3_ksp_type gmres "
-                 "-ptest3_ksp_rtol 1.e-8 "
-                 "-ptest3_ksp_gmres_restart 20 "
-                 "-ptest3_ksp_gmres_classicalgramschmidt "
-                 "-ptest3_pc_type gamg "
-                 "-ptest3_pc_gamg_type agg "
-                 "-ptest3_pc_gamg_agg_nsmooths 2");
+    const char xml[] =
+            "<petsc>"
+            "  <parameters>"
+            "    -ptest3_ksp_type gmres "
+            "    -ptest3_ksp_rtol 1.e-8 "
+            "    -ptest3_ksp_gmres_restart 20 "
+            "    -ptest3_ksp_gmres_classicalgramschmidt "
+            "    -ptest3_pc_type gamg "
+            "    -ptest3_pc_gamg_type agg "
+            "    -ptest3_pc_gamg_agg_nsmooths 2"
+            "  </parameters>"
+            "  <prefix>ptest3</prefix>"
+            "</petsc>";
+    auto const ptree = readXml(xml);
 
     checkLinearSolverInterface<MathLib::PETScMatrix,
                                MathLib::PETScVector,
                                MathLib::PETScLinearSolver>(
-        A, b, "ptest3_",
-        BaseLib::ConfigTree(t_root, "", BaseLib::ConfigTree::onerror,
+        A, b, "",
+        BaseLib::ConfigTree(ptree, "", BaseLib::ConfigTree::onerror,
                             BaseLib::ConfigTree::onwarning)
     );
 }

--- a/Tests/NumLib/ODEs.h
+++ b/Tests/NumLib/ODEs.h
@@ -33,8 +33,8 @@ public:
     void assemble(const double /*t*/, Vector const& /*x*/,
                   Matrix& M, Matrix& K, Vector& b) override
     {
-        MathLib::setMatrix(M, N, N, { 1.0, 0.0,  0.0, 1.0 });
-        MathLib::setMatrix(K, N, N, { 0.0, 1.0, -1.0, 0.0 });
+        MathLib::setMatrix(M, { 1.0, 0.0,  0.0, 1.0 });
+        MathLib::setMatrix(K, { 0.0, 1.0, -1.0, 0.0 });
 
         MathLib::setVector(b, { 0.0, 0.0 });
     }
@@ -106,8 +106,8 @@ public:
     void assemble(const double /*t*/, Vector const& x,
                   Matrix& M, Matrix& K, Vector& b) override
     {
-        MathLib::setMatrix(M, N, N, { 1.0 });
-        MathLib::setMatrix(K, N, N, { x[0] });
+        MathLib::setMatrix(M, { 1.0 });
+        MathLib::setMatrix(K, { x[0] });
         MathLib::setVector(b, { 0.0 });
     }
 
@@ -122,7 +122,7 @@ public:
         BLAS::copy(M, Jac);
         BLAS::scale(Jac, dxdot_dx);
 
-        MathLib::addToMatrix(Jac, N, N, { x[0] }); // add dK_dx
+        MathLib::addToMatrix(Jac, { x[0] }); // add dK_dx
 
         if (dx_dx != 0.0)
         {
@@ -194,13 +194,13 @@ public:
         auto const z = x_curr[2];
 
         MathLib::
-        setMatrix(M, N, N, {       t*y, 1.0,     0.0,
-                                   0.0,  -t,     t*y,
-                             omega*x*t, 0.0, omega*x });
+        setMatrix(M, {       t*y, 1.0,     0.0,
+                             0.0,  -t,     t*y,
+                       omega*x*t, 0.0, omega*x });
         MathLib::
-        setMatrix(K, N, N, {             y,   1.0/t,                       -y,
-                             omega*omega/y,    -0.5,                      0.0,
-                              -0.5*omega*z, y/omega, -(1.0/omega/t+omega)*y*z });
+        setMatrix(K, {             y,   1.0/t,                       -y,
+                       omega*omega/y,    -0.5,                      0.0,
+                        -0.5*omega*z, y/omega, -(1.0/omega/t+omega)*y*z });
         MathLib::
         setVector(b, { 0.0,
                        0.5/t,
@@ -241,24 +241,24 @@ public:
 
             // add dM/dx \cdot \dot x
             MathLib::
-            addToMatrix(Jac, N, N, {                 0.0, t*dx, 0.0,
-                                                     0.0, t*dz, 0.0,
-                                     omega*t*dx+omega*dz,  0.0, 0.0 });
+            addToMatrix(Jac, {                 0.0, t*dx, 0.0,
+                                               0.0, t*dz, 0.0,
+                               omega*t*dx+omega*dz,  0.0, 0.0 });
 
             BLAS::axpy(Jac, dx_dx, K); // add K \cdot dx_dx
 
             // add dK/dx \cdot \dot x
             MathLib::
-            addToMatrix(Jac, N, N, { 0.0, x-z, 0.0,
-                                     0.0, -omega*omega/y/y*x, 0.0,
-                                     0.0, y/omega-(1.0/omega/t+omega)*z*z, // -->
-                                     /* --> */  -0.5*omega*x - (1.0/omega/t+omega)*y*z });
+            addToMatrix(Jac, { 0.0, x-z, 0.0,
+                               0.0, -omega*omega/y/y*x, 0.0,
+                               0.0, y/omega-(1.0/omega/t+omega)*z*z, // -->
+                               /* --> */  -0.5*omega*x - (1.0/omega/t+omega)*y*z });
 
             // add -db/dx
             MathLib::
-            addToMatrix(Jac, N, N, {          0.0, 0.0,          0.0,
-                                              0.0, 0.0,          0.0,
-                                     -0.5*omega*z, 0.0, -0.5*omega*z });
+            addToMatrix(Jac, {          0.0, 0.0,          0.0,
+                                        0.0, 0.0,          0.0,
+                               -0.5*omega*z, 0.0, -0.5*omega*z });
         }
 
         // Eigen::MatrixXd J(Jac.getRawMatrix());

--- a/Tests/NumLib/ODEs.h
+++ b/Tests/NumLib/ODEs.h
@@ -55,7 +55,7 @@ public:
 
     MathLib::MatrixSpecifications getMatrixSpecifications() const override
     {
-        return { N, N };
+        return { N, N, nullptr, nullptr, nullptr };
     }
 
     bool isLinear() const override
@@ -73,12 +73,14 @@ public:
     static void setIC(Vector& x0)
     {
         MathLib::setVector(x0, { 1.0, 0.0 });
+        MathLib::BLAS::finalizeAssembly(x0);
     }
 
     static Vector solution(const double t)
     {
         Vector v(2);
         MathLib::setVector(v, { cos(t), sin(t) });
+        MathLib::BLAS::finalizeAssembly(v);
         return v;
     }
 
@@ -123,12 +125,15 @@ public:
         MathLib::addToMatrix(Jac, N, N, { x[0] }); // add dK_dx
 
         if (dx_dx != 0.0)
+        {
+            BLAS::finalizeAssembly(Jac);
             BLAS::axpy(Jac, dx_dx, K);
+        }
     }
 
     MathLib::MatrixSpecifications getMatrixSpecifications() const override
     {
-        return { N, N };
+        return { N, N, nullptr, nullptr, nullptr };
     }
 
     bool isLinear() const override
@@ -146,12 +151,14 @@ public:
     static void setIC(Vector& x0)
     {
         MathLib::setVector(x0, { 1.0 });
+        MathLib::BLAS::finalizeAssembly(x0);
     }
 
     static Vector solution(const double t)
     {
         Vector v(1);
         MathLib::setVector(v, { 1.0/t });
+        MathLib::BLAS::finalizeAssembly(v);
         return v;
     }
 
@@ -264,7 +271,7 @@ public:
 
     MathLib::MatrixSpecifications getMatrixSpecifications() const override
     {
-        return { N, N };
+        return { N, N, nullptr, nullptr, nullptr };
     }
 
     bool isLinear() const override
@@ -291,6 +298,7 @@ public:
         MathLib::setVector(x0, { sin(omega*t0)/omega/t0,
                                  1.0/t0,
                                  cos(omega*t0) });
+        MathLib::BLAS::finalizeAssembly(x0);
 
         // std::cout << "IC:\n" << Eigen::VectorXd(x0.getRawVector()) << "\n";
     }
@@ -303,6 +311,7 @@ public:
         MathLib::setVector(v, { sin(omega*t)/omega/t,
                                 1.0/t,
                                 cos(omega*t) });
+        MathLib::BLAS::finalizeAssembly(v);
         return v;
     }
 

--- a/Tests/NumLib/TestODEInt.cpp
+++ b/Tests/NumLib/TestODEInt.cpp
@@ -299,21 +299,13 @@ public:
 
 TYPED_TEST_CASE(NumLibODEIntTyped, TestCases);
 
-#ifndef USE_PETSC
 TYPED_TEST(NumLibODEIntTyped, T1)
-#else
-TYPED_TEST(NumLibODEIntTyped, DISABLED_T1)
-#endif
 {
     TestFixture::test();
 }
 
 
-#ifndef USE_PETSC
 TEST(NumLibODEInt, ODE3)
-#else
-TEST(NumLibODEInt, DISABLED_ODE3)
-#endif
 {
     const char* name = "dummy";
     {

--- a/Tests/TestTools.cpp
+++ b/Tests/TestTools.cpp
@@ -1,0 +1,24 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include <boost/property_tree/xml_parser.hpp>
+
+#include "TestTools.h"
+
+boost::property_tree::ptree
+readXml(const char xml[])
+{
+    boost::property_tree::ptree ptree;
+    std::istringstream xml_str(xml);
+    boost::property_tree::read_xml(
+        xml_str, ptree,
+        boost::property_tree::xml_parser::no_comments |
+        boost::property_tree::xml_parser::trim_whitespace);
+    return ptree;
+}

--- a/Tests/TestTools.h
+++ b/Tests/TestTools.h
@@ -13,6 +13,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <boost/property_tree/ptree_fwd.hpp>
 
 #ifndef TESTTOOLS_H_
 #define TESTTOOLS_H_
@@ -24,5 +25,8 @@
 #define ASSERT_ARRAY_EQ(E,A,N)\
     for (std::size_t i=0; i<(unsigned)(N); i++) \
         ASSERT_EQ((E)[i], (A)[i]);
+
+boost::property_tree::ptree
+readXml(const char xml[]);
 
 #endif // TESTTOOLS_H_

--- a/scripts/cmake/Functions.cmake
+++ b/scripts/cmake/Functions.cmake
@@ -7,7 +7,6 @@ endmacro()
 # Returns a list of source files (*.h and *.cpp) in SOURCE_FILES and creates a Visual
 # Studio folder. A (relative) subdirectory can be passed as second parameter (optional).
 macro(GET_SOURCE_FILES SOURCE_FILES)
-
 	if(${ARGC} EQUAL 2)
 		set(DIR "${ARGV1}")
 	else()
@@ -40,7 +39,13 @@ endmacro()
 # Appends a list of source files (*.h and *.cpp) to SOURCE_FILES and creates a Visual
 # Studio folder. A (relative) subdirectory can be passed as second parameter (optional).
 macro(APPEND_SOURCE_FILES SOURCE_FILES)
-	GET_SOURCE_FILES(TMP_SOURCES "${ARGV}")
+	if(${ARGC} EQUAL 2)
+		set(DIR "${ARGV1}")
+	else()
+		set(DIR ".")
+	endif()
+
+	GET_SOURCE_FILES(TMP_SOURCES "${DIR}")
 	set(${SOURCE_FILES} ${${SOURCE_FILES}} ${TMP_SOURCES})
 endmacro()
 


### PR DESCRIPTION
This is a follow-up PR of #1059.

To do
* [x] ~~docu~~
* [x] discuss ctest results
* [x] update test input files
* [x] put disabled unit tests to a separate PR
* [x] linear solver names
```xml
<petsc>
    <prefix>gw</prefix>
    <params>-ksp_type cg -pc_type bjacobi -ksp_rtol 1e-16 -ksp_max_it 10000</params>
 </petsc>
```

Subsequent PRs:
* remove name argument from linear solver constructors
* clean up matrix and vector classes

Biggest changes:
* implemented missing functionality for PETSc
* PETScMatrix/Vector now stores a pointer to matrix/vector. Thereby it is possible to default construct them.
* The option prefix for PETSc linear solvers is now directly obtained from the `<petsc>` config tree section.
* Extended matrix specifications, s.t. now they include the DOF table, the mesh and the sparsity pattern.