### PR TITLE
Target ctest-large now runs all tests.

### DIFF
--- a/scripts/cmake/test/Test.cmake
+++ b/scripts/cmake/test/Test.cmake
@@ -59,7 +59,6 @@ add_custom_target(
     COMMAND ${CMAKE_CTEST_COMMAND} -T Test
     --force-new-ctest-process
     --output-on-failure --output-log Tests/ctest-large.log
-    --tests-regex LARGE
     ${CONFIG_PARAMETER} --parallel ${NUM_PROCESSORS} --test-action test
     DEPENDS ogs vtkdiff ctest-large-cleanup
 )


### PR DESCRIPTION
As requested by @endJunction.