### PR TITLE
Set global vector entries for different types

### DIFF
--- a/MathLib/LinAlg/MatrixVectorTraits.cpp
+++ b/MathLib/LinAlg/MatrixVectorTraits.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "AssemblerLib/LocalToGlobalIndexMap.h"
+#include "MatrixProviderUser.h"
 #include "MatrixVectorTraits.h"
 
 #ifdef OGS_USE_EIGEN

--- a/MathLib/LinAlg/MatrixVectorTraits.h
+++ b/MathLib/LinAlg/MatrixVectorTraits.h
@@ -12,12 +12,12 @@
 
 #include<memory>
 
-#include "MatrixProviderUser.h"
-
 namespace MathLib
 {
 template<typename Matrix>
 struct MatrixVectorTraits;
+
+struct MatrixSpecifications;
 }
 
 #define SPECIALIZE_MATRIX_VECTOR_TRAITS(MATVEC, IDX) \

--- a/MathLib/LinAlg/UnifiedMatrixSetters.cpp
+++ b/MathLib/LinAlg/UnifiedMatrixSetters.cpp
@@ -67,6 +67,12 @@ void setVector(Eigen::VectorXd& v, std::initializer_list<double> values)
     for (std::size_t i=0; i<values.size(); ++i) v[i] = *(it++);
 }
 
+void setVector(Eigen::VectorXd& v, MatrixVectorTraits<Eigen::VectorXd>::Index const index,
+               double const value)
+{
+    v[index] = value;
+}
+
 } // namespace MathLib
 
 #endif // OGS_USE_EIGEN
@@ -95,6 +101,12 @@ void setVector(PETScVector& v,
     std::iota(idcs.begin(), idcs.end(), 0);
 
     v.set(idcs, vals);
+}
+
+void setVector(PETScVector& v, MatrixVectorTraits<PETScVector>::Index const index,
+               double const value)
+{
+    v.set(index, value);
 }
 
 void setMatrix(PETScMatrix& m,
@@ -172,6 +184,13 @@ void setVector(EigenVector& v,
 {
     setVector(v.getRawVector(), values);
 }
+
+void setVector(EigenVector& v, MatrixVectorTraits<EigenVector>::Index const index,
+               double const value)
+{
+    v.getRawVector()[index] = value;
+}
+
 
 void setMatrix(EigenMatrix& m,
                std::initializer_list<double> values)

--- a/MathLib/LinAlg/UnifiedMatrixSetters.h
+++ b/MathLib/LinAlg/UnifiedMatrixSetters.h
@@ -13,6 +13,7 @@
 #define MATHLIB_UNIFIED_MATRIX_SETTERS_H
 
 #include <initializer_list>
+#include "MatrixVectorTraits.h"
 
 #ifdef OGS_USE_EIGEN
 
@@ -35,6 +36,9 @@ double norm(Eigen::VectorXd const& x);
 
 void setVector(Eigen::VectorXd& v, std::initializer_list<double> values);
 
+void setVector(Eigen::VectorXd& v, MatrixVectorTraits<Eigen::VectorXd>::Index const index,
+               double const value);
+
 } // namespace MathLib
 
 #endif // OGS_USE_EIGEN
@@ -54,6 +58,9 @@ double norm(PETScVector const& x);
 
 void setVector(PETScVector& v,
                std::initializer_list<double> values);
+
+void setVector(PETScVector& v, MatrixVectorTraits<PETScVector>::Index const index,
+               double const value);
 
 void setMatrix(PETScMatrix& m, Eigen::MatrixXd const& tmp);
 
@@ -78,6 +85,9 @@ class EigenMatrix;
 
 void setVector(EigenVector& v,
                std::initializer_list<double> values);
+
+void setVector(EigenVector& v, MatrixVectorTraits<EigenVector>::Index const index,
+               double const value);
 
 void setMatrix(EigenMatrix& m,
                std::initializer_list<double> values);


### PR DESCRIPTION
The provided functions allow setting vector entries using the same interface for
`Eigen::VectorXd`, `EigenVector` and `PETScVector`.

This is a precursor to #1130.