### PR TITLE
Simplified VecMatAssembler

### DIFF
--- a/NumLib/Assembler/VectorMatrixAssembler.h
+++ b/NumLib/Assembler/VectorMatrixAssembler.h
@@ -13,10 +13,13 @@
 #include "NumLib/ODESolver/Types.h"
 #include "NumLib/DOF/LocalToGlobalIndexMap.h"
 
-namespace
+namespace NumLib
+{
+
+namespace detail
 {
 inline std::vector<GlobalIndexType>
-getRowColumnIndices(std::size_t const id,
+getIndices(std::size_t const id,
                     NumLib::LocalToGlobalIndexMap const& dof_table)
 {
     assert(dof_table.size() > id);
@@ -41,7 +44,7 @@ prepareLocalVector(
         NumLib::LocalToGlobalIndexMap const& dof_table,
         GlobalVector const& x)
 {
-    auto const indices = getRowColumnIndices(id, dof_table);
+    auto const indices = getIndices(id, dof_table);
 
     std::vector<double> local_x;
     local_x.reserve(indices.size());
@@ -55,9 +58,6 @@ prepareLocalVector(
     return std::make_tuple(local_x, indices);
 }
 }
-
-namespace NumLib
-{
 
 /*! Calls the local assemblers of FEM processes and assembles
  *  \c GlobalMatrix'es and \c GlobalVector's.
@@ -95,7 +95,7 @@ public:
         const double t, GlobalVector const& x,
         GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) const
     {
-        auto const x_and_indices = prepareLocalVector(id, _data_pos, x);
+        auto const x_and_indices = detail::prepareLocalVector(id, _data_pos, x);
         auto const& local_x = std::get<0>(x_and_indices);
         auto const& indices = std::get<1>(x_and_indices);
         auto const r_c_indices =
@@ -114,7 +114,7 @@ public:
                           GlobalVector const& x,
                           GlobalMatrix& Jac) const
     {
-        auto const x_and_indices = prepareLocalVector(id, _data_pos, x);
+        auto const x_and_indices = detail::prepareLocalVector(id, _data_pos, x);
         auto const& local_x = std::get<0>(x_and_indices);
         auto const& indices = std::get<1>(x_and_indices);
         auto const r_c_indices =
@@ -133,7 +133,7 @@ public:
                      double const t,
                      double const delta_t) const
     {
-        auto const x_and_indices = prepareLocalVector(id, _data_pos, x);
+        auto const x_and_indices = detail::prepareLocalVector(id, _data_pos, x);
         auto const& local_x = std::get<0>(x_and_indices);
 
         local_assembler.preTimestep(local_x, t, delta_t);
@@ -146,7 +146,7 @@ public:
                       LocalAssembler& local_assembler,
                       GlobalVector const& x) const
     {
-        auto const x_and_indices = prepareLocalVector(id, _data_pos, x);
+        auto const x_and_indices = detail::prepareLocalVector(id, _data_pos, x);
         auto const& local_x = std::get<0>(x_and_indices);
 
         local_assembler.postTimestep(local_x);
@@ -159,7 +159,7 @@ public:
     void passLocalVector(Callback& cb, std::size_t const id,
                          GlobalVector const& x, Args&&... args)
     {
-        auto const x_and_indices = prepareLocalVector(id, _data_pos, x);
+        auto const x_and_indices = detail::prepareLocalVector(id, _data_pos, x);
         auto const& local_x = std::get<0>(x_and_indices);
         auto const& indices = std::get<1>(x_and_indices);
         auto const r_c_indices =
@@ -193,7 +193,7 @@ public:
         LocalAssembler& local_assembler,
         const double t, GlobalVector& b) const
     {
-        auto const indices = getRowColumnIndices(id, _data_pos);
+        auto const indices = detail::getIndices(id, _data_pos);
         auto const r_c_indices =
             NumLib::LocalToGlobalIndexMap::RowColumnIndices(indices, indices);
 

--- a/NumLib/Assembler/VectorMatrixAssembler.h
+++ b/NumLib/Assembler/VectorMatrixAssembler.h
@@ -10,20 +10,19 @@
 #ifndef NUMLIB_VECTORMATRIXASSEMBLER_H_
 #define NUMLIB_VECTORMATRIXASSEMBLER_H_
 
-#include "NumLib/DOF/LocalToGlobalIndexMap.h"
 #include "NumLib/ODESolver/Types.h"
+#include "NumLib/DOF/LocalToGlobalIndexMap.h"
 
 namespace
 {
-inline NumLib::LocalToGlobalIndexMap::RowColumnIndices
+inline std::vector<GlobalIndexType>
 getRowColumnIndices(std::size_t const id,
-                    NumLib::LocalToGlobalIndexMap const& dof_table,
-                    std::vector<GlobalIndexType>& indices)
+                    NumLib::LocalToGlobalIndexMap const& dof_table)
 {
     assert(dof_table.size() > id);
-    assert(indices.empty());
+    std::vector<GlobalIndexType> indices;
 
-    // Local matrices and vectors will always be ordered by component,
+    // Local matrices and vectors will always be ordered by component
     // no matter what the order of the global matrix is.
     for (unsigned c = 0; c < dof_table.getNumComponents(); ++c)
     {
@@ -32,27 +31,28 @@ getRowColumnIndices(std::size_t const id,
         indices.insert(indices.end(), idcs.begin(), idcs.end());
     }
 
-    return NumLib::LocalToGlobalIndexMap::RowColumnIndices(indices,
-                                                                 indices);
+    return indices;
 }
 
-template <typename Callback, typename GlobalVector, typename... Args>
-void passLocalVector_(Callback& cb, std::size_t const id,
-                      NumLib::LocalToGlobalIndexMap const& dof_table,
-                      GlobalVector const& x, Args&&... args)
+template <typename GlobalVector>
+std::tuple<std::vector<double>, std::vector<GlobalIndexType>>
+prepareLocalVector(
+        std::size_t const id,
+        NumLib::LocalToGlobalIndexMap const& dof_table,
+        GlobalVector const& x)
 {
-    std::vector<GlobalIndexType> indices;
-    auto const r_c_indices = getRowColumnIndices(id, dof_table, indices);
+    auto const indices = getRowColumnIndices(id, dof_table);
 
     std::vector<double> local_x;
     local_x.reserve(indices.size());
 
     for (auto i : indices)
     {
-        local_x.emplace_back(x.get(i));
+        // TODO save some function calls
+        local_x.emplace_back(x[i]);
     }
 
-    cb(local_x, r_c_indices, std::forward<Args>(args)...);
+    return std::make_tuple(local_x, indices);
 }
 }
 
@@ -95,17 +95,14 @@ public:
         const double t, GlobalVector const& x,
         GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) const
     {
-        auto cb = [&local_assembler](
-                std::vector<double> const& local_x,
-                LocalToGlobalIndexMap::RowColumnIndices const& r_c_indices,
-                const double t,
-                GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
-        {
-            local_assembler.assemble(t, local_x);
-            local_assembler.addToGlobal(r_c_indices, M, K, b);
-        };
+        auto const x_and_indices = prepareLocalVector(id, _data_pos, x);
+        auto const& local_x = std::get<0>(x_and_indices);
+        auto const& indices = std::get<1>(x_and_indices);
+        auto const r_c_indices =
+            NumLib::LocalToGlobalIndexMap::RowColumnIndices(indices, indices);
 
-        passLocalVector_(cb, id, _data_pos, x, t, M, K, b);
+        local_assembler.assemble(t, local_x);
+        local_assembler.addToGlobal(r_c_indices, M, K, b);
     }
 
     /// Executes assembleJacobian() of the local assembler for the
@@ -117,17 +114,14 @@ public:
                           GlobalVector const& x,
                           GlobalMatrix& Jac) const
     {
-        auto cb = [&local_assembler](
-            std::vector<double> const& local_x,
-            LocalToGlobalIndexMap::RowColumnIndices const& r_c_indices,
-            const double t,
-            GlobalMatrix& Jac)
-        {
-            local_assembler.assembleJacobian(t, local_x);
-            local_assembler.addJacobianToGlobal(r_c_indices, Jac);
-        };
+        auto const x_and_indices = prepareLocalVector(id, _data_pos, x);
+        auto const& local_x = std::get<0>(x_and_indices);
+        auto const& indices = std::get<1>(x_and_indices);
+        auto const r_c_indices =
+            NumLib::LocalToGlobalIndexMap::RowColumnIndices(indices, indices);
 
-        passLocalVector_(cb, id, _data_pos, x, t, Jac);
+        local_assembler.assembleJacobian(t, local_x);
+        local_assembler.addJacobianToGlobal(r_c_indices, Jac);
     }
 
     /// Executes the preTimestep() method of the local assembler for the
@@ -139,16 +133,10 @@ public:
                      double const t,
                      double const delta_t) const
     {
-        auto cb = [&local_assembler](
-            std::vector<double> const& local_x,
-            LocalToGlobalIndexMap::RowColumnIndices const& /*r_c_indices*/,
-            double const t,
-            double const delta_t)
-        {
-            local_assembler.preTimestep(local_x, t, delta_t);
-        };
+        auto const x_and_indices = prepareLocalVector(id, _data_pos, x);
+        auto const& local_x = std::get<0>(x_and_indices);
 
-        passLocalVector_(cb, id, _data_pos, x, t, delta_t);
+        local_assembler.preTimestep(local_x, t, delta_t);
     }
 
     /// Executes the postTimestep() method of the local assembler for the
@@ -158,14 +146,10 @@ public:
                       LocalAssembler& local_assembler,
                       GlobalVector const& x) const
     {
-        auto cb = [&local_assembler](
-            std::vector<double> const& local_x,
-            LocalToGlobalIndexMap::RowColumnIndices const& /*r_c_indices*/)
-        {
-            local_assembler.postTimestep(local_x);
-        };
+        auto const x_and_indices = prepareLocalVector(id, _data_pos, x);
+        auto const& local_x = std::get<0>(x_and_indices);
 
-        passLocalVector_(cb, id, _data_pos, x);
+        local_assembler.postTimestep(local_x);
     }
 
     /// Executes the given callback function for the given mesh item
@@ -175,7 +159,13 @@ public:
     void passLocalVector(Callback& cb, std::size_t const id,
                          GlobalVector const& x, Args&&... args)
     {
-        passLocalVector_(cb, id, _data_pos, x, std::forward<Args>(args)...);
+        auto const x_and_indices = prepareLocalVector(id, _data_pos, x);
+        auto const& local_x = std::get<0>(x_and_indices);
+        auto const& indices = std::get<1>(x_and_indices);
+        auto const r_c_indices =
+            NumLib::LocalToGlobalIndexMap::RowColumnIndices(indices, indices);
+
+        cb(local_x, r_c_indices, std::forward<Args>(args)...);
     }
 
 private:
@@ -203,8 +193,9 @@ public:
         LocalAssembler& local_assembler,
         const double t, GlobalVector& b) const
     {
-        std::vector<GlobalIndexType> indices;
-        auto const r_c_indices = getRowColumnIndices(id, _data_pos, indices);
+        auto const indices = getRowColumnIndices(id, _data_pos);
+        auto const r_c_indices =
+            NumLib::LocalToGlobalIndexMap::RowColumnIndices(indices, indices);
 
         local_assembler.assemble(t);
         local_assembler.addToGlobal(r_c_indices, b);


### PR DESCRIPTION
@endJunction suggested that some lambdas can be removed. That might increase performance a bit, and it makes the code easier to understand.

There are no logic changes in this PR, it is merely a rewrite of existing code.