### PR TITLE
Simplify concrete processes

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -33,7 +33,7 @@
 
 #include "UncoupledProcessesTimeLoop.h"
 
-#include "ProcessLib/GroundwaterFlowProcess-fwd.h"
+#include "ProcessLib/GroundwaterFlow/GroundwaterFlowProcess-fwd.h"
 
 
 namespace detail
@@ -170,7 +170,8 @@ void ProjectData::buildProcesses()
 			// several meshes. Then we have to assign the referenced mesh
 			// here.
 			_processes.emplace_back(
-				ProcessLib::createGroundwaterFlowProcess<GlobalSetupType>(
+				ProcessLib::GroundwaterFlow::
+				createGroundwaterFlowProcess<GlobalSetupType>(
 				    *_mesh_vec[0], *nl_slv, std::move(time_disc),
 				    _process_variables, _parameters, pc));
 		}

--- a/AssemblerLib/GlobalSetup.h
+++ b/AssemblerLib/GlobalSetup.h
@@ -60,7 +60,8 @@ struct GlobalSetup
         return Executor::transform(std::forward<Args>(args)...);
     }
 
-    GlobalSetup() { }
+    //! Do not create any instances; this struct only has static members.
+    GlobalSetup() = delete;
 };
 
 }   // namespace AssemblerLib

--- a/AssemblerLib/LocalDataInitializer.h
+++ b/AssemblerLib/LocalDataInitializer.h
@@ -119,35 +119,17 @@ namespace AssemblerLib
 /// For example for MeshLib::Line a local assembler data with template argument
 /// NumLib::ShapeLine2 is created.
 template <
-    template <typename, typename> class LocalAssemblerDataInterface_,
-    template <typename, typename, typename, typename, unsigned> class LocalAssemblerData_,
-    typename GlobalMatrix_,
-    typename GlobalVector_,
+    class LocalAssemblerInterface,
+    template <typename, typename, typename, typename, unsigned> class LocalAssemblerData,
+    typename GlobalMatrix,
+    typename GlobalVector,
     unsigned GlobalDim,
     typename... ConstructorArgs>
 class LocalDataInitializer
 {
-    template <typename ShapeFunction_>
-    using IntegrationMethod = typename NumLib::GaussIntegrationPolicy<
-                typename ShapeFunction_::MeshElement>::IntegrationMethod;
-
-    template <typename ShapeFunction_>
-    using LAData = LocalAssemblerData_<
-            ShapeFunction_,
-            IntegrationMethod<ShapeFunction_>,
-            GlobalMatrix_, GlobalVector_, GlobalDim>;
-
-    using LADataIntfPtr
-        = std::unique_ptr<LocalAssemblerDataInterface_<GlobalMatrix_, GlobalVector_>>;
-
-    using LADataBuilder = std::function<LADataIntfPtr(
-            MeshLib::Element const& e,
-            std::size_t const local_matrix_size,
-            unsigned const integration_order,
-            ConstructorArgs&&...
-        )>;
-
 public:
+    using LADataIntfPtr = std::unique_ptr<LocalAssemblerInterface>;
+
     LocalDataInitializer()
     {
         // /// Lines and points ///////////////////////////////////
@@ -280,6 +262,23 @@ public:
     }
 
 private:
+    using LADataBuilder = std::function<LADataIntfPtr(
+            MeshLib::Element const& e,
+            std::size_t const local_matrix_size,
+            unsigned const integration_order,
+            ConstructorArgs&&...
+        )>;
+
+    template <typename ShapeFunction>
+    using IntegrationMethod = typename NumLib::GaussIntegrationPolicy<
+                typename ShapeFunction::MeshElement>::IntegrationMethod;
+
+    template <typename ShapeFunction>
+    using LAData = LocalAssemblerData<
+            ShapeFunction,
+            IntegrationMethod<ShapeFunction>,
+            GlobalMatrix, GlobalVector, GlobalDim>;
+
     // Generates a function that creates a new LocalAssembler of type LAData<SHAPE_FCT>
     template<typename ShapeFct>
     static LADataBuilder makeLocalAssemblerBuilder()

--- a/NumLib/Function/Interpolation.h
+++ b/NumLib/Function/Interpolation.h
@@ -16,38 +16,69 @@
 namespace NumLib
 {
 
-/**
+namespace detail
+{
+
+template<unsigned DOFOffset, typename NodalValues, typename ShapeMatrix>
+void shapeFunctionInterpolate(
+        const NodalValues &/*nodal_values*/,
+        const ShapeMatrix &/*shape_matrix_N*/)
+{}
+
+template<unsigned DOFOffset, typename NodalValues, typename ShapeMatrix, typename... Numbers>
+void shapeFunctionInterpolate(
+        const NodalValues &nodal_values,
+        const ShapeMatrix &shape_matrix_N,
+        double& interpolated_value,
+        Numbers&... interpolated_values)
+{
+    auto const num_nodes = shape_matrix_N.size();
+    double iv = 0.0;
+
+    for (auto n=decltype(num_nodes){0}; n<num_nodes; ++n) {
+        iv += nodal_values[DOFOffset*num_nodes+n] * shape_matrix_N[n];
+    }
+
+    interpolated_value = iv;
+
+    shapeFunctionInterpolate<DOFOffset+1>(nodal_values, shape_matrix_N, interpolated_values...);
+}
+
+} // namespace detail
+
+/*!
  * Interpolates variables given at element nodes according to the given shape matrix.
  *
  * This function simply does the usual finite-element interpolation, i.e. multiplication
  * of nodal values with the shape function.
  *
- * @param nodal_values   vector of nodal values, ordered by component
- * @param shape_matrix_N shape matrix of the point to which will be interpolated
- * @param interpolated_values array of addresses to which the interpolated values will be written
+ * \param nodal_values vector of nodal values, ordered by component
+ * \param shape_matrix_N shape matrix of the point to which will be interpolated
+ * \param interpolated_value interpolated value of the first d.o.f. (output parameter)
+ * \param interpolated_values interpolated value of further d.o.f. (output parameter)
+ *
+ * \note
+ * \c nodal_values have to be ordered by component and it is assumed that all passed d.o.f. are
+ * single-component and are interpolated using the same shape function.
  */
