### PR TITLE
ODESolver: Added pre and post iteration hooks

### DIFF
--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
@@ -37,7 +37,7 @@ private:
     //! An abstract nonlinear solver
     using AbstractNLSolver = NumLib::NonlinearSolverBase<Matrix, Vector>;
     //! An abstract equations system
-    using EquationSystem   = NumLib::EquationSystem;
+    using EquationSystem   = NumLib::EquationSystem<Vector>;
     //! An abstract process
     using Process          = ProcessLib::Process<GlobalSetupType>;
     //! An abstract time discretization

--- a/NumLib/ODESolver/EquationSystem.h
+++ b/NumLib/ODESolver/EquationSystem.h
@@ -18,7 +18,19 @@ namespace NumLib
 //! \addtogroup ODESolver
 //! @{
 
-//! Collection of basic methods every equation system must provide.
+//! Status flags telling the NonlinearSolver if an iteration succeeded.
+enum class IterationResult : char
+{
+    SUCCESS,
+    FAILURE,
+    REPEAT_ITERATION
+};
+
+/*! Collection of basic methods every equation system must provide.
+ *
+ * \tparam Vector the type of the solution vector of the equation.
+ */
+template<typename Vector>
 class EquationSystem
         : public MathLib::MatrixSpecificationsProvider
 {
@@ -32,7 +44,27 @@ public:
      */
     virtual bool isLinear() const = 0;
 
-    virtual ~EquationSystem() = default;
+    /*! Prepares a new iteration in the solution process of this equation.
+     *
+     * \param iter the current iteration number, starting from 1.
+     * \param x    the current approximate solution of the equation.
+     */
+    virtual void preIteration(const unsigned iter, Vector const& x)
+    {
+        (void) iter; (void) x; // by default do nothing
+    }
+
+    /*! Post-processes an iteration in the solution process of this equation.
+     *
+     * \param x the current approximate solution of the equation.
+     *
+     * \return A status flag indicating id the current iteration succeeded.
+     */
+    virtual IterationResult postIteration(Vector const& x)
+    {
+        (void) x; // by default do nothing
+        return IterationResult::SUCCESS;
+    }
 };
 
 //! @}

--- a/NumLib/ODESolver/NonlinearSolver-impl.h
+++ b/NumLib/ODESolver/NonlinearSolver-impl.h
@@ -71,17 +71,17 @@ solve(Vector &x)
         {
             switch(sys.postIteration(x_new))
             {
-            case IterationResult::OK:
+            case IterationResult::SUCCESS:
                 // Don't copy here. The old x might still be used further below.
                 // Although currently it is not.
                 break;
-            case IterationResult::FAILED:
+            case IterationResult::FAILURE:
                 iteration_succeeded = false;
                 // Copy new solution to x.
                 // Thereby the failed solution can be used by the caller for debugging purposes.
                 BLAS::copy(x_new, x);
                 break;
-            case IterationResult::AGAIN:
+            case IterationResult::REPEAT_ITERATION:
                 continue; // That throws the iteration result away.
             }
         }
@@ -190,12 +190,12 @@ solve(Vector &x)
 
             switch(sys.postIteration(x_new))
             {
-            case IterationResult::OK:
+            case IterationResult::SUCCESS:
                 break;
-            case IterationResult::FAILED:
+            case IterationResult::FAILURE:
                 iteration_succeeded = false;
                 break;
-            case IterationResult::AGAIN:
+            case IterationResult::REPEAT_ITERATION:
                 // TODO introduce some onDestroy hook.
                 MathLib::GlobalVectorProvider<Vector>::provider.releaseVector(x_new);
                 continue; // That throws the iteration result away.

--- a/NumLib/ODESolver/NonlinearSolver.h
+++ b/NumLib/ODESolver/NonlinearSolver.h
@@ -122,6 +122,7 @@ private:
     std::size_t _res_id = 0u;           //!< ID of the residual vector.
     std::size_t _J_id = 0u;             //!< ID of the Jacobian matrix.
     std::size_t _minus_delta_x_id = 0u; //!< ID of the \f$ -\Delta x\f$ vector.
+    std::size_t _x_new_id = 0u;         //!< ID of the vector storing \f$ x - (-\Delta x) \f$.
 };
 
 

--- a/NumLib/ODESolver/NonlinearSystem.h
+++ b/NumLib/ODESolver/NonlinearSystem.h
@@ -20,46 +20,6 @@ namespace NumLib
 //! \addtogroup ODESolver
 //! @{
 
-//! Status flags telling the NonlinearSolver if an iteration succeeded.
-enum class IterationResult : char
-{
-    OK,     //!< Iteration succeeded.
-    FAILED, //!< Iteration failed irrecoverably.
-    AGAIN   //!< Iteration has to be repeated.
-};
-
-/*! Common methods all nonlinear systems must provide.
- *
- * \tparam Vector the type of the solution vector of the equation.
- */
-template<typename Vector>
-class NonlinearSystemBase
-        : public EquationSystem
-{
-public:
-    /*! Prepares a new iteration.
-     *
-     * \param iter the current iteration number, starting from 1.
-     * \param x    the current approximate solution of the equation.
-     */
-    virtual void preIteration(unsigned iter, Vector const& x)
-    {
-        (void) iter; (void) x; // by default do nothing
-    }
-
-    /*! Post-processes an iteration.
-     *
-     * \param x the current approximate solution of the equation.
-     *
-     * \return A status flag indicating id the current iteration succeeded.
-     */
-    virtual IterationResult postIteration(Vector const& x)
-    {
-        (void) x; // by default do nothing
-        return IterationResult::OK;
-    }
-};
-
 /*! A System of nonlinear equations.
  *
  * \tparam Matrix the type of matrices occuring in the linearization of the equation.
@@ -80,7 +40,7 @@ class NonlinearSystem;
  */
 template<typename Matrix, typename Vector>
 class NonlinearSystem<Matrix, Vector, NonlinearSolverTag::Newton>
