### PR TITLE
Transfer ownership of mesh_subsets to the DOF-table.

### DIFF
--- a/AssemblerLib/LocalToGlobalIndexMap.cpp
+++ b/AssemblerLib/LocalToGlobalIndexMap.cpp
@@ -52,15 +52,16 @@ LocalToGlobalIndexMap::findGlobalIndices(
 
 
 LocalToGlobalIndexMap::LocalToGlobalIndexMap(
-    std::vector<MeshLib::MeshSubsets*> const& mesh_subsets,
+    std::vector<std::unique_ptr<MeshLib::MeshSubsets>>&& mesh_subsets,
     AssemblerLib::ComponentOrder const order)
-    : _mesh_subsets(mesh_subsets), _mesh_component_map(_mesh_subsets, order)
+    : _mesh_subsets(std::move(mesh_subsets)),
+      _mesh_component_map(_mesh_subsets, order)
 {
     // For all MeshSubsets and each of their MeshSubset's and each element
     // of that MeshSubset save a line of global indices.
 
     unsigned comp_id = 0;
-    for (MeshLib::MeshSubsets const* const mss : _mesh_subsets)
+    for (auto const& mss : _mesh_subsets)
     {
         for (MeshLib::MeshSubset const* const ms : *mss)
         {
@@ -74,7 +75,7 @@ LocalToGlobalIndexMap::LocalToGlobalIndexMap(
 }
 
 LocalToGlobalIndexMap::LocalToGlobalIndexMap(
-    std::vector<MeshLib::MeshSubsets*>&& mesh_subsets,
+    std::vector<std::unique_ptr<MeshLib::MeshSubsets>>&& mesh_subsets,
     std::vector<std::size_t> const& original_indices,
     std::vector<MeshLib::Element*> const& elements,
     AssemblerLib::MeshComponentMap&& mesh_component_map)
@@ -86,7 +87,7 @@ LocalToGlobalIndexMap::LocalToGlobalIndexMap(
     // of that MeshSubset save a line of global indices.
 
     unsigned comp_id = 0;
-    for (MeshLib::MeshSubsets const* const mss : _mesh_subsets)
+    for (auto const& mss : _mesh_subsets)
     {
         if (! mss) continue;
         for (MeshLib::MeshSubset const* const ms : *mss)

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -118,6 +118,14 @@ public:
                                                  range_end);
     }
 
+    MeshLib::MeshSubsets const& getMeshSubsets(std::size_t const /* variable_id */,
+                                        std::size_t const component_id) const
+    {
+        // TODO The (global) component_id should be calculated (looked up) from
+        // variable_id and component_id.
+        return *_mesh_subsets[component_id];
+    }
+
 private:
     /// Private constructor used by internally created local-to-global index
     /// maps. The mesh_component_map is passed as argument instead of being

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -49,20 +49,13 @@ public:
 
     /// Derive a LocalToGlobalIndexMap constrained to a set of mesh subsets and
     /// elements. A new mesh component map will be constructed using the passed
-    /// mesh_subsets.
-    ///
-    /// \param mesh_subsets the subsets to which this map will be constrained.
-    ///        It must hold that: mesh_subsets.size() == _mesh_subsets.size()
-    ///        If a component shall not be present in the derived map, put a nullptr
-    ///        to the respective position in mesh_subsets.
+    /// mesh_subsets for the given variable and component ids.
     ///
     /// \note The elements are not necessarily those used in the mesh_subsets.
-    ///
-    /// \note It is possible to use this method on the returned map only
-    ///       if \c mesh_subsets contains no nullptr!
-    ///
     LocalToGlobalIndexMap* deriveBoundaryConstrainedMap(
-        std::vector<std::unique_ptr<MeshLib::MeshSubsets>>&& mesh_subsets,
+        std::size_t const variable_id,
+        std::size_t const component_id,
+        std::unique_ptr<MeshLib::MeshSubsets>&& mesh_subsets,
         std::vector<MeshLib::Element*> const& elements) const;
 
     /// Returns total number of degrees of freedom.
@@ -134,7 +127,7 @@ private:
     /// this construtor.
     explicit LocalToGlobalIndexMap(
         std::vector<std::unique_ptr<MeshLib::MeshSubsets>>&& mesh_subsets,
-        std::vector<std::size_t> const& original_indices,
+        std::size_t const component_id,
         std::vector<MeshLib::Element*> const& elements,
         AssemblerLib::MeshComponentMap&& mesh_component_map);
 

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -44,7 +44,7 @@ public:
     /// Creates a MeshComponentMap internally and stores the global indices for
     /// each mesh element of the given mesh_subsets.
     explicit LocalToGlobalIndexMap(
-        std::vector<MeshLib::MeshSubsets*> const& mesh_subsets,
+        std::vector<std::unique_ptr<MeshLib::MeshSubsets>>&& mesh_subsets,
         AssemblerLib::ComponentOrder const order);
 
     /// Derive a LocalToGlobalIndexMap constrained to a set of mesh subsets and
@@ -62,7 +62,7 @@ public:
     ///       if \c mesh_subsets contains no nullptr!
     ///
     LocalToGlobalIndexMap* deriveBoundaryConstrainedMap(
-        std::vector<MeshLib::MeshSubsets*> const& mesh_subsets,
+        std::vector<std::unique_ptr<MeshLib::MeshSubsets>>&& mesh_subsets,
         std::vector<MeshLib::Element*> const& elements) const;
 
     /// Returns total number of degrees of freedom.
@@ -133,7 +133,7 @@ private:
     /// \attention The passed mesh_component_map is in undefined state after
     /// this construtor.
     explicit LocalToGlobalIndexMap(
-        std::vector<MeshLib::MeshSubsets*>&& mesh_subsets,
+        std::vector<std::unique_ptr<MeshLib::MeshSubsets>>&& mesh_subsets,
         std::vector<std::size_t> const& original_indices,
         std::vector<MeshLib::Element*> const& elements,
         AssemblerLib::MeshComponentMap&& mesh_component_map);
@@ -146,7 +146,7 @@ private:
 
 private:
     /// A vector of mesh subsets for each process variables' components.
-    std::vector<MeshLib::MeshSubsets*> const _mesh_subsets;
+    std::vector<std::unique_ptr<MeshLib::MeshSubsets>> const _mesh_subsets;
     AssemblerLib::MeshComponentMap _mesh_component_map;
 
     using Table = Eigen::Matrix<LineIndex, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -137,6 +137,7 @@ private:
         const unsigned component_id, const unsigned comp_id_write);
 
 private:
+    /// A vector of mesh subsets for each process variables' components.
     std::vector<MeshLib::MeshSubsets*> const _mesh_subsets;
     AssemblerLib::MeshComponentMap _mesh_component_map;
 

--- a/AssemblerLib/MeshComponentMap.cpp
+++ b/AssemblerLib/MeshComponentMap.cpp
@@ -30,13 +30,14 @@ GlobalIndexType const MeshComponentMap::nop =
 
 #ifdef USE_PETSC
 MeshComponentMap::MeshComponentMap(
-    const std::vector<MeshLib::MeshSubsets*> &components, ComponentOrder order)
+    const std::vector<std::unique_ptr<MeshLib::MeshSubsets>>& components,
+    ComponentOrder order)
     : _num_components(components.size())
 
 {
     // get number of unknows
     GlobalIndexType num_unknowns = 0;
-    for (auto const c : components)
+    for (auto const& c : components)
     {
         assert(c != nullptr);
         for (unsigned mesh_subset_index = 0; mesh_subset_index < c->size();
@@ -57,7 +58,7 @@ MeshComponentMap::MeshComponentMap(
     std::size_t comp_id = 0;
     _num_global_dof = 0;
     _num_local_dof = 0;
-    for (auto const c : components)
+    for (auto const& c : components)
     {
         assert(c != nullptr);
         for (unsigned mesh_subset_index = 0; mesh_subset_index < c->size();
@@ -118,13 +119,14 @@ MeshComponentMap::MeshComponentMap(
 }
 #else
 MeshComponentMap::MeshComponentMap(
-    const std::vector<MeshLib::MeshSubsets*> &components, ComponentOrder order)
+    const std::vector<std::unique_ptr<MeshLib::MeshSubsets>>& components,
+    ComponentOrder order)
     : _num_components(components.size())
 {
     // construct dict (and here we number global_index by component type)
     GlobalIndexType global_index = 0;
     std::size_t comp_id = 0;
-    for (auto const c : components)
+    for (auto const& c : components)
     {
         assert (c != nullptr);
         for (std::size_t mesh_subset_index = 0; mesh_subset_index < c->size(); mesh_subset_index++)
@@ -145,8 +147,8 @@ MeshComponentMap::MeshComponentMap(
 }
 #endif // end of USE_PETSC
 
-MeshComponentMap
-MeshComponentMap::getSubset(std::vector<MeshLib::MeshSubsets*> const& components) const
+MeshComponentMap MeshComponentMap::getSubset(
+    std::vector<std::unique_ptr<MeshLib::MeshSubsets>> const& components) const
 {
     assert(components.size() == _num_components);
     // New dictionary for the subset.
@@ -154,7 +156,7 @@ MeshComponentMap::getSubset(std::vector<MeshLib::MeshSubsets*> const& components
 
     std::size_t comp_id = 0;
     std::size_t num_comp = 0;
-    for (auto c : components)
+    for (auto const& c : components)
     {
         if (c == nullptr)   // deselected component
         {

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -42,7 +42,8 @@ public:
 public:
     /// \param components   a vector of components
     /// \param order        type of ordering values in a vector
-    MeshComponentMap(std::vector<MeshLib::MeshSubsets*> const& components,
+    MeshComponentMap(
+        std::vector<std::unique_ptr<MeshLib::MeshSubsets>> const& components,
         ComponentOrder order);
 
     /// Creates a subset of the current mesh component map.
@@ -59,7 +60,7 @@ public:
     /// \c components.
     ///
     MeshComponentMap getSubset(
-        std::vector<MeshLib::MeshSubsets*> const& components) const;
+        std::vector<std::unique_ptr<MeshLib::MeshSubsets>> const& components) const;
 
     /// The number of components in the map.
     std::size_t size() const

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -46,21 +46,13 @@ public:
         std::vector<std::unique_ptr<MeshLib::MeshSubsets>> const& components,
         ComponentOrder order);
 
-    /// Creates a subset of the current mesh component map.
-    /// The components are those from \c components which are not nullptrs.
-    /// The order (BY_LOCATION/BY_COMPONENT) of components is the same as of the current map.
+    /// Creates a single-component subset of the current mesh component map.
+    /// The order (BY_LOCATION/BY_COMPONENT) of components is the same as of the
+    /// current map.
     ///
     /// \param components components that should remain in the created subset
-    ///
-    /// The size of parameter \c components must be equal to the number of components in this map,
-    /// if an element of \c components is \c nullptr, this component will not be included
-    /// in the subset.
-    ///
-    /// The number of components of the subset will equal the number of non-null pointers in
-    /// \c components.
-    ///
-    MeshComponentMap getSubset(
-        std::vector<std::unique_ptr<MeshLib::MeshSubsets>> const& components) const;
+    MeshComponentMap getSubset(std::size_t const component_id,
+                               MeshLib::MeshSubsets const& components) const;
 
     /// The number of components in the map.
     std::size_t size() const

--- a/ProcessLib/NeumannBc.h
+++ b/ProcessLib/NeumannBc.h
@@ -77,20 +77,15 @@ public:
         // to each of the MeshSubset in the mesh_subsets.
         _mesh_subset_all_nodes =
             mesh_subsets.getMeshSubset(0).getIntersectionByNodes(nodes);
-
-        // A vector is of the same size as in the DOF table. Only the one
-        // component for the current NeumannBC will be set.
-        std::vector<std::unique_ptr<MeshLib::MeshSubsets>> all_mesh_subsets(
-            local_to_global_index_map.getNumComponents());
-        // TODO the component_id in assignment is actually a global_component_id
-        // which must be calculated from variable_id and the (local)
-        // component_id. But for single variable processes both are equal.
-        all_mesh_subsets[component_id] = std::unique_ptr<MeshLib::MeshSubsets>{
+        std::unique_ptr<MeshLib::MeshSubsets> all_mesh_subsets{
             new MeshLib::MeshSubsets{_mesh_subset_all_nodes}};
 
+        // Create local DOF table from intersected mesh subsets for the given
+        // variable and component ids.
         _local_to_global_index_map.reset(
             local_to_global_index_map.deriveBoundaryConstrainedMap(
-                std::move(all_mesh_subsets), _elements));
+                variable_id, component_id, std::move(all_mesh_subsets),
+                _elements));
     }
 
     ~NeumannBc()

--- a/ProcessLib/NeumannBc.h
+++ b/ProcessLib/NeumannBc.h
@@ -56,7 +56,7 @@ public:
         NeumannBcConfig const& bc,
         unsigned const integration_order,
         AssemblerLib::LocalToGlobalIndexMap const& local_to_global_index_map,
-        std::size_t const component_index,
+        std::size_t const component_id,
         MeshLib::MeshSubset const& mesh_subset_all_nodes
         )
         :
@@ -64,7 +64,7 @@ public:
           _all_mesh_subsets(local_to_global_index_map.getNumComponents(), nullptr),
           _integration_order(integration_order)
     {
-        assert(component_index < local_to_global_index_map.getNumComponents());
+        assert(component_id < local_to_global_index_map.getNumComponents());
 
         // deep copy because the neumann bc config destroys the elements.
         std::transform(bc.elementsBegin(), bc.elementsEnd(),
@@ -76,7 +76,8 @@ public:
         _mesh_subset_all_nodes =
             mesh_subset_all_nodes.getIntersectionByNodes(nodes);
 
-        _all_mesh_subsets[component_index] = new MeshLib::MeshSubsets(_mesh_subset_all_nodes);
+        _all_mesh_subsets[component_id] =
+            new MeshLib::MeshSubsets(_mesh_subset_all_nodes);
 
         _local_to_global_index_map.reset(
             local_to_global_index_map.deriveBoundaryConstrainedMap(

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -319,8 +319,8 @@ private:
 		                          _global_setup,
 		                          _integration_order,
 		                          *_local_to_global_index_map,
-		                          component_id,
-		                          *_mesh_subset_all_nodes);
+		                          0,  // 0 is the variable id TODO
+		                          component_id);
 	}
 
 	/// Computes and stores global matrix' sparsity pattern from given

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -72,8 +72,6 @@ public:
 
 	virtual ~Process()
 	{
-		for (auto p : _all_mesh_subsets)
-			delete p;
 		delete _mesh_subset_all_nodes;
 	}
 
@@ -95,12 +93,27 @@ public:
 		DBUG("Initialize process.");
 
 		DBUG("Construct dof mappings.");
-		for (auto const& pv : _process_variables)
-			initializeMeshSubsets(pv);
+		// Create single component dof in every of the mesh's nodes.
+		_mesh_subset_all_nodes =
+		    new MeshLib::MeshSubset(_mesh, &_mesh.getNodes());
+
+		// Collect the mesh subsets in a vector.
+		std::vector<std::unique_ptr<MeshLib::MeshSubsets>> all_mesh_subsets;
+		for (ProcessVariable const& pv : _process_variables)
+		{
+			std::generate_n(
+			    std::back_inserter(all_mesh_subsets),
+			    pv.getNumberOfComponents(),
+			    [&]()
+			    {
+				    return std::unique_ptr<MeshLib::MeshSubsets>{
+				        new MeshLib::MeshSubsets{_mesh_subset_all_nodes}};
+				});
+		}
 
 		_local_to_global_index_map.reset(
 		    new AssemblerLib::LocalToGlobalIndexMap(
-		        _all_mesh_subsets, AssemblerLib::ComponentOrder::BY_COMPONENT));
+		        std::move(all_mesh_subsets), AssemblerLib::ComponentOrder::BY_COMPONENT));
 
 #ifndef USE_PETSC
 		DBUG("Compute sparsity pattern");
@@ -242,24 +255,6 @@ private:
 		std::abort();
 	}
 
-	/// Creates mesh subsets, i.e. components, for given mesh.
-	void initializeMeshSubsets(ProcessVariable const& variable)
-	{
-		// Create single component dof in every of the mesh's nodes.
-		_mesh_subset_all_nodes =
-		    new MeshLib::MeshSubset(_mesh, &_mesh.getNodes());
-
-		// Collect the mesh subsets in a vector.
-		std::generate_n(
-		    std::back_inserter(_all_mesh_subsets),
-		    variable.getNumberOfComponents(),
-		    [&]()
-		    {
-			    return new MeshLib::MeshSubsets(_mesh_subset_all_nodes);
-		    });
-
-	}
-
 	/// Sets the initial condition values in the solution vector x for a given
 	/// process variable and component.
 	void setInitialConditions(ProcessVariable const& variable,
@@ -382,7 +377,6 @@ protected:
 
 	MeshLib::Mesh& _mesh;
 	MeshLib::MeshSubset const* _mesh_subset_all_nodes = nullptr;
-	std::vector<MeshLib::MeshSubsets*> _all_mesh_subsets;
 
 	GlobalSetup _global_setup;
 

--- a/Tests/AssemblerLib/LocalToGlobalIndexMap.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMap.cpp
@@ -26,32 +26,25 @@ class AssemblerLibLocalToGlobalIndexMapTest : public ::testing::Test
 public:
     AssemblerLibLocalToGlobalIndexMapTest()
     {
-        mesh = MeshLib::MeshGenerator::generateLineMesh(1.0, mesh_size);
-        nodesSubset = new MeshLib::MeshSubset(*mesh, &mesh->getNodes());
+        mesh.reset(MeshLib::MeshGenerator::generateLineMesh(1.0, mesh_size));
+        nodesSubset.reset(new MeshLib::MeshSubset(*mesh, &mesh->getNodes()));
 
         // Add two components both based on the same nodesSubset.
-        components.emplace_back(new MeshLib::MeshSubsets{nodesSubset});
-        components.emplace_back(new MeshLib::MeshSubsets{nodesSubset});
-    }
-
-    ~AssemblerLibLocalToGlobalIndexMapTest()
-    {
-        delete dof_map;
-        delete nodesSubset;
-        delete mesh;
+        components.emplace_back(new MeshLib::MeshSubsets{nodesSubset.get()});
+        components.emplace_back(new MeshLib::MeshSubsets{nodesSubset.get()});
     }
 
 protected:
     static std::size_t const mesh_size = 9;
-    MeshLib::Mesh const* mesh = nullptr;
-    MeshLib::MeshSubset const* nodesSubset = nullptr;
+    std::unique_ptr<MeshLib::Mesh const> mesh;
+    std::unique_ptr<MeshLib::MeshSubset const> nodesSubset;
 
     //data component 0 and 1 are assigned to all nodes in the mesh
     static std::size_t const comp0_id = 0;
     static std::size_t const comp1_id = 1;
     std::vector<std::unique_ptr<MeshLib::MeshSubsets>> components;
 
-    AssemblerLib::LocalToGlobalIndexMap const* dof_map = nullptr;
+    std::unique_ptr<AssemblerLib::LocalToGlobalIndexMap const> dof_map;
 };
 
 TEST_F(AssemblerLibLocalToGlobalIndexMapTest, NumberOfRowsByComponent)
@@ -60,8 +53,8 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapTest, NumberOfRowsByComponent)
     // DOF-table.
     std::size_t components_size = components.size();
 
-    dof_map = new AssemblerLib::LocalToGlobalIndexMap(std::move(components),
-        AssemblerLib::ComponentOrder::BY_COMPONENT);
+    dof_map.reset(new AssemblerLib::LocalToGlobalIndexMap(std::move(components),
+        AssemblerLib::ComponentOrder::BY_COMPONENT));
 
     // There must be as many rows as nodes in the input times the number of
     // components.
@@ -74,8 +67,8 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapTest, NumberOfRowsByLocation)
     // DOF-table.
     std::size_t components_size = components.size();
 
-    dof_map = new AssemblerLib::LocalToGlobalIndexMap(std::move(components),
-        AssemblerLib::ComponentOrder::BY_LOCATION);
+    dof_map.reset(new AssemblerLib::LocalToGlobalIndexMap(std::move(components),
+        AssemblerLib::ComponentOrder::BY_LOCATION));
 
     // There must be as many rows as nodes in the input times the number of
     // components.
@@ -84,8 +77,8 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapTest, NumberOfRowsByLocation)
 
 TEST_F(AssemblerLibLocalToGlobalIndexMapTest, SubsetByComponent)
 {
-    dof_map = new AssemblerLib::LocalToGlobalIndexMap(std::move(components),
-        AssemblerLib::ComponentOrder::BY_COMPONENT);
+    dof_map.reset(new AssemblerLib::LocalToGlobalIndexMap(std::move(components),
+        AssemblerLib::ComponentOrder::BY_COMPONENT));
 
     // Select some elements from the full mesh.
     std::array<std::size_t, 3> const ids = {{ 0, 5, 8 }};
@@ -96,21 +89,18 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapTest, SubsetByComponent)
     // Find unique node ids of the selected elements for testing.
     std::vector<MeshLib::Node*> selected_nodes = MeshLib::getUniqueNodes(some_elements);
 
-    MeshLib::MeshSubset const* const selected_subset =
-        nodesSubset->getIntersectionByNodes(selected_nodes);
+    auto const selected_subset = std::unique_ptr<MeshLib::MeshSubset const>{
+        nodesSubset->getIntersectionByNodes(selected_nodes)};
     auto selected_component = std::unique_ptr<MeshLib::MeshSubsets>{
-        new MeshLib::MeshSubsets{selected_subset}};
+        new MeshLib::MeshSubsets{selected_subset.get()}};
 
-    AssemblerLib::LocalToGlobalIndexMap* dof_map_subset =
+    auto dof_map_subset = std::unique_ptr<AssemblerLib::LocalToGlobalIndexMap>{
         dof_map->deriveBoundaryConstrainedMap(0,  // variable id
                                               1,  // component id
                                               std::move(selected_component),
-                                              some_elements);
+                                              some_elements)};
 
     // There must be as many rows as nodes in the input times the number of
     // components.
     ASSERT_EQ(selected_nodes.size(), dof_map_subset->dofSize());
-
-    delete dof_map_subset;
-    delete selected_subset;
 }

--- a/Tests/AssemblerLib/LocalToGlobalIndexMap.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMap.cpp
@@ -30,10 +30,8 @@ public:
         nodesSubset = new MeshLib::MeshSubset(*mesh, &mesh->getNodes());
 
         // Add two components both based on the same nodesSubset.
-        components.emplace_back(std::unique_ptr<MeshLib::MeshSubsets>{
-            new MeshLib::MeshSubsets{nodesSubset}});
-        components.emplace_back(std::unique_ptr<MeshLib::MeshSubsets>{
-            new MeshLib::MeshSubsets{nodesSubset}});
+        components.emplace_back(new MeshLib::MeshSubsets{nodesSubset});
+        components.emplace_back(new MeshLib::MeshSubsets{nodesSubset});
     }
 
     ~AssemblerLibLocalToGlobalIndexMapTest()

