### PR TITLE
Duplicate geometry

### DIFF
--- a/GeoLib/DuplicateGeometry.cpp
+++ b/GeoLib/DuplicateGeometry.cpp
@@ -94,7 +94,7 @@ std::unique_ptr<std::vector<Surface*>> DuplicateGeometry::copySurfacesVector(
             continue;
         (*new_surfaces)[i] = new GeoLib::Surface(*_geo_objects.getPointVec(_output_name));
 
-        std::size_t n_tris (surfaces[i]->getNTriangles());
+        std::size_t n_tris (surfaces[i]->getNumberOfTriangles());
         for (std::size_t j=0; j<n_tris; ++j)
         {
             GeoLib::Triangle const* t = (*surfaces[i])[j];

--- a/GeoLib/DuplicateGeometry.cpp
+++ b/GeoLib/DuplicateGeometry.cpp
@@ -61,9 +61,9 @@ void DuplicateGeometry::duplicate(std::string const& input_name)
 }
 
 std::unique_ptr<std::vector<GeoLib::Polyline*>> DuplicateGeometry::copyPolylinesVector(
-    std::vector<GeoLib::Polyline*> const& polylines)
+    std::vector<GeoLib::Polyline*> const& polylines) const
 {
-    std::size_t n_plys = polylines.size();
+    std::size_t const n_plys = polylines.size();
     std::unique_ptr<std::vector<GeoLib::Polyline*>> new_lines
         (new std::vector<Polyline*>(n_plys, nullptr));
 
@@ -72,7 +72,7 @@ std::unique_ptr<std::vector<GeoLib::Polyline*>> DuplicateGeometry::copyPolylines
         if (polylines[i] == nullptr)
             continue;
         (*new_lines)[i] = new GeoLib::Polyline(*_geo_objects.getPointVec(_output_name));
-        std::size_t nLinePnts (polylines[i]->getNumberOfPoints());
+        std::size_t const nLinePnts (polylines[i]->getNumberOfPoints());
         for (std::size_t j=0; j<nLinePnts; ++j)
             (*new_lines)[i]->addPoint(polylines[i]->getPointID(j));
     }
