### PR TITLE
Break fileIO ApplicationsLib dependency

### DIFF
--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -420,7 +420,12 @@ void MainWindow::save()
 
 	if (fi.suffix().toLower() == "gsp")
 	{
-		XmlGspInterface xml(_project);
+		XmlGspInterface xml(*_project.getGEOObjects(),
+		                    _project.getMeshObjects(),
+		                    [this](MeshLib::Mesh* const mesh)
+		                    {
+			                    _project.addMesh(mesh);
+		                    });
 		xml.writeToFile(fileName.toStdString());
 	}
 	else if (fi.suffix().toLower() == "geo")
@@ -467,7 +472,12 @@ void MainWindow::loadFile(ImportFileType::type t, const QString &fileName)
 		}
 		else if (fi.suffix().toLower() == "gsp")
 		{
-			XmlGspInterface xml(_project);
+			XmlGspInterface xml(*_project.getGEOObjects(),
+			                    _project.getMeshObjects(),
+			                    [this](MeshLib::Mesh* const mesh)
+			                    {
+				                    _project.addMesh(mesh);
+			                    });
 			if (xml.readFile(fileName))
 			{
 				_meshModel->updateModel();

--- a/FileIO/XmlIO/Qt/XmlGspInterface.cpp
+++ b/FileIO/XmlIO/Qt/XmlGspInterface.cpp
@@ -19,7 +19,6 @@
 
 #include <logog/include/logog.hpp>
 
-#include "Applications/ApplicationsLib/ProjectData.h"
 #include "GeoLib/GEOObjects.h"
 
 #include "XmlGmlInterface.h"
@@ -39,9 +38,15 @@
 
 namespace FileIO
 {
-XmlGspInterface::XmlGspInterface(ProjectData& project) :
-	XMLInterface(), XMLQtInterface(BaseLib::FileFinder().getPath("OpenGeoSysProject.xsd")),
-	_project(project)
+XmlGspInterface::XmlGspInterface(
+    GeoLib::GEOObjects& geoObjects,
+    std::vector<MeshLib::Mesh*> const& mesh_vector,
+    std::function<void(MeshLib::Mesh* const)>&& add_mesh_callback)
+    : XMLInterface(),
+      XMLQtInterface(BaseLib::FileFinder().getPath("OpenGeoSysProject.xsd")),
+      _geoObjects(geoObjects),
+      _mesh_vector(mesh_vector),
+      _add_mesh_callback(std::move(add_mesh_callback))
 {
 }
 
@@ -69,7 +74,7 @@ int XmlGspInterface::readFile(const QString &fileName)
 		const QString file_node(fileList.at(i).nodeName());
 		if (file_node.compare("geo") == 0)
 		{
-			XmlGmlInterface gml(*(_project.getGEOObjects()));
+			XmlGmlInterface gml(_geoObjects);
 			const QDomNodeList childList = fileList.at(i).childNodes();
 			for(int j = 0; j < childList.count(); j++)
 			{
@@ -86,7 +91,7 @@ int XmlGspInterface::readFile(const QString &fileName)
 		}
 		else if (file_node.compare("stn") == 0)
 		{
-			XmlStnInterface stn(*(_project.getGEOObjects()));
+			XmlStnInterface stn(_geoObjects);
 			const QDomNodeList childList = fileList.at(i).childNodes();
 			for(int j = 0; j < childList.count(); j++)
 				if (childList.at(j).nodeName().compare("file") == 0)
@@ -98,8 +103,7 @@ int XmlGspInterface::readFile(const QString &fileName)
 			const std::string msh_name = path.toStdString() +
 			                             fileList.at(i).toElement().text().toStdString();
 			MeshLib::Mesh* msh = FileIO::readMeshFromFile(msh_name);
-			if (msh)
-				_project.addMesh(msh);
+			if (msh) _add_mesh_callback(msh);
 		}
 	}
 
@@ -114,7 +118,6 @@ int XmlGspInterface::writeToFile(const std::string& filename)
 
 bool XmlGspInterface::write()
 {
-	GeoLib::GEOObjects* geoObjects = _project.getGEOObjects();
 	QFileInfo fi(QString::fromStdString(_filename));
 	std::string path((fi.absolutePath()).toStdString() + "/");
 
@@ -132,11 +135,11 @@ bool XmlGspInterface::write()
 
 	// GML
 	std::vector<std::string> geoNames;
-	geoObjects->getGeometryNames(geoNames);
+	_geoObjects.getGeometryNames(geoNames);
 	for (std::vector<std::string>::const_iterator it(geoNames.begin()); it != geoNames.end(); ++it)
 	{
 		// write GLI file
-		XmlGmlInterface gml(*geoObjects);
+		XmlGmlInterface gml(_geoObjects);
 		std::string name(*it);
 		gml.setNameForExport(name);
 		if (gml.writeToFile(std::string(path + name + ".gml")))
@@ -153,8 +156,9 @@ bool XmlGspInterface::write()
 	}
 
 	// MSH
-	const std::vector<MeshLib::Mesh*> msh_vec = _project.getMeshObjects();
-	for (std::vector<MeshLib::Mesh*>::const_iterator it(msh_vec.begin()); it != msh_vec.end(); ++it)
+	for (std::vector<MeshLib::Mesh*>::const_iterator it(_mesh_vector.begin());
+	     it != _mesh_vector.end();
+	     ++it)
 	{
 		// write mesh file
 		Legacy::MeshIO meshIO;
@@ -173,11 +177,11 @@ bool XmlGspInterface::write()
 
 	// STN
 	std::vector<std::string> stnNames;
-	geoObjects->getStationVectorNames(stnNames);
+	_geoObjects.getStationVectorNames(stnNames);
 	for (std::vector<std::string>::const_iterator it(stnNames.begin()); it != stnNames.end(); ++it)
 	{
 		// write STN file
-		XmlStnInterface stn(*geoObjects);
+		XmlStnInterface stn(_geoObjects);
 		std::string name(*it);
 		stn.setNameForExport(name);
 

--- a/FileIO/XmlIO/Qt/XmlGspInterface.cpp
+++ b/FileIO/XmlIO/Qt/XmlGspInterface.cpp
@@ -156,14 +156,12 @@ bool XmlGspInterface::write()
 	}
 
 	// MSH
-	for (std::vector<MeshLib::Mesh*>::const_iterator it(_mesh_vector.begin());
-	     it != _mesh_vector.end();
-	     ++it)
+	for (auto const& mesh : _mesh_vector)
 	{
 		// write mesh file
 		Legacy::MeshIO meshIO;
-		meshIO.setMesh(*it);
-		std::string fileName(path + (*it)->getName());
+		meshIO.setMesh(mesh);
+		std::string fileName(path + mesh->getName());
 		meshIO.writeToFile(fileName);
 
 		// write entry in project file
@@ -171,7 +169,7 @@ bool XmlGspInterface::write()
 		root.appendChild(mshTag);
 		QDomElement fileNameTag = doc.createElement("file");
 		mshTag.appendChild(fileNameTag);
-		QDomText fileNameText = doc.createTextNode(QString::fromStdString((*it)->getName()));
+		QDomText fileNameText = doc.createTextNode(QString::fromStdString(mesh->getName()));
 		fileNameTag.appendChild(fileNameText);
 	}
 

--- a/FileIO/XmlIO/Qt/XmlGspInterface.h
+++ b/FileIO/XmlIO/Qt/XmlGspInterface.h
@@ -15,6 +15,8 @@
 #ifndef XMLGSPINTERFACE_H
 #define XMLGSPINTERFACE_H
 
+#include <functional>
+#include <vector>
 #include <string>
 
 #include <QString>
@@ -22,7 +24,15 @@
 #include "../XMLInterface.h"
 #include "XMLQtInterface.h"
 
-class ProjectData;
+namespace MeshLib
+{
+class Mesh;
+}
+
+namespace GeoLib
+{
+class GEOObjects;
+}
 
 namespace FileIO
 {
@@ -33,11 +43,10 @@ namespace FileIO
 class XmlGspInterface : public XMLInterface, public XMLQtInterface
 {
 public:
-	/**
-	 * Constructor
-	 * \param project Project data.
-	 */
-	XmlGspInterface(ProjectData &project);
+	XmlGspInterface(
+	    GeoLib::GEOObjects& geoObjects,
+	    std::vector<MeshLib::Mesh*> const& mesh_vector,
+	    std::function<void(MeshLib::Mesh* const)>&& add_mesh_callback);
 
 	virtual ~XmlGspInterface() {}
 
@@ -54,8 +63,9 @@ protected:
 
 private:
 	std::string _filename;
-
-	ProjectData& _project;
+	GeoLib::GEOObjects& _geoObjects;
+	std::vector<MeshLib::Mesh*> const& _mesh_vector;
+	std::function<void(MeshLib::Mesh* const)> _add_mesh_callback;
 };
 
 }


### PR DESCRIPTION
~~Follow up of ufz/ogs#1133.~~ This PR adds only the one commit [[DE] Break ApplicationLib dependency.](https://github.com/ufz/ogs/pull/1138/commits/7cf6b6068e9984949d35a41ce81d8558bfe7cf4d)

The dependency is caused by usage of ProjectData::addMesh by XmlGspInterface.
Unfortunately the programming of that class and its parents, the XMLInterface and XMLQtInterface is not as separate as it could be, therefore the current solution can be seen as a quickfix.

Clean solution would be, for example, a separation of the reader and the writer parts of the XMLInterface(s) and to use standalone functions for qt's xml validation.