--- a/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
@@ -82,9 +82,8 @@ public:
 		std::vector<std::unique_ptr<MeshLib::MeshSubsets>> components;
 		for (unsigned i=0; i<num_components; ++i)
 		{
-			components.emplace_back(std::unique_ptr<MeshLib::MeshSubsets>{
-                    new MeL::MeshSubsets{
-			    mesh_items_all_nodes.get()}});
+			components.emplace_back(
+			    new MeL::MeshSubsets{mesh_items_all_nodes.get()});
 		}
 		dof_map.reset(
 		    new AL::LocalToGlobalIndexMap(std::move(components), order));

--- a/Tests/AssemblerLib/TestMeshComponentMap.cpp
+++ b/Tests/AssemblerLib/TestMeshComponentMap.cpp
@@ -34,10 +34,8 @@ class AssemblerLibMeshComponentMapTest : public ::testing::Test
         nodesSubset = new MeshLib::MeshSubset(*mesh, &mesh->getNodes());
 
         // Add two components both based on the same nodesSubset.
-        components.emplace_back(std::unique_ptr<MeshLib::MeshSubsets>{
-            new MeshLib::MeshSubsets{nodesSubset}});
-        components.emplace_back(std::unique_ptr<MeshLib::MeshSubsets>{
-            new MeshLib::MeshSubsets{nodesSubset}});
+        components.emplace_back(new MeshLib::MeshSubsets{nodesSubset});
+        components.emplace_back(new MeshLib::MeshSubsets{nodesSubset});
     }
 
     ~AssemblerLibMeshComponentMapTest()

