### PR TITLE
Apply Dirichlet BCs in the Newton scheme

### DIFF
--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
@@ -337,12 +337,16 @@ solveOneTimeStepOneProcess(
 
     setEquationSystem(nonlinear_solver, ode_sys, nl_tag);
 
+    // Note: Order matters!
+    // First advance to the next timestep, then set known solutions at that
+    // time, afterwards pass the right solution vector and time to the
+    // preTimestep() hook.
+
+    time_disc.nextTimestep(t, delta_t);
+
     applyKnownSolutions(ode_sys, nl_tag, x);
 
     process.preTimestep(x, t, delta_t);
-
-    // INFO("time: %e, delta_t: %e", t, delta_t);
-    time_disc.nextTimestep(t, delta_t);
 
     bool nonlinear_solver_succeeded = nonlinear_solver.solve(x);
 

--- a/MathLib/LinAlg/MatrixVectorTraits.cpp
+++ b/MathLib/LinAlg/MatrixVectorTraits.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "AssemblerLib/LocalToGlobalIndexMap.h"
+#include "MatrixProviderUser.h"
 #include "MatrixVectorTraits.h"
 
 #ifdef OGS_USE_EIGEN

--- a/MathLib/LinAlg/MatrixVectorTraits.h
+++ b/MathLib/LinAlg/MatrixVectorTraits.h
@@ -12,12 +12,12 @@
 
 #include<memory>
 
-#include "MatrixProviderUser.h"
-
 namespace MathLib
 {
 template<typename Matrix>
 struct MatrixVectorTraits;
+
+struct MatrixSpecifications;
 }
 
 #define SPECIALIZE_MATRIX_VECTOR_TRAITS(MATVEC, IDX) \

--- a/MathLib/LinAlg/UnifiedMatrixSetters.cpp
+++ b/MathLib/LinAlg/UnifiedMatrixSetters.cpp
@@ -67,6 +67,12 @@ void setVector(Eigen::VectorXd& v, std::initializer_list<double> values)
     for (std::size_t i=0; i<values.size(); ++i) v[i] = *(it++);
 }
 
+void setVector(Eigen::VectorXd& v, MatrixVectorTraits<Eigen::VectorXd>::Index const index,
+               double const value)
+{
+    v[index] = value;
+}
+
 } // namespace MathLib
 
 #endif // OGS_USE_EIGEN
