### PR TITLE
[NL] fixed error computation

### DIFF
--- a/NumLib/ODESolver/NonlinearSolver-impl.h
+++ b/NumLib/ODESolver/NonlinearSolver-impl.h
@@ -70,6 +70,8 @@ solve(Vector &x)
         }
         else
         {
+            sys.applyKnownSolutions(x_new);
+
             switch(sys.postIteration(x_new))
             {
             case IterationResult::SUCCESS:
@@ -193,6 +195,7 @@ solve(Vector &x)
             auto& x_new =
                     MathLib::GlobalVectorProvider<Vector>::provider.getVector(x, _x_new_id);
             BLAS::axpy(x_new, -_alpha, minus_delta_x);
+            sys.applyKnownSolutions(x_new);
 
             switch(sys.postIteration(x_new))
             {


### PR DESCRIPTION
Picard iteration convergence is dramatically improved when applying Dirichlet BCs before computing errors but after solving the linearized system. I guess, the same holds for Newton.
I hope that will finally fix #1180.