### PR TITLE
Fix compilation for PETSc 3.7.0

### DIFF
--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
@@ -46,7 +46,11 @@ PETScLinearSolver::PETScLinearSolver(const std::string /*prefix*/,
             }
         }
     }
+#if PETSC_VERSION_LT(3,7,0)
     PetscOptionsInsertString(petsc_options.c_str());
+#else
+    PetscOptionsInsertString(nullptr, petsc_options.c_str());
+#endif
 
     KSPCreate(PETSC_COMM_WORLD, &_solver);
 


### PR DESCRIPTION
Archlinux now has PETSc 3.7.0 in its repos. This PR accounts for a small API change.