### PR TITLE
set false to AllowShortIfStatementsOnASingleLine in clang-format 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,6 +3,7 @@ Language:        Cpp
 BasedOnStyle:    Google
 
 AccessModifierOffset: -4
+AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 BreakBeforeBraces: Allman


### PR DESCRIPTION
I would like to suggest setting `AllowShortIfStatementsOnASingleLine: false` in clang-format. Without this, 
```
    if (!someVar) {
        return;
    }
```
will be changed to 
```
    if (!someVar) return;
```

However I intentionally use the former because I can set a breakpoint to the line `return;`.  