--- a/Tests/AssemblerLib/TestSerialLinearSolver.cpp
+++ b/Tests/AssemblerLib/TestSerialLinearSolver.cpp
@@ -58,11 +58,11 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
     // Allocate a coefficient matrix, RHS and solution vectors
     //--------------------------------------------------------------------------
     // define a mesh item composition in a vector
-    std::vector<MeshLib::MeshSubsets*> vec_comp_dis;
-    vec_comp_dis.push_back(
-        new MeshLib::MeshSubsets(&mesh_items_all_nodes));
+    std::vector<std::unique_ptr<MeshLib::MeshSubsets>> vec_comp_dis;
+    vec_comp_dis.emplace_back(std::unique_ptr<MeshLib::MeshSubsets>{
+        new MeshLib::MeshSubsets{&mesh_items_all_nodes}});
     AssemblerLib::LocalToGlobalIndexMap local_to_global_index_map(
-            vec_comp_dis, AssemblerLib::ComponentOrder::BY_COMPONENT);
+        std::move(vec_comp_dis), AssemblerLib::ComponentOrder::BY_COMPONENT);
 
     //--------------------------------------------------------------------------
     // Construct a linear system
@@ -158,9 +158,6 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
         solution[i] = (*x)[i];
 
     ASSERT_ARRAY_NEAR(&ex1.exact_solutions[0], &solution[0], ex1.dim_eqs, 1.e-5);
