### PR TITLE
Added assembleJacobian method

### DIFF
--- a/AssemblerLib/VectorMatrixAssembler.h
+++ b/AssemblerLib/VectorMatrixAssembler.h
@@ -89,7 +89,7 @@ public:
     /// into the global matrix and vector.
     /// The positions in the global matrix/vector are taken from
     /// the LocalToGlobalIndexMap provided in the constructor at index \c id.
-    /// \attention The index \c id is not necesserily the mesh item's id.
+    /// \attention The index \c id is not necessarily the mesh item's id.
     template <typename LocalAssembler>
     void operator()(std::size_t const id,
         LocalAssembler& local_assembler,
@@ -109,9 +109,32 @@ public:
         passLocalVector_(cb, id, _data_pos, x, t, M, K, b);
     }
 
+    /// Executes assembleJacobian() of the local assembler for the
+    /// given mesh item passing the mesh item's nodal d.o.f.
+    /// \attention The index \c id is not necessarily the mesh item's id.
+    template <typename LocalAssembler>
+    void assembleJacobian(std::size_t const id,
+                          LocalAssembler& local_assembler,
+                          const double t,
+                          GlobalVector const& x,
+                          GlobalMatrix& Jac) const
+    {
+        auto cb = [&local_assembler](
+            std::vector<double> const& local_x,
+            LocalToGlobalIndexMap::RowColumnIndices const& r_c_indices,
+            const double t,
+            GlobalMatrix& Jac)
+        {
+            local_assembler.assembleJacobian(t, local_x);
+            local_assembler.addJacobianToGlobal(r_c_indices, Jac);
+        };
+
+        passLocalVector_(cb, id, _data_pos, x, t, Jac);
+    }
+
     /// Executes the preTimestep() method of the local assembler for the
     /// given mesh item passing the mesh item's nodal d.o.f.
-    /// \attention The index \c id is not necesserily the mesh item's id.
+    /// \attention The index \c id is not necessarily the mesh item's id.
     template <typename LocalAssembler>
     void preTimestep(std::size_t const id,
                      LocalAssembler& local_assembler,
@@ -129,7 +152,7 @@ public:
 
     /// Executes the postTimestep() method of the local assembler for the
     /// given mesh item passing the mesh item's nodal d.o.f.
-    /// \attention The index \c id is not necesserily the mesh item's id.
+    /// \attention The index \c id is not necessarily the mesh item's id.
     template <typename LocalAssembler>
     void postTimestep(std::size_t const id,
                       LocalAssembler& local_assembler,
@@ -147,7 +170,7 @@ public:
 
     /// Executes the given callback function for the given mesh item
     /// passing the mesh item's nodal d.o.f.
-    /// \attention The index \c id is not necesserily the mesh item's id.
+    /// \attention The index \c id is not necessarily the mesh item's id.
     template <typename Callback, typename... Args>
     void passLocalVector(Callback& cb, std::size_t const id,
                          GlobalVector const& x, Args&&... args)
@@ -175,7 +198,7 @@ public:
     /// into the global matrix and vector.
     /// The positions in the global matrix/vector are taken from
     /// the LocalToGlobalIndexMap provided in the constructor at index \c id.
-    /// \attention The index \c id is not necesserily the mesh item's id.
+    /// \attention The index \c id is not necessarily the mesh item's id.
     template <typename LocalAssembler>
     void operator()(std::size_t const id,
         LocalAssembler& local_assembler,


### PR DESCRIPTION
This PR provides one central building block to be able to assemble processes for a Newton scheme.

Currently the code introduced is not used, but will be, e.g., in @endJunction's mechanics process.