### PR TITLE
Pre post timestep for local asm

### DIFF
--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
@@ -303,6 +303,8 @@ solveOneTimeStepOneProcess(
 
     setEquationSystem(nonlinear_solver, ode_sys, nl_tag);
 
+    process.preTimestep(x);
+
     // INFO("time: %e, delta_t: %e", t, delta_t);
     time_disc.nextTimestep(t, delta_t);
 

--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
@@ -311,7 +311,8 @@ solveOneTimeStepOneProcess(
     auto& mat_strg = process_data.mat_strg;
     time_disc.pushState(t, x, mat_strg);
 
-    process.postTimestep(output_file_name, timestep, x);
+    process.postTimestep(x);
+    process.output(output_file_name, timestep, x);
 
     return nonlinear_solver_succeeded;
 }

--- a/AssemblerLib/VectorMatrixAssembler.h
+++ b/AssemblerLib/VectorMatrixAssembler.h
@@ -109,6 +109,46 @@ public:
         passLocalVector(cb, id, _data_pos, x, t, M, K, b);
     }
 
+    /// Executes preTimestep call for each of the local assemblers for the
+    /// given mesh item.
+    /// The positions in the global matrix/vector are taken from
+    /// the LocalToGlobalIndexMap provided in the constructor at index \c id.
+    /// \attention The index \c id is not necesserily the mesh item's id.
+    template <typename LocalAssembler_>
+    void preTimestep(std::size_t const id,
+                     LocalAssembler_* const local_assembler,
+                     GlobalVector const& x) const
+    {
+        auto cb = [local_assembler](
+            std::vector<double> local_x,
+            LocalToGlobalIndexMap::RowColumnIndices const& r_c_indices)
+        {
+            local_assembler->preTimestep(local_x);
+        };
+
+        passLocalVector(cb, id, _data_pos, x);
+    }
+
+    /// Executes postTimestep call for each of the local assemblers for the
+    /// given mesh item.
+    /// The positions in the global matrix/vector are taken from
+    /// the LocalToGlobalIndexMap provided in the constructor at index \c id.
+    /// \attention The index \c id is not necesserily the mesh item's id.
+    template <typename LocalAssembler_>
+    void postTimestep(std::size_t const id,
+                      LocalAssembler_* const local_assembler,
+                      GlobalVector const& x) const
+    {
+        auto cb = [local_assembler](
+            std::vector<double> local_x,
+            LocalToGlobalIndexMap::RowColumnIndices const& r_c_indices)
+        {
+            local_assembler->postTimestep(local_x);
+        };
+
+        passLocalVector(cb, id, _data_pos, x);
+    }
+
 private:
     LocalToGlobalIndexMap const& _data_pos;
 };

--- a/AssemblerLib/VectorMatrixAssembler.h
+++ b/AssemblerLib/VectorMatrixAssembler.h
@@ -90,9 +90,9 @@ public:
     /// The positions in the global matrix/vector are taken from
     /// the LocalToGlobalIndexMap provided in the constructor at index \c id.
     /// \attention The index \c id is not necesserily the mesh item's id.
-    template <typename LocalAssembler_>
+    template <typename LocalAssembler>
     void operator()(std::size_t const id,
-        LocalAssembler_* const local_assembler,
+        LocalAssembler* const local_assembler,
         const double t, GlobalVector const& x,
         GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) const
     {
@@ -114,9 +114,9 @@ public:
     /// The positions in the global matrix/vector are taken from
     /// the LocalToGlobalIndexMap provided in the constructor at index \c id.
     /// \attention The index \c id is not necesserily the mesh item's id.
-    template <typename LocalAssembler_>
+    template <typename LocalAssembler>
     void preTimestep(std::size_t const id,
-                     LocalAssembler_* const local_assembler,
+                     LocalAssembler* const local_assembler,
                      GlobalVector const& x) const
     {
         auto cb = [local_assembler](
@@ -134,9 +134,9 @@ public:
     /// The positions in the global matrix/vector are taken from
     /// the LocalToGlobalIndexMap provided in the constructor at index \c id.
     /// \attention The index \c id is not necesserily the mesh item's id.
-    template <typename LocalAssembler_>
+    template <typename LocalAssembler>
     void postTimestep(std::size_t const id,
-                      LocalAssembler_* const local_assembler,
+                      LocalAssembler* const local_assembler,
                       GlobalVector const& x) const
     {
         auto cb = [local_assembler](
@@ -170,9 +170,9 @@ public:
     /// The positions in the global matrix/vector are taken from
     /// the LocalToGlobalIndexMap provided in the constructor at index \c id.
     /// \attention The index \c id is not necesserily the mesh item's id.
-    template <typename LocalAssembler_>
+    template <typename LocalAssembler>
     void operator()(std::size_t const id,
-        LocalAssembler_* const local_assembler,
+        LocalAssembler* const local_assembler,
         const double t, GlobalVector& b) const
     {
         std::vector<GlobalIndexType> indices;

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -72,6 +72,9 @@ public:
 	/// Process specific initialization called by initialize().
 	virtual void createLocalAssemblers() = 0;
 
+	/// Preprocessing before starting assembly for new timestep.
+	virtual void preTimestep(GlobalVector const& x) {}
+
 	/// Postprocessing after a complete timestep.
 	virtual void postTimestep(GlobalVector const& x) {}
 

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -82,7 +82,7 @@ public:
 	/// The file_name is indicating the name of possible output file.
 	void output(std::string const& file_name,
 	            const unsigned /*timestep*/,
-	            GlobalVector const& x)
+	            GlobalVector const& x) const
 	{
 		DBUG("Process output.");
 

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -72,14 +72,57 @@ public:
 	/// Process specific initialization called by initialize().
 	virtual void createLocalAssemblers() = 0;
 
-	/// Postprocessing after solve().
+	/// Postprocessing after a complete timestep.
+	virtual void postTimestep(GlobalVector const& x) {}
+
+	/// Process output.
 	/// The file_name is indicating the name of possible output file.
-	void postTimestep(std::string const& file_name,
-	                  const unsigned /*timestep*/,
-	                  GlobalVector const& x)
+	void output(std::string const& file_name,
+	            const unsigned /*timestep*/,
+	            GlobalVector const& x)
 	{
-		post(x);
-		output(file_name, x);
+		DBUG("Process output.");
+
+		// Copy result
+#ifdef USE_PETSC
+		// TODO It is also possible directly to copy the data for single process
+		// variable to a mesh property. It needs a vector of global indices and
+		// some PETSc magic to do so.
+		std::vector<double> x_copy(x.getLocalSize() + x.getGhostSize());
+#else
+		std::vector<double> x_copy(x.size());
+#endif
+		x.copyValues(x_copy);
+
+		std::size_t const n_nodes = _mesh.getNNodes();
+		for (ProcessVariable& pv : _process_variables)
+		{
+			auto& output_data = pv.getOrCreateMeshProperty();
+
+			int const n_components = pv.getNumberOfComponents();
+			for (std::size_t node_id = 0; node_id < n_nodes; ++node_id)
+			{
+				MeshLib::Location const l(_mesh.getID(),
+				                          MeshLib::MeshItemType::Node, node_id);
+				// TODO extend component ids to multiple process variables.
+				for (int component_id = 0; component_id < n_components;
+				     ++component_id)
+				{
+					auto const index =
+					    _local_to_global_index_map->getLocalIndex(
+					        l, component_id, x.getRangeBegin(),
+					        x.getRangeEnd());
+
+					output_data[node_id * n_components + component_id] =
+					    x_copy[index];
+				}
+			}
+		}
+
+		// Write output file
+		DBUG("Writing output to \'%s\'.", file_name.c_str());
+		FileIO::VtuInterface vtu_interface(&_mesh, vtkXMLWriter::Binary, true);
+		vtu_interface.writeToFile(file_name);
 	}
 
 	void initialize()
@@ -181,9 +224,6 @@ public:
 	{
 		return *_time_discretization;
 	}
-
-protected:
-	virtual void post(GlobalVector const& /*x*/) {}
 
 private:
 	virtual void assembleConcreteProcess(
@@ -298,52 +338,6 @@ private:
 	{
 		_sparsity_pattern = std::move(AssemblerLib::computeSparsityPattern(
 		    *_local_to_global_index_map, _mesh));
-	}
-
-	void output(std::string const& file_name, GlobalVector const& x)
-	{
-		DBUG("Process output.");
-
-		// Copy result
-#ifdef USE_PETSC
-		// TODO It is also possible directly to copy the data for single process
-		// variable to a mesh property. It needs a vector of global indices and
-		// some PETSc magic to do so.
-		std::vector<double> x_copy(x.getLocalSize() + x.getGhostSize());
-#else
-		std::vector<double> x_copy(x.size());
-#endif
-		x.copyValues(x_copy);
-
-		std::size_t const n_nodes = _mesh.getNNodes();
-		for (ProcessVariable& pv : _process_variables)
-		{
-			auto& output_data = pv.getOrCreateMeshProperty();
-
-			int const n_components = pv.getNumberOfComponents();
-			for (std::size_t node_id = 0; node_id < n_nodes; ++node_id)
-			{
-				MeshLib::Location const l(_mesh.getID(),
-				                          MeshLib::MeshItemType::Node, node_id);
-				// TODO extend component ids to multiple process variables.
-				for (int component_id = 0; component_id < n_components;
-				     ++component_id)
-				{
-					auto const index =
-					    _local_to_global_index_map->getLocalIndex(
-					        l, component_id, x.getRangeBegin(),
-					        x.getRangeEnd());
-
-					output_data[node_id * n_components + component_id] =
-					    x_copy[index];
-				}
-			}
-		}
-
-		// Write output file
-		DBUG("Writing output to \'%s\'.", file_name.c_str());
-		FileIO::VtuInterface vtu_interface(&_mesh, vtkXMLWriter::Binary, true);
-		vtu_interface.writeToFile(file_name);
 	}
 
 protected:


### PR DESCRIPTION
 - Splitting of `postTimestep()` and `output()`. (No changes, just copy&paste).
 - Implementation of preTimestep and postTimestep executors for local asm.
    
To use in particular process one needs an implementation in FEM part of the process of
```c++
void FEM::preTimestep(std::vector<double> const& local_x) override;
```
and an implementation in the Process calling `FEM::preTimestep`
    
```c++
void SpecificProcess::preTimestep() override
{
    Base::_global_setup.execute(
        [&](std::size_t const id, LocalAssembler* const local_assembler, GlobalVector const& x) -> void
        {
            Base::_global_assembler->preTimestep(id, local_assembler, x);
        },
        _local_assemblers, x);
}
```
