### PR TITLE
Fix surface creation bugs in SHPInterface

### DIFF
--- a/FileIO/SHPInterface.cpp
+++ b/FileIO/SHPInterface.cpp
@@ -175,15 +175,14 @@ void SHPInterface::readPolylines(const SHPHandle &hSHP, int numberOfElements, st
 
 void SHPInterface::readPolygons(const SHPHandle &hSHP, int numberOfElements, const std::string &listName)
 {
-	this->readPolylines(hSHP, numberOfElements, listName);
+	readPolylines(hSHP, numberOfElements, listName);
 
-	const std::vector<GeoLib::Polyline*>* polylines(_geoObjects->getPolylineVec(listName));
+	auto const polylines = _geoObjects->getPolylineVec(listName);
 	auto sfc_vec = std::unique_ptr<std::vector<GeoLib::Surface*>>(
 	    new std::vector<GeoLib::Surface*>);
 
-	for (std::vector<GeoLib::Polyline*>::const_iterator poly_it(polylines->begin()); poly_it
-	                != polylines->end(); ++poly_it) {
-		GeoLib::Surface* sfc(GeoLib::Surface::createSurface(*(*poly_it)));
+	for (auto const* polyline : *polylines) {
+		GeoLib::Surface* sfc(GeoLib::Surface::createSurface(*polyline));
 		if (sfc)
 			sfc_vec->push_back(sfc);
 		else {

--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -126,51 +126,42 @@ bool lineSegmentIntersect(
 	MathLib::Vector3 const qp(a, c);
 	MathLib::Vector3 const pq(c, a);
 
+	auto isLineSegmentIntersectingAB = [&v](MathLib::Vector3 const& ap,
+	                                        std::size_t i)
+	{
+		// check if p is located at v=(a,b): (ap = t*v, t in [0,1])
+		if (0.0 <= ap[i] / v[i] && ap[i] / v[i] <= 1.0) {
+			return true;
+		}
+		return false;
+	};
+
 	if (parallel(v,w)) { // original line segments (a,b) and (c,d) are parallel
 		if (parallel(pq,v)) { // line segment (a,b) and (a,c) are also parallel
-			if (v[0] != 0.0) { // segment (a,b) non perpendicular to x-axis
-				// check if c is located at v (c-a = t (b-a), t in [0,1])
-				if (0.0 <= qp[0] / v[0] && qp[0] / v[0] <= 1.0) {
-					s = c;
-					return true;
-				}
-				// check if d is located at v (d-a = t (b-a), t in [0,1])
-				if (0.0 <= MathLib::Vector3(a, d)[0] / v[0] &&
-				    MathLib::Vector3(a, d)[0] / v[0] <= 1.0) {
-					s = d;
-					return true;
-				}
-				return false;
-			} else if (v[1] != 0.0) {
-				// (a,b) perpendicular to x-axis and not perpendicular to y-axis
-				// check if c is located at v (c-a = t (b-a), t in [0,1])
-				if (0.0 <= qp[1] / v[1] && qp[1] / v[1] <= 1.0) {
-					s = c;
-					return true;
-				}
-				// check if d is located at v (d-a = t (b-a), t in [0,1])
-				if (0.0 <= MathLib::Vector3(a, d)[1] / v[1] &&
-				    MathLib::Vector3(a, d)[1] / v[1] <= 1.0) {
-					s = d;
-					return true;
-				}
-				return false;
-			} else if (v[2] != 0.0) {
-				// (a,b) perpendicular to x- and y-axis and not perpendicular
-				// to z-axis
-				// check if c is located at v (c-a = t (b-a), t in [0,1])
-				if (0.0 <= qp[2] / v[2] && qp[2] / v[2] <= 1.0) {
-					s = c;
-					return true;
-				}
-				// check if d is located at v (d-a = t (b-a), t in [0,1])
-				if (0.0 <= MathLib::Vector3(a, d)[2] / v[2] &&
-				    MathLib::Vector3(a, d)[2] / v[2] <= 1.0) {
-					s = d;
-					return true;
-				}
-				return false;
+			// Here it is already checked that the line segments (a,b) and (c,d)
+			// are parallel. At this point it is also known that the line
+			// segment (a,c) is also parallel to (a,b). In that case it is
+			// possible to express c as c(t) = a + t * (b-a) (analog for the
+			// point d). Since the evaluation of all three coordinate equations
+			// (x,y,z) have to lead to the same solution for the parameter t it
+			// is sufficient to evaluate t only once.
+
+			// Search id of coordinate with largest absolute value which is will
+			// be used in the subsequent computations. This prevents division by
+			// zero in case the line segments are parallel to one of the
+			// coordinate axis.
+			std::size_t i_max(std::abs(v[0]) <= std::abs(v[1]) ? 1 : 0);
+			i_max = std::abs(v[i_max]) <= std::abs(v[2]) ? 2 : i_max;
+			if (isLineSegmentIntersectingAB(qp, i_max)) {
+				s = c;
+				return true;
 			}
+			MathLib::Vector3 const ad(a, d);
+			if (isLineSegmentIntersectingAB(ad, i_max)) {
+				s = d;
+				return true;
+			}
+			return false;
 		}
 		return false;
 	}

--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -121,27 +121,63 @@ bool lineSegmentIntersect(
 		return true;
 	}
 
-	// general case
 	MathLib::Vector3 const v(a, b);
 	MathLib::Vector3 const w(c, d);
 	MathLib::Vector3 const qp(a, c);
 	MathLib::Vector3 const pq(c, a);
 
-	const double sqr_len_v(v.getSqrLength());
-	const double sqr_len_w(w.getSqrLength());
-
-	if (parallel(v,w)) {
-		if (parallel(pq,v)) {
-			// check if c is located at v (c-a = t (b-a), t in [0,1])
-			if (qp[0] / v[0] <= 1.0)
-				return true;
-			// check if d is located at v (d-a = t (b-a), t in [0,1])
-			if (MathLib::Vector3(a,d)[0]/v[0] <= 1.0)
-				return true;
-			return false;
+	if (parallel(v,w)) { // original line segments (a,b) and (c,d) are parallel
+		if (parallel(pq,v)) { // line segment (a,b) and (a,c) are also parallel
+			if (v[0] != 0.0) { // segment (a,b) non perpendicular to x-axis
+				// check if c is located at v (c-a = t (b-a), t in [0,1])
+				if (0.0 <= qp[0] / v[0] && qp[0] / v[0] <= 1.0) {
+					s = c;
+					return true;
+				}
+				// check if d is located at v (d-a = t (b-a), t in [0,1])
+				if (0.0 <= MathLib::Vector3(a, d)[0] / v[0] &&
+				    MathLib::Vector3(a, d)[0] / v[0] <= 1.0) {
+					s = d;
+					return true;
+				}
+				return false;
+			} else if (v[1] != 0.0) {
+				// (a,b) perpendicular to x-axis and not perpendicular to y-axis
+				// check if c is located at v (c-a = t (b-a), t in [0,1])
+				if (0.0 <= qp[1] / v[1] && qp[1] / v[1] <= 1.0) {
+					s = c;
+					return true;
+				}
+				// check if d is located at v (d-a = t (b-a), t in [0,1])
+				if (0.0 <= MathLib::Vector3(a, d)[1] / v[1] &&
+				    MathLib::Vector3(a, d)[1] / v[1] <= 1.0) {
+					s = d;
+					return true;
+				}
+				return false;
+			} else if (v[2] != 0.0) {
+				// (a,b) perpendicular to x- and y-axis and not perpendicular
+				// to z-axis
+				// check if c is located at v (c-a = t (b-a), t in [0,1])
+				if (0.0 <= qp[2] / v[2] && qp[2] / v[2] <= 1.0) {
+					s = c;
+					return true;
+				}
+				// check if d is located at v (d-a = t (b-a), t in [0,1])
+				if (0.0 <= MathLib::Vector3(a, d)[2] / v[2] &&
+				    MathLib::Vector3(a, d)[2] / v[2] <= 1.0) {
+					s = d;
+					return true;
+				}
+				return false;
+			}
 		}
 		return false;
 	}
+
+	// general case
+	const double sqr_len_v(v.getSqrLength());
+	const double sqr_len_w(w.getSqrLength());
 
 	MathLib::DenseMatrix<double> mat(2,2);
 	mat(0,0) = sqr_len_v;

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -395,7 +395,7 @@ void Polygon::splitPolygonAtIntersection (std::list<Polygon*>::iterator polygon_
 		}
 		else
 			delete intersection_pnt;
-		++polygon_it;
+		return;
 	}
 }
 

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -350,53 +350,45 @@ void Polygon::ensureCWOrientation ()
 
 void Polygon::splitPolygonAtIntersection (std::list<Polygon*>::iterator polygon_it)
 {
-	std::size_t idx0 (0), idx1 (0);
-	while (polygon_it != _simple_polygon_list.end())
-	{
-		GeoLib::Point* intersection_pnt (new GeoLib::Point);
-		bool is_simple (!GeoLib::lineSegmentsIntersect (*polygon_it,
-		                                                 idx0,
-		                                                 idx1,
-		                                                 *intersection_pnt));
-		if (!is_simple)
-		{
-			// adding intersection point to pnt_vec
-			std::size_t intersection_pnt_id (_ply_pnts.size());
-			const_cast<std::vector<Point*>& >(_ply_pnts).push_back (intersection_pnt);
-
-			// split Polygon
-			if (idx0 > idx1)
-				std::swap (idx0, idx1);
-
-			GeoLib::Polyline polyline0{(*polygon_it)->getPointsVec()};
-			for (std::size_t k(0); k <= idx0; k++)
-				polyline0.addPoint ((*polygon_it)->getPointID (k));
-			polyline0.addPoint (intersection_pnt_id);
-			for (std::size_t k(idx1 + 1); k < (*polygon_it)->getNumberOfPoints(); k++)
-				polyline0.addPoint ((*polygon_it)->getPointID (k));
-			GeoLib::Polygon *polygon0(new Polygon(polyline0));
-
-			GeoLib::Polyline polyline1{(*polygon_it)->getPointsVec()};
-			polyline1.addPoint (intersection_pnt_id);
-			for (std::size_t k(idx0 + 1); k <= idx1; k++)
-				polyline1.addPoint ((*polygon_it)->getPointID (k));
-			polyline1.addPoint (intersection_pnt_id);
-			GeoLib::Polygon *polygon1(new Polygon(polyline1));
-
-			// remove original polyline and add two new polylines
-			polygon_it = _simple_polygon_list.erase (polygon_it);
-
-			std::list<GeoLib::Polygon*>::iterator polygon1_it =
-			    _simple_polygon_list.insert(polygon_it, polygon1);
-			std::list<GeoLib::Polygon*>::iterator polygon0_it =
-			    _simple_polygon_list.insert(polygon1_it, polygon0);
-			splitPolygonAtIntersection (polygon0_it);
-			splitPolygonAtIntersection (polygon1_it);
-		}
-		else
-			delete intersection_pnt;
+	std::size_t idx0(0), idx1(0);
+	GeoLib::Point intersection_pnt;
+	bool is_simple(!GeoLib::lineSegmentsIntersect(
+	    *polygon_it, idx0, idx1, intersection_pnt));
+	if (is_simple)
 		return;
-	}
+
+	// adding intersection point to pnt_vec
+	std::size_t intersection_pnt_id (_ply_pnts.size());
+	const_cast<std::vector<Point*>&>(_ply_pnts)
+	    .push_back(new GeoLib::Point(intersection_pnt));
+
+	// split Polygon
+	if (idx0 > idx1)
+		std::swap (idx0, idx1);
+
+	GeoLib::Polyline polyline0{(*polygon_it)->getPointsVec()};
+	for (std::size_t k(0); k <= idx0; k++)
+		polyline0.addPoint((*polygon_it)->getPointID(k));
+	polyline0.addPoint(intersection_pnt_id);
+	for (std::size_t k(idx1 + 1); k < (*polygon_it)->getNumberOfPoints(); k++)
+		polyline0.addPoint((*polygon_it)->getPointID(k));
+
+	GeoLib::Polyline polyline1{(*polygon_it)->getPointsVec()};
+	polyline1.addPoint(intersection_pnt_id);
+	for (std::size_t k(idx0 + 1); k <= idx1; k++)
+		polyline1.addPoint((*polygon_it)->getPointID(k));
+	polyline1.addPoint(intersection_pnt_id);
+
+	// remove original polyline and add two new polylines
+	polygon_it = _simple_polygon_list.erase(polygon_it);
+
+	std::list<GeoLib::Polygon*>::iterator polygon1_it =
+	    _simple_polygon_list.insert(polygon_it, new GeoLib::Polygon(polyline1));
+	std::list<GeoLib::Polygon*>::iterator polygon0_it =
+	    _simple_polygon_list.insert(polygon1_it,
+	                                new GeoLib::Polygon(polyline0));
+	splitPolygonAtIntersection(polygon0_it);
+	splitPolygonAtIntersection(polygon1_it);
 }
 
 void Polygon::splitPolygonAtPoint (std::list<GeoLib::Polygon*>::iterator polygon_it)

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -384,11 +384,12 @@ void Polygon::splitPolygonAtIntersection (std::list<Polygon*>::iterator polygon_
 			GeoLib::Polygon *polygon1(new Polygon(polyline1));
 
 			// remove original polyline and add two new polylines
-			std::list<GeoLib::Polygon*>::iterator polygon0_it, polygon1_it;
 			polygon_it = _simple_polygon_list.erase (polygon_it);
-			polygon1_it = _simple_polygon_list.insert (polygon_it, polygon1);
-			polygon0_it = _simple_polygon_list.insert (polygon1_it, polygon0);
 
+			std::list<GeoLib::Polygon*>::iterator polygon1_it =
+			    _simple_polygon_list.insert(polygon_it, polygon1);
+			std::list<GeoLib::Polygon*>::iterator polygon0_it =
+			    _simple_polygon_list.insert(polygon1_it, polygon0);
 			splitPolygonAtIntersection (polygon0_it);
 			splitPolygonAtIntersection (polygon1_it);
 		}

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -368,30 +368,20 @@ void Polygon::splitPolygonAtIntersection (std::list<Polygon*>::iterator polygon_
 			if (idx0 > idx1)
 				std::swap (idx0, idx1);
 
-			GeoLib::Polygon* polygon0 (new GeoLib::Polygon(
-			                                   (*polygon_it)->getPointsVec(), false));
+			GeoLib::Polyline polyline0{(*polygon_it)->getPointsVec()};
 			for (std::size_t k(0); k <= idx0; k++)
-				polygon0->addPoint ((*polygon_it)->getPointID (k));
-			polygon0->addPoint (intersection_pnt_id);
+				polyline0.addPoint ((*polygon_it)->getPointID (k));
+			polyline0.addPoint (intersection_pnt_id);
 			for (std::size_t k(idx1 + 1); k < (*polygon_it)->getNumberOfPoints(); k++)
-				polygon0->addPoint ((*polygon_it)->getPointID (k));
-			if (!polygon0->initialise())
-			{
-				ERR("Polygon::splitPolygonAtIntersection(): Initialization of polygon0 failed.");
-				exit (1);
-			}
+				polyline0.addPoint ((*polygon_it)->getPointID (k));
+			GeoLib::Polygon *polygon0(new Polygon(polyline0));
 
-			GeoLib::Polygon* polygon1 (new GeoLib::Polygon(
-			                                   (*polygon_it)->getPointsVec(), false));
-			polygon1->addPoint (intersection_pnt_id);
+			GeoLib::Polyline polyline1{(*polygon_it)->getPointsVec()};
+			polyline1.addPoint (intersection_pnt_id);
 			for (std::size_t k(idx0 + 1); k <= idx1; k++)
-				polygon1->addPoint ((*polygon_it)->getPointID (k));
-			polygon1->addPoint (intersection_pnt_id);
-			if (!polygon1->initialise())
-			{
-				ERR("Polygon::splitPolygonAtIntersection(): Initialization of polygon1 failed.");
-				exit (1);
-			}
+				polyline1.addPoint ((*polygon_it)->getPointID (k));
+			polyline1.addPoint (intersection_pnt_id);
+			GeoLib::Polygon *polygon1(new Polygon(polyline1));
 
 			// remove original polyline and add two new polylines
 			std::list<GeoLib::Polygon*>::iterator polygon0_it, polygon1_it;

--- a/GeoLib/Polygon.h
+++ b/GeoLib/Polygon.h
@@ -135,7 +135,12 @@ private:
 
 	void ensureCWOrientation ();
 
-	void splitPolygonAtIntersection (std::list<Polygon*>::iterator polygon_it);
+#if __GNUC__ <= 4 && (__GNUC_MINOR__ < 9)
+	void splitPolygonAtIntersection(std::list<Polygon*>::iterator polygon_it);
+#else
+	void splitPolygonAtIntersection(
+	    std::list<Polygon*>::const_iterator polygon_it);
+#endif
 	void splitPolygonAtPoint (std::list<Polygon*>::iterator polygon_it);
 	std::list<Polygon*> _simple_polygon_list;
 	AABB _aabb;


### PR DESCRIPTION
- First bug was that empty polygons were created and the AABB of an empty point set is not allowed.
- Second bug was inproper handling parallel line segments.