### PR TITLE
Clang sanitizer cleanup

### DIFF
--- a/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMapMultiComponent.cpp
@@ -74,6 +74,12 @@ public:
 		    mesh_items_all_nodes->getIntersectionByNodes(nodes));
 	}
 
+	~AssemblerLibLocalToGlobalIndexMapMultiDOFTest()
+	{
+		for (auto e : boundary_elements)
+			delete e;
+	}
+
 	void initComponents(const unsigned num_components, const unsigned selected_component,
 						const AL::ComponentOrder order)
 	{

--- a/Tests/AssemblerLib/TestSerialLinearSolver.cpp
+++ b/Tests/AssemblerLib/TestSerialLinearSolver.cpp
@@ -112,7 +112,8 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
     GlobalAssembler assembler(local_to_global_index_map);
 
     // Call global assembler for each mesh element.
-    auto M_dummy = globalSetup.createMatrix(local_to_global_index_map.dofSize());
+    auto M_dummy = std::unique_ptr<GlobalMatrix>{
+        globalSetup.createMatrix(local_to_global_index_map.dofSize())};
     A->setZero();
     auto const t = 0.0;
     globalSetup.execute(assembler, local_assembler_data, t, *x, *M_dummy, *A, *rhs);

--- a/scripts/cmake/ClangSanitizer.cmake
+++ b/scripts/cmake/ClangSanitizer.cmake
@@ -11,7 +11,7 @@ if(OGS_ADDRESS_SANITIZER)
 endif()
 
 if(OGS_UNDEFINED_BEHAVIOR_SANITIZER)
-	set(SANITIZE_FLAG_VALUE "${SANITIZE_FLAG_VALUE},undefined,integer")
+	set(SANITIZE_FLAG_VALUE "${SANITIZE_FLAG_VALUE},undefined,integer -fsanitize-blacklist=${CMAKE_CURRENT_SOURCE_DIR}/scripts/test/clang_sanitizer_blacklist.txt")
 endif()
 
 if(DEFINED SANITIZE_FLAG_VALUE)

--- a/scripts/jenkins/clang.groovy
+++ b/scripts/jenkins/clang.groovy
@@ -15,11 +15,11 @@ node('docker')
 
 				stage 'Unit tests'
 				sh '''cd build
-				      make tests'''
+				      UBSAN_OPTIONS=print_stacktrace=1 make tests'''
 
 				stage 'End-to-end tests'
 				sh '''cd build
-				      make ctest'''
+				      UBSAN_OPTIONS=print_stacktrace=1 make ctest'''
 			}
 		}
 		step([$class: 'LogParserPublisher', failBuildOnError: true, unstableOnWarning: true,

--- a/scripts/test/clang_sanitizer_blacklist.txt
+++ b/scripts/test/clang_sanitizer_blacklist.txt
@@ -1,0 +1,35 @@
+# Eigen is calling memcpy with source equal nullptr for a SparseMatrix without
+# any space allocated. memcpy with source equal to 0 is undefined behaviour.
+# Eigen-3.2.5: Eigen::internal::smart_copy_helper<double, true>::run
+fun:*smart_copy_helper*
+
+# Computation of ios_fmt_flags relies on some bit-wise operations.
+# STL gcc-4.8: std::operator&=(std::_Ios_Fmtflags&, std::_Ios_Fmtflags)
+fun:*Ios_Fmtflags*
+fun:_ZStaNRSt13_Ios_FmtflagsS_
+src:*/include/c\+\+/4.8/bits/ios_base.h
+src:/usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c\+\+/4.8/bits/ios_base.h
+
+# Comparing a string with a shorter one causes an integer subtraction overflow.
+# STL gcc-5.3: std::string::_S_compare(unsigned long, unsigned long)
+fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_S_compareEmm
+# STL gcc-4.8: std::string::_S_compare(unsigned long, unsigned long)
+fun:_ZNSs10_S_compareEmm
+fun:*_S_compare*
+
+# When looking for a last occurence of a string in another string the algorithm
+# an integer subtraction overflow happens.
+# STL gcc-5.3: std::string::find_last_of(...) const
+fun:_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12find_last_ofEPKcmm
+# STL gcc-4.8: std::string::find_last_of(char const*, unsigned long, unsigned long)
+fun:_ZNKSs12find_last_ofEPKcmm
+
+# Integer subtraction overflow in mersenne_twister_engine
+# STL gcc-5.3:
+fun:_ZNSt23mersenne_twister_engineImLm32ELm624ELm397ELm31ELm2567483615ELm11ELm4294967295ELm7ELm2636928640ELm15ELm4022730752ELm18ELm1812433253EE11_M_gen_randEv
+fun:_ZNSt24uniform_int_distributionIiEclISt23mersenne_twister_engineImLm32ELm624ELm397ELm31ELm2567483615ELm11ELm4294967295ELm7ELm2636928640ELm15ELm4022730752ELm18ELm1812433253EEEEiRT_
+fun:_ZNSt24uniform_int_distributionIiEclISt23mersenne_twister_engineImLm32ELm624ELm397ELm31ELm2567483615ELm11ELm4294967295ELm7ELm2636928640ELm15ELm4022730752ELm18ELm1812433253EEEEiRT_RKNS0_10param_typeE
+
+# valarray fill loop is counting down and reaching integer subtraction overflow
+# STL gcc-5.3: called from operator=(double)
+fun:_ZSt15__valarray_fillIdEvPT_mRKS0_


### PR DESCRIPTION
__1.__ I have checked all of the undefined behaviour checked by clang's sanitizer and think that the blacklisted are not caused by wrong usage from our side.

Because the names in the blacklist are mangled, they could be different on the envinf1 machine; Then the blacklist shall be updated.

 - [ ] Update blacklist for envinf1.
 - [x] Add the blacklist to CXXFLAGS in cmake.

__2.__ Removed remaining memory leaks in the testrunner.

@chleh There are no more memleaks as of now.