### PR TITLE
Fix for Windows submodule and disable unstable builds on warnings (Jenkins)

### DIFF
--- a/scripts/cmake/Find.cmake
+++ b/scripts/cmake/Find.cmake
@@ -22,6 +22,7 @@ find_package(cppcheck QUIET)
 find_package(PythonInterp QUIET)
 
 find_package(Git REQUIRED)
+string(REPLACE "mingw64/" "" GIT_EXECUTABLE ${GIT_EXECUTABLE}) # Windows git submodule fix
 set(GIT_TOOL_PATH ${GIT_EXECUTABLE} CACHE FILEPATH "The git command line interface" FORCE)
 
 # Find bash itself ...

--- a/scripts/jenkins/gcc.groovy
+++ b/scripts/jenkins/gcc.groovy
@@ -42,7 +42,7 @@ def publishTestReports(ctestPattern, gtestPattern, parseRulefile) {
 			[$class: 'GoogleTestType', deleteOutputFiles: true, failIfNotNew: true, pattern: "${gtestPattern}", skipNoTestFiles: false, stopProcessingIfError: true]]
 	])
 
-	step([$class: 'LogParserPublisher', failBuildOnError: true, unstableOnWarning: true,
+	step([$class: 'LogParserPublisher', failBuildOnError: true, unstableOnWarning: false,
 			projectRulePath: "${parseRulefile}", useProjectRule: true])
 
 	step([$class: 'GitHubCommitNotifier', resultOnFailure: 'FAILURE', statusMessage: [content: 'Finished Jenkins gcc build']])

--- a/scripts/jenkins/gcc.groovy
+++ b/scripts/jenkins/gcc.groovy
@@ -8,29 +8,33 @@ node('docker')
 	stage 'Checkout'
 	dir('ogs') { checkout scm }
 
-	stage 'Build'
-	docker.image('ogs6/gcc-base:latest')
-		.inside(defaultDockerArgs) {
-			build 'build', '', 'tests ctest'
-		}
+	docker.image('ogs6/gcc-base:latest').inside(defaultDockerArgs)
+	{
+		stage 'Configure'
+		configure 'build', ''
 
+		stage 'Build'
+		build 'build', ''
+		if (env.BRANCH_NAME == 'master')
+			build 'build', 'package'
+
+		stage 'Test'
+		build 'build', 'tests ctest'
+	}
+
+	stage 'Post'
 	publishTestReports 'build/Testing/**/*.xml', 'build/Tests/testrunner.xml',
 		'ogs/scripts/jenkins/clang-log-parser.rules'
 
-	if (env.BRANCH_NAME == 'master') {
-		build 'build', '', 'package'
-		archive 'build*/*.tar.gz'
-	}
+	archive 'build*/*.tar.gz'
 }
 
-
-def build(buildDir, cmakeOptions, target) {
+def configure(buildDir, cmakeOptions) {
 	sh "rm -rf ${buildDir} && mkdir ${buildDir}"
-
-	stage 'Configure'
 	sh "cd ${buildDir} && cmake ../ogs ${defaultCMakeOptions} ${cmakeOptions}"
+}
 
-	stage 'Build'
+def build(buildDir, target) {
 	sh "cd ${buildDir} && make -j \$(nproc) ${target}"
 }
 

--- a/scripts/jenkins/gcc.groovy
+++ b/scripts/jenkins/gcc.groovy
@@ -11,14 +11,16 @@ node('docker')
 	stage 'Build'
 	docker.image('ogs6/gcc-base:latest')
 		.inside(defaultDockerArgs) {
-			build 'build', '', 'package tests ctest'
+			build 'build', '', 'tests ctest'
 		}
 
 	publishTestReports 'build/Testing/**/*.xml', 'build/Tests/testrunner.xml',
 		'ogs/scripts/jenkins/clang-log-parser.rules'
 
-	if (env.BRANCH_NAME == 'master')
+	if (env.BRANCH_NAME == 'master') {
+		build 'build', '', 'package'
 		archive 'build*/*.tar.gz'
+	}
 }
 
 


### PR DESCRIPTION
The first commit was already pushed a few days ago but maybe was overwritten by a fast-forward. No worries.

The second commit fixes currently failing Pull Requests because of Jenkins marking builds as unstable when there were warnings detected by the console log parser.