### PR TITLE
Pass time to ODESystem::getKnownSolutions();

### DIFF
--- a/NumLib/ODESolver/ODESystem.h
+++ b/NumLib/ODESolver/ODESystem.h
@@ -65,8 +65,12 @@ public:
 
     using Index = typename MathLib::MatrixVectorTraits<Matrix>::Index;
 
-    virtual std::vector<ProcessLib::DirichletBc<Index> > const* getKnownSolutions() const
+    //! Provides known solutions (Dirichlet boundary conditions) vector for
+    //! the ode system at the given time \c t.
+    virtual std::vector<ProcessLib::DirichletBc<Index>> const*
+    getKnownSolutions(double const t) const
     {
+        (void)t;
         return nullptr; // by default there are no known solutions
     }
 };

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.h
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.h
@@ -310,7 +310,8 @@ public:
 
     void applyKnownSolutionsPicard(Matrix& A, Vector& rhs, Vector& x) override
     {
-        auto const* known_solutions = _ode.getKnownSolutions();
+        auto const* known_solutions =
+            _ode.getKnownSolutions(_time_disc.getCurrentTime());
 
         if (known_solutions) {
             for (auto const& bc : *known_solutions) {

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -213,8 +213,8 @@ public:
 		//      VectoMatrixAssembler since that will work for all kinds of processes.
 	}
 
-	std::vector<DirichletBc<Index> > const* getKnownSolutions()
-	const override final
+	std::vector<DirichletBc<Index>> const* getKnownSolutions(
+	    double const /*t*/) const override final
 	{
 		return &_dirichlet_bcs;
 	}


### PR DESCRIPTION
For time-variable boundary conditions the current time is needed.

~~I'm not sure if this is the right solution, therefor it's for discussion.~~
The time is injected in the `TimeDiscretizedODESystem` now and the nonlinear solver is not touched.
The dirichlet bcs needs an update too, but this the point of this PR.