### PR TITLE
Disable Segfaulting PETSc unit tests one by one

### DIFF
--- a/Tests/AssemblerLib/LocalToGlobalIndexMap.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMap.cpp
@@ -47,7 +47,11 @@ protected:
     std::unique_ptr<AssemblerLib::LocalToGlobalIndexMap const> dof_map;
 };
 
+#ifndef USE_PETSC
 TEST_F(AssemblerLibLocalToGlobalIndexMapTest, NumberOfRowsByComponent)
+#else
+TEST_F(AssemblerLibLocalToGlobalIndexMapTest, DISABLED_NumberOfRowsByComponent)
+#endif
 {
     // need to store the size because the components will be moved into the
     // DOF-table.
@@ -61,7 +65,11 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapTest, NumberOfRowsByComponent)
     ASSERT_EQ(mesh->getNNodes() * components_size, dof_map->dofSize());
 }
 
+#ifndef USE_PETSC
 TEST_F(AssemblerLibLocalToGlobalIndexMapTest, NumberOfRowsByLocation)
+#else
+TEST_F(AssemblerLibLocalToGlobalIndexMapTest, DISABLED_NumberOfRowsByLocation)
+#endif
 {
     // need to store the size because the components will be moved into the
     // DOF-table.
@@ -75,7 +83,11 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapTest, NumberOfRowsByLocation)
     ASSERT_EQ(mesh->getNNodes() * components_size, dof_map->dofSize());
 }
 
+#ifndef USE_PETSC
 TEST_F(AssemblerLibLocalToGlobalIndexMapTest, SubsetByComponent)
+#else
+TEST_F(AssemblerLibLocalToGlobalIndexMapTest, DISABLED_SubsetByComponent)
+#endif
 {
     dof_map.reset(new AssemblerLib::LocalToGlobalIndexMap(std::move(components),
         AssemblerLib::ComponentOrder::BY_COMPONENT));

--- a/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
@@ -214,8 +214,11 @@ void assert_equal(AL::LocalToGlobalIndexMap const& dof1, AL::LocalToGlobalIndexM
 	}
 }
 
-
+#ifndef USE_PETSC
 TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, Test1Comp)
+#else
+TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, DISABLED_Test1Comp)
+#endif
 {
 	unsigned const num_components = 1;
 
@@ -233,7 +236,11 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, Test1Comp)
 	assert_equal(*dof_map_boundary, *dof_map_boundary_bc);
 }
 
+#ifndef USE_PETSC
 TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, TestMultiCompByComponent)
+#else
+TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, DISABLED_TestMultiCompByComponent)
+#endif
 {
 	unsigned const num_components = 5;
 	for (unsigned c = 0; c < num_components; ++c)
@@ -242,7 +249,11 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, TestMultiCompByComponent)
 		                           (mesh_subdivs + 1) * (mesh_subdivs + 1)});
 }
 
+#ifndef USE_PETSC
 TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, TestMultiCompByLocation)
+#else
+TEST_F(AssemblerLibLocalToGlobalIndexMapMultiDOFTest, DISABLED_TestMultiCompByLocation)
+#endif
 {
 	unsigned const num_components = 5;
 	for (unsigned c = 0; c < num_components; ++c)

--- a/Tests/AssemblerLib/TestMeshComponentMap.cpp
+++ b/Tests/AssemblerLib/TestMeshComponentMap.cpp
@@ -67,7 +67,11 @@ class AssemblerLibMeshComponentMapTest : public ::testing::Test
 
 };
 
+#ifndef USE_PETSC
 TEST_F(AssemblerLibMeshComponentMapTest, CheckOrderByComponent)
+#else
+TEST_F(AssemblerLibMeshComponentMapTest, DISABLED_CheckOrderByComponent)
+#endif
 {
     // - Entries in the vector are arranged in the order of a component type and then node ID
     // - For example, x=[(node 0, comp 0) (node 1, comp 0) ... (node n, comp0), (node 0, comp1) ... ]
@@ -91,7 +95,11 @@ TEST_F(AssemblerLibMeshComponentMapTest, CheckOrderByComponent)
     }
 }
 
+#ifndef USE_PETSC
 TEST_F(AssemblerLibMeshComponentMapTest, CheckOrderByLocation)
+#else
+TEST_F(AssemblerLibMeshComponentMapTest, DISABLED_CheckOrderByLocation)
+#endif
 {
     // - Entries in the vector are arranged in the order of node ID and then a component type
     // - For example, x=[(node 0, comp 0) (node 0, comp 1) ... (node n, comp0), (node n, comp1) ]
@@ -130,7 +138,11 @@ TEST_F(AssemblerLibMeshComponentMapTest, OutOfRangeAccess)
         Location(mesh->getID(), MeshItemType::Node, 0), 10));
 }
 
+#ifndef USE_PETSC
 TEST_F(AssemblerLibMeshComponentMapTest, SubsetOfNodesByComponent)
+#else
+TEST_F(AssemblerLibMeshComponentMapTest, DISABLED_SubsetOfNodesByComponent)
+#endif
 {
     cmap = new MeshComponentMap(components,
         AssemblerLib::ComponentOrder::BY_COMPONENT);
@@ -163,7 +175,11 @@ TEST_F(AssemblerLibMeshComponentMapTest, SubsetOfNodesByComponent)
     }
 }
 
+#ifndef USE_PETSC
 TEST_F(AssemblerLibMeshComponentMapTest, SubsetOfNodesByLocation)
