### PR TITLE
Use norm of delta x within Newton scheme

### DIFF
--- a/NumLib/ODESolver/NonlinearSolver-impl.h
+++ b/NumLib/ODESolver/NonlinearSolver-impl.h
@@ -160,17 +160,11 @@ solve(Vector &x)
         sys.assembleResidualNewton(x);
         sys.getResidual(x, res);
 
-        // std::cout << "  res:\n" << res << std::endl;
-
-        // TODO streamline that, make consistent with Picard.
-        if (BLAS::norm2(res) < _tol) {
-            error_norms_met = true;
-            break;
-        }
-
         sys.assembleJacobian(x);
         sys.getJacobian(J);
         sys.applyKnownSolutionsNewton(J, res, minus_delta_x);
+
+        auto const error_res = BLAS::norm2(res);
 
         // std::cout << "  J:\n" << Eigen::MatrixXd(J) << std::endl;
 
@@ -213,10 +207,13 @@ solve(Vector &x)
             break;
         }
 
-        // TODO maybe compute norm of _minus_delta_x here.
+        auto const error_dx = BLAS::norm2(minus_delta_x);
+        DBUG("error of -delta_x %g and of residual %g,", error_dx, error_res);
 
-        // auto const dx_norm = _minus_delta_x.norm();
-        // INFO("  newton iteration %u, norm of delta x: %e", iteration, dx_norm);
+        if (error_dx < _tol) {
+            error_norms_met = true;
+            break;
+        }
 
         if (sys.isLinear()) {
             // INFO("  newton linear system. not looping");


### PR DESCRIPTION
The old approach of taking the residual norm was erroneous: It was computed too early (before applying Dirichlet BCs), thus it did not converge.

This PR changes that. And it switches to norm of delta x for now. That's then consistent with the way the Picard solver currently computes errors. Of course, later on there will be more error calculation methods to choose from.