-
-    std::remove_if(vec_comp_dis.begin(), vec_comp_dis.end(),
-        [](MeshLib::MeshSubsets * p) { delete p; return true; });
 
     for (auto p : local_assembler_data)
         delete p;

--- a/Tests/AssemblerLib/TestSerialLinearSolver.cpp
+++ b/Tests/AssemblerLib/TestSerialLinearSolver.cpp
@@ -59,8 +59,7 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
     //--------------------------------------------------------------------------
     // define a mesh item composition in a vector
     std::vector<std::unique_ptr<MeshLib::MeshSubsets>> vec_comp_dis;
-    vec_comp_dis.emplace_back(std::unique_ptr<MeshLib::MeshSubsets>{
-        new MeshLib::MeshSubsets{&mesh_items_all_nodes}});
+    vec_comp_dis.emplace_back(new MeshLib::MeshSubsets{&mesh_items_all_nodes});
     AssemblerLib::LocalToGlobalIndexMap local_to_global_index_map(
         std::move(vec_comp_dis), AssemblerLib::ComponentOrder::BY_COMPONENT);
 

--- a/Tests/AssemblerLib/TestVectorMatrixBuilder.cpp
+++ b/Tests/AssemblerLib/TestVectorMatrixBuilder.cpp
@@ -7,6 +7,7 @@
  *
  */
 
