### PR TITLE
[GL/IO] Increase output precision for gml output.

### DIFF
--- a/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.cpp
@@ -263,6 +263,7 @@ bool BoostXmlGmlInterface::write()
     addSurfacesToPropertyTree(geometry_set);
 
     boost::property_tree::xml_writer_settings<std::string> settings('\t', 1);
+    setPrecision(std::numeric_limits<double>::digits10);
     write_xml(_out, pt, settings);
     return true;
 }

--- a/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
@@ -288,9 +288,18 @@ bool XmlGmlInterface::write()
             {
                 QDomElement pointTag = doc.createElement("point");
                 pointTag.setAttribute("id", QString::number(i));
-                pointTag.setAttribute("x", QString::number((*(*points)[i])[0], 'f'));
-                pointTag.setAttribute("y", QString::number((*(*points)[i])[1], 'f'));
-                pointTag.setAttribute("z", QString::number((*(*points)[i])[2], 'f'));
+                pointTag.setAttribute(
+                    "x",
+                    QString::number((*(*points)[i])[0], 'g',
+                                    std::numeric_limits<double>::digits10));
+                pointTag.setAttribute(
+                    "y",
+                    QString::number((*(*points)[i])[1], 'g',
+                                    std::numeric_limits<double>::digits10));
+                pointTag.setAttribute(
+                    "z",
+                    QString::number((*(*points)[i])[2], 'g',
+                                    std::numeric_limits<double>::digits10));
 
                 std::string const& point_name(pnt_vec->getItemNameByID(i));
                 if (!point_name.empty())


### PR DESCRIPTION
The increase of the output precision solves problem that sometimes not all boundary conditions set via a geometry are found. This can be caused by the different precision the mesh and the geometry are written. This PR tries to resolve the problem.