-template<typename NodalValues, typename ShapeMatrix, std::size_t NodalDOF>
+template<typename NodalValues, typename ShapeMatrix, typename... Numbers>
 void shapeFunctionInterpolate(
         const NodalValues& nodal_values,
         const ShapeMatrix& shape_matrix_N,
-        std::array<double*, NodalDOF> interpolated_values
+        double& interpolated_value,
+        Numbers&... interpolated_values
         )
 {
+    auto const num_nodal_dof = sizeof...(interpolated_values) + 1;
     auto const num_nodes = shape_matrix_N.size();
 
-    assert(num_nodes*NodalDOF == nodal_values.size());
+    assert(num_nodes*num_nodal_dof == nodal_values.size());
+    (void) num_nodal_dof; // no warnings when not in debug build
 
-    for (auto d=decltype(NodalDOF){0}; d<NodalDOF; ++d)
-    {
-        *interpolated_values[d] = 0.0;
-
-        for (auto n=decltype(num_nodes){0}; n<num_nodes; ++n)
-        {
-            *interpolated_values[d] += nodal_values[d*num_nodes+n] * shape_matrix_N[n];
-        }
-    }
+    detail::shapeFunctionInterpolate<0>(nodal_values, shape_matrix_N, interpolated_value,
+                                        interpolated_values...);
 }
 
-}
+} // namespace NumLib
 
 #endif // NUMLIB_INTERPOLATION_H

--- a/ProcessLib/CMakeLists.txt
+++ b/ProcessLib/CMakeLists.txt
@@ -1,7 +1,10 @@
 include(${PROJECT_SOURCE_DIR}/scripts/cmake/OGSEnabledElements.cmake)
 
 # Source files
