### PR TITLE
Parsing of a space delimited config values

### DIFF
--- a/BaseLib/ConfigTree-impl.h
+++ b/BaseLib/ConfigTree-impl.h
@@ -81,6 +81,17 @@ boost::optional<std::vector<T>> ConfigTree::getConfParamOptionalImpl(
         T value;
         while (sstr >> value)
             result.push_back(value);
+        if (!sstr.eof())  // The stream is not read until the end, must be an
+                        // error. result contains number of read values.
+        {
+            error("Value for key <" + param + "> `" +
+                  shortString(sstr.str()) +
+                  "' not convertible to a vector of the desired type."
+                  " Could not convert token no. " +
+                  std::to_string(result.size() + 1) + ".");
+            return boost::none;
+        }
+
         return boost::make_optional(result);
     }
 

--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -15,6 +15,7 @@
 
 #include <functional>
 #include <memory>
+#include <vector>
 
 #include <boost/property_tree/ptree.hpp>
 
@@ -496,6 +497,15 @@ public:
     //! Will print a warning message
     static void onwarning(std::string const& filename, std::string const& path,
                           std::string const& message);
+
+private:
+    //! Default implementation of reading a value of type T.
+    template<typename T> boost::optional<T>
+    getConfParamOptionalImpl(std::string const& param, T*) const;
+
+    //! Implementation of reading a vector of values of type T.
+    template<typename T> boost::optional<std::vector<T>>
+    getConfParamOptionalImpl(std::string const& param, std::vector<T>*) const;
 
 private:
     struct CountType

--- a/Tests/BaseLib/TestConfigTree.cpp
+++ b/Tests/BaseLib/TestConfigTree.cpp
@@ -11,7 +11,9 @@
 #include <logog/include/logog.hpp>
 
 #include <boost/property_tree/xml_parser.hpp>
+#include <numeric>
 #include <sstream>
+#include <vector>
 
 #include "BaseLib/ConfigTree.h"
 #include "Tests/TestTools.h"
@@ -114,6 +116,7 @@ TEST(BaseLibConfigTree, Get)
             "</sub>"
             "<x>Y</x>"
             "<z attr=\"0.5\" optattr=\"false\">32.0</z>"
+            "<vector>0 1 2 3 4</vector>"
             ;
     auto const ptree = readXml(xml);
 
@@ -218,6 +221,17 @@ TEST(BaseLibConfigTree, Get)
             EXPECT_ERR_WARN(cbs, true, false);
             EXPECT_FALSE(z.getConfAttributeOptional<bool>("also_not_an_attr")); // nonexisting attribute
             EXPECT_ERR_WARN(cbs, false, false);
+        }
+
+        // Testing vector
+        {
+            auto v = conf.getConfParam<std::vector<int>>("vector");
+            EXPECT_ERR_WARN(cbs, false, false);
+            EXPECT_EQ(5u, v.size());
+            std::vector<int> expected_vector(5);
+            std::iota(expected_vector.begin(), expected_vector.end(), 0);
+            EXPECT_TRUE(std::equal(expected_vector.begin(),
+                                   expected_vector.end(), v.begin()));
         }
         EXPECT_ERR_WARN(cbs, false, false);
     } // ConfigTree destroyed here

--- a/Tests/BaseLib/TestConfigTree.cpp
+++ b/Tests/BaseLib/TestConfigTree.cpp
@@ -117,6 +117,8 @@ TEST(BaseLibConfigTree, Get)
             "<x>Y</x>"
             "<z attr=\"0.5\" optattr=\"false\">32.0</z>"
             "<vector>0 1 2 3 4</vector>"
+            "<vector_bad1>x 1 2a</vector_bad1>"
+            "<vector_bad2>0 1 2a</vector_bad2>"
             ;
     auto const ptree = readXml(xml);
 
@@ -232,6 +234,12 @@ TEST(BaseLibConfigTree, Get)
             std::iota(expected_vector.begin(), expected_vector.end(), 0);
             EXPECT_TRUE(std::equal(expected_vector.begin(),
                                    expected_vector.end(), v.begin()));
+            EXPECT_ANY_THROW(
+                conf.getConfParam<std::vector<int>>("vector_bad1"));
+            EXPECT_ERR_WARN(cbs, true, false);
+            EXPECT_ANY_THROW(
+                conf.getConfParam<std::vector<int>>("vector_bad2"));
+            EXPECT_ERR_WARN(cbs, true, false);
         }
         EXPECT_ERR_WARN(cbs, false, false);
     } // ConfigTree destroyed here


### PR DESCRIPTION
Provides reading of list of values from a config file.
```xml
<values>0 1 2 5</values>
```
can now be read with
```c++
auto v = config.getConfParam<std::vector<int>>("values");
```

The idea behind this is to overload the implementation on `*T` parameter. (The idea is from [stackoverflow](http://stackoverflow.com/a/8315197).)