### PR TITLE
Multicomponent ICs/BCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,16 @@
  - Extend the LocalAssemblerInterface by adding default implementations of
    pre/postTimestep and assembleJacobian functions. The current time and time
    step size are passed in the preTimestep call to the particular processes. #1214
+ - Add support multi-variable/multi-component in the DOF table interface and
+   extend the initial conditions to multi-components. #1224
  - Major rework of the general process interface. That also affects the
    interface of concrete processes and local assemblers.
- - Added extrapolation functionality from integration points to mesh nodes via
    least squares optimization. #1145
  - Added functionality for the output of secondary variables. #1171
  - Added material properties for zeolite adsorption and Calcium oxide/hydroxide
    reactions. #1178
  - Transferred the TES process, a monolithically coupled THC model for simulating
    thermochemical energy storag devices, from OGS5. #1181
- - Introduced central place to put physical constants. #1228
  - Introduced a general scheme for documenting OGS6 input file settings. #978
  - Added copy constructor for the class Surface, minor improvements in GeoLib. #1237
  - Added classes GeoLib::LineSegment and GeoLib::Polyline::SegmentIterator. #1139

--- a/Documentation/ProjectFile/initial_condition/Uniform/c_Uniform.md
+++ b/Documentation/ProjectFile/initial_condition/Uniform/c_Uniform.md
@@ -1,1 +1,1 @@
-\todo document
+A uniform initial condition is constant in time and space.

--- a/Documentation/ProjectFile/initial_condition/Uniform/t_value.md
+++ b/Documentation/ProjectFile/initial_condition/Uniform/t_value.md
@@ -1,1 +1,6 @@
-\todo document
+The given floating point value will be set as initial condition for the
+respective components on the entire domain.
+
+Same as values but for variables with one component only.  For multi component
+variables use the \ref ogs_file_param__initial_condition__Uniform__values
+"values tag".

--- a/Documentation/ProjectFile/initial_condition/Uniform/t_values.md
+++ b/Documentation/ProjectFile/initial_condition/Uniform/t_values.md
@@ -1,0 +1,8 @@
+A space separated list of floating point values, one for each component.
+The length of the list must match the number of the variable's components.
+
+The given floating point values will be set as initial condition for the
+respective components on the entire domain.
+
+For single component variables one can _optionally_ use the \ref
+ogs_file_param__initial_condition__Uniform__value "value tag".

