### PR TITLE
Fixed-size local matrices for multi-variable processes

### DIFF
--- a/ProcessLib/LocalAssemblerTraits.h
+++ b/ProcessLib/LocalAssemblerTraits.h
@@ -211,7 +211,7 @@ public:
 } // namespace detail
 
 
-#ifndef EIGEN_DYNAMIC_SHAPE_MATRICES
+#ifndef OGS_EIGEN_DYNAMIC_SHAPE_MATRICES
 
 template<typename ShpPol, unsigned NIntPts, unsigned NodalDOF, unsigned Dim>
 using LocalAssemblerTraits = detail::LocalAssemblerTraitsFixed<ShpPol, NIntPts, NodalDOF, Dim>;


### PR DESCRIPTION
GWFlow shall serve as a template for any other processes, at least for the time being. This PR extends GWFlow s.t. it can easily be extended to multiple variables.

Note: The given changes only allow extension to multi-variables if each of them has one component and uses the same shape functions. Generalizations of that are future work. Probably then we will need to discuss if generalizations can be done using fixed matrices (theoretically, yes, but the code could be complicated).