### PR TITLE
[Fix] Generate Gmsh mesh in xz plane

### DIFF
--- a/FileIO/GMSHInterface.h
+++ b/FileIO/GMSHInterface.h
@@ -25,6 +25,8 @@
 #include "GmshIO/GMSHPolygonTree.h"
 #include "GmshIO/GMSHMeshDensityStrategy.h"
 
+#include "MathLib/LinAlg/Dense/DenseMatrix.h"
+
 namespace GeoLib
 {
 	class GEOObjects;
@@ -128,6 +130,9 @@ private:
 	std::vector<FileIO::GMSH::GMSHPoint*> _gmsh_pnts;
 
 	GMSH::GMSHMeshDensityStrategy *_mesh_density_strategy;
+	/// Holds the inverse rotation matrix. The matrix is used in writePoints() to
+	/// revert the rotation done in writeGMSHInputFile().
+	MathLib::DenseMatrix<double> _inverse_rot_mat = MathLib::DenseMatrix<double>(3,3);
 };
 }
 

--- a/FileIO/GmshIO/GMSHPoint.cpp
+++ b/FileIO/GmshIO/GMSHPoint.cpp
@@ -27,7 +27,7 @@ GMSHPoint::GMSHPoint(GeoLib::Point const& pnt, std::size_t id, double mesh_densi
 
 void GMSHPoint::write(std::ostream &os) const
 {
-	os << "Point(" << _id << ") = {" << _x[0] << "," << _x[1] << ", 0.0";
+	os << "Point(" << _id << ") = {" << _x[0] << ", " << _x[1] << ", " << _x[2];
 	if (fabs(_mesh_density) > std::numeric_limits<double>::epsilon()) {
 		os << ", " << _mesh_density << "};";
 	} else {

--- a/GeoLib/AnalyticalGeometry-impl.h
+++ b/GeoLib/AnalyticalGeometry-impl.h
@@ -186,9 +186,10 @@ void rotatePoints(
 }
 
 template <typename InputIterator1, typename InputIterator2>
-void rotatePointsToXY(
-        InputIterator1 p_pnts_begin, InputIterator1 p_pnts_end,
-        InputIterator2 r_pnts_begin, InputIterator2 r_pnts_end)
+MathLib::DenseMatrix<double> rotatePointsToXY(InputIterator1 p_pnts_begin,
+                                              InputIterator1 p_pnts_end,
+                                              InputIterator2 r_pnts_begin,
+                                              InputIterator2 r_pnts_end)
 {
     assert(std::distance(p_pnts_begin, p_pnts_end) > 2);
 
@@ -205,6 +206,8 @@ void rotatePointsToXY(
 
     for (auto it=r_pnts_begin; it!=r_pnts_end; ++it)
         (*(*it))[2] = 0.0; // should be -= d but there are numerical errors
+
+    return rot_mat;
 }
 
 template <typename P>

--- a/GeoLib/AnalyticalGeometry-impl.h
+++ b/GeoLib/AnalyticalGeometry-impl.h
@@ -198,13 +198,10 @@ void rotatePointsToXY(
     // compute the plane normal
     GeoLib::getNewellPlane(p_pnts_begin, p_pnts_end, plane_normal, d);
 
-    const double tol (std::numeric_limits<double>::epsilon());
-    if (std::abs(plane_normal[0]) > tol || std::abs(plane_normal[1]) > tol) {
-        // rotate copied points into x-y-plane
-        MathLib::DenseMatrix<double> rot_mat(3, 3);
-        computeRotationMatrixToXY(plane_normal, rot_mat);
-        rotatePoints(rot_mat, r_pnts_begin, r_pnts_end);
-    }
+    // rotate points into x-y-plane
+    MathLib::DenseMatrix<double> rot_mat(3, 3);
+    computeRotationMatrixToXY(plane_normal, rot_mat);
+    rotatePoints(rot_mat, r_pnts_begin, r_pnts_end);
 
     for (auto it=r_pnts_begin; it!=r_pnts_end; ++it)
         (*(*it))[2] = 0.0; // should be -= d but there are numerical errors

--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -399,9 +399,9 @@ void rotatePoints(MathLib::DenseMatrix<double> const& rot_mat, std::vector<GeoLi
 	rotatePoints(rot_mat, pnts.begin(), pnts.end());
 }
 
-void rotatePointsToXY(std::vector<GeoLib::Point*> &pnts)
+MathLib::DenseMatrix<double> rotatePointsToXY(std::vector<GeoLib::Point*>& pnts)
 {
-	rotatePointsToXY(pnts.begin(), pnts.end(), pnts.begin(), pnts.end());
+	return rotatePointsToXY(pnts.begin(), pnts.end(), pnts.begin(), pnts.end());
 }
 
 void rotatePointsToXZ(std::vector<GeoLib::Point*> &pnts)

--- a/GeoLib/AnalyticalGeometry.h
+++ b/GeoLib/AnalyticalGeometry.h
@@ -150,7 +150,7 @@ void rotatePoints(MathLib::DenseMatrix<double> const& rot_mat,
  * Points are rotated using a rotation matrix computed from the first three points
  * in the vector. Point coordinates are modified as a result of the rotation.
  */
-void rotatePointsToXY(std::vector<GeoLib::Point*> &pnts);
+MathLib::DenseMatrix<double> rotatePointsToXY(std::vector<GeoLib::Point*> &pnts);
 
 /**
  * rotate points to X-Y plane
@@ -162,9 +162,10 @@ void rotatePointsToXY(std::vector<GeoLib::Point*> &pnts);
  * in the vector. Point coordinates are modified as a result of the rotation.
  */
 template <typename InputIterator1, typename InputIterator2>
-void rotatePointsToXY(
-        InputIterator1 p_pnts_begin, InputIterator1 p_pnts_end,
-        InputIterator2 r_pnts_begin, InputIterator2 r_pnts_end);
+MathLib::DenseMatrix<double> rotatePointsToXY(InputIterator1 p_pnts_begin,
+                                              InputIterator1 p_pnts_end,
+                                              InputIterator2 r_pnts_begin,
+                                              InputIterator2 r_pnts_end);
 
 /**
  * rotate points to X-Z plane


### PR DESCRIPTION
This fixes issue #663.

The original input data is rotated to the x-y-plane. All intermediate computations are done and finally to data is rotated back to the original location.

- [x] check with more test examples.