### PR TITLE
Rename and cleanup dofSize relate functions

### DIFF
--- a/AssemblerLib/ComputeSparsityPattern.cpp
+++ b/AssemblerLib/ComputeSparsityPattern.cpp
@@ -34,7 +34,7 @@ computeSparsityPattern(LocalToGlobalIndexMap const& dof_table,
         global_idcs.push_back(dof_table.getGlobalIndices(l));
     }
 
-    SparsityPattern sparsity_pattern(dof_table.dofSize());
+    SparsityPattern sparsity_pattern(dof_table.dofSizeWithGhosts());
 
     // Map adjacent mesh nodes to "adjacent global indices".
     for (std::size_t n=0; n<mesh.getNNodes(); ++n)

--- a/AssemblerLib/LocalToGlobalIndexMap.cpp
+++ b/AssemblerLib/LocalToGlobalIndexMap.cpp
@@ -114,7 +114,7 @@ LocalToGlobalIndexMap* LocalToGlobalIndexMap::deriveBoundaryConstrainedMap(
 std::size_t
 LocalToGlobalIndexMap::dofSizeWithGhosts() const
 {
-    return _mesh_component_map.size();
+    return _mesh_component_map.dofSizeWithGhosts();
 }
 
 std::size_t

--- a/AssemblerLib/LocalToGlobalIndexMap.cpp
+++ b/AssemblerLib/LocalToGlobalIndexMap.cpp
@@ -9,15 +9,8 @@
 
 #include "LocalToGlobalIndexMap.h"
 
-#include "logog/include/logog.hpp"
-
-#include "AssemblerLib/MeshComponentMap.h"
-#include "MeshLib/MeshSubsets.h"
-
 namespace AssemblerLib
 {
-
-
 
 template <typename ElementIterator>
 void

--- a/AssemblerLib/LocalToGlobalIndexMap.cpp
+++ b/AssemblerLib/LocalToGlobalIndexMap.cpp
@@ -119,7 +119,7 @@ LocalToGlobalIndexMap* LocalToGlobalIndexMap::deriveBoundaryConstrainedMap(
 }
 
 std::size_t
-LocalToGlobalIndexMap::dofSize() const
+LocalToGlobalIndexMap::dofSizeWithGhosts() const
 {
     return _mesh_component_map.size();
 }

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -34,7 +34,7 @@ namespace AssemblerLib
 /// The number of rows should be equal to the number of mesh items and the
 /// number of columns should be equal to the number of the components on that
 /// mesh item.
-class LocalToGlobalIndexMap
+class LocalToGlobalIndexMap final
 {
 public:
     typedef MathLib::RowColumnIndices<GlobalIndexType> RowColumnIndices;

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -69,12 +69,6 @@ public:
         return _mesh_component_map.getNLocalUnknowns();
     }
 
-    /// Returns total number of global degrees of freedom for DDC.
-    std::size_t dofSizeGlobal() const
-    {
-        return _mesh_component_map.getNGlobalUnknowns();
-    }
-
     std::size_t size() const;
 
     std::size_t getNumComponents() const { return _mesh_subsets.size(); }

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -62,10 +62,10 @@ public:
     /// the ghost nodes.
     std::size_t dofSizeWithGhosts() const;
 
-    /// Returns total number of local degrees of freedom
-    /// of the present rank, which does not count the unknowns
-    /// associated with ghost nodes (for DDC with node-wise mesh partitioning).
-    std::size_t dofSizeLocal() const
+    /// Returns total number of local degrees of freedom of the present rank,
+    /// which does not count the unknowns associated with ghost nodes (for DDC
+    /// with node-wise mesh partitioning).
+    std::size_t dofSizeWithoutGhosts() const
     {
         return _mesh_component_map.getNLocalUnknowns();
     }

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -58,8 +58,9 @@ public:
         std::unique_ptr<MeshLib::MeshSubsets>&& mesh_subsets,
         std::vector<MeshLib::Element*> const& elements) const;
 
-    /// Returns total number of degrees of freedom.
-    std::size_t dofSize() const;
+    /// Returns total number of degrees of freedom including those located in
+    /// the ghost nodes.
+    std::size_t dofSizeWithGhosts() const;
 
     /// Returns total number of local degrees of freedom
     /// of the present rank, which does not count the unknowns

--- a/AssemblerLib/LocalToGlobalIndexMap.h
+++ b/AssemblerLib/LocalToGlobalIndexMap.h
@@ -67,7 +67,7 @@ public:
     /// with node-wise mesh partitioning).
     std::size_t dofSizeWithoutGhosts() const
     {
-        return _mesh_component_map.getNLocalUnknowns();
+        return _mesh_component_map.dofSizeWithoutGhosts();
     }
 
     std::size_t size() const;

--- a/AssemblerLib/MeshComponentMap.cpp
+++ b/AssemblerLib/MeshComponentMap.cpp
@@ -10,15 +10,13 @@
  *
  */
 
-#include <iostream>
+#include "MeshComponentMap.h"
 
 #include "MeshLib/MeshSubsets.h"
 
 #ifdef USE_PETSC
 #include "MeshLib/NodePartitionedMesh.h"
 #endif
-
-#include "MeshComponentMap.h"
 
 namespace AssemblerLib
 {

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -54,7 +54,7 @@ public:
     MeshComponentMap getSubset(std::size_t const component_id,
                                MeshLib::MeshSubsets const& components) const;
 
-    /// The number of components in the map.
+    /// The number of dofs including the those located in the ghost nodes.
     std::size_t size() const
     {
         return _dict.size();

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -119,12 +119,6 @@ public:
     std::vector<GlobalIndexType> getGlobalIndicesByComponent(
         const std::vector<Location>& ls) const;
 
-    /// Get the number of global unknowns (for DDC).
-    std::size_t getNGlobalUnknowns() const
-    {
-        return _num_global_dof;
-    }
-
     /// Get the number of local unknowns excluding those associated
     /// with ghost nodes (for DDC with node-wise mesh partitioning).
     std::size_t getNLocalUnknowns() const
@@ -183,12 +177,14 @@ private:
 
     detail::ComponentGlobalIndexDict _dict;
 
-    /// Number of global unknowns.
-    std::size_t _num_global_dof = 0;
-
     /// Number of local unknowns excluding those associated
     /// with ghost nodes (for domain decomposition).
     std::size_t _num_local_dof  = 0;
+
+#ifdef USE_PETSC
+    /// Number of global unknowns. Used internally only.
+    std::size_t _num_global_dof = 0;
+#endif
 
     /// Number of components
     /// introduced mainly for error checking

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -13,10 +13,6 @@
 #ifndef ASSEMBLERLIB_MESHCOMPONENTMAP_H_
 #define ASSEMBLERLIB_MESHCOMPONENTMAP_H_
 
-#include <vector>
-
-#include "MeshLib/Location.h"
-
 #include "ComponentGlobalIndexDict.h"
 
 namespace MeshLib

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -51,7 +51,7 @@ public:
                                MeshLib::MeshSubsets const& components) const;
 
     /// The number of dofs including the those located in the ghost nodes.
-    std::size_t size() const
+    std::size_t dofSizeWithGhosts() const
     {
         return _dict.size();
     }
@@ -117,7 +117,7 @@ public:
 
     /// Get the number of local unknowns excluding those associated
     /// with ghost nodes (for DDC with node-wise mesh partitioning).
-    std::size_t getNLocalUnknowns() const
+    std::size_t dofSizeWithoutGhosts() const
     {
         return _num_local_dof;
     }

--- a/AssemblerLib/MeshComponentMap.h
+++ b/AssemblerLib/MeshComponentMap.h
@@ -31,7 +31,7 @@ enum class ComponentOrder
 };
 
 /// Multidirectional mapping between mesh entities and degrees of freedom.
-class MeshComponentMap
+class MeshComponentMap final
 {
 public:
     typedef MeshLib::Location Location;

--- a/MathLib/LinAlg/MatrixVectorTraits.cpp
+++ b/MathLib/LinAlg/MatrixVectorTraits.cpp
@@ -34,7 +34,7 @@ std::unique_ptr<Eigen::MatrixXd>
 MatrixVectorTraits<Eigen::MatrixXd>::
 newInstance(MatrixSpecifications const& spec)
 {
-    auto const nrows = spec.dof_table ? spec.dof_table->dofSize() : spec.nrows;
+    auto const nrows = spec.dof_table ? spec.dof_table->dofSizeWithGhosts() : spec.nrows;
     auto const ncols = spec.dof_table ? nrows : spec.ncols;
 
     return std::unique_ptr<Eigen::MatrixXd>(new Eigen::MatrixXd(nrows, ncols));
@@ -58,7 +58,7 @@ std::unique_ptr<Eigen::VectorXd>
 MatrixVectorTraits<Eigen::VectorXd>::
 newInstance(MatrixSpecifications const& spec)
 {
-    auto const nrows = spec.dof_table ? spec.dof_table->dofSize() : spec.nrows;
+    auto const nrows = spec.dof_table ? spec.dof_table->dofSizeWithGhosts() : spec.nrows;
 
     return std::unique_ptr<Eigen::VectorXd>(new Eigen::VectorXd(nrows));
 }
@@ -177,7 +177,7 @@ std::unique_ptr<EigenMatrix>
 MatrixVectorTraits<EigenMatrix>::
 newInstance(MatrixSpecifications const& spec)
 {
-    auto const nrows = spec.dof_table ? spec.dof_table->dofSize() : spec.nrows;
+    auto const nrows = spec.dof_table ? spec.dof_table->dofSizeWithGhosts() : spec.nrows;
 
     auto A = std::unique_ptr<EigenMatrix>(new EigenMatrix(nrows));
 
@@ -205,7 +205,7 @@ std::unique_ptr<EigenVector>
 MatrixVectorTraits<EigenVector>::
 newInstance(MatrixSpecifications const& spec)
 {
-    auto const nrows = spec.dof_table ? spec.dof_table->dofSize() : spec.nrows;
+    auto const nrows = spec.dof_table ? spec.dof_table->dofSizeWithGhosts() : spec.nrows;
 
     return std::unique_ptr<EigenVector>(new EigenVector(nrows));
 }

--- a/MathLib/LinAlg/MatrixVectorTraits.cpp
+++ b/MathLib/LinAlg/MatrixVectorTraits.cpp
@@ -93,7 +93,8 @@ std::unique_ptr<PETScMatrix>
 MatrixVectorTraits<PETScMatrix>::
 newInstance(MatrixSpecifications const& spec)
 {
-    auto const nrows = spec.dof_table ? spec.dof_table->dofSizeLocal() : spec.nrows;
+    auto const nrows =
+        spec.dof_table ? spec.dof_table->dofSizeWithoutGhosts() : spec.nrows;
     auto const ncols = spec.dof_table ? nrows : spec.ncols;
 
     // TODO I guess it is not hard to make AssemblerLib::computeSparsityPattern()
@@ -143,8 +144,8 @@ newInstance(MatrixSpecifications const& spec)
 
     if (spec.dof_table) {
         auto const& dt = *spec.dof_table;
-        return std::unique_ptr<PETScVector>(
-            new PETScVector(dt.dofSizeLocal(), dt.getGhostIndices(), is_global_size));
+        return std::unique_ptr<PETScVector>(new PETScVector(
+            dt.dofSizeWithoutGhosts(), dt.getGhostIndices(), is_global_size));
     } else {
         return std::unique_ptr<PETScVector>(
             new PETScVector(spec.nrows, is_global_size));

--- a/Tests/AssemblerLib/LocalToGlobalIndexMap.cpp
+++ b/Tests/AssemblerLib/LocalToGlobalIndexMap.cpp
@@ -62,7 +62,7 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapTest, DISABLED_NumberOfRowsByComponent)
 
     // There must be as many rows as nodes in the input times the number of
     // components.
-    ASSERT_EQ(mesh->getNNodes() * components_size, dof_map->dofSize());
+    ASSERT_EQ(mesh->getNNodes() * components_size, dof_map->dofSizeWithGhosts());
 }
 
 #ifndef USE_PETSC
@@ -80,7 +80,7 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapTest, DISABLED_NumberOfRowsByLocation)
 
     // There must be as many rows as nodes in the input times the number of
     // components.
-    ASSERT_EQ(mesh->getNNodes() * components_size, dof_map->dofSize());
+    ASSERT_EQ(mesh->getNNodes() * components_size, dof_map->dofSizeWithGhosts());
 }
 
 #ifndef USE_PETSC
@@ -114,5 +114,5 @@ TEST_F(AssemblerLibLocalToGlobalIndexMapTest, DISABLED_SubsetByComponent)
 
     // There must be as many rows as nodes in the input times the number of
     // components.
-    ASSERT_EQ(selected_nodes.size(), dof_map_subset->dofSize());
+    ASSERT_EQ(selected_nodes.size(), dof_map_subset->dofSizeWithGhosts());
 }

--- a/Tests/AssemblerLib/TestMeshComponentMap.cpp
+++ b/Tests/AssemblerLib/TestMeshComponentMap.cpp
@@ -79,7 +79,7 @@ TEST_F(AssemblerLibMeshComponentMapTest, DISABLED_CheckOrderByComponent)
     cmap = new MeshComponentMap(components,
         AssemblerLib::ComponentOrder::BY_COMPONENT);
 
-    ASSERT_EQ(2 * mesh->getNNodes(), cmap->size());
+    ASSERT_EQ(2 * mesh->getNNodes(), cmap->dofSizeWithGhosts());
     for (std::size_t i = 0; i < mesh_size; i++)
     {
         // Test global indices for the different components of the node.
@@ -107,7 +107,7 @@ TEST_F(AssemblerLibMeshComponentMapTest, DISABLED_CheckOrderByLocation)
     cmap = new MeshComponentMap(components,
         AssemblerLib::ComponentOrder::BY_LOCATION);
 
-    ASSERT_EQ(2 * mesh->getNNodes(), cmap->size());
+    ASSERT_EQ(2 * mesh->getNNodes(), cmap->dofSizeWithGhosts());
     for (std::size_t i = 0; i < mesh_size; i++)
     {
         // Test global indices for the different components of the node.
@@ -168,7 +168,7 @@ TEST_F(AssemblerLibMeshComponentMapTest, DISABLED_SubsetOfNodesByComponent)
         cmap->getSubset(selected_component_id, *selected_component);
 
     // Check number of components as selected
-    ASSERT_EQ(ids.size(), cmap_subset.size());
+    ASSERT_EQ(ids.size(), cmap_subset.dofSizeWithGhosts());
 
     // .. and the content of the subset.
     for (std::size_t id : ids)
@@ -205,7 +205,7 @@ TEST_F(AssemblerLibMeshComponentMapTest, DISABLED_SubsetOfNodesByLocation)
         cmap->getSubset(selected_component_id, *selected_component);
 
     // Check number of components as selected
-    ASSERT_EQ(ids.size(), cmap_subset.size());
+    ASSERT_EQ(ids.size(), cmap_subset.dofSizeWithGhosts());
 
     // .. and the content of the subset.
     for (std::size_t id : ids)

--- a/Tests/AssemblerLib/TestSerialLinearSolver.cpp
+++ b/Tests/AssemblerLib/TestSerialLinearSolver.cpp
@@ -68,12 +68,12 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
     typedef GlobalSetup::VectorType GlobalVector;
     typedef GlobalSetup::MatrixType GlobalMatrix;
     auto A = std::unique_ptr<GlobalMatrix>{
-             GlobalSetup::createMatrix(local_to_global_index_map.dofSize())};
+             GlobalSetup::createMatrix(local_to_global_index_map.dofSizeWithGhosts())};
     A->setZero();
     auto rhs = std::unique_ptr<GlobalVector>{
-               GlobalSetup::createVector(local_to_global_index_map.dofSize())};
+               GlobalSetup::createVector(local_to_global_index_map.dofSizeWithGhosts())};
     auto x   = std::unique_ptr<GlobalVector>{
-               GlobalSetup::createVector(local_to_global_index_map.dofSize())};
+               GlobalSetup::createVector(local_to_global_index_map.dofSizeWithGhosts())};
     // TODO no setZero() for rhs, x?
 
     using LocalAssembler = Example::LocalAssemblerData<GlobalMatrix, GlobalVector>;
