### PR TITLE
Enable shared linking

### DIFF
--- a/Applications/ApplicationsLib/CMakeLists.txt
+++ b/Applications/ApplicationsLib/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(LIB_SOURCES ProjectData.cpp)
 
 # Library
-add_library(ApplicationsLib STATIC ${LIB_SOURCES})
+add_library(ApplicationsLib ${LIB_SOURCES})
 
 target_link_libraries(ApplicationsLib INTERFACE
 	GeoLib

--- a/Applications/ApplicationsLib/CMakeLists.txt
+++ b/Applications/ApplicationsLib/CMakeLists.txt
@@ -9,7 +9,6 @@ target_link_libraries(ApplicationsLib
 	NumLib
 	ProcessLib
 	${VTK_LIBRARIES}
-	logog
 )
 ADD_VTK_DEPENDENCY(ApplicationsLib)
 

--- a/Applications/ApplicationsLib/CMakeLists.txt
+++ b/Applications/ApplicationsLib/CMakeLists.txt
@@ -4,8 +4,7 @@ set(LIB_SOURCES ProjectData.cpp)
 # Library
 add_library(ApplicationsLib ${LIB_SOURCES})
 
-target_link_libraries(ApplicationsLib INTERFACE
-	GeoLib
+target_link_libraries(ApplicationsLib
 	MeshGeoToolsLib
 	NumLib
 	ProcessLib

--- a/Applications/CLI/CMakeLists.txt
+++ b/Applications/CLI/CMakeLists.txt
@@ -5,6 +5,10 @@ add_executable(ogs
 
 target_link_libraries(ogs
     ApplicationsLib
+    AssemblerLib
+    MeshGeoToolsLib
+    ProcessLib
+    NumLib
     FileIO
 )
 

--- a/Applications/DataExplorer/Base/CMakeLists.txt
+++ b/Applications/DataExplorer/Base/CMakeLists.txt
@@ -34,7 +34,7 @@ source_group("UI Files" REGULAR_EXPRESSION "\\w*\\.ui")
 source_group("Moc Files" REGULAR_EXPRESSION "moc_.*")
 
 # Create the library
-add_library(QtBase STATIC
+add_library(QtBase
 	${SOURCES}
 	${HEADERS}
 )

--- a/Applications/DataExplorer/DataExplorer.cmake
+++ b/Applications/DataExplorer/DataExplorer.cmake
@@ -55,6 +55,7 @@ target_link_libraries(DataExplorer
 	ApplicationsLib
 	DataHolderLib
 	FileIO
+	InSituLib
 	QtDataView
 	QtDiagramView
 	QtStratView
@@ -63,6 +64,7 @@ target_link_libraries(DataExplorer
 	Threads::Threads
 	OGSFileConverterLib
 	vtkGUISupportQt
+	logog
 )
 
 if(CMAKE_CROSSCOMPILING)

--- a/Applications/DataExplorer/DataView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/CMakeLists.txt
@@ -124,7 +124,7 @@ if(GEOTIFF_FOUND)
 	include_directories(${GEOTIFF_INCLUDE_DIRS})
 endif() # GEOTIFF_FOUND
 
-add_library(QtDataView STATIC
+add_library(QtDataView
 	${SOURCES}
 	${HEADERS}
 	${UIS}

--- a/Applications/DataExplorer/DataView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/CMakeLists.txt
@@ -130,8 +130,8 @@ add_library(QtDataView
 	${UIS}
 )
 
-target_link_libraries(QtDataView PUBLIC Qt4::QtCore Qt4::QtGui)
-target_link_libraries(QtDataView INTERFACE
+target_link_libraries(QtDataView Qt4::QtCore Qt4::QtGui)
+target_link_libraries(QtDataView
 	FileIO
 	DataHolderLib
 	QtBase
@@ -141,7 +141,7 @@ add_dependencies(QtDataView QtDiagramView QtStratView)
 ADD_VTK_DEPENDENCY(QtDataView)
 
 if(GEOTIFF_FOUND)
-	target_link_libraries( QtDataView INTERFACE ${GEOTIFF_LIBRARIES} )
+	target_link_libraries( QtDataView ${GEOTIFF_LIBRARIES} )
 endif () # GEOTIFF_FOUND
 
 set_property(TARGET QtDataView PROPERTY FOLDER "DataExplorer")

--- a/Applications/DataExplorer/DataView/DiagramView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/DiagramView/CMakeLists.txt
@@ -39,6 +39,6 @@ add_library(QtDiagramView
 	${UIS}
 )
 
-target_link_libraries(QtDiagramView PUBLIC Qt4::QtGui)
+target_link_libraries(QtDiagramView Qt4::QtGui)
 
 set_property(TARGET QtDiagramView PROPERTY FOLDER "DataExplorer")

--- a/Applications/DataExplorer/DataView/DiagramView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/DiagramView/CMakeLists.txt
@@ -33,7 +33,7 @@ include_directories(
 file(GLOB_RECURSE UIS *.ui)
 source_group("UI Files" FILES ${UIS})
 
-add_library(QtDiagramView STATIC
+add_library(QtDiagramView
 	${SOURCES}
 	${HEADERS}
 	${UIS}

--- a/Applications/DataExplorer/DataView/StratView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/StratView/CMakeLists.txt
@@ -30,6 +30,6 @@ add_library(QtStratView
 	${UIS}
 )
 
-target_link_libraries(QtStratView PUBLIC Qt4::QtGui)
+target_link_libraries(QtStratView Qt4::QtGui)
 
 set_property(TARGET QtStratView PROPERTY FOLDER "DataExplorer")

--- a/Applications/DataExplorer/DataView/StratView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/StratView/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(
 file(GLOB_RECURSE UI_FILES *.ui)
 source_group("UI Files" FILES ${UI_FILES})
 
-add_library(QtStratView STATIC
+add_library(QtStratView
 	${SOURCES}
 	${HEADERS}
 	${UIS}

--- a/Applications/DataExplorer/DataView/StratView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/StratView/CMakeLists.txt
@@ -30,6 +30,6 @@ add_library(QtStratView
 	${UIS}
 )
 
-target_link_libraries(QtStratView Qt4::QtGui)
+target_link_libraries(QtStratView Qt4::QtGui QtBase)
 
 set_property(TARGET QtStratView PROPERTY FOLDER "DataExplorer")

--- a/Applications/DataExplorer/VtkAct/CMakeLists.txt
+++ b/Applications/DataExplorer/VtkAct/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library( VtkAct
 
 ADD_VTK_DEPENDENCY(VtkAct)
 
-target_link_libraries( VtkAct PUBLIC Qt4::QtCore )
-target_link_libraries( VtkAct INTERFACE ${VTK_LIBRARIES} )
+target_link_libraries( VtkAct Qt4::QtCore )
+target_link_libraries( VtkAct ${VTK_LIBRARIES} )
 
 set_property(TARGET VtkAct PROPERTY FOLDER "DataExplorer")

--- a/Applications/DataExplorer/VtkAct/CMakeLists.txt
+++ b/Applications/DataExplorer/VtkAct/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(
 	${CMAKE_CURRENT_SOURCE_DIR}/../VtkVis
 )
 
-add_library( VtkAct STATIC
+add_library( VtkAct
 	${SOURCES}
 	${HEADERS}
 )

--- a/Applications/DataExplorer/VtkVis/CMakeLists.txt
+++ b/Applications/DataExplorer/VtkVis/CMakeLists.txt
@@ -113,7 +113,7 @@ include_directories(
 	${CMAKE_CURRENT_BINARY_DIR}/../DataView
 )
 
-add_library(VtkVis STATIC
+add_library(VtkVis
 	${SOURCES}
 	${HEADERS}
 	${UIS}

--- a/Applications/DataExplorer/VtkVis/CMakeLists.txt
+++ b/Applications/DataExplorer/VtkVis/CMakeLists.txt
@@ -123,11 +123,11 @@ ADD_VTK_DEPENDENCY(VtkVis)
 
 if(GEOTIFF_FOUND)
 	include_directories(${GEOTIFF_INCLUDE_DIRS})
-	target_link_libraries(VtkVis INTERFACE ${GEOTIFF_LIBRARIES})
+	target_link_libraries(VtkVis ${GEOTIFF_LIBRARIES})
 endif() # GEOTIFF_FOUND
 
-target_link_libraries(VtkVis PUBLIC Qt4::QtGui QtDataView)
-target_link_libraries(VtkVis INTERFACE VtkAct)
+target_link_libraries(VtkVis Qt4::QtGui QtDataView)
+target_link_libraries(VtkVis VtkAct)
 
 if(VTKOSGCONVERTER_FOUND)
 	USE_OPENSG(VtkVis)

--- a/Applications/Utils/OGSFileConverter/CMakeLists.txt
+++ b/Applications/Utils/OGSFileConverter/CMakeLists.txt
@@ -38,7 +38,12 @@ target_link_libraries(OGSFileConverterLib QtBase)
 
 add_executable(OGSFileConverter main.cpp)
 
-target_link_libraries(OGSFileConverter OGSFileConverterLib FileIO QtBase)
+target_link_libraries(OGSFileConverter
+	ApplicationsLib
+	OGSFileConverterLib
+	FileIO
+	QtBase
+	GeoLib)
 ADD_VTK_DEPENDENCY(OGSFileConverter)
 
 include(${QT_USE_FILE})

--- a/AssemblerLib/CMakeLists.txt
+++ b/AssemblerLib/CMakeLists.txt
@@ -5,7 +5,7 @@ GET_SOURCE_FILES(SOURCES_ASSEMBLERLIB)
 set(SOURCES ${SOURCES_ASSEMBLERLIB})
 
 # Create the library
-add_library(AssemblerLib STATIC ${SOURCES})
+add_library(AssemblerLib ${SOURCES})
 
 target_link_libraries(AssemblerLib INTERFACE
 	MeshLib

--- a/AssemblerLib/CMakeLists.txt
+++ b/AssemblerLib/CMakeLists.txt
@@ -7,7 +7,7 @@ set(SOURCES ${SOURCES_ASSEMBLERLIB})
 # Create the library
 add_library(AssemblerLib ${SOURCES})
 
-target_link_libraries(AssemblerLib INTERFACE
+target_link_libraries(AssemblerLib
 	MeshLib
 )
 

--- a/AssemblerLib/CMakeLists.txt
+++ b/AssemblerLib/CMakeLists.txt
@@ -5,7 +5,7 @@ GET_SOURCE_FILES(SOURCES_ASSEMBLERLIB)
 set(SOURCES ${SOURCES_ASSEMBLERLIB})
 
 # Create the library
-add_library(AssemblerLib ${SOURCES})
+add_library(AssemblerLib STATIC ${SOURCES})
 
 target_link_libraries(AssemblerLib
 	MeshLib

--- a/BaseLib/CMakeLists.txt
+++ b/BaseLib/CMakeLists.txt
@@ -7,12 +7,12 @@ add_library(BaseLib ${SOURCES})
 
 set_target_properties(BaseLib PROPERTIES LINKER_LANGUAGE CXX)
 
-target_link_libraries(BaseLib INTERFACE
+target_link_libraries(BaseLib
 	logog
 )
 
 if(MSVC)
-	target_link_libraries(BaseLib INTERFACE WinMM) # needed for timeGetTime
+	target_link_libraries(BaseLib WinMM) # needed for timeGetTime
 endif()
 
 if(TARGET Eigen)

--- a/BaseLib/CMakeLists.txt
+++ b/BaseLib/CMakeLists.txt
@@ -3,7 +3,7 @@ GET_SOURCE_FILES(SOURCES)
 list(APPEND SOURCES "${CMAKE_CURRENT_BINARY_DIR}/BuildInfo.cpp" BuildInfo.h)
 
 # Create the library
-add_library(BaseLib STATIC ${SOURCES})
+add_library(BaseLib ${SOURCES})
 
 set_target_properties(BaseLib PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/FileIO/CMakeLists.txt
+++ b/FileIO/CMakeLists.txt
@@ -57,8 +57,8 @@ add_library(FileIO ${SOURCES})
 
 target_link_libraries(FileIO
 	GeoLib
-	InSituLib
 	MeshLib
+	InSituLib
 	logog
 )
 if(QT4_FOUND)

--- a/FileIO/CMakeLists.txt
+++ b/FileIO/CMakeLists.txt
@@ -55,24 +55,24 @@ include(${PROJECT_SOURCE_DIR}/scripts/cmake/OGSEnabledElements.cmake)
 # Create the library
 add_library(FileIO ${SOURCES})
 
-target_link_libraries(FileIO INTERFACE
+target_link_libraries(FileIO
 	GeoLib
 	InSituLib
 	MeshLib
 	logog
 )
 if(QT4_FOUND)
-	target_link_libraries(FileIO PUBLIC Qt4::QtXml Qt4::QtXmlPatterns)
+	target_link_libraries(FileIO Qt4::QtXml Qt4::QtXmlPatterns)
 	if(WIN32 AND CMAKE_CROSSCOMPILING)
 		find_package(OpenSSL)
 		if(OPENSSL_FOUND)
-			target_link_libraries(FileIO PUBLIC Qt4::QtNetwork ${OPENSSL_LIBRARIES} ws2_32)
+			target_link_libraries(FileIO Qt4::QtNetwork ${OPENSSL_LIBRARIES} ws2_32)
 		endif()
 	endif()
 endif()
 
 if(Shapelib_FOUND)
-	target_link_libraries(FileIO INTERFACE ${Shapelib_LIBRARIES})
+	target_link_libraries(FileIO ${Shapelib_LIBRARIES})
 endif()
 
 ADD_VTK_DEPENDENCY(FileIO)

--- a/FileIO/CMakeLists.txt
+++ b/FileIO/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 include(${PROJECT_SOURCE_DIR}/scripts/cmake/OGSEnabledElements.cmake)
 
 # Create the library
-add_library(FileIO STATIC ${SOURCES})
+add_library(FileIO ${SOURCES})
 
 target_link_libraries(FileIO INTERFACE
 	GeoLib

--- a/GeoLib/CMakeLists.txt
+++ b/GeoLib/CMakeLists.txt
@@ -2,7 +2,7 @@
 GET_SOURCE_FILES(SOURCES_GeoLib)
 
 # Create the library
-add_library(GeoLib STATIC ${SOURCES_GeoLib}
+add_library(GeoLib ${SOURCES_GeoLib}
 	${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/tetgen/predicates.cxx
 )
 

--- a/GeoLib/CMakeLists.txt
+++ b/GeoLib/CMakeLists.txt
@@ -2,7 +2,7 @@
 GET_SOURCE_FILES(SOURCES_GeoLib)
 
 # Create the library
-add_library(GeoLib ${SOURCES_GeoLib}
+add_library(GeoLib STATIC ${SOURCES_GeoLib}
 	${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/tetgen/predicates.cxx
 )
 

--- a/GeoLib/CMakeLists.txt
+++ b/GeoLib/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(GeoLib ${SOURCES_GeoLib}
 	${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/tetgen/predicates.cxx
 )
 
-target_link_libraries(GeoLib INTERFACE
+target_link_libraries(GeoLib
 	BaseLib
 	MathLib
 	logog

--- a/GeoLib/CMakeLists.txt
+++ b/GeoLib/CMakeLists.txt
@@ -9,7 +9,6 @@ add_library(GeoLib ${SOURCES_GeoLib}
 target_link_libraries(GeoLib
 	BaseLib
 	MathLib
-	logog
 )
 
 if(TARGET Boost)

--- a/InSituLib/CMakeLists.txt
+++ b/InSituLib/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(InSituLib
 	VtkMeshNodalCoordinatesTemplate-impl.h
 )
 
-target_link_libraries(InSituLib INTERFACE MeshLib ${VTK_LIBRARIES})
+target_link_libraries(InSituLib MeshLib ${VTK_LIBRARIES})
 
 ADD_VTK_DEPENDENCY(InSituLib)
 

--- a/MathLib/CMakeLists.txt
+++ b/MathLib/CMakeLists.txt
@@ -56,7 +56,7 @@ if(METIS_FOUND)
 endif()
 
 # Create the library
-add_library(MathLib STATIC ${SOURCES})
+add_library(MathLib ${SOURCES})
 
 set_target_properties(MathLib PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/MathLib/CMakeLists.txt
+++ b/MathLib/CMakeLists.txt
@@ -56,12 +56,12 @@ if(METIS_FOUND)
 endif()
 
 # Create the library
-add_library(MathLib ${SOURCES})
+add_library(MathLib STATIC ${SOURCES})
 
 set_target_properties(MathLib PROPERTIES LINKER_LANGUAGE CXX)
 
 target_link_libraries(MathLib
-    logog
+    AssemblerLib
 )
 
 if(METIS_FOUND)

--- a/MeshGeoToolsLib/CMakeLists.txt
+++ b/MeshGeoToolsLib/CMakeLists.txt
@@ -4,7 +4,7 @@ GET_SOURCE_FILES(SOURCES_MeshGeoToolsLib)
 # Create the library
 add_library(MeshGeoToolsLib ${SOURCES_MeshGeoToolsLib})
 
-target_link_libraries(MeshGeoToolsLib INTERFACE
+target_link_libraries(MeshGeoToolsLib
 	BaseLib
 	MathLib
 	MeshLib

--- a/MeshGeoToolsLib/CMakeLists.txt
+++ b/MeshGeoToolsLib/CMakeLists.txt
@@ -10,7 +10,6 @@ target_link_libraries(MeshGeoToolsLib
 	MeshLib
 	GeoLib
 	FileIO
-	logog
 )
 
 if(TARGET Boost)

--- a/MeshGeoToolsLib/CMakeLists.txt
+++ b/MeshGeoToolsLib/CMakeLists.txt
@@ -2,7 +2,7 @@
 GET_SOURCE_FILES(SOURCES_MeshGeoToolsLib)
 
 # Create the library
-add_library(MeshGeoToolsLib STATIC ${SOURCES_MeshGeoToolsLib})
+add_library(MeshGeoToolsLib ${SOURCES_MeshGeoToolsLib})
 
 target_link_libraries(MeshGeoToolsLib INTERFACE
 	BaseLib

--- a/MeshLib/CMakeLists.txt
+++ b/MeshLib/CMakeLists.txt
@@ -15,7 +15,7 @@ GET_SOURCE_FILES(SOURCES_QUALITY MeshQuality)
 set(SOURCES ${SOURCES_MESHLIB} ${SOURCES_ELEMENTS} ${SOURCES_EDITING} ${SOURCES_GENERATORS} ${SOURCES_QUALITY} ${SOURCES_SEARCH})
 
 # Create the library
-add_library(MeshLib ${SOURCES})
+add_library(MeshLib STATIC ${SOURCES})
 
 target_link_libraries(MeshLib
 	BaseLib

--- a/MeshLib/CMakeLists.txt
+++ b/MeshLib/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(MeshLib
 	GeoLib
 	MathLib
 	${VTK_LIBRARIES}
-	logog
 )
 
 ADD_VTK_DEPENDENCY(MeshLib)

--- a/MeshLib/CMakeLists.txt
+++ b/MeshLib/CMakeLists.txt
@@ -15,7 +15,7 @@ GET_SOURCE_FILES(SOURCES_QUALITY MeshQuality)
 set(SOURCES ${SOURCES_MESHLIB} ${SOURCES_ELEMENTS} ${SOURCES_EDITING} ${SOURCES_GENERATORS} ${SOURCES_QUALITY} ${SOURCES_SEARCH})
 
 # Create the library
-add_library(MeshLib STATIC ${SOURCES})
+add_library(MeshLib ${SOURCES})
 
 target_link_libraries(MeshLib INTERFACE
 	BaseLib

--- a/MeshLib/CMakeLists.txt
+++ b/MeshLib/CMakeLists.txt
@@ -17,7 +17,7 @@ set(SOURCES ${SOURCES_MESHLIB} ${SOURCES_ELEMENTS} ${SOURCES_EDITING} ${SOURCES_
 # Create the library
 add_library(MeshLib ${SOURCES})
 
-target_link_libraries(MeshLib INTERFACE
+target_link_libraries(MeshLib
 	BaseLib
 	GeoLib
 	MathLib

--- a/NumLib/CMakeLists.txt
+++ b/NumLib/CMakeLists.txt
@@ -29,7 +29,7 @@ GET_SOURCE_FILES(SOURCES_EXTRAPOLATION Extrapolation)
 set(SOURCES ${SOURCES} ${SOURCES_EXTRAPOLATION})
 
 # Create the library
-add_library(NumLib STATIC ${SOURCES})
+add_library(NumLib ${SOURCES})
 
 set_target_properties(NumLib PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/NumLib/CMakeLists.txt
+++ b/NumLib/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(NumLib ${SOURCES})
 
 set_target_properties(NumLib PROPERTIES LINKER_LANGUAGE CXX)
 
-target_link_libraries(NumLib INTERFACE
+target_link_libraries(NumLib
 	BaseLib
 	GeoLib
 	MathLib

--- a/ProcessLib/CMakeLists.txt
+++ b/ProcessLib/CMakeLists.txt
@@ -6,7 +6,7 @@ APPEND_SOURCE_FILES(SOURCES)
 add_subdirectory(GroundwaterFlow)
 APPEND_SOURCE_FILES(SOURCES GroundwaterFlow)
 
-add_library(ProcessLib STATIC ${SOURCES})
+add_library(ProcessLib ${SOURCES})
 
 target_link_libraries(ProcessLib INTERFACE
     AssemblerLib

--- a/ProcessLib/CMakeLists.txt
+++ b/ProcessLib/CMakeLists.txt
@@ -10,11 +10,9 @@ add_library(ProcessLib ${SOURCES})
 
 target_link_libraries(ProcessLib
     AssemblerLib
-    MeshLib
     MeshGeoToolsLib
     NumLib # for shape matrices
     ${VTK_LIBRARIES}
-    logog
 )
 
 ADD_VTK_DEPENDENCY(ProcessLib)

--- a/ProcessLib/CMakeLists.txt
+++ b/ProcessLib/CMakeLists.txt
@@ -8,7 +8,7 @@ APPEND_SOURCE_FILES(SOURCES GroundwaterFlow)
 
 add_library(ProcessLib ${SOURCES})
 
-target_link_libraries(ProcessLib INTERFACE
+target_link_libraries(ProcessLib
     AssemblerLib
     MeshLib
     MeshGeoToolsLib

--- a/SimpleTests/MeshTests/CMakeLists.txt
+++ b/SimpleTests/MeshTests/CMakeLists.txt
@@ -11,7 +11,6 @@ target_link_libraries(MeshRead
 	MathLib
 	BaseLib
 	GeoLib
-	logog
 	${BOOST_LIBRARIES}
 )
 
@@ -28,6 +27,5 @@ target_link_libraries(MeshSearchTest
 	MathLib
 	BaseLib
 	GeoLib
-	logog
 	${BOOST_LIBRARIES}
 )

--- a/SimpleTests/MeshTests/MPI/CMakeLists.txt
+++ b/SimpleTests/MeshTests/MPI/CMakeLists.txt
@@ -5,8 +5,6 @@ add_executable(test_node_partitioned_mesh
 target_link_libraries(test_node_partitioned_mesh
 	MeshLib
 	FileIO
-	BaseLib
-	logog
 	${ADDITIONAL_LIBS}
 	${BOOST_LIBRARIES}
 )

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -33,9 +33,11 @@ target_link_libraries(testrunner
 	ApplicationsLib
 	AssemblerLib
 	FileIO
-	MeshGeoToolsLib
-	NumLib
 	GTest
+	InSituLib
+	MeshGeoToolsLib
+	MeshLib
+	NumLib
 	Threads::Threads
 )
 ADD_VTK_DEPENDENCY(testrunner)

--- a/scripts/cmake/CompilerSetup.cmake
+++ b/scripts/cmake/CompilerSetup.cmake
@@ -22,6 +22,12 @@ if(NOT COMPILER_IS_MSVC)
 	set( CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem" CACHE STRING "" FORCE )
 endif()
 
+# When static libraries are used in some shared libraries it is required that
+# also the static libraries have position independent code.
+if(BUILD_SHARED_LIBS)
+    set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+endif()
+
 # Set additional user-given compiler flags
 set(CMAKE_CXX_FLAGS ${OGS_CXX_FLAGS})
 


### PR DESCRIPTION
~~Fixing metis linkage;~~ Remove STATIC from add_library().

With this changes and configuring the build for debug and with `-DBUILD_SHARED_LIBS=On` the compile + linking time for the ogs target (from scratch, no ccache) reduces (for that particular branch endJunction/M2 with dynamic eigen matrices) from 3:45 to 2:55.

The default build process should not change with this PR, because the static linking is chosen by default.

__Update:__ On another machine there is no change, unfortunately, which I don't understand yet.