### PR TITLE
[GL] Introducing class LineSegment.

### DIFF
--- a/FileIO/GmshIO/GMSHPolygonTree.cpp
+++ b/FileIO/GmshIO/GMSHPolygonTree.cpp
@@ -86,7 +86,11 @@ void GMSHPolygonTree::insertPolyline (GeoLib::PolylineWithSegmentMarker * ply)
 			if (! ply->isSegmentMarked(k)) {
 				std::size_t seg_num(0);
 				GeoLib::Point *intersection_pnt(new GeoLib::Point);
-				while (_node_polygon->getNextIntersectionPointPolygonLine(*(ply->getPoint(k)), *(ply->getPoint(k+1)), intersection_pnt, seg_num)) {
+				while (_node_polygon->getNextIntersectionPointPolygonLine(
+				    {const_cast<GeoLib::Point*>(ply->getPoint(k)),
+				     const_cast<GeoLib::Point*>(ply->getPoint(k + 1))},
+				    *intersection_pnt, seg_num))
+				{
 					// insert the intersection point to point vector of GEOObjects instance
 					const std::size_t pnt_vec_size(pnt_vec.size());
 					// appendPoints deletes an already existing point
@@ -110,7 +114,11 @@ void GMSHPolygonTree::insertPolyline (GeoLib::PolylineWithSegmentMarker * ply)
 					}
 
 					std::size_t tmp_seg_num(seg_num+1);
-					if (! _node_polygon->getNextIntersectionPointPolygonLine(*(ply->getPoint(k)), *(ply->getPoint(k+1)), &tmp_pnt, tmp_seg_num)) {
+					if (!_node_polygon->getNextIntersectionPointPolygonLine(
+					        {const_cast<GeoLib::Point*>(ply->getPoint(k)),
+					         const_cast<GeoLib::Point*>(ply->getPoint(k + 1))},
+					        tmp_pnt, tmp_seg_num))
+					{
 						// check a point of the segment except the end points
 						for (std::size_t i(0); i<3; i++) {
 							tmp_pnt[i] = ((*(ply->getPoint(k)))[i] + (*(ply->getPoint(k+1)))[i]) / 2;

--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -215,26 +215,22 @@ bool lineSegmentIntersect(
 }
 
 bool lineSegmentsIntersect(const GeoLib::Polyline* ply,
-                           std::size_t &idx0,
-                           std::size_t &idx1,
+                           GeoLib::Polyline::SegmentIterator &seg_it0,
+                           GeoLib::Polyline::SegmentIterator &seg_it1,
                            GeoLib::Point& intersection_pnt)
 {
-	std::size_t n_segs(ply->getNumberOfPoints() - 1);
-	/**
-	 * computing the intersections of all possible pairs of line segments of the given polyline
-	 * as follows:
-	 * let the segment \f$s_1 = (A,B)\f$ defined by \f$k\f$-th and \f$k+1\f$-st point
-	 * of the polyline and segment \f$s_2 = (C,B)\f$ defined by \f$j\f$-th and
-	 * \f$j+1\f$-st point of the polyline, \f$j>k+1\f$
-	 */
-	for (std::size_t k(0); k < n_segs - 2; k++) {
-		for (std::size_t j(k + 2); j < n_segs; j++) {
-			if (k != 0 || j < n_segs - 1) {
-				if (lineSegmentIntersect(*(ply->getPoint(k)), *(ply->getPoint(k + 1)),
-				                         *(ply->getPoint(j)), *(ply->getPoint(j + 1)),
-				                         intersection_pnt)) {
-					idx0 = k;
-					idx1 = j;
+	std::size_t const n_segs(ply->getNumberOfSegments());
+	// Neighbouring segments always intersects at a common vertex. The algorithm
+	// checks for intersections of non-neighbouring segments.
+	for (seg_it0 = ply->begin(); seg_it0 != ply->end() - 2; ++seg_it0)
+	{
+		seg_it1 = seg_it0+2;
+		std::size_t const seg_num_0 = seg_it0.getSegmentNumber();
+		for ( ; seg_it1 != ply->end(); ++seg_it1) {
+			// Do not check first and last segment, because they are
+			// neighboured.
+			if (!(seg_num_0 == 0 && seg_it1.getSegmentNumber() == n_segs - 1)) {
+				if (lineSegmentIntersect(*seg_it0, *seg_it1, intersection_pnt)) {
 					return true;
 				}
 			}

--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -99,6 +99,14 @@ bool parallel(MathLib::Vector3 v, MathLib::Vector3 w)
 	return parallel;
 }
 
+bool lineSegmentIntersect(GeoLib::LineSegment const& s0,
+                          GeoLib::LineSegment const& s1,
+                          GeoLib::Point& s)
+{
+	return lineSegmentIntersect(s0.getBeginPoint(), s0.getEndPoint(),
+	                            s1.getBeginPoint(), s1.getEndPoint(), s);
+}
+
 bool lineSegmentIntersect(
 	GeoLib::Point const& a,
 	GeoLib::Point const& b,

--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -103,17 +103,11 @@ bool lineSegmentIntersect(GeoLib::LineSegment const& s0,
                           GeoLib::LineSegment const& s1,
                           GeoLib::Point& s)
 {
-	return lineSegmentIntersect(s0.getBeginPoint(), s0.getEndPoint(),
-	                            s1.getBeginPoint(), s1.getEndPoint(), s);
-}
+	GeoLib::Point const& a{s0.getBeginPoint()};
+	GeoLib::Point const& b{s0.getEndPoint()};
+	GeoLib::Point const& c{s1.getBeginPoint()};
+	GeoLib::Point const& d{s1.getEndPoint()};
 
-bool lineSegmentIntersect(
-	GeoLib::Point const& a,
-	GeoLib::Point const& b,
-	GeoLib::Point const& c,
-	GeoLib::Point const& d,
-	GeoLib::Point& s)
-{
 	if (!isCoplanar(a, b, c, d))
 		return false;
 

--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -518,21 +518,30 @@ bool isCoplanar(const MathLib::Point3d& a, const MathLib::Point3d& b,
 void computeAndInsertAllIntersectionPoints(GeoLib::PointVec &pnt_vec,
 	std::vector<GeoLib::Polyline*> & plys)
 {
+	auto computeSegmentIntersections = [&pnt_vec](GeoLib::Polyline& poly0,
+	                                              GeoLib::Polyline& poly1)
+	{
+		for (auto seg0_it(poly0.begin()); seg0_it != poly0.end(); ++seg0_it)
+		{
+			for (auto seg1_it(poly1.begin()); seg1_it != poly1.end(); ++seg1_it)
+			{
+				GeoLib::Point s(0.0, 0.0, 0.0, pnt_vec.size());
+				if (lineSegmentIntersect(*seg0_it, *seg1_it, s))
+				{
+					std::size_t const id(
+					    pnt_vec.push_back(new GeoLib::Point(s)));
+					poly0.insertPoint(seg0_it.getSegmentNumber() + 1, id);
+					poly1.insertPoint(seg1_it.getSegmentNumber() + 1, id);
+				}
+			}
+		}
+	};
+
 	for (auto it0(plys.begin()); it0 != plys.end(); ++it0) {
 		auto it1(it0);
 		++it1;
 		for (; it1 != plys.end(); ++it1) {
-			for (std::size_t i(0); i<(*it0)->getNumberOfPoints()-1; i++) {
-				for (std::size_t j(0); j<(*it1)->getNumberOfPoints()-1; j++) {
-					GeoLib::Point s(0.0, 0.0, 0.0, pnt_vec.size());
-					if (lineSegmentIntersect(*(*it0)->getPoint(i), *(*it0)->getPoint(i+1),
-						*(*it1)->getPoint(j), *(*it1)->getPoint(j+1), s)) {
-						std::size_t const id(pnt_vec.push_back(new GeoLib::Point(s)));
-						(*it0)->insertPoint(i+1, id);
-						(*it1)->insertPoint(j+1, id);
-					}
-				}
-			}
+			computeSegmentIntersections(*(*it0), *(*it1));
 		}
 	}
 }

--- a/GeoLib/AnalyticalGeometry.h
+++ b/GeoLib/AnalyticalGeometry.h
@@ -272,9 +272,9 @@ bool isPointInTetrahedron(MathLib::Point3d const& p,
 /**
  * test for intersections of the line segments of the Polyline
  * @param ply the polyline
- * @param idx0 beginning index of the first line segment that has an intersection
- * @param idx1 beginning index of the second line segment that has an intersection
- * @param intersection_pnt the intersection point if the line segments intersect
+ * @param seg_it0 iterator pointing to the first segment that has an intersection
+ * @param seg_it1 iterator pointing to the second segment that has an intersection
+ * @param intersection_pnt the intersection point if the segments intersect
  * @return true, if the polyline contains intersections
  */
 bool lineSegmentsIntersect(const GeoLib::Polyline* ply,
@@ -300,9 +300,6 @@ bool parallel(MathLib::Vector3 v, MathLib::Vector3 w);
  * @param s the intersection point if the segments do intersect
  * @return true, if the line segments intersect, else false
  */
-bool lineSegmentIntersect (const GeoLib::Point& a, const GeoLib::Point& b,
-        const GeoLib::Point& c, const GeoLib::Point& d, GeoLib::Point& s);
-
 bool lineSegmentIntersect(GeoLib::LineSegment const& s0,
                           GeoLib::LineSegment const& s1, GeoLib::Point& s);
 

--- a/GeoLib/AnalyticalGeometry.h
+++ b/GeoLib/AnalyticalGeometry.h
@@ -30,6 +30,7 @@ namespace MathLib
 namespace GeoLib
 {
 class Polyline;
+class LineSegment;
 
 enum TriangleTest
 {
@@ -301,6 +302,9 @@ bool parallel(MathLib::Vector3 v, MathLib::Vector3 w);
  */
 bool lineSegmentIntersect (const GeoLib::Point& a, const GeoLib::Point& b,
         const GeoLib::Point& c, const GeoLib::Point& d, GeoLib::Point& s);
+
+bool lineSegmentIntersect(GeoLib::LineSegment const& s0,
+                          GeoLib::LineSegment const& s1, GeoLib::Point& s);
 
 /// A line segment is given by its two end-points. The function checks,
 /// if the two line segments (ab) and (cd) intersects. This method checks the

--- a/GeoLib/AnalyticalGeometry.h
+++ b/GeoLib/AnalyticalGeometry.h
@@ -277,10 +277,10 @@ bool isPointInTetrahedron(MathLib::Point3d const& p,
  * @param intersection_pnt the intersection point if the line segments intersect
  * @return true, if the polyline contains intersections
  */
-bool lineSegmentsIntersect (const GeoLib::Polyline* ply,
-                            std::size_t &idx0,
-                            std::size_t &idx1,
-                            GeoLib::Point& intersection_pnt);
+bool lineSegmentsIntersect(const GeoLib::Polyline* ply,
+                           GeoLib::Polyline::SegmentIterator& seg_it0,
+                           GeoLib::Polyline::SegmentIterator& seg_it1,
+                           GeoLib::Point& intersection_pnt);
 
 /**
  * Check if the two vectors \f$v, w \in R^3\f$ are in parallel

--- a/GeoLib/LineSegment.cpp
+++ b/GeoLib/LineSegment.cpp
@@ -1,0 +1,82 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+
+#include "LineSegment.h"
+
+#include <iostream>
+
+namespace GeoLib
+{
+LineSegment::LineSegment(Point* const a, Point* const b,
+                         bool point_mem_management_by_line_segment)
+    : _a(a),
+      _b(b),
+      _point_mem_management_by_line_segment(
+          point_mem_management_by_line_segment)
+{}
+
+LineSegment::LineSegment(LineSegment const& line_segment)
+    : _a(new Point(line_segment.getBeginPoint())),
+      _b(new Point(line_segment.getEndPoint())),
+      _point_mem_management_by_line_segment(true)
+{}
+
+LineSegment::LineSegment(LineSegment&& line_segment)
+    : _a(std::move(line_segment._a)),
+      _b(std::move(line_segment._b)),
+      _point_mem_management_by_line_segment(
+          line_segment._point_mem_management_by_line_segment)
+{
+	line_segment._a = nullptr;
+	line_segment._b = nullptr;
+	line_segment._point_mem_management_by_line_segment = false;
+}
+
+LineSegment::~LineSegment()
+{
+	if (_point_mem_management_by_line_segment) {
+		delete _b;
+		delete _a;
+	}
+}
+
+Point const& LineSegment::getBeginPoint() const
+{
+	return *_a;
+}
+
+Point & LineSegment::getBeginPoint()
+{
+	return *_a;
+}
+
+Point const& LineSegment::getEndPoint() const
+{
+	return *_b;
+}
+
+Point & LineSegment::getEndPoint()
+{
+	return *_b;
+}
+
+std::ostream& operator<< (std::ostream& os, LineSegment const& s)
+{
+	os << "{(" << s.getBeginPoint() << "), (" << s.getEndPoint() << ")}";
+	return os;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         std::pair<GeoLib::LineSegment const&,
+                                   GeoLib::LineSegment const&> const& seg_pair)
+{
+	os << seg_pair.first << " x " << seg_pair.second;
+	return os;
+}
+}

--- a/GeoLib/LineSegment.h
+++ b/GeoLib/LineSegment.h
@@ -9,32 +9,45 @@
 #ifndef LINESEGMENT_H_
 #define LINESEGMENT_H_
 
-#include <iostream>
-
 #include "Point.h"
 
 namespace GeoLib
 {
 
-struct LineSegment
+class LineSegment final
 {
-	GeoLib::Point a;
-	GeoLib::Point b;
+public:
+	/// Constructs a line segment given by its begin and end points.
+	/// @remark The main purpose of class LineSegment is the use within a
+	/// polyline. For this reason the memory is not managed per default. But the
+	/// user has the freedom to hand over the responsibility for the mem
+	/// managment of the points to the object.
+	LineSegment(GeoLib::Point* const beg, GeoLib::Point* const end,
+	            bool point_mem_management_by_line_segment = false);
+
+	LineSegment(LineSegment&& line_segment);
+	LineSegment(LineSegment const& line_segment);
+
+	~LineSegment();
+
+	LineSegment& operator= (LineSegment const& rhs) = delete;
+
+	GeoLib::Point const& getBeginPoint() const;
+	GeoLib::Point & getBeginPoint();
+
+	GeoLib::Point const& getEndPoint() const;
+	GeoLib::Point & getEndPoint();
+
+private:
+	GeoLib::Point* _a = nullptr;
+	GeoLib::Point* _b = nullptr;
+	bool _point_mem_management_by_line_segment = false;
 };
 
-std::ostream& operator<< (std::ostream& os, LineSegment const& s)
-{
-	os << "{(" << s.a << "), (" << s.b << ")}";
-	return os;
-}
+std::ostream& operator<< (std::ostream& os, LineSegment const& s);
 
 std::ostream& operator<<(std::ostream& os,
                          std::pair<GeoLib::LineSegment const&,
-                                   GeoLib::LineSegment const&> const& seg_pair)
-{
-	os << seg_pair.first << " x " << seg_pair.second;
-	return os;
-}
-
+                                   GeoLib::LineSegment const&> const& seg_pair);
 }
 #endif

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -106,10 +106,10 @@ std::vector<GeoLib::Point> Polygon::getAllIntersectionPoints(
 		GeoLib::LineSegment const& segment) const
 {
 	std::vector<GeoLib::Point> intersections;
-	const std::size_t n_segments(getNumberOfPoints() - 1);
 	GeoLib::Point s;
-	for (std::size_t k(0); k < n_segments; k++) {
-		if (GeoLib::lineSegmentIntersect(*(getPoint(k)), *(getPoint(k+1)), a, b, s)) {
+	for (auto seg_it(begin()); seg_it != end(); ++seg_it)
+	{
+		if (GeoLib::lineSegmentIntersect(*seg_it, segment, s)) {
 			intersections.push_back(s);
 		}
 	}

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -356,12 +356,15 @@ void Polygon::splitPolygonAtIntersection(
     std::list<Polygon*>::const_iterator polygon_it)
 #endif
 {
-	std::size_t idx0(0), idx1(0);
+	GeoLib::Polyline::SegmentIterator seg_it0((*polygon_it)->begin());
+	GeoLib::Polyline::SegmentIterator seg_it1((*polygon_it)->begin());
 	GeoLib::Point intersection_pnt;
-	if (!GeoLib::lineSegmentsIntersect(*polygon_it, idx0, idx1,
+	if (!GeoLib::lineSegmentsIntersect(*polygon_it, seg_it0, seg_it1,
 	                                   intersection_pnt))
 		return;
 
+	std::size_t idx0(seg_it0.getSegmentNumber());
+	std::size_t idx1(seg_it1.getSegmentNumber());
 	// adding intersection point to pnt_vec
 	std::size_t const intersection_pnt_id (_ply_pnts.size());
 	const_cast<std::vector<Point*>&>(_ply_pnts)

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -205,27 +205,25 @@ bool Polygon::isPartOfPolylineInPolygon(const Polyline& ply) const
 	return false;
 }
 
-bool Polygon::getNextIntersectionPointPolygonLine (GeoLib::Point const & a,
-                GeoLib::Point const & b, GeoLib::Point* intersection_pnt,
-                std::size_t& seg_num) const
+bool Polygon::getNextIntersectionPointPolygonLine(
+    GeoLib::LineSegment const& seg, GeoLib::Point & intersection,
+    std::size_t& seg_num) const
 {
 	if (_simple_polygon_list.empty()) {
-		const std::size_t n_segments(getNumberOfPoints() - 1);
-		for (std::size_t k(seg_num); k < n_segments; k++) {
-			if (GeoLib::lineSegmentIntersect(*(getPoint(k)), *(getPoint(k + 1)), a, b, *intersection_pnt)) {
-				seg_num = k;
+		for (auto seg_it(begin()+seg_num); seg_it != end(); ++seg_it) {
+			if (GeoLib::lineSegmentIntersect(*seg_it, seg, intersection)) {
+				seg_num = seg_it.getSegmentNumber();
 				return true;
 			}
 		}
 	} else {
 		for (std::list<Polygon*>::const_iterator it(_simple_polygon_list.begin()); it
 					!= _simple_polygon_list.end(); ++it) {
-			const Polygon* polygon(*it);
-			const std::size_t n_nodes_simple_polygon(polygon->getNumberOfPoints() - 1);
-			for (std::size_t k(0); k < n_nodes_simple_polygon; k++) {
-				if (GeoLib::lineSegmentIntersect(*(polygon->getPoint(k)), *(polygon->getPoint(k + 1)),
-								a, b, *intersection_pnt)) {
-					seg_num = k;
+			Polygon const& polygon(*(*it));
+			for (auto seg_it(polygon.begin()); seg_it != polygon.end(); ++seg_it)
+			{
+				if (GeoLib::lineSegmentIntersect(*seg_it, seg, intersection)) {
+					seg_num = seg_it.getSegmentNumber();
 					return true;
 				}
 			}

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -103,7 +103,7 @@ bool Polygon::isPntInPolygon(double x, double y, double z) const
 }
 
 std::vector<GeoLib::Point> Polygon::getAllIntersectionPoints(
-		GeoLib::Point const& a, GeoLib::Point const& b) const
+		GeoLib::LineSegment const& segment) const
 {
 	std::vector<GeoLib::Point> intersections;
 	const std::size_t n_segments(getNumberOfPoints() - 1);
@@ -119,7 +119,7 @@ std::vector<GeoLib::Point> Polygon::getAllIntersectionPoints(
 
 bool Polygon::containsSegment(GeoLib::Point const& a, GeoLib::Point const& b) const
 {
-	std::vector<GeoLib::Point> s(getAllIntersectionPoints(a, b));
+	std::vector<GeoLib::Point> s(getAllIntersectionPoints({a,b}));
 
 	// no intersections -> check if at least one point of segment is in polygon
 	if (s.empty()) {

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -217,9 +217,11 @@ bool Polygon::getNextIntersectionPointPolygonLine(
 			}
 		}
 	} else {
-		for (std::list<Polygon*>::const_iterator it(_simple_polygon_list.begin()); it
-					!= _simple_polygon_list.end(); ++it) {
-			Polygon const& polygon(*(*it));
+		for (auto polygon_it(_simple_polygon_list.begin());
+		     polygon_it != _simple_polygon_list.end();
+		     ++polygon_it)
+		{
+			Polygon const& polygon(*(*polygon_it));
 			for (auto seg_it(polygon.begin()); seg_it != polygon.end(); ++seg_it)
 			{
 				if (GeoLib::lineSegmentIntersect(*seg_it, seg, intersection)) {

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -191,20 +191,16 @@ bool Polygon::isPartOfPolylineInPolygon(const Polyline& ply) const
 			return true;
 		}
 	}
-	// check segment intersections
-	GeoLib::Point* s (new GeoLib::Point (0,0,0));
-	const std::size_t n_nodes(getNumberOfPoints() - 1);
-	for (std::size_t k(0); k < ply_size - 1; k++) {
-		for (std::size_t j(0); j < n_nodes; j++) {
-			if (GeoLib::lineSegmentIntersect(*(getPoint(j)), *(getPoint(j + 1)),
-							*(ply.getPoint(k)), *(ply.getPoint(k + 1)), *s)) {
-				delete s;
+
+	GeoLib::Point s;
+	for (auto polygon_seg : *this) {
+		for (auto polyline_seg : ply) {
+			if (GeoLib::lineSegmentIntersect(polyline_seg, polygon_seg, s)) {
 				return true;
 			}
 		}
 	}
 
-	delete s;
 	return false;
 }
 

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -175,9 +175,8 @@ bool Polygon::containsSegment(GeoLib::LineSegment const& segment) const
 
 bool Polygon::isPolylineInPolygon(const Polyline& ply) const
 {
-	std::size_t const n_segments(ply.getNumberOfPoints()-1);
-	for (std::size_t k(0); k < n_segments; k++) {
-		if (!containsSegment(*ply.getPoint(k), *ply.getPoint(k+1))) {
+	for (auto segment : ply) {
+		if (!containsSegment(segment)) {
 			return false;
 		}
 	}

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -117,10 +117,12 @@ std::vector<GeoLib::Point> Polygon::getAllIntersectionPoints(
 	return intersections;
 }
 
-bool Polygon::containsSegment(GeoLib::Point const& a, GeoLib::Point const& b) const
+bool Polygon::containsSegment(GeoLib::LineSegment const& segment) const
 {
-	std::vector<GeoLib::Point> s(getAllIntersectionPoints({a,b}));
+	std::vector<GeoLib::Point> s(getAllIntersectionPoints(segment));
 
+	GeoLib::Point const& a{segment.getBeginPoint()};
+	GeoLib::Point const& b{segment.getEndPoint()};
 	// no intersections -> check if at least one point of segment is in polygon
 	if (s.empty()) {
 		return (isPntInPolygon(a));

--- a/GeoLib/Polygon.h
+++ b/GeoLib/Polygon.h
@@ -94,18 +94,15 @@ public:
 	bool isPartOfPolylineInPolygon (const Polyline& ply) const;
 
 	/**
-	 * Calculates the next intersection point between the line segment (a,b) and the
-	 * polygon starting with segment seg_num.
-	 * @param a (input) the first point of the line segment
-	 * @param b (input) the second point of the line segment
+	 * Calculates the next intersection point between the line segment \c seg
+	 * and the polygon starting with segment \c seg_num.
+	 * @param seg (input) Line segment to compute intersection.
 	 * @param intersection_pnt (output) next intersection point
-	 * @param seg_num (input/output) the number of the polygon segment that is intersecting
+	 * @param seg_num (in/out) the number of the polygon segment that is intersecting
 	 */
-	bool getNextIntersectionPointPolygonLine(GeoLib::Point const & a,
-									GeoLib::Point const & b,
-									GeoLib::Point* intersection_pnt,
-									std::size_t& seg_num) const;
-
+	bool getNextIntersectionPointPolygonLine(GeoLib::LineSegment const& seg,
+	                                         GeoLib::Point& intersection_pnt,
+	                                         std::size_t& seg_num) const;
 
 	void computeListOfSimplePolygons ();
 	const std::list<Polygon*>& getListOfSimplePolygons ();

--- a/GeoLib/Polygon.h
+++ b/GeoLib/Polygon.h
@@ -115,14 +115,12 @@ public:
 	friend bool operator==(Polygon const& lhs, Polygon const& rhs);
 private:
 	/**
-	 * computes all intersection points of the straight line segment and the polyline boundary
-	 * @param a end point of line segment
-	 * @param b end point of line segment
-	 * @return a vector of tuples, where a tuple contains the intersection point and
-	 * the intersected segment number
+	 * Computes all intersections of the straight line segment and the polyline boundary
+	 * @param segment the line segment that will be processed
+	 * @return a possible empty vector containing the intersection points
 	 */
 	std::vector<GeoLib::Point> getAllIntersectionPoints(
-		GeoLib::Point const& a, GeoLib::Point const& b) const;
+		GeoLib::LineSegment const& segment) const;
 
 	/**
 	 * from book: Computational Geometry and Computer Graphics in C++, page 119

--- a/GeoLib/Polygon.h
+++ b/GeoLib/Polygon.h
@@ -99,6 +99,8 @@ public:
 	 * @param seg (input) Line segment to compute intersection.
 	 * @param intersection_pnt (output) next intersection point
 	 * @param seg_num (in/out) the number of the polygon segment that is intersecting
+	 * @return true, if there was an intersection, i.e., the \c intersection_pnt
+	 * and \c seg_num contains new valid values
 	 */
 	bool getNextIntersectionPointPolygonLine(GeoLib::LineSegment const& seg,
 	                                         GeoLib::Point& intersection_pnt,

--- a/GeoLib/Polygon.h
+++ b/GeoLib/Polygon.h
@@ -73,13 +73,11 @@ public:
 	bool isPntInPolygon (double x, double y, double z) const;
 
 	/**
-	 * Checks if the straight line segment given by its end points a and b
-	 * is contained within the polygon.
-	 * @param a the first end point of the straight line segment
-	 * @param b the second end point of the straight line segment
+	 * Checks if the straight line segment is contained within the polygon.
+	 * @param segment the straight line segment that is checked with
 	 * @return true if the straight line segment is within the polygon, else false
 	 */
-	bool containsSegment(GeoLib::Point const& a, GeoLib::Point const& b) const;
+	bool containsSegment(GeoLib::LineSegment const& segment) const;
 
 	/**
 	 * Method checks if all points of the polyline ply are inside of the polygon.

--- a/GeoLib/Polyline.cpp
+++ b/GeoLib/Polyline.cpp
@@ -450,6 +450,106 @@ double Polyline::getDistanceAlongPolyline(const MathLib::Point3d& pnt,
 	return dist;
 }
 
+Polyline::SegmentIterator::SegmentIterator(Polyline const& polyline,
+                                           std::size_t segment_number)
+    : _polyline(&polyline),
+      _segment_number(
+          static_cast<std::vector<GeoLib::Point*>::size_type>(segment_number))
+{}
+
+Polyline::SegmentIterator::SegmentIterator(SegmentIterator const& src)
+    : _polyline(src._polyline), _segment_number(src._segment_number)
+{}
+
+Polyline::SegmentIterator& Polyline::SegmentIterator::operator=(
+    SegmentIterator const& rhs)
+{
+	if (&rhs == this)
+		return *this;
+
+	_polyline = rhs._polyline;
+	_segment_number = rhs._segment_number;
+	return *this;
+}
+
+std::size_t Polyline::SegmentIterator::getSegmentNumber() const
+{
+	return static_cast<std::size_t>(_segment_number);
+}
+
+Polyline::SegmentIterator& Polyline::SegmentIterator::operator++()
+{
+	++_segment_number;
+	return *this;
+}
+
+LineSegment const Polyline::SegmentIterator::operator*() const
+{
+	return _polyline->getSegment(_segment_number);
+}
+
+LineSegment Polyline::SegmentIterator::operator*()
+{
+	return _polyline->getSegment(_segment_number);
+}
+
+bool Polyline::SegmentIterator::operator==(SegmentIterator const& other)
+{
+	return !(*this != other);
+}
+
+bool Polyline::SegmentIterator::operator!=(SegmentIterator const& other)
+{
+	return other._segment_number != _segment_number ||
+	       other._polyline != _polyline;
+}
+
+Polyline::SegmentIterator& Polyline::SegmentIterator::operator+=(
+    std::vector<GeoLib::Point>::difference_type n)
+{
+	if (n < 0) {
+		_segment_number -=
+		    static_cast<std::vector<GeoLib::Point>::size_type>(-n);
+	} else {
+		_segment_number +=
+		    static_cast<std::vector<GeoLib::Point>::size_type>(n);
+	}
+	if (_segment_number > _polyline->getNumberOfSegments())
+		std::abort();
+	return *this;
+}
+
+Polyline::SegmentIterator Polyline::SegmentIterator::operator+(
+    std::vector<GeoLib::Point>::difference_type n)
+{
+	SegmentIterator t(*this);
+	t += n;
+	return t;
+}
+
+Polyline::SegmentIterator& Polyline::SegmentIterator::operator-=(
+    std::vector<GeoLib::Point>::difference_type n)
+{
+	if (n >= 0) {
+		_segment_number -=
+		    static_cast<std::vector<GeoLib::Point>::size_type>(n);
+	} else {
+		_segment_number +=
+		    static_cast<std::vector<GeoLib::Point>::size_type>(-n);
+	}
+	if (_segment_number > _polyline->getNumberOfSegments())
+		std::abort();
+	return *this;
+}
+
+Polyline::SegmentIterator Polyline::SegmentIterator::operator-(
+    std::vector<GeoLib::Point>::difference_type n)
+{
+	Polyline::SegmentIterator t(*this);
+	t -= n;
+	return t;
+}
+
 std::ostream& operator<< (std::ostream &os, const Polyline &pl)
 {
 	pl.write (os);

--- a/GeoLib/Polyline.cpp
+++ b/GeoLib/Polyline.cpp
@@ -231,6 +231,20 @@ std::size_t Polyline::getPointID(std::size_t i) const
 	return _ply_pnt_ids[i];
 }
 
+LineSegment const Polyline::getSegment(std::size_t i) const
+{
+	assert(i < getNumberOfSegments());
+	return LineSegment(_ply_pnts[_ply_pnt_ids[i]],
+	                   _ply_pnts[_ply_pnt_ids[i + 1]], false);
+}
+
+LineSegment Polyline::getSegment(std::size_t i)
+{
+	assert(i < getNumberOfSegments());
+	return LineSegment(_ply_pnts[_ply_pnt_ids[i]],
+	                   _ply_pnts[_ply_pnt_ids[i + 1]], false);
+}
+
 void Polyline::setPointID(std::size_t idx, std::size_t id)
 {
 	assert(idx < _ply_pnt_ids.size());

--- a/GeoLib/Polyline.cpp
+++ b/GeoLib/Polyline.cpp
@@ -184,6 +184,11 @@ std::size_t Polyline::getNumberOfPoints() const
 	return _ply_pnt_ids.size();
 }
 
+std::size_t Polyline::getNumberOfSegments() const
+{
+	return _ply_pnt_ids.empty() ? 0 : _ply_pnt_ids.size()-1;
+}
+
 bool Polyline::isClosed() const
 {
 	if (_ply_pnt_ids.size() < 3)

--- a/GeoLib/Polyline.cpp
+++ b/GeoLib/Polyline.cpp
@@ -459,20 +459,6 @@ bool containsEdge (const Polyline& ply, std::size_t id0, std::size_t id1)
 	return false;
 }
 
-bool isLineSegmentIntersecting (const Polyline& ply,
-                                GeoLib::Point const& s0,
-                                GeoLib::Point const& s1)
-{
-	const std::size_t n (ply.getNumberOfPoints() - 1);
-	bool intersect(false);
-	GeoLib::Point intersection_pnt;
-	for (std::size_t k(0); k < n && !intersect; k++)
-		intersect = GeoLib::lineSegmentIntersect (*(ply.getPoint(k)), *(ply.getPoint(
-		                                                                         k + 1)),
-		                                           s0, s1, intersection_pnt);
-	return intersect;
-}
-
 bool operator==(Polyline const& lhs, Polyline const& rhs)
 {
 	if (lhs.getNumberOfPoints() != rhs.getNumberOfPoints())

--- a/GeoLib/Polyline.h
+++ b/GeoLib/Polyline.h
@@ -109,6 +109,8 @@ public:
 	 * */
 	std::size_t getNumberOfPoints() const;
 
+	std::size_t getNumberOfSegments() const;
+
 	/** returns true if the polyline is closed */
 	bool isClosed() const;
 

--- a/GeoLib/Polyline.h
+++ b/GeoLib/Polyline.h
@@ -20,6 +20,7 @@
 
 // GeoLib
 #include "GeoObject.h"
+#include "LineSegment.h"
 #include "Point.h"
 
 // MathLib
@@ -183,6 +184,10 @@ protected:
 	 * the k-th element of the vector contains the length of the polyline until the k-th segment
 	 */
 	std::vector<double> _length;
+private:
+	LineSegment const getSegment(std::size_t i) const;
+	LineSegment getSegment(std::size_t i);
+
 };
 
 /** overload the output operator for class Polyline */

--- a/GeoLib/Polyline.h
+++ b/GeoLib/Polyline.h
@@ -188,10 +188,6 @@ std::ostream& operator<< (std::ostream &os, Polyline const& pl);
 
 bool containsEdge (const Polyline& ply, std::size_t id0, std::size_t id1);
 
-bool isLineSegmentIntersecting (const Polyline& ply,
-                                GeoLib::Point const& s0,
-                                GeoLib::Point const& s1);
-
 /**
  * comparison operator
  * @param lhs first polyline

--- a/GeoLib/Polyline.h
+++ b/GeoLib/Polyline.h
@@ -51,6 +51,45 @@ enum class Location
 class Polyline : public GeoObject
 {
 public:
+	class SegmentIterator final
+	    : public std::iterator<std::forward_iterator_tag, LineSegment>
+	{
+	public:
+		explicit SegmentIterator(Polyline const& polyline,
+		                         std::size_t segment_number);
+
+		SegmentIterator(SegmentIterator const& src);
+
+		SegmentIterator() = delete;
+		~SegmentIterator() = default;
+
+		SegmentIterator& operator=(SegmentIterator const& rhs);
+
+		std::size_t getSegmentNumber() const;
+
+		SegmentIterator& operator++();
+
+		LineSegment const operator*() const;
+
+		LineSegment operator*();
+
+		bool operator==(SegmentIterator const& other);
+
+		bool operator!=(SegmentIterator const& other);
+
+		SegmentIterator& operator+=(std::vector<GeoLib::Point>::difference_type n);
+
+		SegmentIterator operator+(std::vector<GeoLib::Point>::difference_type n);
+
+		SegmentIterator& operator-=(std::vector<GeoLib::Point>::difference_type n);
+
+		SegmentIterator operator-(std::vector<GeoLib::Point>::difference_type n);
+
+	private:
+		GeoLib::Polyline const* _polyline;
+		std::vector<GeoLib::Point*>::size_type _segment_number;
+	};
+
 	friend class Polygon;
 	/** constructor
 	 * \param pnt_vec a reference to the point vector
@@ -144,6 +183,16 @@ public:
 	 * */
 	const Point* getPoint(std::size_t i) const;
 
+	SegmentIterator begin() const
+	{
+		return SegmentIterator(*this, 0);
+	}
+
+	SegmentIterator end() const
+	{
+		return SegmentIterator(*this, getNumberOfSegments());
+	}
+
 	std::vector<Point*> const& getPointsVec () const;
 
 	/**
@@ -187,7 +236,6 @@ protected:
 private:
 	LineSegment const getSegment(std::size_t i) const;
 	LineSegment getSegment(std::size_t i);
-
 };
 
 /** overload the output operator for class Polyline */

--- a/Tests/GeoLib/AutoCheckGenerators.h
+++ b/Tests/GeoLib/AutoCheckGenerators.h
@@ -68,10 +68,9 @@ struct SymmSegmentGeneratorXY
 
 	result_type operator()(std::size_t /*size*/ = 0)
 	{
-		result_type rv;
-		rv.a = GeoLib::Point(source(), 0);
-		rv.b = GeoLib::Point(function(rv.a), 1);
-		return rv;
+		std::unique_ptr<GeoLib::Point> a{new GeoLib::Point{source(), 0}};
+		std::unique_ptr<GeoLib::Point> b{new GeoLib::Point{function(*a), 1}};
+		return result_type{a.release(), b.release(), true};
 	}
 
 	Gen source;
@@ -81,14 +80,13 @@ struct SymmSegmentGeneratorXY
 GeoLib::LineSegment translate(MathLib::Vector3 const& translation,
                               GeoLib::LineSegment const& line_seg)
 {
-	GeoLib::LineSegment s;
-	s.a = line_seg.a;
+	std::unique_ptr<GeoLib::Point> a{new GeoLib::Point{line_seg.getBeginPoint()}};
+	std::unique_ptr<GeoLib::Point> b{new GeoLib::Point{line_seg.getEndPoint()}};
 	for (std::size_t k(0); k<3; ++k)
-		s.a[k] += translation[k];
-	s.b = line_seg.b;
+		(*a)[k] += translation[k];
 	for (std::size_t k(0); k<3; ++k)
-		s.b[k] += translation[k];
-	return s;
+		(*b)[k] += translation[k];
+	return GeoLib::LineSegment{a.release(), b.release(), true};
 }
 
 template <typename Gen = SymmSegmentGeneratorXY<
@@ -105,10 +103,9 @@ struct PairSegmentGeneratorXY
 
 	result_type operator()(std::size_t /*size*/ = 0)
 	{
-		result_type rv;
-		rv.first = segment_generator();
-		rv.second = function(rv.first);
-		return rv;
+		auto first = segment_generator();
+		auto second = function(first);
+		return result_type{first, second};
 	}
 
 	Gen segment_generator;

--- a/Tests/GeoLib/TestLineSegmentIntersect.cpp
+++ b/Tests/GeoLib/TestLineSegmentIntersect.cpp
@@ -26,7 +26,7 @@ TEST(GeoLib, TestXAxisParallelLineSegmentIntersection2d)
 	GeoLib::Point d(1.5, 0.0, 0.0);
 	GeoLib::Point s;
 
-	EXPECT_TRUE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_TRUE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 }
 
 TEST(GeoLib, TestParallelLineSegmentIntersection2d)
@@ -38,7 +38,7 @@ TEST(GeoLib, TestParallelLineSegmentIntersection2d)
 	GeoLib::Point d(1.5, 1.5, 0.0);
 	GeoLib::Point s;
 
-	EXPECT_TRUE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_TRUE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 }
 
 TEST(GeoLib, TestNonIntersectingParallelLineSegments2dCaseI)
@@ -50,7 +50,7 @@ TEST(GeoLib, TestNonIntersectingParallelLineSegments2dCaseI)
 	GeoLib::Point d(2.5, 2.5, 0.0);
 	GeoLib::Point s;
 
-	EXPECT_FALSE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_FALSE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 }
 
 TEST(GeoLib, TestNonIntersectingParallelLineSegments2dCaseII)
@@ -62,7 +62,7 @@ TEST(GeoLib, TestNonIntersectingParallelLineSegments2dCaseII)
 	GeoLib::Point d(-1.0, 0.0, 0.0);
 	GeoLib::Point s;
 
-	EXPECT_FALSE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_FALSE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 }
 
 TEST(GeoLib, TestIntersectingLineSegments2d)
@@ -74,7 +74,7 @@ TEST(GeoLib, TestIntersectingLineSegments2d)
 	GeoLib::Point d(1.0, 0.0, 0.0);
 	GeoLib::Point s;
 
-	EXPECT_TRUE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_TRUE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 }
 
 TEST(GeoLib, TestIntersectingLineSegments3d)
@@ -86,18 +86,18 @@ TEST(GeoLib, TestIntersectingLineSegments3d)
 	GeoLib::Point d(1.0, 0.0, 1.0);
 	GeoLib::Point s;
 
-	EXPECT_TRUE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_TRUE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 
 	// disturb one point a little bit
 	double const eps(std::numeric_limits<float>::epsilon());
 	d[2] += eps;
-	EXPECT_TRUE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_TRUE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 	d[2] = 1.0+1e-9;
-	EXPECT_TRUE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_TRUE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 	d[2] = 1.0+1e-8;
-	EXPECT_TRUE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_TRUE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 	d[2] = 1.0 + 5e-6;
-	EXPECT_FALSE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_FALSE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 }
 
 TEST(GeoLib, TestParallelLineSegmentIntersection3d)
@@ -109,7 +109,7 @@ TEST(GeoLib, TestParallelLineSegmentIntersection3d)
 	GeoLib::Point d(1.5, 1.5, 1.5);
 	GeoLib::Point s;
 
-	EXPECT_TRUE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_TRUE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 }
 
 TEST(GeoLib, TestNonIntersectingParallelLineSegments3d)
@@ -120,7 +120,7 @@ TEST(GeoLib, TestNonIntersectingParallelLineSegments3d)
 	GeoLib::Point c(1.5, 1.5, 1.5);
 	GeoLib::Point d(2.5, 2.5, 2.5);
 	GeoLib::Point s;
-	EXPECT_FALSE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_FALSE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 
 	// two axis parallel line segments that do not intersect
 	b[0] = 3.0;
@@ -132,7 +132,7 @@ TEST(GeoLib, TestNonIntersectingParallelLineSegments3d)
 	d[0] = 10.0;
 	d[1] = 0.0;
 	d[2] = 0.0;
-	EXPECT_FALSE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_FALSE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 
 	// two axis parallel line segments that do not intersect
 	a[0] = 1000.0;
@@ -147,7 +147,7 @@ TEST(GeoLib, TestNonIntersectingParallelLineSegments3d)
 	d[0] = 0.0;
 	d[1] = 0.0;
 	d[2] = 100.0;
-	EXPECT_FALSE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+	EXPECT_FALSE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 }
 
 TEST(GeoLib, TestRandomLineSegments3d)
@@ -171,7 +171,7 @@ TEST(GeoLib, TestRandomLineSegments3d)
 				0.5*(b[2]+a[2]) - w[2]);
 		GeoLib::Point s;
 
-		EXPECT_TRUE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
+		EXPECT_TRUE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
 	}
 
 	// line segment (c,d) intersects (a,b) at end point a
@@ -186,8 +186,8 @@ TEST(GeoLib, TestRandomLineSegments3d)
 		GeoLib::Point d(a[0] - w[0], a[1] - w[1], a[2] - w[2]);
 		GeoLib::Point s;
 
-		EXPECT_TRUE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
-		EXPECT_TRUE(GeoLib::lineSegmentIntersect(c,d,a,b,s));
+		EXPECT_TRUE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
+		EXPECT_TRUE(GeoLib::lineSegmentIntersect({&c,&d}, {&a,&b}, s));
 	}
 
 	// line segment (c,d) intersects (a,b) at end point b
@@ -202,8 +202,8 @@ TEST(GeoLib, TestRandomLineSegments3d)
 		GeoLib::Point d(b[0] - w[0], b[1] - w[1], b[2] - w[2]);
 		GeoLib::Point s;
 
-		EXPECT_TRUE(GeoLib::lineSegmentIntersect(a,b,c,d,s));
-		EXPECT_TRUE(GeoLib::lineSegmentIntersect(c,d,a,b,s));
+		EXPECT_TRUE(GeoLib::lineSegmentIntersect({&a,&b}, {&c,&d}, s));
+		EXPECT_TRUE(GeoLib::lineSegmentIntersect({&c,&d}, {&a,&b}, s));
 	}
 }
 

--- a/Tests/GeoLib/TestLineSegmentIntersect2d.cpp
+++ b/Tests/GeoLib/TestLineSegmentIntersect2d.cpp
@@ -50,6 +50,13 @@ public:
 	ac::gtest_reporter gtest_reporter;
 };
 
+#if !defined(_MSC_VER) || (_MSC_VER >= 1900)
+// Compilers of MVS below 2015 do not support unrestricted unions. The
+// unrestricted union is used by autocheck to handle test data. The autocheck
+// workaround for MVS compilers (below version 2015) contains a bug and in the
+// consequence the tests crashes. For this reason the tests are disabled under
+// this environments.
+
 // Test the intersection of intersecting line segments. Line segments are chords
 // of the same circle that both contains the center of the circle. As a
 // consequence the center of the circle is the intersection point.
@@ -145,3 +152,5 @@ TEST_F(LineSegmentIntersect2dTest, ParallelIntersectingSegmentOrientation)
 	    ac::make_arbitrary(pair_segment_generator2),
 	    gtest_reporter);
 }
+
+#endif

--- a/Tests/GeoLib/TestLineSegmentIntersect2d.cpp
+++ b/Tests/GeoLib/TestLineSegmentIntersect2d.cpp
@@ -55,13 +55,17 @@ public:
 // consequence the center of the circle is the intersection point.
 TEST_F(LineSegmentIntersect2dTest, RandomSegmentOrientationIntersecting)
 {
-	auto intersect =
-	    [](GeoLib::LineSegment const& s0, GeoLib::LineSegment const& s1)
+	auto intersect = [](GeoLib::LineSegment const& s0,
+	                    GeoLib::LineSegment const& s1)
 	{
-		auto ipnts = GeoLib::lineSegmentIntersect2d(s0.a, s0.b, s1.a, s1.b);
-		if (ipnts.size() == 1) {
+		auto ipnts = GeoLib::lineSegmentIntersect2d(
+		    s0.getBeginPoint(), s0.getEndPoint(), s1.getBeginPoint(),
+		    s1.getEndPoint());
+		if (ipnts.size() == 1)
+		{
 			MathLib::Point3d const center{std::array<double, 3>{
-			    {(s0.a[0] + s0.b[0]) / 2, (s0.a[1] + s0.b[1]) / 2, 0.0}}};
+			    {(s0.getBeginPoint()[0] + s0.getEndPoint()[0]) / 2,
+			     (s0.getBeginPoint()[1] + s0.getEndPoint()[1]) / 2, 0.0}}};
 			const double sqr_dist(MathLib::sqrDist(ipnts[0], center));
 			if (sqr_dist < std::numeric_limits<double>::epsilon())
 				return true;
@@ -84,7 +88,9 @@ TEST_F(LineSegmentIntersect2dTest, RandomSegmentOrientationNonIntersecting)
 	auto intersect =
 	    [](GeoLib::LineSegment const& s0, GeoLib::LineSegment const& s1)
 	{
-		auto ipnts = GeoLib::lineSegmentIntersect2d(s0.a, s0.b, s1.a, s1.b);
+		auto ipnts = GeoLib::lineSegmentIntersect2d(
+		    s0.getBeginPoint(), s0.getEndPoint(), s1.getBeginPoint(),
+		    s1.getEndPoint());
 		return ipnts.empty();
 	};
 
@@ -103,9 +109,11 @@ TEST_F(LineSegmentIntersect2dTest, ParallelNonIntersectingSegmentOrientation)
 	    std::pair<GeoLib::LineSegment const&, GeoLib::LineSegment const&> const&
 	        segment_pair)
 	{
-		auto ipnts = GeoLib::lineSegmentIntersect2d(
-		    segment_pair.first.a, segment_pair.first.b, segment_pair.second.a,
-		    segment_pair.second.b);
+		auto ipnts =
+		    GeoLib::lineSegmentIntersect2d(segment_pair.first.getBeginPoint(),
+		                                   segment_pair.first.getEndPoint(),
+		                                   segment_pair.second.getBeginPoint(),
+		                                   segment_pair.second.getEndPoint());
 		return ipnts.empty();
 	};
 
@@ -123,9 +131,11 @@ TEST_F(LineSegmentIntersect2dTest, ParallelIntersectingSegmentOrientation)
 	    std::pair<GeoLib::LineSegment const&, GeoLib::LineSegment const&> const&
 	        segment_pair)
 	{
-		auto ipnts = GeoLib::lineSegmentIntersect2d(
-		    segment_pair.first.a, segment_pair.first.b, segment_pair.second.a,
-		    segment_pair.second.b);
+		auto ipnts =
+		    GeoLib::lineSegmentIntersect2d(segment_pair.first.getBeginPoint(),
+		                                   segment_pair.first.getEndPoint(),
+		                                   segment_pair.second.getBeginPoint(),
+		                                   segment_pair.second.getEndPoint());
 		return ipnts.size() == 2;
 	};
 

--- a/Tests/GeoLib/TestPolygon.cpp
+++ b/Tests/GeoLib/TestPolygon.cpp
@@ -14,6 +14,7 @@
 #include "gtest/gtest.h"
 
 #include "GeoLib/Point.h"
+#include "GeoLib/LineSegment.h"
 #include "GeoLib/Polygon.h"
 
 /**
@@ -138,9 +139,10 @@ TEST_F(PolygonTest, isPntInPolygonCheckOuterPoints)
 TEST_F(PolygonTest, containsSegment)
 {
 	{ // test segment (2,6)
-		GeoLib::Point const& a(*(_polygon->getPoint(2)));
-		GeoLib::Point const& b(*(_polygon->getPoint(6)));
-		ASSERT_FALSE(_polygon->containsSegment(a, b));
+		GeoLib::LineSegment const segment{
+		    const_cast<GeoLib::Point*>(_polygon->getPoint(2)),
+		    const_cast<GeoLib::Point*>(_polygon->getPoint(6))};
+		ASSERT_FALSE(_polygon->containsSegment(segment));
 	}
 
 	// test all segments of polygon
@@ -151,27 +153,31 @@ TEST_F(PolygonTest, containsSegment)
 	}
 
 	{ // 70
-		GeoLib::Point const& a = *(_polygon->getPoint(7));
-		GeoLib::Point const& b = *(_polygon->getPoint(0));
-		ASSERT_TRUE(_polygon->containsSegment(a, b));
+		GeoLib::LineSegment const segment{
+		    const_cast<GeoLib::Point*>(_polygon->getPoint(7)),
+		    const_cast<GeoLib::Point*>(_polygon->getPoint(0))};
+		ASSERT_TRUE(_polygon->containsSegment(segment));
 	}
 
 	{ // test segment (3,5)
-		GeoLib::Point const& a = *(_polygon->getPoint(3));
-		GeoLib::Point const& b = *(_polygon->getPoint(5));
-		ASSERT_TRUE(_polygon->containsSegment(a, b));
+		GeoLib::LineSegment const segment{
+		    const_cast<GeoLib::Point*>(_polygon->getPoint(3)),
+		    const_cast<GeoLib::Point*>(_polygon->getPoint(5))};
+		ASSERT_TRUE(_polygon->containsSegment(segment));
 	}
 
 	{ // test segment (1,7)
-		GeoLib::Point const& a = *(_polygon->getPoint(1));
-		GeoLib::Point const& b = *(_polygon->getPoint(7));
-		ASSERT_TRUE(_polygon->containsSegment(a, b));
+		GeoLib::LineSegment const segment{
+		    const_cast<GeoLib::Point*>(_polygon->getPoint(1)),
+		    const_cast<GeoLib::Point*>(_polygon->getPoint(7))};
+		ASSERT_TRUE(_polygon->containsSegment(segment));
 	}
 
 	{ // test segment (1,4)
-		GeoLib::Point const& a = *(_polygon->getPoint(1));
-		GeoLib::Point const& b = *(_polygon->getPoint(4));
-		ASSERT_FALSE(_polygon->containsSegment(a, b));
+		GeoLib::LineSegment const segment{
+		    const_cast<GeoLib::Point*>(_polygon->getPoint(1)),
+		    const_cast<GeoLib::Point*>(_polygon->getPoint(4))};
+		ASSERT_FALSE(_polygon->containsSegment(segment));
 	}
 }
 

--- a/Tests/GeoLib/TestPolygon.cpp
+++ b/Tests/GeoLib/TestPolygon.cpp
@@ -146,10 +146,10 @@ TEST_F(PolygonTest, containsSegment)
 	}
 
 	// test all segments of polygon
-	for (std::size_t k(0); k<_polygon->getNumberOfPoints()-1;k++) {
-		GeoLib::Point const& a = *(_polygon->getPoint(k));
-		GeoLib::Point const& b = *(_polygon->getPoint(k+1));
-		EXPECT_TRUE(_polygon->containsSegment(a, b));
+	for (auto segment_it(_polygon->begin()); segment_it != _polygon->end();
+	     ++segment_it)
+	{
+		EXPECT_TRUE(_polygon->containsSegment(*segment_it));
 	}
 
 	{ // 70

--- a/Tests/GeoLib/TestPolyline.cpp
+++ b/Tests/GeoLib/TestPolyline.cpp
@@ -102,6 +102,13 @@ TEST(GeoLib, PolylineTest)
 	ply.closePolyline();
 	ASSERT_TRUE(ply.isClosed());
 
+	std::size_t segment_cnt(0);
+	for (auto seg_it(ply.begin()); seg_it != ply.end(); ++seg_it)
+	{
+		++segment_cnt;
+	}
+	ASSERT_EQ(ply.getNumberOfSegments(), segment_cnt);
+
 	for (std::size_t k(0); k < ply_pnts.size(); ++k)
 		delete ply_pnts[k];
 }


### PR DESCRIPTION
PR improves the existing class `LineSegment` and establishs it at some places in the `GeoLib`. The changes should improve the readability.

Furthermore the PR introduces a `SegmentIterator` in class `Polyline`. The iterator class allows to use algorithms from the standard library and makes the code more readable at some places.