@@ -110,7 +110,7 @@ TEST(AssemblerLibSerialLinearSolver, Steady2DdiffusionQuadElem)
 
     // Call global assembler for each mesh element.
     auto M_dummy = std::unique_ptr<GlobalMatrix>{
-        GlobalSetup::createMatrix(local_to_global_index_map.dofSize())};
+        GlobalSetup::createMatrix(local_to_global_index_map.dofSizeWithGhosts())};
     A->setZero();
     auto const t = 0.0;
     GlobalSetup::executeMemberDereferenced(

--- a/Tests/AssemblerLib/TestVectorMatrixBuilder.cpp
+++ b/Tests/AssemblerLib/TestVectorMatrixBuilder.cpp
@@ -68,10 +68,10 @@ TYPED_TEST_P(AssemblerLibVectorMatrixBuilder, DISABLED_createVector)
 {
     typedef typename TestFixture::VectorType V;
     typedef TypeParam Builder;
-    V* v = Builder::createVector(this->cmap->size());
+    V* v = Builder::createVector(this->cmap->dofSizeWithGhosts());
 
     ASSERT_TRUE(v != nullptr);
-    ASSERT_EQ(this->cmap->size(), v->size());
+    ASSERT_EQ(this->cmap->dofSizeWithGhosts(), v->size());
 
     delete v;
 }
@@ -84,11 +84,11 @@ TYPED_TEST_P(AssemblerLibVectorMatrixBuilder, DISABLED_createMatrix)
 {
     typedef typename TestFixture::MatrixType M;
     typedef TypeParam Builder;
-    M* m = Builder::createMatrix(this->cmap->size());
+    M* m = Builder::createMatrix(this->cmap->dofSizeWithGhosts());
 
     ASSERT_TRUE(m != nullptr);
-    ASSERT_EQ(this->cmap->size(), m->getNRows());
-    ASSERT_EQ(this->cmap->size(), m->getNCols());
+    ASSERT_EQ(this->cmap->dofSizeWithGhosts(), m->getNRows());
+    ASSERT_EQ(this->cmap->dofSizeWithGhosts(), m->getNCols());
 
     delete m;
 }


### PR DESCRIPTION
 - Remove unused code.
 - Rename two of very similar named dofSize* functions to clarify their meaning.
 - Remove not strictly required includes.