### PR TITLE
[GL] Polygon: Impl. of copy constructor and assignment operator

### DIFF
--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -396,7 +396,7 @@ void Polygon::splitPolygonAtIntersection(
 
 void Polygon::splitPolygonAtPoint (std::list<GeoLib::Polygon*>::iterator polygon_it)
 {
-	std::size_t n ((*polygon_it)->getNumberOfPoints() - 1), idx0 (0), idx1(0);
+	std::size_t n((*polygon_it)->getNumberOfPoints() - 1), idx0(0), idx1(0);
 	std::vector<std::size_t> id_vec(n);
 	std::vector<std::size_t> perm(n);
 	for (std::size_t k(0); k < n; k++)
@@ -417,27 +417,25 @@ void Polygon::splitPolygonAtPoint (std::list<GeoLib::Polygon*>::iterator polygon
 				std::swap (idx0, idx1);
 
 			// create two closed polylines
-			GeoLib::Polygon* polygon0 (new GeoLib::Polygon(*(*polygon_it)));
-			for (std::size_t k(0); k <= idx0; k++)
-				polygon0->addPoint ((*polygon_it)->getPointID (k));
-			for (std::size_t k(idx1 + 1); k < (*polygon_it)->getNumberOfPoints(); k++)
-				polygon0->addPoint ((*polygon_it)->getPointID (k));
-			polygon0->initialise();
+			GeoLib::Polyline polyline0{*(*polygon_it)};
+			for (std::size_t j(0); j <= idx0; j++)
+				polyline0.addPoint((*polygon_it)->getPointID(j));
+			for (std::size_t j(idx1 + 1);
+			     j < (*polygon_it)->getNumberOfPoints(); j++)
+				polyline0.addPoint((*polygon_it)->getPointID(j));
 
-			GeoLib::Polygon* polygon1 (new GeoLib::Polygon(*(*polygon_it)));
-			for (std::size_t k(idx0); k <= idx1; k++)
-				polygon1->addPoint ((*polygon_it)->getPointID (k));
-			polygon1->initialise();
+			GeoLib::Polyline polyline1{*(*polygon_it)};
+			for (std::size_t j(idx0); j <= idx1; j++)
+				polyline1.addPoint((*polygon_it)->getPointID(j));
 
 			// remove original polygon and add two new polygons
-			std::list<GeoLib::Polygon*>::iterator polygon0_it, polygon1_it;
-			polygon1_it =
-			        _simple_polygon_list.insert (_simple_polygon_list.erase (
-			                                             polygon_it), polygon1);
-			polygon0_it = _simple_polygon_list.insert (polygon1_it, polygon0);
+			auto polygon1_it = _simple_polygon_list.insert(
+			    _simple_polygon_list.erase(polygon_it), new Polygon(polyline1));
+			auto polygon0_it = _simple_polygon_list.insert(
+			    polygon1_it, new Polygon(polyline0));
 
-			splitPolygonAtPoint (polygon0_it);
-			splitPolygonAtPoint (polygon1_it);
+			splitPolygonAtPoint(polygon0_it);
+			splitPolygonAtPoint(polygon1_it);
 
 			return;
 		}

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -30,6 +30,14 @@ Polygon::Polygon(const Polyline &ply, bool init) :
 		initialise ();
 }
 
+Polygon::Polygon(Polygon const& other)
+    : Polyline(other), _aabb(other._aabb)
+{
+	for (auto const* sub_polygon : other._simple_polygon_list) {
+		_simple_polygon_list.emplace_back(new Polygon(*sub_polygon));
+	}
+}
+
 Polygon::~Polygon()
 {
 	// remove polygons from list

--- a/GeoLib/Polygon.h
+++ b/GeoLib/Polygon.h
@@ -53,6 +53,8 @@ public:
 	Polygon(const Polyline &ply, bool init = true);
 
 	Polygon(Polygon const& other);
+	Polygon& operator=(Polygon const& rhs) = delete;
+
 	virtual ~Polygon();
 
 	bool initialise ();

--- a/GeoLib/Polygon.h
+++ b/GeoLib/Polygon.h
@@ -52,6 +52,7 @@ public:
 	 */
 	Polygon(const Polyline &ply, bool init = true);
 
+	Polygon(Polygon const& other);
 	virtual ~Polygon();
 
 	bool initialise ();

--- a/GeoLib/Polyline.cpp
+++ b/GeoLib/Polyline.cpp
@@ -28,16 +28,12 @@ Polyline::Polyline(const std::vector<Point*>& pnt_vec) :
 	_length.push_back (0.0);
 }
 
-Polyline::Polyline(const Polyline& ply) :
-	GeoObject(), _ply_pnts (ply._ply_pnts)
-{
-	for (std::size_t k(0); k < ply.getNumberOfPoints(); ++k)
-		_ply_pnt_ids.push_back (ply.getPointID (k));
-
-	if (ply.getNumberOfPoints() > 0)
-		for (std::size_t k(0); k < ply.getNumberOfPoints(); ++k)
-			_length.push_back (ply.getLength (k));
-}
+Polyline::Polyline(const Polyline& ply)
+    : GeoObject(),
+      _ply_pnts(ply._ply_pnts),
+      _ply_pnt_ids(ply._ply_pnt_ids),
+      _length(ply._length)
+{}
 
 void Polyline::write(std::ostream &os) const
 {

--- a/GeoLib/Polyline.h
+++ b/GeoLib/Polyline.h
@@ -100,6 +100,7 @@ public:
 	 * @param ply Polyline
 	 */
 	Polyline(const Polyline& ply);
+	Polyline& operator=(Polyline const& other) = delete;
 
 	virtual ~Polyline() {}
 

--- a/Tests/GeoLib/TestPolygon.cpp
+++ b/Tests/GeoLib/TestPolygon.cpp
@@ -204,3 +204,14 @@ TEST_F(PolygonTest, isPolylineInPolygon)
 	for (std::size_t k(0); k<pnts.size(); k++)
 		delete pnts[k];
 }
+
+TEST_F(PolygonTest, CopyConstructor)
+{
+	GeoLib::Polygon polygon_copy(*_polygon);
+	ASSERT_EQ(_polygon->getNumberOfSegments(), polygon_copy.getNumberOfSegments());
+
+	// Check if all line segments of the original polygon are contained in the
+	// copy
+	for (auto const& segment : *_polygon)
+		ASSERT_TRUE(polygon_copy.containsSegment(segment));
+}


### PR DESCRIPTION
As titled.

Fixes issue #1155.

**Update (2016-04-25)**
Removed the assignment operator since it isn't used anywhere and marked it explicitly as deleted.