### PR TITLE
Prevent passing temporaries to ConfigTree ctor

### DIFF
--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -256,9 +256,16 @@ public:
      * i.e., warnings will also result in program abortion!
      */
     explicit ConfigTree(PTree const& tree,
-                           std::string const& filename,
-                           Callback const& error_cb,
-                           Callback const& warning_cb);
+                        std::string const& filename,
+                        Callback const& error_cb,
+                        Callback const& warning_cb);
+
+    /*! This constructor is deleted in order to prevent the user from passing
+     * temporary instances of \c PTree.
+     * Doing so would lead to a dangling reference \c _tree and to program crash.
+     */
+    explicit ConfigTree(PTree&&, std::string const&,
+                        Callback const&, Callback const&) = delete;
 
     //! copying is not compatible with the semantics of this class
     ConfigTree(ConfigTree const&) = delete;


### PR DESCRIPTION
This PR explicitly deletes the ctor of ConfigTree that takes an r-value reference of boost::property_tree. That way passing temporaries will lead to a compilation error.

It is tempting to pass temporaries in unit tests, e.g. when there is only an empty config tree needed to construct some objects. However, passing a temporary leads to dangling references and program crash.

The change in this PR of course will only prevent passing temporaries directly to the ctor. If they are passed, e.g., via `const&` to a function that passes them on, you are screwed :smile: