### PR TITLE
Fix Properties::excludeCopyProperties()

### DIFF
--- a/MeshLib/MeshEditing/RemoveMeshComponents.cpp
+++ b/MeshLib/MeshEditing/RemoveMeshComponents.cpp
@@ -75,10 +75,10 @@ MeshLib::Mesh* removeElements(const MeshLib::Mesh& mesh, const std::vector<std::
 
 	if (!new_elems.empty())
 	{
-		MeshLib::Mesh* new_mesh = new MeshLib::Mesh(new_mesh_name,
-			new_nodes, new_elems,
-			mesh.getProperties().excludeCopyProperties(removed_element_ids)
-		);
+		MeshLib::Mesh* new_mesh =
+		    new MeshLib::Mesh(new_mesh_name, new_nodes, new_elems,
+		                      mesh.getProperties().excludeCopyProperties(
+		                          removed_element_ids, removed_node_ids));
 		return new_mesh;
 	}
 	else
@@ -126,10 +126,10 @@ MeshLib::Mesh* removeNodes(const MeshLib::Mesh &mesh, const std::vector<std::siz
 
 	if (!new_elems.empty())
 	{
-		MeshLib::Mesh* new_mesh = new MeshLib::Mesh(new_mesh_name,
-			new_nodes, new_elems,
-			mesh.getProperties().excludeCopyProperties(removed_element_ids)
-		);
+		MeshLib::Mesh* new_mesh =
+		    new MeshLib::Mesh(new_mesh_name, new_nodes, new_elems,
+		                      mesh.getProperties().excludeCopyProperties(
+		                          removed_element_ids, del_nodes_idx));
 		return new_mesh;
 	}
 	else

--- a/MeshLib/Properties.cpp
+++ b/MeshLib/Properties.cpp
@@ -49,14 +49,25 @@ std::vector<std::string> Properties::getPropertyVectorNames() const
 	return names;
 }
 
-Properties Properties::excludeCopyProperties(std::vector<std::size_t> const& exclude_ids) const
+Properties Properties::excludeCopyProperties(
+    std::vector<std::size_t> const& exclude_elem_ids,
+    std::vector<std::size_t> const& exclude_node_ids) const
 {
 	Properties exclude_copy;
 	for (auto property_vector : _properties) {
-		exclude_copy._properties.insert(
-			std::make_pair(property_vector.first,
-			property_vector.second->clone(exclude_ids))
-		);
+		if (property_vector.second->getMeshItemType() == MeshItemType::Cell) {
+			exclude_copy._properties.insert(
+				std::make_pair(property_vector.first,
+				property_vector.second->clone(exclude_elem_ids))
+			);
+		}
+		else if (property_vector.second->getMeshItemType() == MeshItemType::Node)
+		{
+			exclude_copy._properties.insert(
+				std::make_pair(property_vector.first,
+				property_vector.second->clone(exclude_node_ids))
+			);
+		}
 	}
 	return exclude_copy;
 }

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -105,10 +105,12 @@ public:
 	std::vector<std::string> getPropertyVectorNames() const;
 
 	/** copy all PropertyVector objects stored in the (internal) map but only
-	 * those values of a PropertyVector whose ids are not in the vector
-	 * exclude_ids.
+	 * those nodes/elements of a PropertyVector whose ids are not in the vectors
+	 * exclude_*_ids.
 	 */
-	Properties excludeCopyProperties(std::vector<std::size_t> const& exclude_ids) const;
+	Properties excludeCopyProperties(
+	    std::vector<std::size_t> const& exclude_elem_ids,
+	    std::vector<std::size_t> const& exclude_node_ids) const;
 
 	Properties() {}
 

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -31,6 +31,23 @@ public:
 		std::vector<std::size_t> const& exclude_positions
 	) const = 0;
 	virtual ~PropertyVectorBase() = default;
