### PR TITLE
remove #ifdef OGS_USE_EIGEN from local matrix related files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ option(OGS_USE_PETSC "Use PETSc routines" OFF)
 option(OGS_USE_MPI "Use MPI" OFF)
 
 # Eigen
-option(OGS_USE_EIGEN "Use EIGEN for local matrix and vector" ON)
+option(OGS_USE_EIGEN "Use Eigen linear solver" ON)
 option(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES "Use dynamically allocated shape matrices" ON)
 option(EIGEN_NO_DEBUG "Disables Eigen's assertions" OFF)
 
@@ -134,15 +134,16 @@ if(OGS_USE_MPI)
     add_definitions(-DUSE_MPI)
 endif()
 
+add_definitions(-DEIGEN_INITIALIZE_MATRICES_BY_ZERO) # TODO check if needed
+if (EIGEN_NO_DEBUG)
+    add_definitions(-DEIGEN_NO_DEBUG)
+endif()
+if(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES)
+    add_definitions(-DOGS_EIGEN_DYNAMIC_SHAPE_MATRICES)
+endif()
+
 if(OGS_USE_EIGEN)
-    add_definitions(-DEIGEN_INITIALIZE_MATRICES_BY_ZERO) # TODO check if needed
     add_definitions(-DOGS_USE_EIGEN)
-    if (EIGEN_NO_DEBUG)
-        add_definitions(-DEIGEN_NO_DEBUG)
-    endif()
-    if(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES)
-        add_definitions(-DOGS_EIGEN_DYNAMIC_SHAPE_MATRICES)
-    endif()
 endif()
 
 if (OGS_USE_EIGENLIS)
@@ -175,10 +176,8 @@ else()
 endif()
 
 include_directories( SYSTEM ${Boost_INCLUDE_DIRS} )
-if(OGS_USE_EIGEN)
-    include(scripts/cmake/ExternalProjectEigen.cmake)
-    include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR})
-endif()
+include(scripts/cmake/ExternalProjectEigen.cmake)
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR})
 
 # Add subdirectories with the projects
 add_subdirectory( ThirdParty )

--- a/MathLib/LinAlg/MatrixTools.h
+++ b/MathLib/LinAlg/MatrixTools.h
@@ -12,15 +12,12 @@
 
 #include <type_traits>
 
-#ifdef OGS_USE_EIGEN
 #include <Eigen/Eigen>
-#endif
 
 
 namespace MathLib
 {
 
-#ifdef OGS_USE_EIGEN
 namespace details
 {
 
@@ -115,9 +112,6 @@ void inverse(Eigen::MatrixBase<Derived> const& mat, double det_mat, Eigen::Matri
     using MatrixType = Eigen::MatrixBase<Derived>;
     return details::Inverse<MatrixType, MatrixType::SizeAtCompileTime>::eval(mat, det_mat, result);
 }
-
-
-#endif
 
 } // namespace
 

--- a/MeshLib/ElementCoordinatesMappingLocal.cpp
+++ b/MeshLib/ElementCoordinatesMappingLocal.cpp
@@ -86,13 +86,7 @@ ElementCoordinatesMappingLocal::ElementCoordinatesMappingLocal(
     }
 
     detail::getRotationMatrixToGlobal(element_dimension, global_dimension, _points, _matR2global);
-#ifdef OGS_USE_EIGEN
     detail::rotateToLocal(_matR2global.transpose(), _points);
-#else
-    RotationMatrix* m(_matR2global.transpose());
-    detail::rotateToLocal(*m, _points);
-    delete m;
-#endif
 }
 
 } // MeshLib

--- a/MeshLib/ElementCoordinatesMappingLocal.h
+++ b/MeshLib/ElementCoordinatesMappingLocal.h
@@ -11,11 +11,7 @@
 
 #include <vector>
 
-#ifdef OGS_USE_EIGEN
 #include <Eigen/Eigen>
-#else
-#include "MathLib/LinAlg/Dense/DenseMatrix.h"
-#endif
 
 #include "MathLib/Point3d.h"
 
