### PR TITLE
Extend local asm interface

### DIFF
--- a/AssemblerLib/VectorMatrixAssembler.h
+++ b/AssemblerLib/VectorMatrixAssembler.h
@@ -136,16 +136,20 @@ public:
     /// \attention The index \c id is not necessarily the mesh item's id.
     void preTimestep(std::size_t const id,
                      LocalAssembler& local_assembler,
-                     GlobalVector const& x) const
+                     GlobalVector const& x,
+                     double const t,
+                     double const delta_t) const
     {
         auto cb = [&local_assembler](
             std::vector<double> const& local_x,
-            LocalToGlobalIndexMap::RowColumnIndices const& /*r_c_indices*/)
+            LocalToGlobalIndexMap::RowColumnIndices const& /*r_c_indices*/,
+            double const t,
+            double const delta_t)
         {
-            local_assembler.preTimestep(local_x);
+            local_assembler.preTimestep(local_x, t, delta_t);
         };
 
-        passLocalVector_(cb, id, _data_pos, x);
+        passLocalVector_(cb, id, _data_pos, x, t, delta_t);
     }
 
     /// Executes the postTimestep() method of the local assembler for the

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -26,8 +26,34 @@ public:
 
     virtual void assemble(double const t, std::vector<double> const& local_x) = 0;
 
-    virtual void addToGlobal(AssemblerLib::LocalToGlobalIndexMap::RowColumnIndices const&,
-            GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) const = 0;
+    virtual void addToGlobal(
+        AssemblerLib::LocalToGlobalIndexMap::RowColumnIndices const&,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) const = 0;
+
+    virtual void assembleJacobian(double const /*t*/,
+                                  std::vector<double> const& /*local_x*/)
+    {
+        ERR(
+            "assembleJacobian function is not implemented in the local "
+            "assembler.");
+        std::abort();
+    }
+
+    virtual void addJacobianToGlobal(AssemblerLib::LocalToGlobalIndexMap::
+                                         RowColumnIndices const& /*indices*/,
+                                     GlobalMatrix& /*Jac*/) const
+    {
+        ERR(
+            "addJacobianToGlobal function is not implemented in the local "
+            "assembler.");
+        std::abort();
+    }
+
+    virtual void preTimestep(std::vector<double> const& /*local_x*/,
+                             double const /*t*/, double const /*delta_t*/)
+    {
+    }
+    virtual void postTimestep(std::vector<double> const& /*local_x*/) {}
 };
 
 } // namespace ProcessLib


### PR DESCRIPTION
This adds missing functions to the interface for the jacobian assembly and the pre/post timestep operations.