### PR TITLE
Download Boost from non-encrypted website

### DIFF
--- a/scripts/cmake/ThirdPartyLibVersions.cmake
+++ b/scripts/cmake/ThirdPartyLibVersions.cmake
@@ -1,6 +1,6 @@
 set(OGS_BOOST_VERSION 1.56.0)
 string(REPLACE "." "_" OGS_BOOST_VERSION_UNDERLINE ${OGS_BOOST_VERSION})
-set(OGS_BOOST_URL "http://sourceforge.net/projects/boost/files/boost/${OGS_BOOST_VERSION}/boost_${OGS_BOOST_VERSION_UNDERLINE}.tar.bz2/download")
+set(OGS_BOOST_URL "http://opengeosys.s3.amazonaws.com/ogs6-lib-sources/boost_${OGS_BOOST_VERSION_UNDERLINE}.tar.bz2")
 set(OGS_BOOST_MD5 "a744cf167b05d72335f27c88115f211d")
 
 set(OGS_EIGEN_URL "http://opengeosys.s3.amazonaws.com/ogs6-lib-sources/eigen-3.2.5.tar.gz")


### PR DESCRIPTION
I uploaded Boost 1.56.0 to our Amazon S3 bucket.

Fixes #1064