-        : public NonlinearSystemBase<Vector>
+        : public EquationSystem<Vector>
 {
 public:
     //! Assembles the residual at the point \c x.
@@ -121,7 +81,7 @@ public:
  */
 template<typename Matrix, typename Vector>
 class NonlinearSystem<Matrix, Vector, NonlinearSolverTag::Picard>
-        : public NonlinearSystemBase<Vector>
+        : public EquationSystem<Vector>
 {
 public:
     //! Assembles the linearized equation at point \c x.

--- a/NumLib/ODESolver/NonlinearSystem.h
+++ b/NumLib/ODESolver/NonlinearSystem.h
@@ -20,6 +20,46 @@ namespace NumLib
 //! \addtogroup ODESolver
 //! @{
 
+//! Status flags telling the NonlinearSolver if an iteration succeeded.
+enum class IterationResult : char
+{
+    OK,     //!< Iteration succeeded.
+    FAILED, //!< Iteration failed irrecoverably.
+    AGAIN   //!< Iteration has to be repeated.
+};
+
+/*! Common methods all nonlinear systems must provide.
+ *
+ * \tparam Vector the type of the solution vector of the equation.
+ */
+template<typename Vector>
+class NonlinearSystemBase
+        : public EquationSystem
+{
+public:
+    /*! Prepares a new iteration.
+     *
+     * \param iter the current iteration number, starting from 1.
+     * \param x    the current approximate solution of the equation.
+     */
+    virtual void preIteration(unsigned iter, Vector const& x)
+    {
+        (void) iter; (void) x; // by default do nothing
+    }
+
+    /*! Post-processes an iteration.
+     *
+     * \param x the current approximate solution of the equation.
+     *
+     * \return A status flag indicating id the current iteration succeeded.
+     */
+    virtual IterationResult postIteration(Vector const& x)
+    {
+        (void) x; // by default do nothing
+        return IterationResult::OK;
+    }
+};
+
 /*! A System of nonlinear equations.
  *
  * \tparam Matrix the type of matrices occuring in the linearization of the equation.
@@ -40,7 +80,7 @@ class NonlinearSystem;
  */
 template<typename Matrix, typename Vector>
 class NonlinearSystem<Matrix, Vector, NonlinearSolverTag::Newton>
-        : public EquationSystem
+        : public NonlinearSystemBase<Vector>
 {
 public:
     //! Assembles the residual at the point \c x.
@@ -81,10 +121,10 @@ public:
  */
 template<typename Matrix, typename Vector>
 class NonlinearSystem<Matrix, Vector, NonlinearSolverTag::Picard>
-        : public EquationSystem
+        : public NonlinearSystemBase<Vector>
 {
 public:
-    //! Assembles the linearized eqation at point \c x.
+    //! Assembles the linearized equation at point \c x.
     virtual void assembleMatricesPicard(Vector const& x) = 0;
 
     //! Writes the linearized equation system matrix to \c A.

--- a/NumLib/ODESolver/ODESystem.h
+++ b/NumLib/ODESolver/ODESystem.h
@@ -53,7 +53,7 @@ template<typename Matrix, typename Vector>
 class ODESystem<Matrix, Vector,
                 ODESystemTag::FirstOrderImplicitQuasilinear,
                 NonlinearSolverTag::Picard>
-        : public EquationSystem
+        : public EquationSystem<Vector>
 {
 public:
     //! A tag indicating the type of ODE.

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.h
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.h
@@ -186,6 +186,16 @@ public:
         return _time_disc.isLinearTimeDisc() || _ode.isLinear();
     }
 
+    void preIteration(const unsigned iter, Vector const& x) override
+    {
+        _ode.preIteration(iter, x);
+    }
+
+    IterationResult postIteration(Vector const& x) override
+    {
+        return _ode.postIteration(x);
+    }
+
     void pushMatrices() const override
     {
         _mat_trans->pushMatrices(*_M, *_K, *_b);
@@ -313,6 +323,16 @@ public:
     bool isLinear() const override
     {
         return _time_disc.isLinearTimeDisc() || _ode.isLinear();
+    }
+
+    void preIteration(const unsigned iter, Vector const& x) override
+    {
+        _ode.preIteration(iter, x);
+    }
+
+    IterationResult postIteration(Vector const& x) override
+    {
+        return _ode.postIteration(x);
     }
 
     void pushMatrices() const override


### PR DESCRIPTION
Said hooks are called before and after each iteration of the nonlinear solver.

I need that functionality for TES in order to be able to drop some nonsensible iteration results.