### PR TITLE
Move AssemblerLib parts to MathLib and ProcessLib

### DIFF
--- a/AssemblerLib/ComputeSparsityPattern.cpp
+++ b/AssemblerLib/ComputeSparsityPattern.cpp
@@ -7,18 +7,15 @@
  *
  */
 
-#include "MeshLib/NodeAdjacencyTable.h"
-#include "LocalToGlobalIndexMap.h"
-
 #include "ComputeSparsityPattern.h"
+
+#include "LocalToGlobalIndexMap.h"
+#include "MeshLib/NodeAdjacencyTable.h"
 
 namespace AssemblerLib
 {
-
-SparsityPattern
-computeSparsityPattern(LocalToGlobalIndexMap const& dof_table,
-        MeshLib::Mesh const& mesh
-        )
+MathLib::SparsityPattern computeSparsityPattern(
+    LocalToGlobalIndexMap const& dof_table, MeshLib::Mesh const& mesh)
 {
     MeshLib::NodeAdjacencyTable node_adjacency_table;
     node_adjacency_table.createTable(mesh.getNodes());
@@ -34,7 +31,7 @@ computeSparsityPattern(LocalToGlobalIndexMap const& dof_table,
         global_idcs.push_back(dof_table.getGlobalIndices(l));
     }
 
-    SparsityPattern sparsity_pattern(dof_table.dofSizeWithGhosts());
+    MathLib::SparsityPattern sparsity_pattern(dof_table.dofSizeWithGhosts());
 
     // Map adjacent mesh nodes to "adjacent global indices".
     for (std::size_t n=0; n<mesh.getNNodes(); ++n)

--- a/AssemblerLib/ComputeSparsityPattern.h
+++ b/AssemblerLib/ComputeSparsityPattern.h
@@ -12,6 +12,7 @@
 
 #include <vector>
 
+#include "MathLib/LinAlg/SparsityPattern.h"
 #include "ProcessLib/NumericsConfig.h"
 
 namespace MeshLib
@@ -23,9 +24,6 @@ namespace AssemblerLib
 {
 class LocalToGlobalIndexMap;
 
-/// A vector telling how many nonzeros there are in each global matrix row.
-using SparsityPattern = std::vector<GlobalIndexType>;
-
 /**
  * @brief Computes a sparsity pattern for the given inputs.
  *
@@ -34,11 +32,8 @@ using SparsityPattern = std::vector<GlobalIndexType>;
  *
  * @return The computed sparsity pattern.
  */
-SparsityPattern
-computeSparsityPattern(
-        LocalToGlobalIndexMap const& dof_table,
-        MeshLib::Mesh const& mesh
-        );
+MathLib::SparsityPattern computeSparsityPattern(
+    LocalToGlobalIndexMap const& dof_table, MeshLib::Mesh const& mesh);
 }
 
 #endif // ASSEMBLERLIB_COMPUTESPARSITYPATTERN_H

--- a/MathLib/LinAlg/MatrixProviderUser.h
+++ b/MathLib/LinAlg/MatrixProviderUser.h
@@ -12,7 +12,10 @@
 
 #include <cstddef>
 
-#include "AssemblerLib/ComputeSparsityPattern.h"
+#include "SparsityPattern.h"
+
+namespace AssemblerLib { class LocalToGlobalIndexMap; }
+namespace MeshLib { class Mesh; }
 
 namespace MathLib
 {
@@ -20,7 +23,7 @@ namespace MathLib
 struct MatrixSpecifications
 {
     MatrixSpecifications(std::size_t const nrows_, std::size_t const ncols_,
-                         AssemblerLib::SparsityPattern const*const sparsity_pattern_,
+                         SparsityPattern const*const sparsity_pattern_,
                          AssemblerLib::LocalToGlobalIndexMap const*const dof_table_,
                          MeshLib::Mesh const*const mesh_)
         : nrows(nrows_), ncols(ncols_), sparsity_pattern(sparsity_pattern_)
@@ -29,7 +32,7 @@ struct MatrixSpecifications
 
     std::size_t const nrows;
     std::size_t const ncols;
-    AssemblerLib::SparsityPattern const*const sparsity_pattern;
+    SparsityPattern const*const sparsity_pattern;
     AssemblerLib::LocalToGlobalIndexMap const*const dof_table;
     MeshLib::Mesh const*const mesh;
 };

--- a/MathLib/LinAlg/SparsityPattern.h
+++ b/MathLib/LinAlg/SparsityPattern.h
@@ -1,0 +1,23 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef MATHLIB_LINALG_SPARSITYPATTERN_H
+#define MATHLIB_LINALG_SPARSITYPATTERN_H
+
+#include <vector>
+
+#include "ProcessLib/NumericsConfig.h"
+
+namespace MathLib
+{
+/// A vector telling how many nonzeros there are in each global matrix row.
+using SparsityPattern = std::vector<GlobalIndexType>;
+}
+
+#endif // MATHLIB_LINALG_SPARSITYPATTERN_H

--- a/ProcessLib/GlobalSetup.h
+++ b/ProcessLib/GlobalSetup.h
@@ -7,12 +7,12 @@
  *
  */
 
-#ifndef ASSEMBLERLIB_GLOBALSETUP_H_
-#define ASSEMBLERLIB_GLOBALSETUP_H_
+#ifndef PROCESS_LIB_GLOBAL_SETUP_H_
+#define PROCESS_LIB_GLOBAL_SETUP_H_
 
 #include <functional>
 
-namespace AssemblerLib
+namespace ProcessLib
 {
 
 /// The GlobalSetup collects vector and matrix builder and corresponding global
@@ -64,6 +64,6 @@ struct GlobalSetup
     GlobalSetup() = delete;
 };
 
-}   // namespace AssemblerLib
+}   // namespace ProcessLib
 
-#endif  // ASSEMBLERLIB_GLOBALSETUP_H_
+#endif  // PROCESS_LIB_GLOBAL_SETUP_H_

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -17,7 +17,7 @@
 #include "ProcessLib/LocalAssemblerInterface.h"
 #include "ProcessLib/LocalAssemblerTraits.h"
 #include "ProcessLib/Parameter.h"
-#include "ProcessLib/ProcessUtil.h"
+#include "ProcessLib/Utils/InitShapeMatrices.h"
 #include "GroundwaterFlowProcessData.h"
 
 namespace ProcessLib

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -14,7 +14,7 @@
 
 #include "AssemblerLib/VectorMatrixAssembler.h"
 #include "ProcessLib/Process.h"
-#include "ProcessLib/ProcessUtil.h"
+#include "ProcessLib/Utils/CreateLocalAssemblers.h"
 
 #include "GroundwaterFlowFEM.h"
 #include "GroundwaterFlowProcessData.h"

--- a/ProcessLib/NeumannBc.h
+++ b/ProcessLib/NeumannBc.h
@@ -20,9 +20,10 @@
 #include "MeshLib/MeshSubset.h"
 #include "MeshLib/MeshSearch/NodeSearch.h"
 
+#include "Utils/CreateLocalAssemblers.h"
+
 #include "NeumannBcConfig.h"
 #include "NeumannBcAssembler.h"
-#include "ProcessUtil.h"
 
 namespace ProcessLib
 {

--- a/ProcessLib/NumericsConfig.h
+++ b/ProcessLib/NumericsConfig.h
@@ -16,7 +16,7 @@
  * This file provides a configuration of the global matrix/vector and
  * corresponding linear solver, and the global executer types.
  * The configuration is collected in the GlobalSetupType being a particular
- * instantiation of the AssemblerLib::GlobalSetup template.
+ * instantiation of the ProcessLib::GlobalSetup template.
  * The existence of the GlobalSetupType is checked at the end of the file.
  */
 
@@ -117,9 +117,9 @@ using GlobalExecutorType = AssemblerLib::SerialExecutor;
 ///
 /// Global setup collects the previous configuration in single place.
 ///
-#include "AssemblerLib/GlobalSetup.h"
+#include "GlobalSetup.h"
 using GlobalSetupType =
-    AssemblerLib::GlobalSetup<
+    ProcessLib::GlobalSetup<
         detail::GlobalVectorMatrixBuilderType,
         detail::GlobalExecutorType,
         detail::LinearSolverType>;

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -9,12 +9,6 @@
 
 #include "Process.h"
 
-#include <algorithm>
-
-#include <logog/include/logog.hpp>
-
-#include "ProcessVariable.h"
-
 namespace ProcessLib
 {
 ProcessVariable& findProcessVariable(

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -20,6 +20,7 @@
 #include "BaseLib/ConfigTree.h"
 #include "FileIO/VtkIO/VtuInterface.h"
 #include "MeshGeoToolsLib/MeshNodeSearcher.h"
+#include "MathLib/LinAlg/SparsityPattern.h"
 #include "MeshLib/MeshSubset.h"
 #include "MeshLib/MeshSubsets.h"
 
@@ -351,7 +352,7 @@ private:
 	std::unique_ptr<AssemblerLib::LocalToGlobalIndexMap>
 	    _local_to_global_index_map;
 
-	AssemblerLib::SparsityPattern _sparsity_pattern;
+	MathLib::SparsityPattern _sparsity_pattern;
 
 	std::vector<DirichletBc<GlobalIndexType>> _dirichlet_bcs;
 	std::vector<std::unique_ptr<NeumannBc<GlobalSetup>>> _neumann_bcs;

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -10,35 +10,14 @@
 #ifndef PROCESS_LIB_PROCESS_H_
 #define PROCESS_LIB_PROCESS_H_
 
-#include <memory>
-#include <string>
-
-#include <logog/include/logog.hpp>
-
 #include "AssemblerLib/ComputeSparsityPattern.h"
-#include "AssemblerLib/LocalToGlobalIndexMap.h"
-#include "BaseLib/ConfigTree.h"
 #include "FileIO/VtkIO/VtuInterface.h"
-#include "MeshGeoToolsLib/MeshNodeSearcher.h"
-#include "MathLib/LinAlg/SparsityPattern.h"
-#include "MeshLib/MeshSubset.h"
-#include "MeshLib/MeshSubsets.h"
-
-#include "DirichletBc.h"
-#include "NeumannBc.h"
-#include "NeumannBcAssembler.h"
-#include "Parameter.h"
-#include "ProcessVariable.h"
-#include "UniformDirichletBoundaryCondition.h"
-
-#include "NumLib/ODESolver/NonlinearSolver.h"
 #include "NumLib/ODESolver/ODESystem.h"
 #include "NumLib/ODESolver/TimeDiscretization.h"
+#include "NumLib/ODESolver/NonlinearSolver.h"
 
-namespace MeshLib
-{
-class Mesh;
-}
+#include "Parameter.h"
+#include "ProcessVariable.h"
 
 namespace ProcessLib
 {

--- a/ProcessLib/ProcessUtil.h
+++ b/ProcessLib/ProcessUtil.h
@@ -10,57 +10,13 @@
 #define PROCESSLIB_PROCESSUTIL_H
 
 #include <vector>
-#include <logog/include/logog.hpp>
 
-#include "AssemblerLib/LocalToGlobalIndexMap.h"
-
-#include "Utils/LocalDataInitializer.h"
+#include "MeshLib/Elements/Element.h"
+#include "NumLib/Fem/FiniteElement/TemplateIsoparametric.h"
 
 
 namespace ProcessLib
 {
-
-namespace detail
-{
-
-template<unsigned GlobalDim, typename GlobalSetup,
-         template <typename, typename, typename, typename, unsigned> class
-         LocalAssemblerImplementation,
-         typename LocalAssemblerInterface,
-         typename... ExtraCtorArgs>
-void createLocalAssemblers(
-        AssemblerLib::LocalToGlobalIndexMap const& dof_table,
-        std::vector<MeshLib::Element*> const& mesh_elements,
-        unsigned const integration_order,
-        std::vector<std::unique_ptr<LocalAssemblerInterface>>& local_assemblers,
-        ExtraCtorArgs&&... extra_ctor_args
-        )
-{
-    // Shape matrices initializer
-    using LocalDataInitializer = LocalDataInitializer<
-        LocalAssemblerInterface,
-        LocalAssemblerImplementation,
-        typename GlobalSetup::MatrixType,
-        typename GlobalSetup::VectorType,
-        GlobalDim,
-        ExtraCtorArgs...>;
-
-    DBUG("Create local assemblers.");
-    // Populate the vector of local assemblers.
-    local_assemblers.resize(mesh_elements.size());
-
-    LocalDataInitializer initializer(dof_table);
-
-    DBUG("Calling local assembler builder for all mesh elements.");
-    GlobalSetup::transformDereferenced(
-            initializer,
-            mesh_elements,
-            local_assemblers,
-            integration_order,
-            std::forward<ExtraCtorArgs>(extra_ctor_args)...);
-}
-
-} // namespace detail
 
 
 template<typename ShapeFunction, typename ShapeMatricesType, typename IntegrationMethod,
@@ -88,63 +44,6 @@ initShapeMatrices(MeshLib::Element const& e, unsigned integration_order)
     }
 
     return shape_matrices;
-}
-
-/*! Creates local assemblers for each element of the given \c mesh.
- *
- * \tparam GlobalSetup the global setup of the process
- * \tparam LocalAssemblerImplementation the individual local assembler type
- * \tparam LocalAssemblerInterface the general local assembler interface
- * \tparam ExtraCtorArgs types of additional constructor arguments.
- *         Those arguments will be passed to the constructor of
- *         \c LocalAssemblerImplementation.
- *
- * The first two template parameters cannot be deduced from the arguments.
- * Therefore they always have to be provided manually.
- */
-template<typename GlobalSetup,
-         template <typename, typename, typename, typename, unsigned> class
-         LocalAssemblerImplementation,
-         typename LocalAssemblerInterface,
-         typename... ExtraCtorArgs>
-void createLocalAssemblers(
-        const unsigned dimension,
-        std::vector<MeshLib::Element*> const& mesh_elements,
-        AssemblerLib::LocalToGlobalIndexMap const& dof_table,
-        unsigned const integration_order,
-        std::vector<std::unique_ptr<LocalAssemblerInterface>>& local_assemblers,
-        ExtraCtorArgs&&... extra_ctor_args
-        )
-{
-    DBUG("Create local assemblers.");
-
-    switch (dimension)
-    {
-    case 1:
-        detail::createLocalAssemblers<
-            1, GlobalSetup, LocalAssemblerImplementation>(
-                dof_table, mesh_elements, integration_order,
-                local_assemblers,
-                std::forward<ExtraCtorArgs>(extra_ctor_args)...);
-        break;
-    case 2:
-        detail::createLocalAssemblers<
-            2, GlobalSetup, LocalAssemblerImplementation>(
-                dof_table, mesh_elements, integration_order,
-                local_assemblers,
-                std::forward<ExtraCtorArgs>(extra_ctor_args)...);
-        break;
-    case 3:
-        detail::createLocalAssemblers<
-            3, GlobalSetup, LocalAssemblerImplementation>(
-                dof_table, mesh_elements, integration_order,
-                local_assemblers,
-                std::forward<ExtraCtorArgs>(extra_ctor_args)...);
-        break;
-    default:
-        ERR("Meshes with dimension greater than three are not supported.");
-        std::abort();
-    }
 }
 
 } // ProcessLib

--- a/ProcessLib/ProcessUtil.h
+++ b/ProcessLib/ProcessUtil.h
@@ -12,8 +12,9 @@
 #include <vector>
 #include <logog/include/logog.hpp>
 
-#include "AssemblerLib/LocalDataInitializer.h"
 #include "AssemblerLib/LocalToGlobalIndexMap.h"
+
+#include "Utils/LocalDataInitializer.h"
 
 
 namespace ProcessLib
@@ -36,7 +37,7 @@ void createLocalAssemblers(
         )
 {
     // Shape matrices initializer
-    using LocalDataInitializer = AssemblerLib::LocalDataInitializer<
+    using LocalDataInitializer = LocalDataInitializer<
         LocalAssemblerInterface,
         LocalAssemblerImplementation,
         typename GlobalSetup::MatrixType,

--- a/ProcessLib/Utils/CreateLocalAssemblers.h
+++ b/ProcessLib/Utils/CreateLocalAssemblers.h
@@ -1,0 +1,126 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ */
+
+#ifndef PROCESSLIB_UTILS_CREATE_LOCAL_ASSEMBLERS_H_
+#define PROCESSLIB_UTILS_CREATE_LOCAL_ASSEMBLERS_H_
+
+#include <vector>
+#include <logog/include/logog.hpp>
+
+#include "AssemblerLib/LocalToGlobalIndexMap.h"
+
+#include "LocalDataInitializer.h"
+
+
+namespace ProcessLib
+{
+
+namespace detail
+{
+
+template<unsigned GlobalDim, typename GlobalSetup,
+         template <typename, typename, typename, typename, unsigned> class
+         LocalAssemblerImplementation,
+         typename LocalAssemblerInterface,
+         typename... ExtraCtorArgs>
+void createLocalAssemblers(
+        AssemblerLib::LocalToGlobalIndexMap const& dof_table,
+        std::vector<MeshLib::Element*> const& mesh_elements,
+        unsigned const integration_order,
+        std::vector<std::unique_ptr<LocalAssemblerInterface>>& local_assemblers,
+        ExtraCtorArgs&&... extra_ctor_args
+        )
+{
+    // Shape matrices initializer
+    using LocalDataInitializer = LocalDataInitializer<
+        LocalAssemblerInterface,
+        LocalAssemblerImplementation,
+        typename GlobalSetup::MatrixType,
+        typename GlobalSetup::VectorType,
+        GlobalDim,
+        ExtraCtorArgs...>;
+
+    DBUG("Create local assemblers.");
+    // Populate the vector of local assemblers.
+    local_assemblers.resize(mesh_elements.size());
+
+    LocalDataInitializer initializer(dof_table);
+
+    DBUG("Calling local assembler builder for all mesh elements.");
+    GlobalSetup::transformDereferenced(
+            initializer,
+            mesh_elements,
+            local_assemblers,
+            integration_order,
+            std::forward<ExtraCtorArgs>(extra_ctor_args)...);
+}
+
+} // namespace detail
+
+
+/*! Creates local assemblers for each element of the given \c mesh.
+ *
+ * \tparam GlobalSetup the global setup of the process
+ * \tparam LocalAssemblerImplementation the individual local assembler type
+ * \tparam LocalAssemblerInterface the general local assembler interface
+ * \tparam ExtraCtorArgs types of additional constructor arguments.
+ *         Those arguments will be passed to the constructor of
+ *         \c LocalAssemblerImplementation.
+ *
+ * The first two template parameters cannot be deduced from the arguments.
+ * Therefore they always have to be provided manually.
+ */
+template<typename GlobalSetup,
+         template <typename, typename, typename, typename, unsigned> class
+         LocalAssemblerImplementation,
+         typename LocalAssemblerInterface,
+         typename... ExtraCtorArgs>
+void createLocalAssemblers(
+        const unsigned dimension,
+        std::vector<MeshLib::Element*> const& mesh_elements,
+        AssemblerLib::LocalToGlobalIndexMap const& dof_table,
+        unsigned const integration_order,
+        std::vector<std::unique_ptr<LocalAssemblerInterface>>& local_assemblers,
+        ExtraCtorArgs&&... extra_ctor_args
+        )
+{
+    DBUG("Create local assemblers.");
+
+    switch (dimension)
+    {
+    case 1:
+        detail::createLocalAssemblers<
+            1, GlobalSetup, LocalAssemblerImplementation>(
+                dof_table, mesh_elements, integration_order,
+                local_assemblers,
+                std::forward<ExtraCtorArgs>(extra_ctor_args)...);
+        break;
+    case 2:
+        detail::createLocalAssemblers<
+            2, GlobalSetup, LocalAssemblerImplementation>(
+                dof_table, mesh_elements, integration_order,
+                local_assemblers,
+                std::forward<ExtraCtorArgs>(extra_ctor_args)...);
+        break;
+    case 3:
+        detail::createLocalAssemblers<
+            3, GlobalSetup, LocalAssemblerImplementation>(
+                dof_table, mesh_elements, integration_order,
+                local_assemblers,
+                std::forward<ExtraCtorArgs>(extra_ctor_args)...);
+        break;
+    default:
+        ERR("Meshes with dimension greater than three are not supported.");
+        std::abort();
+    }
+}
+
+} // ProcessLib
+
+
+#endif // PROCESSLIB_UTILS_CREATE_LOCAL_ASSEMBLERS_H_

--- a/ProcessLib/Utils/InitShapeMatrices.h
+++ b/ProcessLib/Utils/InitShapeMatrices.h
@@ -6,8 +6,8 @@
  *              http://www.opengeosys.org/project/license
  */
 
-#ifndef PROCESSLIB_PROCESSUTIL_H
-#define PROCESSLIB_PROCESSUTIL_H
+#ifndef PROCESSLIB_UTILS_INIT_SHAPE_MATRICES_H_
+#define PROCESSLIB_UTILS_INIT_SHAPE_MATRICES_H_
 
 #include <vector>
 
@@ -49,4 +49,4 @@ initShapeMatrices(MeshLib::Element const& e, unsigned integration_order)
 } // ProcessLib
 
 
-#endif // PROCESSLIB_PROCESSUTIL_H
+#endif // PROCESSLIB_UTILS_INIT_SHAPE_MATRICES_H_

--- a/ProcessLib/Utils/LocalDataInitializer.h
+++ b/ProcessLib/Utils/LocalDataInitializer.h
@@ -7,8 +7,8 @@
  *
  */
 
-#ifndef ASSEMBLER_LIB_LOCALDATAINITIALIZER_H_
-#define ASSEMBLER_LIB_LOCALDATAINITIALIZER_H_
+#ifndef PROCESS_LIB_LOCALDATAINITIALIVER_H_
+#define PROCESS_LIB_LOCALDATAINITIALIVER_H_
 
 #include <functional>
 #include <memory>
@@ -16,9 +16,9 @@
 #include <typeinfo>
 #include <unordered_map>
 
+#include "AssemblerLib/LocalToGlobalIndexMap.h"
 #include "MeshLib/Elements/Elements.h"
 #include "NumLib/Fem/Integration/GaussIntegrationPolicy.h"
-#include "LocalToGlobalIndexMap.h"
 
 
 #ifndef OGS_MAX_ELEMENT_DIM
@@ -112,7 +112,7 @@ static_assert(false, "The macro OGS_MAX_ELEMENT_ORDER is undefined.");
 #include "NumLib/Fem/ShapeFunction/ShapePyra5.h"
 #endif
 
-namespace AssemblerLib
+namespace ProcessLib
 {
 
 /// The LocalDataInitializer is a functor creating a local assembler data with
@@ -132,7 +132,8 @@ class LocalDataInitializer final
 public:
     using LADataIntfPtr = std::unique_ptr<LocalAssemblerInterface>;
 
-    explicit LocalDataInitializer(LocalToGlobalIndexMap const& dof_table)
+    explicit LocalDataInitializer(
+        AssemblerLib::LocalToGlobalIndexMap const& dof_table)
         : _dof_table(dof_table)
     {
         // /// Lines and points ///////////////////////////////////
@@ -307,10 +308,10 @@ private:
     /// Mapping of element types to local assembler constructors.
     std::unordered_map<std::type_index, LADataBuilder> _builder;
 
-    LocalToGlobalIndexMap const& _dof_table;
+    AssemblerLib::LocalToGlobalIndexMap const& _dof_table;
 };
 
-}   // namespace AssemblerLib
+}   // namespace ProcessLib
 
 
 #undef ENABLED_ELEMENT_TYPE_SIMPLEX
@@ -322,4 +323,4 @@ private:
 #undef ENABLED_ELEMENT_TYPE_QUAD
 #undef OGS_ENABLED_ELEMENTS
 
-#endif  // ASSEMBLER_LIB_LOCALDATAINITIALIZER_H_
+#endif  // PROCESS_LIB_LOCALDATAINITIALIVER_H_

--- a/Tests/NumLib/TestExtrapolation.cpp
+++ b/Tests/NumLib/TestExtrapolation.cpp
@@ -26,6 +26,7 @@
 
 #include "ProcessLib/NumericsConfig.h"
 #include "ProcessLib/Utils/LocalDataInitializer.h"
+#include "ProcessLib/Utils/CreateLocalAssemblers.h"
 #include "ProcessLib/ProcessUtil.h"
 
 

--- a/Tests/NumLib/TestExtrapolation.cpp
+++ b/Tests/NumLib/TestExtrapolation.cpp
@@ -10,7 +10,6 @@
 #include <random>
 #include <gtest/gtest.h>
 
-#include "AssemblerLib/LocalDataInitializer.h"
 #include "AssemblerLib/VectorMatrixAssembler.h"
 
 #include "MathLib/LinAlg/BLAS.h"
@@ -26,6 +25,7 @@
 #include "NumLib/Fem/ShapeMatrixPolicy.h"
 
 #include "ProcessLib/NumericsConfig.h"
+#include "ProcessLib/Utils/LocalDataInitializer.h"
 #include "ProcessLib/ProcessUtil.h"
 
 
@@ -233,7 +233,7 @@ private:
     template<unsigned GlobalDim>
     void createLocalAssemblers(MeshLib::Mesh const& mesh)
     {
-        using LocalDataInitializer = AssemblerLib::LocalDataInitializer<
+        using LocalDataInitializer = ProcessLib::LocalDataInitializer<
             LocalAssembler, LocalAssemblerData,
             GlobalMatrix, GlobalVector, GlobalDim>;
 

--- a/Tests/NumLib/TestExtrapolation.cpp
+++ b/Tests/NumLib/TestExtrapolation.cpp
@@ -27,7 +27,7 @@
 #include "ProcessLib/NumericsConfig.h"
 #include "ProcessLib/Utils/LocalDataInitializer.h"
 #include "ProcessLib/Utils/CreateLocalAssemblers.h"
-#include "ProcessLib/ProcessUtil.h"
+#include "ProcessLib/Utils/InitShapeMatrices.h"
 
 
 namespace


### PR DESCRIPTION
 - Move SparsityPattern typedef to MathLib; Breaking one small bit of circular dependency.
 - Those parts dealing with creation of the local assemblers belong to the ProcessLib.
 - The `GlobalSetup` is used in ProcessLib/NumericsConfig.h; so it is moved to ProcessLib too.

The previously ProcessUtils.h is split into two files for `createLocalAssemblers` and `initShapeMatrices` both placed in ProcessLib/Utils/. I can imagine that ProcessLib/LocalAssemblerUtils would be a better directory name.

No code changes, just includes and moves.