@@ -80,9 +80,9 @@ std::unique_ptr<std::vector<GeoLib::Polyline*>> DuplicateGeometry::copyPolylines
 }
 
 std::unique_ptr<std::vector<Surface*>> DuplicateGeometry::copySurfacesVector(
-    std::vector<Surface*> const& surfaces)
+    std::vector<Surface*> const& surfaces) const
 {
-    std::size_t n_sfc = surfaces.size();
+    std::size_t const n_sfc = surfaces.size();
     std::unique_ptr<std::vector<GeoLib::Surface*>> new_surfaces
         (new std::vector<Surface*>(n_sfc, nullptr));
 
@@ -92,7 +92,7 @@ std::unique_ptr<std::vector<Surface*>> DuplicateGeometry::copySurfacesVector(
             continue;
         (*new_surfaces)[i] = new GeoLib::Surface(*_geo_objects.getPointVec(_output_name));
 
-        std::size_t n_tris (surfaces[i]->getNumberOfTriangles());
+        std::size_t const n_tris (surfaces[i]->getNumberOfTriangles());
         for (std::size_t j=0; j<n_tris; ++j)
         {
             GeoLib::Triangle const* t = (*surfaces[i])[j];

--- a/GeoLib/DuplicateGeometry.cpp
+++ b/GeoLib/DuplicateGeometry.cpp
@@ -9,12 +9,10 @@
 
 #include "DuplicateGeometry.h"
 
-#include <memory>
-#include <vector>
-
 // ThirdParty/logog
 #include <logog/include/logog.hpp>
 
+#include "GeoLib/GEOObjects.h"
 #include "GeoLib/Point.h"
 #include "GeoLib/Polyline.h"
 #include "GeoLib/Surface.h"

--- a/GeoLib/DuplicateGeometry.cpp
+++ b/GeoLib/DuplicateGeometry.cpp
@@ -1,0 +1,123 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "DuplicateGeometry.h"
+
+#include <memory>
+#include <vector>
+
+// ThirdParty/logog
+#include "logog/include/logog.hpp"
+
+#include "GeoLib/Point.h"
+#include "GeoLib/Polyline.h"
+#include "GeoLib/Surface.h"
+#include "GeoLib/Triangle.h"
+
+
+namespace GeoLib
+{
+
+DuplicateGeometry::DuplicateGeometry(GeoLib::GEOObjects &geo_objects,
+	std::string const& input_name,
+	std::string const& output_name)
+: _output_name(output_name), _geo_objects(geo_objects)
+{
+	duplicate(input_name);
+}
+
+void DuplicateGeometry::duplicate(std::string const& input_name)
+{
+	std::vector<GeoLib::Point*> const*const pnts (_geo_objects.getPointVec(input_name));
+	if (pnts == nullptr)
+	{
+		ERR("Geometry \"%s\" not found.", input_name.c_str());
+		return;
+	}
+
+	std::unique_ptr< std::vector<GeoLib::Point*> > new_pnts (new std::vector<GeoLib::Point*>);
+	new_pnts->reserve(pnts->size());
+	std::transform(pnts->cbegin(), pnts->cend(), std::back_inserter(*new_pnts),
+		[](GeoLib::Point* point) { return new GeoLib::Point(*point); });
+	_geo_objects.addPointVec(std::move(new_pnts), _output_name);
+
+	std::vector<GeoLib::Polyline*> const* plys (_geo_objects.getPolylineVec(input_name));
+	if (plys)
+	{
+		auto new_plys = copyPolylinesVector(*plys);
+		_geo_objects.addPolylineVec(std::move(new_plys), _output_name);
+	}
+
+	std::vector<GeoLib::Surface*> const* sfcs (_geo_objects.getSurfaceVec(input_name));
+	if (sfcs)
+	{
+		auto new_sfcs = copySurfacesVector(*sfcs);
+		_geo_objects.addSurfaceVec(std::move(new_sfcs), _output_name);
+	}
+}
+
+std::unique_ptr<std::vector<GeoLib::Polyline*>> DuplicateGeometry::copyPolylinesVector(
+	std::vector<GeoLib::Polyline*> const& polylines)
+{
+	std::size_t n_plys = polylines.size();
+	std::unique_ptr<std::vector<GeoLib::Polyline*>> new_lines
+		(new std::vector<Polyline*>(n_plys, nullptr));
+
+	for (std::size_t i=0; i<n_plys; ++i)
+	{
+		if (polylines[i] == nullptr)
+			continue;
+		(*new_lines)[i] = new GeoLib::Polyline(*_geo_objects.getPointVec(_output_name));
+		std::size_t nLinePnts (polylines[i]->getNumberOfPoints());
+		for (std::size_t j=0; j<nLinePnts; ++j)
+			(*new_lines)[i]->addPoint(polylines[i]->getPointID(j));
+	}
+	return new_lines;
+}
+
+std::unique_ptr<std::vector<Surface*>> DuplicateGeometry::copySurfacesVector(
+	std::vector<Surface*> const& surfaces)
+{
+	std::size_t n_sfc = surfaces.size();
+	std::unique_ptr<std::vector<GeoLib::Surface*>> new_surfaces
+		(new std::vector<Surface*>(n_sfc, nullptr));
+
+	for (std::size_t i=0; i<n_sfc; ++i)
+	{
+		if (surfaces[i] == nullptr)
+			continue;
+		(*new_surfaces)[i] = new GeoLib::Surface(*_geo_objects.getPointVec(_output_name));
+
+		std::size_t n_tris (surfaces[i]->getNTriangles());
+		for (std::size_t j=0; j<n_tris; ++j)
+		{
+			GeoLib::Triangle const* t = (*surfaces[i])[j];
+			(*new_surfaces)[i]->addTriangle(
+				t->getPoint(0)->getID(), t->getPoint(1)->getID(), t->getPoint(2)->getID());
+		}
+	}
+	return new_surfaces;
+}
+
+std::vector<GeoLib::Point*>& DuplicateGeometry::getPointVectorCopy()
+{
+	return const_cast<std::vector<GeoLib::Point*>&>(*_geo_objects.getPointVec(_output_name));
+}
+
+std::vector<GeoLib::Polyline*>& DuplicateGeometry::getPolylineVectorCopy()
+{
+	return const_cast<std::vector<GeoLib::Polyline*>&>(*_geo_objects.getPolylineVec(_output_name));
+}
+
+std::vector<GeoLib::Surface*>& DuplicateGeometry::getSurfaceVectorCopy()
+{
+	return const_cast<std::vector<GeoLib::Surface*>&>(*_geo_objects.getSurfaceVec(_output_name));
+}
+
+}

--- a/GeoLib/DuplicateGeometry.cpp
+++ b/GeoLib/DuplicateGeometry.cpp
@@ -13,7 +13,7 @@
 #include <vector>
 
 // ThirdParty/logog
-#include "logog/include/logog.hpp"
+#include <logog/include/logog.hpp>
 
 #include "GeoLib/Point.h"
 #include "GeoLib/Polyline.h"
@@ -25,99 +25,99 @@ namespace GeoLib
 {
 
 DuplicateGeometry::DuplicateGeometry(GeoLib::GEOObjects &geo_objects,
-	std::string const& input_name,
-	std::string const& output_name)
+    std::string const& input_name,
+    std::string const& output_name)
 : _output_name(output_name), _geo_objects(geo_objects)
 {
-	duplicate(input_name);
+    duplicate(input_name);
 }
 
 void DuplicateGeometry::duplicate(std::string const& input_name)
 {
-	std::vector<GeoLib::Point*> const*const pnts (_geo_objects.getPointVec(input_name));
-	if (pnts == nullptr)
-	{
-		ERR("Geometry \"%s\" not found.", input_name.c_str());
-		return;
-	}
+    std::vector<GeoLib::Point*> const*const pnts (_geo_objects.getPointVec(input_name));
+    if (pnts == nullptr)
+    {
+        ERR("Geometry \"%s\" not found.", input_name.c_str());
+        return;
+    }
 
-	std::unique_ptr< std::vector<GeoLib::Point*> > new_pnts (new std::vector<GeoLib::Point*>);
-	new_pnts->reserve(pnts->size());
-	std::transform(pnts->cbegin(), pnts->cend(), std::back_inserter(*new_pnts),
-		[](GeoLib::Point* point) { return new GeoLib::Point(*point); });
-	_geo_objects.addPointVec(std::move(new_pnts), _output_name);
+    std::unique_ptr< std::vector<GeoLib::Point*> > new_pnts (new std::vector<GeoLib::Point*>);
+    new_pnts->reserve(pnts->size());
+    std::transform(pnts->cbegin(), pnts->cend(), std::back_inserter(*new_pnts),
+        [](GeoLib::Point* point) { return new GeoLib::Point(*point); });
+    _geo_objects.addPointVec(std::move(new_pnts), _output_name);
 
-	std::vector<GeoLib::Polyline*> const* plys (_geo_objects.getPolylineVec(input_name));
-	if (plys)
-	{
-		auto new_plys = copyPolylinesVector(*plys);
-		_geo_objects.addPolylineVec(std::move(new_plys), _output_name);
-	}
+    std::vector<GeoLib::Polyline*> const* plys (_geo_objects.getPolylineVec(input_name));
+    if (plys)
+    {
+        auto new_plys = copyPolylinesVector(*plys);
+        _geo_objects.addPolylineVec(std::move(new_plys), _output_name);
+    }
 
-	std::vector<GeoLib::Surface*> const* sfcs (_geo_objects.getSurfaceVec(input_name));
-	if (sfcs)
-	{
-		auto new_sfcs = copySurfacesVector(*sfcs);
-		_geo_objects.addSurfaceVec(std::move(new_sfcs), _output_name);
-	}
+    std::vector<GeoLib::Surface*> const* sfcs (_geo_objects.getSurfaceVec(input_name));
+    if (sfcs)
+    {
+        auto new_sfcs = copySurfacesVector(*sfcs);
+        _geo_objects.addSurfaceVec(std::move(new_sfcs), _output_name);
+    }
 }
 
 std::unique_ptr<std::vector<GeoLib::Polyline*>> DuplicateGeometry::copyPolylinesVector(
-	std::vector<GeoLib::Polyline*> const& polylines)
+    std::vector<GeoLib::Polyline*> const& polylines)
 {
-	std::size_t n_plys = polylines.size();
-	std::unique_ptr<std::vector<GeoLib::Polyline*>> new_lines
-		(new std::vector<Polyline*>(n_plys, nullptr));
+    std::size_t n_plys = polylines.size();
+    std::unique_ptr<std::vector<GeoLib::Polyline*>> new_lines
+        (new std::vector<Polyline*>(n_plys, nullptr));
 
-	for (std::size_t i=0; i<n_plys; ++i)
-	{
-		if (polylines[i] == nullptr)
-			continue;
-		(*new_lines)[i] = new GeoLib::Polyline(*_geo_objects.getPointVec(_output_name));
-		std::size_t nLinePnts (polylines[i]->getNumberOfPoints());
-		for (std::size_t j=0; j<nLinePnts; ++j)
-			(*new_lines)[i]->addPoint(polylines[i]->getPointID(j));
-	}
-	return new_lines;
+    for (std::size_t i=0; i<n_plys; ++i)
+    {
+        if (polylines[i] == nullptr)
+            continue;
+        (*new_lines)[i] = new GeoLib::Polyline(*_geo_objects.getPointVec(_output_name));
+        std::size_t nLinePnts (polylines[i]->getNumberOfPoints());
+        for (std::size_t j=0; j<nLinePnts; ++j)
+            (*new_lines)[i]->addPoint(polylines[i]->getPointID(j));
+    }
+    return new_lines;
 }
 
 std::unique_ptr<std::vector<Surface*>> DuplicateGeometry::copySurfacesVector(
-	std::vector<Surface*> const& surfaces)
+    std::vector<Surface*> const& surfaces)
 {
-	std::size_t n_sfc = surfaces.size();
-	std::unique_ptr<std::vector<GeoLib::Surface*>> new_surfaces
-		(new std::vector<Surface*>(n_sfc, nullptr));
+    std::size_t n_sfc = surfaces.size();
+    std::unique_ptr<std::vector<GeoLib::Surface*>> new_surfaces
+        (new std::vector<Surface*>(n_sfc, nullptr));
 
-	for (std::size_t i=0; i<n_sfc; ++i)
-	{
-		if (surfaces[i] == nullptr)
-			continue;
-		(*new_surfaces)[i] = new GeoLib::Surface(*_geo_objects.getPointVec(_output_name));
+    for (std::size_t i=0; i<n_sfc; ++i)
+    {
+        if (surfaces[i] == nullptr)
+            continue;
+        (*new_surfaces)[i] = new GeoLib::Surface(*_geo_objects.getPointVec(_output_name));
 
-		std::size_t n_tris (surfaces[i]->getNTriangles());
-		for (std::size_t j=0; j<n_tris; ++j)
-		{
-			GeoLib::Triangle const* t = (*surfaces[i])[j];
-			(*new_surfaces)[i]->addTriangle(
-				t->getPoint(0)->getID(), t->getPoint(1)->getID(), t->getPoint(2)->getID());
-		}
-	}
-	return new_surfaces;
+        std::size_t n_tris (surfaces[i]->getNTriangles());
+        for (std::size_t j=0; j<n_tris; ++j)
+        {
+            GeoLib::Triangle const* t = (*surfaces[i])[j];
+            (*new_surfaces)[i]->addTriangle(
+                t->getPoint(0)->getID(), t->getPoint(1)->getID(), t->getPoint(2)->getID());
+        }
+    }
+    return new_surfaces;
 }
 
 std::vector<GeoLib::Point*>& DuplicateGeometry::getPointVectorCopy()
 {
-	return const_cast<std::vector<GeoLib::Point*>&>(*_geo_objects.getPointVec(_output_name));
+    return const_cast<std::vector<GeoLib::Point*>&>(*_geo_objects.getPointVec(_output_name));
 }
 
 std::vector<GeoLib::Polyline*>& DuplicateGeometry::getPolylineVectorCopy()
 {
-	return const_cast<std::vector<GeoLib::Polyline*>&>(*_geo_objects.getPolylineVec(_output_name));
+    return const_cast<std::vector<GeoLib::Polyline*>&>(*_geo_objects.getPolylineVec(_output_name));
 }
 
 std::vector<GeoLib::Surface*>& DuplicateGeometry::getSurfaceVectorCopy()
 {
-	return const_cast<std::vector<GeoLib::Surface*>&>(*_geo_objects.getSurfaceVec(_output_name));
+    return const_cast<std::vector<GeoLib::Surface*>&>(*_geo_objects.getSurfaceVec(_output_name));
 }
 
 }