@@ -95,6 +101,12 @@ void setVector(PETScVector& v,
     std::iota(idcs.begin(), idcs.end(), 0);
 
     v.set(idcs, vals);
+}
+
+void setVector(PETScVector& v, MatrixVectorTraits<PETScVector>::Index const index,
+               double const value)
+{
+    v.set(index, value); // TODO handle negative indices
 }
 
 void setMatrix(PETScMatrix& m,
@@ -172,6 +184,13 @@ void setVector(EigenVector& v,
 {
     setVector(v.getRawVector(), values);
 }
+
+void setVector(EigenVector& v, MatrixVectorTraits<EigenVector>::Index const index,
+               double const value)
+{
+    v.getRawVector()[index] = value;
+}
+
 
 void setMatrix(EigenMatrix& m,
                std::initializer_list<double> values)

--- a/MathLib/LinAlg/UnifiedMatrixSetters.h
+++ b/MathLib/LinAlg/UnifiedMatrixSetters.h
@@ -13,6 +13,7 @@
 #define MATHLIB_UNIFIED_MATRIX_SETTERS_H
 
 #include <initializer_list>
+#include "MatrixVectorTraits.h"
 
 #ifdef OGS_USE_EIGEN
 
@@ -35,6 +36,9 @@ double norm(Eigen::VectorXd const& x);
 
 void setVector(Eigen::VectorXd& v, std::initializer_list<double> values);
 
+void setVector(Eigen::VectorXd& v, MatrixVectorTraits<Eigen::VectorXd>::Index const index,
+               double const value);
+
 } // namespace MathLib
 
 #endif // OGS_USE_EIGEN
@@ -54,6 +58,9 @@ double norm(PETScVector const& x);
 
 void setVector(PETScVector& v,
                std::initializer_list<double> values);
+
+void setVector(PETScVector& v, MatrixVectorTraits<PETScVector>::Index const index,
+               double const value);
 
 void setMatrix(PETScMatrix& m, Eigen::MatrixXd const& tmp);
 
@@ -78,6 +85,9 @@ class EigenMatrix;
 
 void setVector(EigenVector& v,
                std::initializer_list<double> values);
+
+void setVector(EigenVector& v, MatrixVectorTraits<EigenVector>::Index const index,
+               double const value);
 
 void setMatrix(EigenMatrix& m,
                std::initializer_list<double> values);

--- a/NumLib/ODESolver/NonlinearSystem.h
+++ b/NumLib/ODESolver/NonlinearSystem.h
@@ -64,6 +64,9 @@ public:
      */
     virtual void getJacobian(Matrix& Jac) const = 0;
 
+    //! Apply known solutions to the solution vector \c x.
+    virtual void applyKnownSolutions(Vector& x) const = 0;
+
     //! Apply known solutions to the linearized equation system
     //! \f$ \mathit{Jac} \cdot (-\Delta x) = \mathit{res} \f$.
     virtual void applyKnownSolutionsNewton(
@@ -92,6 +95,9 @@ public:
 
     //! Writes the linearized equation system right-hand side to \c rhs.
     virtual void getRhs(Vector& rhs) const = 0;
+
+    //! Apply known solutions to the solution vector \c x.
+    virtual void applyKnownSolutions(Vector& x) const = 0;
 
     //! Apply known solutions to the linearized equation system
     //! \f$ A \cdot x = \mathit{rhs} \f$.

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.h
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.h
@@ -201,8 +201,20 @@ public:
     void applyKnownSolutionsNewton(Matrix& Jac, Vector& res,
                                     Vector& minus_delta_x) override
     {
-        (void) Jac; (void) res; (void) minus_delta_x;
-        INFO("Method applyKnownSolutionsNewton() not implemented."); // TODO implement
+        auto const* known_solutions =
+            _ode.getKnownSolutions(_time_disc.getCurrentTime());
+
+        if (known_solutions) {
+            std::vector<double> values;
+
+            for (auto const& bc : *known_solutions) {
+                // TODO this is the quick and dirty and bad performance solution.
+                values.resize(bc.values.size(), 0.0);
+
+                // TODO maybe it would be faster to apply all at once
+                MathLib::applyKnownSolution(Jac, res, minus_delta_x, bc.global_ids, values);
+            }
+        }
     }
 
     bool isLinear() const override

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.h
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.h
@@ -13,6 +13,7 @@
 #include <memory>
 
 #include "MathLib/LinAlg/ApplyKnownSolution.h"
+#include "MathLib/LinAlg/UnifiedMatrixSetters.h"
 #include "ProcessLib/DirichletBc.h"
 
 #include "ODESystem.h"
@@ -20,6 +21,23 @@
 #include "TimeDiscretization.h"
 #include "MatrixTranslator.h"
 
+namespace detail
+{
+//! Applies known solutions to the solution vector \c x.
+template<typename Solutions, typename Vector>
+void applyKnownSolutions(std::vector<Solutions> const*const known_solutions,
+                         Vector& x)
+{
+    if (!known_solutions) return;
+
+    for (auto const& bc : *known_solutions) {
+        for (std::size_t i=0; i<bc.global_ids.size(); ++i) {
+            // TODO that might have bad performance for some Vector types, e.g., PETSc.
+            MathLib::setVector(x, bc.global_ids[i], bc.values[i]);
+        }
+    }
+}
+}
 
 namespace NumLib
 {
@@ -174,6 +192,12 @@ public:
         _mat_trans->computeJacobian(*_Jac, Jac);
     }
 
+    void applyKnownSolutions(Vector& x) const override
+    {
+        ::detail::applyKnownSolutions(
+                    _ode.getKnownSolutions(_time_disc.getCurrentTime()), x);
+    }
+
     void applyKnownSolutionsNewton(Matrix& Jac, Vector& res,
                                     Vector& minus_delta_x) override
     {
@@ -306,6 +330,12 @@ public:
     void getRhs(Vector& rhs) const override
     {
         _mat_trans->computeRhs(*_M, *_K, *_b, rhs);
+    }
+
+    void applyKnownSolutions(Vector& x) const override
+    {
+        ::detail::applyKnownSolutions(
+                    _ode.getKnownSolutions(_time_disc.getCurrentTime()), x);
     }
 
     void applyKnownSolutionsPicard(Matrix& A, Vector& rhs, Vector& x) override


### PR DESCRIPTION
The `applyKnownSolutions()` methods in the time loop do safe downcasting, similar to the `setEquationSystem()` methods that are already present.

The provided implementations of `applyKnownSolutions()` in NumLib are definitely not perfect, but they should work. Performance optimizations to be done later on.

This is a follow-up PR of #1127.