### PR TITLE
Misc changes

### DIFF
--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
@@ -301,7 +301,8 @@ setInitialConditions(ProjectData& project,
 
         // append a solution vector of suitable size
         _process_solutions.emplace_back(
-                    &MathLib::GlobalVectorProvider<Vector>::provider.getVector(ode_sys));
+                    &MathLib::GlobalVectorProvider<Vector>::provider.getVector(
+                        ode_sys.getMatrixSpecifications()));
 
         auto& x0 = *_process_solutions[pcs_idx];
         pcs.setInitialConditions(x0);

--- a/AssemblerLib/LocalDataInitializer.h
+++ b/AssemblerLib/LocalDataInitializer.h
@@ -11,6 +11,7 @@
 #define ASSEMBLER_LIB_LOCALDATAINITIALIZER_H_
 
 #include <functional>
+#include <memory>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>

--- a/AssemblerLib/MeshComponentMap.cpp
+++ b/AssemblerLib/MeshComponentMap.cpp
@@ -66,6 +66,8 @@ MeshComponentMap::MeshComponentMap(
         {
             MeshLib::MeshSubset const& mesh_subset =
                 c->getMeshSubset(mesh_subset_index);
+            assert(dynamic_cast<MeshLib::NodePartitionedMesh const*>(
+                       &mesh_subset.getMesh()) != nullptr);
             std::size_t const mesh_id = mesh_subset.getMeshID();
             const MeshLib::NodePartitionedMesh& mesh =
                 static_cast<const MeshLib::NodePartitionedMesh&>(

--- a/AssemblerLib/SerialExecutor.h
+++ b/AssemblerLib/SerialExecutor.h
@@ -58,12 +58,17 @@ struct SerialExecutor
     ///
     /// This method is very similar to executeDereferenced().
     ///
+    /// \param container collection of objects having pointer semantics.
+    /// \param object    the object whose method will be called.
+    /// \param method    the method being called, i.e., a member function pointer
+    ///                  to a member function of the class \c Object.
+    /// \param Args      types of further arguments passed on to the method
+    ///
     /// \see executeDereferenced()
-    template <typename Container, typename Object, typename... MethodArgs, typename... Args>
+    template <typename Container, typename Object, typename Method, typename... Args>
     static void
     executeMemberDereferenced(
-            Object& object,
-            void (Object::*method)(MethodArgs... method_args) const,
+            Object& object, Method method,
             Container const& container, Args&&... args)
     {
         for (std::size_t i = 0; i < container.size(); i++) {

--- a/MathLib/LinAlg/BLAS.cpp
+++ b/MathLib/LinAlg/BLAS.cpp
@@ -20,11 +20,27 @@ namespace MathLib { namespace BLAS
 {
 
 // Explicit specialization
+// Computes the Manhattan norm of x
+template<>
+double norm1(Eigen::VectorXd const& x)
+{
+    return x.lpNorm<1>();
+}
+
+// Explicit specialization
 // Computes the Euclidean norm of x
 template<>
 double norm2(Eigen::VectorXd const& x)
 {
     return x.norm();
+}
+
+// Explicit specialization
+// Computes the Maximum norm of x
+template<>
+double normMax(Eigen::VectorXd const& x)
+{
+    return x.lpNorm<Eigen::Infinity>();
 }
 
 } } // namespaces
@@ -75,11 +91,27 @@ void axpby(PETScVector& y, double const a, double const b, PETScVector const& x)
 }
 
 // Explicit specialization
+// Computes the Manhattan norm of x
+template<>
+double norm1(PETScVector const& x)
+{
+    return x.getNorm(MathLib::VecNormType::NORM1);
+}
+
+// Explicit specialization
 // Computes the Euclidean norm of x
 template<>
 double norm2(PETScVector const& x)
 {
     return x.getNorm(MathLib::VecNormType::NORM2);
+}
+
+// Explicit specialization
+// Computes the Maximum norm of x
+template<>
+double normMax(PETScVector const& x)
+{
+    return x.getNorm(MathLib::VecNormType::INFINITY_N);
 }
 
 
@@ -193,11 +225,27 @@ void axpby(EigenVector& y, double const a, double const b, EigenVector const& x)
 }
 
 // Explicit specialization
+// Computes the Manhattan norm of x
+template<>
+double norm1(EigenVector const& x)
+{
+    return x.getRawVector().lpNorm<1>();
+}
+
+// Explicit specialization
 // Euclidean norm
 template<>
 double norm2(EigenVector const& x)
 {
     return x.getRawVector().norm();
+}
+
+// Explicit specialization
+// Computes the Maximum norm of x
+template<>
+double normMax(EigenVector const& x)
+{
+    return x.getRawVector().lpNorm<Eigen::Infinity>();
 }
 
 

--- a/MathLib/LinAlg/BLAS.cpp
+++ b/MathLib/LinAlg/BLAS.cpp
@@ -20,6 +20,15 @@ namespace MathLib { namespace BLAS
 {
 
 // Explicit specialization
+// Computes w = x/y componentwise.
+template<>
+void componentwiseDivide(Eigen::VectorXd& w,
+                         Eigen::VectorXd const& x, Eigen::VectorXd const& y)
+{
+    w.noalias() = x.cwiseQuotient(y);
+}
+
+// Explicit specialization
 // Computes the Manhattan norm of x
 template<>
 double norm1(Eigen::VectorXd const& x)
@@ -88,6 +97,15 @@ void axpby(PETScVector& y, double const a, double const b, PETScVector const& x)
 {
     // TODO check sizes
     VecAXPBY(*y.getRawVector(), a, b, *x.getRawVector());
+}
+
+// Explicit specialization
+// Computes w = x/y componentwise.
+template<>
+void componentwiseDivide(PETScVector& w,
+                         PETScVector const& x, PETScVector const& y)
+{
+    VecPointwiseDivide(*w.getRawVector(), *x.getRawVector(), *y.getRawVector());
 }
 
 // Explicit specialization
@@ -222,6 +240,16 @@ void axpby(EigenVector& y, double const a, double const b, EigenVector const& x)
 {
     // TODO: does that break anything?
     y.getRawVector() = a*x.getRawVector() + b*y.getRawVector();
+}
+
+// Explicit specialization
+// Computes w = x/y componentwise.
+template<>
+void componentwiseDivide(EigenVector& w,
+                         EigenVector const& x, EigenVector const& y)
+{
+    w.getRawVector().noalias() =
+            x.getRawVector().cwiseQuotient(y.getRawVector());
 }
 
 // Explicit specialization

--- a/MathLib/LinAlg/BLAS.h
+++ b/MathLib/LinAlg/BLAS.h
@@ -66,6 +66,11 @@ void axpby(MatrixOrVector& y, double const a, double const b, MatrixOrVector con
     y = a*x + b*y;
 }
 
+//! Computes \f$w = x/y\f$ componentwise.
+template<typename MatrixOrVector>
+void componentwiseDivide(MatrixOrVector& w,
+                         MatrixOrVector const& x, MatrixOrVector const& y);
+
 //! Computes the Manhattan norm of \c x.
 template<typename MatrixOrVector>
 double norm1(MatrixOrVector const& x);

--- a/MathLib/LinAlg/BLAS.h
+++ b/MathLib/LinAlg/BLAS.h
@@ -66,9 +66,17 @@ void axpby(MatrixOrVector& y, double const a, double const b, MatrixOrVector con
     y = a*x + b*y;
 }
 
+//! Computes the Manhattan norm of \c x.
+template<typename MatrixOrVector>
+double norm1(MatrixOrVector const& x);
+
 //! Computes the Euclidean norm of \c x.
 template<typename MatrixOrVector>
 double norm2(MatrixOrVector const& x);
+
+//! Computes the maximum norm of \c x.
+template<typename MatrixOrVector>
+double normMax(MatrixOrVector const& x);
 
 template<typename Matrix>
 void finalizeAssembly(Matrix& /*A*/)

--- a/MathLib/LinAlg/Eigen/EigenVector.h
+++ b/MathLib/LinAlg/Eigen/EigenVector.h
@@ -50,7 +50,7 @@ public:
     std::size_t getRangeBegin() const { return 0;}
 
     /// return an end index of the active data range
-    std::size_t getRangeEnd() const { return this->size(); }
+    std::size_t getRangeEnd() const { return size(); }
 
     /// set all values in this vector
     EigenVector& operator= (double v) { _vec.setConstant(v); return *this; }
@@ -88,7 +88,7 @@ public:
     void add(const std::vector<IndexType> &pos, const T_SUBVEC &sub_vec)
     {
         for (std::size_t i=0; i<pos.size(); ++i) {
-            this->add(pos[i], sub_vec[i]);
+            add(pos[i], sub_vec[i]);
         }
     }
 
@@ -111,13 +111,13 @@ public:
     const RawVectorType& getRawVector() const {return _vec; }
 
     /// vector operation: set data
-    EigenVector& operator= (const EigenVector &src) { _vec = static_cast<const EigenVector&>(src)._vec; return *this; }
+    EigenVector& operator= (const EigenVector &src) { _vec = src._vec; return *this; }
 
     /// vector operation: add
-    void operator+= (const EigenVector& v) { _vec += static_cast<const EigenVector&>(v)._vec; }
+    void operator+= (const EigenVector& v) { _vec += v._vec; }
 
     /// vector operation: subtract
-    void operator-= (const EigenVector& v) { _vec -= static_cast<const EigenVector&>(v)._vec; }
+    void operator-= (const EigenVector& v) { _vec -= v._vec; }
 
 private:
     RawVectorType _vec;

--- a/MathLib/LinAlg/MatrixProviderUser.h
+++ b/MathLib/LinAlg/MatrixProviderUser.h
@@ -71,8 +71,6 @@ template<typename Vector>
 class VectorProvider
 {
 public:
-    using MSP = MatrixSpecificationsProvider;
-
     //! Get an uninitialized vector.
     virtual Vector& getVector() = 0;
 
@@ -86,11 +84,11 @@ public:
     virtual Vector& getVector(Vector const& x, std::size_t& id) = 0;
 
     //! Get a vector according to the given specifications.
-    virtual Vector& getVector(MSP const& msp) = 0;
+    virtual Vector& getVector(MatrixSpecifications const& ms) = 0;
 
     //! Get a vector according to the given specifications in the storage
     //! of the vector with the given \c id.
-    virtual Vector& getVector(MSP const& msp, std::size_t& id) = 0;
+    virtual Vector& getVector(MatrixSpecifications const& ms, std::size_t& id) = 0;
 
     //! Release the given vector.
     //!
@@ -109,8 +107,6 @@ template<typename Matrix>
 class MatrixProvider
 {
 public:
-    using MSP = MatrixSpecificationsProvider;
-
     //! Get an uninitialized matrix.
     virtual Matrix& getMatrix() = 0;
 
@@ -124,11 +120,11 @@ public:
     virtual Matrix& getMatrix(Matrix const& A, std::size_t& id) = 0;
 
     //! Get a matrix according to the given specifications.
-    virtual Matrix& getMatrix(MSP const& msp) = 0;
+    virtual Matrix& getMatrix(MatrixSpecifications const& ms) = 0;
 
     //! Get a matrix according to the given specifications in the storage
     //! of the matrix with the given \c id.
-    virtual Matrix& getMatrix(MSP const& msp, std::size_t& id) = 0;
+    virtual Matrix& getMatrix(MatrixSpecifications const& ms, std::size_t& id) = 0;
 
     //! Release the given matrix.
     //!

--- a/MathLib/LinAlg/PETSc/PETScVector.cpp
+++ b/MathLib/LinAlg/PETSc/PETScVector.cpp
@@ -45,7 +45,7 @@ PETScVector::PETScVector(const PetscInt vec_size, const bool is_global_size)
 PETScVector::PETScVector(const PetscInt vec_size,
                          const std::vector<PetscInt>& ghost_ids,
                          const bool is_global_size)
-    : _size_ghosts{ghost_ids.size()}
+    : _size_ghosts{static_cast<PetscInt>(ghost_ids.size())}
     , _has_ghost_id{true}
 {
     _v.reset(new PETSc_Vec);

--- a/MathLib/LinAlg/SimpleMatrixVectorProvider-impl.h
+++ b/MathLib/LinAlg/SimpleMatrixVectorProvider-impl.h
@@ -116,21 +116,19 @@ getMatrix(std::size_t& id)
 template<typename Matrix, typename Vector>
 Matrix&
 SimpleMatrixVectorProvider<Matrix, Vector>::
-getMatrix(MatrixSpecificationsProvider const& msp)
+getMatrix(MatrixSpecifications const& ms)
 {
     std::size_t id = 0u;
-    auto const& mat_spec = msp.getMatrixSpecifications();
-    return *getMatrix_<false>(id, mat_spec).first;
+    return *getMatrix_<false>(id, ms).first;
     // TODO assert that the returned object always is of the right size
 }
 
 template<typename Matrix, typename Vector>
 Matrix&
 SimpleMatrixVectorProvider<Matrix, Vector>::
-getMatrix(MatrixSpecificationsProvider const& msp, std::size_t& id)
+getMatrix(MatrixSpecifications const& ms, std::size_t& id)
 {
-    auto const& mat_spec = msp.getMatrixSpecifications();
-    return *getMatrix_<true>(id, mat_spec).first;
+    return *getMatrix_<true>(id, ms).first;
     // TODO assert that the returned object always is of the right size
 }
 
@@ -201,21 +199,19 @@ getVector(std::size_t& id)
 template<typename Matrix, typename Vector>
 Vector&
 SimpleMatrixVectorProvider<Matrix, Vector>::
-getVector(MatrixSpecificationsProvider const& msp)
+getVector(MatrixSpecifications const& ms)
 {
     std::size_t id = 0u;
-    auto const& mat_spec = msp.getMatrixSpecifications();
-    return *getVector_<false>(id, mat_spec).first;
+    return *getVector_<false>(id, ms).first;
     // TODO assert that the returned object always is of the right size
 }
 
 template<typename Matrix, typename Vector>
 Vector&
 SimpleMatrixVectorProvider<Matrix, Vector>::
-getVector(MatrixSpecificationsProvider const& msp, std::size_t& id)
+getVector(MatrixSpecifications const& ms, std::size_t& id)
 {
-    auto const& mat_spec = msp.getMatrixSpecifications();
-    return *getVector_<true>(id, mat_spec).first;
+    return *getVector_<true>(id, ms).first;
     // TODO assert that the returned object always is of the right size
 }
 

--- a/MathLib/LinAlg/SimpleMatrixVectorProvider.h
+++ b/MathLib/LinAlg/SimpleMatrixVectorProvider.h
@@ -37,16 +37,14 @@ public:
     SimpleMatrixVectorProvider(SimpleMatrixVectorProvider const&) = delete;
     SimpleMatrixVectorProvider& operator=(SimpleMatrixVectorProvider const&) = delete;
 
-    using MSP = MatrixSpecificationsProvider;
-
     Vector& getVector() override;
     Vector& getVector(std::size_t& id) override;
 
     Vector& getVector(Vector const& x) override;
     Vector& getVector(Vector const& x, std::size_t& id) override;
 
-    Vector& getVector(MSP const& msp) override;
-    Vector& getVector(MSP const& msp, std::size_t& id) override;
+    Vector& getVector(MatrixSpecifications const& ms) override;
+    Vector& getVector(MatrixSpecifications const& ms, std::size_t& id) override;
 
     void releaseVector(Vector const& x) override;
 
@@ -56,8 +54,8 @@ public:
     Matrix& getMatrix(Matrix const& A) override;
     Matrix& getMatrix(Matrix const& A, std::size_t& id) override;
 
-    Matrix& getMatrix(MSP const& msp) override;
-    Matrix& getMatrix(MSP const& msp, std::size_t& id) override;
+    Matrix& getMatrix(MatrixSpecifications const& ms) override;
+    Matrix& getMatrix(MatrixSpecifications const& ms, std::size_t& id) override;
 
     void releaseMatrix(Matrix const& A) override;
 

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.h
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.h
@@ -116,13 +116,13 @@ public:
         , _mat_trans(createMatrixTranslator<Matrix, Vector, ODETag>(time_discretization))
     {
         _Jac  = &MathLib::GlobalMatrixProvider<Matrix>::provider.getMatrix(
-                    _ode, _Jac_id);
+                    _ode.getMatrixSpecifications(), _Jac_id);
         _M    = &MathLib::GlobalMatrixProvider<Matrix>::provider.getMatrix(
-                    _ode, _M_id);
+                    _ode.getMatrixSpecifications(), _M_id);
         _K    = &MathLib::GlobalMatrixProvider<Matrix>::provider.getMatrix(
-                    _ode, _K_id);
+                    _ode.getMatrixSpecifications(), _K_id);
         _b    = &MathLib::GlobalVectorProvider<Vector>::provider.getVector(
-                    _ode, _b_id);
+                    _ode.getMatrixSpecifications(), _b_id);
     }
 
     ~TimeDiscretizedODESystem()
@@ -304,9 +304,12 @@ public:
         , _mat_trans(createMatrixTranslator<Matrix, Vector, ODETag>(
                          time_discretization))
     {
-        _M = &MathLib::GlobalMatrixProvider<Matrix>::provider.getMatrix(ode, _M_id);
-        _K = &MathLib::GlobalMatrixProvider<Matrix>::provider.getMatrix(ode, _K_id);
-        _b = &MathLib::GlobalVectorProvider<Vector>::provider.getVector(ode, _b_id);
+        _M = &MathLib::GlobalMatrixProvider<Matrix>::provider.getMatrix(
+                    ode.getMatrixSpecifications(), _M_id);
+        _K = &MathLib::GlobalMatrixProvider<Matrix>::provider.getMatrix(
+                    ode.getMatrixSpecifications(), _K_id);
+        _b = &MathLib::GlobalVectorProvider<Vector>::provider.getVector(
+                    ode.getMatrixSpecifications(), _b_id);
     }
 
     ~TimeDiscretizedODESystem()

--- a/Tests/MathLib/AutoCheckTools.h
+++ b/Tests/MathLib/AutoCheckTools.h
@@ -96,7 +96,7 @@ struct randomCoordinateIndexGenerator
     }
 };
 
-static double absoluteValue(double&& v, std::size_t)
+inline double absoluteValue(double&& v, std::size_t)
 {
     return std::abs(v);
 }


### PR DESCRIPTION
This PR is a prerequisite for #1145.

Review component-wise.
Probably the biggest change is that `MatrixVectorProvider` gets not passed a `MatrixSpecificationsProvider` anymore, but rather is called directly with `MatrixSpecifications`.