-GET_SOURCE_FILES(SOURCES)
+APPEND_SOURCE_FILES(SOURCES)
+
+add_subdirectory(GroundwaterFlow)
+APPEND_SOURCE_FILES(SOURCES GroundwaterFlow)
 
 add_library(ProcessLib STATIC ${SOURCES})
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -25,20 +25,19 @@ namespace ProcessLib
 namespace GroundwaterFlow
 {
 
-template <typename ShapeFunction_,
-         typename IntegrationMethod_,
+template <typename ShapeFunction,
+         typename IntegrationMethod,
          typename GlobalMatrix,
          typename GlobalVector,
          unsigned GlobalDim>
 class LocalAssemblerData : public ProcessLib::LocalAssemblerInterface<GlobalMatrix, GlobalVector>
 {
-public:
-    using ShapeFunction = ShapeFunction_;
     using ShapeMatricesType = ShapeMatrixPolicyType<ShapeFunction, GlobalDim>;
     using NodalMatrixType = typename ShapeMatricesType::NodalMatrixType;
     using NodalVectorType = typename ShapeMatricesType::NodalVectorType;
     using ShapeMatrices = typename ShapeMatricesType::ShapeMatrices;
 
+public:
     /// The hydraulic_conductivity factor is directly integrated into the local
     /// element matrix.
     LocalAssemblerData(MeshLib::Element const& element,
@@ -47,7 +46,7 @@ public:
                        GroundwaterFlowProcessData const& process_data)
         : _element(element)
         , _shape_matrices(
-              initShapeMatrices<ShapeFunction, ShapeMatricesType, IntegrationMethod_, GlobalDim>(
+              initShapeMatrices<ShapeFunction, ShapeMatricesType, IntegrationMethod, GlobalDim>(
                   element, integration_order))
         , _process_data(process_data)
         , _localA(local_matrix_size, local_matrix_size) // TODO narrowing conversion
@@ -60,7 +59,7 @@ public:
         _localA.setZero();
         _localRhs.setZero();
 
-        IntegrationMethod_ integration_method(_integration_order);
+        IntegrationMethod integration_method(_integration_order);
         unsigned const n_integration_points = integration_method.getNPoints();
 
         for (std::size_t ip(0); ip < n_integration_points; ip++) {

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -14,10 +14,8 @@
 
 #include "NumLib/Fem/FiniteElement/TemplateIsoparametric.h"
 #include "NumLib/Fem/ShapeMatrixPolicy.h"
-
-#include "Parameter.h"
-#include "ProcessUtil.h"
-
+#include "ProcessLib/Parameter.h"
+#include "ProcessLib/ProcessUtil.h"
 
 namespace ProcessLib
 {

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -14,6 +14,7 @@
 
 #include "NumLib/Fem/FiniteElement/TemplateIsoparametric.h"
 #include "NumLib/Fem/ShapeMatrixPolicy.h"
+#include "ProcessLib/LocalAssemblerInterface.h"
 #include "ProcessLib/Parameter.h"
 #include "ProcessLib/ProcessUtil.h"
 
@@ -23,26 +24,12 @@ namespace ProcessLib
 namespace GroundwaterFlow
 {
 
-// TODO now this interface is basically the same for all processes that assemble a
-//      FirstOrderImplicitQuasiLinear ODE system.
-template <typename GlobalMatrix, typename GlobalVector>
-class LocalAssemblerDataInterface
-{
-public:
-    virtual ~LocalAssemblerDataInterface() = default;
-
-    virtual void assemble(double const t, std::vector<double> const& local_x) = 0;
-
-    virtual void addToGlobal(AssemblerLib::LocalToGlobalIndexMap::RowColumnIndices const&,
-            GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) const = 0;
-};
-
 template <typename ShapeFunction_,
          typename IntegrationMethod_,
          typename GlobalMatrix,
          typename GlobalVector,
          unsigned GlobalDim>
-class LocalAssemblerData : public LocalAssemblerDataInterface<GlobalMatrix, GlobalVector>
+class LocalAssemblerData : public ProcessLib::LocalAssemblerInterface<GlobalMatrix, GlobalVector>
 {
 public:
     using ShapeFunction = ShapeFunction_;

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess-fwd.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess-fwd.h
@@ -11,8 +11,8 @@
 #define PROCESS_LIB_GROUNDWATERFLOWPROCESS_FWD_H_
 
 #include "GroundwaterFlowProcess.h"
-#include "NumericsConfig.h"
+#include "ProcessLib/NumericsConfig.h"
 
-extern template class ProcessLib::GroundwaterFlowProcess<GlobalSetupType>;
+extern template class ProcessLib::GroundwaterFlow::GroundwaterFlowProcess<GlobalSetupType>;
 
 #endif  // PROCESS_LIB_GROUNDWATERFLOWPROCESS_FWD_H_

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -10,9 +10,10 @@
 #include "GroundwaterFlowProcess-fwd.h"
 #include "GroundwaterFlowProcess.h"
 
-namespace ProcessLib
-{
+namespace ProcessLib {
+namespace GroundwaterFlow {
 
 template class GroundwaterFlowProcess<GlobalSetupType>;
 
-}   // namespace ProcessLib
+}
+}

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -12,13 +12,11 @@
 
 #include <cassert>
 
-#include <boost/optional.hpp>
-
 #include "AssemblerLib/LocalAssemblerBuilder.h"
 #include "AssemblerLib/LocalDataInitializer.h"
+#include "ProcessLib/Process.h"
 
 #include "GroundwaterFlowFEM.h"
-#include "Process.h"
 
 namespace MeshLib
 {
@@ -28,6 +26,9 @@ namespace MeshLib
 }
 
 namespace ProcessLib
+{
+
+namespace GroundwaterFlow
 {
 
 template<typename GlobalSetup>
@@ -192,6 +193,8 @@ createGroundwaterFlowProcess(
             hydraulic_conductivity
     }};
 }
+
+}   // namespace GroundwaterFlow
 }   // namespace ProcessLib
 
 #endif  // PROCESS_LIB_GROUNDWATERFLOWPROCESS_H_

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -81,11 +81,11 @@ public:
 private:
     Parameter<double, MeshLib::Element const&> const& _hydraulic_conductivity;
 
-    using LocalAssembler = GroundwaterFlow::LocalAssemblerDataInterface<
-        typename GlobalSetup::MatrixType, typename GlobalSetup::VectorType>;
+    using LocalAssemblerInterface =
+        ProcessLib::LocalAssemblerInterface<GlobalMatrix, GlobalVector>;
 
     using GlobalAssembler = AssemblerLib::VectorMatrixAssembler<
-            GlobalMatrix, GlobalVector, LocalAssembler,
+            GlobalMatrix, GlobalVector, LocalAssemblerInterface,
             NumLib::ODESystemTag::FirstOrderImplicitQuasilinear>;
 
     template <unsigned GlobalDim>
@@ -98,12 +98,12 @@ private:
         _local_assemblers.resize(mesh.getNElements());
         // Shape matrices initializer
         using LocalDataInitializer = AssemblerLib::LocalDataInitializer<
-            GroundwaterFlow::LocalAssemblerDataInterface,
+            ProcessLib::LocalAssemblerInterface,
             GroundwaterFlow::LocalAssemblerData,
             typename GlobalSetup::MatrixType,
             typename GlobalSetup::VectorType,
             GlobalDim,
-            Parameter<double, MeshLib::Element const&> const&>;
+            ProcessLib::Parameter<double, MeshLib::Element const&> const&>;
 
         LocalDataInitializer initializer;
 
@@ -155,7 +155,7 @@ private:
     }
 
     std::unique_ptr<GlobalAssembler> _global_assembler;
-    std::vector<std::unique_ptr<LocalAssembler>> _local_assemblers;
+    std::vector<std::unique_ptr<LocalAssemblerInterface>> _local_assemblers;
 };
 
 template <typename GlobalSetup>

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -12,6 +12,7 @@
 
 #include <cassert>
 
+#include "AssemblerLib/VectorMatrixAssembler.h"
 #include "ProcessLib/Process.h"
 #include "ProcessLib/ProcessUtil.h"
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -35,15 +35,14 @@ class GroundwaterFlowProcess final
         : public Process<GlobalSetup>
 {
     using Base = Process<GlobalSetup>;
-
-public:
     using GlobalMatrix = typename GlobalSetup::MatrixType;
     using GlobalVector = typename GlobalSetup::VectorType;
 
+public:
     GroundwaterFlowProcess(
         MeshLib::Mesh& mesh,
-        typename Process<GlobalSetup>::NonlinearSolver& nonlinear_solver,
-        std::unique_ptr<typename Process<GlobalSetup>::TimeDiscretization>&& time_discretization,
+        typename Base::NonlinearSolver& nonlinear_solver,
+        std::unique_ptr<typename Base::TimeDiscretization>&& time_discretization,
         std::vector<std::reference_wrapper<ProcessVariable>>&& process_variables,
         GroundwaterFlowProcessData&& process_data)
         : Process<GlobalSetup>(mesh, nonlinear_solver, std::move(time_discretization),
@@ -87,25 +86,23 @@ private:
                                MeshLib::Mesh const& mesh,
                                unsigned const integration_order)
     {
-        DBUG("Create local assemblers.");
-        // Populate the vector of local assemblers.
-        _local_assemblers.resize(mesh.getNElements());
         // Shape matrices initializer
         using LocalDataInitializer = AssemblerLib::LocalDataInitializer<
             LocalAssemblerInterface,
             GroundwaterFlow::LocalAssemblerData,
-            typename GlobalSetup::MatrixType,
-            typename GlobalSetup::VectorType,
-            GlobalDim,
+            GlobalMatrix, GlobalVector, GlobalDim,
             GroundwaterFlowProcessData const&>;
-
-        LocalDataInitializer initializer;
 
         using LocalAssemblerBuilder =
             AssemblerLib::LocalAssemblerBuilder<
                 MeshLib::Element,
                 LocalDataInitializer>;
 
+        DBUG("Create local assemblers.");
+        // Populate the vector of local assemblers.
+        _local_assemblers.resize(mesh.getNElements());
+
+        LocalDataInitializer initializer;
         LocalAssemblerBuilder local_asm_builder(initializer, dof_table);
 
         DBUG("Calling local assembler builder for all mesh elements.");

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -21,8 +21,6 @@
 namespace MeshLib
 {
     class Element;
-    class Mesh;
-    template <typename PROP_VAL_TYPE> class PropertyVector;
 }
 
 namespace ProcessLib
@@ -144,8 +142,6 @@ private:
     void assembleConcreteProcess(const double t, GlobalVector const& x,
                                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) override
     {
-        // TODO It looks like, with little work this entire method can be moved to the Process class.
-
         DBUG("Assemble GroundwaterFlowProcess.");
 
         // Call global assembler for each local assembly item.

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -98,7 +98,7 @@ private:
         _local_assemblers.resize(mesh.getNElements());
         // Shape matrices initializer
         using LocalDataInitializer = AssemblerLib::LocalDataInitializer<
-            ProcessLib::LocalAssemblerInterface,
+            LocalAssemblerInterface,
             GroundwaterFlow::LocalAssemblerData,
             typename GlobalSetup::MatrixType,
             typename GlobalSetup::VectorType,

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcessData.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcessData.h
@@ -1,0 +1,50 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_GROUNDWATERFLOW_GROUNDWATERFLOWPROCESSDATA_H
+#define PROCESSLIB_GROUNDWATERFLOW_GROUNDWATERFLOWPROCESSDATA_H
+
+namespace MeshLib
+{
+    class Element;
+}
+
+
+namespace ProcessLib
+{
+
+template <typename ReturnType, typename... Args>
+struct Parameter;
+
+namespace GroundwaterFlow
+{
+
+struct GroundwaterFlowProcessData
+{
+    GroundwaterFlowProcessData(
+            ProcessLib::Parameter<double, MeshLib::Element const&> const&
+            hydraulic_conductivity_
+            )
+        : hydraulic_conductivity(hydraulic_conductivity_)
+    {}
+
+    GroundwaterFlowProcessData(GroundwaterFlowProcessData&& other)
+        : hydraulic_conductivity(other.hydraulic_conductivity)
+    {}
+
+    //! Copies are forbidden.
+    GroundwaterFlowProcessData(GroundwaterFlowProcessData const&) = delete;
+
+    Parameter<double, MeshLib::Element const&> const& hydraulic_conductivity;
+};
+
+} // namespace GroundwaterFlow
+} // namespace ProcessLib
+
+#endif // PROCESSLIB_GROUNDWATERFLOW_GROUNDWATERFLOWPROCESSDATA_H

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -68,6 +68,26 @@ public:
         }
     }
 
+    //! \name ODESystem interface
+    //! @{
+
+    bool isLinear() const override
+    {
+        return true;
+    }
+
+    //! @}
+
+private:
+    Parameter<double, MeshLib::Element const&> const& _hydraulic_conductivity;
+
+    using LocalAssembler = GroundwaterFlow::LocalAssemblerDataInterface<
+        typename GlobalSetup::MatrixType, typename GlobalSetup::VectorType>;
+
+    using GlobalAssembler = AssemblerLib::VectorMatrixAssembler<
+            GlobalMatrix, GlobalVector, LocalAssembler,
+            NumLib::ODESystemTag::FirstOrderImplicitQuasilinear>;
+
     template <unsigned GlobalDim>
     void createLocalAssemblers(AssemblerLib::LocalToGlobalIndexMap const& dof_table,
                                MeshLib::Mesh const& mesh,
@@ -120,27 +140,6 @@ public:
         else
             assert(false);
     }
-
-    //! \name ODESystem interface
-    //! @{
-
-    bool isLinear() const override
-    {
-        return true;
-    }
-
-    //! @}
-
-private:
-    Parameter<double, MeshLib::Element const&> const& _hydraulic_conductivity;
-
-    using LocalAssembler = GroundwaterFlow::LocalAssemblerDataInterface<
-        typename GlobalSetup::MatrixType, typename GlobalSetup::VectorType>;
-
-    using GlobalAssembler = AssemblerLib::VectorMatrixAssembler<
-            GlobalMatrix, GlobalVector, LocalAssembler,
-            NumLib::ODESystemTag::FirstOrderImplicitQuasilinear>;
-
 
     void assembleConcreteProcess(const double t, GlobalVector const& x,
                                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) override

--- a/ProcessLib/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlowProcess.h
@@ -34,7 +34,6 @@ template<typename GlobalSetup>
 class GroundwaterFlowProcess final
         : public Process<GlobalSetup>
 {
-    // TODO change "this->" to "Base::"
     using Base = Process<GlobalSetup>;
 
 public:
@@ -52,7 +51,7 @@ public:
         : Process<GlobalSetup>(mesh, nonlinear_solver, std::move(time_discretization)),
           _hydraulic_conductivity(hydraulic_conductivity)
     {
-        this->_process_variables.emplace_back(variable);
+        Base::_process_variables.emplace_back(variable);
 
         if (dynamic_cast<NumLib::ForwardEuler<GlobalVector>*>(
                     &Base::getTimeDiscretization()) != nullptr)
@@ -115,7 +114,7 @@ private:
         LocalAssemblerBuilder local_asm_builder(initializer, dof_table);
 
         DBUG("Calling local assembler builder for all mesh elements.");
-        this->_global_setup.transform(
+        GlobalSetup::transform(
                 local_asm_builder,
                 mesh.getElements(),
                 _local_assemblers,
@@ -149,7 +148,7 @@ private:
         DBUG("Assemble GroundwaterFlowProcess.");
 
         // Call global assembler for each local assembly item.
-        this->_global_setup.executeMemberDereferenced(
+        GlobalSetup::executeMemberDereferenced(
             *_global_assembler, &GlobalAssembler::assemble,
             _local_assemblers, t, x, M, K, b);
     }

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -1,0 +1,35 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_LOCALASSEMBLERINTERFACE_H
+#define PROCESSLIB_LOCALASSEMBLERINTERFACE_H
+
+namespace ProcessLib
+{
+
+/*! Common interface for local assemblers
+ * NumLib::ODESystemTag::FirstOrderImplicitQuasilinear ODE systems.
+ *
+ * \todo Generalize to other NumLib::ODESystemTag's.
+ */
+template <typename GlobalMatrix, typename GlobalVector>
+class LocalAssemblerInterface
+{
+public:
+    virtual ~LocalAssemblerInterface() = default;
+
+    virtual void assemble(double const t, std::vector<double> const& local_x) = 0;
+
+    virtual void addToGlobal(AssemblerLib::LocalToGlobalIndexMap::RowColumnIndices const&,
+            GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) const = 0;
+};
+
+} // namespace ProcessLib
+
+#endif // PROCESSLIB_LOCALASSEMBLERINTERFACE_H

--- a/ProcessLib/NeumannBc.h
+++ b/ProcessLib/NeumannBc.h
@@ -98,23 +98,21 @@ public:
 
     /// Calls local assemblers which calculate their contributions to the global
     /// matrix and the right-hand-side.
-    void integrate(GlobalSetup const& global_setup,
-                   const double t, GlobalVector& b)
+    void integrate(const double t, GlobalVector& b)
     {
-        global_setup.executeMemberDereferenced(
+        GlobalSetup::executeMemberDereferenced(
                     *_global_assembler, &GlobalAssembler::assemble,
                     _local_assemblers, t, b);
     }
 
-    void initialize(GlobalSetup const& global_setup,
-        unsigned global_dim)
+    void initialize(unsigned global_dim)
     {
         if (global_dim==1)
-            initialize<1u>(global_setup);
+            initialize<1u>();
         else if (global_dim==2)
-            initialize<2u>(global_setup);
+            initialize<2u>();
         else if (global_dim==3)
-            initialize<3u>(global_setup);
+            initialize<3u>();
     }
 
 
@@ -122,8 +120,7 @@ private:
     /// Allocates the local assemblers for each element and stores references to
     /// global matrix and the right-hand-side.
     template <unsigned GlobalDim>
-    void
-    initialize(GlobalSetup const& global_setup)
+    void initialize()
     {
         // Shape matrices initializer
         using LocalDataInitializer = AssemblerLib::LocalDataInitializer<
@@ -151,7 +148,7 @@ private:
         };
 
         DBUG("Calling local Neumann assembler builder for Neumann boundary elements.");
-        global_setup.transform(
+        GlobalSetup::transform(
                 local_asm_builder,
                 _elements,
                 _local_assemblers,

--- a/ProcessLib/NeumannBc.h
+++ b/ProcessLib/NeumannBc.h
@@ -17,14 +17,12 @@
 #include "NumLib/Fem/ShapeMatrixPolicy.h"
 
 #include "AssemblerLib/VectorMatrixAssembler.h"
-#include "AssemblerLib/LocalToGlobalIndexMap.h"
-#include "AssemblerLib/LocalDataInitializer.h"
-#include "AssemblerLib/LocalAssemblerBuilder.h"
 #include "MeshLib/MeshSubset.h"
 #include "MeshLib/MeshSearch/NodeSearch.h"
 
 #include "NeumannBcConfig.h"
 #include "NeumannBcAssembler.h"
+#include "ProcessUtil.h"
 
 namespace ProcessLib
 {
@@ -107,60 +105,24 @@ public:
 
     void initialize(unsigned global_dim)
     {
-        if (global_dim==1)
-            initialize<1u>();
-        else if (global_dim==2)
-            initialize<2u>();
-        else if (global_dim==3)
-            initialize<3u>();
-    }
-
-
-private:
-    /// Allocates the local assemblers for each element and stores references to
-    /// global matrix and the right-hand-side.
-    template <unsigned GlobalDim>
-    void initialize()
-    {
-        // Shape matrices initializer
-        using LocalDataInitializer = AssemblerLib::LocalDataInitializer<
-            LocalNeumannBcAsmDataInterface<GlobalMatrix, GlobalVector>,
-            LocalNeumannBcAsmData,
-            GlobalMatrix, GlobalVector,
-            GlobalDim,
-            std::function<double (MeshLib::Element const&)> const&>;
-
-        LocalDataInitializer initializer;
-
-        using LocalAssemblerBuilder =
-            AssemblerLib::LocalAssemblerBuilder<
-                MeshLib::Element,
-                LocalDataInitializer>;
-
-        // Populate the vector of local assemblers.
-        _local_assemblers.resize(_elements.size());
-        LocalAssemblerBuilder local_asm_builder(
-            initializer, *_local_to_global_index_map);
+        DBUG("Create global assembler.");
+        _global_assembler.reset(
+            new GlobalAssembler(*_local_to_global_index_map));
 
         auto elementValueLookup = [this](MeshLib::Element const&)
         {
             return _function();
         };
 
-        DBUG("Calling local Neumann assembler builder for Neumann boundary elements.");
-        GlobalSetup::transform(
-                local_asm_builder,
-                _elements,
-                _local_assemblers,
-                _integration_order,
-                elementValueLookup);
-
-        DBUG("Create global assembler.");
-        _global_assembler.reset(
-            new GlobalAssembler(*_local_to_global_index_map));
+        createLocalAssemblers<GlobalSetup, LocalNeumannBcAsmData>(
+            global_dim, _elements,
+            *_local_to_global_index_map, _integration_order,
+            _local_assemblers,
+            elementValueLookup
+            );
     }
 
-
+private:
     /// The right-hand-side function of the Neumann boundary condition given as
     /// \f$ \alpha(x) \, \partial u(x) / \partial n = \text{_function}(x)\f$.
     MathLib::ConstantFunction<double> const _function;

--- a/ProcessLib/NeumannBc.h
+++ b/ProcessLib/NeumannBc.h
@@ -124,7 +124,7 @@ private:
     {
         // Shape matrices initializer
         using LocalDataInitializer = AssemblerLib::LocalDataInitializer<
-            LocalNeumannBcAsmDataInterface,
+            LocalNeumannBcAsmDataInterface<GlobalMatrix, GlobalVector>,
             LocalNeumannBcAsmData,
             GlobalMatrix, GlobalVector,
             GlobalDim,

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -18,11 +18,11 @@
 namespace ProcessLib
 {
 ProcessVariable& findProcessVariable(
-    BaseLib::ConfigTree const& process_config, std::string const& tag,
-    std::vector<ProcessVariable> const& variables)
+    std::vector<ProcessVariable> const& variables,
+    BaseLib::ConfigTree const& pv_config, std::string const& tag)
 {
 	// Find process variable name in process config.
-	std::string const name = process_config.getConfParam<std::string>(tag);
+	std::string const name = pv_config.getConfParam<std::string>(tag);
 
         // Find corresponding variable by name.
 	auto variable = std::find_if(variables.cbegin(), variables.cend(),
@@ -39,10 +39,29 @@ ProcessVariable& findProcessVariable(
 		    name.c_str(), tag.c_str());
 		std::abort();
 	}
-	DBUG("Found process variable \'%s\'.", variable->getName().c_str());
+	DBUG("Found process variable \'%s\' for config tag <%s>.",
+		 variable->getName().c_str(), tag.c_str());
 
 	// Const cast is needed because of variables argument constness.
 	return const_cast<ProcessVariable&>(*variable);
+}
+
+std::vector<std::reference_wrapper<ProcessVariable>>
+findProcessVariables(
+		std::vector<ProcessVariable> const& variables,
+		BaseLib::ConfigTree const& process_config,
+		std::initializer_list<std::string> tag_names)
+{
+	std::vector<std::reference_wrapper<ProcessVariable>> vars;
+	vars.reserve(tag_names.size());
+
+	auto const pv_conf = process_config.getConfSubtree("process_variables");
+
+	for (auto const& tag : tag_names) {
+		vars.emplace_back(findProcessVariable(variables, pv_conf, tag));
+	}
+
+	return vars;
 }
 
 }  // namespace ProcessLib

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -65,11 +65,6 @@ public:
 	    , _time_discretization(std::move(time_discretization))
 	{}
 
-	virtual ~Process()
-	{
-		delete _mesh_subset_all_nodes;
-	}
-
 	/// Preprocessing before starting assembly for new timestep.
 	virtual void preTimestep(GlobalVector const& /*x*/,
 	                         const double /*t*/, const double /*delta_t*/) {}
@@ -250,8 +245,8 @@ private:
 	void constructDofTable()
 	{
 		// Create single component dof in every of the mesh's nodes.
-		_mesh_subset_all_nodes =
-		    new MeshLib::MeshSubset(_mesh, &_mesh.getNodes());
+		_mesh_subset_all_nodes.reset(
+		    new MeshLib::MeshSubset(_mesh, &_mesh.getNodes()));
 
 		// Collect the mesh subsets in a vector.
 		std::vector<std::unique_ptr<MeshLib::MeshSubsets>> all_mesh_subsets;
@@ -263,7 +258,7 @@ private:
 			    [&]()
 			    {
 				    return std::unique_ptr<MeshLib::MeshSubsets>{
-				        new MeshLib::MeshSubsets{_mesh_subset_all_nodes}};
+				        new MeshLib::MeshSubsets{_mesh_subset_all_nodes.get()}};
 				});
 		}
 
@@ -352,7 +347,7 @@ private:
 	unsigned const _integration_order = 2;
 
 	MeshLib::Mesh& _mesh;
-	MeshLib::MeshSubset const* _mesh_subset_all_nodes = nullptr;
+	std::unique_ptr<MeshLib::MeshSubset const> _mesh_subset_all_nodes;
 
 	std::unique_ptr<AssemblerLib::LocalToGlobalIndexMap>
 	    _local_to_global_index_map;

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -60,9 +60,9 @@ public:
 	Process(MeshLib::Mesh& mesh,
 	        NonlinearSolver& nonlinear_solver,
 	        std::unique_ptr<TimeDiscretization>&& time_discretization)
-	    : _nonlinear_solver(nonlinear_solver)
+	    : _mesh(mesh)
+		, _nonlinear_solver(nonlinear_solver)
 	    , _time_discretization(std::move(time_discretization))
-	    , _mesh(mesh)
 	{}
 
 	virtual ~Process()
@@ -345,26 +345,27 @@ private:
 	}
 
 protected:
+	/// Variables used by this process.
+	std::vector<std::reference_wrapper<ProcessVariable>> _process_variables;
+
+private:
+	unsigned const _integration_order = 2;
+
+	MeshLib::Mesh& _mesh;
 	MeshLib::MeshSubset const* _mesh_subset_all_nodes = nullptr;
 
 	GlobalSetup _global_setup;
+
+	std::unique_ptr<AssemblerLib::LocalToGlobalIndexMap>
+	    _local_to_global_index_map;
 
 	AssemblerLib::SparsityPattern _sparsity_pattern;
 
 	std::vector<DirichletBc<GlobalIndexType>> _dirichlet_bcs;
 	std::vector<std::unique_ptr<NeumannBc<GlobalSetup>>> _neumann_bcs;
 
-	/// Variables used by this process.
-	std::vector<std::reference_wrapper<ProcessVariable>> _process_variables;
-
 	NonlinearSolver& _nonlinear_solver;
 	std::unique_ptr<TimeDiscretization> _time_discretization;
-
-private:
-	MeshLib::Mesh& _mesh;
-	std::unique_ptr<AssemblerLib::LocalToGlobalIndexMap>
-	    _local_to_global_index_map;
-	unsigned const _integration_order = 2;
 };
 
 /// Find a process variable for a name given in the process configuration under

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -17,7 +17,6 @@
 
 #include "AssemblerLib/ComputeSparsityPattern.h"
 #include "AssemblerLib/LocalToGlobalIndexMap.h"
-#include "AssemblerLib/VectorMatrixAssembler.h"
 #include "BaseLib/ConfigTree.h"
 #include "FileIO/VtkIO/VtuInterface.h"
 #include "MeshGeoToolsLib/MeshNodeSearcher.h"

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -60,10 +60,13 @@ public:
 
 	Process(MeshLib::Mesh& mesh,
 	        NonlinearSolver& nonlinear_solver,
-	        std::unique_ptr<TimeDiscretization>&& time_discretization)
+	        std::unique_ptr<TimeDiscretization>&& time_discretization,
+	        std::vector<std::reference_wrapper<ProcessVariable>>&&
+			process_variables)
 	    : _mesh(mesh)
-		, _nonlinear_solver(nonlinear_solver)
+	    , _nonlinear_solver(nonlinear_solver)
 	    , _time_discretization(std::move(time_discretization))
+		, _process_variables(std::move(process_variables))
 	{}
 
 	/// Preprocessing before starting assembly for new timestep.
@@ -340,10 +343,6 @@ private:
 		    *_local_to_global_index_map, _mesh));
 	}
 
-protected:
-	/// Variables used by this process.
-	std::vector<std::reference_wrapper<ProcessVariable>> _process_variables;
-
 private:
 	unsigned const _integration_order = 2;
 
@@ -360,23 +359,34 @@ private:
 
 	NonlinearSolver& _nonlinear_solver;
 	std::unique_ptr<TimeDiscretization> _time_discretization;
+
+	/// Variables used by this process.
+	std::vector<std::reference_wrapper<ProcessVariable>> _process_variables;
 };
 
-/// Find a process variable for a name given in the process configuration under
-/// the tag.
+/// Find process variables in \c variables whose names match the settings under
+/// the given \c tag_names in the \c process_config.
+///
 /// In the process config a process variable is referenced by a name. For
 /// example it will be looking for a variable named "H" in the list of process
 /// variables when the tag is "hydraulic_head":
 /// \code
 ///     <process>
 ///         ...
-///         <hydraulic_head>H</hydraulic_head>
+///         <process_variables>
+///             <hydraulic_head>H</hydraulic_head>
+///             ...
+///         </process_variables>
+///         ...
 ///     </process>
 /// \endcode
-/// and return a reference to that variable.
-ProcessVariable& findProcessVariable(
-    BaseLib::ConfigTree const& process_config, std::string const& tag,
-    std::vector<ProcessVariable> const& variables);
+///
+/// \return a vector of references to the found variable(s).
+std::vector<std::reference_wrapper<ProcessVariable>>
+findProcessVariables(
+        std::vector<ProcessVariable> const& variables,
+        BaseLib::ConfigTree const& process_config,
+        std::initializer_list<std::string> tag_names);
 
 /// Find a parameter of specific type for a name given in the process
 /// configuration under the tag.

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -42,6 +42,7 @@ class Mesh;
 
 namespace ProcessLib
 {
+
 template <typename GlobalSetup>
 class Process
 		: public NumLib::ODESystem<typename GlobalSetup::MatrixType,

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -149,7 +149,7 @@ public:
 		}
 
 		for (auto& bc : _neumann_bcs)
-			bc->initialize(_global_setup, _mesh.getDimension());
+			bc->initialize(_mesh.getDimension());
 	}
 
 	void setInitialConditions(GlobalVector& x)
@@ -176,7 +176,7 @@ public:
 
 		// Call global assembler for each Neumann boundary local assembler.
 		for (auto const& bc : _neumann_bcs)
-			bc->integrate(_global_setup, t, b);
+			bc->integrate(t, b);
 	}
 
 	void assembleJacobian(
@@ -327,9 +327,9 @@ private:
 
 		// Create a neumann BC for the process variable storing them in the
 		// _neumann_bcs vector.
-		variable.createNeumannBcs(std::back_inserter(_neumann_bcs),
+		variable.createNeumannBcs<GlobalSetup>(
+		                          std::back_inserter(_neumann_bcs),
 		                          mesh_element_searcher,
-		                          _global_setup,
 		                          _integration_order,
 		                          *_local_to_global_index_map,
 		                          0,  // 0 is the variable id TODO
@@ -353,8 +353,6 @@ private:
 
 	MeshLib::Mesh& _mesh;
 	MeshLib::MeshSubset const* _mesh_subset_all_nodes = nullptr;
-
-	GlobalSetup _global_setup;
 
 	std::unique_ptr<AssemblerLib::LocalToGlobalIndexMap>
 	    _local_to_global_index_map;

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -61,11 +61,11 @@ public:
 	        NonlinearSolver& nonlinear_solver,
 	        std::unique_ptr<TimeDiscretization>&& time_discretization,
 	        std::vector<std::reference_wrapper<ProcessVariable>>&&
-			process_variables)
+	        process_variables)
 	    : _mesh(mesh)
 	    , _nonlinear_solver(nonlinear_solver)
 	    , _time_discretization(std::move(time_discretization))
-		, _process_variables(std::move(process_variables))
+	    , _process_variables(std::move(process_variables))
 	{}
 
 	/// Preprocessing before starting assembly for new timestep.

--- a/ProcessLib/ProcessUtil.h
+++ b/ProcessLib/ProcessUtil.h
@@ -10,9 +10,64 @@
 #define PROCESSLIB_PROCESSUTIL_H
 
 #include <vector>
+#include <logog/include/logog.hpp>
+
+#include "AssemblerLib/LocalAssemblerBuilder.h"
+#include "AssemblerLib/LocalDataInitializer.h"
+#include "AssemblerLib/LocalToGlobalIndexMap.h"
+
 
 namespace ProcessLib
 {
+
+namespace detail
+{
+
+template<unsigned GlobalDim, typename GlobalSetup,
+         template <typename, typename, typename, typename, unsigned> class
+         LocalAssemblerImplementation,
+         typename LocalAssemblerInterface,
+         typename... ExtraCtorArgs>
+void createLocalAssemblers(
+        AssemblerLib::LocalToGlobalIndexMap const& dof_table,
+        std::vector<MeshLib::Element*> const& mesh_elements,
+        unsigned const integration_order,
+        std::vector<std::unique_ptr<LocalAssemblerInterface>>& local_assemblers,
+        ExtraCtorArgs&&... extra_ctor_args
+        )
+{
+    // Shape matrices initializer
+    using LocalDataInitializer = AssemblerLib::LocalDataInitializer<
+        LocalAssemblerInterface,
+        LocalAssemblerImplementation,
+        typename GlobalSetup::MatrixType,
+        typename GlobalSetup::VectorType,
+        GlobalDim,
+        ExtraCtorArgs...>;
+
+    using LocalAssemblerBuilder =
+        AssemblerLib::LocalAssemblerBuilder<
+            MeshLib::Element,
+            LocalDataInitializer>;
+
+    DBUG("Create local assemblers.");
+    // Populate the vector of local assemblers.
+    local_assemblers.resize(mesh_elements.size());
+
+    LocalDataInitializer initializer;
+    LocalAssemblerBuilder local_asm_builder(initializer, dof_table);
+
+    DBUG("Calling local assembler builder for all mesh elements.");
+    GlobalSetup::transform(
+            local_asm_builder,
+            mesh_elements,
+            local_assemblers,
+            integration_order,
+            std::forward<ExtraCtorArgs>(extra_ctor_args)...);
+}
+
+} // namespace detail
+
 
 template<typename ShapeFunction, typename ShapeMatricesType, typename IntegrationMethod,
          unsigned GlobalDim>
@@ -39,6 +94,63 @@ initShapeMatrices(MeshLib::Element const& e, unsigned integration_order)
     }
 
     return shape_matrices;
+}
+
+/*! Creates local assemblers for each element of the given \c mesh.
+ *
+ * \tparam GlobalSetup the global setup of the process
+ * \tparam LocalAssemblerImplementation the individual local assembler type
+ * \tparam LocalAssemblerInterface the general local assembler interface
+ * \tparam ExtraCtorArgs types of additional constructor arguments.
+ *         Those arguments will be passed to the constructor of
+ *         \c LocalAssemblerImplementation.
+ *
+ * The first two template parameters cannot be deduced from the arguments.
+ * Therefore they always have to be provided manually.
+ */
+template<typename GlobalSetup,
+         template <typename, typename, typename, typename, unsigned> class
+         LocalAssemblerImplementation,
+         typename LocalAssemblerInterface,
+         typename... ExtraCtorArgs>
+void createLocalAssemblers(
+        const unsigned dimension,
+        std::vector<MeshLib::Element*> const& mesh_elements,
+        AssemblerLib::LocalToGlobalIndexMap const& dof_table,
+        unsigned const integration_order,
+        std::vector<std::unique_ptr<LocalAssemblerInterface>>& local_assemblers,
+        ExtraCtorArgs&&... extra_ctor_args
+        )
+{
+    DBUG("Create local assemblers.");
+
+    switch (dimension)
+    {
+    case 1:
+        detail::createLocalAssemblers<
+            1, GlobalSetup, LocalAssemblerImplementation>(
+                dof_table, mesh_elements, integration_order,
+                local_assemblers,
+                std::forward<ExtraCtorArgs>(extra_ctor_args)...);
+        break;
+    case 2:
+        detail::createLocalAssemblers<
+            2, GlobalSetup, LocalAssemblerImplementation>(
+                dof_table, mesh_elements, integration_order,
+                local_assemblers,
+                std::forward<ExtraCtorArgs>(extra_ctor_args)...);
+        break;
+    case 3:
+        detail::createLocalAssemblers<
+            3, GlobalSetup, LocalAssemblerImplementation>(
+                dof_table, mesh_elements, integration_order,
+                local_assemblers,
+                std::forward<ExtraCtorArgs>(extra_ctor_args)...);
+        break;
+    default:
+        ERR("Meshes with dimension greater than three are not supported.");
+        std::abort();
+    }
 }
 
 } // ProcessLib

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -75,10 +75,9 @@ public:
 		}
 	}
 