--- a/GeoLib/DuplicateGeometry.h
+++ b/GeoLib/DuplicateGeometry.h
@@ -28,39 +28,39 @@ class DuplicateGeometry final
 {
 
 public:
-	/**
-	 * Creates a copy of a geometry within GEOObjects
-	 * \param geo_objects The container for geometries
-	 * \param input_name  The geometry to be copied
-	 * \param output_name The name of the copy (note: this might be modified by GEOObjects)
-	 */
-	DuplicateGeometry(GeoLib::GEOObjects &geo_objects,
-		std::string const& input_name,
-		std::string const& output_name);
+    /**
+     * Creates a copy of a geometry within GEOObjects
+     * \param geo_objects The container for geometries
+     * \param input_name  The geometry to be copied
+     * \param output_name The name of the copy (note: this might be modified by GEOObjects)
+     */
+    DuplicateGeometry(GeoLib::GEOObjects &geo_objects,
+        std::string const& input_name,
+        std::string const& output_name);
 
-	// Returns the (possibly modified) output name of the new geometry.
-	std::string const& getFinalizedOutputName() { return _output_name; }
-	// Returns a reference to the copied point vector for modification
-	std::vector<GeoLib::Point*>& getPointVectorCopy();
-	// Returns a reference to the copied polyline vector for modification
-	std::vector<GeoLib::Polyline*>& getPolylineVectorCopy();
-	// Returns a reference to the copied surface vector for modification
-	std::vector<GeoLib::Surface*>& getSurfaceVectorCopy();
+    // Returns the (possibly modified) output name of the new geometry.
+    std::string const& getFinalizedOutputName() { return _output_name; }
+    // Returns a reference to the copied point vector for modification
+    std::vector<GeoLib::Point*>& getPointVectorCopy();
+    // Returns a reference to the copied polyline vector for modification
+    std::vector<GeoLib::Polyline*>& getPolylineVectorCopy();
+    // Returns a reference to the copied surface vector for modification
+    std::vector<GeoLib::Surface*>& getSurfaceVectorCopy();
 
 private:
-	// creates a deep copy of the designated geometry
-	void duplicate(std::string const& input_name);
+    // creates a deep copy of the designated geometry
+    void duplicate(std::string const& input_name);
 
-	// creates a deep copy of the polyline vector
-	std::unique_ptr<std::vector<GeoLib::Polyline*>> copyPolylinesVector(
-		std::vector<GeoLib::Polyline*> const& polylines);
+    // creates a deep copy of the polyline vector
+    std::unique_ptr<std::vector<GeoLib::Polyline*>> copyPolylinesVector(
+        std::vector<GeoLib::Polyline*> const& polylines);
 
-	// creates a deep copy of the surface vector
-	std::unique_ptr<std::vector<GeoLib::Surface*>> copySurfacesVector(
-		std::vector<GeoLib::Surface*> const& surfaces);
+    // creates a deep copy of the surface vector
+    std::unique_ptr<std::vector<GeoLib::Surface*>> copySurfacesVector(
+        std::vector<GeoLib::Surface*> const& surfaces);
 
-	std::string _output_name;
-	GeoLib::GEOObjects& _geo_objects;
+    std::string _output_name;
+    GeoLib::GEOObjects& _geo_objects;
 
 }; // class
 