--- a/ProcessLib/InitialCondition.cpp
+++ b/ProcessLib/InitialCondition.cpp
@@ -28,6 +28,21 @@ std::unique_ptr<InitialCondition> createUniformInitialCondition(
     //! \ogs_file_param{initial_condition__type}
     config.checkConfigParameter("type", "Uniform");
 
+    // Optional case for single-component variables where the value can be used.
+    // If the 'value' tag is found, use it and return. Otherwise continue with
+    // then required tag 'values'.
+    if (n_components == 1)
+    {
+        //! \ogs_file_param{initial_condition__Uniform__value}
+        auto const value = config.getConfigParameterOptional<double>("value");
+        if (value)
+        {
+            DBUG("Using value %g for the initial condition.", *value);
+            return std::unique_ptr<InitialCondition>{
+                new UniformInitialCondition{std::vector<double>{*value}}};
+        }
+    }
+
     std::vector<double> const values =
         //! \ogs_file_param{initial_condition__Uniform__values}
         config.getConfigParameter<std::vector<double>>("values");

--- a/ProcessLib/InitialCondition.cpp
+++ b/ProcessLib/InitialCondition.cpp
@@ -23,17 +23,30 @@
 namespace ProcessLib
 {
 std::unique_ptr<InitialCondition> createUniformInitialCondition(
-    BaseLib::ConfigTree const& config, int const /*n_components*/)
+    BaseLib::ConfigTree const& config, int const n_components)
 {
     //! \ogs_file_param{initial_condition__type}
     config.checkConfigParameter("type", "Uniform");
 
-    //! \ogs_file_param{initial_condition__Uniform__value}
-    auto value = config.getConfigParameter<double>("value");
-    DBUG("Using value %g", value);
+    std::vector<double> const values =
+        //! \ogs_file_param{initial_condition__Uniform__values}
+        config.getConfigParameter<std::vector<double>>("values");
+    if (values.size() != n_components)
+    {
+        OGS_FATAL(
+            "Number of values for the initial condition is different from the "
+            "number of components.");
+    }
 
-    return std::unique_ptr<InitialCondition>(
-        new UniformInitialCondition(value));
+    DBUG("Using following values for the initial condition:");
+    for (double const v : values)
+    {
+        (void)v;    // unused value if building w/o DBUG output.
+        DBUG("\t%g", v);
+    }
+
+    return std::unique_ptr<InitialCondition>{
+        new UniformInitialCondition{values}};
 }
 
 std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(

--- a/ProcessLib/InitialCondition.h
+++ b/ProcessLib/InitialCondition.h
@@ -42,19 +42,18 @@ public:
 class UniformInitialCondition : public InitialCondition
 {
 public:
-    UniformInitialCondition(double const value) : _value(value)
+    UniformInitialCondition(std::vector<double> const& values) : _values(values)
     {
     }
     /// Returns a value for given node and component.
-    /// \todo The component_id is to be implemented.
     virtual double getValue(MeshLib::Node const&,
-                            int const /* component_id */) const override
+                            int const component_id) const override
     {
-        return _value;
+        return _values[component_id];
     }
 
 private:
-    double _value;
+    std::vector<double> const _values;
 };
 
 /// Construct a UniformInitialCondition from configuration.
@@ -75,6 +74,7 @@ public:
         assert(_property.getMeshItemType() == MeshLib::MeshItemType::Node);
     }
 
