### PR TITLE
Disallow 32-bit Windows builds.

### DIFF
--- a/scripts/cmake/ProjectSetup.cmake
+++ b/scripts/cmake/ProjectSetup.cmake
@@ -1,3 +1,10 @@
+# Check requirements / supported configurations
+if(MSVC AND NOT HAVE_64_BIT AND NOT OGS_32_BIT)
+    message(FATAL_ERROR "Building OGS on Windows with 32-bit is not supported! \
+Either use the correct generator, e.g. 'Visual Studio 14 2015 Win64' or define \
+'-DOGS_32_BIT=ON' if you know what you are doing.")
+endif()
+
 # Set build directories
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)


### PR DESCRIPTION
Can be forced by setting `OGS_32_BIT=ON`.

In general Windows 32-bit builds are not supported but often are accidentally configured (because CMake defaults to a 32-bit generator). Beside running OGS on Win XP there is no reason to build for 32-bit Windows.