--- a/GeoLib/DuplicateGeometry.h
+++ b/GeoLib/DuplicateGeometry.h
@@ -1,0 +1,69 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef DUPLICATEGEOMETRY_H_
+#define DUPLICATEGEOMETRY_H_
+
+#include <string>
+
+#include "GeoLib/GEOObjects.h"
+
+namespace GeoLib
+{
+
+class Point;
+class Polyline;
+class Surface;
+
+/**
+ * Creates a copy of a geometry within GEOObjects
+ */
+class DuplicateGeometry final
+{
+
+public:
+	/**
+	 * Creates a copy of a geometry within GEOObjects
+	 * \param geo_objects The container for geometries
+	 * \param input_name  The geometry to be copied
+	 * \param output_name The name of the copy (note: this might be modified by GEOObjects)
+	 */
+	DuplicateGeometry(GeoLib::GEOObjects &geo_objects,
+		std::string const& input_name,
+		std::string const& output_name);
+
+	// Returns the (possibly modified) output name of the new geometry.
+	std::string const& getFinalizedOutputName() { return _output_name; }
+	// Returns a reference to the copied point vector for modification
+	std::vector<GeoLib::Point*>& getPointVectorCopy();
+	// Returns a reference to the copied polyline vector for modification
+	std::vector<GeoLib::Polyline*>& getPolylineVectorCopy();
+	// Returns a reference to the copied surface vector for modification
+	std::vector<GeoLib::Surface*>& getSurfaceVectorCopy();
+
+private:
+	// creates a deep copy of the designated geometry
+	void duplicate(std::string const& input_name);
+
+	// creates a deep copy of the polyline vector
+	std::unique_ptr<std::vector<GeoLib::Polyline*>> copyPolylinesVector(
+		std::vector<GeoLib::Polyline*> const& polylines);
+
+	// creates a deep copy of the surface vector
+	std::unique_ptr<std::vector<GeoLib::Surface*>> copySurfacesVector(
+		std::vector<GeoLib::Surface*> const& surfaces);
+
+	std::string _output_name;
+	GeoLib::GEOObjects& _geo_objects;
+
+}; // class
+
+} // namespace
+
+#endif /* DUPLICATEGEOMETRY_H_ */

--- a/GeoLib/DuplicateGeometry.h
+++ b/GeoLib/DuplicateGeometry.h
@@ -10,13 +10,13 @@
 #ifndef DUPLICATEGEOMETRY_H_
 #define DUPLICATEGEOMETRY_H_
 
+#include <memory>
 #include <string>
-
-#include "GeoLib/GEOObjects.h"
+#include <vector>
 
 namespace GeoLib
 {
-
+class GEOObjects;
 class Point;
 class Polyline;
 class Surface;

--- a/GeoLib/DuplicateGeometry.h
+++ b/GeoLib/DuplicateGeometry.h
@@ -39,7 +39,7 @@ public:
         std::string const& output_name);
 
     // Returns the (possibly modified) output name of the new geometry.
-    std::string const& getFinalizedOutputName() { return _output_name; }
+    std::string const& getFinalizedOutputName() const { return _output_name; }
     // Returns a reference to the copied point vector for modification
     std::vector<GeoLib::Point*>& getPointVectorCopy();
     // Returns a reference to the copied polyline vector for modification

--- a/GeoLib/DuplicateGeometry.h
+++ b/GeoLib/DuplicateGeometry.h
@@ -53,11 +53,11 @@ private:
 
     // creates a deep copy of the polyline vector
     std::unique_ptr<std::vector<GeoLib::Polyline*>> copyPolylinesVector(
-        std::vector<GeoLib::Polyline*> const& polylines);
+        std::vector<GeoLib::Polyline*> const& polylines) const;
 
     // creates a deep copy of the surface vector
     std::unique_ptr<std::vector<GeoLib::Surface*>> copySurfacesVector(
-        std::vector<GeoLib::Surface*> const& surfaces);
+        std::vector<GeoLib::Surface*> const& surfaces) const;
 
     std::string _output_name;
     GeoLib::GEOObjects& _geo_objects;

