### PR TITLE
Use https for thirdparty downloads.

### DIFF
--- a/scripts/cmake/ThirdPartyLibVersions.cmake
+++ b/scripts/cmake/ThirdPartyLibVersions.cmake
@@ -1,13 +1,13 @@
 set(OGS_BOOST_VERSION 1.56.0)
 string(REPLACE "." "_" OGS_BOOST_VERSION_UNDERLINE ${OGS_BOOST_VERSION})
-set(OGS_BOOST_URL "http://sourceforge.net/projects/boost/files/boost/${OGS_BOOST_VERSION}/boost_${OGS_BOOST_VERSION_UNDERLINE}.tar.bz2/download")
+set(OGS_BOOST_URL "https://sourceforge.net/projects/boost/files/boost/${OGS_BOOST_VERSION}/boost_${OGS_BOOST_VERSION_UNDERLINE}.tar.bz2/download")
 set(OGS_BOOST_MD5 "a744cf167b05d72335f27c88115f211d")
 
 set(OGS_EIGEN_URL "http://opengeosys.s3.amazonaws.com/ogs6-lib-sources/eigen-3.2.5.tar.gz")
 set(OGS_EIGEN_MD5 "8cc513ac6ec687117acadddfcacf551b")
 
 set(OGS_VTK_VERSION 6.3.0)
-set(OGS_VTK_URL "http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz")
+set(OGS_VTK_URL "https://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz")
 set(OGS_VTK_MD5 "0231ca4840408e9dd60af48b314c5b6d")
 
 set(OGS_TIFF_URL "https://github.com/ufz/tiff/archive/4.0.1.zip")

--- a/scripts/travis/boost.sh
+++ b/scripts/travis/boost.sh
@@ -4,7 +4,7 @@ set -e
 if [ ! -d "$HOME/boost_1_56_0/boost" ]; then
 	TAR="boost_1_56_0.tar.gz"
 	cd $HOME
-	curl -L -o $TAR http://sourceforge.net/projects/boost/files/boost/1.56.0/$TAR/download;
+	curl -L -o $TAR https://sourceforge.net/projects/boost/files/boost/1.56.0/$TAR/download;
 	tar -xzf $TAR;
 else
 	echo 'Using cached boost directory.';


### PR DESCRIPTION
~~I hope this will fix the download issues.~~
Using https for thirdparty downloads. This avoids some redirects.

Does not fix issue https://github.com/ufz/ogs/issues/1064, because the problem is not the link, but the downloader.