+
+	MeshItemType getMeshItemType() const { return _mesh_item_type; }
+	std::string const& getPropertyName() const { return _property_name; }
+	std::size_t getNumberOfComponents() const { return _n_components; }
+
+protected:
+	PropertyVectorBase(std::string const& property_name,
+	                   MeshItemType mesh_item_type,
+	                   std::size_t n_components)
+	    : _n_components(n_components),
+	      _mesh_item_type(mesh_item_type),
+	      _property_name(property_name)
+	{}
+
+	std::size_t const _n_components;
+	MeshItemType const _mesh_item_type;
+	std::string const _property_name;
 };
 
 /// Class template PropertyVector is a std::vector with template parameter
@@ -44,13 +61,10 @@ class PropertyVector : public std::vector<PROP_VAL_TYPE>,
 friend class Properties;
 
 public:
-	std::size_t getNumberOfComponents() const { return _n_components; }
 	std::size_t getNumberOfTuples() const
 	{
 		return std::vector<PROP_VAL_TYPE>::size() / _n_components;
 	}
-	MeshItemType getMeshItemType() const { return _mesh_item_type; }
-	std::string const& getPropertyName() const { return _property_name; }
 
 	PropertyVectorBase* clone(std::vector<std::size_t> const& exclude_positions) const
 	{
@@ -76,9 +90,7 @@ protected:
 	                        MeshItemType mesh_item_type,
 	                        std::size_t n_components)
 	    : std::vector<PROP_VAL_TYPE>(),
-	      _n_components(n_components),
-	      _mesh_item_type(mesh_item_type),
-	      _property_name(property_name)
+	      PropertyVectorBase(property_name, mesh_item_type, n_components)
 	{}
 
 	/// @brief The constructor taking meta information for the data.
@@ -93,13 +105,8 @@ protected:
 	               MeshItemType mesh_item_type,
 	               std::size_t n_components)
 	    : std::vector<PROP_VAL_TYPE>(n_property_values * n_components),
-	      _mesh_item_type(mesh_item_type),
-	      _property_name(property_name)
+	      PropertyVectorBase(property_name, mesh_item_type, n_components)
 	{}
-
-	std::size_t const _n_components;
-	MeshItemType const _mesh_item_type;
-	std::string const _property_name;
 };
 
 /// Class template PropertyVector is a std::vector with template parameter
@@ -141,7 +148,6 @@ public:
 		_values[group_id] = new T(value);
 	}
 
-	std::size_t getNumberOfComponents() const { return _n_components; }
 	std::size_t getNumberOfTuples() const
 	{
 		return std::vector<std::size_t>::size();
@@ -151,8 +157,6 @@ public:
 	{
 		return _n_components * std::vector<std::size_t>::size();
 	}
-	MeshItemType getMeshItemType() const { return _mesh_item_type; }
-	std::string const& getPropertyName() const { return _property_name; }
 
 	PropertyVectorBase* clone(std::vector<std::size_t> const& exclude_positions) const
 	{
@@ -204,16 +208,9 @@ protected:
 	               MeshItemType mesh_item_type,
 	               std::size_t n_components)
 	    : std::vector<std::size_t>(item2group_mapping),
-	      _n_components(n_components),
-	      _mesh_item_type(mesh_item_type),
-	      _property_name(property_name),
+	      PropertyVectorBase(property_name, mesh_item_type, n_components),
 	      _values(n_prop_groups * n_components)
 	{}
-
-protected:
-	std::size_t const _n_components;
-	MeshItemType const _mesh_item_type;
-	std::string const _property_name;
 
 private:
 	std::vector<T*> _values;


### PR DESCRIPTION
This PR adds a second argument to the method `Properties::excludeCopyProperties()` such that both property types, cell and node properties can be correctly copied. Furthermore it was necessary to move some attributes / methods from `PropertyVector` to the abstract  base class `PropertyVectorBase`.

This fixes issue #1117 .