-	template <typename OutputIterator, typename GlobalSetup, typename... Args>
+	template <typename GlobalSetup, typename OutputIterator, typename... Args>
 	void createNeumannBcs(OutputIterator bcs,
 	                      MeshGeoToolsLib::BoundaryElementsSearcher& searcher,
-	                      GlobalSetup const&,
 	                      Args&&... args)
 	{
 		for (auto& config : _neumann_bc_configs)

--- a/Tests/AssemblerLib/TestSerialLinearSolver.cpp
+++ b/Tests/AssemblerLib/TestSerialLinearSolver.cpp
@@ -46,7 +46,6 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
     // Choose implementation type
     //--------------------------------------------------------------------------
     using GlobalSetup = GlobalSetupType;    // defined in numerics config
-    const GlobalSetup globalSetup;
 
     //--------------------------------------------------------------------------
     // Prepare mesh items where data are assigned
@@ -70,12 +69,12 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
     typedef GlobalSetup::VectorType GlobalVector;
     typedef GlobalSetup::MatrixType GlobalMatrix;
     auto A = std::unique_ptr<GlobalMatrix>{
-             globalSetup.createMatrix(local_to_global_index_map.dofSize())};
+             GlobalSetup::createMatrix(local_to_global_index_map.dofSize())};
     A->setZero();
     auto rhs = std::unique_ptr<GlobalVector>{
-               globalSetup.createVector(local_to_global_index_map.dofSize())};
+               GlobalSetup::createVector(local_to_global_index_map.dofSize())};
     auto x   = std::unique_ptr<GlobalVector>{
-               globalSetup.createVector(local_to_global_index_map.dofSize())};
+               GlobalSetup::createVector(local_to_global_index_map.dofSize())};
     // TODO no setZero() for rhs, x?
 
     using LocalAssembler = Example::LocalAssemblerData<GlobalMatrix, GlobalVector>;