--- a/Tests/GeoLib/TestDuplicateGeometry.cpp
+++ b/Tests/GeoLib/TestDuplicateGeometry.cpp
@@ -111,7 +111,7 @@ TEST(GeoLib, DuplicateGeometry)
         GeoLib::Surface* sfc = new GeoLib::Surface(*geo.getPointVec(input_name));
         for (std::size_t j=0; j<n_tris; ++j)
             sfc->addTriangle(rand() % n_pnts, rand() % n_pnts, rand() % n_pnts);
-        if (sfc->getNTriangles() > 0)
+        if (sfc->getNumberOfTriangles() > 0)
             sfcs->push_back(sfc);
         else
             delete sfc;
@@ -131,8 +131,8 @@ TEST(GeoLib, DuplicateGeometry)
 
         for (std::size_t i=0; i<n_sfcs; ++i)
         {
-            std::size_t const n_tris ((*new_sfcs)[i]->getNTriangles());
-            ASSERT_EQ(n_tris, (*sfcs)[i]->getNTriangles());
+            std::size_t const n_tris ((*new_sfcs)[i]->getNumberOfTriangles());
+            ASSERT_EQ(n_tris, (*sfcs)[i]->getNumberOfTriangles());
             for (std::size_t j=0; j<n_tris; ++j)
                 for (std::size_t k=0; k<3; ++k)
                     ASSERT_EQ((*(*(*sfcs)[i])[j])[k], (*(*(*new_sfcs)[i])[j])[k]);

--- a/Tests/GeoLib/TestDuplicateGeometry.cpp
+++ b/Tests/GeoLib/TestDuplicateGeometry.cpp
@@ -24,127 +24,130 @@
 
 TEST(GeoLib, DuplicateGeometry)
 {
-	GeoLib::GEOObjects geo;
-	std::string input_name ("input");
+    GeoLib::GEOObjects geo;
+    std::string input_name ("input");
 
-	// generate points
-	srand ( static_cast<unsigned>(time(nullptr)) );
-	std::size_t n_pnts (rand() % 1000 + 100);
-	int box_size (rand());
-	double half_box_size(box_size/2);
-	std::unique_ptr<std::vector<GeoLib::Point*>> pnts (new std::vector<GeoLib::Point*>);
-	pnts->reserve(n_pnts);
-	for (int k(0); k<n_pnts; k++) {
-		pnts->push_back(new GeoLib::Point(rand() % box_size - half_box_size, rand() % box_size - half_box_size, rand() % box_size - half_box_size));
-	}
-	geo.addPointVec(std::move(pnts), input_name);
-	std::string output ("output_geometry");
+    // generate points
+    std::srand ( static_cast<unsigned>(std::time(nullptr)) );
+    std::size_t n_pnts (rand() % 1000 + 100);
+    int box_size (rand());
+    double half_box_size(box_size/2);
+    std::unique_ptr<std::vector<GeoLib::Point*>> pnts (new std::vector<GeoLib::Point*>);
+    pnts->reserve(n_pnts);
+    for (int k(0); k<n_pnts; k++) {
+        pnts->push_back(new GeoLib::Point(
+            rand() % box_size - half_box_size,
+            rand() % box_size - half_box_size,
+            rand() % box_size - half_box_size));
+    }
+    geo.addPointVec(std::move(pnts), input_name);
+    std::string output ("output_geometry");
 
-	// duplicate points
-	{
-		GeoLib::DuplicateGeometry dup (geo, input_name, output);
+    // duplicate points
+    {
+        GeoLib::DuplicateGeometry dup (geo, input_name, output);
 
-		std::vector<GeoLib::Point*> const*const pnts (geo.getPointVec(input_name));
-		std::vector<GeoLib::Point*> const*const new_pnts (geo.getPointVec(output));
-		std::vector<GeoLib::Point*>& mod_pnts (dup.getPointVectorCopy());
-		ASSERT_EQ(n_pnts, new_pnts->size());
-		ASSERT_EQ(n_pnts, mod_pnts.size());
+        std::vector<GeoLib::Point*> const*const pnts (geo.getPointVec(input_name));
+        std::vector<GeoLib::Point*> const*const new_pnts (geo.getPointVec(output));
+        std::vector<GeoLib::Point*>& mod_pnts (dup.getPointVectorCopy());
+        ASSERT_EQ(n_pnts, new_pnts->size());
+        ASSERT_EQ(n_pnts, mod_pnts.size());
 
-		for (std::size_t i=0; i<n_pnts; ++i)
-		{
-			ASSERT_EQ((*(*pnts)[i])[0], (*(*new_pnts)[i])[0]);
-			ASSERT_EQ((*(*pnts)[i])[1], (*(*new_pnts)[i])[1]);
-			ASSERT_EQ((*(*pnts)[i])[2], (*(*new_pnts)[i])[2]);
-		}
-		mod_pnts.push_back(new GeoLib::Point(0,0,0));
-		ASSERT_EQ(mod_pnts.size(), pnts->size() + 1);
-		ASSERT_EQ(mod_pnts.size(), new_pnts->size());
-	}
+        for (std::size_t i=0; i<n_pnts; ++i)
+        {
+            ASSERT_EQ((*(*pnts)[i])[0], (*(*new_pnts)[i])[0]);
+            ASSERT_EQ((*(*pnts)[i])[1], (*(*new_pnts)[i])[1]);
+            ASSERT_EQ((*(*pnts)[i])[2], (*(*new_pnts)[i])[2]);
+        }
+        mod_pnts.push_back(new GeoLib::Point(0,0,0));
+        ASSERT_EQ(mod_pnts.size(), pnts->size() + 1);
+        ASSERT_EQ(mod_pnts.size(), new_pnts->size());
+    }
 
-	// add polylines
-	std::size_t n_plys (rand() % 10 + 1);
-	std::unique_ptr<std::vector<GeoLib::Polyline*>> plys (new std::vector<GeoLib::Polyline*>);
-	for (std::size_t i=0; i<n_plys; ++i)
-	{
-		int n_ply_pnts (rand() % 100 + 2);
-		GeoLib::Polyline* line = new GeoLib::Polyline(*geo.getPointVec(input_name));
-		for (std::size_t j=0; j<n_ply_pnts; ++j)
-			line->addPoint(rand() % n_pnts);
-		plys->push_back(line);
-	}
-	geo.addPolylineVec(std::move(plys), input_name);
+    // add polylines
+    std::size_t n_plys (rand() % 10 + 1);
+    std::unique_ptr<std::vector<GeoLib::Polyline*>> plys (new std::vector<GeoLib::Polyline*>);
+    for (std::size_t i=0; i<n_plys; ++i)
+    {
+        int n_ply_pnts (rand() % 100 + 2);
+        GeoLib::Polyline* line = new GeoLib::Polyline(*geo.getPointVec(input_name));
+        for (std::size_t j=0; j<n_ply_pnts; ++j)
+            line->addPoint(rand() % n_pnts);
+        plys->push_back(line);
+    }
+    geo.addPolylineVec(std::move(plys), input_name);
 
-	// duplicate polylines
-	{
-		GeoLib::DuplicateGeometry dup (geo, input_name, output);
-		std::string const& output2 = dup.getFinalizedOutputName();
-		ASSERT_FALSE(output == output2);
+    // duplicate polylines
+    {
+        GeoLib::DuplicateGeometry dup (geo, input_name, output);
+        std::string const& output2 = dup.getFinalizedOutputName();
+        ASSERT_FALSE(output == output2);
 
-		std::vector<GeoLib::Polyline*> const*const plys (geo.getPolylineVec(input_name));
-		std::vector<GeoLib::Polyline*> const*const new_plys (geo.getPolylineVec(output2));
-		ASSERT_EQ(n_plys, new_plys->size());
+        std::vector<GeoLib::Polyline*> const*const plys (geo.getPolylineVec(input_name));
+        std::vector<GeoLib::Polyline*> const*const new_plys (geo.getPolylineVec(output2));
+        ASSERT_EQ(n_plys, new_plys->size());
 
-		for (std::size_t i=0; i<n_plys; ++i)
-		{
-			std::size_t const n_ply_pnts ((*new_plys)[i]->getNumberOfPoints());
-			ASSERT_EQ(n_ply_pnts, (*plys)[i]->getNumberOfPoints());
-			ASSERT_EQ((*new_plys)[i]->getNumberOfSegments(), (*plys)[i]->getNumberOfSegments());
-			for (std::size_t j=0; j<n_ply_pnts; ++j)
-				ASSERT_EQ((*plys)[i]->getPointID(j), (*new_plys)[i]->getPointID(j));
-		}
+        for (std::size_t i=0; i<n_plys; ++i)
+        {
+            std::size_t const n_ply_pnts ((*new_plys)[i]->getNumberOfPoints());
+            ASSERT_EQ(n_ply_pnts, (*plys)[i]->getNumberOfPoints());
+            ASSERT_EQ((*new_plys)[i]->getNumberOfSegments(), (*plys)[i]->getNumberOfSegments());
+            for (std::size_t j=0; j<n_ply_pnts; ++j)
+                ASSERT_EQ((*plys)[i]->getPointID(j), (*new_plys)[i]->getPointID(j));
+        }
 
-		std::vector<GeoLib::Polyline*>& mod_plys (dup.getPolylineVectorCopy());
-		mod_plys.push_back(new GeoLib::Polyline(*(*new_plys)[0]));
-		ASSERT_EQ(mod_plys.size(), plys->size() + 1);
-		ASSERT_EQ(mod_plys.size(), new_plys->size());
-	}
+        std::vector<GeoLib::Polyline*>& mod_plys (dup.getPolylineVectorCopy());
+        mod_plys.push_back(new GeoLib::Polyline(*(*new_plys)[0]));
+        ASSERT_EQ(mod_plys.size(), plys->size() + 1);
+        ASSERT_EQ(mod_plys.size(), new_plys->size());
+    }
 
-	// add surfaces
-	std::size_t n_sfcs (rand() % 10 + 1);
-	std::unique_ptr<std::vector<GeoLib::Surface*>> sfcs (new std::vector<GeoLib::Surface*>);
-	for (std::size_t i=0; i<n_sfcs; ++i)
-	{
-		int n_tris (rand() % 10);
-		GeoLib::Surface* sfc = new GeoLib::Surface(*geo.getPointVec(input_name));
-		for (std::size_t j=0; j<n_tris; ++j)
-			sfc->addTriangle(rand() % n_pnts, rand() % n_pnts, rand() % n_pnts);
-		if (sfc->getNTriangles() > 0)
-			sfcs->push_back(sfc);
-		else
-			delete sfc;
-	}
-	n_sfcs = sfcs->size();
-	geo.addSurfaceVec(std::move(sfcs), input_name);
+    // add surfaces
+    std::size_t n_sfcs (rand() % 10 + 1);
+    std::unique_ptr<std::vector<GeoLib::Surface*>> sfcs (new std::vector<GeoLib::Surface*>);
+    for (std::size_t i=0; i<n_sfcs; ++i)
+    {
+        int n_tris (rand() % 10);
+        GeoLib::Surface* sfc = new GeoLib::Surface(*geo.getPointVec(input_name));
+        for (std::size_t j=0; j<n_tris; ++j)
+            sfc->addTriangle(rand() % n_pnts, rand() % n_pnts, rand() % n_pnts);
+        if (sfc->getNTriangles() > 0)
+            sfcs->push_back(sfc);
+        else
+            delete sfc;
+    }
+    n_sfcs = sfcs->size();
+    geo.addSurfaceVec(std::move(sfcs), input_name);
 
-	// duplicate surfaces
-	{
-		GeoLib::DuplicateGeometry dup (geo, input_name, output);
-		std::string const& output2 = dup.getFinalizedOutputName();
-		ASSERT_FALSE(output == output2);
+    // duplicate surfaces
+    {
+        GeoLib::DuplicateGeometry dup (geo, input_name, output);
+        std::string const& output2 = dup.getFinalizedOutputName();
+        ASSERT_FALSE(output == output2);
 
-		std::vector<GeoLib::Surface*> const* sfcs (geo.getSurfaceVec(input_name));
-		std::vector<GeoLib::Surface*> const* new_sfcs (geo.getSurfaceVec(output2));
-		ASSERT_EQ(n_sfcs, new_sfcs->size());
+        std::vector<GeoLib::Surface*> const* sfcs (geo.getSurfaceVec(input_name));
+        std::vector<GeoLib::Surface*> const* new_sfcs (geo.getSurfaceVec(output2));
+        ASSERT_EQ(n_sfcs, new_sfcs->size());
 
-		for (std::size_t i=0; i<n_sfcs; ++i)
-		{
-			std::size_t const n_tris ((*new_sfcs)[i]->getNTriangles());
-			ASSERT_EQ(n_tris, (*sfcs)[i]->getNTriangles());
-			for (std::size_t j=0; j<n_tris; ++j)
-				for (std::size_t k=0; k<3; ++k)
-					ASSERT_EQ((*(*(*sfcs)[i])[j])[k], (*(*(*new_sfcs)[i])[j])[k]);
-		}
+        for (std::size_t i=0; i<n_sfcs; ++i)
+        {
+            std::size_t const n_tris ((*new_sfcs)[i]->getNTriangles());
+            ASSERT_EQ(n_tris, (*sfcs)[i]->getNTriangles());
+            for (std::size_t j=0; j<n_tris; ++j)
+                for (std::size_t k=0; k<3; ++k)
+                    ASSERT_EQ((*(*(*sfcs)[i])[j])[k], (*(*(*new_sfcs)[i])[j])[k]);
+        }
 
-		std::vector<GeoLib::Point*>& mod_pnts (dup.getPointVectorCopy());
-		std::vector<GeoLib::Surface*>& mod_sfcs (dup.getSurfaceVectorCopy());
-		std::size_t n_pnts = mod_pnts.size();
-		mod_pnts.push_back(new GeoLib::Point(1,0,0,n_pnts));
-		mod_pnts.push_back(new GeoLib::Point(0,1,0,n_pnts+1));
-		mod_pnts.push_back(new GeoLib::Point(0,0,1,n_pnts+2));
-		GeoLib::Surface* sfc = new GeoLib::Surface(mod_pnts);
-		sfc->addTriangle(n_pnts, n_pnts+1, n_pnts+2);
-		mod_sfcs.push_back(sfc);
-		ASSERT_EQ(mod_sfcs.size(), sfcs->size() + 1);
-		ASSERT_EQ(mod_sfcs.size(), new_sfcs->size());
-	}
+        std::vector<GeoLib::Point*>& mod_pnts (dup.getPointVectorCopy());
+        std::vector<GeoLib::Surface*>& mod_sfcs (dup.getSurfaceVectorCopy());
+        std::size_t n_pnts = mod_pnts.size();
+        mod_pnts.push_back(new GeoLib::Point(1,0,0,n_pnts));
+        mod_pnts.push_back(new GeoLib::Point(0,1,0,n_pnts+1));
+        mod_pnts.push_back(new GeoLib::Point(0,0,1,n_pnts+2));
+        GeoLib::Surface* sfc = new GeoLib::Surface(mod_pnts);
+        sfc->addTriangle(n_pnts, n_pnts+1, n_pnts+2);
+        mod_sfcs.push_back(sfc);
+        ASSERT_EQ(mod_sfcs.size(), sfcs->size() + 1);
+        ASSERT_EQ(mod_sfcs.size(), new_sfcs->size());
+    }
 }

--- a/Tests/GeoLib/TestDuplicateGeometry.cpp
+++ b/Tests/GeoLib/TestDuplicateGeometry.cpp
@@ -1,0 +1,150 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ *
+ */
+
+#include <cstdlib>
+#include <ctime>
+#include <random>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "GeoLib/DuplicateGeometry.h"
+#include "GeoLib/GEOObjects.h"
+#include "GeoLib/Point.h"
+#include "GeoLib/Polyline.h"
+#include "GeoLib/Surface.h"
+#include "GeoLib/Triangle.h"
+
+TEST(GeoLib, DuplicateGeometry)
+{
+	GeoLib::GEOObjects geo;
+	std::string input_name ("input");
+
+	// generate points
+	srand ( static_cast<unsigned>(time(nullptr)) );
+	std::size_t n_pnts (rand() % 1000 + 100);
+	int box_size (rand());
+	double half_box_size(box_size/2);
+	std::unique_ptr<std::vector<GeoLib::Point*>> pnts (new std::vector<GeoLib::Point*>);
+	pnts->reserve(n_pnts);
+	for (int k(0); k<n_pnts; k++) {
+		pnts->push_back(new GeoLib::Point(rand() % box_size - half_box_size, rand() % box_size - half_box_size, rand() % box_size - half_box_size));
+	}
+	geo.addPointVec(std::move(pnts), input_name);
+	std::string output ("output_geometry");
+
+	// duplicate points
+	{
+		GeoLib::DuplicateGeometry dup (geo, input_name, output);
+
+		std::vector<GeoLib::Point*> const*const pnts (geo.getPointVec(input_name));
+		std::vector<GeoLib::Point*> const*const new_pnts (geo.getPointVec(output));
+		std::vector<GeoLib::Point*>& mod_pnts (dup.getPointVectorCopy());
+		ASSERT_EQ(n_pnts, new_pnts->size());
+		ASSERT_EQ(n_pnts, mod_pnts.size());
+
+		for (std::size_t i=0; i<n_pnts; ++i)
+		{
+			ASSERT_EQ((*(*pnts)[i])[0], (*(*new_pnts)[i])[0]);
+			ASSERT_EQ((*(*pnts)[i])[1], (*(*new_pnts)[i])[1]);
+			ASSERT_EQ((*(*pnts)[i])[2], (*(*new_pnts)[i])[2]);
+		}
+		mod_pnts.push_back(new GeoLib::Point(0,0,0));
+		ASSERT_EQ(mod_pnts.size(), pnts->size() + 1);
+		ASSERT_EQ(mod_pnts.size(), new_pnts->size());
+	}
+
+	// add polylines
+	std::size_t n_plys (rand() % 10 + 1);
+	std::unique_ptr<std::vector<GeoLib::Polyline*>> plys (new std::vector<GeoLib::Polyline*>);
+	for (std::size_t i=0; i<n_plys; ++i)
+	{
+		int n_ply_pnts (rand() % 100 + 2);
+		GeoLib::Polyline* line = new GeoLib::Polyline(*geo.getPointVec(input_name));
+		for (std::size_t j=0; j<n_ply_pnts; ++j)
+			line->addPoint(rand() % n_pnts);
+		plys->push_back(line);
+	}
+	geo.addPolylineVec(std::move(plys), input_name);
+
+	// duplicate polylines
+	{
+		GeoLib::DuplicateGeometry dup (geo, input_name, output);
+		std::string const& output2 = dup.getFinalizedOutputName();
+		ASSERT_FALSE(output == output2);
+
+		std::vector<GeoLib::Polyline*> const*const plys (geo.getPolylineVec(input_name));
+		std::vector<GeoLib::Polyline*> const*const new_plys (geo.getPolylineVec(output2));
+		ASSERT_EQ(n_plys, new_plys->size());
+
+		for (std::size_t i=0; i<n_plys; ++i)
+		{
+			std::size_t const n_ply_pnts ((*new_plys)[i]->getNumberOfPoints());
+			ASSERT_EQ(n_ply_pnts, (*plys)[i]->getNumberOfPoints());
+			ASSERT_EQ((*new_plys)[i]->getNumberOfSegments(), (*plys)[i]->getNumberOfSegments());
+			for (std::size_t j=0; j<n_ply_pnts; ++j)
+				ASSERT_EQ((*plys)[i]->getPointID(j), (*new_plys)[i]->getPointID(j));
+		}
+
+		std::vector<GeoLib::Polyline*>& mod_plys (dup.getPolylineVectorCopy());
+		mod_plys.push_back(new GeoLib::Polyline(*(*new_plys)[0]));
+		ASSERT_EQ(mod_plys.size(), plys->size() + 1);
+		ASSERT_EQ(mod_plys.size(), new_plys->size());
+	}
+
+	// add surfaces
+	std::size_t n_sfcs (rand() % 10 + 1);
+	std::unique_ptr<std::vector<GeoLib::Surface*>> sfcs (new std::vector<GeoLib::Surface*>);
+	for (std::size_t i=0; i<n_sfcs; ++i)
+	{
+		int n_tris (rand() % 10);
+		GeoLib::Surface* sfc = new GeoLib::Surface(*geo.getPointVec(input_name));
+		for (std::size_t j=0; j<n_tris; ++j)
+			sfc->addTriangle(rand() % n_pnts, rand() % n_pnts, rand() % n_pnts);
+		if (sfc->getNTriangles() > 0)
+			sfcs->push_back(sfc);
+		else
+			delete sfc;
+	}
+	n_sfcs = sfcs->size();
+	geo.addSurfaceVec(std::move(sfcs), input_name);
+
+	// duplicate surfaces
+	{
+		GeoLib::DuplicateGeometry dup (geo, input_name, output);
+		std::string const& output2 = dup.getFinalizedOutputName();
+		ASSERT_FALSE(output == output2);
+
+		std::vector<GeoLib::Surface*> const* sfcs (geo.getSurfaceVec(input_name));
+		std::vector<GeoLib::Surface*> const* new_sfcs (geo.getSurfaceVec(output2));
+		ASSERT_EQ(n_sfcs, new_sfcs->size());
+
+		for (std::size_t i=0; i<n_sfcs; ++i)
+		{
+			std::size_t const n_tris ((*new_sfcs)[i]->getNTriangles());
+			ASSERT_EQ(n_tris, (*sfcs)[i]->getNTriangles());
+			for (std::size_t j=0; j<n_tris; ++j)
+				for (std::size_t k=0; k<3; ++k)
+					ASSERT_EQ((*(*(*sfcs)[i])[j])[k], (*(*(*new_sfcs)[i])[j])[k]);
+		}
+
+		std::vector<GeoLib::Point*>& mod_pnts (dup.getPointVectorCopy());
+		std::vector<GeoLib::Surface*>& mod_sfcs (dup.getSurfaceVectorCopy());
+		std::size_t n_pnts = mod_pnts.size();
+		mod_pnts.push_back(new GeoLib::Point(1,0,0,n_pnts));
+		mod_pnts.push_back(new GeoLib::Point(0,1,0,n_pnts+1));
+		mod_pnts.push_back(new GeoLib::Point(0,0,1,n_pnts+2));
+		GeoLib::Surface* sfc = new GeoLib::Surface(mod_pnts);
+		sfc->addTriangle(n_pnts, n_pnts+1, n_pnts+2);
+		mod_sfcs.push_back(sfc);
+		ASSERT_EQ(mod_sfcs.size(), sfcs->size() + 1);
+		ASSERT_EQ(mod_sfcs.size(), new_sfcs->size());
+	}
+}

--- a/Tests/GeoLib/TestDuplicateGeometry.cpp
+++ b/Tests/GeoLib/TestDuplicateGeometry.cpp
@@ -30,15 +30,15 @@ TEST(GeoLib, DuplicateGeometry)
     // generate points
     std::srand ( static_cast<unsigned>(std::time(nullptr)) );
     std::size_t n_pnts (rand() % 1000 + 100);
-    int box_size (rand());
+    int box_size (std::rand());
     double half_box_size(box_size/2);
     std::unique_ptr<std::vector<GeoLib::Point*>> pnts (new std::vector<GeoLib::Point*>);
     pnts->reserve(n_pnts);
     for (int k(0); k<n_pnts; k++) {
         pnts->push_back(new GeoLib::Point(
-            rand() % box_size - half_box_size,
-            rand() % box_size - half_box_size,
-            rand() % box_size - half_box_size));
+            std::rand() % box_size - half_box_size,
+            std::rand() % box_size - half_box_size,
+            std::rand() % box_size - half_box_size));
     }
     geo.addPointVec(std::move(pnts), input_name);
     std::string output ("output_geometry");


### PR DESCRIPTION
This adds a class for creating a deep copy of an existing geometry. I needed this for a number of external tools and we discussed that it might make sense to put this into GeoLib.

@TomFischer : maybe you can use the surface-copy routine as a blueprint for the surface copy ctor.