### PR TITLE
Added executeMemberDereferenced() + (minor) cleanup

### DIFF
--- a/AssemblerLib/GlobalSetup.h
+++ b/AssemblerLib/GlobalSetup.h
@@ -41,13 +41,6 @@ struct GlobalSetup
 
     template <typename... Args>
     static
-    void execute(Args&& ... args)
-    {
-        return Executor::execute(std::forward<Args>(args)...);
-    }
-
-    template <typename... Args>
-    static
     void executeDereferenced(Args&& ... args)
     {
         return Executor::executeDereferenced(std::forward<Args>(args)...);

--- a/AssemblerLib/GlobalSetup.h
+++ b/AssemblerLib/GlobalSetup.h
@@ -55,6 +55,13 @@ struct GlobalSetup
 
     template <typename... Args>
     static
+    void executeMemberDereferenced(Args&& ... args)
+    {
+        return Executor::executeMemberDereferenced(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    static
     void transform(Args&& ... args)
     {
         return Executor::transform(std::forward<Args>(args)...);

--- a/AssemblerLib/SerialExecutor.h
+++ b/AssemblerLib/SerialExecutor.h
@@ -18,37 +18,28 @@ namespace AssemblerLib
 
 struct SerialExecutor
 {
-    /// Executes a \c f for each element from the input container.
+    /// Executes \c f for each element from the input container.
+    ///
+    /// The elements of \c c are dereferenced before being passed to \c f.
     /// Return values of the function call are ignored.
     ///
-    /// \tparam F   \c f type.
-    /// \tparam C   input container type.
+    /// \note
+    /// This function is intended to be used if \c f is a plain function,
+    /// a static class method, a lambda or an object having a call operator
+    /// defined. For non-static member functions you are encouraged to use
+    /// executeMemberDereferenced(), if applicable.
     ///
-    /// \param f    a function that accepts a pointer to container's elements and
-    ///             an index as arguments.
+    /// \tparam F    type of the callback function \c f.
+    /// \tparam C    input container type.
+    /// \tparam Args types additional arguments passed to \c f.
+    ///
+    /// \param f    a function that accepts a a reference to container's elements,
+    ///             an index as arguments (and possibly further arguments).
     /// \param c    a container supporting access over operator[].
-    /// \param args additional arguments passed to \c f
-    template <typename F, typename C, typename ...Args_>
-    static
-    void
-#if defined(_MSC_VER) && (_MSC_VER >= 1700)
-    execute(F& f, C const& c, Args_&&... args)
-#else
-    execute(F const& f, C const& c, Args_&&... args)
-#endif
-    {
-        for (std::size_t i = 0; i < c.size(); i++)
-            f(i, c[i], std::forward<Args_>(args)...);
-    }
-
-    /// Executes a \c f for each element from the input container.
+    ///             The elements of \c c must have pointer semantics, i.e.,
+    ///             support dereferencing via unary operator*().
+    /// \param args additional arguments passed to \c f.
     ///
-    /// Return values of the function call are ignored.
-    /// This method is very similar to execute() the only difference
-    /// between the two is that here the elements of \c c are dereferenced
-    /// before being passed to the function \c f.
-    ///
-    /// \see execute()
     template <typename F, typename C, typename ...Args_>
     static
     void

--- a/AssemblerLib/SerialExecutor.h
+++ b/AssemblerLib/SerialExecutor.h
@@ -62,6 +62,24 @@ struct SerialExecutor
             f(i, *c[i], std::forward<Args_>(args)...);
     }
 
+    /// Executes the given \c method of the given \c object for each element
+    /// from the input \c container.
+    ///
+    /// This method is very similar to executeDereferenced().
+    ///
+    /// \see executeDereferenced()
+    template <typename Container, typename Object, typename... MethodArgs, typename... Args>
+    static void
+    executeMemberDereferenced(
+            Object& object,
+            void (Object::*method)(MethodArgs... method_args) const,
+            Container const& container, Args&&... args)
+    {
+        for (std::size_t i = 0; i < container.size(); i++) {
+            (object.*method)(i, *container[i], std::forward<Args>(args)...);
+        }
+    }
+
     /// Same as execute(f, c), but with two containers, where the second one is
     /// modified.
     ///

--- a/AssemblerLib/VectorMatrixAssembler.h
+++ b/AssemblerLib/VectorMatrixAssembler.h
@@ -70,13 +70,14 @@ namespace AssemblerLib
  * VectorMatrixAssembler type.
  */
 template<typename GlobalMatrix, typename GlobalVector,
+         typename LocalAssembler,
          NumLib::ODESystemTag ODETag>
 class VectorMatrixAssembler;
 
 
 //! Specialization for first-order implicit quasi-linear systems.
-template<typename GlobalMatrix, typename GlobalVector>
-class VectorMatrixAssembler<GlobalMatrix, GlobalVector,
+template<typename GlobalMatrix, typename GlobalVector, typename LocalAssembler>
+class VectorMatrixAssembler<GlobalMatrix, GlobalVector, LocalAssembler,
         NumLib::ODESystemTag::FirstOrderImplicitQuasilinear> final
 {
 public:
@@ -90,8 +91,7 @@ public:
     /// The positions in the global matrix/vector are taken from
     /// the LocalToGlobalIndexMap provided in the constructor at index \c id.
     /// \attention The index \c id is not necessarily the mesh item's id.
-    template <typename LocalAssembler>
-    void operator()(std::size_t const id,
+    void assemble(std::size_t const id,
         LocalAssembler& local_assembler,
         const double t, GlobalVector const& x,
         GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) const
@@ -112,7 +112,6 @@ public:
     /// Executes assembleJacobian() of the local assembler for the
     /// given mesh item passing the mesh item's nodal d.o.f.
     /// \attention The index \c id is not necessarily the mesh item's id.
-    template <typename LocalAssembler>
     void assembleJacobian(std::size_t const id,
                           LocalAssembler& local_assembler,
                           const double t,
@@ -135,7 +134,6 @@ public:
     /// Executes the preTimestep() method of the local assembler for the
     /// given mesh item passing the mesh item's nodal d.o.f.
     /// \attention The index \c id is not necessarily the mesh item's id.
-    template <typename LocalAssembler>
     void preTimestep(std::size_t const id,
                      LocalAssembler& local_assembler,
                      GlobalVector const& x) const
@@ -153,7 +151,6 @@ public:
     /// Executes the postTimestep() method of the local assembler for the
     /// given mesh item passing the mesh item's nodal d.o.f.
     /// \attention The index \c id is not necessarily the mesh item's id.
-    template <typename LocalAssembler>
     void postTimestep(std::size_t const id,
                       LocalAssembler& local_assembler,
                       GlobalVector const& x) const
@@ -184,8 +181,8 @@ private:
 
 
 //! Specialization used to add Neumann boundary conditions.
-template<typename GlobalMatrix, typename GlobalVector>
-class VectorMatrixAssembler<GlobalMatrix, GlobalVector,
+template<typename GlobalMatrix, typename GlobalVector, typename LocalAssembler>
+class VectorMatrixAssembler<GlobalMatrix, GlobalVector, LocalAssembler,
         NumLib::ODESystemTag::NeumannBC> final
 {
 public:
@@ -199,8 +196,7 @@ public:
     /// The positions in the global matrix/vector are taken from
     /// the LocalToGlobalIndexMap provided in the constructor at index \c id.
     /// \attention The index \c id is not necessarily the mesh item's id.
-    template <typename LocalAssembler>
-    void operator()(std::size_t const id,
+    void assemble(std::size_t const id,
         LocalAssembler& local_assembler,
         const double t, GlobalVector& b) const
     {

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -69,11 +69,13 @@ public:
     }
 
     template <unsigned GlobalDim>
-    void createLocalAssemblers()
+    void createLocalAssemblers(AssemblerLib::LocalToGlobalIndexMap const& dof_table,
+                               MeshLib::Mesh const& mesh,
+                               unsigned const integration_order)
     {
         DBUG("Create local assemblers.");
         // Populate the vector of local assemblers.
-        _local_assemblers.resize(this->_mesh.getNElements());
+        _local_assemblers.resize(mesh.getNElements());
         // Shape matrices initializer
         using LocalDataInitializer = AssemblerLib::LocalDataInitializer<
             GroundwaterFlow::LocalAssemblerDataInterface,
@@ -90,26 +92,31 @@ public:
                 MeshLib::Element,
                 LocalDataInitializer>;
 
-        LocalAssemblerBuilder local_asm_builder(
-            initializer, *this->_local_to_global_index_map);
+        LocalAssemblerBuilder local_asm_builder(initializer, dof_table);
 
         DBUG("Calling local assembler builder for all mesh elements.");
         this->_global_setup.transform(
                 local_asm_builder,
-                this->_mesh.getElements(),
+                mesh.getElements(),
                 _local_assemblers,
-                this->_integration_order,
+                integration_order,
                 _hydraulic_conductivity);
     }
 
-    void createLocalAssemblers() override
+    void createAssemblers(AssemblerLib::LocalToGlobalIndexMap const& dof_table,
+                          MeshLib::Mesh const& mesh,
+                          unsigned const integration_order) override
     {
-        if (this->_mesh.getDimension()==1)
-            createLocalAssemblers<1>();
-        else if (this->_mesh.getDimension()==2)
-            createLocalAssemblers<2>();
-        else if (this->_mesh.getDimension()==3)
-            createLocalAssemblers<3>();
+        DBUG("Create global assembler.");
+        _global_assembler.reset(new GlobalAssembler(dof_table));
+
+        auto const dim = mesh.getDimension();
+        if (dim==1)
+            createLocalAssemblers<1>(dof_table, mesh, integration_order);
+        else if (dim==2)
+            createLocalAssemblers<2>(dof_table, mesh, integration_order);
+        else if (dim==3)
+            createLocalAssemblers<3>(dof_table, mesh, integration_order);
         else
             assert(false);
     }
@@ -130,6 +137,10 @@ private:
     using LocalAssembler = GroundwaterFlow::LocalAssemblerDataInterface<
         typename GlobalSetup::MatrixType, typename GlobalSetup::VectorType>;
 
+    using GlobalAssembler = AssemblerLib::VectorMatrixAssembler<
+            GlobalMatrix, GlobalVector, LocalAssembler,
+            NumLib::ODESystemTag::FirstOrderImplicitQuasilinear>;
+
 
     void assembleConcreteProcess(const double t, GlobalVector const& x,
                                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) override
@@ -139,10 +150,12 @@ private:
         DBUG("Assemble GroundwaterFlowProcess.");
 
         // Call global assembler for each local assembly item.
-        this->_global_setup.executeDereferenced(
-            *this->_global_assembler, _local_assemblers, t, x, M, K, b);
+        this->_global_setup.executeMemberDereferenced(
+            *_global_assembler, &GlobalAssembler::assemble,
+            _local_assemblers, t, x, M, K, b);
     }
 
+    std::unique_ptr<GlobalAssembler> _global_assembler;
     std::vector<std::unique_ptr<LocalAssembler>> _local_assemblers;
 };
 

--- a/ProcessLib/NeumannBc.h
+++ b/ProcessLib/NeumannBc.h
@@ -101,7 +101,9 @@ public:
     void integrate(GlobalSetup const& global_setup,
                    const double t, GlobalVector& b)
     {
-        global_setup.executeDereferenced(*_global_assembler, _local_assemblers, t, b);
+        global_setup.executeMemberDereferenced(
+                    *_global_assembler, &GlobalAssembler::assemble,
+                    _local_assemblers, t, b);
     }
 
     void initialize(GlobalSetup const& global_setup,
@@ -180,15 +182,15 @@ private:
     /// the #_function.
     unsigned const _integration_order;
 
+    using LocalAssembler = LocalNeumannBcAsmDataInterface<
+        GlobalMatrix, GlobalVector>;
+
     using GlobalAssembler =
         AssemblerLib::VectorMatrixAssembler<
-            GlobalMatrix, GlobalVector,
+            GlobalMatrix, GlobalVector, LocalAssembler,
             NumLib::ODESystemTag::NeumannBC>;
 
     std::unique_ptr<GlobalAssembler> _global_assembler;
-
-    using LocalAssembler = LocalNeumannBcAsmDataInterface<
-        GlobalMatrix, GlobalVector>;
 
     /// Local assemblers for each element of #_elements.
     std::vector<std::unique_ptr<LocalAssembler>> _local_assemblers;

--- a/Tests/AssemblerLib/TestSerialLinearSolver.cpp
+++ b/Tests/AssemblerLib/TestSerialLinearSolver.cpp
@@ -78,9 +78,9 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
                globalSetup.createVector(local_to_global_index_map.dofSize())};
     // TODO no setZero() for rhs, x?
 
+    using LocalAssembler = Example::LocalAssemblerData<GlobalMatrix, GlobalVector>;
     // Initializer of the local assembler data.
-    std::vector<Example::LocalAssemblerData<
-        GlobalMatrix, GlobalVector>*> local_assembler_data;
+    std::vector<LocalAssembler*> local_assembler_data;
     local_assembler_data.resize(ex1.msh->getNElements());
 
     typedef AssemblerLib::LocalAssemblerBuilder<
@@ -106,7 +106,7 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
     // TODO in the future use simpler NumLib::ODESystemTag
     // Local and global assemblers.
     typedef AssemblerLib::VectorMatrixAssembler<
-            GlobalMatrix, GlobalVector,
+            GlobalMatrix, GlobalVector, LocalAssembler,
             NumLib::ODESystemTag::FirstOrderImplicitQuasilinear> GlobalAssembler;
 
     GlobalAssembler assembler(local_to_global_index_map);
@@ -116,8 +116,9 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
         globalSetup.createMatrix(local_to_global_index_map.dofSize())};
     A->setZero();
     auto const t = 0.0;
-    globalSetup.executeDereferenced(
-        assembler, local_assembler_data, t, *x, *M_dummy, *A, *rhs);
+    globalSetup.executeMemberDereferenced(
+                assembler, &GlobalAssembler::assemble,
+                local_assembler_data, t, *x, *M_dummy, *A, *rhs);
 
     //std::cout << "A=\n";
     //A->write(std::cout);


### PR DESCRIPTION
Changes:
1. `operator()()` in `VectorMatrixAssembler` renamed to `assemble()`.
That change makes the assembly routine an "ordinary" member, like all the other methods.
2. `LocalAssembler` now is a tpl param of the class `VectorMatrixAssembler`, not of its methods anymore (needed for the next point)
3. added `executeMemberDereferenced()` to `SerialExecutor`. Thereby one does not have to use lambdas when executing member methods other than `operator()()`, cf. https://github.com/ufz/ogs/compare/master...chleh:execute-overload?expand=1#diff-f2f37a7122ad44875cbf665ce72096deR153.
4. the `GlobalAssembler` now is owned by the concrete process (since it now depends on the specific `LocalAssembler`).

Point (3) makes `GlobaLSetup::execute...()` calls more readable in the specific process. I admit, that it does not help much (but maybe a little bit) to make the control flow easier to understand. But, this change hides the inner details better from process developers. I assume, that it makes the code look a little bit simpler to new developers (who don't care about inner details), since they now are not confronted with lambdas immediately.