@@ -28,11 +24,7 @@ namespace MeshLib
 
 namespace MeshLib
 {
-#ifdef OGS_USE_EIGEN
 typedef Eigen::Matrix<double, 3u, 3u, Eigen::RowMajor> RotationMatrix;
-#else
-typedef MathLib::DenseMatrix<double> RotationMatrix;
-#endif
 
 /**
  * This class maps node coordinates on intrinsic coordinates of the given element.

--- a/NumLib/Fem/CoordinatesMapping/ShapeMatrices.h
+++ b/NumLib/Fem/CoordinatesMapping/ShapeMatrices.h
@@ -15,9 +15,8 @@
 
 #include <ostream>
 
-#ifdef OGS_USE_EIGEN
 #include <Eigen/Eigen>
-#endif
+
 namespace NumLib
 {
 
@@ -105,9 +104,7 @@ struct ShapeMatrices
      */
     void write (std::ostream& out) const;
 
-#ifdef OGS_USE_EIGEN
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-#endif
 
 }; // ShapeMatrices
 

--- a/NumLib/Fem/ShapeMatrixPolicy.h
+++ b/NumLib/Fem/ShapeMatrixPolicy.h
@@ -12,7 +12,6 @@
 
 #include "NumLib/Fem/CoordinatesMapping/ShapeMatrices.h"
 
-#ifdef OGS_USE_EIGEN
 #include <Eigen/Dense>
 
 namespace detail
@@ -118,8 +117,6 @@ using ShapeMatrixPolicyType = EigenFixedShapeMatrixPolicy<ShapeFunction, GlobalD
 
 const unsigned OGS_EIGEN_DYNAMIC_SHAPE_MATRICES_FLAG = 0;
 #endif
-
-#endif  // OGS_USE_EIGEN
 
 //static_assert(std::is_class<ShapeMatrixPolicyType<>::value,
         //"ShapeMatrixPolicyType was not defined.");

--- a/Tests/MathLib/TestLocalMatrixFunctions.cpp
+++ b/Tests/MathLib/TestLocalMatrixFunctions.cpp
@@ -8,15 +8,12 @@
 
 #include <gtest/gtest.h>
 
-#ifdef OGS_USE_EIGEN
 #include <Eigen/Eigen>
-#endif
 
 #include "MathLib/LinAlg/MatrixTools.h"
 
 #include "Tests/TestTools.h"
 
-#ifdef OGS_USE_EIGEN
 TEST(MathLib, LocalMatrixDeterminantInverse_Eigen)
 {
     Eigen::Matrix3d fMat, fInv;
@@ -34,4 +31,3 @@ TEST(MathLib, LocalMatrixDeterminantInverse_Eigen)
     ASSERT_NEAR(fMat_det, dMat_det, std::numeric_limits<double>::epsilon());
     ASSERT_ARRAY_NEAR(fInv.data(), dInv.data(), fInv.size(), std::numeric_limits<double>::epsilon());
 }
-#endif

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -8,9 +8,7 @@
 
 #include <numeric>
 
-#ifdef OGS_USE_EIGEN
 #include <Eigen/Eigen>
-#endif
 
 #include "gtest/gtest.h"
 
@@ -360,7 +358,6 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
     }
 
     // *** add a 3rd property ***
-#ifdef OGS_USE_EIGEN
     std::string const& prop_name_3("ItemwiseEigenMatrixProperties");
     // check if the property is already assigned to the mesh
     ASSERT_FALSE(mesh->getProperties().hasPropertyVector(prop_name_3));
@@ -403,7 +400,6 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
             }
         }
     }
-#endif
 }
 
 TEST_F(MeshLibProperties, CopyConstructor)

--- a/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
+++ b/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
@@ -14,9 +14,7 @@
 #include <cmath>
 #include <memory>
 
-#ifdef OGS_USE_EIGEN
 #include <Eigen/Eigen>
-#endif
 
 #include "GeoLib/AnalyticalGeometry.h"
 #include "MathLib/LinAlg/Dense/DenseMatrix.h"

--- a/Tests/NumLib/TestCoordinatesMapping.cpp
+++ b/Tests/NumLib/TestCoordinatesMapping.cpp
@@ -12,9 +12,7 @@
 #include <algorithm>
 #include <vector>
 
-#ifdef OGS_USE_EIGEN
 #include <Eigen/Eigen>
-#endif
 
 #include "NumLib/Fem/CoordinatesMapping/ShapeMatrices.h"
 #include "NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.h"
@@ -52,12 +50,10 @@ public:
     static const unsigned e_nnodes = T_TEST::e_nnodes;
     static const unsigned global_dim = T_TEST::global_dim;
     // Matrix types
