### PR TITLE
Unclutter Jenkins error parser

### DIFF
--- a/MeshLib/MeshEditing/MeshRevision.cpp
+++ b/MeshLib/MeshEditing/MeshRevision.cpp
@@ -90,7 +90,7 @@ MeshLib::Mesh* MeshRevision::simplifyMesh(const std::string &new_mesh_name,
 					subdivideElement(elem, new_nodes, new_elements));
 				if (n_new_elements == 0)
 				{
-					ERR("Error: Element %d has unknown element type.", k);
+					ERR("Element %d has unknown element type.", k);
 					this->resetNodeIDs();
 					this->cleanUp(new_nodes, new_elements);
 					return nullptr;
@@ -158,7 +158,7 @@ MeshLib::Mesh* MeshRevision::subdivideMesh(const std::string &new_mesh_name) con
 				subdivideElement(elem, new_nodes, new_elements));
 			if (n_new_elements == 0)
 			{
-				ERR("Error: Element %d has unknown element type.", k);
+				ERR("Element %d has unknown element type.", k);
 				this->cleanUp(new_nodes, new_elements);
 				return nullptr;
 			}
@@ -321,7 +321,7 @@ std::size_t MeshRevision::reduceElement(MeshLib::Element const*const element,
 		return reducePrism(element, n_unique_nodes, nodes, elements, min_elem_dim);
 	}
 
-	ERR ("Error: Unknown element type.");
+	ERR ("Unknown element type.");
 	return 0;
 }
 

--- a/MeshLib/MeshSearch/MeshElementGrid.cpp
+++ b/MeshLib/MeshSearch/MeshElementGrid.cpp
@@ -104,7 +104,7 @@ void MeshElementGrid::sortElementsInGridCells(MeshLib::Mesh const& sfc_mesh)
 {
 	for (auto const element : sfc_mesh.getElements()) {
 		if (! sortElementInGridCells(*element)) {
-			ERR("Fatal error: Sorting element (id=%d) into mesh element grid.",
+			ERR("Sorting element (id=%d) into mesh element grid.",
 			    element->getID());
 			std::abort();
 		}

--- a/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping-impl.h
+++ b/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping-impl.h
@@ -91,7 +91,7 @@ computeMappingMatrices(
 
 #ifndef NDEBUG
     if (shapemat.detJ<=.0)
-        ERR("***error: det|J|=%e is not positive.\n", shapemat.detJ);
+        ERR("det|J|=%e is not positive.\n", shapemat.detJ);
 #endif
 }
 template <class T_MESH_ELEMENT, class T_SHAPE_FUNC, class T_SHAPE_MATRICES>

--- a/SimpleTests/MatrixTests/DenseGaussEliminationChecker.cpp
+++ b/SimpleTests/MatrixTests/DenseGaussEliminationChecker.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
 	std::string const fname_mat(matrix_arg.getValue());
 	std::ifstream in(fname_mat.c_str());
 	if (!in) {
-		ERR("error reading matrix from %s", fname_mat.c_str());
+		INFO("error reading matrix from %s", fname_mat.c_str());
 		return -1;
 	}
 	INFO("reading matrix from %s ...", fname_mat.c_str());

--- a/SimpleTests/MatrixTests/MatMult.cpp
+++ b/SimpleTests/MatrixTests/MatMult.cpp
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
 		CS_read(in, n, iA, jA, A);
 		INFO("\t- took %e s", timer.elapsed());
 	} else {
-		ERR("error reading matrix from %s", fname_mat.c_str());
+		INFO("error reading matrix from %s", fname_mat.c_str());
 		return -1;
 	}
 	unsigned nnz(iA[n]);

--- a/SimpleTests/MatrixTests/MatVecMultPthreads.cpp
+++ b/SimpleTests/MatrixTests/MatVecMultPthreads.cpp
@@ -109,7 +109,7 @@ INFO("%s was build with compiler %s",
 		CS_read(in, n, iA, jA, A);
 		INFO("\t- took %e s", timer.elapsed());
 	} else {
-		ERR("error reading matrix from %s", fname_mat.c_str());
+		INFO("error reading matrix from %s", fname_mat.c_str());
 		return -1;
 	}
 	unsigned nnz(iA[n]);


### PR DESCRIPTION
With the changes introduces Jenkins should no longer point us to, e.g.
```
***error: det|J|=-1.000000e+00 is not positive.
```