@@ -97,7 +96,7 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
         local_to_global_index_map);
 
     // Call global initializer for each mesh element.
-    globalSetup.transform(
+    GlobalSetup::transform(
             local_asm_builder,
             ex1.msh->getElements(),
             local_assembler_data,
@@ -113,10 +112,10 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
 
     // Call global assembler for each mesh element.
     auto M_dummy = std::unique_ptr<GlobalMatrix>{
-        globalSetup.createMatrix(local_to_global_index_map.dofSize())};
+        GlobalSetup::createMatrix(local_to_global_index_map.dofSize())};
     A->setZero();
     auto const t = 0.0;
-    globalSetup.executeMemberDereferenced(
+    GlobalSetup::executeMemberDereferenced(
                 assembler, &GlobalAssembler::assemble,
                 local_assembler_data, t, *x, *M_dummy, *A, *rhs);
 

--- a/Tests/NumLib/TestFunctionInterpolation.cpp
+++ b/Tests/NumLib/TestFunctionInterpolation.cpp
@@ -26,7 +26,6 @@ TEST(NumLibFunctionInterpolationTest, TwoVariablesTwoNodes)
 {
     double variable1 = 0.0;
     double variable2 = 0.0;
-    std::array<double*, 2> interpolated_values = {{&variable1, &variable2}};
 
     const std::array<double, 4> nodal_values = {{
         0.0, 1.0,  // for variable1
@@ -36,7 +35,7 @@ TEST(NumLibFunctionInterpolationTest, TwoVariablesTwoNodes)
     const std::array<double, 2> shape_matrix = {{0.25, 0.75}};
 
     NumLib::shapeFunctionInterpolate(nodal_values, shape_matrix,
-                                     interpolated_values);
+                                     variable1, variable2);
 
     ASSERT_EQ(0.75, variable1);
     ASSERT_EQ(0.5,  variable2);
@@ -78,7 +77,6 @@ TEST(NumLibFunctionInterpolationTest, Linear1DElement)
     // actual test
     double variable1 = 0.0;
     double variable2 = 0.0;
-    std::array<double*, 2> interpolated_values = {{&variable1, &variable2}};
 
     const std::array<double, 4> nodal_values = {{
         0.0, 1.0,  // for variable1
@@ -86,7 +84,7 @@ TEST(NumLibFunctionInterpolationTest, Linear1DElement)
     }};
 
     NumLib::shapeFunctionInterpolate(nodal_values, shape_matrix.N,
-                                     interpolated_values);
+                                     variable1, variable2);
 
     const double n0 = shape_matrix.N[0];
     const double n1 = shape_matrix.N[1];


### PR DESCRIPTION
This is a follow-up of #1136.

Changes:
* interpolation (necessary for nonlinear processes) does not require passing arrays anymore
* GWFlow moved to separate subdir, and entirely to separate namespace
* defined common local assembler interface for all processes
* store process data in a separate struct
Thereby it is easier for users to add own properties to a process, to read those properties from file, etc.
* process_variables are passed as a list – first step towards multi-variable processes
* `createLocalAssemblers()` now done by a general function – users see less template stuff.

The aim of this PR is that we can tell users who start implementing their processes: "Copy and paste GWFlow and be happy.". The changes should cover most things needed to implement nonlinear, monolithic processes having only single-component process variables.
A PR regarding secondary variable output will come soon.