-#ifdef OGS_USE_EIGEN
     typedef Eigen::Matrix<double, e_nnodes, 1> NodalVector;
     typedef Eigen::Matrix<double, dim, e_nnodes, Eigen::RowMajor> DimNodalMatrix;
     typedef Eigen::Matrix<double, dim, dim, Eigen::RowMajor> DimMatrix;
     typedef Eigen::Matrix<double, global_dim, e_nnodes, Eigen::RowMajor> GlobalDimNodalMatrix;
-#endif
     // Shape data type
     typedef ShapeMatrices<NodalVector,DimNodalMatrix,DimMatrix,GlobalDimNodalMatrix> ShapeMatricesType;
     // Natural coordinates mapping type
@@ -282,12 +278,10 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckZeroVolume)
 
 TEST(NumLib, FemNaturalCoordinatesMappingLineY)
 {
-#ifdef OGS_USE_EIGEN
     typedef Eigen::Matrix<double, 2, 1> NodalVector;
     typedef Eigen::Matrix<double, 1, 2, Eigen::RowMajor> DimNodalMatrix;
     typedef Eigen::Matrix<double, 1, 1, Eigen::RowMajor> DimMatrix;
     typedef Eigen::Matrix<double, 2, 2, Eigen::RowMajor> GlobalDimNodalMatrix;
-#endif
     // Shape data type
     typedef ShapeMatrices<NodalVector,DimNodalMatrix,DimMatrix,GlobalDimNodalMatrix> ShapeMatricesType;
     typedef NaturalCoordinatesMapping<MeshLib::Line, ShapeLine2, ShapeMatricesType> MappingType;

--- a/Tests/NumLib/TestFe.cpp
+++ b/Tests/NumLib/TestFe.cpp
@@ -11,9 +11,8 @@
 
 #include <vector>
 #include <cmath>
-#ifdef OGS_USE_EIGEN
+
 #include <Eigen/Eigen>
-#endif
 
 #include "MeshLib/ElementCoordinatesMappingLocal.h"
 #include "MeshLib/CoordinateSystem.h"
@@ -53,7 +52,6 @@ struct TestCase
 };
 
 typedef ::testing::Types<
-#ifdef OGS_USE_EIGEN
     TestCase<TestFeHEX8, EigenDynamicShapeMatrixPolicy>,
     TestCase<TestFeLINE2, EigenDynamicShapeMatrixPolicy>,
     TestCase<TestFeLINE2Y, EigenDynamicShapeMatrixPolicy>,
@@ -73,7 +71,6 @@ typedef ::testing::Types<
     TestCase<TestFeQUAD4, EigenFixedShapeMatrixPolicy>,
     TestCase<TestFeTET4, EigenFixedShapeMatrixPolicy>,
     TestCase<TestFeTRI3, EigenFixedShapeMatrixPolicy>
-#endif
     > TestTypes;
 }
 
@@ -160,9 +157,7 @@ class NumLibFemIsoTest : public ::testing::Test, public T::TestFeType
     MeshElementType* mesh_element;
 
  public:
-#ifdef OGS_USE_EIGEN
    EIGEN_MAKE_ALIGNED_OPERATOR_NEW // required to use fixed size Eigen matrices
-#endif
 }; // NumLibFemIsoTest
 
 template <class T>

--- a/Tests/NumLib/TestShapeMatrices.cpp
+++ b/Tests/NumLib/TestShapeMatrices.cpp
@@ -11,9 +11,7 @@
 
 #include <gtest/gtest.h>
 
-#ifdef OGS_USE_EIGEN
 #include <Eigen/Eigen>
-#endif
 
 #include "NumLib/Fem/CoordinatesMapping/ShapeMatrices.h"
 
@@ -22,7 +20,6 @@
 using namespace NumLib;
 
 
-#ifdef OGS_USE_EIGEN
 TEST(NumLib, FemShapeMatricesWithEigen)
 {
     const static unsigned dim = 2;
@@ -127,6 +124,3 @@ TEST(NumLib, FemShapeMatricesWithEigen)
     EXPECT_TRUE(shape.invJ.isZero());
     EXPECT_EQ(0.0, shape.detJ);
 }
-#endif
-
-


### PR DESCRIPTION
as titled. #ifdef OGS_USE_EIGEN is still used for global matrix, vector, and linear solver. 