### PR TITLE
Add parsing of piecewise linear curves.

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -359,8 +359,8 @@ void ProjectData::parseNonlinearSolvers(BaseLib::ConfigTree const& config)
 static std::unique_ptr<MathLib::PiecewiseLinearInterpolation>
 createPiecewiseLinearInterpolation(BaseLib::ConfigTree const& config)
 {
-	auto const coords = config.getConfParam<std::vector<double>>("coords");
-	auto const values = config.getConfParam<std::vector<double>>("values");
+	auto coords = config.getConfParam<std::vector<double>>("coords");
+	auto values = config.getConfParam<std::vector<double>>("values");
 	if (coords.empty() || values.empty())
 	{
 		ERR("The given co-ordinates or values vector is empty.");
@@ -373,7 +373,8 @@ createPiecewiseLinearInterpolation(BaseLib::ConfigTree const& config)
 	}
 
 	return std::unique_ptr<MathLib::PiecewiseLinearInterpolation>{
-	    new MathLib::PiecewiseLinearInterpolation{coords, values}};
+	    new MathLib::PiecewiseLinearInterpolation{std::move(coords),
+	                                              std::move(values)}};
 }
 
 void ProjectData::parseCurves(

--- a/Applications/ApplicationsLib/ProjectData.h
+++ b/Applications/ApplicationsLib/ProjectData.h
@@ -13,7 +13,10 @@
 #ifndef PROJECTDATA_H_
 #define PROJECTDATA_H_
 
+#include <map>
 #include <memory>
+#include <string>
+#include <boost/optional/optional.hpp>
 
 #include "BaseLib/ConfigTree.h"
 
@@ -26,6 +29,9 @@
 
 #include "NumLib/ODESolver/Types.h"
 
+namespace MathLib {
+	class PiecewiseLinearInterpolation;
+}
 namespace MeshLib {
 	class Mesh;
 }
@@ -193,6 +199,8 @@ private:
 
 	void parseNonlinearSolvers(BaseLib::ConfigTree const& config);
 
+	void parseCurves(boost::optional<BaseLib::ConfigTree> const& config);
+
 private:
 	GeoLib::GEOObjects *_geoObjects = new GeoLib::GEOObjects();
 	std::vector<MeshLib::Mesh*> _mesh_vec;
@@ -216,6 +224,8 @@ private:
 
 	using NonlinearSolver = NumLib::NonlinearSolverBase<GlobalMatrix, GlobalVector>;
 	std::map<std::string, std::unique_ptr<NonlinearSolver> > _nonlinear_solvers;
+	std::map<std::string,
+	         std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> _curves;
 };
 
 #endif //PROJECTDATA_H_

--- a/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.cpp
+++ b/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.cpp
@@ -13,6 +13,7 @@
  */
 #include <cmath>
 #include <limits>
+#include <utility>
 
 #include "PiecewiseLinearInterpolation.h"
 