+#include <memory>
 #include <gtest/gtest.h>
 
 #include "AssemblerLib/MeshComponentMap.h"
@@ -35,8 +36,10 @@ class AssemblerLibVectorMatrixBuilder : public ::testing::Test
         nodesSubset = new MeshLib::MeshSubset(*mesh, &mesh->getNodes());
 
         // Add two components both based on the same nodesSubset.
-        components.emplace_back(new MeshLib::MeshSubsets(nodesSubset));
-        components.emplace_back(new MeshLib::MeshSubsets(nodesSubset));
+        components.emplace_back(std::unique_ptr<MeshLib::MeshSubsets>{
+            new MeshLib::MeshSubsets{nodesSubset}});
+        components.emplace_back(std::unique_ptr<MeshLib::MeshSubsets>{
+            new MeshLib::MeshSubsets{nodesSubset}});
 
         cmap = new MeshComponentMap(components,
             AssemblerLib::ComponentOrder::BY_COMPONENT);
@@ -45,8 +48,6 @@ class AssemblerLibVectorMatrixBuilder : public ::testing::Test
     ~AssemblerLibVectorMatrixBuilder()
     {
         delete cmap;
-        std::remove_if(components.begin(), components.end(),
-            [](MeshLib::MeshSubsets* p) { delete p; return true; });
         delete nodesSubset;
         delete mesh;
     }
