### PR TITLE
Remove mesh lib on file io dependency

### DIFF
--- a/MeshLib/MeshGenerators/MeshLayerMapper.cpp
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.cpp
@@ -18,8 +18,6 @@
 
 #include "logog/include/logog.hpp"
 
-#include "FileIO/AsciiRasterInterface.h"
-
 #include "GeoLib/Raster.h"
 
 #include "MathLib/MathTools.h"
@@ -229,18 +227,6 @@ void MeshLayerMapper::addLayerToMesh(const MeshLib::Mesh &dem_mesh, unsigned lay
             continue;
         }
     }
-}
-
-bool MeshLayerMapper::layerMapping(MeshLib::Mesh &new_mesh, std::string const& rasterfile, double noDataReplacementValue = 0.0)
-{
-	const GeoLib::Raster *raster(FileIO::AsciiRasterInterface::readRaster(rasterfile));
-	if (! raster) {
-		ERR("MshLayerMapper::layerMapping - could not read raster file %s", rasterfile.c_str());
-		return false;
-	}
-	const bool result = layerMapping(new_mesh, *raster, noDataReplacementValue);
-	delete raster;
-	return result;
 }
 
 bool MeshLayerMapper::layerMapping(MeshLib::Mesh &new_mesh, GeoLib::Raster const& raster, double noDataReplacementValue = 0.0)

--- a/MeshLib/MeshGenerators/MeshLayerMapper.h
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.h
@@ -56,8 +56,9 @@ public:
 	                        double noDataReplacementValue = 0.0);
 
 	/**
-	* Maps the elevation of nodes of a given 2D mesh according to the raster. At locations wher no
-	* information is given, node elevation is set to noDataReplacementValue.
+	* Maps the elevation of nodes of a given 2D mesh according to the raster. At
+	* locations where no information is given, node elevation is set to
+	* noDataReplacementValue.
 	*/
 	static bool layerMapping(MeshLib::Mesh &mesh, const GeoLib::Raster &raster, double noDataReplacementValue);
 

--- a/MeshLib/MeshGenerators/MeshLayerMapper.h
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.h
@@ -56,12 +56,6 @@ public:
 	                        double noDataReplacementValue = 0.0);
 
 	/**
-	* Maps the elevation of nodes of a given 2D mesh according to the raster specified by the file path.
-	* At locations wher no information is given, node elevation is set to noDataReplacementValue.
-	*/
-	static bool layerMapping(MeshLib::Mesh &mesh, const std::string &rasterfile, double noDataReplacementValue);
-
-	/**
 	* Maps the elevation of nodes of a given 2D mesh according to the raster. At locations wher no
 	* information is given, node elevation is set to noDataReplacementValue.
 	*/


### PR DESCRIPTION
Somehow this dependency slipped past my mind.
Moving reading of the file into DE.

Use instead layered mesh constructor taking a GeoLib::Raster.
Reading of the raster happens inside the application now.

Typo was "wher". No changes to the comment otherwise.