+    // TODO replace Node with node's id.
     virtual double getValue(MeshLib::Node const& n,
                             int const component_id) const override
     {

--- a/ProcessLib/InitialCondition.h
+++ b/ProcessLib/InitialCondition.h
@@ -12,7 +12,6 @@
 
 #include <cassert>
 #include "BaseLib/ConfigTree.h"
-#include "MeshLib/Node.h"
 #include "MeshLib/PropertyVector.h"
 
 namespace BaseLib
@@ -35,7 +34,8 @@ class InitialCondition
 {
 public:
     virtual ~InitialCondition() = default;
-    virtual double getValue(MeshLib::Node const&, int const component_id) const = 0;
+    virtual double getValue(std::size_t const node_id,
+                            int const component_id) const = 0;
 };
 
 /// Uniform value initial condition
@@ -46,7 +46,7 @@ public:
     {
     }
     /// Returns a value for given node and component.
-    virtual double getValue(MeshLib::Node const&,
+    virtual double getValue(std::size_t const /*node_id*/,
                             int const component_id) const override
     {
         return _values[component_id];
@@ -74,11 +74,10 @@ public:
         assert(_property.getMeshItemType() == MeshLib::MeshItemType::Node);
     }
 
-    // TODO replace Node with node's id.
-    virtual double getValue(MeshLib::Node const& n,
+    virtual double getValue(std::size_t const node_id,
                             int const component_id) const override
     {
-        return _property[n.getID() * _property.getNumberOfComponents() +
+        return _property[node_id * _property.getNumberOfComponents() +
                          component_id];
     }
 

--- a/ProcessLib/InitialCondition.h
+++ b/ProcessLib/InitialCondition.h
@@ -42,7 +42,8 @@ public:
 class UniformInitialCondition : public InitialCondition
 {
 public:
-    UniformInitialCondition(std::vector<double> const& values) : _values(values)
+    explicit UniformInitialCondition(std::vector<double> const& values)
+        : _values(values)
     {
     }
     /// Returns a value for given node and component.

--- a/ProcessLib/NeumannBc.h
+++ b/ProcessLib/NeumannBc.h
@@ -55,8 +55,8 @@ public:
         NeumannBcConfig const& bc,
         unsigned const integration_order,
         NumLib::LocalToGlobalIndexMap const& local_to_global_index_map,
-        std::size_t const variable_id,
-        std::size_t const component_id)
+        int const variable_id,
+        int const component_id)
         : _function(*bc.getFunction()),
           _integration_order(integration_order)
     {

--- a/ProcessLib/NeumannBcConfig.h
+++ b/ProcessLib/NeumannBcConfig.h
@@ -28,14 +28,14 @@ namespace ProcessLib
 class BoundaryConditionConfig
 {
 public:
-    BoundaryConditionConfig(GeoLib::GeoObject const* const geometry)
+    BoundaryConditionConfig(GeoLib::GeoObject const& geometry)
         : _geometry(geometry)
     { }
 
     virtual ~BoundaryConditionConfig() = default;
 
 protected:
-    GeoLib::GeoObject const* const _geometry;
+    GeoLib::GeoObject const& _geometry;
 };
 
 
@@ -43,8 +43,8 @@ protected:
 class NeumannBcConfig : public BoundaryConditionConfig
 {
 public:
-    NeumannBcConfig(GeoLib::GeoObject const* const geometry,
-            BaseLib::ConfigTree const& config)
+    NeumannBcConfig(GeoLib::GeoObject const& geometry,
+                    BaseLib::ConfigTree const& config)
         : BoundaryConditionConfig(geometry)
     {
         DBUG("Constructing NeumannBcConfig from config.");
@@ -71,7 +71,8 @@ public:
     /// The elements are appended to the \c elements vector.
     void initialize(MeshGeoToolsLib::BoundaryElementsSearcher& searcher)
     {
-        std::vector<MeshLib::Element*> elems = searcher.getBoundaryElements(*_geometry);
+        std::vector<MeshLib::Element*> elems =
+            searcher.getBoundaryElements(_geometry);
 
         // deep copy because the searcher destroys the elements.
         std::transform(elems.cbegin(), elems.cend(),

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -266,8 +266,7 @@ private:
                 global_index = 0;
 #endif
             x.set(global_index,
-                  variable.getInitialConditionValue(*_mesh.getNode(node_id),
-                                                    component_id));
+                  variable.getInitialConditionValue(node_id, component_id));
         }
     }
 

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -9,6 +9,8 @@
 
 #include "ProcessVariable.h"
 
+#include <utility>
+
 #include "logog/include/logog.hpp"
 
 #include "GeoLib/GEOObjects.h"
@@ -83,13 +85,18 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
 
             if (type == "UniformDirichlet")
             {
-                _dirichlet_bc_configs.emplace_back(
-                    new UniformDirichletBoundaryCondition(geometry, bc_config));
+                _dirichlet_bc_configs.emplace_back(std::make_pair(
+                    std::unique_ptr<UniformDirichletBoundaryCondition>(
+                        new UniformDirichletBoundaryCondition(geometry,
+                                                              bc_config)),
+                    0));  // TODO, the 0 stands for component_id. Need parser.
             }
             else if (type == "UniformNeumann")
             {
-                _neumann_bc_configs.emplace_back(
-                    new NeumannBcConfig(geometry, bc_config));
+                _neumann_bc_configs.emplace_back(std::make_pair(
+                    std::unique_ptr<NeumannBcConfig>{
+                        new NeumannBcConfig(geometry, bc_config)},
+                    0));  // TODO, the 0 stands for component_id. Need parser.
             }
             else
             {

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -73,11 +73,14 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
                     //! \ogs_file_param{boundary_condition__geometry}
                     bc_config.getConfigParameter<std::string>("geometry");
 
-            GeoLib::GeoObject const* const geometry =
+            GeoLib::GeoObject const* const geometry_ptr =
                 geometries.getGeoObject(geometrical_set_name, geometry_name);
+            assert(geometry_ptr != nullptr);
+            GeoLib::GeoObject const& geometry = *geometry_ptr;
+
             DBUG(
                 "Found geometry type \"%s\"",
-                GeoLib::convertGeoTypeToString(geometry->getGeoType()).c_str());
+                GeoLib::convertGeoTypeToString(geometry.getGeoType()).c_str());
 
             // Construct type dependent boundary condition
             //! \ogs_file_param{boundary_condition__type}

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -145,7 +145,7 @@ MeshLib::PropertyVector<double>& ProcessVariable::getOrCreateMeshProperty()
     else
     {
         result = _mesh.getProperties().template createNewPropertyVector<double>(
-            _name, MeshLib::MeshItemType::Node);
+            _name, MeshLib::MeshItemType::Node, _n_components);
         assert(result);
         result->resize(_mesh.getNumberOfNodes() * _n_components);
     }

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -25,7 +25,6 @@ class BoundaryElementsSearcher;
 namespace MeshLib
 {
 class Mesh;
-class Node;
 }
 
 namespace GeoLib
@@ -101,10 +100,10 @@ public:
         }
     }
 
-    double getInitialConditionValue(MeshLib::Node const& n,
+    double getInitialConditionValue(std::size_t const node_id,
                                     int const component_id) const
     {
-        return _initial_condition->getValue(n, component_id);
+        return _initial_condition->getValue(node_id, component_id);
     }
 
     // Get or create a property vector for results.

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -67,10 +67,14 @@ public:
         const int variable_id,
         const int component_id)
     {
+        // Find all boundary conditions matching the component id. There can be
+        // more than one such boundary condition.
         for (auto& bc_config : _dirichlet_bc_configs)
         {
             if (bc_config.second != component_id)
                 continue;
+            // Create/initialize the boundary condition with matching component
+            // id and output it through the OutputIterator.
             DirichletBc<GlobalIndexType> bc;
             bc_config.first->initialize(searcher, dof_table, variable_id,
                                         component_id, bc);
@@ -86,10 +90,15 @@ public:
                           const int variable_id,
                           const int component_id)
     {
+        // Find all boundary conditions matching the component id. There can be
+        // more than one such boundary condition.
         for (auto& bc_config : _neumann_bc_configs)
         {
             if (bc_config.second != component_id)
                 continue;
+
+            // Create/initialize the boundary condition with matching component
+            // id and output it through the OutputIterator.
             bc_config.first->initialize(searcher);
             bcs++ = std::unique_ptr<NeumannBc<GlobalSetup>>{
                 new NeumannBc<GlobalSetup>(*bc_config.first,

--- a/ProcessLib/UniformDirichletBoundaryCondition.cpp
+++ b/ProcessLib/UniformDirichletBoundaryCondition.cpp
@@ -1,0 +1,78 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "UniformDirichletBoundaryCondition.h"
+
+#include <algorithm>
+#include <vector>
+
+#include <logog/include/logog.hpp>
+
+namespace ProcessLib
+{
+UniformDirichletBoundaryCondition::UniformDirichletBoundaryCondition(
+    GeoLib::GeoObject const* const geometry, BaseLib::ConfigTree const& config)
+    : _geometry(geometry)
+{
+    DBUG("Constructing UniformDirichletBoundaryCondition from config.");
+    //! \ogs_file_param{boundary_condition__type}
+    config.checkConfigParameter("type", "UniformDirichlet");
+
+    //! \ogs_file_param{boundary_condition__UniformDirichlet__value}
+    _value = config.getConfigParameter<double>("value");
+    DBUG("Using value %g", _value);
+}
+
+UniformDirichletBoundaryCondition::UniformDirichletBoundaryCondition(
+    GeoLib::GeoObject const* const geometry, double value)
+    : _value(value), _geometry(geometry)
+{
+    DBUG("Constructed UniformDirichletBoundaryCondition using value %g",
+         _value);
+}
+
+/// Initialize Dirichlet type boundary conditions.
+/// Fills in global_ids of the particular geometry of the boundary condition
+/// and the corresponding values.
+/// The ids and the constant values are then used to construct DirichletBc
+/// object.
+void UniformDirichletBoundaryCondition::initialize(
+    MeshGeoToolsLib::MeshNodeSearcher& searcher,
+    NumLib::LocalToGlobalIndexMap const& dof_table,
+    std::size_t component_id,
+    DirichletBc<GlobalIndexType>& bc)
+{
+    // Find nodes' ids on the given mesh on which this boundary condition
+    // is defined.
+    std::vector<std::size_t> ids = searcher.getMeshNodeIDs(*_geometry);
+
+    // convert mesh node ids to global index for the given component
+    bc.ids.reserve(bc.ids.size() + ids.size());
+    bc.values.reserve(bc.values.size() + ids.size());
+    for (auto& id : ids)
+    {
+        MeshLib::Location l(searcher.getMeshId(), MeshLib::MeshItemType::Node,
+                            id);
+        // TODO: that might be slow, but only done once
+        const auto g_idx = dof_table.getGlobalIndex(l, component_id);
+        // For the DDC approach (e.g. with PETSc option), the negative
+        // index of g_idx means that the entry by that index is a ghost one,
+        // which should be dropped. Especially for PETSc routines MatZeroRows
+        // and MatZeroRowsColumns, which are called to apply the Dirichlet BC,
+        // the negative index is not accepted like other matrix or vector
+        // PETSc routines. Therefore, the following if-condition is applied.
+        if (g_idx >= 0)
+        {
+            bc.ids.emplace_back(g_idx);
+            bc.values.emplace_back(_value);
+        }
+    }
+}
+
+}   // namespace ProcessLib

--- a/ProcessLib/UniformDirichletBoundaryCondition.cpp
+++ b/ProcessLib/UniformDirichletBoundaryCondition.cpp
@@ -45,7 +45,8 @@ UniformDirichletBoundaryCondition::UniformDirichletBoundaryCondition(
 void UniformDirichletBoundaryCondition::initialize(
     MeshGeoToolsLib::MeshNodeSearcher& searcher,
     NumLib::LocalToGlobalIndexMap const& dof_table,
-    std::size_t component_id,
+    int const component_id,
+    int const variable_id,
     DirichletBc<GlobalIndexType>& bc)
 {
     // Find nodes' ids on the given mesh on which this boundary condition
@@ -60,7 +61,8 @@ void UniformDirichletBoundaryCondition::initialize(
         MeshLib::Location l(searcher.getMeshId(), MeshLib::MeshItemType::Node,
                             id);
         // TODO: that might be slow, but only done once
-        const auto g_idx = dof_table.getGlobalIndex(l, component_id);
+        const auto g_idx =
+            dof_table.getGlobalIndex(l, variable_id, component_id);
         // For the DDC approach (e.g. with PETSc option), the negative
         // index of g_idx means that the entry by that index is a ghost one,
         // which should be dropped. Especially for PETSc routines MatZeroRows

--- a/ProcessLib/UniformDirichletBoundaryCondition.cpp
+++ b/ProcessLib/UniformDirichletBoundaryCondition.cpp
@@ -17,7 +17,7 @@
 namespace ProcessLib
 {
 UniformDirichletBoundaryCondition::UniformDirichletBoundaryCondition(
-    GeoLib::GeoObject const* const geometry, BaseLib::ConfigTree const& config)
+    GeoLib::GeoObject const& geometry, BaseLib::ConfigTree const& config)
     : _geometry(geometry)
 {
     DBUG("Constructing UniformDirichletBoundaryCondition from config.");
@@ -30,7 +30,7 @@ UniformDirichletBoundaryCondition::UniformDirichletBoundaryCondition(
 }
 
 UniformDirichletBoundaryCondition::UniformDirichletBoundaryCondition(
-    GeoLib::GeoObject const* const geometry, double value)
+    GeoLib::GeoObject const& geometry, double value)
     : _value(value), _geometry(geometry)
 {
     DBUG("Constructed UniformDirichletBoundaryCondition using value %g",
@@ -51,7 +51,7 @@ void UniformDirichletBoundaryCondition::initialize(
 {
     // Find nodes' ids on the given mesh on which this boundary condition
     // is defined.
-    std::vector<std::size_t> ids = searcher.getMeshNodeIDs(*_geometry);
+    std::vector<std::size_t> ids = searcher.getMeshNodeIDs(_geometry);
 
     // convert mesh node ids to global index for the given component
     bc.ids.reserve(bc.ids.size() + ids.size());

--- a/ProcessLib/UniformDirichletBoundaryCondition.h
+++ b/ProcessLib/UniformDirichletBoundaryCondition.h
@@ -10,11 +10,6 @@
 #ifndef PROCESS_LIB_BOUNDARY_CONDITION_H_
 #define PROCESS_LIB_BOUNDARY_CONDITION_H_
 
-#include <algorithm>
-#include <vector>
-
-#include <logog/include/logog.hpp>
-
 #include "BaseLib/ConfigTree.h"
 #include "MeshGeoToolsLib/MeshNodeSearcher.h"
 #include "NumLib/DOF/LocalToGlobalIndexMap.h"
@@ -24,12 +19,11 @@
 
 namespace GeoLib
 {
-    class GeoObject;
+class GeoObject;
 }
 
 namespace ProcessLib
 {
-
 /// The UniformDirichletBoundaryCondition class describes a constant in space
 /// and time Dirichlet boundary condition.
 /// The expected parameter in the passed configuration is "value" which, when
@@ -38,71 +32,26 @@ class UniformDirichletBoundaryCondition
 {
 public:
     UniformDirichletBoundaryCondition(GeoLib::GeoObject const* const geometry,
-                                      BaseLib::ConfigTree const& config)
-        : _geometry(geometry)
-    {
-        DBUG("Constructing UniformDirichletBoundaryCondition from config.");
-        //! \ogs_file_param{boundary_condition__type}
-        config.checkConfigParameter("type", "UniformDirichlet");
-
-        //! \ogs_file_param{boundary_condition__UniformDirichlet__value}
-        _value = config.getConfigParameter<double>("value");
-        DBUG("Using value %g", _value);
-    }
+                                      BaseLib::ConfigTree const& config);
 
     UniformDirichletBoundaryCondition(GeoLib::GeoObject const* const geometry,
-                                      double value)
-        : _value(value), _geometry(geometry)
-    {
-        DBUG("Constructed UniformDirichletBoundaryCondition using value %g",
-            _value);
-    }
+                                      double value);
 
     /// Initialize Dirichlet type boundary conditions.
     /// Fills in global_ids of the particular geometry of the boundary condition
     /// and the corresponding values.
     /// The ids and the constant values are then used to construct DirichletBc
     /// object.
-    void initialize(
-            MeshGeoToolsLib::MeshNodeSearcher& searcher,
-            NumLib::LocalToGlobalIndexMap const& dof_table,
-            std::size_t component_id,
-            DirichletBc<GlobalIndexType>& bc)
-    {
-        // Find nodes' ids on the given mesh on which this boundary condition
-        // is defined.
-        std::vector<std::size_t> ids = searcher.getMeshNodeIDs(*_geometry);
-
-        // convert mesh node ids to global index for the given component
-        bc.ids.reserve(bc.ids.size() + ids.size());
-        bc.values.reserve(bc.values.size() + ids.size());
-        for (auto& id : ids)
-        {
-            MeshLib::Location l(searcher.getMeshId(),
-                                MeshLib::MeshItemType::Node,
-                                id);
-            // TODO: that might be slow, but only done once
-            const auto g_idx = dof_table.getGlobalIndex(l, component_id);
-            // For the DDC approach (e.g. with PETSc option), the negative
-            // index of g_idx means that the entry by that index is a ghost one,
-            // which should be dropped. Especially for PETSc routines MatZeroRows
-            // and MatZeroRowsColumns, which are called to apply the Dirichlet BC,
-            // the negative index is not accepted like other matrix or vector
-            // PETSc routines. Therefore, the following if-condition is applied.
-            if (g_idx >= 0)
-            {
-                bc.ids.emplace_back(g_idx);
-                bc.values.emplace_back(_value);
-            }
-        }
-    }
+    void initialize(MeshGeoToolsLib::MeshNodeSearcher& searcher,
+                    NumLib::LocalToGlobalIndexMap const& dof_table,
+                    std::size_t component_id,
+                    DirichletBc<GlobalIndexType>& bc);
 
 private:
     double _value;
     GeoLib::GeoObject const* const _geometry;
 };
 
-
-}   // namespace ProcessLib
+}  // namespace ProcessLib
 
 #endif  // PROCESS_LIB_BOUNDARY_CONDITION_H_

--- a/ProcessLib/UniformDirichletBoundaryCondition.h
+++ b/ProcessLib/UniformDirichletBoundaryCondition.h
@@ -44,7 +44,8 @@ public:
     /// object.
     void initialize(MeshGeoToolsLib::MeshNodeSearcher& searcher,
                     NumLib::LocalToGlobalIndexMap const& dof_table,
-                    std::size_t component_id,
+                    int const variable_id,
+                    int const component_id,
                     DirichletBc<GlobalIndexType>& bc);
 
 private:

--- a/ProcessLib/UniformDirichletBoundaryCondition.h
+++ b/ProcessLib/UniformDirichletBoundaryCondition.h
@@ -31,10 +31,10 @@ namespace ProcessLib
 class UniformDirichletBoundaryCondition
 {
 public:
-    UniformDirichletBoundaryCondition(GeoLib::GeoObject const* const geometry,
+    UniformDirichletBoundaryCondition(GeoLib::GeoObject const& geometry,
                                       BaseLib::ConfigTree const& config);
 
-    UniformDirichletBoundaryCondition(GeoLib::GeoObject const* const geometry,
+    UniformDirichletBoundaryCondition(GeoLib::GeoObject const& geometry,
                                       double value);
 
     /// Initialize Dirichlet type boundary conditions.
@@ -50,7 +50,7 @@ public:
 
 private:
     double _value;
-    GeoLib::GeoObject const* const _geometry;
+    GeoLib::GeoObject const& _geometry;
 };
 
 }  // namespace ProcessLib

--- a/ProcessLib/UniformDirichletBoundaryCondition.h
+++ b/ProcessLib/UniformDirichletBoundaryCondition.h
@@ -50,6 +50,14 @@ public:
         DBUG("Using value %g", _value);
     }
 
+    UniformDirichletBoundaryCondition(GeoLib::GeoObject const* const geometry,
+                                      double value)
+        : _value(value), _geometry(geometry)
+    {
+        DBUG("Constructed UniformDirichletBoundaryCondition using value %g",
+            _value);
+    }
+
     /// Initialize Dirichlet type boundary conditions.
     /// Fills in global_ids of the particular geometry of the boundary condition
     /// and the corresponding values.


### PR DESCRIPTION
Introduce variable_id to get multivariable/multicomponent processes set up correctly with their ICs and BCs. Also see the Tests/Data, where `<component_value_0>` is used for example for the second component instead of `<value>`. Other ideas to mark the components are welcome.

The uniform initial conditions for multicomponent variable can be given in the form
```xml
<values>0.5 0.7 0.9</values>
```
for a three component variable.

Not implemented and explicitly marked as such is the reading of the multicomponent boundary conditions.