### PR TITLE
Split FileIO MeshLib dependency in LayeredMeshGenerator

### DIFF
--- a/Applications/DataExplorer/DataView/MeshLayerEditDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshLayerEditDialog.cpp
@@ -22,6 +22,7 @@
 #include "StringTools.h"
 #include "Mesh.h"
 
+#include "FileIO/AsciiRasterInterface.h"
 #include "TetGenInterface.h"
 
 #include <QCheckBox>
@@ -188,7 +189,9 @@ MeshLib::Mesh* MeshLayerEditDialog::createPrismMesh()
 		std::vector<std::string> raster_paths;
 		for (int i=nLayers; i>=0; --i)
 			raster_paths.push_back(this->_edits[i]->text().toStdString());
-		if (mapper.createLayers(*_msh, raster_paths, minimum_thickness))
+
+		auto const rasters = FileIO::readRasters(raster_paths);
+		if (rasters && mapper.createLayers(*_msh, *rasters, minimum_thickness))
 		{
 			INFO("Mesh construction time: %d ms.", myTimer0.elapsed());
 			return mapper.getMesh("SubsurfaceMesh").release();
@@ -227,7 +230,9 @@ MeshLib::Mesh* MeshLayerEditDialog::createTetMesh()
 		for (int i=nLayers; i>=0; --i)
 			raster_paths.push_back(this->_edits[i]->text().toStdString());
 		LayeredVolume lv;
-		if (lv.createLayers(*_msh, raster_paths, minimum_thickness))
+
+		auto const rasters = FileIO::readRasters(raster_paths);
+		if (rasters && lv.createLayers(*_msh, *rasters, minimum_thickness))
 			tg_mesh = lv.getMesh("SubsurfaceMesh").release();
 
 		if (tg_mesh)

--- a/Applications/Utils/MeshEdit/createLayeredMeshFromRasters.cpp
+++ b/Applications/Utils/MeshEdit/createLayeredMeshFromRasters.cpp
@@ -23,6 +23,7 @@
 #include "BaseLib/FileTools.h"
 
 #include "FileIO/readMeshFromFile.h"
+#include "FileIO/AsciiRasterInterface.h"
 #include "FileIO/writeMeshToFile.h"
 
 #include "MeshLib/Mesh.h"
@@ -113,7 +114,12 @@ int main (int argc, char* argv[])
 		return EXIT_FAILURE;
 
 	MeshLib::MeshLayerMapper mapper;
-	if (!mapper.createLayers(*sfc_mesh, raster_paths, min_thickness))
+	if (auto rasters = FileIO::readRasters(raster_paths))
+	{
+		if (!mapper.createLayers(*sfc_mesh, *rasters, min_thickness))
+			return EXIT_FAILURE;
+	}
+	else
 		return EXIT_FAILURE;
 
 	std::string output_name (mesh_out_arg.getValue());

--- a/FileIO/AsciiRasterInterface.cpp
+++ b/FileIO/AsciiRasterInterface.cpp
@@ -215,4 +215,15 @@ void AsciiRasterInterface::writeRasterAsASC(GeoLib::Raster const& raster, std::s
     out.close();
 }
 
-} // end namespace GeoLib
+bool allRastersExist(std::vector<std::string> const& raster_paths)
+{
+	for (auto raster = raster_paths.begin(); raster != raster_paths.end();
+	     ++raster)
+	{
+		std::ifstream file_stream(*raster, std::ifstream::in);
+		if (!file_stream.good()) return false;
+		file_stream.close();
+	}
+	return true;
+}
+}

--- a/FileIO/AsciiRasterInterface.cpp
+++ b/FileIO/AsciiRasterInterface.cpp
@@ -216,7 +216,9 @@ void AsciiRasterInterface::writeRasterAsASC(GeoLib::Raster const& raster, std::s
     out.close();
 }
 
-bool allRastersExist(std::vector<std::string> const& raster_paths)
+
+/// Checks if all raster files actually exist
+static bool allRastersExist(std::vector<std::string> const& raster_paths)
 {
 	for (auto raster = raster_paths.begin(); raster != raster_paths.end();
 	     ++raster)

--- a/FileIO/AsciiRasterInterface.cpp
+++ b/FileIO/AsciiRasterInterface.cpp
@@ -14,6 +14,7 @@
 #include "AsciiRasterInterface.h"
 
 #include <logog/include/logog.hpp>
+#include <boost/optional.hpp>
 
 #include "BaseLib/FileTools.h"
 #include "BaseLib/StringTools.h"
@@ -225,5 +226,17 @@ bool allRastersExist(std::vector<std::string> const& raster_paths)
 		file_stream.close();
 	}
 	return true;
+}
+
+boost::optional<std::vector<GeoLib::Raster const*>> readRasters(
+    std::vector<std::string> const& raster_paths)
+{
+	if (!allRastersExist(raster_paths)) return boost::none;
+
+	std::vector<GeoLib::Raster const*> rasters;
+	rasters.reserve(raster_paths.size());
+	for (auto const& path : raster_paths)
+		rasters.push_back(FileIO::AsciiRasterInterface::readRaster(path));
+    return boost::make_optional(rasters);
 }
 }

--- a/FileIO/AsciiRasterInterface.h
+++ b/FileIO/AsciiRasterInterface.h
@@ -15,6 +15,9 @@
 #define ASCIIRASTERINTERFACE_H_
 
 #include <fstream>
+#include <vector>
+#include <string>
+#include <boost/optional.hpp>
 
 #include "GeoLib/Raster.h"
 
@@ -48,6 +51,11 @@ private:
     static bool readSurferHeader(std::ifstream &in, GeoLib::RasterHeader &header,
                                  double &min, double &max);
 };
+
+/// Reads a vector of rasters given by file names. On error nothing is returned,
+/// otherwise the returned vector contains pointers to the read rasters.
+boost::optional<std::vector<GeoLib::Raster const*>> readRasters(
+    std::vector<std::string> const& raster_paths);
 
 /// Checks if all raster files actually exist
 bool allRastersExist(std::vector<std::string> const& raster_paths);

--- a/FileIO/AsciiRasterInterface.h
+++ b/FileIO/AsciiRasterInterface.h
@@ -49,6 +49,9 @@ private:
                                  double &min, double &max);
 };
 
+/// Checks if all raster files actually exist
+bool allRastersExist(std::vector<std::string> const& raster_paths);
+
 }
 
 #endif /* ASCIIRASTERINTERFACE_H_ */

--- a/FileIO/AsciiRasterInterface.h
+++ b/FileIO/AsciiRasterInterface.h
@@ -56,10 +56,6 @@ private:
 /// otherwise the returned vector contains pointers to the read rasters.
 boost::optional<std::vector<GeoLib::Raster const*>> readRasters(
     std::vector<std::string> const& raster_paths);
-
-/// Checks if all raster files actually exist
-bool allRastersExist(std::vector<std::string> const& raster_paths);
-
 }
 
 #endif /* ASCIIRASTERINTERFACE_H_ */

