### PR TITLE
[FileIO] GmshInterface 

### DIFF
--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -898,11 +898,11 @@ void MainWindow::callGMSH(std::vector<std::string> & selectedGeometries,
         if (!fileName.isEmpty())
         {
             if (param4 == -1) { // adaptive meshing selected
-                gmsh_io.setPrecision(20);
                 GMSHInterface gmsh_io(
                     *(_project.getGEOObjects()), true,
                     FileIO::GMSH::MeshDensityAlgorithm::AdaptiveMeshDensity,
                     param2, param3, param1, selectedGeometries);
+                gmsh_io.setPrecision(std::numeric_limits<double>::digits10);
                 gmsh_io.writeToFile(fileName.toStdString());
             } else { // homogeneous meshing selected
                 GMSHInterface gmsh_io(

--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -426,15 +426,18 @@ void MainWindow::save()
     }
     else if (fi.suffix().toLower() == "geo")
     {
-        int const return_val =
-            FileIO::GMSHInterface::writeGeoFile(_project.getGEOObjects(), fileName.toStdString());
+        std::vector<std::string> selected_geometries;
+        _project.getGEOObjects().getGeometryNames(selected_geometries);
 
-        if (return_val == 1)
+        GMSHInterface gmsh_io(
+            _project.getGEOObjects(), true,
+            FileIO::GMSH::MeshDensityAlgorithm::AdaptiveMeshDensity,
+            0.05, 0.5, 2, selected_geometries);
+        gmsh_io.setPrecision(std::numeric_limits<double>::digits10);
+        bool const success = gmsh_io.writeToFile(fileName.toStdString());
+
+        if (!success)
             OGSError::box(" No geometry available\n to write to geo-file");
-        else if (return_val == 2)
-            OGSError::box("Error merging geometries");
-        else if (return_val == 3)
-            OGSError::box("Error writing geo-file.");
     }
 }
 
@@ -899,14 +902,14 @@ void MainWindow::callGMSH(std::vector<std::string> & selectedGeometries,
         {
             if (param4 == -1) { // adaptive meshing selected
                 GMSHInterface gmsh_io(
-                    *(_project.getGEOObjects()), true,
+                    _project.getGEOObjects(), true,
                     FileIO::GMSH::MeshDensityAlgorithm::AdaptiveMeshDensity,
                     param2, param3, param1, selectedGeometries);
                 gmsh_io.setPrecision(std::numeric_limits<double>::digits10);
                 gmsh_io.writeToFile(fileName.toStdString());
             } else { // homogeneous meshing selected
                 GMSHInterface gmsh_io(
-                    *(_project.getGEOObjects()), true,
+                    _project.getGEOObjects(), true,
                     FileIO::GMSH::MeshDensityAlgorithm::FixedMeshDensity,
                     param4, param3, param1, selectedGeometries);
                 gmsh_io.setPrecision(std::numeric_limits<double>::digits10);

--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -898,16 +898,18 @@ void MainWindow::callGMSH(std::vector<std::string> & selectedGeometries,
         if (!fileName.isEmpty())
         {
             if (param4 == -1) { // adaptive meshing selected
-                GMSHInterface gmsh_io(*(static_cast<GeoLib::GEOObjects*> (&_project.getGEOObjects())), true,
-                                FileIO::GMSH::MeshDensityAlgorithm::AdaptiveMeshDensity, param2, param3, param1,
-                                selectedGeometries);
                 gmsh_io.setPrecision(20);
+                GMSHInterface gmsh_io(
+                    *(_project.getGEOObjects()), true,
+                    FileIO::GMSH::MeshDensityAlgorithm::AdaptiveMeshDensity,
+                    param2, param3, param1, selectedGeometries);
                 gmsh_io.writeToFile(fileName.toStdString());
             } else { // homogeneous meshing selected
-                GMSHInterface gmsh_io(*(static_cast<GeoLib::GEOObjects*> (&_project.getGEOObjects())), true,
-                                FileIO::GMSH::MeshDensityAlgorithm::FixedMeshDensity, param4, param3, param1,
-                                selectedGeometries);
-                gmsh_io.setPrecision(20);
+                GMSHInterface gmsh_io(
+                    *(_project.getGEOObjects()), true,
+                    FileIO::GMSH::MeshDensityAlgorithm::FixedMeshDensity,
+                    param4, param3, param1, selectedGeometries);
+                gmsh_io.setPrecision(std::numeric_limits<double>::digits10);
                 gmsh_io.writeToFile(fileName.toStdString());
             }
 

--- a/Applications/Utils/FileConverter/GMSH2OGS.cpp
+++ b/Applications/Utils/FileConverter/GMSH2OGS.cpp
@@ -45,7 +45,7 @@ int main (int argc, char* argv[])
     TCLAP::ValueArg<std::string> ogs_mesh_arg(
         "o",
         "out",
-        "filename for output mesh (if extension is msh, old OGS fileformat is written)",
+        "filename for output mesh (if extension is .msh, old OGS-5 fileformat is written, if extension is .vtu, a vtk unstructure grid file is written (OGS-6 mesh format))",
         true,
         "",
         "filename as string");

--- a/FileIO/GMSHInterface.cpp
+++ b/FileIO/GMSHInterface.cpp
@@ -1,18 +1,10 @@
 /**
- * \file
- * \author Thomas Fischer
- * \date   2010-04-29
- * \brief  Implementation of the GMSHInterface class.
  *
  * \copyright
  * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
  *            Distributed under a Modified BSD License.
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
- *
- * @file GMSHInterface.cpp
- * @date 2010-04-29
- * @author Thomas Fischer
  */
 
 #include <fstream>

--- a/FileIO/GMSHInterface.cpp
+++ b/FileIO/GMSHInterface.cpp
@@ -332,7 +332,9 @@ int GMSHInterface::writeGMSHInputFile(std::ostream& out)
         remove_geometry = false;
     }
 
-    std::vector<GeoLib::Point*> * merged_pnts(const_cast<std::vector<GeoLib::Point*> *>(_geo_objs.getPointVec(_gmsh_geo_name)));
+    std::vector<GeoLib::Point*>* merged_pnts(
+        const_cast<std::vector<GeoLib::Point*>*>(
+            _geo_objs.getPointVec(_gmsh_geo_name)));
     if (! merged_pnts) {
         ERR("GMSHInterface::writeGMSHInputFile(): Did not found any points.");
         return 2;
@@ -352,16 +354,18 @@ int GMSHInterface::writeGMSHInputFile(std::ostream& out)
             (*pnt)[2] = 0.0;
     }
 
-    std::vector<GeoLib::Polyline*> const* merged_plys(_geo_objs.getPolylineVec(_gmsh_geo_name));
+    std::vector<GeoLib::Polyline*> const* merged_plys(
+        _geo_objs.getPolylineVec(_gmsh_geo_name));
     DBUG("GMSHInterface::writeGMSHInputFile(): \t ok.");
 
     if (!merged_plys) {
-        ERR("GMSHInterface::writeGMSHInputFile(): Did not found any polylines.");
+        ERR("GMSHInterface::writeGMSHInputFile(): Did not find any polylines.");
         return 2;
     }
 
     // *** compute and insert all intersection points between polylines
-    GeoLib::PointVec &pnt_vec(*const_cast<GeoLib::PointVec*>(_geo_objs.getPointVecObj(_gmsh_geo_name)));
+    GeoLib::PointVec& pnt_vec(*const_cast<GeoLib::PointVec*>(
+        _geo_objs.getPointVecObj(_gmsh_geo_name)));
     GeoLib::computeAndInsertAllIntersectionPoints(pnt_vec,
         *(const_cast<std::vector<GeoLib::Polyline*>*>(merged_plys)));
 
@@ -377,9 +381,15 @@ int GMSHInterface::writeGMSHInputFile(std::ostream& out)
             );
         }
     }
-    DBUG("GMSHInterface::writeGMSHInputFile(): Compute topological hierarchy - detected %d polygons.", _polygon_tree_list.size());
+    DBUG(
+        "GMSHInterface::writeGMSHInputFile(): Computed topological hierarchy - "
+        "detected %d polygons.",
+        _polygon_tree_list.size());
     GeoLib::createPolygonTrees<GMSH::GMSHPolygonTree>(_polygon_tree_list);
-    DBUG("GMSHInterface::writeGMSHInputFile(): Compute topological hierarchy - calculated %d polygon trees.", _polygon_tree_list.size());
+    DBUG(
+        "GMSHInterface::writeGMSHInputFile(): Computed topological hierarchy - "
+        "calculated %d polygon trees.",
+        _polygon_tree_list.size());
 
     // *** Mark in each polygon tree the segments shared by two polygons.
     for (auto it(_polygon_tree_list.begin()); it != _polygon_tree_list.end(); it++) {

--- a/FileIO/GMSHInterface.cpp
+++ b/FileIO/GMSHInterface.cpp
@@ -338,10 +338,19 @@ int GMSHInterface::writeGMSHInputFile(std::ostream& out)
         return 2;
     }
 
-    // Rotate points to the x-y-plane.
-    _inverse_rot_mat = GeoLib::rotatePointsToXY(*merged_pnts);
-    // Compute inverse rotation matrix to reverse the rotation later on.
-    _inverse_rot_mat.transposeInPlace();
+    if (_rotate) {
+        // Rotate points to the x-y-plane.
+        _inverse_rot_mat = GeoLib::rotatePointsToXY(*merged_pnts);
+        // Compute inverse rotation matrix to reverse the rotation later on.
+        _inverse_rot_mat.transposeInPlace();
+    } else {
+        // project data on the x-y-plane
+        _inverse_rot_mat(0,0) = 1.0;
+        _inverse_rot_mat(1,1) = 1.0;
+        _inverse_rot_mat(2,2) = 1.0;
+        for (auto pnt : *merged_pnts)
+            (*pnt)[2] = 0.0;
+    }
 
     std::vector<GeoLib::Polyline*> const* merged_plys(_geo_objs.getPolylineVec(_gmsh_geo_name));
     DBUG("GMSHInterface::writeGMSHInputFile(): \t ok.");

--- a/FileIO/GMSHInterface.cpp
+++ b/FileIO/GMSHInterface.cpp
@@ -396,6 +396,24 @@ void GMSHInterface::writeGMSHInputFile(std::ostream& out)
         return;
     }
 
+    // *** compute and insert all intersection points between polylines
+    GeoLib::PointVec * pnt_vec(const_cast<GeoLib::PointVec*>(_geo_objs.getPointVecObj(_gmsh_geo_name)));
+    for (auto it0(merged_plys->begin()); it0 != merged_plys->end(); it0++) {
+        auto it1(it0);
+        it1++;
+        for (; it1 != merged_plys->end(); it1++) {
+            std::vector<std::tuple<std::size_t, std::size_t, GeoLib::Point>> intersection_info(
+                GeoLib::computeIntersectionPoints(*(*it0), *(*it1)));
+
+            for (auto it(intersection_info.begin()); it != intersection_info.end(); it++) {
+                // add point to GeoLib::PointVec object
+                std::size_t const id(pnt_vec->push_back(new GeoLib::Point(std::get<2>(*it))));
+                (*it0)->insertPoint(std::get<0>(*it)+1, id); // insert intersection pnt in ply
+                (*it1)->insertPoint(std::get<1>(*it)+1, id); // insert intersection pnt in ply
+            }
+        }
+    }
+
     // *** compute topological hierarchy of polygons
     for (std::vector<GeoLib::Polyline*>::const_iterator it(merged_plys->begin());
         it!=merged_plys->end(); it++) {

--- a/FileIO/GMSHInterface.cpp
+++ b/FileIO/GMSHInterface.cpp
@@ -35,6 +35,7 @@
 #include "GeoLib/Polygon.h"
 #include "GeoLib/Polyline.h"
 #include "GeoLib/PolylineWithSegmentMarker.h"
+#include "GeoLib/PolygonWithSegmentMarker.h"
 #include "GeoLib/QuadTree.h"
 
 #include "MathLib/LinAlg/Solvers/GaussAlgorithm.h"
@@ -418,7 +419,12 @@ void GMSHInterface::writeGMSHInputFile(std::ostream& out)
     for (std::vector<GeoLib::Polyline*>::const_iterator it(merged_plys->begin());
         it!=merged_plys->end(); it++) {
         if ((*it)->isClosed()) {
-            _polygon_tree_list.push_back(new GMSH::GMSHPolygonTree(new GeoLib::Polygon(*(*it), true), NULL, _geo_objs, _gmsh_geo_name, _mesh_density_strategy));
+            _polygon_tree_list.push_back(
+                new GMSH::GMSHPolygonTree(
+                    new GeoLib::PolygonWithSegmentMarker(*(*it)),
+                    nullptr, _geo_objs, _gmsh_geo_name, _mesh_density_strategy
+                )
+            );
         }
     }
     DBUG("GMSHInterface::writeGMSHInputFile(): Compute topological hierarchy - detected %d polygons.", _polygon_tree_list.size());

--- a/FileIO/GMSHInterface.cpp
+++ b/FileIO/GMSHInterface.cpp
@@ -440,7 +440,7 @@ int GMSHInterface::writeGMSHInputFile(std::ostream& out)
     const std::size_t n_merged_pnts(merged_pnts->size());
     _gmsh_pnts.resize(n_merged_pnts);
     for (std::size_t k(0); k<n_merged_pnts; k++) {
-        _gmsh_pnts[k] = NULL;
+        _gmsh_pnts[k] = nullptr;
     }
     for (std::list<GMSH::GMSHPolygonTree*>::iterator it(_polygon_tree_list.begin());
         it != _polygon_tree_list.end(); ++it) {

--- a/FileIO/GMSHInterface.cpp
+++ b/FileIO/GMSHInterface.cpp
@@ -454,9 +454,10 @@ void GMSHInterface::writeGMSHInputFile(std::ostream& out)
     const std::size_t n_plys(merged_plys->size());
     for (std::size_t k(0); k<n_plys; k++) {
         if (! (*merged_plys)[k]->isClosed()) {
-            for (std::list<GMSH::GMSHPolygonTree*>::iterator it(_polygon_tree_list.begin());
-                it != _polygon_tree_list.end(); ++it) {
-                (*it)->insertPolyline(new GeoLib::PolylineWithSegmentMarker(*(*merged_plys)[k]));
+            for (auto * polygon_tree : _polygon_tree_list) {
+                auto polyline_with_segment_marker =
+                    new GeoLib::PolylineWithSegmentMarker(*(*merged_plys)[k]);
+                polygon_tree->insertPolyline(polyline_with_segment_marker);
             }
         }
     }

--- a/FileIO/GMSHInterface.cpp
+++ b/FileIO/GMSHInterface.cpp
@@ -74,45 +74,6 @@ GMSHInterface::~GMSHInterface()
         delete polygon_tree;
 }
 
-int GMSHInterface::writeGeoFile(GeoLib::GEOObjects &geo_objects, std::string const& file_name)
-{
-    std::vector<std::string> names;
-    geo_objects.getGeometryNames(names);
-
-    if (names.empty())
-    {
-        ERR ("No geometry information available.");
-        return 1;
-    }
-
-    bool const multiple_geometries = (names.size() > 1);
-    std::string merge_name("MergedGeometry");
-    if (multiple_geometries)
-    {
-        if (geo_objects.mergeGeometries (names, merge_name) != 1)
-            return 2;
-        names.clear();
-        names.push_back(merge_name);
-    }
-    else
-        merge_name = names[0];
-
-    // default parameters for GMSH interface
-    double param1(0.5);    // mesh density scaling on normal points
-    double param2(0.05);   // mesh density scaling on station points
-    std::size_t param3(2); // points per leaf
-    GMSHInterface gmsh_io(geo_objects, true, FileIO::GMSH::MeshDensityAlgorithm::AdaptiveMeshDensity, param1, param2, param3, names);
-    int const writer_return_val = gmsh_io.writeToFile(file_name);
-
-    if (multiple_geometries)
-    {
-        geo_objects.removeSurfaceVec(merge_name);
-        geo_objects.removePolylineVec(merge_name);
-        geo_objects.removePointVec(merge_name);
-    }
-    return (writer_return_val==1) ? 0 : 3;
-}
-
 bool GMSHInterface::isGMSHMeshFile(const std::string& fname)
 {
     std::ifstream input(fname.c_str());

--- a/FileIO/GMSHInterface.cpp
+++ b/FileIO/GMSHInterface.cpp
@@ -36,7 +36,6 @@
 #include "GeoLib/Polyline.h"
 #include "GeoLib/PolylineWithSegmentMarker.h"
 #include "GeoLib/PolygonWithSegmentMarker.h"
-#include "GeoLib/QuadTree.h"
 
 #include "MathLib/LinAlg/Solvers/GaussAlgorithm.h"
 

--- a/FileIO/GMSHInterface.h
+++ b/FileIO/GMSHInterface.h
@@ -76,6 +76,11 @@ public:
                   double param1, double param2, std::size_t param3,
                   std::vector<std::string>& selected_geometries);
 
+    GMSHInterface(GMSHInterface const&) = delete;
+    GMSHInterface(GMSHInterface &&) = delete;
+    GMSHInterface& operator=(GMSHInterface const&) = delete;
+    GMSHInterface& operator=(GMSHInterface &&) = delete;
+
     ~GMSHInterface();
 
     /**

--- a/FileIO/GMSHInterface.h
+++ b/FileIO/GMSHInterface.h
@@ -128,6 +128,9 @@ private:
     /// Holds the inverse rotation matrix. The matrix is used in writePoints() to
     /// revert the rotation done in writeGMSHInputFile().
     MathLib::DenseMatrix<double> _inverse_rot_mat = MathLib::DenseMatrix<double>(3,3);
+    /// Signals if the input points should be rotated or projected to the
+    /// \f$x\f$-\f$y\f$-plane
+    bool _rotate = false;
 };
 }
 

--- a/FileIO/GMSHInterface.h
+++ b/FileIO/GMSHInterface.h
@@ -91,14 +91,6 @@ public:
      */
     static MeshLib::Mesh* readGMSHMesh (std::string const& fname);
 
-    /**
-     * Export script for writing geo files.
-     * To do this, all geometries currently loaded are merged, the merged result is written to a
-     * file and then the merged geometry is removed again.
-     * @return error code, i.e. 0 = okay, 1 = geo_objects is empty, 2 = error while merging, 3 = error writing file
-     */
-    static int writeGeoFile(GeoLib::GEOObjects &geo_objects, std::string const& file_name);
-
 protected:
     bool write();
 

--- a/FileIO/GMSHInterface.h
+++ b/FileIO/GMSHInterface.h
@@ -54,7 +54,7 @@ enum class MeshDensityAlgorithm {
 /**
  * \brief Reads and writes GMSH-files to and from OGS data structures.
  */
-class GMSHInterface : public BaseLib::IO::Writer
+class GMSHInterface final : public BaseLib::IO::Writer
 {
 public:
 

--- a/FileIO/GMSHInterface.h
+++ b/FileIO/GMSHInterface.h
@@ -112,8 +112,11 @@ private:
      * 1. get and merge data from _geo_objs
      * 2. compute topological hierarchy
      * @param out
+     * @todo activate error codes and hand them on to the Writer class,
+     * i.e. 0 = okay, 1 = geo_objects is empty, 2 = error while merging,
+     * 3 = error writing file
      */
-    void writeGMSHInputFile(std::ostream & out);
+    int writeGMSHInputFile(std::ostream & out);
 
     static void readNodeIDs(std::ifstream &in, unsigned n_nodes, std::vector<unsigned> &node_ids, std::map<unsigned, unsigned> const& id_map);
 

--- a/FileIO/GMSHInterface.h
+++ b/FileIO/GMSHInterface.h
@@ -57,24 +57,32 @@ enum class MeshDensityAlgorithm {
 class GMSHInterface final : public BaseLib::IO::Writer
 {
 public:
-
     /**
-     *
-     * @param geo_objs reference tp instance of class GEOObject that maintains the geometries.
-     *     The instance is used for preparation geometries for writing them to the gmsh file format.
-     * @param include_stations_as_constraints switch to enable writing stations as constraints
-     * @param mesh_density_algorithm one of the mesh density algorithms (\@see enum MeshDensityAlgorithm)
+     * @param geo_objs reference to instance of class GEOObject that maintains
+     * the geometries.
+     *     The instance is used for preparation geometries for writing them to
+     * the gmsh file format.
+     * @param include_stations_as_constraints switch to enable writing stations
+     * as constraints
+     * @param mesh_density_algorithm one of the mesh density algorithms (\@see
+     * enum MeshDensityAlgorithm)
      * @param param1 parameter that can be used for the mesh density algorithm
      * @param param2 parameter that can be used for the mesh density algorithm
      * @param param3 parameter that can be used for the mesh density algorithm
-     * @param selected_geometries vector of names of geometries, that should be employed for mesh generation.
-     * @return
+     * @param selected_geometries vector of names of geometries, that should be
+     * employed for mesh generation.
+     * @param rotate if the value of the parameter is true then the input points
+     * will be rotated on the \f$x\f$-\f$y\f$-plane, else the input points will
+     * be (orthogonal) projected to the \f$x\f$-\f$y\f$-plane.
+     * @param keep_preprocessed_geometry keep the pre-processed geometry, useful
+     * for debugging the mesh creation
      */
     GMSHInterface(GeoLib::GEOObjects& geo_objs,
                   bool include_stations_as_constraints,
                   GMSH::MeshDensityAlgorithm mesh_density_algorithm,
                   double param1, double param2, std::size_t param3,
-                  std::vector<std::string>& selected_geometries);
+                  std::vector<std::string>& selected_geometries,
+                  bool rotate = false, bool keep_preprocessed_geometry = false);
 
     GMSHInterface(GMSHInterface const&) = delete;
     GMSHInterface(GMSHInterface &&) = delete;
@@ -140,6 +148,7 @@ private:
     /// Signals if the input points should be rotated or projected to the
     /// \f$x\f$-\f$y\f$-plane
     bool _rotate = false;
+    bool _keep_preprocessed_geometry = true;
 };
 }
 

--- a/FileIO/GMSHInterface.h
+++ b/FileIO/GMSHInterface.h
@@ -70,11 +70,11 @@ public:
      * @param selected_geometries vector of names of geometries, that should be employed for mesh generation.
      * @return
      */
-    GMSHInterface (GeoLib::GEOObjects & geo_objs,
-                    bool include_stations_as_constraints,
-                    GMSH::MeshDensityAlgorithm mesh_density_algorithm,
-                    double param1, double param2, std::size_t param3,
-                    std::vector<std::string> & selected_geometries);
+    GMSHInterface(GeoLib::GEOObjects& geo_objs,
+                  bool include_stations_as_constraints,
+                  GMSH::MeshDensityAlgorithm mesh_density_algorithm,
+                  double param1, double param2, std::size_t param3,
+                  std::vector<std::string>& selected_geometries);
 
     ~GMSHInterface();
 
@@ -96,7 +96,8 @@ protected:
 
 private:
     /// Reads a mesh element from the input stream
-    static std::pair<MeshLib::Element*, int> readElement(std::ifstream &in,
+    static std::pair<MeshLib::Element*, int> readElement(
+        std::ifstream& in,
         std::vector<MeshLib::Node*> const& nodes,
         std::map<unsigned, unsigned> const& id_map);
 
@@ -110,7 +111,9 @@ private:
      */
     int writeGMSHInputFile(std::ostream & out);
 
-    static void readNodeIDs(std::ifstream &in, unsigned n_nodes, std::vector<unsigned> &node_ids, std::map<unsigned, unsigned> const& id_map);
+    static void readNodeIDs(std::ifstream& in, unsigned n_nodes,
+                            std::vector<unsigned>& node_ids,
+                            std::map<unsigned, unsigned> const& id_map);
 
     void writePoints(std::ostream& out) const;
 
@@ -127,7 +130,8 @@ private:
     GMSH::GMSHMeshDensityStrategy *_mesh_density_strategy;
     /// Holds the inverse rotation matrix. The matrix is used in writePoints() to
     /// revert the rotation done in writeGMSHInputFile().
-    MathLib::DenseMatrix<double> _inverse_rot_mat = MathLib::DenseMatrix<double>(3,3);
+    MathLib::DenseMatrix<double> _inverse_rot_mat =
+        MathLib::DenseMatrix<double>(3, 3, 0);
     /// Signals if the input points should be rotated or projected to the
     /// \f$x\f$-\f$y\f$-plane
     bool _rotate = false;

--- a/FileIO/GmshIO/GMSHPolygonTree.cpp
+++ b/FileIO/GmshIO/GMSHPolygonTree.cpp
@@ -311,7 +311,7 @@ void GMSHPolygonTree::writeLineConstraints(std::size_t& line_offset,
                                            std::size_t sfc_number,
                                            std::ostream& out) const
 {
-    for (auto polyline : *_plys)
+    for (auto polyline : _plys)
     {
         const std::size_t n_pnts(polyline->getNumberOfPoints());
         std::size_t first_pnt_id(polyline->getPointID(0)), second_pnt_id;
@@ -319,7 +319,8 @@ void GMSHPolygonTree::writeLineConstraints(std::size_t& line_offset,
         {
             second_pnt_id = polyline->getPointID(k);
             if (polyline->isSegmentMarked(k - 1) &&
-                _node_polygon->isPntInPolygon(*(polyline->getPoint(k))))
+                _node_polygon->isPntInPolygon(*(polyline->getPoint(k))) &&
+                !GeoLib::containsEdge(*_node_polygon, first_pnt_id, second_pnt_id))
             {
                 out << "Line(" << line_offset + k - 1 << ") = {" << first_pnt_id
                     << "," << second_pnt_id << "};\n";

--- a/FileIO/GmshIO/GMSHPolygonTree.cpp
+++ b/FileIO/GmshIO/GMSHPolygonTree.cpp
@@ -110,6 +110,12 @@ void GMSHPolygonTree::insertPolyline(GeoLib::PolylineWithSegmentMarker * ply)
         if (ply->isSegmentMarked(k))
             continue;
 
+        if (_node_polygon->containsSegment(*(ply->getPoint(k)),
+                                           *(ply->getPoint(k + 1)))) {
+            ply->markSegment(k, true);
+            continue;
+        }
+
         std::size_t seg_num(0);
         GeoLib::Point *intersection_pnt(new GeoLib::Point);
         while (_node_polygon->getNextIntersectionPointPolygonLine(

--- a/FileIO/GmshIO/GMSHPolygonTree.cpp
+++ b/FileIO/GmshIO/GMSHPolygonTree.cpp
@@ -269,6 +269,9 @@ void GMSHPolygonTree::createGMSHPoints(std::vector<FileIO::GMSH::GMSHPoint*> & g
         for (std::size_t j(0); j<n_pnts_in_ply; j++) {
             if (_node_polygon->isPntInPolygon(*(_plys[k]->getPoint(j)))) {
                 const std::size_t id (_plys[k]->getPointID(j));
+                // if this point was already part of another polyline
+                if (gmsh_pnts[id] != nullptr)
+                    continue;
                 GeoLib::Point const*const pnt(_plys[k]->getPoint(j));
                 gmsh_pnts[id] = new GMSHPoint(*pnt, id, _mesh_density_strategy->getMeshDensityAtPoint(pnt));
             }

--- a/FileIO/GmshIO/GMSHPolygonTree.cpp
+++ b/FileIO/GmshIO/GMSHPolygonTree.cpp
@@ -391,11 +391,6 @@ void GMSHPolygonTree::writeAdditionalPointData(std::size_t & pnt_id_offset, std:
 
 void GMSHPolygonTree::getPointsFromSubPolygons(std::vector<GeoLib::Point const*>& pnts)
 {
-    const std::size_t n_pnts_polygon (_node_polygon->getNumberOfPoints());
-    for (std::size_t k(0); k<n_pnts_polygon; k++) {
-        pnts.push_back(_node_polygon->getPoint(k));
-    }
-
     for (std::list<SimplePolygonTree*>::const_iterator it (_children.begin()); it != _children.end(); ++it) {
         dynamic_cast<GMSHPolygonTree*>((*it))->getPointsFromSubPolygons(pnts);
     }

--- a/FileIO/GmshIO/GMSHPolygonTree.cpp
+++ b/FileIO/GmshIO/GMSHPolygonTree.cpp
@@ -311,14 +311,16 @@ void GMSHPolygonTree::writeLineConstraints(std::size_t& line_offset,
                                            std::size_t sfc_number,
                                            std::ostream& out) const
 {
-    const std::size_t n_plys (_plys.size());
-    for (std::size_t j(0); j<n_plys; j++) {
-        const std::size_t n_pnts(_plys[j]->getNumberOfPoints());
-        std::size_t first_pnt_id(_plys[j]->getPointID(0)), second_pnt_id;
-            second_pnt_id = _plys[j]->getPointID(k);
-            if (_plys[j]->isSegmentMarked(k-1) && _node_polygon->isPntInPolygon(*(_plys[j]->getPoint(k)))) {
+    for (auto polyline : *_plys)
+    {
+        const std::size_t n_pnts(polyline->getNumberOfPoints());
+        std::size_t first_pnt_id(polyline->getPointID(0)), second_pnt_id;
         for (std::size_t k(1); k < n_pnts; k++)
         {
+            second_pnt_id = polyline->getPointID(k);
+            if (polyline->isSegmentMarked(k - 1) &&
+                _node_polygon->isPntInPolygon(*(polyline->getPoint(k))))
+            {
                 out << "Line(" << line_offset + k - 1 << ") = {" << first_pnt_id
                     << "," << second_pnt_id << "};\n";
                 out << "Line { " << line_offset + k - 1 << " } In Surface { "

--- a/FileIO/GmshIO/GMSHPolygonTree.cpp
+++ b/FileIO/GmshIO/GMSHPolygonTree.cpp
@@ -22,12 +22,14 @@
 #include "GeoLib/Point.h"
 #include "GeoLib/Polygon.h"
 #include "GeoLib/PolylineWithSegmentMarker.h"
+#include "GeoLib/PolygonWithSegmentMarker.h"
 
 namespace FileIO
 {
 namespace GMSH {
 
-GMSHPolygonTree::GMSHPolygonTree(GeoLib::Polygon* polygon, GMSHPolygonTree* parent,
+GMSHPolygonTree::GMSHPolygonTree(GeoLib::PolygonWithSegmentMarker* polygon,
+                GMSHPolygonTree* parent,
                 GeoLib::GEOObjects &geo_objs, std::string const& geo_name,
                 GMSHMeshDensityStrategy * mesh_density_strategy) :
     GeoLib::SimplePolygonTree(polygon, parent), _geo_objs(geo_objs), _geo_name(geo_name),

--- a/FileIO/GmshIO/GMSHPolygonTree.cpp
+++ b/FileIO/GmshIO/GMSHPolygonTree.cpp
@@ -257,7 +257,7 @@ void GMSHPolygonTree::initMeshDensityStrategy()
 void GMSHPolygonTree::createGMSHPoints(std::vector<FileIO::GMSH::GMSHPoint*> & gmsh_pnts) const
 {
     const std::size_t n_pnts_polygon (_node_polygon->getNumberOfPoints());
-    for (std::size_t k(0); k<n_pnts_polygon; k++) {
+    for (std::size_t k(0); k<n_pnts_polygon-1; k++) {
         const std::size_t id (_node_polygon->getPointID(k));
         GeoLib::Point const*const pnt(_node_polygon->getPoint(k));
         gmsh_pnts[id] = new GMSHPoint(*pnt, id, _mesh_density_strategy->getMeshDensityAtPoint(pnt));

--- a/FileIO/GmshIO/GMSHPolygonTree.cpp
+++ b/FileIO/GmshIO/GMSHPolygonTree.cpp
@@ -260,7 +260,11 @@ void GMSHPolygonTree::createGMSHPoints(std::vector<FileIO::GMSH::GMSHPoint*> & g
     for (std::size_t k(0); k<n_pnts_polygon-1; k++) {
         const std::size_t id (_node_polygon->getPointID(k));
         GeoLib::Point const*const pnt(_node_polygon->getPoint(k));
-        gmsh_pnts[id] = new GMSHPoint(*pnt, id, _mesh_density_strategy->getMeshDensityAtPoint(pnt));
+        // if this point was already part of another polyline
+        if (gmsh_pnts[id] != nullptr)
+            continue;
+        gmsh_pnts[id] = new GMSHPoint(
+            *pnt, id, _mesh_density_strategy->getMeshDensityAtPoint(pnt));
     }
 
     const std::size_t n_plys(_plys.size());
@@ -273,7 +277,9 @@ void GMSHPolygonTree::createGMSHPoints(std::vector<FileIO::GMSH::GMSHPoint*> & g
                 if (gmsh_pnts[id] != nullptr)
                     continue;
                 GeoLib::Point const*const pnt(_plys[k]->getPoint(j));
-                gmsh_pnts[id] = new GMSHPoint(*pnt, id, _mesh_density_strategy->getMeshDensityAtPoint(pnt));
+                gmsh_pnts[id] = new GMSHPoint(
+                    *pnt, id,
+                    _mesh_density_strategy->getMeshDensityAtPoint(pnt));
             }
         }
     }

--- a/FileIO/GmshIO/GMSHPolygonTree.cpp
+++ b/FileIO/GmshIO/GMSHPolygonTree.cpp
@@ -307,17 +307,22 @@ void GMSHPolygonTree::writeLineLoop(std::size_t &line_offset, std::size_t &sfc_o
     sfc_offset++;
 }
 
-void GMSHPolygonTree::writeLineConstraints(std::size_t &line_offset, std::size_t sfc_number, std::ostream& out) const
+void GMSHPolygonTree::writeLineConstraints(std::size_t& line_offset,
+                                           std::size_t sfc_number,
+                                           std::ostream& out) const
 {
     const std::size_t n_plys (_plys.size());
     for (std::size_t j(0); j<n_plys; j++) {
         const std::size_t n_pnts(_plys[j]->getNumberOfPoints());
         std::size_t first_pnt_id(_plys[j]->getPointID(0)), second_pnt_id;
-        for (std::size_t k(1); k<n_pnts; k++) {
             second_pnt_id = _plys[j]->getPointID(k);
             if (_plys[j]->isSegmentMarked(k-1) && _node_polygon->isPntInPolygon(*(_plys[j]->getPoint(k)))) {
-                out << "Line(" << line_offset + k-1 << ") = {" << first_pnt_id << "," << second_pnt_id << "};\n";
-                out << "Line { " << line_offset+k-1 << " } In Surface { " << sfc_number << " };\n";
+        for (std::size_t k(1); k < n_pnts; k++)
+        {
+                out << "Line(" << line_offset + k - 1 << ") = {" << first_pnt_id
+                    << "," << second_pnt_id << "};\n";
+                out << "Line { " << line_offset + k - 1 << " } In Surface { "
+                    << sfc_number << " };\n";
             }
             first_pnt_id = second_pnt_id;
         }

--- a/FileIO/GmshIO/GMSHPolygonTree.cpp
+++ b/FileIO/GmshIO/GMSHPolygonTree.cpp
@@ -48,6 +48,25 @@ GMSHPolygonTree::~GMSHPolygonTree()
     delete _node_polygon;
 }
 
+void GMSHPolygonTree::markSharedSegments()
+{
+    if (_children.empty())
+        return;
+
+    if (_parent == nullptr)
+        return;
+
+    for (auto it(_children.begin()); it != _children.end(); it++) {
+        std::size_t const n_pnts((*it)->getPolygon()->getNumberOfPoints());
+        for (std::size_t k(1); k<n_pnts; k++) {
+            if (GeoLib::containsEdge(*(_parent->getPolygon()),
+                _node_polygon->getPointID(k-1),
+                _node_polygon->getPointID(k)))
+            static_cast<GeoLib::PolygonWithSegmentMarker*>(_node_polygon)->markSegment(k, true);
+        }
+    }
+}
+
 bool GMSHPolygonTree::insertStation(GeoLib::Point const* station)
 {
     if (_node_polygon->isPntInPolygon(*station)) {

--- a/FileIO/GmshIO/GMSHPolygonTree.h
+++ b/FileIO/GmshIO/GMSHPolygonTree.h
@@ -43,6 +43,9 @@ public:
                     GMSHMeshDensityStrategy * mesh_density_strategy);
     virtual ~GMSHPolygonTree();
 
+    /** Mark the segments shared by several polygons. */
+    void markSharedSegments();
+
     /**
      * If the station point is inside the polygon, the method inserts the station into
      * the internal vector of stations. This method works recursive!

--- a/FileIO/GmshIO/GMSHPolygonTree.h
+++ b/FileIO/GmshIO/GMSHPolygonTree.h
@@ -29,6 +29,7 @@ namespace GeoLib
     class GEOObjects;
     class Polygon;
     class PolylineWithSegmentMarker;
+    class PolygonWithSegmentMarker;
 }
 
 namespace FileIO
@@ -37,7 +38,7 @@ namespace GMSH {
 
 class GMSHPolygonTree: public GeoLib::SimplePolygonTree {
 public:
-    GMSHPolygonTree(GeoLib::Polygon* polygon, GMSHPolygonTree * parent,
+    GMSHPolygonTree(GeoLib::PolygonWithSegmentMarker* polygon, GMSHPolygonTree * parent,
                     GeoLib::GEOObjects &geo_objs, std::string const& geo_name,
                     GMSHMeshDensityStrategy * mesh_density_strategy);
     virtual ~GMSHPolygonTree();

--- a/FileIO/GmshIO/GMSHPolygonTree.h
+++ b/FileIO/GmshIO/GMSHPolygonTree.h
@@ -1,7 +1,7 @@
 /**
  * \file
  * \author Thomas Fischer
- * \date   Mar 27m 2012
+ * \date   Mar 27 2012
  * \brief  Definition of the GMSHPolygonTree class.
  *
  * \copyright
@@ -86,6 +86,8 @@ public:
 private:
     void getPointsFromSubPolygons(std::vector<GeoLib::Point const*>& pnts);
     void getStationsInsideSubPolygons(std::vector<GeoLib::Point const*>& stations);
+    void checkIntersectionsSegmentExistingPolylines(GeoLib::PolylineWithSegmentMarker * ply,
+            std::size_t & ply_segment_number);
 
     GeoLib::GEOObjects & _geo_objs;
     std::string const& _geo_name;

--- a/FileIO/GmshIO/GMSHPolygonTree.h
+++ b/FileIO/GmshIO/GMSHPolygonTree.h
@@ -90,8 +90,9 @@ public:
 private:
     void getPointsFromSubPolygons(std::vector<GeoLib::Point const*>& pnts);
     void getStationsInsideSubPolygons(std::vector<GeoLib::Point const*>& stations);
-    void checkIntersectionsSegmentExistingPolylines(GeoLib::PolylineWithSegmentMarker * ply,
-            std::size_t & ply_segment_number);
+    void checkIntersectionsSegmentExistingPolylines(
+        GeoLib::PolylineWithSegmentMarker* ply,
+        GeoLib::Polyline::SegmentIterator const& segment_iterator);
 
     GeoLib::GEOObjects & _geo_objs;
     std::string const& _geo_name;

--- a/GeoLib/PolygonWithSegmentMarker.cpp
+++ b/GeoLib/PolygonWithSegmentMarker.cpp
@@ -1,0 +1,48 @@
+/**
+ *
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ */
+
+#include "PolygonWithSegmentMarker.h"
+
+namespace GeoLib {
+PolygonWithSegmentMarker::PolygonWithSegmentMarker(
+    GeoLib::Polyline const& polyline)
+    : GeoLib::Polygon(polyline, true),
+      _marker(polyline.getNumberOfPoints(), false)
+{
+}
+
+void PolygonWithSegmentMarker::markSegment(std::size_t seg_num, bool mark_val)
+{
+    _marker[seg_num] = mark_val;
+}
+
+bool PolygonWithSegmentMarker::isSegmentMarked(std::size_t seg_num) const
+{
+    return _marker[seg_num];
+}
+
+bool PolygonWithSegmentMarker::addPoint(std::size_t pnt_id)
+{
+    if (Polyline::addPoint(pnt_id)) {
+        _marker.push_back(false);
+        return true;
+    }
+    return false;
+}
+
+bool PolygonWithSegmentMarker::insertPoint(std::size_t pos, std::size_t pnt_id)
+{
+    if (Polyline::insertPoint(pos, pnt_id)) {
+        _marker.insert(_marker.begin()+pos, _marker[pos]);
+        return true;
+    }
+    return false;
+}
+
+} // end GeoLib

--- a/GeoLib/PolygonWithSegmentMarker.h
+++ b/GeoLib/PolygonWithSegmentMarker.h
@@ -1,0 +1,57 @@
+/**
+ *
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef POLYGONWITHSEGMENTMARKER_H_
+#define POLYGONWITHSEGMENTMARKER_H_
+
+#include "Polygon.h"
+
+namespace GeoLib {
+
+class PolygonWithSegmentMarker final : public GeoLib::Polygon
+{
+public:
+    explicit PolygonWithSegmentMarker(GeoLib::Polyline const& polyline);
+
+    /**
+     * Method marks the segment (default mark is true).
+     * @param seg_num the segment number that should be marked
+     * @param mark_val the value of the flag (true or false)
+     */
+    void markSegment(std::size_t seg_num, bool mark_val = true);
+
+    /**
+     * Method returns the value of the mark for the given segment.
+     * @param seg_num segment number
+     * @return either true if the segment is marked or false else
+     */
+    bool isSegmentMarked(std::size_t seg_num) const;
+
+    /**
+     * Method calls @see Polyline::addPoint() and initializes the mark of the
+     * corresponding line segment.
+     * @see Polyline::addPoint()
+     */
+    virtual bool addPoint(std::size_t pnt_id) override;
+
+    /**
+     * Method calls the @see Polyline::insertPoint() and initializes the inserted line
+     * segment with the same value the previous line segment had.
+     * @see Polyline::insertPoint()
+     */
+    virtual bool insertPoint(std::size_t pos, std::size_t pnt_id) override;
+
+private:
+    std::vector<bool> _marker;
+};
+
+} // end namespace GeoLib
+
+#endif /* POLYGONWITHSEGMENTMARKER_H_ */

--- a/GeoLib/Polyline.cpp
+++ b/GeoLib/Polyline.cpp
@@ -421,7 +421,7 @@ double Polyline::getDistanceAlongPolyline(const MathLib::Point3d& pnt,
     double dist(-1.0), lambda;
     bool found = false;
     // loop over all line segments of the polyline
-    for (std::size_t k = 0; k < getNumberOfPoints() - 1; k++) {
+    for (std::size_t k = 0; k < getNumberOfSegments(); k++) {
         // is the orthogonal projection of the j-th node to the
         // line g(lambda) = _ply->getPoint(k) + lambda * (_ply->getPoint(k+1) - _ply->getPoint(k))
         // at the k-th line segment of the polyline, i.e. 0 <= lambda <= 1?

--- a/GeoLib/Polyline.h
+++ b/GeoLib/Polyline.h
@@ -118,7 +118,7 @@ public:
      * addition of the point would result in empty line segment \c false is
      * returned.
      */
-    bool addPoint(std::size_t pnt_id);
+    virtual bool addPoint(std::size_t pnt_id);
 
     /**
      * Method inserts a new point (that have to be inside the _ply_pnts vector)
@@ -131,7 +131,7 @@ public:
      * @return true if the point could be inserted, else false (if empty line
      * segments would be created).
      */
-    bool insertPoint(std::size_t pos, std::size_t pnt_id);
+    virtual bool insertPoint(std::size_t pos, std::size_t pnt_id);
 
     /**
      * Method removes a point from the polyline. The connecting line segments will

--- a/GeoLib/PolylineWithSegmentMarker.cpp
+++ b/GeoLib/PolylineWithSegmentMarker.cpp
@@ -25,21 +25,28 @@ void PolylineWithSegmentMarker::markSegment(std::size_t seg_num, bool mark_val)
 {
     _marker[seg_num] = mark_val;
 }
+
 bool PolylineWithSegmentMarker::isSegmentMarked(std::size_t seg_num) const
 {
     return _marker[seg_num];
 }
 
-void PolylineWithSegmentMarker::addPoint(std::size_t pnt_id)
+bool PolylineWithSegmentMarker::addPoint(std::size_t pnt_id)
 {
-    Polyline::addPoint(pnt_id);
-    _marker.push_back(false);
+    if (Polyline::addPoint(pnt_id)) {
+        _marker.push_back(false);
+        return true;
+    }
+    return false;
 }
 
-void PolylineWithSegmentMarker::insertPoint(std::size_t pos, std::size_t pnt_id)
+bool PolylineWithSegmentMarker::insertPoint(std::size_t pos, std::size_t pnt_id)
 {
-    Polyline::insertPoint(pos, pnt_id);
-    _marker.insert(_marker.begin()+pos, _marker[pos]);
+    if (Polyline::insertPoint(pos, pnt_id)) {
+        _marker.insert(_marker.begin()+pos, _marker[pos]);
+        return true;
+    }
+    return false;
 }
 
 } // end GeoLib

--- a/GeoLib/PolylineWithSegmentMarker.cpp
+++ b/GeoLib/PolylineWithSegmentMarker.cpp
@@ -15,15 +15,10 @@
 #include "PolylineWithSegmentMarker.h"
 
 namespace GeoLib {
-
-PolylineWithSegmentMarker::PolylineWithSegmentMarker(GeoLib::Polyline const& polyline)
-    : GeoLib::Polyline(polyline)
+PolylineWithSegmentMarker::PolylineWithSegmentMarker(
+    GeoLib::Polyline const& polyline)
+    : GeoLib::Polyline(polyline), _marker(polyline.getNumberOfSegments(), false)
 {
-    const std::size_t n_pnts(getNumberOfPoints());
-    _marker.resize(n_pnts);
-    for (std::size_t k(0); k<n_pnts; k++) {
-        _marker[k] = false;
-    }
 }
 
 void PolylineWithSegmentMarker::markSegment(std::size_t seg_num, bool mark_val)

--- a/GeoLib/PolylineWithSegmentMarker.cpp
+++ b/GeoLib/PolylineWithSegmentMarker.cpp
@@ -26,10 +26,6 @@ PolylineWithSegmentMarker::PolylineWithSegmentMarker(GeoLib::Polyline const& pol
     }
 }
 
-PolylineWithSegmentMarker::~PolylineWithSegmentMarker()
-{}
-
-
 void PolylineWithSegmentMarker::markSegment(std::size_t seg_num, bool mark_val)
 {
     _marker[seg_num] = mark_val;

--- a/GeoLib/PolylineWithSegmentMarker.h
+++ b/GeoLib/PolylineWithSegmentMarker.h
@@ -26,7 +26,7 @@ namespace GeoLib {
 class PolylineWithSegmentMarker: public GeoLib::Polyline {
 public:
     PolylineWithSegmentMarker(GeoLib::Polyline const& polyline);
-    virtual ~PolylineWithSegmentMarker();
+
     /**
      * Method marks the segment (default mark is true).
      * @param seg_num the segment number that should be marked

--- a/GeoLib/PolylineWithSegmentMarker.h
+++ b/GeoLib/PolylineWithSegmentMarker.h
@@ -23,9 +23,9 @@ namespace GeoLib {
  * This is a polyline with the possibility to mark some segments. Thus class
  * PolylineWithSegmentMarker is derived from class Polyline.
  */
-class PolylineWithSegmentMarker: public GeoLib::Polyline {
+class PolylineWithSegmentMarker final : public GeoLib::Polyline {
 public:
-    PolylineWithSegmentMarker(GeoLib::Polyline const& polyline);
+    explicit PolylineWithSegmentMarker(GeoLib::Polyline const& polyline);
 
     /**
      * Method marks the segment (default mark is true).

--- a/GeoLib/PolylineWithSegmentMarker.h
+++ b/GeoLib/PolylineWithSegmentMarker.h
@@ -45,14 +45,14 @@ public:
      * corresponding line segment.
      * @see Polyline::addPoint()
      */
-    virtual void addPoint(std::size_t pnt_id);
+    virtual bool addPoint(std::size_t pnt_id) override;
 
     /**
      * Method calls the @see Polyline::insertPoint() and initializes the inserted line segment with the same
      * value the previous line segment had.
      * @see Polyline::insertPoint()
      */
-    virtual void insertPoint(std::size_t pos, std::size_t pnt_id);
+    virtual bool insertPoint(std::size_t pos, std::size_t pnt_id) override;
 
 private:
     std::vector<bool> _marker;


### PR DESCRIPTION
The PR 
- Reintroduces the possibility to orthogonal project the input points to the x-y-plane instead of rotating it. (Rotating is still possible.)
- Introduces `PolygonWithSegmentMarker` and `PolylineWithSegmentMarker` in `GeoLib` in order to mark already preprocessed line segments in the GMSHPolygonTree.
- Fixes some mem leaks.
- Uses C++11 style at some places.