+#else
+TEST_F(AssemblerLibMeshComponentMapTest, DISABLED_SubsetOfNodesByLocation)
+#endif
 {
     cmap = new MeshComponentMap(components,
         AssemblerLib::ComponentOrder::BY_LOCATION);

--- a/Tests/AssemblerLib/TestVectorMatrixBuilder.cpp
+++ b/Tests/AssemblerLib/TestVectorMatrixBuilder.cpp
@@ -60,7 +60,11 @@ class AssemblerLibVectorMatrixBuilder : public ::testing::Test
 
 TYPED_TEST_CASE_P(AssemblerLibVectorMatrixBuilder);
 
+#ifndef USE_PETSC
 TYPED_TEST_P(AssemblerLibVectorMatrixBuilder, createVector)
+#else
+TYPED_TEST_P(AssemblerLibVectorMatrixBuilder, DISABLED_createVector)
+#endif
 {
     typedef typename TestFixture::VectorType V;
     typedef TypeParam Builder;
@@ -72,7 +76,11 @@ TYPED_TEST_P(AssemblerLibVectorMatrixBuilder, createVector)
     delete v;
 }
 
+#ifndef USE_PETSC
 TYPED_TEST_P(AssemblerLibVectorMatrixBuilder, createMatrix)
+#else
+TYPED_TEST_P(AssemblerLibVectorMatrixBuilder, DISABLED_createMatrix)
+#endif
 {
     typedef typename TestFixture::MatrixType M;
     typedef TypeParam Builder;
@@ -85,8 +93,13 @@ TYPED_TEST_P(AssemblerLibVectorMatrixBuilder, createMatrix)
     delete m;
 }
 
+#ifndef USE_PETSC
 REGISTER_TYPED_TEST_CASE_P(AssemblerLibVectorMatrixBuilder,
     createVector, createMatrix);
+#else
+REGISTER_TYPED_TEST_CASE_P(AssemblerLibVectorMatrixBuilder,
+    DISABLED_createVector, DISABLED_createMatrix);
+#endif
 
 #include "MathLib/LinAlg/Dense/DenseVector.h"
 #include "MathLib/LinAlg/Dense/GlobalDenseMatrix.h"
@@ -125,4 +138,3 @@ typedef ::testing::Types
 
 INSTANTIATE_TYPED_TEST_CASE_P(templated, AssemblerLibVectorMatrixBuilder,
     TestTypes);
-

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -79,7 +79,7 @@ set(TESTRUNNER_ADDITIONAL_ARGUMENTS ${TESTRUNNER_ADDITIONAL_ARGUMENTS}
 add_custom_target(tests-cleanup ${CMAKE_COMMAND} -E remove testrunner.xml)
 
 if(OGS_USE_PETSC)
-	set(TEST_FILTER_MPI --gtest_filter=-MPITest*:*Assembler*:*MeshSubsets*:*PointVec*:*InsertZeroPointsInGrid*:InSituMesh.MappedMeshSourceRoundtrip)
+	set(TEST_FILTER_MPI --gtest_filter=-MPITest_Math.*)
 	add_custom_target(tests
 		mpirun -np 1 $<TARGET_FILE:testrunner> ${TESTRUNNER_ADDITIONAL_ARGUMENTS} ${TEST_FILTER_MPI}
 		DEPENDS testrunner tests-cleanup

--- a/Tests/FileIO/TestTetGenInterface.cpp
+++ b/Tests/FileIO/TestTetGenInterface.cpp
@@ -44,7 +44,11 @@ TEST(FileIO, TetGenSmeshReader)
 }
 
 // existing mesh to TetGen geometry
+#ifndef USE_PETSC
 TEST(FileIO, TetGenSmeshInterface)
+#else
+TEST(FileIO, DISABLED_TetGenSmeshInterface)
+#endif
 {
 	std::string const file_name (BaseLib::BuildInfo::data_path + "/FileIO/AmmerSubsurfaceCoarse.vtu");
 	std::unique_ptr<MeshLib::Mesh const> const mesh (FileIO::readMeshFromFile(file_name));

--- a/Tests/InSituLib/TestVtkMappedMeshSource.cpp
+++ b/Tests/InSituLib/TestVtkMappedMeshSource.cpp
@@ -143,7 +143,11 @@ TEST_F(InSituMesh, MappedMesh)
 
 // Writes the mesh into a vtk file, reads the file back and converts it into a
 // OGS mesh
+#ifndef USE_PETSC
 TEST_F(InSituMesh, MappedMeshSourceRoundtrip)
+#else
+TEST_F(InSituMesh, DISABLED_MappedMeshSourceRoundtrip)
+#endif
 {
 	// TODO Add more comparison criteria
 

--- a/Tests/NumLib/TestODEInt.cpp
+++ b/Tests/NumLib/TestODEInt.cpp
@@ -302,13 +302,21 @@ public:
 
 TYPED_TEST_CASE(NumLibODEIntTyped, TestCases);
 
+#ifndef USE_PETSC
 TYPED_TEST(NumLibODEIntTyped, T1)
+#else
+TYPED_TEST(NumLibODEIntTyped, DISABLED_T1)
+#endif
 {
     TestFixture::test();
 }
 
 
+#ifndef USE_PETSC
 TEST(NumLibODEInt, ODE3)
+#else
+TEST(NumLibODEInt, DISABLED_ODE3)
+#endif
 {
     const char* name = "dummy";
 


### PR DESCRIPTION
This PR
* removes the catch-all regular expression filters that disable unit tests for PETSc
* disables only the segfaulting tests for PETSc one by one

Thus, new unit tests will by default also be run in the PETSc build. Furthermore, it will be possible to run `testrunner` also for PETSc without having to pass filters.