--- a/MeshLib/CMakeLists.txt
+++ b/MeshLib/CMakeLists.txt
@@ -19,7 +19,6 @@ add_library(MeshLib STATIC ${SOURCES})
 
 target_link_libraries(MeshLib INTERFACE
 	BaseLib
-	FileIO
 	GeoLib
 	MathLib
 	${VTK_LIBRARIES}

--- a/MeshLib/MeshGenerators/LayeredMeshGenerator.cpp
+++ b/MeshLib/MeshGenerators/LayeredMeshGenerator.cpp
@@ -19,8 +19,6 @@
 
 #include <logog/include/logog.hpp>
 
-#include "FileIO/AsciiRasterInterface.h"
-
 #include "GeoLib/Raster.h"
 
 #include "MeshLib/Mesh.h"
@@ -37,18 +35,14 @@ LayeredMeshGenerator::LayeredMeshGenerator()
 {
 }
 
-bool LayeredMeshGenerator::createLayers(MeshLib::Mesh const& mesh,
-                                        std::vector<std::string> const& raster_paths,
-                                        double minimum_thickness,
-                                        double noDataReplacementValue)
+bool LayeredMeshGenerator::createLayers(
+    MeshLib::Mesh const& mesh,
+    std::vector<GeoLib::Raster const*> const& rasters,
+    double minimum_thickness,
+    double noDataReplacementValue)
 {
-    if (mesh.getDimension() != 2 || !FileIO::allRastersExist(raster_paths))
+    if (mesh.getDimension() != 2)
         return false;
-
-    std::vector<GeoLib::Raster const*> rasters;
-    rasters.reserve(raster_paths.size());
-    for (auto path = raster_paths.begin(); path != raster_paths.end(); ++path)
-        rasters.push_back(FileIO::AsciiRasterInterface::readRaster(*path));
 
     bool result = createRasterLayers(mesh, rasters, minimum_thickness, noDataReplacementValue);
     std::for_each(rasters.begin(), rasters.end(), [](GeoLib::Raster const*const raster){ delete raster; });

--- a/MeshLib/MeshGenerators/LayeredMeshGenerator.cpp
+++ b/MeshLib/MeshGenerators/LayeredMeshGenerator.cpp
@@ -42,7 +42,7 @@ bool LayeredMeshGenerator::createLayers(MeshLib::Mesh const& mesh,
                                         double minimum_thickness,
                                         double noDataReplacementValue)
 {
-    if (mesh.getDimension() != 2 || !allRastersExist(raster_paths))
+    if (mesh.getDimension() != 2 || !FileIO::allRastersExist(raster_paths))
         return false;
 
     std::vector<GeoLib::Raster const*> rasters;
@@ -105,18 +105,6 @@ MeshLib::Node* LayeredMeshGenerator::getNewLayerNode(MeshLib::Node const& dem_no
         return new MeshLib::Node(last_layer_node);
     else
         return new MeshLib::Node(dem_node[0], dem_node[1], elevation, new_node_id);
-}
-
-bool LayeredMeshGenerator::allRastersExist(std::vector<std::string> const& raster_paths) const
-{
-    for (auto raster = raster_paths.begin(); raster != raster_paths.end(); ++raster)
-    {
-        std::ifstream file_stream (*raster, std::ifstream::in);
-        if (!file_stream.good())
-            return false;
-        file_stream.close();
-    }
-    return true;
 }
 
 void LayeredMeshGenerator::cleanUpOnError()

--- a/MeshLib/MeshGenerators/LayeredMeshGenerator.h
+++ b/MeshLib/MeshGenerators/LayeredMeshGenerator.h
@@ -90,9 +90,6 @@ protected:
 	/// Calculates a data-dependent epsilon value
 	double calcEpsilon(GeoLib::Raster const& low, GeoLib::Raster const& high);
 
-	/// Checks if all raster files actually exist
-	bool allRastersExist(std::vector<std::string> const& raster_paths) const;
-
 	/// Cleans up the already created objects in case of an error
 	void cleanUpOnError();
 

--- a/MeshLib/MeshGenerators/LayeredMeshGenerator.h
+++ b/MeshLib/MeshGenerators/LayeredMeshGenerator.h
@@ -39,13 +39,13 @@ public:
 	/**
 	* Returns a subsurface representation of a region represented by a 2D  mesh by reading raster files and calling the appropriate construction method.
 	* @param mesh                    The 2D surface mesh that is used as a basis for the subsurface mesh
-	* @param raster_paths            Containing all the raster-file-names for the subsurface layers from bottom to top (starting with the bottom of the oldest layer and ending with the DEM)
+	* @param rasters                 Containing all the rasters for the subsurface layers from bottom to top (starting with the bottom of the oldest layer and ending with the DEM)
 	* @param minimum_thickness       Minimum thickness of each of the newly created layers (i.e. nodes with a vertical distance smaller than this will be collapsed)
 	* @param noDataReplacementValue  Default z-coordinate if there are mesh nodes not located on the DEM raster (i.e. raster_paths[0])
 	* @result true if the subsurface representation has been created, false if there was an error
 	*/
 	virtual bool createLayers(MeshLib::Mesh const& mesh,
-	                          std::vector<std::string> const& raster_paths,
+	                          std::vector<GeoLib::Raster const*> const& rasters,
 	                          double minimum_thickness,
 	                          double noDataReplacementValue = 0.0) final;
 


### PR DESCRIPTION
Move reading of raster files out of layered mesh generator.

Add convenience function to read all raster files given by a list of file names.