@@ -55,7 +56,7 @@ class AssemblerLibVectorMatrixBuilder : public ::testing::Test
     MeshLib::Mesh const* mesh;
     MeshLib::MeshSubset const* nodesSubset;
 
-    std::vector<MeshLib::MeshSubsets*> components;
+    std::vector<std::unique_ptr<MeshLib::MeshSubsets>> components;
     MeshComponentMap const* cmap;
 };
 

--- a/Tests/AssemblerLib/TestVectorMatrixBuilder.cpp
+++ b/Tests/AssemblerLib/TestVectorMatrixBuilder.cpp
@@ -36,10 +36,8 @@ class AssemblerLibVectorMatrixBuilder : public ::testing::Test
         nodesSubset = new MeshLib::MeshSubset(*mesh, &mesh->getNodes());
 
         // Add two components both based on the same nodesSubset.
-        components.emplace_back(std::unique_ptr<MeshLib::MeshSubsets>{
-            new MeshLib::MeshSubsets{nodesSubset}});
-        components.emplace_back(std::unique_ptr<MeshLib::MeshSubsets>{
-            new MeshLib::MeshSubsets{nodesSubset}});
+        components.emplace_back(new MeshLib::MeshSubsets{nodesSubset});
+        components.emplace_back(new MeshLib::MeshSubsets{nodesSubset});
 
         cmap = new MeshComponentMap(components,
             AssemblerLib::ComponentOrder::BY_COMPONENT);


### PR DESCRIPTION
Starting with usage of `vector<unique_ptr<MeshSubsets>>` in Process the ownership is transferred to the DOF-table (`LocalToGlobalIndexMap`). All the interfaces involved in construction of the `MeshComponentMap` and the DOF-table are changed either to accept references or rvalues.

While implementation of the ownership improvement the difference between a variable_id (_e.g._ pressure is nr 5), component_id (_e.g._ the z-component is nr 2), and global component_id used in the DOF-table arouse. Most of the functions involving the variable/component ids are broken. _i.e._ the ids are always 0, which is fine for single-variable/single-component id.
The variable_id/component_id are marked as todo.