@@ -20,10 +21,12 @@
 
 namespace MathLib
 {
-PiecewiseLinearInterpolation::PiecewiseLinearInterpolation(const std::vector<double>& supporting_points,
-                                                           const std::vector<double>& values_at_supp_pnts,
-                                                           bool supp_pnts_sorted) :
-	_supp_pnts(supporting_points), _values_at_supp_pnts(values_at_supp_pnts)
+PiecewiseLinearInterpolation::PiecewiseLinearInterpolation(
+    std::vector<double> supporting_points,
+    std::vector<double> values_at_supp_pnts,
+    bool supp_pnts_sorted)
+    : _supp_pnts(std::move(supporting_points)),
+      _values_at_supp_pnts(std::move(values_at_supp_pnts))
 {
 	if (!supp_pnts_sorted) {
 		BaseLib::quicksort<double, double>(_supp_pnts, static_cast<std::size_t> (0),
@@ -31,12 +34,14 @@ PiecewiseLinearInterpolation::PiecewiseLinearInterpolation(const std::vector<dou
 	}
 }
 
-PiecewiseLinearInterpolation::PiecewiseLinearInterpolation(const std::vector<double>& supporting_points,
-                                                           const std::vector<double>& values_at_supp_pnts,
-                                                           const std::vector<double>& points_to_interpolate,
-                                                           std::vector<double>& values_at_interpol_pnts,
-                                                           bool supp_pnts_sorted) :
-	_supp_pnts(supporting_points), _values_at_supp_pnts(values_at_supp_pnts)
+PiecewiseLinearInterpolation::PiecewiseLinearInterpolation(
+    std::vector<double> supporting_points,
+    std::vector<double> values_at_supp_pnts,
+    const std::vector<double>& points_to_interpolate,
+    std::vector<double>& values_at_interpol_pnts,
+    bool supp_pnts_sorted)
+    : _supp_pnts(std::move(supporting_points)),
+      _values_at_supp_pnts(std::move(values_at_supp_pnts))
 {
 	if (!supp_pnts_sorted) {
 		BaseLib::quicksort<double, double>(_supp_pnts, static_cast<std::size_t> (0),

--- a/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.cpp
+++ b/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.cpp
@@ -34,9 +34,6 @@ PiecewiseLinearInterpolation::PiecewiseLinearInterpolation(
 	}
 }
 
-PiecewiseLinearInterpolation::~PiecewiseLinearInterpolation()
-{}
-
 double PiecewiseLinearInterpolation::getValue(double pnt_to_interpolate) const
 {
 	// search interval that has the point inside

--- a/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.cpp
+++ b/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.cpp
@@ -22,8 +22,8 @@
 namespace MathLib
 {
 PiecewiseLinearInterpolation::PiecewiseLinearInterpolation(
-    std::vector<double> supporting_points,
-    std::vector<double> values_at_supp_pnts,
+    std::vector<double>&& supporting_points,
+    std::vector<double>&& values_at_supp_pnts,
     bool supp_pnts_sorted)
     : _supp_pnts(std::move(supporting_points)),
       _values_at_supp_pnts(std::move(values_at_supp_pnts))
@@ -35,8 +35,8 @@ PiecewiseLinearInterpolation::PiecewiseLinearInterpolation(
 }
 
 PiecewiseLinearInterpolation::PiecewiseLinearInterpolation(
-    std::vector<double> supporting_points,
-    std::vector<double> values_at_supp_pnts,
+    std::vector<double>&& supporting_points,
+    std::vector<double>&& values_at_supp_pnts,
     const std::vector<double>& points_to_interpolate,
     std::vector<double>& values_at_interpol_pnts,
     bool supp_pnts_sorted)

--- a/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.cpp
+++ b/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.cpp
@@ -34,27 +34,6 @@ PiecewiseLinearInterpolation::PiecewiseLinearInterpolation(
 	}
 }
 
-PiecewiseLinearInterpolation::PiecewiseLinearInterpolation(
-    std::vector<double>&& supporting_points,
-    std::vector<double>&& values_at_supp_pnts,
-    const std::vector<double>& points_to_interpolate,
-    std::vector<double>& values_at_interpol_pnts,
-    bool supp_pnts_sorted)
-    : _supp_pnts(std::move(supporting_points)),
-      _values_at_supp_pnts(std::move(values_at_supp_pnts))
-{
-	if (!supp_pnts_sorted) {
-		BaseLib::quicksort<double, double>(_supp_pnts, static_cast<std::size_t> (0),
-		                                   _supp_pnts.size(),
-		                                   _values_at_supp_pnts);
-	}
-
-	values_at_interpol_pnts.resize(points_to_interpolate.size());
-	std::transform(points_to_interpolate.begin(), points_to_interpolate.end(),
-	               values_at_interpol_pnts.begin(),
-	               [&](double const& p) { return this->getValue(p); } );
-}
-
 PiecewiseLinearInterpolation::~PiecewiseLinearInterpolation()
 {}
 

--- a/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h
+++ b/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h
@@ -47,24 +47,7 @@ public:
 	PiecewiseLinearInterpolation(std::vector<double>&& supporting_points,
 	                             std::vector<double>&& values_at_supp_pnts,
 	                             bool supp_pnts_sorted = false);
-	/**
-	 * The same requirements on the input vectors supporting_points and values_at_supp_pnts
-	 * have to apply as for the previous constructor.
-	 * @param supporting_points vector of supporting points
-	 * @param values_at_supp_pnts vector of values at the supporting points
-	 * @param points_to_interpolate The points should be located within the range
-	 * \f$[x_{\min}, x_{\max}]\f$, where \f$x_{\min} = \min_{1 \le j \le n} x_j\f$ and
-	 * \f$x_{\max} = \max_{1 \le j \le n} x_j\f$. Points outside of this interval are extrapolated.
-	 * @param values_at_interpol_pnts The interpolated values corresponding to the entries
-	 * of the vector points_to_interpolate.
-	 * @param supp_pnts_sorted Is set to false per default. If it is sure that the supporting
-	 * points are sorted one can set the switch to true.
-	 */
-	PiecewiseLinearInterpolation(std::vector<double>&& supporting_points,
-	                             std::vector<double>&& values_at_supp_pnts,
-	                             const std::vector<double>& points_to_interpolate,
-	                             std::vector<double>& values_at_interpol_pnts,
-	                             bool supp_pnts_sorted = false);
+
 	virtual ~PiecewiseLinearInterpolation();
 
 	/**

--- a/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h
+++ b/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h
@@ -44,8 +44,8 @@ public:
 	 * @param supp_pnts_sorted false (default), if it is sure the supporting points are sorted
 	 * one can set the switch to true
 	 */
-	PiecewiseLinearInterpolation(std::vector<double> supporting_points,
-	                             std::vector<double> values_at_supp_pnts,
+	PiecewiseLinearInterpolation(std::vector<double>&& supporting_points,
+	                             std::vector<double>&& values_at_supp_pnts,
 	                             bool supp_pnts_sorted = false);
 	/**
 	 * The same requirements on the input vectors supporting_points and values_at_supp_pnts
@@ -60,8 +60,8 @@ public:
 	 * @param supp_pnts_sorted Is set to false per default. If it is sure that the supporting
 	 * points are sorted one can set the switch to true.
 	 */
-	PiecewiseLinearInterpolation(std::vector<double> supporting_points,
-	                             std::vector<double> values_at_supp_pnts,
+	PiecewiseLinearInterpolation(std::vector<double>&& supporting_points,
+	                             std::vector<double>&& values_at_supp_pnts,
 	                             const std::vector<double>& points_to_interpolate,
 	                             std::vector<double>& values_at_interpol_pnts,
 	                             bool supp_pnts_sorted = false);

--- a/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h
+++ b/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h
@@ -44,8 +44,8 @@ public:
 	 * @param supp_pnts_sorted false (default), if it is sure the supporting points are sorted
 	 * one can set the switch to true
 	 */
-	PiecewiseLinearInterpolation(const std::vector<double>& supporting_points,
-	                             const std::vector<double>& values_at_supp_pnts,
+	PiecewiseLinearInterpolation(std::vector<double> supporting_points,
+	                             std::vector<double> values_at_supp_pnts,
 	                             bool supp_pnts_sorted = false);
 	/**
 	 * The same requirements on the input vectors supporting_points and values_at_supp_pnts
@@ -60,8 +60,8 @@ public:
 	 * @param supp_pnts_sorted Is set to false per default. If it is sure that the supporting
 	 * points are sorted one can set the switch to true.
 	 */
-	PiecewiseLinearInterpolation(const std::vector<double>& supporting_points,
-	                             const std::vector<double>& values_at_supp_pnts,
+	PiecewiseLinearInterpolation(std::vector<double> supporting_points,
+	                             std::vector<double> values_at_supp_pnts,
 	                             const std::vector<double>& points_to_interpolate,
 	                             std::vector<double>& values_at_interpol_pnts,
 	                             bool supp_pnts_sorted = false);

--- a/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h
+++ b/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h
@@ -22,7 +22,7 @@ namespace MathLib
 /**
  * This class implements a one dimensional piecewise linear interpolation algorithm.
  */
-class PiecewiseLinearInterpolation
+class PiecewiseLinearInterpolation final
 {
 public:
 	/**
@@ -47,8 +47,6 @@ public:
 	PiecewiseLinearInterpolation(std::vector<double>&& supporting_points,
 	                             std::vector<double>&& values_at_supp_pnts,
 	                             bool supp_pnts_sorted = false);
-
-	virtual ~PiecewiseLinearInterpolation();
 
 	/**
 	 * \brief Calculates the interpolation value.

--- a/NumLib/Function/LinearInterpolationAlongPolyline.cpp
+++ b/NumLib/Function/LinearInterpolationAlongPolyline.cpp
@@ -55,7 +55,8 @@ MathLib::PiecewiseLinearInterpolation LinearInterpolationAlongPolyline::createIn
 		}
 	}
 
-	return MathLib::PiecewiseLinearInterpolation(vec_known_dist, vec_known_values);
+	return MathLib::PiecewiseLinearInterpolation{std::move(vec_known_dist),
+	                                             std::move(vec_known_values)};
 }
 
 double LinearInterpolationAlongPolyline::operator()(const MathLib::Point3d& pnt) const

--- a/Tests/MathLib/TestPiecewiseLinearInterpolation.cpp
+++ b/Tests/MathLib/TestPiecewiseLinearInterpolation.cpp
@@ -32,7 +32,8 @@ TEST(MathLibInterpolationAlgorithms, PiecewiseLinearInterpolation)
 		}
 	}
 
-	MathLib::PiecewiseLinearInterpolation interpolation(supp_pnts, values);
+	MathLib::PiecewiseLinearInterpolation interpolation{std::move(supp_pnts),
+	                                                    std::move(values)};
 	// Interpolation
 	for (std::size_t k(0); k<size-1; ++k) {
 		ASSERT_NEAR(0.5, interpolation.getValue(k+0.5), std::numeric_limits<double>::epsilon());
@@ -67,7 +68,8 @@ TEST(MathLibInterpolationAlgorithms, PiecewiseLinearInterpolationSupportPntsInRe
 		}
 	}
 
-	MathLib::PiecewiseLinearInterpolation interpolation(supp_pnts, values);
+	MathLib::PiecewiseLinearInterpolation interpolation{std::move(supp_pnts),
+	                                                    std::move(values)};
 	// Interpolation
 	for (std::size_t k(0); k<size-1; ++k) {
 		ASSERT_NEAR(0.5, interpolation.getValue(k+0.5), std::numeric_limits<double>::epsilon());


### PR DESCRIPTION
Adds a `_curves` map from names to `MathLib::PiecewiseLinearInterpolation`s to project data when
```xml
<curves>
  <curve>
    <name>curveA</name>
    <coords>0 1 1.5</coords>
    <values>10 11 12.3</values>
  </curve>
</curves>
```
is present in the project file.

I currently use this feature to create time-dependent boundary conditions (but this is too early for PR); and @yonghui56 started work on Richard's flow, where the curves are used for parameters.