### PR TITLE
Consistent naming

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -57,13 +57,13 @@ ProjectData::ProjectData(BaseLib::ConfigTree const& project_config,
 {
     std::string const geometry_file = BaseLib::copyPathToFileName(
             //! \ogs_file_param{prj__geometry}
-            project_config.getParameter<std::string>("geometry"), project_directory
+            project_config.getConfigParameter<std::string>("geometry"), project_directory
         );
     detail::readGeometry(geometry_file, *_geoObjects);
 
     std::string const mesh_file = BaseLib::copyPathToFileName(
             //! \ogs_file_param{prj__mesh}
-            project_config.getParameter<std::string>("mesh"), project_directory
+            project_config.getConfigParameter<std::string>("mesh"), project_directory
         );
 
     MeshLib::Mesh* const mesh = MeshLib::IO::readMeshFromFile(mesh_file);
@@ -75,28 +75,28 @@ ProjectData::ProjectData(BaseLib::ConfigTree const& project_config,
     _mesh_vec.push_back(mesh);
 
     //! \ogs_file_param{prj__curves}
-    parseCurves(project_config.getSubtreeOptional("curves"));
+    parseCurves(project_config.getConfigSubtreeOptional("curves"));
 
     //! \ogs_file_param{prj__process_variables}
-    parseProcessVariables(project_config.getSubtree("process_variables"));
+    parseProcessVariables(project_config.getConfigSubtree("process_variables"));
 
     //! \ogs_file_param{prj__parameters}
-    parseParameters(project_config.getSubtree("parameters"));
+    parseParameters(project_config.getConfigSubtree("parameters"));
 
     //! \ogs_file_param{prj__processes}
-    parseProcesses(project_config.getSubtree("processes"));
+    parseProcesses(project_config.getConfigSubtree("processes"));
 
     //! \ogs_file_param{prj__output}
-    parseOutput(project_config.getSubtree("output"), output_directory);
+    parseOutput(project_config.getConfigSubtree("output"), output_directory);
 
     //! \ogs_file_param{prj__time_stepping}
-    parseTimeStepping(project_config.getSubtree("time_stepping"));
+    parseTimeStepping(project_config.getConfigSubtree("time_stepping"));
 
     //! \ogs_file_param{prj__linear_solvers}
-    parseLinearSolvers(project_config.getSubtree("linear_solvers"));
+    parseLinearSolvers(project_config.getConfigSubtree("linear_solvers"));
 
     //! \ogs_file_param{prj__nonlinear_solvers}
-    parseNonlinearSolvers(project_config.getSubtree("nonlinear_solvers"));
+    parseNonlinearSolvers(project_config.getConfigSubtree("nonlinear_solvers"));
 }
 
 ProjectData::~ProjectData()
@@ -159,16 +159,16 @@ void ProjectData::buildProcesses()
     for (auto const& pc : _process_configs)
     {
         //! \ogs_file_param{process__type}
-        auto const type = pc.peekParameter<std::string>("type");
+        auto const type = pc.peekConfigParameter<std::string>("type");
 
         //! \ogs_file_param{process__nonlinear_solver}
-        auto const nl_slv_name = pc.getParameter<std::string>("nonlinear_solver");
+        auto const nl_slv_name = pc.getConfigParameter<std::string>("nonlinear_solver");
         auto& nl_slv = BaseLib::getOrError(_nonlinear_solvers, nl_slv_name,
             "A nonlinear solver with the given name has not been defined.");
 
         auto time_disc = NumLib::createTimeDiscretization<GlobalVector>(
                 //! \ogs_file_param{process__time_discretization}
-                pc.getSubtree("time_discretization")
+                pc.getConfigSubtree("time_discretization")
             );
 
         if (type == "GROUNDWATER_FLOW")
@@ -264,7 +264,7 @@ void ProjectData::parseProcessVariables(
 
     for (auto var_config
          //! \ogs_file_param{prj__process_variables__process_variable}
-         : process_variables_config.getSubtreeList("process_variable")) {
+         : process_variables_config.getConfigSubtreeList("process_variable")) {
         // TODO Extend to referenced meshes.
         _process_variables.emplace_back(var_config, *_mesh_vec[0], *_geoObjects);
     }
@@ -276,12 +276,12 @@ void ProjectData::parseParameters(BaseLib::ConfigTree const& parameters_config)
 
     DBUG("Reading parameters:");
     //! \ogs_file_param{prj__parameters__parameter}
-    for (auto parameter_config : parameters_config.getSubtreeList("parameter"))
+    for (auto parameter_config : parameters_config.getConfigSubtreeList("parameter"))
     {
         //! \ogs_file_param{parameter__name}
-        auto name = parameter_config.getParameter<std::string>("name");
+        auto name = parameter_config.getConfigParameter<std::string>("name");
         //! \ogs_file_param{parameter__type}
-        auto type = parameter_config.peekParameter<std::string>("type");
+        auto type = parameter_config.peekConfigParameter<std::string>("type");
 
         // Create parameter based on the provided type.
         if (type == "Constant")
@@ -310,11 +310,11 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config)
 {
     DBUG("Reading processes:");
     //! \ogs_file_param{prj__processes__process}
-    for (auto process_config : processes_config.getSubtreeList("process")) {
+    for (auto process_config : processes_config.getConfigSubtreeList("process")) {
         // process type must be specified.
         //! \ogs_file_param{process__type}
-        process_config.peekParameter<std::string>("type");
-        process_config.ignoreParameter("name");
+        process_config.peekConfigParameter<std::string>("type");
+        process_config.ignoreConfigParameter("name");
         _process_configs.push_back(std::move(process_config));
     }
 }
@@ -323,7 +323,7 @@ void ProjectData::parseOutput(BaseLib::ConfigTree const& output_config,
     std::string const& output_directory)
 {
     //! \ogs_file_param{prj__output__type}
-    output_config.checkParameter("type", "VTK");
+    output_config.checkConfigParameter("type", "VTK");
     DBUG("Parse output configuration:");
 
     _output = ProcessLib::Output<GlobalSetupType>::newInstance(output_config, output_directory);
@@ -348,10 +348,10 @@ void ProjectData::parseLinearSolvers(BaseLib::ConfigTree const& config)
     DBUG("Reading linear solver configuration.");
 
     //! \ogs_file_param{prj__linear_solvers__linear_solver}
-    for (auto conf : config.getSubtreeList("linear_solver"))
+    for (auto conf : config.getConfigSubtreeList("linear_solver"))
     {
         //! \ogs_file_param{prj__linear_solvers__linear_solver__name}
-        auto const name = conf.getParameter<std::string>("name");
+        auto const name = conf.getConfigParameter<std::string>("name");
         BaseLib::insertIfKeyUniqueElseError(_linear_solvers,
             name,
             MathLib::createLinearSolver<GlobalMatrix, GlobalVector,
@@ -365,15 +365,15 @@ void ProjectData::parseNonlinearSolvers(BaseLib::ConfigTree const& config)
     DBUG("Reading linear solver configuration.");
 
     //! \ogs_file_param{prj__nonlinear_solvers__nonlinear_solver}
-    for (auto conf : config.getSubtreeList("nonlinear_solver"))
+    for (auto conf : config.getConfigSubtreeList("nonlinear_solver"))
     {
         //! \ogs_file_param{prj__nonlinear_solvers__nonlinear_solver__linear_solver}
-        auto const ls_name = conf.getParameter<std::string>("linear_solver");
+        auto const ls_name = conf.getConfigParameter<std::string>("linear_solver");
         auto& linear_solver = BaseLib::getOrError(_linear_solvers,
             ls_name, "A linear solver with the given name does not exist.");
 
         //! \ogs_file_param{prj__nonlinear_solvers__nonlinear_solver__name}
-        auto const name = conf.getParameter<std::string>("name");
+        auto const name = conf.getConfigParameter<std::string>("name");
         BaseLib::insertIfKeyUniqueElseError(_nonlinear_solvers,
             name,
             NumLib::createNonlinearSolver<GlobalMatrix, GlobalVector>(
@@ -386,9 +386,9 @@ static std::unique_ptr<MathLib::PiecewiseLinearInterpolation>
 createPiecewiseLinearInterpolation(BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{prj__curves__curve__coords}
-    auto coords = config.getParameter<std::vector<double>>("coords");
+    auto coords = config.getConfigParameter<std::vector<double>>("coords");
     //! \ogs_file_param{prj__curves__curve__values}
-    auto values = config.getParameter<std::vector<double>>("values");
+    auto values = config.getConfigParameter<std::vector<double>>("values");
     if (coords.empty() || values.empty())
     {
         ERR("The given co-ordinates or values vector is empty.");
@@ -413,10 +413,10 @@ void ProjectData::parseCurves(
     DBUG("Reading curves configuration.");
 
     //! \ogs_file_param{prj__curves__curve}
-    for (auto conf : config->getSubtreeList("curve"))
+    for (auto conf : config->getConfigSubtreeList("curve"))
     {
         //! \ogs_file_param{prj__curves__curve__name}
-        auto const name = conf.getParameter<std::string>("name");
+        auto const name = conf.getConfigParameter<std::string>("name");
         BaseLib::insertIfKeyUniqueElseError(
             _curves,
             name,

--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
@@ -369,7 +369,7 @@ loop(ProjectData& project)
     auto per_process_data = initInternalData(project);
 
     auto& out_ctrl = project.getOutputControl();
-    out_ctrl.init(project.processesBegin(), project.processesEnd());
+    out_ctrl.initialize(project.processesBegin(), project.processesEnd());
 
     auto const t0 = _timestepper->getTimeStep().current(); // time of the IC
 

--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
@@ -232,12 +232,12 @@ std::unique_ptr<UncoupledProcessesTimeLoop<Matrix, Vector> >
 createUncoupledProcessesTimeLoop(BaseLib::ConfigTree const& conf)
 {
     //! \ogs_file_param{prj__time_stepping__type}
-    auto const type = conf.peekParameter<std::string>("type");
+    auto const type = conf.peekConfigParameter<std::string>("type");
 
     std::unique_ptr<NumLib::ITimeStepAlgorithm> timestepper;
 
     if (type == "SingleStep") {
-        conf.ignoreParameter("type");
+        conf.ignoreConfigParameter("type");
         timestepper.reset(new NumLib::FixedTimeStepping(0.0, 1.0, 1.0));
     } else if (type == "FixedTimeStepping") {
         timestepper = NumLib::FixedTimeStepping::newInstance(conf);

--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
@@ -232,12 +232,12 @@ std::unique_ptr<UncoupledProcessesTimeLoop<Matrix, Vector> >
 createUncoupledProcessesTimeLoop(BaseLib::ConfigTree const& conf)
 {
     //! \ogs_file_param{prj__time_stepping__type}
-    auto const type = conf.peekConfParam<std::string>("type");
+    auto const type = conf.peekParameter<std::string>("type");
 
     std::unique_ptr<NumLib::ITimeStepAlgorithm> timestepper;
 
     if (type == "SingleStep") {
-        conf.ignoreConfParam("type");
+        conf.ignoreParameter("type");
         timestepper.reset(new NumLib::FixedTimeStepping(0.0, 1.0, 1.0));
     } else if (type == "FixedTimeStepping") {
         timestepper = NumLib::FixedTimeStepping::newInstance(conf);

--- a/Applications/DataExplorer/DataView/CreateStructuredGridDialog.cpp
+++ b/Applications/DataExplorer/DataView/CreateStructuredGridDialog.cpp
@@ -249,8 +249,8 @@ void CreateStructuredGridDialog::accept()
 
     boost::optional<MeshLib::PropertyVector<int>&> mat_ids (
         mesh->getProperties().createNewPropertyVector<int>("MaterialIDs", MeshLib::MeshItemType::Cell));
-    mat_ids->reserve(mesh->getNElements());
-    std::fill_n(std::back_inserter(*mat_ids), mesh->getNElements(), 0);
+    mat_ids->reserve(mesh->getNumberOfElements());
+    std::fill_n(std::back_inserter(*mat_ids), mesh->getNumberOfElements(), 0);
     emit meshAdded(mesh);
     this->done(QDialog::Accepted);
 }

--- a/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
+++ b/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
@@ -88,7 +88,7 @@ const std::vector< std::pair<std::size_t,double> >& DirectConditionGenerator::di
     std::vector<double> node_area_vec =
         MeshLib::MeshSurfaceExtraction::getSurfaceAreaForNodes(*surface_mesh);
     const std::vector<MeshLib::Node*> &surface_nodes(surface_mesh->getNodes());
-    const std::size_t nNodes(surface_mesh->getNNodes());
+    const std::size_t nNodes(surface_mesh->getNumberOfNodes());
     const double no_data(raster->getHeader().no_data);
 
     boost::optional<MeshLib::PropertyVector<int> const&> opt_node_id_pv(

--- a/Applications/DataExplorer/DataView/ElementTreeModel.cpp
+++ b/Applications/DataExplorer/DataView/ElementTreeModel.cpp
@@ -84,7 +84,7 @@ void ElementTreeModel::setElement(vtkUnstructuredGridAlgorithm const*const grid,
     elemItem->appendChild(nodeListItem);
 
     //const std::vector<MeshLib::Node*> nodes_vec = grid->getNodes();
-    std::size_t nElemNodes = elem->getNBaseNodes();
+    std::size_t nElemNodes = elem->getNumberOfBaseNodes();
     for (std::size_t i = 0; i < nElemNodes; i++)
     {
         const MeshLib::Node* node = elem->getNode(i);
@@ -114,12 +114,12 @@ void ElementTreeModel::setMesh(MeshLib::Mesh const& mesh)
     _rootItem->appendChild(name_item);
 
     QList<QVariant> nodes_number;
-    nodes_number << "#Nodes: " << QString::number(mesh.getNNodes()) << "" << "";
+    nodes_number << "#Nodes: " << QString::number(mesh.getNumberOfNodes()) << "" << "";
     TreeItem* nodes_item = new TreeItem(nodes_number, _rootItem);
     _rootItem->appendChild(nodes_item);
 
     QList<QVariant> elements_number;
-    elements_number << "#Elements: " << QString::number(mesh.getNElements()) << "" << "";
+    elements_number << "#Elements: " << QString::number(mesh.getNumberOfElements()) << "" << "";
     TreeItem* elements_item = new TreeItem(elements_number, _rootItem);
     _rootItem->appendChild(elements_item);
 

--- a/Applications/DataExplorer/DataView/GEOModels.cpp
+++ b/Applications/DataExplorer/DataView/GEOModels.cpp
@@ -237,7 +237,7 @@ void GEOModels::addNameForObjectPoints(const std::string &geometry_name,
     else if (object_type == GeoLib::GEOTYPE::SURFACE)
     {
         const GeoLib::Surface* sfc = dynamic_cast<const GeoLib::Surface*>(obj);
-        std::size_t nTriangles = sfc->getNTriangles();
+        std::size_t nTriangles = sfc->getNumberOfTriangles();
         for (std::size_t i = 0; i < nTriangles; i++)
         {
             const GeoLib::Triangle* tri = (*sfc)[i];

--- a/Applications/DataExplorer/DataView/GeoTreeModel.cpp
+++ b/Applications/DataExplorer/DataView/GeoTreeModel.cpp
@@ -237,7 +237,7 @@ void GeoTreeModel::addChildren(GeoObjectListItem* sfcList,
         GeoTreeItem* surfaceItem(new GeoTreeItem(surface, sfcList, &sfc));
         sfcList->appendChild(surfaceItem);
 
-        int nElems = static_cast<int>((*surfaces)[i]->getNTriangles());
+        int nElems = static_cast<int>((*surfaces)[i]->getNumberOfTriangles());
         for (int j = 0; j < nElems; j++)
         {
             QList<QVariant> elem;

--- a/Applications/DataExplorer/DataView/MeshAnalysisDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshAnalysisDialog.cpp
@@ -57,12 +57,12 @@ void MeshAnalysisDialog::on_startButton_pressed()
     MeshLib::MeshRevision rev(const_cast<MeshLib::Mesh&>(mesh));
     std::vector<std::size_t> const& collapsibleNodeIds (rev.collapseNodeIndices(
         this->collapsibleNodesThreshold->text().toDouble() + std::numeric_limits<double>::epsilon()));
-    this->nodesGroupBox->setTitle("Nodes (out of " + QString::number(mesh.getNNodes()) + ")");
+    this->nodesGroupBox->setTitle("Nodes (out of " + QString::number(mesh.getNumberOfNodes()) + ")");
     this->nodesMsgOutput(unusedNodesIdx, collapsibleNodeIds);
 
     const std::vector<ElementErrorCode> element_error_codes (MeshLib::MeshValidation::testElementGeometry(
         mesh, this->zeroVolumeThreshold->text().toDouble() + std::numeric_limits<double>::epsilon()));
-    this->elementsGroupBox->setTitle("Elements (out of " + QString::number(mesh.getNElements()) + ")");
+    this->elementsGroupBox->setTitle("Elements (out of " + QString::number(mesh.getNumberOfElements()) + ")");
     this->elementsMsgOutput(element_error_codes);
 
     unsigned const n_holes (MeshLib::MeshValidation::detectHoles(mesh));

--- a/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
@@ -178,10 +178,10 @@ void MeshElementRemovalDialog::on_materialIDCheckBox_toggled(bool is_checked)
             return;
         }
         auto const& mat_ids = opt_mat_ids.get();
-        if (mat_ids.size() != mesh->getNElements()) {
+        if (mat_ids.size() != mesh->getNumberOfElements()) {
             INFO("Size mismatch: Properties \"MaterialIDs\" contains %u values,"
                 " the mesh \"%s\" contains %u elements.", mat_ids.size(),
-                mesh->getName().c_str(), mesh->getNElements());
+                mesh->getName().c_str(), mesh->getNumberOfElements());
             return;
         }
         auto max_material = std::max_element(mat_ids.cbegin(), mat_ids.cend());
@@ -203,7 +203,7 @@ void MeshElementRemovalDialog::on_meshNameComboBox_currentIndexChanged(int idx)
     auto materialIds = mesh->getProperties().getPropertyVector<int>("MaterialIDs");
     if (materialIds)
     {
-        if (materialIds->size() != mesh->getNElements())
+        if (materialIds->size() != mesh->getNumberOfElements())
         {
             ERR ("Incorrect mesh structure: Number of Material IDs does not match number of mesh elements.");
             OGSError::box("Incorrect mesh structure detected.\n Number of Material IDs does not match number of mesh elements");

--- a/Applications/DataExplorer/DataView/MeshLayerEditDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshLayerEditDialog.cpp
@@ -237,7 +237,7 @@ MeshLib::Mesh* MeshLayerEditDialog::createTetMesh()
 
         if (tg_mesh)
         {
-            std::vector<MeshLib::Node> tg_attr (lv.getAttributePoints());
+            std::vector<MeshLib::Node> tg_attr (lv.getConfigAttributePoints());
             FileIO::TetGenInterface tetgen_interface;
             tetgen_interface.writeTetGenSmesh(filename.toStdString(), *tg_mesh, tg_attr);
         }

--- a/Applications/DataExplorer/VtkVis/VtkSurfacesSource.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkSurfacesSource.cpp
@@ -95,7 +95,7 @@ int VtkSurfacesSource::RequestData( vtkInformation* request,
     for (std::vector<GeoLib::Surface*>::const_iterator it = _surfaces->begin();
          it != _surfaces->end(); ++it)
     {
-        const std::size_t nTriangles = (*it)->getNTriangles();
+        const std::size_t nTriangles = (*it)->getNumberOfTriangles();
 
         for (std::size_t i = 0; i < nTriangles; ++i)
         {

--- a/Applications/FileIO/SHPInterface.cpp
+++ b/Applications/FileIO/SHPInterface.cpp
@@ -202,7 +202,7 @@ bool SHPInterface::write2dMeshToSHP(const std::string &file_name, const MeshLib:
         return false;
     }
 
-    unsigned nElements (mesh.getNElements());
+    unsigned nElements (mesh.getNumberOfElements());
     if (nElements<1)
     {
         ERR ("SHPInterface::write2dMeshToSHP(): Mesh contains no elements.");
@@ -241,7 +241,7 @@ bool SHPInterface::write2dMeshToSHP(const std::string &file_name, const MeshLib:
             if (materialIds)
                 DBFWriteIntegerAttribute(hDBF, polygon_id, mat_field, (*materialIds)[i]);
 
-            unsigned nNodes (e->getNBaseNodes());
+            unsigned nNodes (e->getNumberOfBaseNodes());
             padfX = new double[nNodes+1];
             padfY = new double[nNodes+1];
             padfZ = new double[nNodes+1];

--- a/Applications/Utils/FileConverter/FEFLOW2OGS.cpp
+++ b/Applications/Utils/FileConverter/FEFLOW2OGS.cpp
@@ -77,7 +77,7 @@ int main (int argc, char* argv[])
     INFO("Mem for mesh: %i MB", (mem_with_mesh - mem_without_mesh)/(1024*1024));
 #endif
     INFO("Time for reading: %f seconds.", run_time.elapsed());
-    INFO("Read %d nodes and %d elements.", mesh->getNNodes(), mesh->getNElements());
+    INFO("Read %d nodes and %d elements.", mesh->getNumberOfNodes(), mesh->getNumberOfElements());
 
     std::string ogs_mesh_fname(ogs_mesh_arg.getValue());
     INFO("Writing %s.", ogs_mesh_fname.c_str());

--- a/Applications/Utils/FileConverter/GMSH2OGS.cpp
+++ b/Applications/Utils/FileConverter/GMSH2OGS.cpp
@@ -86,7 +86,7 @@ int main (int argc, char* argv[])
 #endif
 
     INFO("Time for reading: %f seconds.", run_time.elapsed());
-    INFO("Read %d nodes and %d elements.", mesh->getNNodes(), mesh->getNElements());
+    INFO("Read %d nodes and %d elements.", mesh->getNumberOfNodes(), mesh->getNumberOfElements());
 
     // *** remove line elements on request
     if (exclude_lines_arg.getValue()) {
@@ -94,7 +94,7 @@ int main (int argc, char* argv[])
         ex.searchByElementType(MeshLib::MeshElemType::LINE);
         auto m = MeshLib::removeElements(*mesh, ex.getSearchedElementIDs(), mesh->getName()+"-withoutLines");
         if (m != nullptr) {
-            INFO("Removed %d lines.", mesh->getNElements() - m->getNElements());
+            INFO("Removed %d lines.", mesh->getNumberOfElements() - m->getNumberOfElements());
             std::swap(m, mesh);
             delete m;
         } else {

--- a/Applications/Utils/FileConverter/OGS2VTK.cpp
+++ b/Applications/Utils/FileConverter/OGS2VTK.cpp
@@ -39,7 +39,7 @@ int main (int argc, char* argv[])
 
     std::unique_ptr<MeshLib::Mesh const> mesh(
         MeshLib::IO::readMeshFromFile(mesh_in.getValue()));
-    INFO("Mesh read: %d nodes, %d elements.", mesh->getNNodes(), mesh->getNElements());
+    INFO("Mesh read: %d nodes, %d elements.", mesh->getNumberOfNodes(), mesh->getNumberOfElements());
 
     MeshLib::IO::VtuInterface vtu(mesh.get());
     vtu.writeToFile(mesh_out.getValue());

--- a/Applications/Utils/FileConverter/TIN2VTK.cpp
+++ b/Applications/Utils/FileConverter/TIN2VTK.cpp
@@ -56,11 +56,11 @@ int main (int argc, char* argv[])
         GeoLib::IO::TINInterface::readTIN(tinFileName, point_vec));
     if (!sfc)
         return EXIT_FAILURE;
-    INFO("TIN read:  %d points, %d triangles", pnt_vec->size(), sfc->getNTriangles());
+    INFO("TIN read:  %d points, %d triangles", pnt_vec->size(), sfc->getNumberOfTriangles());
 
     INFO("converting to mesh data");
     std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::convertSurfaceToMesh(*sfc, BaseLib::extractBaseNameWithoutExtension(tinFileName), std::numeric_limits<double>::epsilon()));
-    INFO("Mesh created: %d nodes, %d elements.", mesh->getNNodes(), mesh->getNElements());
+    INFO("Mesh created: %d nodes, %d elements.", mesh->getNumberOfNodes(), mesh->getNumberOfElements());
 
     INFO("Write it into VTU");
     MeshLib::IO::VtuInterface writer(mesh.get());

--- a/Applications/Utils/FileConverter/VTK2OGS.cpp
+++ b/Applications/Utils/FileConverter/VTK2OGS.cpp
@@ -39,7 +39,7 @@ int main (int argc, char* argv[])
     cmd.parse(argc, argv);
 
     MeshLib::Mesh* mesh (MeshLib::IO::VtuInterface::readVTUFile(mesh_in.getValue()));
-    INFO("Mesh read: %d nodes, %d elements.", mesh->getNNodes(), mesh->getNElements());
+    INFO("Mesh read: %d nodes, %d elements.", mesh->getNumberOfNodes(), mesh->getNumberOfElements());
 
     MeshLib::IO::Legacy::MeshIO meshIO;
     meshIO.setMesh(mesh);

--- a/Applications/Utils/FileConverter/VTK2TIN.cpp
+++ b/Applications/Utils/FileConverter/VTK2TIN.cpp
@@ -49,7 +49,7 @@ int main (int argc, char* argv[])
     cmd.parse(argc, argv);
 
     std::unique_ptr<MeshLib::Mesh> mesh (MeshLib::IO::VtuInterface::readVTUFile(mesh_in.getValue()));
-    INFO("Mesh read: %d nodes, %d elements.", mesh->getNNodes(), mesh->getNElements());
+    INFO("Mesh read: %d nodes, %d elements.", mesh->getNumberOfNodes(), mesh->getNumberOfElements());
 
     INFO("Converting the mesh to TIN");
     GeoLib::GEOObjects geo_objects;

--- a/Applications/Utils/FileConverter/generateMatPropsFromMatID.cpp
+++ b/Applications/Utils/FileConverter/generateMatPropsFromMatID.cpp
@@ -59,9 +59,9 @@ int main (int argc, char* argv[])
     }
 
     std::size_t const n_properties(materialIds->size());
-    if (n_properties != mesh->getNElements()) {
+    if (n_properties != mesh->getNumberOfElements()) {
         ERR("Size mismatch: number of elements (%u) != number of material "
-            "properties (%u).", mesh->getNElements(), n_properties);
+            "properties (%u).", mesh->getNumberOfElements(), n_properties);
         return EXIT_FAILURE;
     }
     std::string const name = BaseLib::extractBaseNameWithoutExtension(mesh_arg.getValue());

--- a/Applications/Utils/MeshEdit/ExtractSurface.cpp
+++ b/Applications/Utils/MeshEdit/ExtractSurface.cpp
@@ -62,7 +62,7 @@ int main (int argc, char* argv[])
 
     std::unique_ptr<MeshLib::Mesh const> mesh(
         MeshLib::IO::readMeshFromFile(mesh_in.getValue()));
-    INFO("Mesh read: %u nodes, %u elements.", mesh->getNNodes(), mesh->getNElements());
+    INFO("Mesh read: %u nodes, %u elements.", mesh->getNumberOfNodes(), mesh->getNumberOfElements());
 
     // extract surface
     MathLib::Vector3 const dir(x.getValue(), y.getValue(), z.getValue());

--- a/Applications/Utils/MeshEdit/NodeReordering.cpp
+++ b/Applications/Utils/MeshEdit/NodeReordering.cpp
@@ -30,7 +30,7 @@ void reorderNodes(std::vector<MeshLib::Element*> &elements)
     std::size_t nElements (elements.size());
     for (std::size_t i=0; i<nElements; ++i)
     {
-        const unsigned nElemNodes (elements[i]->getNBaseNodes());
+        const unsigned nElemNodes (elements[i]->getNumberOfBaseNodes());
         std::vector<MeshLib::Node*> nodes(elements[i]->getNodes(), elements[i]->getNodes() + nElemNodes);
 
         switch (elements[i]->getGeomType())
@@ -70,7 +70,7 @@ void reorderNodes2(std::vector<MeshLib::Element*> &elements)
     std::size_t nElements (elements.size());
     for (std::size_t i=0; i<nElements; ++i)
     {
-        const unsigned nElemNodes (elements[i]->getNBaseNodes());
+        const unsigned nElemNodes (elements[i]->getNumberOfBaseNodes());
         std::vector<MeshLib::Node*> nodes(elements[i]->getNodes(), elements[i]->getNodes() + nElemNodes);
 
         for(std::size_t j = 0; j < nElemNodes; ++j)

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -100,8 +100,8 @@ void resetMeshElementProperty(MeshLib::Mesh &mesh, GeoLib::Polygon const& polygo
     for(std::size_t j(0); j<mesh.getElements().size(); ++j) {
         bool elem_out(true);
         MeshLib::Element const*const elem(mesh.getElements()[j]);
-        for (auto k = decltype(elem->getNNodes()){0};
-             k < elem->getNNodes() && elem_out; ++k)
+        for (auto k = decltype(elem->getNumberOfNodes()){0};
+             k < elem->getNumberOfNodes() && elem_out; ++k)
         {
             if (! outside[elem->getNode(k)->getID()]) {
                 elem_out = false;

--- a/Applications/Utils/MeshEdit/appendLinesAlongPolyline.cpp
+++ b/Applications/Utils/MeshEdit/appendLinesAlongPolyline.cpp
@@ -69,12 +69,12 @@ int main (int argc, char* argv[])
         ERR("Mesh file \"%s\" not found", mesh_in.getValue().c_str());
         return EXIT_FAILURE;
     }
-    INFO("Mesh read: %d nodes, %d elements.", mesh->getNNodes(), mesh->getNElements());
+    INFO("Mesh read: %d nodes, %d elements.", mesh->getNumberOfNodes(), mesh->getNumberOfElements());
 
     // add line elements
     std::unique_ptr<MeshLib::Mesh> new_mesh =
         MeshGeoToolsLib::appendLinesAlongPolylines(*mesh, *ply_vec);
-    INFO("Mesh created: %d nodes, %d elements.", new_mesh->getNNodes(), new_mesh->getNElements());
+    INFO("Mesh created: %d nodes, %d elements.", new_mesh->getNumberOfNodes(), new_mesh->getNumberOfElements());
 
     MeshLib::IO::writeMeshToFile(*new_mesh, mesh_out.getValue());
 

--- a/Applications/Utils/MeshEdit/editMaterialID.cpp
+++ b/Applications/Utils/MeshEdit/editMaterialID.cpp
@@ -73,7 +73,7 @@ int main (int argc, char* argv[])
 
     std::unique_ptr<MeshLib::Mesh> mesh(
         MeshLib::IO::readMeshFromFile(mesh_in.getValue()));
-    INFO("Mesh read: %d nodes, %d elements.", mesh->getNNodes(), mesh->getNElements());
+    INFO("Mesh read: %d nodes, %d elements.", mesh->getNumberOfNodes(), mesh->getNumberOfElements());
 
     if (condenseArg.isSet()) {
         INFO("Condensing material ID...");

--- a/Applications/Utils/MeshEdit/moveMeshNodes.cpp
+++ b/Applications/Utils/MeshEdit/moveMeshNodes.cpp
@@ -133,7 +133,7 @@ int main (int argc, char* argv[])
         INFO("Moving all mesh nodes by %g in direction %d (%s)...", value, idx,
              dir.c_str());
         //double value(-10);
-        const std::size_t nNodes(mesh->getNNodes());
+        const std::size_t nNodes(mesh->getNumberOfNodes());
         std::vector<MeshLib::Node*> nodes (mesh->getNodes());
         for (std::size_t i=0; i<nNodes; i++)
         {
@@ -160,7 +160,7 @@ int main (int argc, char* argv[])
         MathLib::Point3d const& min(bounding_box.getMinPoint());
         MathLib::Point3d const& max(bounding_box.getMaxPoint());
 
-        const std::size_t nNodes(mesh->getNNodes());
+        const std::size_t nNodes(mesh->getNumberOfNodes());
         std::vector<MeshLib::Node*> nodes (mesh->getNodes());
 
         for (std::size_t i=0; i<nNodes; i++)
@@ -179,7 +179,7 @@ int main (int argc, char* argv[])
     // weighted by 2 and the elevation of each connected node weighted by 1
     if (current_key.compare("-LOWPASS")==0)
     {
-        const std::size_t nNodes(mesh->getNNodes());
+        const std::size_t nNodes(mesh->getNumberOfNodes());
         std::vector<MeshLib::Node*> nodes (mesh->getNodes());
 
         std::vector<double> elevation(nNodes);

--- a/Applications/Utils/MeshEdit/queryMesh.cpp
+++ b/Applications/Utils/MeshEdit/queryMesh.cpp
@@ -60,11 +60,11 @@ int main(int argc, char *argv[])
         if (materialIds)
             out << "Mat ID : " << (*materialIds)[ele_id] << std::endl;
         out << "Nodes: " << std::endl;
-        for (unsigned i=0; i<ele->getNNodes(); i++)
+        for (unsigned i=0; i<ele->getNumberOfNodes(); i++)
             out <<  ele->getNode(i)->getID() << " " << *ele->getNode(i) << std::endl;
         out << "Content: " << ele->getContent() << std::endl;
         out << "Neighbors: ";
-        for (unsigned i=0; i<ele->getNNeighbors(); i++)
+        for (unsigned i=0; i<ele->getNumberOfNeighbors(); i++)
         {
             if (ele->getNeighbor(i))
                 out << ele->getNeighbor(i)->getID() << " ";
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
         out << "# Node" << node->getID() << std::endl;
         out << "Coordinates: " << *node << std::endl;
         out << "Connected elements: " ;
-        for (unsigned i=0; i<node->getNElements(); i++)
+        for (unsigned i=0; i<node->getNumberOfElements(); i++)
             out << node->getElement(i)->getID() << " ";
         out << std::endl;
         INFO("%s", out.str().c_str());

--- a/Applications/Utils/MeshEdit/removeMeshElements.cpp
+++ b/Applications/Utils/MeshEdit/removeMeshElements.cpp
@@ -99,7 +99,7 @@ int main (int argc, char* argv[])
 
     std::unique_ptr<MeshLib::Mesh const> mesh(
         MeshLib::IO::readMeshFromFile(mesh_in.getValue()));
-    INFO("Mesh read: %d nodes, %d elements.", mesh->getNNodes(), mesh->getNElements());
+    INFO("Mesh read: %d nodes, %d elements.", mesh->getNumberOfNodes(), mesh->getNumberOfElements());
     MeshLib::ElementSearch searcher(*mesh);
 
     // search elements IDs to be removed

--- a/Applications/Utils/MeshEdit/reviseMesh.cpp
+++ b/Applications/Utils/MeshEdit/reviseMesh.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
         MeshLib::IO::readMeshFromFile(input_arg.getValue()));
     if (!org_mesh)
         return EXIT_FAILURE;
-    INFO("Mesh read: %d nodes, %d elements.", org_mesh->getNNodes(), org_mesh->getNElements());
+    INFO("Mesh read: %d nodes, %d elements.", org_mesh->getNumberOfNodes(), org_mesh->getNumberOfElements());
 
     // revise the mesh
     std::unique_ptr<MeshLib::Mesh> new_mesh;
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
 
     // write into a file
     if (new_mesh) {
-        INFO("Revised mesh: %d nodes, %d elements.", new_mesh->getNNodes(), new_mesh->getNElements());
+        INFO("Revised mesh: %d nodes, %d elements.", new_mesh->getNumberOfNodes(), new_mesh->getNumberOfElements());
         MeshLib::IO::writeMeshToFile(*new_mesh, output_arg.getValue());
     }
 

--- a/Applications/Utils/MeshGeoTools/ComputeSurfaceNodeIDsInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshGeoTools/ComputeSurfaceNodeIDsInPolygonalRegion.cpp
@@ -88,7 +88,7 @@ int main (int argc, char* argv[])
     cmd.parse(argc, argv);
 
     std::unique_ptr<MeshLib::Mesh const> mesh(MeshLib::IO::readMeshFromFile(mesh_in.getValue()));
-    INFO("Mesh read: %u nodes, %u elements.", mesh->getNNodes(), mesh->getNElements());
+    INFO("Mesh read: %u nodes, %u elements.", mesh->getNumberOfNodes(), mesh->getNumberOfElements());
 
     GeoLib::GEOObjects geo_objs;
     GeoLib::IO::readGeometryFromFile(geo_in.getValue(), geo_objs);

--- a/Applications/Utils/ModelPreparation/ComputeNodeAreasFromSurfaceMesh.cpp
+++ b/Applications/Utils/ModelPreparation/ComputeNodeAreasFromSurfaceMesh.cpp
@@ -79,8 +79,8 @@ int main (int argc, char* argv[])
 
     std::unique_ptr<MeshLib::Mesh> surface_mesh(
         MeshLib::IO::readMeshFromFile(mesh_in.getValue()));
-    INFO("Mesh read: %u nodes, %u elements.", surface_mesh->getNNodes(),
-         surface_mesh->getNElements());
+    INFO("Mesh read: %u nodes, %u elements.", surface_mesh->getNumberOfNodes(),
+         surface_mesh->getNumberOfElements());
     // ToDo check if mesh is read correct and if the mesh is a surface mesh
 
     // check if a node property containing the subsurface ids is available
@@ -96,7 +96,7 @@ int main (int argc, char* argv[])
             ERR("Fatal error: could not create property.");
             return EXIT_FAILURE;
         }
-        node_ids->resize(surface_mesh->getNNodes());
+        node_ids->resize(surface_mesh->getNumberOfNodes());
         std::iota(node_ids->begin(), node_ids->end(), 0);
         orig_node_ids = node_ids;
     }

--- a/Applications/Utils/SimpleMeshCreation/createMeshElemPropertiesFromASCRaster.cpp
+++ b/Applications/Utils/SimpleMeshCreation/createMeshElemPropertiesFromASCRaster.cpp
@@ -189,7 +189,7 @@ int main (int argc, char* argv[])
     compressed_src_properties[n_mat - 1] = src_properties[mat_map_size - 1];
 
     // reset materials in source mesh
-    const std::size_t n_mesh_elements(src_mesh->getNElements());
+    const std::size_t n_mesh_elements(src_mesh->getNumberOfElements());
     auto materialIds = src_mesh->getProperties().getPropertyVector<int>("MaterialIDs");
     if (!materialIds)
     {
@@ -203,11 +203,11 @@ int main (int argc, char* argv[])
     // do the interpolation
     MeshLib::Mesh2MeshPropertyInterpolation mesh_interpolation(src_mesh.get(),
                                                                &compressed_src_properties);
-    std::vector<double> dest_properties(dest_mesh->getNElements());
+    std::vector<double> dest_properties(dest_mesh->getNumberOfElements());
     mesh_interpolation.setPropertiesForMesh(dest_mesh.get(),
                                             dest_properties);
 
-    const std::size_t n_dest_mesh_elements(dest_mesh->getNElements());
+    const std::size_t n_dest_mesh_elements(dest_mesh->getNumberOfElements());
 
     { // write property file
         std::string property_fname(mapping_arg.getValue());

--- a/Applications/Utils/SimpleMeshCreation/generateStructuredMesh.cpp
+++ b/Applications/Utils/SimpleMeshCreation/generateStructuredMesh.cpp
@@ -213,7 +213,7 @@ int main (int argc, char* argv[])
 
     if (mesh)
     {
-        INFO("Mesh created: %d nodes, %d elements.", mesh->getNNodes(), mesh->getNElements());
+        INFO("Mesh created: %d nodes, %d elements.", mesh->getNumberOfNodes(), mesh->getNumberOfElements());
 
         // write into a file
         MeshLib::IO::writeMeshToFile(*(mesh.get()), mesh_out.getValue());

--- a/BaseLib/ConfigTree-impl.h
+++ b/BaseLib/ConfigTree-impl.h
@@ -33,9 +33,9 @@ private:
 template<typename T>
 T
 ConfigTree::
-getConfParam(std::string const& param) const
+getParameter(std::string const& param) const
 {
-    if (auto p = getConfParamOptional<T>(param))
+    if (auto p = getParameterOptional<T>(param))
         return *p;
 
     error("Key <" + param + "> has not been found");
@@ -44,37 +44,37 @@ getConfParam(std::string const& param) const
 template<typename T>
 T
 ConfigTree::
-getConfParam(std::string const& param, T const& default_value) const
+getParameter(std::string const& param, T const& default_value) const
 {
-    if (auto p = getConfParamOptional<T>(param))
+    if (auto p = getParameterOptional<T>(param))
         return *p;
 
     return default_value;
 }
 
 template <typename T>
-boost::optional<T> ConfigTree::getConfParamOptional(
+boost::optional<T> ConfigTree::getParameterOptional(
     std::string const& param) const
 {
     checkUnique(param);
 
-    return getConfParamOptionalImpl(param, static_cast<T*>(nullptr));
+    return getParameterOptionalImpl(param, static_cast<T*>(nullptr));
 }
 
 template <typename T>
-boost::optional<T> ConfigTree::getConfParamOptionalImpl(
+boost::optional<T> ConfigTree::getParameterOptionalImpl(
     std::string const& param, T*) const
 {
-    if (auto p = getConfSubtreeOptional(param)) return p->getValue<T>();
+    if (auto p = getSubtreeOptional(param)) return p->getValue<T>();
 
     return boost::none;
 }
 
 template <typename T>
-boost::optional<std::vector<T>> ConfigTree::getConfParamOptionalImpl(
+boost::optional<std::vector<T>> ConfigTree::getParameterOptionalImpl(
     std::string const& param, std::vector<T>*) const
 {
-    if (auto p = getConfSubtreeOptional(param))
+    if (auto p = getSubtreeOptional(param))
     {
         std::istringstream sstr{p->getValue<std::string>()};
         std::vector<T> result;
@@ -101,7 +101,7 @@ boost::optional<std::vector<T>> ConfigTree::getConfParamOptionalImpl(
 template<typename T>
 Range<ConfigTree::ValueIterator<T> >
 ConfigTree::
-getConfParamList(std::string const& param) const
+getParameterList(std::string const& param) const
 {
     checkUnique(param);
     markVisited<T>(param, Attr::TAG, true);
@@ -115,7 +115,7 @@ getConfParamList(std::string const& param) const
 template<typename T>
 T
 ConfigTree::
-peekConfParam(std::string const& param) const
+peekParameter(std::string const& param) const
 {
     checkKeyname(param);
 
@@ -134,9 +134,9 @@ peekConfParam(std::string const& param) const
 template<typename T>
 void
 ConfigTree::
-checkConfParam(std::string const& param, T const& value) const
+checkParameter(std::string const& param, T const& value) const
 {
-    if (getConfParam<T>(param) != value) {
+    if (getParameter<T>(param) != value) {
         error("The value of key <" + param + "> is not the expected one.");
     }
 }
@@ -144,9 +144,9 @@ checkConfParam(std::string const& param, T const& value) const
 template<typename Ch>
 void
 ConfigTree::
-checkConfParam(std::string const& param, Ch const* value) const
+checkParameter(std::string const& param, Ch const* value) const
 {
-    if (getConfParam<std::string>(param) != value) {
+    if (getParameter<std::string>(param) != value) {
         error("The value of key <" + param + "> is not the expected one.");
     }
 }
@@ -173,9 +173,9 @@ getValue() const
 template<typename T>
 T
 ConfigTree::
-getConfAttribute(std::string const& attr) const
+getAttribute(std::string const& attr) const
 {
-    if (auto a = getConfAttributeOptional<T>(attr))
+    if (auto a = getAttributeOptional<T>(attr))
         return *a;
 
     error("Did not find XML attribute with name \"" + attr + "\".");
@@ -184,7 +184,7 @@ getConfAttribute(std::string const& attr) const
 template<typename T>
 boost::optional<T>
 ConfigTree::
-getConfAttributeOptional(std::string const& attr) const
+getAttributeOptional(std::string const& attr) const
 {
     checkUniqueAttr(attr);
     auto& ct = markVisited<T>(attr, Attr::ATTR, true);

--- a/BaseLib/ConfigTree-impl.h
+++ b/BaseLib/ConfigTree-impl.h
@@ -33,9 +33,9 @@ private:
 template<typename T>
 T
 ConfigTree::
-getParameter(std::string const& param) const
+getConfigParameter(std::string const& param) const
 {
-    if (auto p = getParameterOptional<T>(param))
+    if (auto p = getConfigParameterOptional<T>(param))
         return *p;
 
     error("Key <" + param + "> has not been found");
@@ -44,37 +44,37 @@ getParameter(std::string const& param) const
 template<typename T>
 T
 ConfigTree::
-getParameter(std::string const& param, T const& default_value) const
+getConfigParameter(std::string const& param, T const& default_value) const
 {
-    if (auto p = getParameterOptional<T>(param))
+    if (auto p = getConfigParameterOptional<T>(param))
         return *p;
 
     return default_value;
 }
 
 template <typename T>
-boost::optional<T> ConfigTree::getParameterOptional(
+boost::optional<T> ConfigTree::getConfigParameterOptional(
     std::string const& param) const
 {
     checkUnique(param);
 
-    return getParameterOptionalImpl(param, static_cast<T*>(nullptr));
+    return getConfigParameterOptionalImpl(param, static_cast<T*>(nullptr));
 }
 
 template <typename T>
-boost::optional<T> ConfigTree::getParameterOptionalImpl(
+boost::optional<T> ConfigTree::getConfigParameterOptionalImpl(
     std::string const& param, T*) const
 {
-    if (auto p = getSubtreeOptional(param)) return p->getValue<T>();
+    if (auto p = getConfigSubtreeOptional(param)) return p->getValue<T>();
 
     return boost::none;
 }
 
 template <typename T>
-boost::optional<std::vector<T>> ConfigTree::getParameterOptionalImpl(
+boost::optional<std::vector<T>> ConfigTree::getConfigParameterOptionalImpl(
     std::string const& param, std::vector<T>*) const
 {
-    if (auto p = getSubtreeOptional(param))
+    if (auto p = getConfigSubtreeOptional(param))
     {
         std::istringstream sstr{p->getValue<std::string>()};
         std::vector<T> result;
@@ -101,7 +101,7 @@ boost::optional<std::vector<T>> ConfigTree::getParameterOptionalImpl(
 template<typename T>
 Range<ConfigTree::ValueIterator<T> >
 ConfigTree::
-getParameterList(std::string const& param) const
+getConfigParameterList(std::string const& param) const
 {
     checkUnique(param);
     markVisited<T>(param, Attr::TAG, true);
@@ -115,7 +115,7 @@ getParameterList(std::string const& param) const
 template<typename T>
 T
 ConfigTree::
-peekParameter(std::string const& param) const
+peekConfigParameter(std::string const& param) const
 {
     checkKeyname(param);
 
@@ -134,9 +134,9 @@ peekParameter(std::string const& param) const
 template<typename T>
 void
 ConfigTree::
-checkParameter(std::string const& param, T const& value) const
+checkConfigParameter(std::string const& param, T const& value) const
 {
-    if (getParameter<T>(param) != value) {
+    if (getConfigParameter<T>(param) != value) {
         error("The value of key <" + param + "> is not the expected one.");
     }
 }
@@ -144,9 +144,9 @@ checkParameter(std::string const& param, T const& value) const
 template<typename Ch>
 void
 ConfigTree::
-checkParameter(std::string const& param, Ch const* value) const
+checkConfigParameter(std::string const& param, Ch const* value) const
 {
-    if (getParameter<std::string>(param) != value) {
+    if (getConfigParameter<std::string>(param) != value) {
         error("The value of key <" + param + "> is not the expected one.");
     }
 }
@@ -173,9 +173,9 @@ getValue() const
 template<typename T>
 T
 ConfigTree::
-getAttribute(std::string const& attr) const
+getConfigAttribute(std::string const& attr) const
 {
-    if (auto a = getAttributeOptional<T>(attr))
+    if (auto a = getConfigAttributeOptional<T>(attr))
         return *a;
 
     error("Did not find XML attribute with name \"" + attr + "\".");
@@ -184,7 +184,7 @@ getAttribute(std::string const& attr) const
 template<typename T>
 boost::optional<T>
 ConfigTree::
-getAttributeOptional(std::string const& attr) const
+getConfigAttributeOptional(std::string const& attr) const
 {
     checkUniqueAttr(attr);
     auto& ct = markVisited<T>(attr, Attr::ATTR, true);

--- a/BaseLib/ConfigTree.cpp
+++ b/BaseLib/ConfigTree.cpp
@@ -87,7 +87,7 @@ operator=(ConfigTree&& other)
 
 Range<ConfigTree::ParameterIterator>
 ConfigTree::
-getConfParamList(const std::string &param) const
+getParameterList(const std::string &param) const
 {
     checkUnique(param);
     markVisited(param, Attr::TAG, true);
@@ -101,9 +101,9 @@ getConfParamList(const std::string &param) const
 
 ConfigTree
 ConfigTree::
-getConfSubtree(std::string const& root) const
+getSubtree(std::string const& root) const
 {
-    if (auto t = getConfSubtreeOptional(root)) {
+    if (auto t = getSubtreeOptional(root)) {
         return std::move(*t);
     } else {
         error("Key <" + root + "> has not been found.");
@@ -112,7 +112,7 @@ getConfSubtree(std::string const& root) const
 
 boost::optional<ConfigTree>
 ConfigTree::
-getConfSubtreeOptional(std::string const& root) const
+getSubtreeOptional(std::string const& root) const
 {
     checkUnique(root);
 
@@ -127,7 +127,7 @@ getConfSubtreeOptional(std::string const& root) const
 
 Range<ConfigTree::SubtreeIterator>
 ConfigTree::
-getConfSubtreeList(std::string const& root) const
+getSubtreeList(std::string const& root) const
 {
     checkUnique(root);
     markVisited(root, Attr::TAG, true);
@@ -139,7 +139,7 @@ getConfSubtreeList(std::string const& root) const
                 SubtreeIterator(p.second, root, *this));
 }
 
-void ConfigTree::ignoreConfParam(const std::string &param) const
+void ConfigTree::ignoreParameter(const std::string &param) const
 {
     checkUnique(param);
     // if not found, peek only
@@ -147,7 +147,7 @@ void ConfigTree::ignoreConfParam(const std::string &param) const
     markVisited(param, Attr::TAG, peek_only);
 }
 
-void ConfigTree::ignoreConfAttribute(const std::string &attr) const
+void ConfigTree::ignoreAttribute(const std::string &attr) const
 {
     checkUniqueAttr(attr);
 
@@ -158,7 +158,7 @@ void ConfigTree::ignoreConfAttribute(const std::string &attr) const
     markVisited(attr, Attr::ATTR, peek_only);
 }
 
-void ConfigTree::ignoreConfParamAll(const std::string &param) const
+void ConfigTree::ignoreParameterAll(const std::string &param) const
 {
     checkUnique(param);
     auto& ct = markVisited(param, Attr::TAG, true);

--- a/BaseLib/ConfigTree.cpp
+++ b/BaseLib/ConfigTree.cpp
@@ -85,9 +85,29 @@ operator=(ConfigTree&& other)
     return *this;
 }
 
+ConfigTree
+ConfigTree::
+getConfigParameter(std::string const& root) const
+{
+    auto ct = getConfigSubtree(root);
+    if (ct.hasChildren())
+        error("Requested parameter <" + root + "> actually is a subtree.");
+    return ct;
+}
+
+boost::optional<ConfigTree>
+ConfigTree::
+getConfigParameterOptional(std::string const& root) const
+{
+    auto ct = getConfigSubtreeOptional(root);
+    if (ct && ct->hasChildren())
+        error("Requested parameter <" + root + "> actually is a subtree.");
+    return ct;
+}
+
 Range<ConfigTree::ParameterIterator>
 ConfigTree::
-getParameterList(const std::string &param) const
+getConfigParameterList(const std::string &param) const
 {
     checkUnique(param);
     markVisited(param, Attr::TAG, true);
@@ -101,9 +121,9 @@ getParameterList(const std::string &param) const
 
 ConfigTree
 ConfigTree::
-getSubtree(std::string const& root) const
+getConfigSubtree(std::string const& root) const
 {
-    if (auto t = getSubtreeOptional(root)) {
+    if (auto t = getConfigSubtreeOptional(root)) {
         return std::move(*t);
     } else {
         error("Key <" + root + "> has not been found.");
@@ -112,7 +132,7 @@ getSubtree(std::string const& root) const
 
 boost::optional<ConfigTree>
 ConfigTree::
-getSubtreeOptional(std::string const& root) const
+getConfigSubtreeOptional(std::string const& root) const
 {
     checkUnique(root);
 
@@ -127,7 +147,7 @@ getSubtreeOptional(std::string const& root) const
 
 Range<ConfigTree::SubtreeIterator>
 ConfigTree::
-getSubtreeList(std::string const& root) const
+getConfigSubtreeList(std::string const& root) const
 {
     checkUnique(root);
     markVisited(root, Attr::TAG, true);
@@ -139,7 +159,7 @@ getSubtreeList(std::string const& root) const
                 SubtreeIterator(p.second, root, *this));
 }
 
-void ConfigTree::ignoreParameter(const std::string &param) const
+void ConfigTree::ignoreConfigParameter(const std::string &param) const
 {
     checkUnique(param);
     // if not found, peek only
@@ -147,7 +167,7 @@ void ConfigTree::ignoreParameter(const std::string &param) const
     markVisited(param, Attr::TAG, peek_only);
 }
 
-void ConfigTree::ignoreAttribute(const std::string &attr) const
+void ConfigTree::ignoreConfigAttribute(const std::string &attr) const
 {
     checkUniqueAttr(attr);
 
@@ -158,7 +178,7 @@ void ConfigTree::ignoreAttribute(const std::string &attr) const
     markVisited(attr, Attr::ATTR, peek_only);
 }
 
-void ConfigTree::ignoreParameterAll(const std::string &param) const
+void ConfigTree::ignoreConfigParameterAll(const std::string &param) const
 {
     checkUnique(param);
     auto& ct = markVisited(param, Attr::TAG, true);

--- a/BaseLib/ConfigTree.cpp
+++ b/BaseLib/ConfigTree.cpp
@@ -85,26 +85,6 @@ operator=(ConfigTree&& other)
     return *this;
 }
 
-ConfigTree
-ConfigTree::
-getConfParam(std::string const& root) const
-{
-    auto ct = getConfSubtree(root);
-    if (ct.hasChildren())
-        error("Requested parameter <" + root + "> actually is a subtree.");
-    return ct;
-}
-
-boost::optional<ConfigTree>
-ConfigTree::
-getConfParamOptional(std::string const& root) const
-{
-    auto ct = getConfSubtreeOptional(root);
-    if (ct && ct->hasChildren())
-        error("Requested parameter <" + root + "> actually is a subtree.");
-    return ct;
-}
-
 Range<ConfigTree::ParameterIterator>
 ConfigTree::
 getConfParamList(const std::string &param) const

--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -70,7 +70,7 @@ template<typename Iterator> class Range;
  * existing configuration parameters from the source code.
  *
  * This class maintains a read counter for each parameter accessed through any of its methods.
- * Read counters are increased with every read (the only exception being the peekParameter() method).
+ * Read counters are increased with every read (the only exception being the peekConfigParameter() method).
  * The destructor finally decreases the read counter for every tag/attribute it find on the
  * current level of the XML tree. If the increases/decreases don't cancel each other, warning
  * messages are generated. This check can also be enforced before destruction by using the
@@ -293,28 +293,28 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> T
-    getParameter(std::string const& param) const;
+    getConfigParameter(std::string const& param) const;
 
     /*! Get parameter \c param of type \c T from the configuration tree or the \c default_value.
      *
-     * This method has a similar behaviour as getParameter(std::string const&) except in case
+     * This method has a similar behaviour as getConfigParameter(std::string const&) except in case
      * of errors the \c default_value is returned.
      *
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> T
-    getParameter(std::string const& param, T const& default_value) const;
+    getConfigParameter(std::string const& param, T const& default_value) const;
 
     /*! Get parameter \c param of type \c T from the configuration tree if present
      *
-     * This method has a similar behaviour as getParameter(std::string const&) except
+     * This method has a similar behaviour as getConfigParameter(std::string const&) except
      * no errors are raised. Rather it can be told from the return value if the
      * parameter could be read.
      *
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> boost::optional<T>
-    getParameterOptional(std::string const& param) const;
+    getConfigParameterOptional(std::string const& param) const;
 
     /*! Fetches all parameters with name \c param from the current level of the tree.
      *
@@ -323,13 +323,13 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> Range<ValueIterator<T> >
-    getParameterList(std::string const& param) const;
+    getConfigParameterList(std::string const& param) const;
 
     //!\}
 
     /*! \name Methods for accessing parameters that have attributes
      *
-     * The <tt>getParameter...()</tt> methods in this group---note: they do not have template
+     * The <tt>getConfigParameter...()</tt> methods in this group---note: they do not have template
      * parameters---check that the queried parameters do not have any children (apart from XML
      * attributes); if they do, error() is called.
      *
@@ -338,6 +338,24 @@ public:
      */
     //!\{
 
+    /*! Get parameter \c param from the configuration tree.
+     *
+     * \return the subtree representing the requested parameter
+     *
+     * \pre \c param must not have been read before from this ConfigTree.
+     */
+    ConfigTree
+    getConfigParameter(std::string const& param) const;
+
+    /*! Get parameter \c param from the configuration tree if present.
+     *
+     * \return the subtree representing the requested parameter
+     *
+     * \pre \c param must not have been read before from this ConfigTree.
+     */
+    boost::optional<ConfigTree>
+    getConfigParameterOptional(std::string const& param) const;
+
     /*! Fetches all parameters with name \c param from the current level of the tree.
      *
      * The return value is suitable to be used with range-base for-loops.
@@ -345,7 +363,7 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     Range<ParameterIterator>
-    getParameterList(std::string const& param) const;
+    getConfigParameterList(std::string const& param) const;
 
     /*! Get the plain data contained in the current level of the tree.
      *
@@ -363,7 +381,7 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> T
-    getAttribute(std::string const& attr) const;
+    getConfigAttribute(std::string const& attr) const;
 
     /*! Get XML attribute \c attr of type \c T for the current parameter if present.
      *
@@ -372,7 +390,7 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> boost::optional<T>
-    getAttributeOptional(std::string const& attr) const;
+    getConfigAttributeOptional(std::string const& attr) const;
 
     //!\}
 
@@ -392,21 +410,21 @@ public:
      * But in order that the requested parameter counts as "completely parsed", it has to be
      * read through some other method, too.
      *
-     * Return value and error behaviour are the same as for getParameter<T>(std::string const&).
+     * Return value and error behaviour are the same as for getConfigParameter<T>(std::string const&).
      */
     template<typename T> T
-    peekParameter(std::string const& param) const;
+    peekConfigParameter(std::string const& param) const;
 
     /*! Assert that \c param has the given \c value.
      *
-     * Convenience method combining getParameter(std::string const&) with a check.
+     * Convenience method combining getConfigParameter(std::string const&) with a check.
      */
     template<typename T> void
-    checkParameter(std::string const& param, T const& value) const;
+    checkConfigParameter(std::string const& param, T const& value) const;
 
-    //! Make checkParameter() work for string literals.
+    //! Make checkConfigParameter() work for string literals.
     template<typename Ch> void
-    checkParameter(std::string const& param, Ch const* value) const;
+    checkConfigParameter(std::string const& param, Ch const* value) const;
 
     //!\}
 
@@ -422,14 +440,14 @@ public:
      * \pre \c root must not have been read before from this ConfigTree.
      */
     ConfigTree
-    getSubtree(std::string const& root) const;
+    getConfigSubtree(std::string const& root) const;
 
     /*! Get the subtree rooted at \c root if present
      *
      * \pre \c root must not have been read before from this ConfigTree.
      */
     boost::optional<ConfigTree>
-    getSubtreeOptional(std::string const& root) const;
+    getConfigSubtreeOptional(std::string const& root) const;
 
     /*! Get all subtrees that have a root \c root from the current level of the tree.
      *
@@ -438,7 +456,7 @@ public:
      * \pre \c root must not have been read before from this ConfigTree.
      */
     Range<SubtreeIterator>
-    getSubtreeList(std::string const& root) const;
+    getConfigSubtreeList(std::string const& root) const;
 
     //!\}
 
@@ -453,7 +471,7 @@ public:
      *
      * \pre \c param must not have been read before from this ConfigTree.
      */
-    void ignoreParameter(std::string const& param) const;
+    void ignoreConfigParameter(std::string const& param) const;
 
     /*! Tell this instance to ignore all parameters \c param on the current level of the tree.
      *
@@ -461,7 +479,7 @@ public:
      *
      * \pre \c param must not have been read before from this ConfigTree.
      */
-    void ignoreParameterAll(std::string const& param) const;
+    void ignoreConfigParameterAll(std::string const& param) const;
 
     /*! Tell this instance to ignore the XML attribute \c attr.
      *
@@ -469,7 +487,7 @@ public:
      *
      * \pre \c attr must not have been read before from this ConfigTree.
      */
-    void ignoreAttribute(std::string const& attr) const;
+    void ignoreConfigAttribute(std::string const& attr) const;
 
     //!\}
 
@@ -490,11 +508,11 @@ public:
 private:
     //! Default implementation of reading a value of type T.
     template<typename T> boost::optional<T>
-    getParameterOptionalImpl(std::string const& param, T*) const;
+    getConfigParameterOptionalImpl(std::string const& param, T*) const;
 
     //! Implementation of reading a vector of values of type T.
     template<typename T> boost::optional<std::vector<T>>
-    getParameterOptionalImpl(std::string const& param, std::vector<T>*) const;
+    getConfigParameterOptionalImpl(std::string const& param, std::vector<T>*) const;
 
 private:
     struct CountType

--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -70,7 +70,7 @@ template<typename Iterator> class Range;
  * existing configuration parameters from the source code.
  *
  * This class maintains a read counter for each parameter accessed through any of its methods.
- * Read counters are increased with every read (the only exception being the peekConfParam() method).
+ * Read counters are increased with every read (the only exception being the peekParameter() method).
  * The destructor finally decreases the read counter for every tag/attribute it find on the
  * current level of the XML tree. If the increases/decreases don't cancel each other, warning
  * messages are generated. This check can also be enforced before destruction by using the
@@ -293,28 +293,28 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> T
-    getConfParam(std::string const& param) const;
+    getParameter(std::string const& param) const;
 
     /*! Get parameter \c param of type \c T from the configuration tree or the \c default_value.
      *
-     * This method has a similar behaviour as getConfParam(std::string const&) except in case
+     * This method has a similar behaviour as getParameter(std::string const&) except in case
      * of errors the \c default_value is returned.
      *
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> T
-    getConfParam(std::string const& param, T const& default_value) const;
+    getParameter(std::string const& param, T const& default_value) const;
 
     /*! Get parameter \c param of type \c T from the configuration tree if present
      *
-     * This method has a similar behaviour as getConfParam(std::string const&) except
+     * This method has a similar behaviour as getParameter(std::string const&) except
      * no errors are raised. Rather it can be told from the return value if the
      * parameter could be read.
      *
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> boost::optional<T>
-    getConfParamOptional(std::string const& param) const;
+    getParameterOptional(std::string const& param) const;
 
     /*! Fetches all parameters with name \c param from the current level of the tree.
      *
@@ -323,13 +323,13 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> Range<ValueIterator<T> >
-    getConfParamList(std::string const& param) const;
+    getParameterList(std::string const& param) const;
 
     //!\}
 
     /*! \name Methods for accessing parameters that have attributes
      *
-     * The <tt>getConfParam...()</tt> methods in this group---note: they do not have template
+     * The <tt>getParameter...()</tt> methods in this group---note: they do not have template
      * parameters---check that the queried parameters do not have any children (apart from XML
      * attributes); if they do, error() is called.
      *
@@ -345,7 +345,7 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     Range<ParameterIterator>
-    getConfParamList(std::string const& param) const;
+    getParameterList(std::string const& param) const;
 
     /*! Get the plain data contained in the current level of the tree.
      *
@@ -363,7 +363,7 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> T
-    getConfAttribute(std::string const& attr) const;
+    getAttribute(std::string const& attr) const;
 
     /*! Get XML attribute \c attr of type \c T for the current parameter if present.
      *
@@ -372,7 +372,7 @@ public:
      * \pre \c param must not have been read before from this ConfigTree.
      */
     template<typename T> boost::optional<T>
-    getConfAttributeOptional(std::string const& attr) const;
+    getAttributeOptional(std::string const& attr) const;
 
     //!\}
 
@@ -392,21 +392,21 @@ public:
      * But in order that the requested parameter counts as "completely parsed", it has to be
      * read through some other method, too.
      *
-     * Return value and error behaviour are the same as for getConfParam<T>(std::string const&).
+     * Return value and error behaviour are the same as for getParameter<T>(std::string const&).
      */
     template<typename T> T
-    peekConfParam(std::string const& param) const;
+    peekParameter(std::string const& param) const;
 
     /*! Assert that \c param has the given \c value.
      *
-     * Convenience method combining getConfParam(std::string const&) with a check.
+     * Convenience method combining getParameter(std::string const&) with a check.
      */
     template<typename T> void
-    checkConfParam(std::string const& param, T const& value) const;
+    checkParameter(std::string const& param, T const& value) const;
 
-    //! Make checkConfParam() work for string literals.
+    //! Make checkParameter() work for string literals.
     template<typename Ch> void
-    checkConfParam(std::string const& param, Ch const* value) const;
+    checkParameter(std::string const& param, Ch const* value) const;
 
     //!\}
 
@@ -422,14 +422,14 @@ public:
      * \pre \c root must not have been read before from this ConfigTree.
      */
     ConfigTree
-    getConfSubtree(std::string const& root) const;
+    getSubtree(std::string const& root) const;
 
     /*! Get the subtree rooted at \c root if present
      *
      * \pre \c root must not have been read before from this ConfigTree.
      */
     boost::optional<ConfigTree>
-    getConfSubtreeOptional(std::string const& root) const;
+    getSubtreeOptional(std::string const& root) const;
 
     /*! Get all subtrees that have a root \c root from the current level of the tree.
      *
@@ -438,7 +438,7 @@ public:
      * \pre \c root must not have been read before from this ConfigTree.
      */
     Range<SubtreeIterator>
-    getConfSubtreeList(std::string const& root) const;
+    getSubtreeList(std::string const& root) const;
 
     //!\}
 
@@ -453,7 +453,7 @@ public:
      *
      * \pre \c param must not have been read before from this ConfigTree.
      */
-    void ignoreConfParam(std::string const& param) const;
+    void ignoreParameter(std::string const& param) const;
 
     /*! Tell this instance to ignore all parameters \c param on the current level of the tree.
      *
@@ -461,7 +461,7 @@ public:
      *
      * \pre \c param must not have been read before from this ConfigTree.
      */
-    void ignoreConfParamAll(std::string const& param) const;
+    void ignoreParameterAll(std::string const& param) const;
 
     /*! Tell this instance to ignore the XML attribute \c attr.
      *
@@ -469,7 +469,7 @@ public:
      *
      * \pre \c attr must not have been read before from this ConfigTree.
      */
-    void ignoreConfAttribute(std::string const& attr) const;
+    void ignoreAttribute(std::string const& attr) const;
 
     //!\}
 
@@ -490,11 +490,11 @@ public:
 private:
     //! Default implementation of reading a value of type T.
     template<typename T> boost::optional<T>
-    getConfParamOptionalImpl(std::string const& param, T*) const;
+    getParameterOptionalImpl(std::string const& param, T*) const;
 
     //! Implementation of reading a vector of values of type T.
     template<typename T> boost::optional<std::vector<T>>
-    getConfParamOptionalImpl(std::string const& param, std::vector<T>*) const;
+    getParameterOptionalImpl(std::string const& param, std::vector<T>*) const;
 
 private:
     struct CountType

--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -338,24 +338,6 @@ public:
      */
     //!\{
 
-    /*! Get parameter \c param from the configuration tree.
-     *
-     * \return the subtree representing the requested parameter
-     *
-     * \pre \c param must not have been read before from this ConfigTree.
-     */
-    ConfigTree
-    getConfParam(std::string const& param) const;
-
-    /*! Get parameter \c param from the configuration tree if present.
-     *
-     * \return the subtree representing the requested parameter
-     *
-     * \pre \c param must not have been read before from this ConfigTree.
-     */
-    boost::optional<ConfigTree>
-    getConfParamOptional(std::string const& param) const;
-
     /*! Fetches all parameters with name \c param from the current level of the tree.
      *
      * The return value is suitable to be used with range-base for-loops.

--- a/BaseLib/Histogram.h
+++ b/BaseLib/Histogram.h
@@ -102,7 +102,7 @@ public:
 
     const Data& getSortedData() const { return _data; }
     const std::vector<std::size_t>& getBinCounts() const { return _histogram; }
-    const unsigned int& getNrBins() const { return _nr_bins; }
+    const unsigned int& getNumberOfBins() const { return _nr_bins; }
     const T& getMinimum() const { return _min; }
     const T& getMaximum() const { return _max; }
     const T& getBinWidth() const { return _bin_width; }
@@ -142,7 +142,7 @@ public:
         }
 
         out << "# Histogram for parameter " << param_name << " of data set " << data_set_name << "\n";
-        std::size_t const n_bins = this->getNrBins();
+        std::size_t const n_bins = this->getNumberOfBins();
         std::vector<std::size_t> const& bin_cnts(this->getBinCounts());
         double const min (this->getMinimum());
         double const bin_width (this->getBinWidth());
@@ -188,7 +188,7 @@ template <typename T>
 std::ostream&
 operator<<(std::ostream& os, const Histogram<T>& h)
 {
-    os << h.getNrBins() << " "
+    os << h.getNumberOfBins() << " "
        << h.getMinimum() << " "
        << h.getMaximum() << " ";
     std::copy(h.getBinCounts().begin(), h.getBinCounts().end(),

--- a/FileIO/TetGenInterface.cpp
+++ b/FileIO/TetGenInterface.cpp
@@ -185,7 +185,7 @@ bool TetGenInterface::parseSmeshFacets(std::ifstream &input,
 
     std::size_t nTotalTriangles (0);
     for (std::size_t i=0; i<surfaces.size(); ++i)
-        nTotalTriangles += surfaces[i]->getNTriangles();
+        nTotalTriangles += surfaces[i]->getNumberOfTriangles();
     if (nTotalTriangles == nFacets)
         return true;
 
@@ -539,12 +539,12 @@ bool TetGenInterface::writeTetGenSmesh(const std::string &file_name,
     const std::size_t nSurfaces = (surfaces) ? surfaces->size() : 0;
     std::size_t nTotalTriangles (0);
     for (std::size_t i=0; i<nSurfaces; ++i)
-        nTotalTriangles += (*surfaces)[i]->getNTriangles();
+        nTotalTriangles += (*surfaces)[i]->getNumberOfTriangles();
     out << nTotalTriangles << " 1\n";
 
     for (std::size_t i=0; i<nSurfaces; ++i)
     {
-        const std::size_t nTriangles ((*surfaces)[i]->getNTriangles());
+        const std::size_t nTriangles ((*surfaces)[i]->getNumberOfTriangles());
         const std::size_t marker (i+1); // must NOT be 0!
         // the poly list
         for (std::size_t j=0; j<nTriangles; ++j)
@@ -605,7 +605,7 @@ bool TetGenInterface::writeTetGenSmesh(const std::string &file_name,
             out << i+1 << " " << attribute_points[i][0] << " " << attribute_points[i][1] << " " << attribute_points[i][2] << " " << 10*attribute_points[i].getID() << "\n";
     }
 
-    INFO ("TetGenInterface::writeTetGenPoly() - %d points and %d surfaces successfully written.", nPoints, mesh.getNElements());
+    INFO ("TetGenInterface::writeTetGenPoly() - %d points and %d surfaces successfully written.", nPoints, mesh.getNumberOfElements());
     out.close();
     return true;
 }
@@ -649,7 +649,7 @@ void TetGenInterface::write3dElements(std::ofstream &out,
         if (elements[i]->getDimension() < 3)
             continue;
 
-        const unsigned nFaces (elements[i]->getNNeighbors());
+        const unsigned nFaces (elements[i]->getNumberOfNeighbors());
         std::string const mat_id_str = (materialIds) ? std::to_string((*materialIds)[i]) : "";
         for (std::size_t j=0; j<nFaces; ++j)
         {

--- a/GeoLib/GEOObjects.cpp
+++ b/GeoLib/GEOObjects.cpp
@@ -492,7 +492,7 @@ void GEOObjects::mergeSurfaces(std::vector<std::string> const & geo_names,
             for (std::size_t k(0); k < sfcs->size(); k++) {
                 GeoLib::Surface* kth_sfc_new(new GeoLib::Surface (*merged_points));
                 GeoLib::Surface const* const kth_sfc_old ((*sfcs)[k]);
-                const std::size_t size_of_kth_sfc (kth_sfc_old->getNTriangles());
+                const std::size_t size_of_kth_sfc (kth_sfc_old->getNumberOfTriangles());
                 // clone surface elements using new ids
                 for (std::size_t i(0); i < size_of_kth_sfc; i++) {
                     const GeoLib::Triangle* tri ((*kth_sfc_old)[i]);

--- a/GeoLib/IO/Gmsh/GMSHAdaptiveMeshDensity.cpp
+++ b/GeoLib/IO/Gmsh/GMSHAdaptiveMeshDensity.cpp
@@ -45,7 +45,7 @@ GMSHAdaptiveMeshDensity::~GMSHAdaptiveMeshDensity()
     delete _quad_tree;
 }
 
-void GMSHAdaptiveMeshDensity::init(std::vector<GeoLib::Point const*> const& pnts)
+void GMSHAdaptiveMeshDensity::initialize(std::vector<GeoLib::Point const*> const& pnts)
 {
     // *** QuadTree - determining bounding box
     DBUG("GMSHAdaptiveMeshDensity::init(): computing axis aligned bounding box (2D) for quadtree.");

--- a/GeoLib/IO/Gmsh/GMSHAdaptiveMeshDensity.h
+++ b/GeoLib/IO/Gmsh/GMSHAdaptiveMeshDensity.h
@@ -34,7 +34,7 @@ public:
                             double station_density,
                             std::size_t max_pnts_per_leaf);
     virtual ~GMSHAdaptiveMeshDensity();
-    void init(std::vector<GeoLib::Point const*> const& pnts);
+    void initialize(std::vector<GeoLib::Point const*> const& pnts);
     double getMeshDensityAtPoint(GeoLib::Point const* const pnt) const;
     void addPoints(std::vector<GeoLib::Point const*> const& pnts);
     double getMeshDensityAtStation(GeoLib::Point const* const) const;

--- a/GeoLib/IO/Gmsh/GMSHFixedMeshDensity.cpp
+++ b/GeoLib/IO/Gmsh/GMSHFixedMeshDensity.cpp
@@ -22,7 +22,7 @@ GMSHFixedMeshDensity::GMSHFixedMeshDensity(double mesh_density) :
 {
 }
 
-void GMSHFixedMeshDensity::init(std::vector<GeoLib::Point const*> const& vec)
+void GMSHFixedMeshDensity::initialize(std::vector<GeoLib::Point const*> const& vec)
 {
     // to avoid a warning here:
     (void)(vec);

--- a/GeoLib/IO/Gmsh/GMSHFixedMeshDensity.h
+++ b/GeoLib/IO/Gmsh/GMSHFixedMeshDensity.h
@@ -24,7 +24,7 @@ class GMSHFixedMeshDensity : public GMSHMeshDensityStrategy
 {
 public:
     GMSHFixedMeshDensity(double mesh_density);
-    void init(std::vector<GeoLib::Point const*> const& vec);
+    void initialize(std::vector<GeoLib::Point const*> const& vec);
     double getMeshDensityAtPoint(GeoLib::Point const*const) const;
     double getMeshDensityAtStation(GeoLib::Point const*const) const;
     virtual ~GMSHFixedMeshDensity() {}

--- a/GeoLib/IO/Gmsh/GMSHMeshDensityStrategy.h
+++ b/GeoLib/IO/Gmsh/GMSHMeshDensityStrategy.h
@@ -28,7 +28,7 @@ class GMSHMeshDensityStrategy
 {
 public:
     virtual ~GMSHMeshDensityStrategy() {}
-    virtual void init(std::vector<GeoLib::Point const*> const&) = 0;
+    virtual void initialize(std::vector<GeoLib::Point const*> const&) = 0;
     virtual double getMeshDensityAtPoint(GeoLib::Point const*const) const = 0;
     virtual double getMeshDensityAtStation(GeoLib::Point const*const) const = 0;
 };

--- a/GeoLib/IO/Gmsh/GMSHPolygonTree.cpp
+++ b/GeoLib/IO/Gmsh/GMSHPolygonTree.cpp
@@ -242,7 +242,7 @@ void GMSHPolygonTree::initMeshDensityStrategy()
         }
 
         // give collected points to the mesh density strategy
-        _mesh_density_strategy->init(pnts);
+        _mesh_density_strategy->initialize(pnts);
         // insert constraints
         dynamic_cast<GMSHAdaptiveMeshDensity*>(_mesh_density_strategy)->addPoints(_stations);
         std::vector<GeoLib::Point const*> stations;

--- a/GeoLib/IO/Gmsh/GMSHPolygonTree.cpp
+++ b/GeoLib/IO/Gmsh/GMSHPolygonTree.cpp
@@ -75,7 +75,7 @@ bool GMSHPolygonTree::insertStation(GeoLib::Point const* station)
             if (((*it)->getPolygon())->isPntInPolygon (*station)) {
                 bool rval(dynamic_cast<GMSHPolygonTree*>((*it))->insertStation (station));
                 // stop recursion if sub SimplePolygonTree is a leaf
-                if (rval && (*it)->getNChildren() == 0)
+                if (rval && (*it)->getNumberOfChildren() == 0)
                     _stations.push_back (station);
                 return rval;
             }

--- a/GeoLib/IO/TINInterface.cpp
+++ b/GeoLib/IO/TINInterface.cpp
@@ -115,7 +115,7 @@ GeoLib::Surface* TINInterface::readTIN(std::string const& fname,
         }
     }
 
-    if (sfc->getNTriangles() == 0) {
+    if (sfc->getNumberOfTriangles() == 0) {
         WARN("readTIN(): No triangle found.", fname.c_str());
         if (errors)
             errors->push_back ("readTIN error because of no triangle found");
@@ -134,7 +134,7 @@ void TINInterface::writeSurfaceAsTIN(GeoLib::Surface const& surface, std::string
         return;
     }
     os.precision(std::numeric_limits<double>::digits10);
-    const std::size_t n_tris (surface.getNTriangles());
+    const std::size_t n_tris (surface.getNumberOfTriangles());
     for (std::size_t l(0); l < n_tris; l++) {
         GeoLib::Triangle const& tri (*(surface[l]));
         os << l << " " << *(tri.getPoint(0)) << " " << *(tri.getPoint(1)) << " " << *(tri.getPoint(2)) << "\n";

--- a/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.cpp
@@ -41,9 +41,9 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
     auto doc = BaseLib::makeConfigTree(fname, true, "OpenGeoSysGLI");
 
     // ignore attributes related to XML schema
-    doc->ignoreAttribute("xmlns:xsi");
-    doc->ignoreAttribute("xsi:noNamespaceSchemaLocation");
-    doc->ignoreAttribute("xmlns:ogs");
+    doc->ignoreConfigAttribute("xmlns:xsi");
+    doc->ignoreConfigAttribute("xsi:noNamespaceSchemaLocation");
+    doc->ignoreConfigAttribute("xmlns:ogs");
 
     auto points = std::unique_ptr<std::vector<GeoLib::Point*>>(
         new std::vector<GeoLib::Point*>);
@@ -58,7 +58,7 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
     std::unique_ptr<MapNameId> sfc_names{new MapNameId};
 
     //! \ogs_file_param{gml__name}
-    auto geo_name = doc->getParameter<std::string>("name");
+    auto geo_name = doc->getConfigParameter<std::string>("name");
     if (geo_name.empty())
     {
         ERR("BoostXmlGmlInterface::readFile(): <name> tag is empty.");
@@ -66,14 +66,14 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
     }
 
     //! \ogs_file_param{gml__points}
-    for (auto st : doc->getSubtreeList("points"))
+    for (auto st : doc->getConfigSubtreeList("points"))
     {
         readPoints(st, *points, *pnt_names);
         _geo_objects.addPointVec(std::move(points), geo_name, pnt_names.release());
     }
 
     //! \ogs_file_param{gml__polylines}
-    for (auto st : doc->getSubtreeList("polylines"))
+    for (auto st : doc->getConfigSubtreeList("polylines"))
     {
         readPolylines(st,
                       *polylines,
@@ -83,7 +83,7 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
     }
 
     //! \ogs_file_param{gml__surfaces}
-    for (auto st : doc->getSubtreeList("surfaces"))
+    for (auto st : doc->getConfigSubtreeList("surfaces"))
     {
         readSurfaces(st,
                      *surfaces,
@@ -108,16 +108,16 @@ void BoostXmlGmlInterface::readPoints(BaseLib::ConfigTree const& pointsRoot,
                                       std::map<std::string, std::size_t>& pnt_names )
 {
     //! \ogs_file_param{gml__points__point}
-    for (auto const pt : pointsRoot.getParameterList("point"))
+    for (auto const pt : pointsRoot.getConfigParameterList("point"))
     {
         //! \ogs_file_attr{gml__points__point__id}
-        auto const p_id = pt.getAttribute<std::size_t>("id");
+        auto const p_id = pt.getConfigAttribute<std::size_t>("id");
         //! \ogs_file_attr{gml__points__point__x}
-        auto const p_x  = pt.getAttribute<double>("x");
+        auto const p_x  = pt.getConfigAttribute<double>("x");
         //! \ogs_file_attr{gml__points__point__y}
-        auto const p_y  = pt.getAttribute<double>("y");
+        auto const p_y  = pt.getConfigAttribute<double>("y");
         //! \ogs_file_attr{gml__points__point__z}
-        auto const p_z  = pt.getAttribute<double>("z");
+        auto const p_z  = pt.getConfigAttribute<double>("z");
 
         auto const p_size = points.size();
         BaseLib::insertIfKeyUniqueElseError(_idx_map, p_id, p_size,
@@ -125,7 +125,7 @@ void BoostXmlGmlInterface::readPoints(BaseLib::ConfigTree const& pointsRoot,
         points.push_back(new GeoLib::Point(p_x, p_y, p_z, p_id));
 
         //! \ogs_file_attr{gml__points__point__name}
-        if (auto const p_name = pt.getAttributeOptional<std::string>("name"))
+        if (auto const p_name = pt.getConfigAttributeOptional<std::string>("name"))
         {
             if (p_name->empty()) {
                 ERR("Empty point name found in geometry file.");
@@ -146,10 +146,10 @@ void BoostXmlGmlInterface::readPolylines(
     std::map<std::string, std::size_t>& ply_names)
 {
     //! \ogs_file_param{gml__polylines__polyline}
-    for (auto const pl : polylinesRoot.getSubtreeList("polyline"))
+    for (auto const pl : polylinesRoot.getConfigSubtreeList("polyline"))
     {
         //! \ogs_file_attr{gml__polylines__polyline__id}
-        auto const id = pl.getAttribute<std::size_t>("id");
+        auto const id = pl.getConfigAttribute<std::size_t>("id");
         // The id is not used but must be present in the GML file.
         // That's why pl.ignore...() cannot be used.
         (void) id;
@@ -157,7 +157,7 @@ void BoostXmlGmlInterface::readPolylines(
         polylines.push_back(new GeoLib::Polyline(points));
 
         //! \ogs_file_attr{gml__polylines__polyline__name}
-        if (auto const p_name = pl.getAttributeOptional<std::string>("name"))
+        if (auto const p_name = pl.getConfigAttributeOptional<std::string>("name"))
         {
             if (p_name->empty()) {
                 ERR("Empty polyline name found in geometry file.");
@@ -168,14 +168,14 @@ void BoostXmlGmlInterface::readPolylines(
                 "The polyline name is not unique.");
 
             //! \ogs_file_param{gml__polylines__polyline__pnt}
-            for (auto const pt : pl.getParameterList<std::size_t>("pnt")) {
+            for (auto const pt : pl.getConfigParameterList<std::size_t>("pnt")) {
                 polylines.back()->addPoint(pnt_id_map[_idx_map[pt]]);
             }
         }
         else
         {
             // polyline has no name, ignore it.
-            pl.ignoreParameterAll("pnt");
+            pl.ignoreConfigParameterAll("pnt");
         }
     }
 }
@@ -188,17 +188,17 @@ void BoostXmlGmlInterface::readSurfaces(
     std::map<std::string, std::size_t>& sfc_names)
 {
     //! \ogs_file_param{gml__surfaces__surface}
-    for (auto const& sfc : surfacesRoot.getSubtreeList("surface"))
+    for (auto const& sfc : surfacesRoot.getConfigSubtreeList("surface"))
     {
         //! \ogs_file_attr{gml__surfaces__surface__id}
-        auto const id = sfc.getAttribute<std::size_t>("id");
+        auto const id = sfc.getConfigAttribute<std::size_t>("id");
         // The id is not used but must be present in the GML file.
         // That's why sfc.ignore...() cannot be used.
         (void) id;
         surfaces.push_back(new GeoLib::Surface(points));
 
         //! \ogs_file_attr{gml__surfaces__surface__name}
-        if (auto const s_name = sfc.getAttributeOptional<std::string>("name"))
+        if (auto const s_name = sfc.getConfigAttributeOptional<std::string>("name"))
         {
             if (s_name->empty()) {
                 ERR("Empty surface name found in geometry file.");
@@ -209,13 +209,13 @@ void BoostXmlGmlInterface::readSurfaces(
                 "The surface name is not unique.");
 
             //! \ogs_file_param{gml__surfaces__surface__element}
-            for (auto const& element : sfc.getParameterList("element")) {
+            for (auto const& element : sfc.getConfigParameterList("element")) {
                 //! \ogs_file_attr{gml__surfaces__surface__element__p1}
-                auto const p1_attr = element.getAttribute<std::size_t>("p1");
+                auto const p1_attr = element.getConfigAttribute<std::size_t>("p1");
                 //! \ogs_file_attr{gml__surfaces__surface__element__p2}
-                auto const p2_attr = element.getAttribute<std::size_t>("p2");
+                auto const p2_attr = element.getConfigAttribute<std::size_t>("p2");
                 //! \ogs_file_attr{gml__surfaces__surface__element__p3}
-                auto const p3_attr = element.getAttribute<std::size_t>("p3");
+                auto const p3_attr = element.getConfigAttribute<std::size_t>("p3");
 
                 auto const p1 = pnt_id_map[_idx_map[p1_attr]];
                 auto const p2 = pnt_id_map[_idx_map[p2_attr]];
@@ -226,7 +226,7 @@ void BoostXmlGmlInterface::readSurfaces(
         else
         {
             // surface has no name, ignore it.
-            sfc.ignoreParameterAll("element");
+            sfc.ignoreConfigParameterAll("element");
         }
     }
 }

--- a/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.cpp
@@ -41,9 +41,9 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
     auto doc = BaseLib::makeConfigTree(fname, true, "OpenGeoSysGLI");
 
     // ignore attributes related to XML schema
-    doc->ignoreConfAttribute("xmlns:xsi");
-    doc->ignoreConfAttribute("xsi:noNamespaceSchemaLocation");
-    doc->ignoreConfAttribute("xmlns:ogs");
+    doc->ignoreAttribute("xmlns:xsi");
+    doc->ignoreAttribute("xsi:noNamespaceSchemaLocation");
+    doc->ignoreAttribute("xmlns:ogs");
 
     auto points = std::unique_ptr<std::vector<GeoLib::Point*>>(
         new std::vector<GeoLib::Point*>);
@@ -58,7 +58,7 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
     std::unique_ptr<MapNameId> sfc_names{new MapNameId};
 
     //! \ogs_file_param{gml__name}
-    auto geo_name = doc->getConfParam<std::string>("name");
+    auto geo_name = doc->getParameter<std::string>("name");
     if (geo_name.empty())
     {
         ERR("BoostXmlGmlInterface::readFile(): <name> tag is empty.");
@@ -66,14 +66,14 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
     }
 
     //! \ogs_file_param{gml__points}
-    for (auto st : doc->getConfSubtreeList("points"))
+    for (auto st : doc->getSubtreeList("points"))
     {
         readPoints(st, *points, *pnt_names);
         _geo_objects.addPointVec(std::move(points), geo_name, pnt_names.release());
     }
 
     //! \ogs_file_param{gml__polylines}
-    for (auto st : doc->getConfSubtreeList("polylines"))
+    for (auto st : doc->getSubtreeList("polylines"))
     {
         readPolylines(st,
                       *polylines,
@@ -83,7 +83,7 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
     }
 
     //! \ogs_file_param{gml__surfaces}
-    for (auto st : doc->getConfSubtreeList("surfaces"))
+    for (auto st : doc->getSubtreeList("surfaces"))
     {
         readSurfaces(st,
                      *surfaces,
@@ -108,16 +108,16 @@ void BoostXmlGmlInterface::readPoints(BaseLib::ConfigTree const& pointsRoot,
                                       std::map<std::string, std::size_t>& pnt_names )
 {
     //! \ogs_file_param{gml__points__point}
-    for (auto const pt : pointsRoot.getConfParamList("point"))
+    for (auto const pt : pointsRoot.getParameterList("point"))
     {
         //! \ogs_file_attr{gml__points__point__id}
-        auto const p_id = pt.getConfAttribute<std::size_t>("id");
+        auto const p_id = pt.getAttribute<std::size_t>("id");
         //! \ogs_file_attr{gml__points__point__x}
-        auto const p_x  = pt.getConfAttribute<double>("x");
+        auto const p_x  = pt.getAttribute<double>("x");
         //! \ogs_file_attr{gml__points__point__y}
-        auto const p_y  = pt.getConfAttribute<double>("y");
+        auto const p_y  = pt.getAttribute<double>("y");
         //! \ogs_file_attr{gml__points__point__z}
-        auto const p_z  = pt.getConfAttribute<double>("z");
+        auto const p_z  = pt.getAttribute<double>("z");
 
         auto const p_size = points.size();
         BaseLib::insertIfKeyUniqueElseError(_idx_map, p_id, p_size,
@@ -125,7 +125,7 @@ void BoostXmlGmlInterface::readPoints(BaseLib::ConfigTree const& pointsRoot,
         points.push_back(new GeoLib::Point(p_x, p_y, p_z, p_id));
 
         //! \ogs_file_attr{gml__points__point__name}
-        if (auto const p_name = pt.getConfAttributeOptional<std::string>("name"))
+        if (auto const p_name = pt.getAttributeOptional<std::string>("name"))
         {
             if (p_name->empty()) {
                 ERR("Empty point name found in geometry file.");
@@ -146,10 +146,10 @@ void BoostXmlGmlInterface::readPolylines(
     std::map<std::string, std::size_t>& ply_names)
 {
     //! \ogs_file_param{gml__polylines__polyline}
-    for (auto const pl : polylinesRoot.getConfSubtreeList("polyline"))
+    for (auto const pl : polylinesRoot.getSubtreeList("polyline"))
     {
         //! \ogs_file_attr{gml__polylines__polyline__id}
-        auto const id = pl.getConfAttribute<std::size_t>("id");
+        auto const id = pl.getAttribute<std::size_t>("id");
         // The id is not used but must be present in the GML file.
         // That's why pl.ignore...() cannot be used.
         (void) id;
@@ -157,7 +157,7 @@ void BoostXmlGmlInterface::readPolylines(
         polylines.push_back(new GeoLib::Polyline(points));
 
         //! \ogs_file_attr{gml__polylines__polyline__name}
-        if (auto const p_name = pl.getConfAttributeOptional<std::string>("name"))
+        if (auto const p_name = pl.getAttributeOptional<std::string>("name"))
         {
             if (p_name->empty()) {
                 ERR("Empty polyline name found in geometry file.");
@@ -168,14 +168,14 @@ void BoostXmlGmlInterface::readPolylines(
                 "The polyline name is not unique.");
 
             //! \ogs_file_param{gml__polylines__polyline__pnt}
-            for (auto const pt : pl.getConfParamList<std::size_t>("pnt")) {
+            for (auto const pt : pl.getParameterList<std::size_t>("pnt")) {
                 polylines.back()->addPoint(pnt_id_map[_idx_map[pt]]);
             }
         }
         else
         {
             // polyline has no name, ignore it.
-            pl.ignoreConfParamAll("pnt");
+            pl.ignoreParameterAll("pnt");
         }
     }
 }
@@ -188,17 +188,17 @@ void BoostXmlGmlInterface::readSurfaces(
     std::map<std::string, std::size_t>& sfc_names)
 {
     //! \ogs_file_param{gml__surfaces__surface}
-    for (auto const& sfc : surfacesRoot.getConfSubtreeList("surface"))
+    for (auto const& sfc : surfacesRoot.getSubtreeList("surface"))
     {
         //! \ogs_file_attr{gml__surfaces__surface__id}
-        auto const id = sfc.getConfAttribute<std::size_t>("id");
+        auto const id = sfc.getAttribute<std::size_t>("id");
         // The id is not used but must be present in the GML file.
         // That's why sfc.ignore...() cannot be used.
         (void) id;
         surfaces.push_back(new GeoLib::Surface(points));
 
         //! \ogs_file_attr{gml__surfaces__surface__name}
-        if (auto const s_name = sfc.getConfAttributeOptional<std::string>("name"))
+        if (auto const s_name = sfc.getAttributeOptional<std::string>("name"))
         {
             if (s_name->empty()) {
                 ERR("Empty surface name found in geometry file.");
@@ -209,13 +209,13 @@ void BoostXmlGmlInterface::readSurfaces(
                 "The surface name is not unique.");
 
             //! \ogs_file_param{gml__surfaces__surface__element}
-            for (auto const& element : sfc.getConfParamList("element")) {
+            for (auto const& element : sfc.getParameterList("element")) {
                 //! \ogs_file_attr{gml__surfaces__surface__element__p1}
-                auto const p1_attr = element.getConfAttribute<std::size_t>("p1");
+                auto const p1_attr = element.getAttribute<std::size_t>("p1");
                 //! \ogs_file_attr{gml__surfaces__surface__element__p2}
-                auto const p2_attr = element.getConfAttribute<std::size_t>("p2");
+                auto const p2_attr = element.getAttribute<std::size_t>("p2");
                 //! \ogs_file_attr{gml__surfaces__surface__element__p3}
-                auto const p3_attr = element.getConfAttribute<std::size_t>("p3");
+                auto const p3_attr = element.getAttribute<std::size_t>("p3");
 
                 auto const p1 = pnt_id_map[_idx_map[p1_attr]];
                 auto const p2 = pnt_id_map[_idx_map[p2_attr]];
@@ -226,7 +226,7 @@ void BoostXmlGmlInterface::readSurfaces(
         else
         {
             // surface has no name, ignore it.
-            sfc.ignoreConfParamAll("element");
+            sfc.ignoreParameterAll("element");
         }
     }
 }

--- a/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.cpp
@@ -318,7 +318,7 @@ void BoostXmlGmlInterface::addSurfacesToPropertyTree(
         surface_tag.put("<xmlattr>.id", i);
         if (!sfc_name.empty())
             surface_tag.put("<xmlattr>.name", sfc_name);
-        for (std::size_t j=0; j<surface->getNTriangles(); ++j) {
+        for (std::size_t j=0; j<surface->getNumberOfTriangles(); ++j) {
             auto& element_tag = surface_tag.add("element", "");
             element_tag.put("<xmlattr>.p1", (*(*surface)[j])[0]);
             element_tag.put("<xmlattr>.p2", (*(*surface)[j])[1]);

--- a/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
@@ -394,7 +394,7 @@ bool XmlGmlInterface::write()
                     sfcListTag.appendChild(surfaceTag);
 
                     // writing the elements compromising the surface
-                    std::size_t nElements = ((*surfaces)[i])->getNTriangles();
+                    std::size_t nElements = ((*surfaces)[i])->getNumberOfTriangles();
                     for (std::size_t j = 0; j < nElements; j++)
                     {
                         QDomElement elementTag = doc.createElement("element");

--- a/GeoLib/Raster.cpp
+++ b/GeoLib/Raster.cpp
@@ -62,7 +62,7 @@ Raster* Raster::getRasterFromSurface(Surface const& sfc, double cell_size, doubl
 
     const std::size_t n_cols = static_cast<std::size_t>(std::abs(ur[0]-ll[0]) / cell_size)+1;
     const std::size_t n_rows = static_cast<std::size_t>(std::abs(ur[1]-ll[1]) / cell_size)+1;
-    const std::size_t n_triangles(sfc.getNTriangles());
+    const std::size_t n_triangles(sfc.getNumberOfTriangles());
     double *z_vals (new double[n_cols*n_rows]);
     std::size_t k(0);
 

--- a/GeoLib/SimplePolygonTree.h
+++ b/GeoLib/SimplePolygonTree.h
@@ -55,7 +55,7 @@ public:
     const Polygon* getPolygon () const;
 
     /** returns the number of children */
-    std::size_t getNChildren() const { return _children.size(); }
+    std::size_t getNumberOfChildren() const { return _children.size(); }
 
 protected:
     /**

--- a/GeoLib/Surface.cpp
+++ b/GeoLib/Surface.cpp
@@ -126,7 +126,7 @@ Surface* Surface::createSurface(const Polyline& ply)
         }
     }
     delete polygon;
-    if (sfc->getNTriangles() == 0)
+    if (sfc->getNumberOfTriangles() == 0)
     {
         WARN(
             "Surface::createSurface(): Triangulation does not contain any "
@@ -137,7 +137,7 @@ Surface* Surface::createSurface(const Polyline& ply)
     return sfc;
 }
 
-std::size_t Surface::getNTriangles() const
+std::size_t Surface::getNumberOfTriangles() const
 {
     return _sfc_triangles.size();
 }

--- a/GeoLib/Surface.h
+++ b/GeoLib/Surface.h
@@ -56,7 +56,7 @@ public:
     /**
      * returns the number of triangles describing the Surface
      * */
-    std::size_t getNTriangles() const;
+    std::size_t getNumberOfTriangles() const;
 
     /** \brief const access operator for the access to the i-th Triangle of the
      * surface.

--- a/GeoLib/SurfaceGrid.cpp
+++ b/GeoLib/SurfaceGrid.cpp
@@ -58,7 +58,7 @@ SurfaceGrid::SurfaceGrid(Surface const*const sfc) :
         delta[2] = _max_pnt[2] - _min_pnt[2];
     }
 
-    const std::size_t n_tris(sfc->getNTriangles());
+    const std::size_t n_tris(sfc->getNumberOfTriangles());
     const std::size_t n_tris_per_cell(5);
 
     std::bitset<3> dim; // all bits are set to zero.
@@ -115,7 +115,7 @@ SurfaceGrid::SurfaceGrid(Surface const*const sfc) :
 
 void SurfaceGrid::sortTrianglesInGridCells(Surface const*const sfc)
 {
-    for (std::size_t l(0); l<sfc->getNTriangles(); l++) {
+    for (std::size_t l(0); l<sfc->getNumberOfTriangles(); l++) {
         if (! sortTriangleInGridCells((*sfc)[l])) {
             Point const& p0(*((*sfc)[l]->getPoint(0)));
             Point const& p1(*((*sfc)[l]->getPoint(1)));

--- a/MaterialsLib/Adsorption/Reaction.cpp
+++ b/MaterialsLib/Adsorption/Reaction.cpp
@@ -33,7 +33,7 @@ Reaction::
 newInstance(BaseLib::ConfigTree const& conf)
 {
     //! \ogs_file_param{materials__adsorption__reaction__type}
-    auto const type = conf.getConfParam<std::string>("type");
+    auto const type = conf.getParameter<std::string>("type");
 
     if (type == "Z13XBF")
         return std::unique_ptr<Reaction>(new DensityLegacy);

--- a/MaterialsLib/Adsorption/Reaction.cpp
+++ b/MaterialsLib/Adsorption/Reaction.cpp
@@ -33,7 +33,7 @@ Reaction::
 newInstance(BaseLib::ConfigTree const& conf)
 {
     //! \ogs_file_param{materials__adsorption__reaction__type}
-    auto const type = conf.getParameter<std::string>("type");
+    auto const type = conf.getConfigParameter<std::string>("type");
 
     if (type == "Z13XBF")
         return std::unique_ptr<Reaction>(new DensityLegacy);

--- a/MaterialsLib/Adsorption/ReactionCaOH2.h
+++ b/MaterialsLib/Adsorption/ReactionCaOH2.h
@@ -28,7 +28,7 @@ class ReactionCaOH2 final : public Reaction
 public:
     explicit ReactionCaOH2(BaseLib::ConfigTree const& conf) :
         //! \ogs_file_param{materials__adsorption__reaction__CaOH2__ode_solver_config}
-        _ode_solver_config{conf.getSubtree("ode_solver_config")}
+        _ode_solver_config{conf.getConfigSubtree("ode_solver_config")}
     {}
 
     double getEnthalpy(const double /*p_Ads*/, const double /*T_Ads*/,

--- a/MaterialsLib/Adsorption/ReactionCaOH2.h
+++ b/MaterialsLib/Adsorption/ReactionCaOH2.h
@@ -28,7 +28,7 @@ class ReactionCaOH2 final : public Reaction
 public:
     explicit ReactionCaOH2(BaseLib::ConfigTree const& conf) :
         //! \ogs_file_param{materials__adsorption__reaction__CaOH2__ode_solver_config}
-        _ode_solver_config{conf.getConfSubtree("ode_solver_config")}
+        _ode_solver_config{conf.getSubtree("ode_solver_config")}
     {}
 
     double getEnthalpy(const double /*p_Ads*/, const double /*T_Ads*/,

--- a/MaterialsLib/Adsorption/ReactionSinusoidal.h
+++ b/MaterialsLib/Adsorption/ReactionSinusoidal.h
@@ -23,7 +23,7 @@ class ReactionSinusoidal final : public Reaction
 public:
     explicit ReactionSinusoidal(BaseLib::ConfigTree const& conf) :
         //! \ogs_file_param{materials__adsorption__reaction__Sinusoidal__reaction_enthalpy}
-        _enthalpy(conf.getConfParam<double>("reaction_enthalpy"))
+        _enthalpy(conf.getParameter<double>("reaction_enthalpy"))
     {
     }
 

--- a/MaterialsLib/Adsorption/ReactionSinusoidal.h
+++ b/MaterialsLib/Adsorption/ReactionSinusoidal.h
@@ -23,7 +23,7 @@ class ReactionSinusoidal final : public Reaction
 public:
     explicit ReactionSinusoidal(BaseLib::ConfigTree const& conf) :
         //! \ogs_file_param{materials__adsorption__reaction__Sinusoidal__reaction_enthalpy}
-        _enthalpy(conf.getParameter<double>("reaction_enthalpy"))
+        _enthalpy(conf.getConfigParameter<double>("reaction_enthalpy"))
     {
     }
 

--- a/MathLib/LinAlg/Dense/DenseMatrix-impl.h
+++ b/MathLib/LinAlg/Dense/DenseMatrix-impl.h
@@ -33,14 +33,14 @@ DenseMatrix<FP_TYPE, IDX_TYPE>::DenseMatrix(IDX_TYPE rows, IDX_TYPE cols,
 
 template<typename FP_TYPE, typename IDX_TYPE>
 DenseMatrix<FP_TYPE, IDX_TYPE>::DenseMatrix (const DenseMatrix<FP_TYPE, IDX_TYPE>& src) :
-        _n_rows(src.getNRows ()), _n_cols(src.getNCols ()), _data (new FP_TYPE[_n_rows * _n_cols])
+        _n_rows(src.getNumberOfRows ()), _n_cols(src.getNumberOfColumns ()), _data (new FP_TYPE[_n_rows * _n_cols])
 {
     std::copy(src._data, src._data+_n_rows*_n_cols, _data);
 }
 
 template<typename FP_TYPE, typename IDX_TYPE>
 DenseMatrix<FP_TYPE, IDX_TYPE>::DenseMatrix (DenseMatrix<FP_TYPE, IDX_TYPE> &&src) :
-       _n_rows(src.getNRows()), _n_cols(src.getNCols())
+       _n_rows(src.getNumberOfRows()), _n_cols(src.getNumberOfColumns())
 {
     src._n_rows = 0;
     src._n_cols = 0;
@@ -62,12 +62,12 @@ DenseMatrix<FP_TYPE, IDX_TYPE>::operator=(DenseMatrix<FP_TYPE, IDX_TYPE> const& 
     if (this == &rhs)
         return *this;
 
-    if (_n_rows != rhs.getNRows() || _n_cols != rhs.getNCols()) {
+    if (_n_rows != rhs.getNumberOfRows() || _n_cols != rhs.getNumberOfColumns()) {
         std::string msg("DenseMatrix::operator=(DenseMatrix const& rhs), Dimension mismatch, ");
         msg += " left hand side: " + std::to_string(_n_rows) + " x "
                 + std::to_string(_n_cols);
-        msg += " right hand side: " + std::to_string(rhs.getNRows()) + " x "
-                + std::to_string(rhs.getNCols());
+        msg += " right hand side: " + std::to_string(rhs.getNumberOfRows()) + " x "
+                + std::to_string(rhs.getNumberOfColumns());
         throw std::range_error(msg);
         return *this;
     }
@@ -168,7 +168,7 @@ DenseMatrix<FP_TYPE, IDX_TYPE>*
 DenseMatrix<FP_TYPE, IDX_TYPE>::operator+(const DenseMatrix<FP_TYPE, IDX_TYPE>& mat) const
 {
     // make sure the two matrices have the same dimension.
-    if (_n_rows != mat.getNRows() || _n_cols != mat.getNCols())
+    if (_n_rows != mat.getNumberOfRows() || _n_cols != mat.getNumberOfColumns())
         throw std::range_error("DenseMatrix::operator+, illegal matrix size!");
 
     DenseMatrix<FP_TYPE, IDX_TYPE>* y(new DenseMatrix<FP_TYPE, IDX_TYPE>(_n_rows, _n_cols));
@@ -186,7 +186,7 @@ DenseMatrix<FP_TYPE, IDX_TYPE>*
 DenseMatrix<FP_TYPE, IDX_TYPE>::operator-(const DenseMatrix<FP_TYPE, IDX_TYPE>& mat) const
 {
     // make sure the two matrices have the same dimension.
-    if (_n_rows != mat.getNRows() || _n_cols != mat.getNCols())
+    if (_n_rows != mat.getNumberOfRows() || _n_cols != mat.getNumberOfColumns())
         throw std::range_error("DenseMatrix::operator-, illegal matrix size!");
 
     DenseMatrix<FP_TYPE, IDX_TYPE>* y(new DenseMatrix<FP_TYPE, IDX_TYPE>(_n_rows, _n_cols));
@@ -204,11 +204,11 @@ DenseMatrix<FP_TYPE, IDX_TYPE>*
 DenseMatrix<FP_TYPE, IDX_TYPE>::operator*(const DenseMatrix<FP_TYPE, IDX_TYPE>& mat) const
 {
     // make sure the two matrices have the same dimension.
-    if (_n_cols != mat.getNRows())
+    if (_n_cols != mat.getNumberOfRows())
         throw std::range_error(
                 "DenseMatrix::operator*, number of rows and cols should be the same!");
 
-    IDX_TYPE y_cols(mat.getNCols());
+    IDX_TYPE y_cols(mat.getNumberOfColumns());
     DenseMatrix<FP_TYPE, IDX_TYPE>* y(
             new DenseMatrix<FP_TYPE, IDX_TYPE>(_n_rows, y_cols, FP_TYPE(0)));
 
@@ -282,11 +282,11 @@ void
 DenseMatrix<FP_TYPE, IDX_TYPE>::setSubMatrix(IDX_TYPE b_row, IDX_TYPE b_col,
         const DenseMatrix<FP_TYPE, IDX_TYPE>& sub_mat)
 {
-    if (b_row + sub_mat.getNRows() > _n_rows | b_col + sub_mat.getNCols() > _n_cols)
+    if (b_row + sub_mat.getNumberOfRows() > _n_rows | b_col + sub_mat.getNumberOfColumns() > _n_cols)
         throw std::range_error("DenseMatrix::setSubMatrix() sub matrix to big");
 
-    for (IDX_TYPE i = 0; i < sub_mat.getNRows(); i++) {
-        for (IDX_TYPE j = 0; j < sub_mat.getNCols(); j++) {
+    for (IDX_TYPE i = 0; i < sub_mat.getNumberOfRows(); i++) {
+        for (IDX_TYPE j = 0; j < sub_mat.getNumberOfColumns(); j++) {
             _data[address(i + b_row, j + b_col)] = sub_mat(i, j);
         }
     }
@@ -338,8 +338,8 @@ sqrFrobNrm (const DenseMatrix<FP_TYPE, IDX_TYPE> &mat)
 {
     FP_TYPE nrm(static_cast<FP_TYPE>(0));
     IDX_TYPE i, j;
-    for (j = 0; j < mat.getNCols(); j++)
-        for (i = 0; i < mat.getNRows(); i++)
+    for (j = 0; j < mat.getNumberOfColumns(); j++)
+        for (i = 0; i < mat.getNumberOfRows(); i++)
             nrm += mat(i, j) * mat(i, j);
 
     return nrm;

--- a/MathLib/LinAlg/Dense/DenseMatrix.h
+++ b/MathLib/LinAlg/Dense/DenseMatrix.h
@@ -143,12 +143,12 @@ public:
      * get the number of rows
      * @return the number of rows
      */
-    IDX_TYPE getNRows () const { return _n_rows; }
+    IDX_TYPE getNumberOfRows () const { return _n_rows; }
     /**
      * get the number of columns
      * @return the number of columns
      */
-    IDX_TYPE getNCols () const { return _n_cols; }
+    IDX_TYPE getNumberOfColumns () const { return _n_cols; }
 
     /**
      * get the number of entries in the matrix

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -144,24 +144,24 @@ void EigenLinearSolver::setOption(BaseLib::ConfigTree const& option)
 {
     ignoreOtherLinearSolvers(option, "eigen");
     //! \ogs_file_param{linear_solver__eigen}
-    auto const ptSolver = option.getConfSubtreeOptional("eigen");
+    auto const ptSolver = option.getSubtreeOptional("eigen");
     if (!ptSolver)
         return;
 
     //! \ogs_file_param{linear_solver__eigen__solver_type}
-    if (auto solver_type = ptSolver->getConfParamOptional<std::string>("solver_type")) {
+    if (auto solver_type = ptSolver->getParameterOptional<std::string>("solver_type")) {
         _option.solver_type = _option.getSolverType(*solver_type);
     }
     //! \ogs_file_param{linear_solver__eigen__precon_type}
-    if (auto precon_type = ptSolver->getConfParamOptional<std::string>("precon_type")) {
+    if (auto precon_type = ptSolver->getParameterOptional<std::string>("precon_type")) {
         _option.precon_type = _option.getPreconType(*precon_type);
     }
     //! \ogs_file_param{linear_solver__eigen__error_tolerance}
-    if (auto error_tolerance = ptSolver->getConfParamOptional<double>("error_tolerance")) {
+    if (auto error_tolerance = ptSolver->getParameterOptional<double>("error_tolerance")) {
         _option.error_tolerance = *error_tolerance;
     }
     //! \ogs_file_param{linear_solver__eigen__max_iteration_step}
-    if (auto max_iteration_step = ptSolver->getConfParamOptional<int>("max_iteration_step")) {
+    if (auto max_iteration_step = ptSolver->getParameterOptional<int>("max_iteration_step")) {
         _option.max_iterations = *max_iteration_step;
     }
 }

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -144,24 +144,24 @@ void EigenLinearSolver::setOption(BaseLib::ConfigTree const& option)
 {
     ignoreOtherLinearSolvers(option, "eigen");
     //! \ogs_file_param{linear_solver__eigen}
-    auto const ptSolver = option.getSubtreeOptional("eigen");
+    auto const ptSolver = option.getConfigSubtreeOptional("eigen");
     if (!ptSolver)
         return;
 
     //! \ogs_file_param{linear_solver__eigen__solver_type}
-    if (auto solver_type = ptSolver->getParameterOptional<std::string>("solver_type")) {
+    if (auto solver_type = ptSolver->getConfigParameterOptional<std::string>("solver_type")) {
         _option.solver_type = _option.getSolverType(*solver_type);
     }
     //! \ogs_file_param{linear_solver__eigen__precon_type}
-    if (auto precon_type = ptSolver->getParameterOptional<std::string>("precon_type")) {
+    if (auto precon_type = ptSolver->getConfigParameterOptional<std::string>("precon_type")) {
         _option.precon_type = _option.getPreconType(*precon_type);
     }
     //! \ogs_file_param{linear_solver__eigen__error_tolerance}
-    if (auto error_tolerance = ptSolver->getParameterOptional<double>("error_tolerance")) {
+    if (auto error_tolerance = ptSolver->getConfigParameterOptional<double>("error_tolerance")) {
         _option.error_tolerance = *error_tolerance;
     }
     //! \ogs_file_param{linear_solver__eigen__max_iteration_step}
-    if (auto max_iteration_step = ptSolver->getParameterOptional<int>("max_iteration_step")) {
+    if (auto max_iteration_step = ptSolver->getConfigParameterOptional<int>("max_iteration_step")) {
         _option.max_iterations = *max_iteration_step;
     }
 }

--- a/MathLib/LinAlg/Eigen/EigenMatrix.h
+++ b/MathLib/LinAlg/Eigen/EigenMatrix.h
@@ -49,16 +49,16 @@ public:
     }
 
     /// return the number of rows
-    std::size_t getNRows() const { return _mat.rows(); }
+    std::size_t getNumberOfRows() const { return _mat.rows(); }
 
     /// return the number of columns
-    std::size_t getNCols() const { return _mat.cols(); }
+    std::size_t getNumberOfColumns() const { return _mat.cols(); }
 
     /// return a start index of the active data range
     std::size_t getRangeBegin() const  { return 0; }
 
     /// return an end index of the active data range
-    std::size_t getRangeEnd() const  { return getNRows(); }
+    std::size_t getRangeEnd() const  { return getNumberOfRows(); }
 
     /// reset data entries to zero.
     void setZero()
@@ -73,7 +73,7 @@ public:
     /// dynamically allocates it.
     int setValue(IndexType row, IndexType col, double val)
     {
-        assert(row < (IndexType) getNRows() && col < (IndexType) getNCols());
+        assert(row < (IndexType) getNumberOfRows() && col < (IndexType) getNumberOfColumns());
         if (val != 0.0) _mat.coeffRef(row, col) = val;
         return 0;
     }
@@ -206,7 +206,7 @@ void operator()(EigenMatrix &matrix, SPARSITY_PATTERN const& sparsity_pattern)
                   "Set matrix sparsity relies on the EigenMatrix to be in "
                   "row-major storage order.");
 
-    assert(matrix.getNRows() == sparsity_pattern.size());
+    assert(matrix.getNumberOfRows() == sparsity_pattern.size());
 
     matrix.getRawMatrix().reserve(sparsity_pattern);
 }

--- a/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
+++ b/MathLib/LinAlg/EigenLis/EigenLisLinearSolver.cpp
@@ -45,7 +45,7 @@ bool EigenLisLinearSolver::solve(EigenMatrix &A_, EigenVector& b_,
     int* ptr = A.outerIndexPtr();
     int* col = A.innerIndexPtr();
     double* data = A.valuePtr();
-    LisMatrix lisA(A_.getNRows(), nnz, ptr, col, data);
+    LisMatrix lisA(A_.getNumberOfRows(), nnz, ptr, col, data);
     LisVector lisb(b.rows(), b.data());
     LisVector lisx(x.rows(), x.data());
 

--- a/MathLib/LinAlg/LinearSolverOptions.cpp
+++ b/MathLib/LinAlg/LinearSolverOptions.cpp
@@ -18,7 +18,7 @@ ignoreOtherLinearSolvers(const BaseLib::ConfigTree &config,
                          const std::string &solver_name)
 {
     for (auto const& s : known_linear_solvers) {
-        if (s!=solver_name) config.ignoreConfParam(s);
+        if (s!=solver_name) config.ignoreParameter(s);
     }
 }
 

--- a/MathLib/LinAlg/LinearSolverOptions.cpp
+++ b/MathLib/LinAlg/LinearSolverOptions.cpp
@@ -18,7 +18,7 @@ ignoreOtherLinearSolvers(const BaseLib::ConfigTree &config,
                          const std::string &solver_name)
 {
     for (auto const& s : known_linear_solvers) {
-        if (s!=solver_name) config.ignoreParameter(s);
+        if (s!=solver_name) config.ignoreConfigParameter(s);
     }
 }
 

--- a/MathLib/LinAlg/Lis/LisMatrix.h
+++ b/MathLib/LinAlg/Lis/LisMatrix.h
@@ -89,10 +89,10 @@ public:
     virtual ~LisMatrix();
 
     /// return the number of rows
-    std::size_t getNRows() const { return _n_rows; }
+    std::size_t getNumberOfRows() const { return _n_rows; }
 
     /// return the number of columns
-    std::size_t getNCols() const { return getNRows(); }
+    std::size_t getNumberOfColumns() const { return getNumberOfRows(); }
 
     /// return a start index of the active data range
     std::size_t getRangeBegin() const { return _is; }
@@ -196,7 +196,7 @@ struct SetMatrixSparsity<LisMatrix, SPARSITY_PATTERN>
 
 void operator()(LisMatrix &matrix, SPARSITY_PATTERN const& sparsity_pattern)
 {
-    auto const n_rows = matrix.getNRows();
+    auto const n_rows = matrix.getNumberOfRows();
     std::vector<LisMatrix::IndexType> row_sizes;
     row_sizes.reserve(n_rows);
 

--- a/MathLib/LinAlg/Lis/LisOption.h
+++ b/MathLib/LinAlg/Lis/LisOption.h
@@ -45,7 +45,7 @@ struct LisOption
         if (options) {
             ignoreOtherLinearSolvers(*options, "lis");
             //! \ogs_file_param{linear_solver__lis}
-            if (auto s = options->getConfParamOptional<std::string>("lis")) {
+            if (auto s = options->getParameterOptional<std::string>("lis")) {
                 if (!s->empty()) {
                     _option_string += " " + *s;
                     INFO("Lis options: \"%s\"", _option_string.c_str());

--- a/MathLib/LinAlg/Lis/LisOption.h
+++ b/MathLib/LinAlg/Lis/LisOption.h
@@ -45,7 +45,7 @@ struct LisOption
         if (options) {
             ignoreOtherLinearSolvers(*options, "lis");
             //! \ogs_file_param{linear_solver__lis}
-            if (auto s = options->getParameterOptional<std::string>("lis")) {
+            if (auto s = options->getConfigParameterOptional<std::string>("lis")) {
                 if (!s->empty()) {
                     _option_string += " " + *s;
                     INFO("Lis options: \"%s\"", _option_string.c_str());

--- a/MathLib/LinAlg/MatrixVectorTraits.h
+++ b/MathLib/LinAlg/MatrixVectorTraits.h
@@ -35,8 +35,8 @@ struct MatrixSpecifications;
 
 namespace MathLib
 {
-SPECIALIZE_MATRIX_VECTOR_TRAITS(Eigen::MatrixXd, Eigen::MatrixXd::Index);
-SPECIALIZE_MATRIX_VECTOR_TRAITS(Eigen::VectorXd, Eigen::VectorXd::Index);
+SPECIALIZE_MATRIX_VECTOR_TRAITS(Eigen::MatrixXd, Eigen::MatrixXd::Index)
+SPECIALIZE_MATRIX_VECTOR_TRAITS(Eigen::VectorXd, Eigen::VectorXd::Index)
 }
 
 #endif
@@ -61,8 +61,8 @@ SPECIALIZE_MATRIX_VECTOR_TRAITS(PETScVector, PETScVector::IndexType);
 
 namespace MathLib
 {
-SPECIALIZE_MATRIX_VECTOR_TRAITS(EigenMatrix, EigenMatrix::IndexType);
-SPECIALIZE_MATRIX_VECTOR_TRAITS(EigenVector, EigenVector::IndexType);
+SPECIALIZE_MATRIX_VECTOR_TRAITS(EigenMatrix, EigenMatrix::IndexType)
+SPECIALIZE_MATRIX_VECTOR_TRAITS(EigenVector, EigenVector::IndexType)
 }
 
 #endif

--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
@@ -38,12 +38,12 @@ PETScLinearSolver::PETScLinearSolver(const std::string /*prefix*/,
         {
             if (auto const parameters =
                 //! \ogs_file_param{linear_solver__petsc__parameters}
-                subtree->getConfParamOptional<std::string>("parameters")) {
+                subtree->getParameterOptional<std::string>("parameters")) {
                 petsc_options = *parameters;
             }
 
             //! \ogs_file_param{linear_solver__petsc__prefix}
-            if (auto const pre = subtree->getConfParamOptional<std::string>("prefix")) {
+            if (auto const pre = subtree->getParameterOptional<std::string>("prefix")) {
                 if (!pre->empty())
                     prefix = *pre + "_";
             }

--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
@@ -34,16 +34,16 @@ PETScLinearSolver::PETScLinearSolver(const std::string /*prefix*/,
         ignoreOtherLinearSolvers(*option, "petsc");
 
         //! \ogs_file_param{linear_solver__petsc}
-        if (auto const subtree = option->getConfSubtreeOptional("petsc"))
+        if (auto const subtree = option->getConfigSubtreeOptional("petsc"))
         {
             if (auto const parameters =
                 //! \ogs_file_param{linear_solver__petsc__parameters}
-                subtree->getParameterOptional<std::string>("parameters")) {
+                subtree->getConfigParameterOptional<std::string>("parameters")) {
                 petsc_options = *parameters;
             }
 
             //! \ogs_file_param{linear_solver__petsc__prefix}
-            if (auto const pre = subtree->getParameterOptional<std::string>("prefix")) {
+            if (auto const pre = subtree->getConfigParameterOptional<std::string>("prefix")) {
                 if (!pre->empty())
                     prefix = *pre + "_";
             }

--- a/MathLib/LinAlg/PETSc/PETScMatrix.h
+++ b/MathLib/LinAlg/PETSc/PETScMatrix.h
@@ -83,7 +83,7 @@ class PETScMatrix
         }
 
         /// Get the number of columns.
-        PetscInt getNumberOfCols() const
+        PetscInt getNumberOfColumns() const
         {
             return _ncols;
         }

--- a/MathLib/LinAlg/PETSc/PETScMatrix.h
+++ b/MathLib/LinAlg/PETSc/PETScMatrix.h
@@ -77,26 +77,26 @@ class PETScMatrix
         }
 
         /// Get the number of rows.
-        PetscInt getNRows() const
+        PetscInt getNumberOfRows() const
         {
             return _nrows;
         }
 
         /// Get the number of columns.
-        PetscInt getNCols() const
+        PetscInt getNumberOfCols() const
         {
             return _ncols;
         }
 
 
         /// Get the number of local rows.
-        PetscInt getNLocalRows() const
+        PetscInt getNumberOfLocalRows() const
         {
             return _n_loc_rows;
         }
 
         /// Get the number of local columns.
-        PetscInt getNLocalColumns() const
+        PetscInt getNumberOfLocalColumns() const
         {
             return _n_loc_cols;
         }

--- a/MathLib/LinAlg/Solvers/GaussAlgorithm-impl.h
+++ b/MathLib/LinAlg/Solvers/GaussAlgorithm-impl.h
@@ -22,8 +22,8 @@ namespace MathLib
 template <typename MAT_T, typename VEC_T>
 void GaussAlgorithm<MAT_T, VEC_T>::performLU(MAT_T& A)
 {
-    IDX_T const nr(A.getNRows());
-    IDX_T const nc(A.getNCols());
+    IDX_T const nr(A.getNumberOfRows());
+    IDX_T const nc(A.getNumberOfColumns());
 
     for (IDX_T k=0; k<nc; k++) {
         // search pivot
@@ -59,7 +59,7 @@ template <typename V>
 void GaussAlgorithm<MAT_T, VEC_T>::
 solve (MAT_T& A, V& b, bool decompose)
 {
-    _perm.resize(A.getNRows());
+    _perm.resize(A.getNumberOfRows());
 
     if (decompose)
         performLU(A);
@@ -72,7 +72,7 @@ template <typename MAT_T, typename VEC_T>
 void GaussAlgorithm<MAT_T, VEC_T>::
 solve (MAT_T& A, FP_T* & b, bool decompose)
 {
-    _perm.resize(A.getNRows());
+    _perm.resize(A.getNumberOfRows());
 
     if (decompose)
         performLU(A);
@@ -86,7 +86,7 @@ void GaussAlgorithm<MAT_T, VEC_T>::solve (
         MAT_T& A, VEC_T const& b, VEC_T & x,
         bool decompose)
 {
-    for (std::size_t k(0); k<A.getNRows(); k++)
+    for (std::size_t k(0); k<A.getNumberOfRows(); k++)
         x[k] = b[k];
     solve(A, x, decompose);
 }

--- a/MathLib/LinAlg/Solvers/TriangularSolve-impl.h
+++ b/MathLib/LinAlg/Solvers/TriangularSolve-impl.h
@@ -18,7 +18,7 @@ template <typename FP_T, typename VEC_T>
 void forwardSolve (const DenseMatrix <FP_T> &L, VEC_T& b)
 {
     typedef typename DenseMatrix<FP_T>::IDX_T IDX_T;
-    IDX_T m (L.getNRows());
+    IDX_T m (L.getNumberOfRows());
     FP_T t;
 
     for (IDX_T r=0; r<m; r++) {
@@ -35,7 +35,7 @@ void backwardSolve (const DenseMatrix <FP_T> &mat, VEC_T& b)
 {
     FP_T t;
     typedef typename DenseMatrix<FP_T>::IDX_T IDX_T;
-    IDX_T m (mat.getNRows()), n(mat.getNCols());
+    IDX_T m (mat.getNumberOfRows()), n(mat.getNumberOfColumns());
     for (int r=m-1; r>=0; r--) {
         t = 0.0;
         for (IDX_T c=r+1; c<n; c++) {
@@ -49,7 +49,7 @@ template <typename FP_T, typename VEC_T>
 void backwardSolve ( DenseMatrix<FP_T> const& mat, VEC_T& x, VEC_T const& b)
 {
     typedef typename DenseMatrix<FP_T>::IDX_T IDX_T;
-    IDX_T n_cols (mat.getNCols());
+    IDX_T n_cols (mat.getNumberOfColumns());
     for (int r = (n_cols - 1); r >= 0; r--) {
         FP_T t = 0.0;
 

--- a/MathLib/LinAlg/UnifiedMatrixSetters.cpp
+++ b/MathLib/LinAlg/UnifiedMatrixSetters.cpp
@@ -124,7 +124,7 @@ void setMatrix(PETScMatrix& m, Eigen::MatrixXd const& tmp)
     auto const rows = tmp.rows();
     auto const cols = tmp.cols();
 
-    assert(rows == m.getNRows() && cols == m.getNCols());
+    assert(rows == m.getNumberOfRows() && cols == m.getNumberOfColumns());
 
     m.setZero();
     std::vector<IndexType> row_idcs(rows);
@@ -144,8 +144,8 @@ void addToMatrix(PETScMatrix& m,
 {
     using IndexType = PETScMatrix::IndexType;
 
-    auto const rows = m.getNRows();
-    auto const cols = m.getNCols();
+    auto const rows = m.getNumberOfRows();
+    auto const cols = m.getNumberOfColumns();
 
     assert((IndexType) values.size() == rows*cols);
 
@@ -196,8 +196,8 @@ void setVector(EigenVector& v, MatrixVectorTraits<EigenVector>::Index const inde
 void setMatrix(EigenMatrix& m,
                std::initializer_list<double> values)
 {
-    auto const rows = m.getNRows();
-    auto const cols = m.getNCols();
+    auto const rows = m.getNumberOfRows();
+    auto const cols = m.getNumberOfColumns();
 
     assert(values.size() == rows*cols);
     Eigen::MatrixXd tmp(rows, cols);
@@ -220,8 +220,8 @@ void setMatrix(EigenMatrix& m, Eigen::MatrixXd const& tmp)
 void addToMatrix(EigenMatrix& m,
                  std::initializer_list<double> values)
 {
-    auto const rows = m.getNRows();
-    auto const cols = m.getNCols();
+    auto const rows = m.getNumberOfRows();
+    auto const cols = m.getNumberOfColumns();
 
     assert(values.size() == rows*cols);
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> tmp(rows, cols);

--- a/MathLib/Nonlinear/NewtonRaphson.h
+++ b/MathLib/Nonlinear/NewtonRaphson.h
@@ -75,7 +75,7 @@ public:
     bool solve(F_RESIDUAL &f_residual, F_DX &f_dx, const T_VALUE &x0, T_VALUE &x_new);
 
     /// return the number of iterations
-    std::size_t getNIterations() const {return _n_iterations; }
+    std::size_t getNumberOfIterations() const {return _n_iterations; }
 
     /// return absolute error in the last iteration
     double getAbsResidualError() const {return _r_abs_error; }

--- a/MathLib/Nonlinear/Picard.h
+++ b/MathLib/Nonlinear/Picard.h
@@ -66,7 +66,7 @@ public:
     bool solve(T_FUNCTOR &functor,  const T_VALUE &x0, T_VALUE &x_new);
 
     /// return the number of iterations
-    std::size_t getNIterations() const {return _n_iterations; }
+    std::size_t getNumberOfIterations() const {return _n_iterations; }
 
     /// return absolute error in the last iteration
     double getAbsError() const {return _abs_error; }

--- a/MathLib/ODE/CVodeSolver.cpp
+++ b/MathLib/ODE/CVodeSolver.cpp
@@ -134,7 +134,7 @@ CVodeSolverImpl::CVodeSolverImpl(const BaseLib::ConfigTree& config,
 {
     if (auto const param =
         //! \ogs_file_param{ode_solver__CVODE__linear_multistep_method}
-        config.getParameterOptional<std::string>("linear_multistep_method"))
+        config.getConfigParameterOptional<std::string>("linear_multistep_method"))
     {
         DBUG("setting linear multistep method (config: %s)", param->c_str());
 
@@ -155,7 +155,7 @@ CVodeSolverImpl::CVodeSolverImpl(const BaseLib::ConfigTree& config,
 
     if (auto const param =
         //! \ogs_file_param{ode_solver__CVODE__nonlinear_solver_iteration}
-        config.getParameterOptional<std::string>("nonlinear_solver_iteration"))
+        config.getConfigParameterOptional<std::string>("nonlinear_solver_iteration"))
     {
         DBUG("setting nonlinear solver iteration (config: %s)", param->c_str());
 

--- a/MathLib/ODE/CVodeSolver.cpp
+++ b/MathLib/ODE/CVodeSolver.cpp
@@ -134,7 +134,7 @@ CVodeSolverImpl::CVodeSolverImpl(const BaseLib::ConfigTree& config,
 {
     if (auto const param =
         //! \ogs_file_param{ode_solver__CVODE__linear_multistep_method}
-        config.getConfParamOptional<std::string>("linear_multistep_method"))
+        config.getParameterOptional<std::string>("linear_multistep_method"))
     {
         DBUG("setting linear multistep method (config: %s)", param->c_str());
 
@@ -155,7 +155,7 @@ CVodeSolverImpl::CVodeSolverImpl(const BaseLib::ConfigTree& config,
 
     if (auto const param =
         //! \ogs_file_param{ode_solver__CVODE__nonlinear_solver_iteration}
-        config.getConfParamOptional<std::string>("nonlinear_solver_iteration"))
+        config.getParameterOptional<std::string>("nonlinear_solver_iteration"))
     {
         DBUG("setting nonlinear solver iteration (config: %s)", param->c_str());
 

--- a/MathLib/ODE/FunctionHandles.h
+++ b/MathLib/ODE/FunctionHandles.h
@@ -48,7 +48,7 @@ public:
     virtual bool hasJacobian() const = 0;
 
     //! Returns the number of equations in the ODE system.
-    virtual unsigned getNumEquations() const = 0;
+    virtual unsigned getNumberOfEquations() const = 0;
 
     virtual ~FunctionHandles() = default;
 };
@@ -101,7 +101,7 @@ struct FunctionHandlesImpl final : public FunctionHandles
     }
 
     bool hasJacobian() const override { return df != nullptr; }
-    unsigned getNumEquations() const override { return N; }
+    unsigned getNumberOfEquations() const override { return N; }
     Function<N> f;
     JacobianFunction<N> df;
 };

--- a/MathLib/ODE/ODESolver.h
+++ b/MathLib/ODE/ODESolver.h
@@ -111,7 +111,7 @@ public:
     virtual bool solve(const double t) = 0;
 
     //! Returns the number of equations.
-    virtual unsigned getNumEquations() const { return NumEquations; }
+    virtual unsigned getNumberOfEquations() const { return NumEquations; }
     //! Returns the solution vector \c y
     virtual MappedConstVector<NumEquations> getSolution() const = 0;
 

--- a/MeshGeoToolsLib/BoundaryElementsAlongPolyline.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsAlongPolyline.cpp
@@ -39,7 +39,7 @@ BoundaryElementsAlongPolyline::BoundaryElementsAlongPolyline(MeshLib::Mesh const
         if (!e->isBoundaryElement())
             continue;
         // find edges on the polyline
-        for (unsigned i=0; i<e->getNEdges(); i++) {
+        for (unsigned i=0; i<e->getNumberOfEdges(); i++) {
             auto* edge = e->getEdge(i);
             // check if all edge nodes are along the polyline (if yes, store a distance)
             std::vector<std::size_t> edge_node_distances_along_ply;
@@ -75,14 +75,14 @@ BoundaryElementsAlongPolyline::~BoundaryElementsAlongPolyline()
 bool BoundaryElementsAlongPolyline::includesAllEdgeNodeIDs(const std::vector<std::size_t> &vec_node_ids, const MeshLib::Element &edge, std::vector<std::size_t> &edge_node_distances) const
 {
     unsigned j=0;
-    for (; j<edge.getNBaseNodes(); j++) {
+    for (; j<edge.getNumberOfBaseNodes(); j++) {
         auto itr = std::find(vec_node_ids.begin(), vec_node_ids.end(), edge.getNodeIndex(j));
         if (itr != vec_node_ids.end())
             edge_node_distances.push_back(std::distance(vec_node_ids.begin(), itr));
         else
             break;
     }
-    return (j==edge.getNBaseNodes());
+    return (j==edge.getNumberOfBaseNodes());
 }
 
 MeshLib::Element* BoundaryElementsAlongPolyline::modifyEdgeNodeOrdering(const MeshLib::Element &edge, const GeoLib::Polyline &ply, const std::vector<std::size_t> &edge_node_distances_along_ply, const std::vector<std::size_t> &node_ids_on_poly) const
@@ -92,8 +92,8 @@ MeshLib::Element* BoundaryElementsAlongPolyline::modifyEdgeNodeOrdering(const Me
     // Otherwise, create a new element with reversed local node index
     if (edge_node_distances_along_ply.front() > edge_node_distances_along_ply.back()
             || (ply.isClosed() && edge_node_distances_along_ply.back() == node_ids_on_poly.size()-1)) {
-        MeshLib::Node** new_nodes = new MeshLib::Node*[edge.getNBaseNodes()];
-        std::reverse_copy(edge.getNodes(), edge.getNodes()+edge.getNBaseNodes(), new_nodes);
+        MeshLib::Node** new_nodes = new MeshLib::Node*[edge.getNumberOfBaseNodes()];
+        std::reverse_copy(edge.getNodes(), edge.getNodes()+edge.getNumberOfBaseNodes(), new_nodes);
         new_edge = new MeshLib::Line(new_nodes);
     }
     return new_edge;

--- a/MeshGeoToolsLib/BoundaryElementsOnSurface.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsOnSurface.cpp
@@ -35,18 +35,18 @@ BoundaryElementsOnSurface::BoundaryElementsOnSurface(MeshLib::Mesh const& mesh, 
         if (!e->isBoundaryElement())
             continue;
         // find faces on surface
-        for (unsigned i=0; i<e->getNFaces(); i++) {
+        for (unsigned i=0; i<e->getNumberOfFaces(); i++) {
             auto* face = e->getFace(i);
             // check
             std::size_t cnt_match = 0;
-            for (std::size_t j=0; j<face->getNBaseNodes(); j++) {
+            for (std::size_t j=0; j<face->getNumberOfBaseNodes(); j++) {
                 if (std::find(node_ids_on_sfc.begin(), node_ids_on_sfc.end(), face->getNodeIndex(j)) != node_ids_on_sfc.end())
                     cnt_match++;
                 else
                     break;
             }
             // update the list
-            if (cnt_match==face->getNBaseNodes())
+            if (cnt_match==face->getNumberOfBaseNodes())
                 _boundary_elements.push_back(const_cast<MeshLib::Element*>(face));
             else
                 delete face;

--- a/MeshGeoToolsLib/GeoMapper.cpp
+++ b/MeshGeoToolsLib/GeoMapper.cpp
@@ -100,7 +100,7 @@ void GeoMapper::mapOnMesh(const MeshLib::Mesh* mesh)
     MathLib::Point3d origin(std::array<double,3>{{0,0,0}});
     MathLib::Vector3 normal(0,0,-1);
     std::vector<MeshLib::Node> flat_nodes;
-    flat_nodes.reserve(_surface_mesh->getNNodes());
+    flat_nodes.reserve(_surface_mesh->getNumberOfNodes());
     // copy nodes and project the copied nodes to the x-y-plane, i.e. set
     // z-coordinate to zero
     for (auto n_ptr : _surface_mesh->getNodes()) {
@@ -269,7 +269,7 @@ void GeoMapper::advancedMapOnMesh(
     // squared so it can be compared to the squared distances calculated later
     max_segment_length *= max_segment_length;
 
-    const unsigned nMeshNodes ( mesh->getNNodes() );
+    const unsigned nMeshNodes ( mesh->getNumberOfNodes() );
     // index of closest geo point for each mesh node in (x,y)-plane
     std::vector<int> closest_geo_point(nMeshNodes, -1);
     // distance between geo points and mesh nodes in (x,y)-plane
@@ -317,7 +317,7 @@ void GeoMapper::advancedMapOnMesh(
             const std::size_t nElems = elements.size();
             for (std::size_t e=0; e<nElems; ++e)
             {
-                const unsigned nEdges (elements[e]->getNEdges());
+                const unsigned nEdges (elements[e]->getNumberOfEdges());
                 unsigned intersection_count (0);
 
                 for (unsigned n=0; n<nEdges; ++n)

--- a/MeshGeoToolsLib/HeuristicSearchLength.cpp
+++ b/MeshGeoToolsLib/HeuristicSearchLength.cpp
@@ -31,7 +31,7 @@ HeuristicSearchLength::HeuristicSearchLength(MeshLib::Mesh const& mesh, LengthTy
     if (length_type==LengthType::Edge) {
         for (std::vector<MeshLib::Element*>::const_iterator it(elements.cbegin());
                 it != elements.cend(); ++it) {
-            std::size_t const n_edges((*it)->getNEdges());
+            std::size_t const n_edges((*it)->getNumberOfEdges());
             for (std::size_t k(0); k<n_edges; k++) {
                 auto edge = (*it)->getEdge(k);    // allocation inside getEdge().
                 double const len = edge->getContent();
@@ -48,7 +48,7 @@ HeuristicSearchLength::HeuristicSearchLength(MeshLib::Mesh const& mesh, LengthTy
             sum += std::sqrt(min);
             sum_of_sqr += min;
         }
-        n_sampling = _mesh.getNElements();
+        n_sampling = _mesh.getNumberOfElements();
     }
 
     const double mean (sum/n_sampling);

--- a/MeshGeoToolsLib/MeshNodesAlongPolyline.cpp
+++ b/MeshGeoToolsLib/MeshNodesAlongPolyline.cpp
@@ -30,7 +30,7 @@ MeshNodesAlongPolyline::MeshNodesAlongPolyline(
     _mesh(mesh), _ply(ply)
 {
     assert(epsilon_radius > 0);
-    const std::size_t n_nodes (search_all_nodes ? _mesh.getNNodes() : _mesh.getNBaseNodes());
+    const std::size_t n_nodes (search_all_nodes ? _mesh.getNumberOfNodes() : _mesh.getNumberOfBaseNodes());
     auto &mesh_nodes = _mesh.getNodes();
     // loop over all nodes
     for (std::size_t i = 0; i < n_nodes; i++) {

--- a/MeshGeoToolsLib/MeshNodesAlongSurface.cpp
+++ b/MeshGeoToolsLib/MeshNodesAlongSurface.cpp
@@ -30,7 +30,7 @@ MeshNodesAlongSurface::MeshNodesAlongSurface(
     _mesh(mesh), _sfc(sfc)
 {
     auto& mesh_nodes = _mesh.getNodes();
-    const std::size_t n_nodes (search_all_nodes ? _mesh.getNNodes() : _mesh.getNBaseNodes());
+    const std::size_t n_nodes (search_all_nodes ? _mesh.getNumberOfNodes() : _mesh.getNumberOfBaseNodes());
     // loop over all nodes
     for (std::size_t i = 0; i < n_nodes; i++) {
         auto* node = mesh_nodes[i];

--- a/MeshLib/CoordinateSystem.cpp
+++ b/MeshLib/CoordinateSystem.cpp
@@ -16,7 +16,7 @@ namespace MeshLib
 
 CoordinateSystem::CoordinateSystem(const Element &ele)
 {
-    GeoLib::AABB const aabb(ele.getNodes(), ele.getNodes() + ele.getNNodes());
+    GeoLib::AABB const aabb(ele.getNodes(), ele.getNodes() + ele.getNumberOfNodes());
     CoordinateSystem const bboxCoordSys(getCoordinateSystem(aabb));
     if (bboxCoordSys.getDimension() >= ele.getDimension()) {
         _type = bboxCoordSys.getType();

--- a/MeshLib/ElementCoordinatesMappingLocal.cpp
+++ b/MeshLib/ElementCoordinatesMappingLocal.cpp
@@ -72,8 +72,8 @@ ElementCoordinatesMappingLocal::ElementCoordinatesMappingLocal(
 : _coords(global_coords), _matR2global(3,3)
 {
     assert(e.getDimension() <= global_coords.getDimension());
-    _points.reserve(e.getNNodes());
-    for(unsigned i = 0; i < e.getNNodes(); i++)
+    _points.reserve(e.getNumberOfNodes());
+    for(unsigned i = 0; i < e.getNumberOfNodes(); i++)
         _points.emplace_back(*(e.getNode(i)));
 
     auto const element_dimension = e.getDimension();

--- a/MeshLib/ElementStatus.cpp
+++ b/MeshLib/ElementStatus.cpp
@@ -22,12 +22,12 @@ namespace MeshLib {
 
 ElementStatus::ElementStatus(Mesh const* const mesh, bool hasAnyInactive)
     : _mesh(mesh),
-      _element_status(mesh->getNElements(), true),
+      _element_status(mesh->getNumberOfElements(), true),
       _hasAnyInactive(hasAnyInactive)
 {
     const std::vector<MeshLib::Node*>& nodes(_mesh->getNodes());
     for (auto node : nodes)
-        _active_nodes.push_back(node->getNElements());
+        _active_nodes.push_back(node->getNumberOfElements());
 }
 
 ElementStatus::ElementStatus(Mesh const* const mesh,
@@ -45,14 +45,14 @@ ElementStatus::ElementStatus(Mesh const* const mesh,
         }
     }
 
-    _vec_active_eles.reserve(getNActiveElements());
-    const std::size_t nElems (_mesh->getNElements());
+    _vec_active_eles.reserve(getNumberOfActiveElements());
+    const std::size_t nElems (_mesh->getNumberOfElements());
     for (std::size_t i=0; i<nElems; ++i)
         if (_element_status[i])
             _vec_active_eles.push_back(const_cast<MeshLib::Element*>(_mesh->getElement(i)));
 
-    _vec_active_nodes.reserve(this->getNActiveNodes());
-    const std::size_t nNodes (_mesh->getNNodes());
+    _vec_active_nodes.reserve(this->getNumberOfActiveNodes());
+    const std::size_t nNodes (_mesh->getNumberOfNodes());
     for (std::size_t i=0; i<nNodes; ++i)
         if (_active_nodes[i]>0)
             _vec_active_nodes.push_back(const_cast<MeshLib::Node*>(_mesh->getNode(i)));
@@ -96,12 +96,12 @@ std::vector<MeshLib::Element*> ElementStatus::getActiveElementsAtNode(std::size_
     return active_elements;
 }
 
-std::size_t ElementStatus::getNActiveNodes() const
+std::size_t ElementStatus::getNumberOfActiveNodes() const
 {
     return _active_nodes.size() - std::count(_active_nodes.cbegin(), _active_nodes.cend(), 0);
 }
 
-std::size_t ElementStatus::getNActiveElements() const
+std::size_t ElementStatus::getNumberOfActiveElements() const
 {
     return static_cast<std::size_t>(
         std::count(_element_status.cbegin(), _element_status.cend(), true));
@@ -113,7 +113,7 @@ void ElementStatus::setElementStatus(std::size_t i, bool status)
     {
         const int change = (status) ? 1 : -1;
         _element_status[i] = status;
-        const unsigned nElemNodes (_mesh->getElement(i)->getNBaseNodes());
+        const unsigned nElemNodes (_mesh->getElement(i)->getNumberOfBaseNodes());
         MeshLib::Node const*const*const nodes = _mesh->getElement(i)->getNodes();
         for (unsigned j=0; j<nElemNodes; ++j)
         {

--- a/MeshLib/ElementStatus.h
+++ b/MeshLib/ElementStatus.h
@@ -47,10 +47,10 @@ public:
     std::vector<MeshLib::Element*> getActiveElementsAtNode(std::size_t node_id) const;
 
     /// Returns the total number of active nodes
-    std::size_t getNActiveNodes() const;
+    std::size_t getNumberOfActiveNodes() const;
 
     /// Returns the total number of active elements
-    std::size_t getNActiveElements() const;
+    std::size_t getNumberOfActiveElements() const;
 
 protected:
     /// Sets the status of element i

--- a/MeshLib/Elements/CellRule.cpp
+++ b/MeshLib/Elements/CellRule.cpp
@@ -19,7 +19,7 @@ namespace MeshLib {
 bool CellRule::testElementNodeOrder(const Element* e)
 {
     const MathLib::Vector3 c (e->getCenterOfGravity());
-    const unsigned nFaces (e->getNFaces());
+    const unsigned nFaces (e->getNumberOfFaces());
     for (unsigned j=0; j<nFaces; ++j)
     {
         MeshLib::Element const*const face (e->getFace(j));

--- a/MeshLib/Elements/EdgeReturn.cpp
+++ b/MeshLib/Elements/EdgeReturn.cpp
@@ -20,7 +20,7 @@ namespace MeshLib
 
 const Element* LinearEdgeReturn::getEdge(const Element* e, unsigned i)
 {
-    if (i < e->getNEdges())
+    if (i < e->getNumberOfEdges())
     {
         Node** nodes = new Node*[2];
         nodes[0] = const_cast<Node*>(e->getEdgeNode(i,0));
@@ -33,7 +33,7 @@ const Element* LinearEdgeReturn::getEdge(const Element* e, unsigned i)
 
 const Element* QuadraticEdgeReturn::getEdge(const Element* e, unsigned i)
 {
-    if (i < e->getNEdges())
+    if (i < e->getNumberOfEdges())
     {
         Node** nodes = new Node*[3];
         nodes[0] = const_cast<Node*>(e->getEdgeNode(i,0));

--- a/MeshLib/Elements/EdgeRule.h
+++ b/MeshLib/Elements/EdgeRule.h
@@ -28,7 +28,7 @@ public:
     static const unsigned n_edges = 0;
 
     /// Get the number of nodes for face i.
-    static unsigned getNFaceNodes(unsigned /*i*/) { return 0; }
+    static unsigned getNumberOfFaceNodes(unsigned /*i*/) { return 0; }
 
     /// Returns the i-th face of the element.
     static const Element* getFace(const Element* /*e*/, unsigned /*i*/) { return nullptr; }

--- a/MeshLib/Elements/Element.cpp
+++ b/MeshLib/Elements/Element.cpp
@@ -53,8 +53,8 @@ boost::optional<unsigned> Element::addNeighbor(Element* e)
         return boost::optional<unsigned>();
 
     Node* face_nodes[3];
-    const unsigned nNodes (this->getNBaseNodes());
-    const unsigned eNodes (e->getNBaseNodes());
+    const unsigned nNodes (this->getNumberOfBaseNodes());
+    const unsigned eNodes (e->getNumberOfBaseNodes());
     const Node* const* e_nodes = e->getNodes();
     unsigned count(0);
     const unsigned dim (this->getDimension());
@@ -76,7 +76,7 @@ boost::optional<unsigned> Element::addNeighbor(Element* e)
 
 MeshLib::Node Element::getCenterOfGravity() const
 {
-    const unsigned nNodes (this->getNBaseNodes());
+    const unsigned nNodes (this->getNumberOfBaseNodes());
     MeshLib::Node center(0,0,0);
     for (unsigned i=0; i<nNodes; ++i)
     {
@@ -94,7 +94,7 @@ void Element::computeSqrEdgeLengthRange(double &min, double &max) const
 {
     min = std::numeric_limits<double>::max();
     max = 0;
-    const unsigned nEdges (this->getNEdges());
+    const unsigned nEdges (this->getNumberOfEdges());
     for (unsigned i=0; i<nEdges; i++)
     {
         const double dist (MathLib::sqrDist(*getEdgeNode(i,0), *getEdgeNode(i,1)));
@@ -107,7 +107,7 @@ void Element::computeSqrNodeDistanceRange(double &min, double &max, bool check_a
 {
     min = std::numeric_limits<double>::max();
     max = 0;
-    const unsigned nnodes = check_allnodes ? getNNodes() : getNBaseNodes();
+    const unsigned nnodes = check_allnodes ? getNumberOfNodes() : getNumberOfBaseNodes();
     for (unsigned i=0; i<nnodes; i++)
     {
         for (unsigned j=i+1; j<nnodes; j++)
@@ -122,7 +122,7 @@ void Element::computeSqrNodeDistanceRange(double &min, double &max, bool check_a
 const Element* Element::getNeighbor(unsigned i) const
 {
 #ifndef NDEBUG
-    if (i < getNNeighbors())
+    if (i < getNumberOfNeighbors())
 #endif
         return _neighbors[i];
 #ifndef NDEBUG
@@ -133,7 +133,7 @@ const Element* Element::getNeighbor(unsigned i) const
 
 unsigned Element::getNodeIDinElement(const MeshLib::Node* node) const
 {
-    const unsigned nNodes (this->getNBaseNodes());
+    const unsigned nNodes (this->getNumberOfBaseNodes());
     for (unsigned i(0); i<nNodes; i++)
         if (node == _nodes[i])
             return i;
@@ -143,7 +143,7 @@ unsigned Element::getNodeIDinElement(const MeshLib::Node* node) const
 const Node* Element::getNode(unsigned i) const
 {
 #ifndef NDEBUG
-    if (i < getNNodes())
+    if (i < getNumberOfNodes())
 #endif
         return _nodes[i];
 #ifndef NDEBUG
@@ -155,7 +155,7 @@ const Node* Element::getNode(unsigned i) const
 void Element::setNode(unsigned idx, Node* node)
 {
 #ifndef NDEBUG
-    if (idx < getNNodes())
+    if (idx < getNumberOfNodes())
 #endif
         _nodes[idx] = node;
 }
@@ -163,7 +163,7 @@ void Element::setNode(unsigned idx, Node* node)
 unsigned Element::getNodeIndex(unsigned i) const
 {
 #ifndef NDEBUG
-    if (i<getNNodes())
+    if (i<getNumberOfNodes())
 #endif
         return _nodes[i]->getID();
 #ifndef NDEBUG
@@ -174,7 +174,7 @@ unsigned Element::getNodeIndex(unsigned i) const
 
 bool Element::hasNeighbor(Element* elem) const
 {
-    unsigned nNeighbors (this->getNNeighbors());
+    unsigned nNeighbors (this->getNumberOfNeighbors());
     for (unsigned i=0; i<nNeighbors; i++)
         if (this->_neighbors[i]==elem)
             return true;
@@ -183,17 +183,17 @@ bool Element::hasNeighbor(Element* elem) const
 
 bool Element::isBoundaryElement() const
 {
-    return std::any_of(_neighbors, _neighbors + this->getNNeighbors(),
+    return std::any_of(_neighbors, _neighbors + this->getNumberOfNeighbors(),
         [](MeshLib::Element const*const e){ return e == nullptr; });
 }
 
 #ifndef NDEBUG
 std::ostream& operator<<(std::ostream& os, Element const& e)
 {
-    os << "Element #" << e._id << " @ " << &e << " with " << e.getNNeighbors()
+    os << "Element #" << e._id << " @ " << &e << " with " << e.getNumberOfNeighbors()
        << " neighbours\n";
 
-    unsigned const nnodes = e.getNNodes();
+    unsigned const nnodes = e.getNumberOfNodes();
     MeshLib::Node* const* const nodes = e.getNodes();
     os << "MeshElemType: "
         << static_cast<std::underlying_type<MeshElemType>::type>(e.getGeomType())

--- a/MeshLib/Elements/Element.h
+++ b/MeshLib/Elements/Element.h
@@ -62,7 +62,7 @@ public:
      * Get node with local index i where i should be at most the number
      * of nodes of the element
      * @param i local index of node, at most the number of nodes of the
-     * element that you can obtain with Element::getNBaseNodes()
+     * element that you can obtain with Element::getNumberOfBaseNodes()
      * @return a pointer to the appropriate (and constant, i.e. not
      * modifiable by the user) instance of class Node or a NULL pointer
      * @sa Element::getNodeIndex()
@@ -92,27 +92,27 @@ public:
     virtual std::size_t getID() const final { return _id; }
 
     /// Get the number of edges for this element.
-    virtual unsigned getNEdges() const = 0;
+    virtual unsigned getNumberOfEdges() const = 0;
 
     /// Get the number of nodes for face i.
-    virtual unsigned getNFaceNodes(unsigned i) const = 0;
+    virtual unsigned getNumberOfFaceNodes(unsigned i) const = 0;
 
     /// Get the number of faces for this element.
-    virtual unsigned getNFaces() const = 0;
+    virtual unsigned getNumberOfFaces() const = 0;
 
     /// Get the specified neighbor.
     const Element* getNeighbor(unsigned i) const;
 
     /// Get the number of neighbors for this element.
-    virtual unsigned getNNeighbors() const = 0;
+    virtual unsigned getNumberOfNeighbors() const = 0;
 
     /**
      * Returns the number of linear nodes.
      */
-    virtual unsigned getNBaseNodes() const = 0;
+    virtual unsigned getNumberOfBaseNodes() const = 0;
 
     /// Returns the number of all nodes including both linear and nonlinear nodes
-    virtual unsigned getNNodes() const = 0;
+    virtual unsigned getNumberOfNodes() const = 0;
 
     /// Returns the position of the given node in the node array of this element.
     virtual unsigned getNodeIDinElement(const MeshLib::Node* node) const;
@@ -121,7 +121,7 @@ public:
      * Get the global index for the Node with local index i.
      * The index i should be at most the number of nodes of the element.
      * @param i local index of Node, at most the number of nodes of the
-     * element that you can obtain with Element::getNBaseNodes()
+     * element that you can obtain with Element::getNumberOfBaseNodes()
      * @return the global index or std::numeric_limits<unsigned>::max()
      * @sa Element::getNode()
      */

--- a/MeshLib/Elements/FaceRule.h
+++ b/MeshLib/Elements/FaceRule.h
@@ -26,7 +26,7 @@ public:
     static const Element* getFace(const Element* e, unsigned i) { return e->getEdge(i); }
 
     /// Get the number of nodes for face i.
-    static unsigned getNFaceNodes(unsigned /*i*/) { return 2; }
+    static unsigned getNumberOfFaceNodes(unsigned /*i*/) { return 2; }
 
     /// Constant: The number of faces
     static const unsigned n_faces = 0;

--- a/MeshLib/Elements/HexRule20.h
+++ b/MeshLib/Elements/HexRule20.h
@@ -62,7 +62,7 @@ public:
     typedef QuadraticEdgeReturn EdgeReturn;
 
     /// Get the number of nodes for face i.
-    static unsigned getNFaceNodes(unsigned /*i*/) { return 8; }
+    static unsigned getNumberOfFaceNodes(unsigned /*i*/) { return 8; }
 
     /// Returns the i-th face of the element.
     static const Element* getFace(const Element* e, unsigned i);

--- a/MeshLib/Elements/HexRule8.h
+++ b/MeshLib/Elements/HexRule8.h
@@ -77,7 +77,7 @@ public:
     typedef LinearEdgeReturn EdgeReturn;
 
     /// Get the number of nodes for face i.
-    static unsigned getNFaceNodes(unsigned /*i*/) { return 4; }
+    static unsigned getNumberOfFaceNodes(unsigned /*i*/) { return 4; }
 
     /// Returns the i-th face of the element.
     static const Element* getFace(const Element* e, unsigned i);

--- a/MeshLib/Elements/PrismRule15.cpp
+++ b/MeshLib/Elements/PrismRule15.cpp
@@ -43,11 +43,11 @@ const unsigned PrismRule15::edge_nodes[9][3] =
 
 const unsigned PrismRule15::n_face_nodes[5] = { 6, 8, 8, 8, 6 };
 
-unsigned PrismRule15::getNFaceNodes(unsigned i)
+unsigned PrismRule15::getNumberOfFaceNodes(unsigned i)
 {
     if (i<5)
         return n_face_nodes[i];
-    ERR("Error in MeshLib::Element::getNFaceNodes() - Index %d does not exist.", i);
+    ERR("Error in MeshLib::Element::getNumberOfFaceNodes() - Index %d does not exist.", i);
     return 0;
 }
 
@@ -55,7 +55,7 @@ const Element* PrismRule15::getFace(const Element* e, unsigned i)
 {
     if (i < n_faces)
     {
-        unsigned nFaceNodes (e->getNFaceNodes(i));
+        unsigned nFaceNodes (e->getNumberOfFaceNodes(i));
         Node** nodes = new Node*[nFaceNodes];
         for (unsigned j=0; j<nFaceNodes; j++)
             nodes[j] = const_cast<Node*>(e->getNode(face_nodes[i][j]));

--- a/MeshLib/Elements/PrismRule15.h
+++ b/MeshLib/Elements/PrismRule15.h
@@ -63,7 +63,7 @@ public:
     typedef QuadraticEdgeReturn EdgeReturn;
 
     /// Get the number of nodes for face i.
-    static unsigned getNFaceNodes(unsigned i);
+    static unsigned getNumberOfFaceNodes(unsigned i);
 
     /// Returns the i-th face of the element.
     static const Element* getFace(const Element* e, unsigned i);

--- a/MeshLib/Elements/PrismRule6.cpp
+++ b/MeshLib/Elements/PrismRule6.cpp
@@ -43,11 +43,11 @@ const unsigned PrismRule6::edge_nodes[9][2] =
 
 const unsigned PrismRule6::n_face_nodes[5] = { 3, 4, 4, 4, 3 };
 
-unsigned PrismRule6::getNFaceNodes(unsigned i)
+unsigned PrismRule6::getNumberOfFaceNodes(unsigned i)
 {
     if (i<5)
         return n_face_nodes[i];
-    ERR("Error in MeshLib::Element::getNFaceNodes() - Index %d does not exist.", i);
+    ERR("Error in MeshLib::Element::getNumberOfFaceNodes() - Index %d does not exist.", i);
     return 0;
 }
 
@@ -55,7 +55,7 @@ const Element* PrismRule6::getFace(const Element* e, unsigned i)
 {
     if (i < n_faces)
     {
-        unsigned nFaceNodes (e->getNFaceNodes(i));
+        unsigned nFaceNodes (e->getNumberOfFaceNodes(i));
         Node** nodes = new Node*[nFaceNodes];
         for (unsigned j=0; j<nFaceNodes; j++)
             nodes[j] = const_cast<Node*>(e->getNode(face_nodes[i][j]));

--- a/MeshLib/Elements/PrismRule6.h
+++ b/MeshLib/Elements/PrismRule6.h
@@ -78,7 +78,7 @@ public:
     typedef LinearEdgeReturn EdgeReturn;
 
     /// Get the number of nodes for face i.
-    static unsigned getNFaceNodes(unsigned i);
+    static unsigned getNumberOfFaceNodes(unsigned i);
 
     /// Returns the i-th face of the element.
     static const Element* getFace(const Element* e, unsigned i);

--- a/MeshLib/Elements/PyramidRule13.cpp
+++ b/MeshLib/Elements/PyramidRule13.cpp
@@ -42,19 +42,19 @@ const unsigned PyramidRule13::edge_nodes[8][3] =
 
 const unsigned PyramidRule13::n_face_nodes[5] = { 6, 6, 6, 6, 8 };
 
-unsigned PyramidRule13::getNFaceNodes(unsigned i)
+unsigned PyramidRule13::getNumberOfFaceNodes(unsigned i)
 {
     if (i<5)
         return n_face_nodes[i];
-    ERR("Error in MeshLib::Element::getNFaceNodes() - Index %d does not exist.", i);
+    ERR("Error in MeshLib::Element::getNumberOfFaceNodes() - Index %d does not exist.", i);
     return 0;
 }
 
 const Element* PyramidRule13::getFace(const Element* e, unsigned i)
 {
-    if (i<e->getNFaces())
+    if (i<e->getNumberOfFaces())
     {
-        unsigned nFaceNodes (e->getNFaceNodes(i));
+        unsigned nFaceNodes (e->getNumberOfFaceNodes(i));
         Node** nodes = new Node*[nFaceNodes];
         for (unsigned j=0; j<nFaceNodes; j++)
             nodes[j] = const_cast<Node*>(e->getNode(face_nodes[i][j]));

--- a/MeshLib/Elements/PyramidRule13.h
+++ b/MeshLib/Elements/PyramidRule13.h
@@ -62,7 +62,7 @@ public:
     typedef QuadraticEdgeReturn EdgeReturn;
 
     /// Get the number of nodes for face i.
-    static unsigned getNFaceNodes(unsigned i);
+    static unsigned getNumberOfFaceNodes(unsigned i);
 
     /// Returns the i-th face of the element.
     static const Element* getFace(const Element* e, unsigned i);

--- a/MeshLib/Elements/PyramidRule5.cpp
+++ b/MeshLib/Elements/PyramidRule5.cpp
@@ -42,19 +42,19 @@ const unsigned PyramidRule5::edge_nodes[8][2] =
 
 const unsigned PyramidRule5::n_face_nodes[5] = { 3, 3, 3, 3, 4 };
 
-unsigned PyramidRule5::getNFaceNodes(unsigned i)
+unsigned PyramidRule5::getNumberOfFaceNodes(unsigned i)
 {
     if (i<5)
         return n_face_nodes[i];
-    ERR("Error in MeshLib::Element::getNFaceNodes() - Index %d does not exist.", i);
+    ERR("Error in MeshLib::Element::getNumberOfFaceNodes() - Index %d does not exist.", i);
     return 0;
 }
 
 const Element* PyramidRule5::getFace(const Element* e, unsigned i)
 {
-    if (i<e->getNFaces())
+    if (i<e->getNumberOfFaces())
     {
-        unsigned nFaceNodes (e->getNFaceNodes(i));
+        unsigned nFaceNodes (e->getNumberOfFaceNodes(i));
         Node** nodes = new Node*[nFaceNodes];
         for (unsigned j=0; j<nFaceNodes; j++)
             nodes[j] = const_cast<Node*>(e->getNode(face_nodes[i][j]));

--- a/MeshLib/Elements/PyramidRule5.h
+++ b/MeshLib/Elements/PyramidRule5.h
@@ -77,7 +77,7 @@ public:
     typedef LinearEdgeReturn EdgeReturn;
 
     /// Get the number of nodes for face i.
-    static unsigned getNFaceNodes(unsigned i);
+    static unsigned getNumberOfFaceNodes(unsigned i);
 
     /// Returns the i-th face of the element.
     static const Element* getFace(const Element* e, unsigned i);

--- a/MeshLib/Elements/TemplateElement-impl.h
+++ b/MeshLib/Elements/TemplateElement-impl.h
@@ -17,8 +17,8 @@ TemplateElement<ELEMENT_RULE>::TemplateElement(Node* nodes[n_all_nodes], std::si
 : Element(id)
 {
     this->_nodes = nodes;
-    this->_neighbors = new Element*[getNNeighbors()];
-    std::fill(this->_neighbors, this->_neighbors + getNNeighbors(), nullptr);
+    this->_neighbors = new Element*[getNumberOfNeighbors()];
+    std::fill(this->_neighbors, this->_neighbors + getNumberOfNeighbors(), nullptr);
     this->_content = ELEMENT_RULE::computeVolume(this->_nodes);
 }
 
@@ -28,8 +28,8 @@ TemplateElement<ELEMENT_RULE>::TemplateElement(std::array<Node*, n_all_nodes> co
 {
     this->_nodes = new Node*[n_all_nodes];
     std::copy(nodes.begin(), nodes.end(), this->_nodes);
-    this->_neighbors = new Element*[getNNeighbors()];
-    std::fill(this->_neighbors, this->_neighbors + getNNeighbors(), nullptr);
+    this->_neighbors = new Element*[getNumberOfNeighbors()];
+    std::fill(this->_neighbors, this->_neighbors + getNumberOfNeighbors(), nullptr);
     this->_content = ELEMENT_RULE::computeVolume(this->_nodes);
 }
 
@@ -40,8 +40,8 @@ TemplateElement<ELEMENT_RULE>::TemplateElement(const TemplateElement &e)
     this->_nodes = new Node*[n_all_nodes];
     for (unsigned i=0; i<n_all_nodes; i++)
         this->_nodes[i] = e._nodes[i];
-    this->_neighbors = new Element*[getNNeighbors()];
-    for (unsigned i=0; i<getNNeighbors(); i++)
+    this->_neighbors = new Element*[getNumberOfNeighbors()];
+    for (unsigned i=0; i<getNumberOfNeighbors(); i++)
         this->_neighbors[i] = e._neighbors[i];
     this->_content = e.getContent();
 }
@@ -72,7 +72,7 @@ isEdge(unsigned const (&/*edge_nodes*/)[1], unsigned /*idx1*/, unsigned /*idx2*/
 template <class ELEMENT_RULE>
 bool TemplateElement<ELEMENT_RULE>::isEdge(unsigned idx1, unsigned idx2) const
 {
-    for (unsigned i(0); i<getNEdges(); i++)
+    for (unsigned i(0); i<getNumberOfEdges(); i++)
     {
         if (detail::isEdge(ELEMENT_RULE::edge_nodes[i], idx1, idx2)) return true;
     }

--- a/MeshLib/Elements/TemplateElement.h
+++ b/MeshLib/Elements/TemplateElement.h
@@ -79,22 +79,22 @@ public:
     const Element* getFace(unsigned i) const { return ELEMENT_RULE::getFace(this, i); }
 
     /// Get the number of edges for this element.
-    unsigned getNEdges() const { return ELEMENT_RULE::n_edges; }
+    unsigned getNumberOfEdges() const { return ELEMENT_RULE::n_edges; }
 
     /// Get the number of nodes for face i.
-    unsigned getNFaceNodes(unsigned i) const { return ELEMENT_RULE::getNFaceNodes(i); }
+    unsigned getNumberOfFaceNodes(unsigned i) const { return ELEMENT_RULE::getNumberOfFaceNodes(i); }
 
     /// Get the number of faces for this element.
-    unsigned getNFaces() const { return ELEMENT_RULE::n_faces; }
+    unsigned getNumberOfFaces() const { return ELEMENT_RULE::n_faces; }
 
     /// Get the number of neighbors for this element.
-    unsigned getNNeighbors() const { return ELEMENT_RULE::n_neighbors; }
+    unsigned getNumberOfNeighbors() const { return ELEMENT_RULE::n_neighbors; }
 
     /// Get the number of linear nodes for this element.
-    virtual unsigned getNBaseNodes() const { return n_base_nodes; }
+    virtual unsigned getNumberOfBaseNodes() const { return n_base_nodes; }
 
     /// Get the number of all nodes for this element.
-    virtual unsigned getNNodes() const { return n_all_nodes; }
+    virtual unsigned getNumberOfNodes() const { return n_all_nodes; }
 
     /// Get the type of this element.
     virtual MeshElemType getGeomType() const { return ELEMENT_RULE::mesh_elem_type; }
@@ -136,7 +136,7 @@ public:
     /// Return a specific edge node.
     virtual inline Node* getEdgeNode(unsigned edge_id, unsigned node_id) const
     {
-        if (getNEdges()>0)
+        if (getNumberOfEdges()>0)
             return const_cast<Node*>(this->_nodes[ELEMENT_RULE::edge_nodes[edge_id][node_id]]);
         else
             return nullptr;

--- a/MeshLib/Elements/TetRule10.h
+++ b/MeshLib/Elements/TetRule10.h
@@ -57,7 +57,7 @@ public:
     typedef QuadraticEdgeReturn EdgeReturn;
 
     /// Get the number of nodes for face i.
-    static unsigned getNFaceNodes(unsigned /*i*/) { return 6; }
+    static unsigned getNumberOfFaceNodes(unsigned /*i*/) { return 6; }
 
     /// Returns the i-th face of the element.
     static const Element* getFace(const Element* e, unsigned i);

--- a/MeshLib/Elements/TetRule4.h
+++ b/MeshLib/Elements/TetRule4.h
@@ -72,7 +72,7 @@ public:
     typedef LinearEdgeReturn EdgeReturn;
 
     /// Get the number of nodes for face i.
-    static unsigned getNFaceNodes(unsigned /*i*/) { return 3; }
+    static unsigned getNumberOfFaceNodes(unsigned /*i*/) { return 3; }
 
     /// Returns the i-th face of the element.
     static const Element* getFace(const Element* e, unsigned i);

--- a/MeshLib/Elements/VertexRule.h
+++ b/MeshLib/Elements/VertexRule.h
@@ -28,7 +28,7 @@ public:
     static const unsigned n_edges = 0;
 
     /// Get the number of nodes for face i.
-    static unsigned getNFaceNodes(unsigned /*i*/)
+    static unsigned getNumberOfFaceNodes(unsigned /*i*/)
     {
         return 0;
     }

--- a/MeshLib/IO/FEFLOW/FEFLOWMeshInterface.cpp
+++ b/MeshLib/IO/FEFLOW/FEFLOWMeshInterface.cpp
@@ -558,7 +558,7 @@ void FEFLOWMeshInterface::setMaterialIDs(
         {
             MeshLib::Element* e = vec_elements[i];
             unsigned e_min_nodeID = std::numeric_limits<unsigned>::max();
-            for (std::size_t j = 0; j < e->getNBaseNodes(); j++)
+            for (std::size_t j = 0; j < e->getNumberOfBaseNodes(); j++)
                 e_min_nodeID = std::min(e_min_nodeID, e->getNodeIndex(j));
             std::size_t layer_id = e_min_nodeID / no_nodes_per_layer;
             material_ids[i] = layer_id;

--- a/MeshLib/IO/Legacy/MeshIO.cpp
+++ b/MeshLib/IO/Legacy/MeshIO.cpp
@@ -271,7 +271,7 @@ bool MeshIO::write()
         << "  NO_PCS\n"
         << "$NODES\n"
         << "  ";
-    const std::size_t n_nodes(_mesh->getNNodes());
+    const std::size_t n_nodes(_mesh->getNumberOfNodes());
     _out << n_nodes << "\n";
     for (std::size_t i(0); i < n_nodes; ++i) {
         _out << i << " " << *(_mesh->getNode(i)) << "\n";
@@ -308,7 +308,7 @@ void MeshIO::writeElements(std::vector<MeshLib::Element*> const& ele_vec,
         else
             out << (*material_ids)[i] << " ";
         out << this->ElemType2StringOutput(ele_vec[i]->getGeomType()) << " ";
-        unsigned nElemNodes (ele_vec[i]->getNBaseNodes());
+        unsigned nElemNodes (ele_vec[i]->getNumberOfBaseNodes());
         for(std::size_t j = 0; j < nElemNodes; ++j)
             out << ele_vec[i]->getNode(j)->getID() << " ";
         out << "\n";

--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -56,8 +56,8 @@ Mesh::Mesh(const Mesh &mesh)
     : _id(_counter_value-1), _mesh_dimension(mesh.getDimension()),
       _edge_length(mesh._edge_length.first, mesh._edge_length.second),
       _node_distance(mesh._node_distance.first, mesh._node_distance.second),
-      _name(mesh.getName()), _nodes(mesh.getNNodes()), _elements(mesh.getNElements()),
-      _n_base_nodes(mesh.getNBaseNodes()),
+      _name(mesh.getName()), _nodes(mesh.getNumberOfNodes()), _elements(mesh.getNumberOfElements()),
+      _n_base_nodes(mesh.getNumberOfBaseNodes()),
       _properties(mesh._properties)
 {
     const std::vector<Node*> nodes (mesh.getNodes());
@@ -69,7 +69,7 @@ Mesh::Mesh(const Mesh &mesh)
     const std::size_t nElements (elements.size());
     for (unsigned i=0; i<nElements; ++i)
     {
-        const std::size_t nElemNodes = elements[i]->getNBaseNodes();
+        const std::size_t nElemNodes = elements[i]->getNumberOfBaseNodes();
         _elements[i] = elements[i]->clone();
         for (unsigned j=0; j<nElemNodes; ++j)
             _elements[i]->_nodes[j] = _nodes[elements[i]->getNode(j)->getID()];
@@ -103,7 +103,7 @@ void Mesh::addElement(Element* elem)
     _elements.push_back(elem);
 
     // add element information to nodes
-    unsigned nNodes (elem->getNBaseNodes());
+    unsigned nNodes (elem->getNumberOfBaseNodes());
     for (unsigned i=0; i<nNodes; ++i)
         elem->_nodes[i]->addElement(elem);
 }
@@ -134,7 +134,7 @@ void Mesh::setElementsConnectedToNodes()
 {
     for (auto e = _elements.begin(); e != _elements.end(); ++e)
     {
-        const unsigned nNodes ((*e)->getNBaseNodes());
+        const unsigned nNodes ((*e)->getNumberOfBaseNodes());
         for (unsigned j=0; j<nNodes; ++j)
             (*e)->_nodes[j]->addElement(*e);
     }
@@ -154,7 +154,7 @@ void Mesh::calcEdgeLengthRange()
     this->_edge_length.second = 0;
     double min_length(0);
     double max_length(0);
-    const std::size_t nElems (this->getNElements());
+    const std::size_t nElems (this->getNumberOfElements());
     for (std::size_t i=0; i<nElems; ++i)
     {
         _elements[i]->computeSqrEdgeLengthRange(min_length, max_length);
@@ -171,7 +171,7 @@ void Mesh::calcNodeDistanceRange()
     this->_node_distance.second = 0;
     double min_length(0);
     double max_length(0);
-    const std::size_t nElems (this->getNElements());
+    const std::size_t nElems (this->getNumberOfElements());
     for (std::size_t i=0; i<nElems; ++i)
     {
         _elements[i]->computeSqrNodeDistanceRange(min_length, max_length);
@@ -190,7 +190,7 @@ void Mesh::setElementNeighbors()
         // create vector with all elements connected to current element (includes lots of doubles!)
         Element *const element = *it;
 
-        const std::size_t nNodes (element->getNBaseNodes());
+        const std::size_t nNodes (element->getNumberOfBaseNodes());
         for (unsigned n(0); n<nNodes; ++n)
         {
             std::vector<Element*> const& conn_elems ((element->getNode(n)->getElements()));
@@ -223,7 +223,7 @@ void Mesh::setNodesConnectedByEdges()
         for (unsigned j=0; j<nConnElems; ++j)
         {
             const unsigned idx (conn_elems[j]->getNodeIDinElement(node));
-            const unsigned nElemNodes (conn_elems[j]->getNBaseNodes());
+            const unsigned nElemNodes (conn_elems[j]->getNumberOfBaseNodes());
             for (unsigned k(0); k<nElemNodes; ++k)
             {
                 bool is_in_vector (false);
@@ -255,7 +255,7 @@ void Mesh::setNodesConnectedByElements()
         for (Element const* const element : conn_elems)
         {
             Node* const* const single_elem_nodes = element->getNodes();
-            std::size_t const nnodes = element->getNBaseNodes();
+            std::size_t const nnodes = element->getNumberOfBaseNodes();
             for (std::size_t n = 0; n < nnodes; n++)
                 adjacent_nodes.push_back(single_elem_nodes[n]);
         }

--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -87,10 +87,10 @@ public:
     double getMaxNodeDistance() const { return _node_distance.second; }
 
     /// Get the number of elements
-    std::size_t getNElements() const { return _elements.size(); }
+    std::size_t getNumberOfElements() const { return _elements.size(); }
 
     /// Get the number of nodes
-    std::size_t getNNodes() const { return _nodes.size(); }
+    std::size_t getNumberOfNodes() const { return _nodes.size(); }
 
     /// Get name of the mesh.
     const std::string getName() const { return _name; }
@@ -114,13 +114,13 @@ public:
     std::size_t getID() const {return _id; }
 
     /// Get the number of base nodes
-    std::size_t getNBaseNodes() const { return _n_base_nodes; }
+    std::size_t getNumberOfBaseNodes() const { return _n_base_nodes; }
 
     /// Return true if the given node is a basic one (i.e. linear order node)
     bool isBaseNode(std::size_t node_idx) const {return node_idx < _n_base_nodes; }
 
     /// Return true if the mesh has any nonlinear nodes
-    bool isNonlinear() const { return (getNNodes() != getNBaseNodes()); }
+    bool isNonlinear() const { return (getNumberOfNodes() != getNumberOfBaseNodes()); }
 
     MeshLib::Properties & getProperties() { return _properties; }
     MeshLib::Properties const& getProperties() const { return _properties; }

--- a/MeshLib/MeshEditing/AddLayerToMesh.cpp
+++ b/MeshLib/MeshEditing/AddLayerToMesh.cpp
@@ -52,7 +52,7 @@ MeshLib::Element* extrudeElement(std::vector<MeshLib::Node*> const& subsfc_nodes
     if (sfc_elem.getDimension() > 2)
         return nullptr;
 
-    const unsigned nElemNodes(sfc_elem.getNBaseNodes());
+    const unsigned nElemNodes(sfc_elem.getNumberOfBaseNodes());
     MeshLib::Node** new_nodes = new MeshLib::Node*[2*nElemNodes];
 
     for (unsigned j=0; j<nElemNodes; ++j)
@@ -111,7 +111,7 @@ MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh, double thickness,
             sfc_mesh->getProperties().createNewPropertyVector<std::size_t>(
                 prop_name, MeshLib::MeshItemType::Node, 1));
         if (pv) {
-            pv->resize(sfc_mesh->getNNodes());
+            pv->resize(sfc_mesh->getNumberOfNodes());
             std::iota(pv->begin(), pv->end(), 0);
         } else {
             ERR("Could not create and initialize property.");
@@ -178,7 +178,7 @@ MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh, double thickness,
             new_materials->reserve(subsfc_elements.size());
             int new_layer_id (*(std::max_element(opt_materials->cbegin(), opt_materials->cend()))+1);
             std::copy(opt_materials->cbegin(), opt_materials->cend(), std::back_inserter(*new_materials));
-            auto const n_new_props(subsfc_elements.size()-mesh.getNElements());
+            auto const n_new_props(subsfc_elements.size()-mesh.getNumberOfElements());
             std::fill_n(std::back_inserter(*new_materials), n_new_props, new_layer_id);
         }
     } else {

--- a/MeshLib/MeshEditing/DuplicateMeshComponents.cpp
+++ b/MeshLib/MeshEditing/DuplicateMeshComponents.cpp
@@ -64,8 +64,8 @@ MeshLib::Element* copyElement(MeshLib::Element const*const element, const std::v
 template <typename E>
 MeshLib::Element* copyElement(MeshLib::Element const*const element, const std::vector<MeshLib::Node*> &nodes)
 {
-    MeshLib::Node** new_nodes = new MeshLib::Node*[element->getNBaseNodes()];
-    for (unsigned i=0; i<element->getNBaseNodes(); ++i)
+    MeshLib::Node** new_nodes = new MeshLib::Node*[element->getNumberOfBaseNodes()];
+    for (unsigned i=0; i<element->getNumberOfBaseNodes(); ++i)
         new_nodes[i] = nodes[element->getNode(i)->getID()];
     return new E(new_nodes);
 }

--- a/MeshLib/MeshEditing/FlipElements.cpp
+++ b/MeshLib/MeshEditing/FlipElements.cpp
@@ -24,7 +24,7 @@ std::unique_ptr<MeshLib::Element> createFlippedElement(MeshLib::Element const& e
     if (elem.getDimension()>2)
         return nullptr;
 
-    unsigned const n_nodes (elem.getNNodes());
+    unsigned const n_nodes (elem.getNumberOfNodes());
     MeshLib::Node** elem_nodes = new MeshLib::Node*[n_nodes];
     for (unsigned i=0; i<n_nodes; ++i)
         elem_nodes[i] = nodes[elem.getNode(i)->getID()];
@@ -50,7 +50,7 @@ std::unique_ptr<MeshLib::Mesh> createFlippedMesh(MeshLib::Mesh const& mesh)
     std::vector<MeshLib::Node*> new_nodes (MeshLib::copyNodeVector(mesh.getNodes()));
     std::vector<MeshLib::Element*> const& elems (mesh.getElements());
     std::vector<MeshLib::Element*> new_elems;
-    std::size_t n_elems (mesh.getNElements());
+    std::size_t n_elems (mesh.getNumberOfElements());
     new_elems.reserve(n_elems);
 
     for (std::size_t i=0; i<n_elems; ++i)

--- a/MeshLib/MeshEditing/Mesh2MeshPropertyInterpolation.cpp
+++ b/MeshLib/MeshEditing/Mesh2MeshPropertyInterpolation.cpp
@@ -65,7 +65,7 @@ bool Mesh2MeshPropertyInterpolation::setPropertiesForMesh(Mesh *dest_mesh, std::
 void Mesh2MeshPropertyInterpolation::interpolatePropertiesForMesh(Mesh *dest_mesh, std::vector<double>& dest_properties) const
 {
     // carry over property information from source elements to source nodes
-    std::vector<double> interpolated_src_node_properties(_src_mesh->getNNodes());
+    std::vector<double> interpolated_src_node_properties(_src_mesh->getNumberOfNodes());
     interpolateElementPropertiesToNodeProperties(interpolated_src_node_properties);
 
     // looping over the destination elements and calculate properties
@@ -89,7 +89,7 @@ void Mesh2MeshPropertyInterpolation::interpolatePropertiesForMesh(Mesh *dest_mes
     for (std::size_t k(0); k<n_dest_elements; k++)
     {
         // compute axis aligned bounding box around the current element
-        const GeoLib::AABB elem_aabb(dest_elements[k]->getNodes(), dest_elements[k]->getNodes()+dest_elements[k]->getNBaseNodes());
+        const GeoLib::AABB elem_aabb(dest_elements[k]->getNodes(), dest_elements[k]->getNodes()+dest_elements[k]->getNumberOfBaseNodes());
 
         // request "interesting" nodes from grid
         std::vector<std::vector<MeshLib::Node*> const*> nodes;
@@ -157,7 +157,7 @@ void Mesh2MeshPropertyInterpolation::interpolateElementPropertiesToNodePropertie
     std::vector<MeshLib::Node*> const& src_nodes(_src_mesh->getNodes());
     const std::size_t n_src_nodes(src_nodes.size());
     for (std::size_t k(0); k<n_src_nodes; k++) {
-        const std::size_t n_con_elems (src_nodes[k]->getNElements());
+        const std::size_t n_con_elems (src_nodes[k]->getNumberOfElements());
         interpolated_node_properties[k] = (*_src_properties)[(*materialIds)[src_nodes[k]->getElement(0)->getID()]];
         for (std::size_t j(1); j<n_con_elems; j++) {
             interpolated_node_properties[k] += (*_src_properties)[(*materialIds)[src_nodes[k]->getElement(j)->getID()]];

--- a/MeshLib/MeshEditing/MeshRevision.cpp
+++ b/MeshLib/MeshEditing/MeshRevision.cpp
@@ -44,7 +44,7 @@ MeshLib::Mesh* MeshRevision::collapseNodes(const std::string &new_mesh_name, dou
     return new MeshLib::Mesh(new_mesh_name, new_nodes, new_elements, _mesh.getProperties());
 }
 
-unsigned MeshRevision::getNCollapsableNodes(double eps) const
+unsigned MeshRevision::getNumberOfCollapsableNodes(double eps) const
 {
     std::vector<std::size_t> id_map(this->collapseNodeIndices(eps));
     std::size_t nNodes(id_map.size());
@@ -58,7 +58,7 @@ unsigned MeshRevision::getNCollapsableNodes(double eps) const
 MeshLib::Mesh* MeshRevision::simplifyMesh(const std::string &new_mesh_name,
     double eps, unsigned min_elem_dim)
 {
-    if (this->_mesh.getNElements() == 0)
+    if (this->_mesh.getNumberOfElements() == 0)
         return nullptr;
 
     // original data
@@ -79,8 +79,8 @@ MeshLib::Mesh* MeshRevision::simplifyMesh(const std::string &new_mesh_name,
 
     for (std::size_t k(0); k<elements.size(); ++k) {
         MeshLib::Element const*const elem(elements[k]);
-        unsigned n_unique_nodes(this->getNUniqueNodes(elem));
-        if (n_unique_nodes == elem->getNBaseNodes()
+        unsigned n_unique_nodes(this->getNumberOfUniqueNodes(elem));
+        if (n_unique_nodes == elem->getNumberOfBaseNodes()
             && elem->getDimension() >= min_elem_dim)
         {
             ElementErrorCode e(elem->validate());
@@ -106,7 +106,7 @@ MeshLib::Mesh* MeshRevision::simplifyMesh(const std::string &new_mesh_name,
                     new_material_vec->push_back((*material_vec)[k]);
             }
         }
-        else if (n_unique_nodes < elem->getNBaseNodes() && n_unique_nodes>1) {
+        else if (n_unique_nodes < elem->getNumberOfBaseNodes() && n_unique_nodes>1) {
             std::size_t const n_new_elements(reduceElement(
                 elem, n_unique_nodes, new_nodes, new_elements, min_elem_dim)
             );
@@ -129,7 +129,7 @@ MeshLib::Mesh* MeshRevision::simplifyMesh(const std::string &new_mesh_name,
 
 MeshLib::Mesh* MeshRevision::subdivideMesh(const std::string &new_mesh_name) const
 {
-    if (this->_mesh.getNElements() == 0)
+    if (this->_mesh.getNumberOfElements() == 0)
         return nullptr;
 
     // original data
@@ -186,7 +186,7 @@ MeshLib::Mesh* MeshRevision::subdivideMesh(const std::string &new_mesh_name) con
 std::vector<std::size_t> MeshRevision::collapseNodeIndices(double eps) const
 {
     const std::vector<MeshLib::Node*> &nodes(_mesh.getNodes());
-    const std::size_t nNodes(_mesh.getNNodes());
+    const std::size_t nNodes(_mesh.getNumberOfNodes());
     std::vector<std::size_t> id_map(nNodes);
     const double half_eps(eps / 2.0);
     const double sqr_eps(eps*eps);
@@ -250,9 +250,9 @@ std::vector<MeshLib::Node*> MeshRevision::constructNewNodesArray(const std::vect
     return new_nodes;
 }
 
-unsigned MeshRevision::getNUniqueNodes(MeshLib::Element const*const element) const
+unsigned MeshRevision::getNumberOfUniqueNodes(MeshLib::Element const*const element) const
 {
-    unsigned const nNodes(element->getNBaseNodes());
+    unsigned const nNodes(element->getNumberOfBaseNodes());
     unsigned count(nNodes);
 
     for (unsigned i = 0; i < nNodes - 1; ++i)
@@ -267,7 +267,7 @@ unsigned MeshRevision::getNUniqueNodes(MeshLib::Element const*const element) con
 
 void MeshRevision::resetNodeIDs()
 {
-    const std::size_t nNodes(this->_mesh.getNNodes());
+    const std::size_t nNodes(this->_mesh.getNumberOfNodes());
     const std::vector<MeshLib::Node*> &nodes(_mesh.getNodes());
     for (std::size_t i = 0; i < nNodes; ++i)
         nodes[i]->setID(i);
@@ -687,7 +687,7 @@ MeshLib::Element* MeshRevision::constructLine(MeshLib::Element const*const eleme
     MeshLib::Node** line_nodes = new MeshLib::Node*[2];
     line_nodes[0] = nodes[element->getNode(0)->getID()];
     line_nodes[1] = nullptr;
-    for (unsigned i=1; i<element->getNBaseNodes(); ++i)
+    for (unsigned i=1; i<element->getNumberOfBaseNodes(); ++i)
     {
         if (element->getNode(i)->getID() != element->getNode(0)->getID())
         {
@@ -708,12 +708,12 @@ MeshLib::Element* MeshRevision::constructTri(MeshLib::Element const*const elemen
     MeshLib::Node** tri_nodes = new MeshLib::Node*[3];
     tri_nodes[0] = nodes[element->getNode(0)->getID()];
     tri_nodes[2] = nullptr;
-    for (unsigned i = 1; i < element->getNBaseNodes(); ++i)
+    for (unsigned i = 1; i < element->getNumberOfBaseNodes(); ++i)
     {
         if (element->getNode(i)->getID() != tri_nodes[0]->getID())
         {
             tri_nodes[1] = nodes[element->getNode(i)->getID()];
-            for (unsigned j = i + 1; j < element->getNBaseNodes(); ++j)
+            for (unsigned j = i + 1; j < element->getNumberOfBaseNodes(); ++j)
             {
                 if (element->getNode(j)->getID() != tri_nodes[1]->getID())
                 {
@@ -736,7 +736,7 @@ MeshLib::Element* MeshRevision::constructFourNodeElement(
     MeshLib::Node** new_nodes = new MeshLib::Node*[4];
     unsigned count(0);
     new_nodes[count++] = nodes[element->getNode(0)->getID()];
-    for (unsigned i=1; i<element->getNBaseNodes(); ++i)
+    for (unsigned i=1; i<element->getNumberOfBaseNodes(); ++i)
     {
         if (count>3)
             break;
@@ -781,7 +781,7 @@ MeshLib::Element* MeshRevision::constructFourNodeElement(
 unsigned MeshRevision::findPyramidTopNode(MeshLib::Element const& element,
     std::array<std::size_t,4> const& base_node_ids) const
 {
-    const std::size_t nNodes (element.getNBaseNodes());
+    const std::size_t nNodes (element.getNumberOfBaseNodes());
     for (std::size_t i=0; i<nNodes; ++i)
     {
         bool top_node=true;

--- a/MeshLib/MeshEditing/MeshRevision.h
+++ b/MeshLib/MeshEditing/MeshRevision.h
@@ -53,7 +53,7 @@ public:
     MeshLib::Mesh* collapseNodes(const std::string &new_mesh_name, double eps);
 
     /// Returns the number of potentially collapsable nodes
-    unsigned getNCollapsableNodes(double eps = std::numeric_limits<double>::epsilon()) const;
+    unsigned getNumberOfCollapsableNodes(double eps = std::numeric_limits<double>::epsilon()) const;
 
     /// Designates nodes to be collapsed by setting their ID to the index of the node they will get merged with.
     std::vector<std::size_t> collapseNodeIndices(double eps) const;
@@ -81,7 +81,7 @@ private:
         const std::vector<std::size_t> &id_map) const;
 
     /// Calculates the number of unique nodes in an element (i.e. uncollapsed nodes)
-    unsigned getNUniqueNodes(MeshLib::Element const*const element) const;
+    unsigned getNumberOfUniqueNodes(MeshLib::Element const*const element) const;
 
     /// Resets the node IDs of the source mesh (needs to be called after everything is done).
     void resetNodeIDs();

--- a/MeshLib/MeshEditing/RemoveMeshComponents.cpp
+++ b/MeshLib/MeshEditing/RemoveMeshComponents.cpp
@@ -111,7 +111,7 @@ MeshLib::Mesh* removeNodes(const MeshLib::Mesh &mesh, const std::vector<std::siz
     // check unused nodes due to element deletion
     std::vector<bool> node_delete_flag(new_nodes.size(), true);
     for (auto e : new_elems) {
-        for (unsigned i=0; i<e->getNNodes(); i++)
+        for (unsigned i=0; i<e->getNumberOfNodes(); i++)
             node_delete_flag[e->getNodeIndex(i)] = false;
     }
 

--- a/MeshLib/MeshEditing/projectMeshOntoPlane.h
+++ b/MeshLib/MeshEditing/projectMeshOntoPlane.h
@@ -38,7 +38,7 @@ MeshLib::Mesh* projectMeshOntoPlane(MeshLib::Mesh const& mesh,
                                     MathLib::Point3d const& plane_origin,
                                     MathLib::Vector3 const& plane_normal)
 {
-    std::size_t const n_nodes (mesh.getNNodes());
+    std::size_t const n_nodes (mesh.getNumberOfNodes());
     std::vector<MeshLib::Node*> const& nodes (mesh.getNodes());
     MathLib::Vector3 normal (plane_normal);
     normal.normalize();

--- a/MeshLib/MeshGenerators/LayeredVolume.cpp
+++ b/MeshLib/MeshGenerators/LayeredVolume.cpp
@@ -72,14 +72,14 @@ bool LayeredVolume::createRasterLayers(const MeshLib::Mesh &mesh,
 
     // close boundaries between layers
     this->addLayerBoundaries(*top, nRasters);
-    this->removeCongruentElements(nRasters, top->getNElements());
+    this->removeCongruentElements(nRasters, top->getNumberOfElements());
 
     return true;
 }
 
 void LayeredVolume::addLayerToMesh(const MeshLib::Mesh &dem_mesh, unsigned layer_id, GeoLib::Raster const& raster)
 {
-    const std::size_t nNodes (dem_mesh.getNNodes());
+    const std::size_t nNodes (dem_mesh.getNumberOfNodes());
     const std::vector<MeshLib::Node*> &nodes (dem_mesh.getNodes());
     const std::size_t node_id_offset (_nodes.size());
     const std::size_t last_layer_node_offset (node_id_offset-nNodes);
@@ -113,11 +113,11 @@ void LayeredVolume::addLayerToMesh(const MeshLib::Mesh &dem_mesh, unsigned layer
 void LayeredVolume::addLayerBoundaries(const MeshLib::Mesh &layer, std::size_t nLayers)
 {
     const unsigned nLayerBoundaries (nLayers-1);
-    const std::size_t nNodes (layer.getNNodes());
+    const std::size_t nNodes (layer.getNumberOfNodes());
     const std::vector<MeshLib::Element*> &layer_elements (layer.getElements());
     for (MeshLib::Element* elem : layer_elements)
     {
-        const std::size_t nElemNodes (elem->getNBaseNodes());
+        const std::size_t nElemNodes (elem->getNumberOfBaseNodes());
         for (unsigned i=0; i<nElemNodes; ++i)
             if (elem->getNeighbor(i) == nullptr)
                 for (unsigned j=0; j<nLayerBoundaries; ++j)
@@ -156,7 +156,7 @@ void LayeredVolume::removeCongruentElements(std::size_t nLayers, std::size_t nEl
             MeshLib::Element *const low  (_elements[lower_offset+j]);
 
             unsigned count(0);
-            const std::size_t nElemNodes (low->getNBaseNodes());
+            const std::size_t nElemNodes (low->getNumberOfBaseNodes());
             for (std::size_t k=0; k<nElemNodes; ++k)
                 if (high->getNodeIndex(k) == low->getNodeIndex(k))
                 {

--- a/MeshLib/MeshGenerators/LayeredVolume.h
+++ b/MeshLib/MeshGenerators/LayeredVolume.h
@@ -49,7 +49,7 @@ public:
                             double noDataReplacementValue = 0.0);
 
     /// Returns the region attribute vector necessary for assigning region attributes via TetGen
-    std::vector<MeshLib::Node> getAttributePoints() { return _attribute_points; }
+    std::vector<MeshLib::Node> getConfigAttributePoints() { return _attribute_points; }
 
 private:
     /// Adds another layer to the subsurface mesh

--- a/MeshLib/MeshGenerators/MeshGenerator.cpp
+++ b/MeshLib/MeshGenerators/MeshGenerator.cpp
@@ -452,7 +452,7 @@ Mesh* MeshGenerator::generateRegularPrismMesh(
 {
     std::unique_ptr<MeshLib::Mesh> mesh (
         generateRegularTriMesh(n_x_cells, n_y_cells, cell_size_x, cell_size_y, origin, mesh_name));
-    std::size_t const n_tris (mesh->getNElements());
+    std::size_t const n_tris (mesh->getNumberOfElements());
     for (std::size_t i=0; i<n_z_cells; ++i)
         mesh.reset(MeshLib::addTopLayerToMesh(*mesh, cell_size_z, mesh_name));
     std::vector<std::size_t> elem_ids (n_tris);

--- a/MeshLib/MeshGenerators/MeshLayerMapper.cpp
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.cpp
@@ -48,12 +48,12 @@ MeshLib::Mesh* MeshLayerMapper::createStaticLayers(MeshLib::Mesh const& mesh, st
         return nullptr;
     }
 
-    const std::size_t nNodes = mesh.getNNodes();
+    const std::size_t nNodes = mesh.getNumberOfNodes();
     // count number of 2d elements in the original mesh
     const std::size_t nElems (std::count_if(mesh.getElements().begin(), mesh.getElements().end(),
             [](MeshLib::Element const* elem) { return (elem->getDimension() == 2);}));
 
-    const std::size_t nOrgElems (mesh.getNElements());
+    const std::size_t nOrgElems (mesh.getNumberOfElements());
     const std::vector<MeshLib::Node*> &nodes = mesh.getNodes();
     const std::vector<MeshLib::Element*> &elems = mesh.getElements();
     std::vector<MeshLib::Node*> new_nodes(nNodes + (nLayers * nNodes));
@@ -94,7 +94,7 @@ MeshLib::Mesh* MeshLayerMapper::createStaticLayers(MeshLib::Mesh const& mesh, st
             if (sfc_elem->getDimension() < 2) // ignore line-elements
                 continue;
 
-            const unsigned nElemNodes(sfc_elem->getNBaseNodes());
+            const unsigned nElemNodes(sfc_elem->getNumberOfBaseNodes());
             MeshLib::Node** e_nodes = new MeshLib::Node*[2*nElemNodes];
 
             for (unsigned j=0; j<nElemNodes; ++j)
@@ -140,7 +140,7 @@ bool MeshLayerMapper::createRasterLayers(
     }
 
     this->_minimum_thickness = minimum_thickness;
-    std::size_t const nNodes = mesh.getNNodes();
+    std::size_t const nNodes = mesh.getNumberOfNodes();
     _nodes.reserve(nLayers * nNodes);
 
     // number of triangles in the original mesh
@@ -173,7 +173,7 @@ void MeshLayerMapper::addLayerToMesh(const MeshLib::Mesh &dem_mesh, unsigned lay
         {0, 3, 4, 1}, // Point 6 missing
     };
 
-    std::size_t const nNodes = dem_mesh.getNNodes();
+    std::size_t const nNodes = dem_mesh.getNumberOfNodes();
     std::vector<MeshLib::Node*> const& nodes = dem_mesh.getNodes();
     int const last_layer_node_offset = layer_id * nNodes;
 
@@ -182,7 +182,7 @@ void MeshLayerMapper::addLayerToMesh(const MeshLib::Mesh &dem_mesh, unsigned lay
         _nodes.push_back(getNewLayerNode(*nodes[i], *_nodes[last_layer_node_offset + i], raster, _nodes.size()));
 
     std::vector<MeshLib::Element*> const& elems = dem_mesh.getElements();
-    std::size_t const nElems (dem_mesh.getNElements());
+    std::size_t const nElems (dem_mesh.getNumberOfElements());
 
     for (std::size_t i=0; i<nElems; ++i)
     {
@@ -245,7 +245,7 @@ bool MeshLayerMapper::layerMapping(MeshLib::Mesh &new_mesh, GeoLib::Raster const
     const std::pair<double, double> xDim(x0, x0 + header.n_cols * delta); // extension in x-dimension
     const std::pair<double, double> yDim(y0, y0 + header.n_rows * delta); // extension in y-dimension
 
-    const std::size_t nNodes (new_mesh.getNNodes());
+    const std::size_t nNodes (new_mesh.getNumberOfNodes());
     const std::vector<MeshLib::Node*> &nodes = new_mesh.getNodes();
     for (unsigned i = 0; i < nNodes; ++i)
     {

--- a/MeshLib/MeshQuality/AngleSkewMetric.cpp
+++ b/MeshLib/MeshQuality/AngleSkewMetric.cpp
@@ -35,7 +35,7 @@ AngleSkewMetric::~AngleSkewMetric()
 void AngleSkewMetric::calculateQuality ()
 {
     const std::vector<MeshLib::Element*>& elements(_mesh.getElements());
-    const std::size_t nElements (_mesh.getNElements());
+    const std::size_t nElements (_mesh.getNumberOfElements());
 
     for (std::size_t k(0); k < nElements; k++)
     {

--- a/MeshLib/MeshQuality/EdgeRatioMetric.cpp
+++ b/MeshLib/MeshQuality/EdgeRatioMetric.cpp
@@ -28,7 +28,7 @@ void EdgeRatioMetric::calculateQuality()
 {
     // get all elements of mesh
     const std::vector<MeshLib::Element*>& elements(_mesh.getElements());
-    const std::size_t nElements (_mesh.getNElements());
+    const std::size_t nElements (_mesh.getNumberOfElements());
     for (std::size_t k(0); k < nElements; k++)
     {
         Element const& elem (*elements[k]);

--- a/MeshLib/MeshQuality/ElementQualityMetric.cpp
+++ b/MeshLib/MeshQuality/ElementQualityMetric.cpp
@@ -24,13 +24,13 @@ namespace MeshLib
 ElementQualityMetric::ElementQualityMetric(Mesh const& mesh) :
     _min (std::numeric_limits<double>::max()), _max (0), _mesh (mesh)
 {
-    _element_quality_metric.resize (_mesh.getNElements(), -1.0);
+    _element_quality_metric.resize (_mesh.getNumberOfElements(), -1.0);
 }
 
 BaseLib::Histogram<double> ElementQualityMetric::getHistogram (std::size_t n_bins) const
 {
     if (n_bins == 0)
-        n_bins = static_cast<std::size_t>(1 + 3.3 * log (static_cast<float>((_mesh.getNElements()))));
+        n_bins = static_cast<std::size_t>(1 + 3.3 * log (static_cast<float>((_mesh.getNumberOfElements()))));
 
     return BaseLib::Histogram<double>(getElementQuality(), n_bins, true);
 }
@@ -39,7 +39,7 @@ void ElementQualityMetric::errorMsg (Element const& elem, std::size_t idx) const
 {
     ERR ("Error in MeshQualityChecker::check() - Calculated value of element is below double precision minimum.");
     ERR ("Points of %s-Element %d: ", MeshElemType2String(elem.getGeomType()).c_str(), idx);
-    for (std::size_t i(0); i < elem.getNBaseNodes(); i++)
+    for (std::size_t i(0); i < elem.getNumberOfBaseNodes(); i++)
     {
         const double* coords = elem.getNode(i)->getCoords();
         ERR ("\t Node %d: (%f, %f, %f)", i, coords[0], coords[1], coords[2]);

--- a/MeshLib/MeshQuality/MeshValidation.cpp
+++ b/MeshLib/MeshQuality/MeshValidation.cpp
@@ -39,7 +39,7 @@ MeshValidation::MeshValidation(MeshLib::Mesh &mesh)
         INFO ("%d unused mesh nodes found.", ns.getSearchedNodeIDs().size());
     }
     MeshRevision rev(mesh);
-    INFO ("Found %d potentially collapsable nodes.", rev.getNCollapsableNodes());
+    INFO ("Found %d potentially collapsable nodes.", rev.getNumberOfCollapsableNodes());
 
     const std::vector<ElementErrorCode> codes (this->testElementGeometry(mesh));
     std::array<std::string, static_cast<std::size_t>(ElementErrorFlag::MaxValue)> output_str (this->ElementErrorCodeOutput(codes));
@@ -53,7 +53,7 @@ std::vector<ElementErrorCode> MeshValidation::testElementGeometry(const MeshLib:
     const std::size_t nErrorCodes (static_cast<std::size_t>(ElementErrorFlag::MaxValue));
     unsigned error_count[nErrorCodes];
     std::fill_n(error_count, 4, 0);
-    const std::size_t nElements (mesh.getNElements());
+    const std::size_t nElements (mesh.getNumberOfElements());
     const std::vector<MeshLib::Element*> &elements (mesh.getElements());
     std::vector<ElementErrorCode> error_code_vector;
     error_code_vector.reserve(nElements);
@@ -157,7 +157,7 @@ void MeshValidation::trackSurface(MeshLib::Element const* element, std::vector<u
         MeshLib::Element const*const elem = elem_stack.top();
         elem_stack.pop();
         sfc_idx[elem->getID()] = current_index;
-        std::size_t const n_neighbors (elem->getNNeighbors());
+        std::size_t const n_neighbors (elem->getNumberOfNeighbors());
         for (std::size_t i=0; i<n_neighbors; ++i)
         {
             MeshLib::Element const* neighbor (elem->getNeighbor(i));

--- a/MeshLib/MeshQuality/RadiusEdgeRatioMetric.cpp
+++ b/MeshLib/MeshQuality/RadiusEdgeRatioMetric.cpp
@@ -27,11 +27,11 @@ RadiusEdgeRatioMetric::RadiusEdgeRatioMetric(Mesh const& mesh)
 void RadiusEdgeRatioMetric::calculateQuality ()
 {
     std::vector<MeshLib::Element*> const& elements(_mesh.getElements());
-    std::size_t const nElements (_mesh.getNElements());
+    std::size_t const nElements (_mesh.getNumberOfElements());
     for (std::size_t k(0); k < nElements; k++)
     {
         Element const& elem (*elements[k]);
-        std::size_t const n_nodes (elem.getNBaseNodes());
+        std::size_t const n_nodes (elem.getNumberOfBaseNodes());
         std::vector<MathLib::Point3d*> pnts(n_nodes);
         std::copy_n(elem.getNodes(), n_nodes, pnts.begin());
         GeoLib::MinimalBoundingSphere const s(pnts);

--- a/MeshLib/MeshQuality/SizeDifferenceMetric.cpp
+++ b/MeshLib/MeshQuality/SizeDifferenceMetric.cpp
@@ -26,7 +26,7 @@ ElementQualityMetric(mesh)
 void SizeDifferenceMetric::calculateQuality()
 {
     std::vector<MeshLib::Element*> const& elements(_mesh.getElements());
-    std::size_t const nElements (_mesh.getNElements());
+    std::size_t const nElements (_mesh.getNumberOfElements());
     std::size_t const mesh_dim (_mesh.getDimension());
 
     for (std::size_t k=0; k < nElements; ++k)
@@ -38,7 +38,7 @@ void SizeDifferenceMetric::calculateQuality()
             continue;
         }
 
-        std::size_t const n_neighbors (elem.getNNeighbors());
+        std::size_t const n_neighbors (elem.getNumberOfNeighbors());
         double const vol_a (elem.getContent());
 
         double worst_ratio(1.0);

--- a/MeshLib/MeshSearch/ElementSearch.cpp
+++ b/MeshLib/MeshSearch/ElementSearch.cpp
@@ -57,7 +57,7 @@ std::size_t ElementSearch::searchByBoundingBox(
 {
     auto matchedIDs = filter(_mesh.getElements(),
         [&aabb](MeshLib::Element* e) {
-            std::size_t const nElemNodes (e->getNBaseNodes());
+            std::size_t const nElemNodes (e->getNumberOfBaseNodes());
             for (std::size_t n=0; n < nElemNodes; ++n)
                 if (aabb.containsPoint(*e->getNode(n)))
                     return true;    // any node of element is in aabb.

--- a/MeshLib/MeshSearch/MeshElementGrid.cpp
+++ b/MeshLib/MeshSearch/MeshElementGrid.cpp
@@ -48,7 +48,7 @@ MeshElementGrid::MeshElementGrid(MeshLib::Mesh const& sfc_mesh) :
     std::array<double, 3> delta{{ max_pnt[0] - min_pnt[0],
         max_pnt[1] - min_pnt[1], max_pnt[2] - min_pnt[2] }};
 
-    const std::size_t n_eles(sfc_mesh.getNElements());
+    const std::size_t n_eles(sfc_mesh.getNumberOfElements());
     const std::size_t n_eles_per_cell(100);
 
     // *** condition: n_eles / n_cells < n_eles_per_cell
@@ -134,8 +134,8 @@ bool MeshElementGrid::sortElementInGridCells(MeshLib::Element const& element)
         return false;
     }
 
-    std::vector<std::array<std::size_t,3>> coord_vecs(element.getNNodes());
-    for (std::size_t k(1); k<element.getNNodes(); ++k) {
+    std::vector<std::array<std::size_t,3>> coord_vecs(element.getNumberOfNodes());
+    for (std::size_t k(1); k<element.getNumberOfNodes(); ++k) {
         // compute coordinates of the grid for each node of the element
         c = getGridCellCoordinates(*(static_cast<MathLib::Point3d const*>(element.getNode(k))));
         if (!c.first)

--- a/MeshLib/MeshSearch/NodeSearch.cpp
+++ b/MeshLib/MeshSearch/NodeSearch.cpp
@@ -31,12 +31,12 @@ std::size_t NodeSearch::searchNodesConnectedToOnlyGivenElements(
     //
     // Note: If there are only few elements to be removed, using a different
     // algorithm might be more memory efficient.
-    std::vector<std::size_t> node_marked_counts(_mesh.getNNodes(), 0);
+    std::vector<std::size_t> node_marked_counts(_mesh.getNumberOfNodes(), 0);
 
     for(std::size_t eid : elements)
     {
         auto* e = _mesh.getElement(eid);
-        for (unsigned i=0; i<e->getNBaseNodes(); i++) {
+        for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++) {
             node_marked_counts[e->getNodeIndex(i)]++;
         }
     }
@@ -57,12 +57,12 @@ std::size_t NodeSearch::searchNodesConnectedToOnlyGivenElements(
 
 std::size_t NodeSearch::searchUnused()
 {
-    const std::size_t nNodes (_mesh.getNNodes());
+    const std::size_t nNodes (_mesh.getNumberOfNodes());
     const std::vector<MeshLib::Node*> &nodes (_mesh.getNodes());
     std::vector<std::size_t> del_node_idx;
 
     for (unsigned i=0; i<nNodes; ++i)
-        if (nodes[i]->getNElements() == 0)
+        if (nodes[i]->getNumberOfElements() == 0)
             del_node_idx.push_back(i);
 
     this->updateUnion(del_node_idx);
@@ -83,7 +83,7 @@ std::vector<Node*> getUniqueNodes(std::vector<Element*> const& elements)
     for (auto e : elements)
     {
         Node* const* nodes = e->getNodes();
-        unsigned const nnodes = e->getNNodes();
+        unsigned const nnodes = e->getNumberOfNodes();
         nodes_set.insert(nodes, nodes + nnodes);
     }
 

--- a/MeshLib/MeshSubset.h
+++ b/MeshLib/MeshSubset.h
@@ -74,9 +74,9 @@ public:
     }
 
     /// return the total number of mesh items
-    std::size_t getNTotalItems() const
+    std::size_t getNumberOfTotalItems() const
     {
-        return getNNodes() + getNElements();
+        return getNumberOfNodes() + getNumberOfElements();
     }
 
     /// return this mesh ID
@@ -86,7 +86,7 @@ public:
     }
 
     /// return the number of registered nodes
-    std::size_t getNNodes() const
+    std::size_t getNumberOfNodes() const
     {
         return (_nodes==nullptr) ? 0 : _nodes->size();
     }
@@ -101,7 +101,7 @@ public:
     }
 
     /// return the number of registered elements
-    std::size_t getNElements() const
+    std::size_t getNumberOfElements() const
     {
         return (_eles==nullptr) ? 0 : _eles->size();
     }

--- a/MeshLib/MeshSubsets.h
+++ b/MeshLib/MeshSubsets.h
@@ -35,7 +35,7 @@ public:
     MeshSubsets(const MeshSubset* mesh_subset)
     {
         _mesh_subsets.push_back(mesh_subset);
-        _n_total_items = mesh_subset->getNTotalItems();
+        _n_total_items = mesh_subset->getNumberOfTotalItems();
     }
 
     /// Construct MeshSubsets from a range of MeshSubset. InputIterator must
@@ -55,12 +55,12 @@ public:
         _n_total_items = std::accumulate(first, last, 0u,
             [](std::size_t const& sum, MeshSubset const* const mesh_subset)
             {
-                return sum + mesh_subset->getNTotalItems();
+                return sum + mesh_subset->getNumberOfTotalItems();
             });
     }
 
     /// return the total number of mesh items (in all meshes) where this component is assigned
-    std::size_t getNMeshItems() const
+    std::size_t getNumberOfMeshItems() const
     {
         return _n_total_items;
     }

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -44,7 +44,7 @@ std::vector<double> MeshSurfaceExtraction::getSurfaceAreaForNodes(const MeshLib:
 
     // for each node, a vector containing all the element idget every element
     const std::vector<MeshLib::Node*> &nodes = mesh.getNodes();
-    const std::size_t nNodes ( mesh.getNNodes() );
+    const std::size_t nNodes ( mesh.getNumberOfNodes() );
     for (std::size_t n=0; n<nNodes; ++n)
     {
         double node_area (0);
@@ -87,15 +87,15 @@ MeshLib::Mesh* MeshSurfaceExtraction::getMeshSurface(
         return nullptr;
 
     std::vector<MeshLib::Node*> sfc_nodes;
-    std::vector<std::size_t> node_id_map(mesh.getNNodes());
-    get2DSurfaceNodes(sfc_nodes, mesh.getNNodes(), sfc_elements, node_id_map);
+    std::vector<std::size_t> node_id_map(mesh.getNumberOfNodes());
+    get2DSurfaceNodes(sfc_nodes, mesh.getNumberOfNodes(), sfc_elements, node_id_map);
 
     // create new elements vector with newly created nodes
     std::vector<MeshLib::Element*> new_elements;
     new_elements.reserve(sfc_elements.size());
     for (auto elem = sfc_elements.cbegin(); elem != sfc_elements.cend(); ++elem)
     {
-        unsigned const n_elem_nodes ((*elem)->getNBaseNodes());
+        unsigned const n_elem_nodes ((*elem)->getNumberOfBaseNodes());
         MeshLib::Node** new_nodes = new MeshLib::Node*[n_elem_nodes];
         for (unsigned k(0); k<n_elem_nodes; k++)
             new_nodes[k] = sfc_nodes[node_id_map[(*elem)->getNode(k)->getID()]];
@@ -149,7 +149,7 @@ MeshLib::Mesh* MeshSurfaceExtraction::getMeshBoundary(const MeshLib::Mesh &mesh)
     for (auto it=org_elems.begin(); it!=org_elems.end(); ++it)
     {
         MeshLib::Element* elem (*it);
-        std::size_t const n_edges (elem->getNEdges());
+        std::size_t const n_edges (elem->getNumberOfEdges());
         for (std::size_t i=0; i<n_edges; ++i)
             if (elem->getNeighbor(i) == nullptr)
             {
@@ -200,7 +200,7 @@ void MeshSurfaceExtraction::get2DSurfaceElements(const std::vector<MeshLib::Elem
         {
             if (!(*elem)->isBoundaryElement())
                 continue;
-            const unsigned nFaces ((*elem)->getNFaces());
+            const unsigned nFaces ((*elem)->getNumberOfFaces());
             for (unsigned j=0; j<nFaces; ++j)
             {
                 if ((*elem)->getNeighbor(j) != nullptr)
@@ -230,7 +230,7 @@ void MeshSurfaceExtraction::get2DSurfaceNodes(std::vector<MeshLib::Node*> &sfc_n
     for (std::size_t i=0; i<nNewElements; ++i)
     {
         const MeshLib::Element* elem (sfc_elements[i]);
-        for (unsigned j=0; j<elem->getNBaseNodes(); ++j)
+        for (unsigned j=0; j<elem->getNumberOfBaseNodes(); ++j)
         {
             const MeshLib::Node* node (elem->getNode(j));
             tmp_nodes[node->getID()] = node;
@@ -254,8 +254,8 @@ std::vector<GeoLib::Point*> MeshSurfaceExtraction::getSurfaceNodes(const MeshLib
     get2DSurfaceElements(mesh.getElements(), sfc_elements, dir, angle, mesh.getDimension());
 
     std::vector<MeshLib::Node*> sfc_nodes;
-    std::vector<std::size_t> node_id_map(mesh.getNNodes());
-    get2DSurfaceNodes(sfc_nodes, mesh.getNNodes(), sfc_elements, node_id_map);
+    std::vector<std::size_t> node_id_map(mesh.getNumberOfNodes());
+    get2DSurfaceNodes(sfc_nodes, mesh.getNumberOfNodes(), sfc_elements, node_id_map);
 
     for (auto e : sfc_elements)
         delete e;

--- a/MeshLib/Node.h
+++ b/MeshLib/Node.h
@@ -59,7 +59,7 @@ public:
     const std::vector<Element*>& getElements() const { return _elements; }
 
     /// Get number of elements the node is part of.
-    std::size_t getNElements() const { return _elements.size(); }
+    std::size_t getNumberOfElements() const { return _elements.size(); }
 
     /// Destructor
     virtual ~Node();

--- a/MeshLib/NodePartitionedMesh.h
+++ b/MeshLib/NodePartitionedMesh.h
@@ -68,13 +68,13 @@ class NodePartitionedMesh : public Mesh
         }
 
         /// Get the number of nodes of the global mesh for linear elements.
-        std::size_t getNGlobalBaseNodes() const
+        std::size_t getNumberOfGlobalBaseNodes() const
         {
             return _n_global_base_nodes;
         }
 
         /// Get the number of all nodes of the global mesh.
-        std::size_t getNGlobalNodes() const
+        std::size_t getNumberOfGlobalNodes() const
         {
             return _n_global_nodes;
         }
@@ -86,13 +86,13 @@ class NodePartitionedMesh : public Mesh
         }
 
         /// Get the number of the active nodes of the partition for linear elements.
-        std::size_t getNActiveBaseNodes() const
+        std::size_t getNumberOfActiveBaseNodes() const
         {
             return _n_active_base_nodes;
         }
 
         /// Get the number of all active nodes of the partition.
-        std::size_t getNActiveNodes() const
+        std::size_t getNumberOfActiveNodes() const
         {
             return _n_active_nodes;
         }
@@ -115,7 +115,7 @@ class NodePartitionedMesh : public Mesh
         }
 
         /// Get the number of non-ghost elements, or the start entry ID of ghost elements in element vector.
-        std::size_t getNNonGhostElements() const
+        std::size_t getNumberOfNonGhostElements() const
         {
             return _n_nghost_elem;
         }

--- a/MeshLib/Vtk/VtkMappedMesh.cpp
+++ b/MeshLib/Vtk/VtkMappedMesh.cpp
@@ -66,7 +66,7 @@ int VtkMappedMeshImpl::GetCellType(vtkIdType cellId)
 void VtkMappedMeshImpl::GetCellPoints(vtkIdType cellId, vtkIdList *ptIds)
 {
     const MeshLib::Element* const elem = (*_elements)[cellId];
-    const unsigned numNodes(elem->getNNodes());
+    const unsigned numNodes(elem->getNumberOfNodes());
     const MeshLib::Node* const* nodes = (*_elements)[cellId]->getNodes();
     ptIds->SetNumberOfIds(numNodes);
 
@@ -115,7 +115,7 @@ int VtkMappedMeshImpl::GetMaxCellSize()
 {
     unsigned int size = 0;
     for (auto elem(_elements->begin()); elem != _elements->end(); ++elem)
-        size = std::max(size, (*elem)->getNNodes());
+        size = std::max(size, (*elem)->getNumberOfNodes());
     return size;
 }
 

--- a/MeshLib/Vtk/VtkMappedMeshSource.cpp
+++ b/MeshLib/Vtk/VtkMappedMeshSource.cpp
@@ -111,7 +111,7 @@ int VtkMappedMeshSource::RequestInformation(
     vtkInformation *, vtkInformationVector **, vtkInformationVector *)
 {
     this->NumberOfDimensions = 3;
-    this->NumberOfNodes = _mesh->getNNodes();
+    this->NumberOfNodes = _mesh->getNumberOfNodes();
 
     return 1;
 }

--- a/MeshLib/convertMeshToGeo.cpp
+++ b/MeshLib/convertMeshToGeo.cpp
@@ -41,7 +41,7 @@ bool convertMeshToGeo(const MeshLib::Mesh &mesh, GeoLib::GEOObjects &geo_objects
     {
         auto points = std::unique_ptr<std::vector<GeoLib::Point*>>(
             new std::vector<GeoLib::Point*>);
-        points->reserve(mesh.getNNodes());
+        points->reserve(mesh.getNumberOfNodes());
 
         for (auto node_ptr : mesh.getNodes())
             points->push_back(new GeoLib::Point(*node_ptr, node_ptr->getID()));
@@ -61,7 +61,7 @@ bool convertMeshToGeo(const MeshLib::Mesh &mesh, GeoLib::GEOObjects &geo_objects
         sfcs->push_back(new GeoLib::Surface(points));
 
     const std::vector<MeshLib::Element*> &elements = mesh.getElements();
-    const std::size_t nElems (mesh.getNElements());
+    const std::size_t nElems (mesh.getNumberOfElements());
 
     auto materialIds = mesh.getProperties().getPropertyVector<int>(mat_name);
     auto const materialIdExist = bool(materialIds);
@@ -80,7 +80,7 @@ bool convertMeshToGeo(const MeshLib::Mesh &mesh, GeoLib::GEOObjects &geo_objects
         // all other element types are ignored (i.e. lines)
     }
 
-    std::for_each(sfcs->begin(), sfcs->end(), [](GeoLib::Surface* sfc){ if (sfc->getNTriangles()==0) delete sfc; sfc = nullptr;});
+    std::for_each(sfcs->begin(), sfcs->end(), [](GeoLib::Surface* sfc){ if (sfc->getNumberOfTriangles()==0) delete sfc; sfc = nullptr;});
     auto sfcs_end = std::remove(sfcs->begin(), sfcs->end(), nullptr);
     sfcs->erase(sfcs_end, sfcs->end());
 
@@ -94,7 +94,7 @@ MeshLib::Mesh* convertSurfaceToMesh(const GeoLib::Surface &sfc, const std::strin
     std::vector<MeshLib::Node*> nodes;
     std::vector<MeshLib::Element*> elements;
     std::size_t nodeId = 0;
-    for (std::size_t i=0; i<sfc.getNTriangles(); i++)
+    for (std::size_t i=0; i<sfc.getNumberOfTriangles(); i++)
     {
         auto* tri = sfc[i];
         MeshLib::Node** tri_nodes = new MeshLib::Node*[3];

--- a/NumLib/DOF/ComputeSparsityPattern.cpp
+++ b/NumLib/DOF/ComputeSparsityPattern.cpp
@@ -40,8 +40,8 @@ GlobalSparsityPattern computeSparsityPatternNonPETSc(
     // It acts as a cache for dof table queries.
     std::vector<std::vector<GlobalIndexType>> global_idcs;
 
-    global_idcs.reserve(mesh.getNNodes());
-    for (std::size_t n = 0; n < mesh.getNNodes(); ++n)
+    global_idcs.reserve(mesh.getNumberOfNodes());
+    for (std::size_t n = 0; n < mesh.getNumberOfNodes(); ++n)
     {
         MeshLib::Location l(mesh.getID(), MeshLib::MeshItemType::Node, n);
         global_idcs.push_back(dof_table.getGlobalIndices(l));
@@ -50,7 +50,7 @@ GlobalSparsityPattern computeSparsityPatternNonPETSc(
     GlobalSparsityPattern sparsity_pattern(dof_table.dofSizeWithGhosts());
 
     // Map adjacent mesh nodes to "adjacent global indices".
-    for (std::size_t n = 0; n < mesh.getNNodes(); ++n)
+    for (std::size_t n = 0; n < mesh.getNumberOfNodes(); ++n)
     {
         auto const& node_ids = node_adjacency_table.getAdjacentNodes(n);
         for (auto an : node_ids)

--- a/NumLib/DOF/LocalToGlobalIndexMap.cpp
+++ b/NumLib/DOF/LocalToGlobalIndexMap.cpp
@@ -26,7 +26,7 @@ LocalToGlobalIndexMap::findGlobalIndices(
     std::size_t elem_id = 0;
     for (ElementIterator e = first; e != last; ++e, ++elem_id)
     {
-        std::size_t const nnodes = (*e)->getNNodes();
+        std::size_t const nnodes = (*e)->getNumberOfNodes();
 
         LineIndex indices;
         indices.reserve(nnodes);

--- a/NumLib/DOF/MeshComponentMap.cpp
+++ b/NumLib/DOF/MeshComponentMap.cpp
@@ -47,7 +47,7 @@ MeshComponentMap::MeshComponentMap(
             const MeshLib::NodePartitionedMesh& mesh =
                 static_cast<const MeshLib::NodePartitionedMesh&>(
                     mesh_subset.getMesh());
-            num_unknowns += mesh.getNGlobalNodes();
+            num_unknowns += mesh.getNumberOfGlobalNodes();
         }
     }
 
@@ -72,7 +72,7 @@ MeshComponentMap::MeshComponentMap(
                     mesh_subset.getMesh());
 
             // mesh items are ordered first by node, cell, ....
-            for (std::size_t j = 0; j < mesh_subset.getNNodes(); j++)
+            for (std::size_t j = 0; j < mesh_subset.getNumberOfNodes(); j++)
             {
                 GlobalIndexType global_id = 0;
                 if (order == ComponentOrder::BY_LOCATION)
@@ -107,12 +107,12 @@ MeshComponentMap::MeshComponentMap(
             // Note: If the cells are really used (e.g. for the mixed FEM),
             // the following global cell index must be reconsidered
             // according to the employed cell indexing method.
-            for (std::size_t j = 0; j < mesh_subset.getNElements(); j++)
+            for (std::size_t j = 0; j < mesh_subset.getNumberOfElements(); j++)
                 _dict.insert(
                     Line(Location(mesh_id, MeshLib::MeshItemType::Cell, j),
                          comp_id, cell_index++));
 
-            _num_global_dof += mesh.getNGlobalNodes();
+            _num_global_dof += mesh.getNumberOfGlobalNodes();
         }
         comp_id++;
     }
@@ -134,9 +134,9 @@ MeshComponentMap::MeshComponentMap(
             MeshLib::MeshSubset const& mesh_subset = c->getMeshSubset(mesh_subset_index);
             std::size_t const mesh_id = mesh_subset.getMeshID();
             // mesh items are ordered first by node, cell, ....
-            for (std::size_t j=0; j<mesh_subset.getNNodes(); j++)
+            for (std::size_t j=0; j<mesh_subset.getNumberOfNodes(); j++)
                 _dict.insert(Line(Location(mesh_id, MeshLib::MeshItemType::Node, mesh_subset.getNodeID(j)), comp_id, global_index++));
-            for (std::size_t j=0; j<mesh_subset.getNElements(); j++)
+            for (std::size_t j=0; j<mesh_subset.getNumberOfElements(); j++)
                 _dict.insert(Line(Location(mesh_id, MeshLib::MeshItemType::Cell, mesh_subset.getElementID(j)), comp_id, global_index++));
         }
         comp_id++;
@@ -161,12 +161,12 @@ MeshComponentMap MeshComponentMap::getSubset(
         std::size_t const mesh_id = mesh_subset->getMeshID();
         // Lookup the locations in the current mesh component map and
         // insert the full lines into the subset dictionary.
-        for (std::size_t j = 0; j < mesh_subset->getNNodes(); j++)
+        for (std::size_t j = 0; j < mesh_subset->getNumberOfNodes(); j++)
             subset_dict.insert(
                 getLine(Location(mesh_id, MeshLib::MeshItemType::Node,
                                  mesh_subset->getNodeID(j)),
                         component_id));
-        for (std::size_t j = 0; j < mesh_subset->getNElements(); j++)
+        for (std::size_t j = 0; j < mesh_subset->getNumberOfElements(); j++)
             subset_dict.insert(
                 getLine(Location(mesh_id, MeshLib::MeshItemType::Cell,
                                  mesh_subset->getElementID(j)),

--- a/NumLib/Fem/Integration/IntegrationGaussPrism.h
+++ b/NumLib/Fem/Integration/IntegrationGaussPrism.h
@@ -39,14 +39,14 @@ public:
     void setIntegrationOrder(std::size_t /*order*/)
     {
         _order = 2; // fixed
-        _n_sampl_pt = getNPoints(_order);
+        _n_sampl_pt = getNumberOfPoints(_order);
     }
 
     /// return current integration order.
     std::size_t getIntegrationOrder() const {return _order;}
 
     /// return the number of sampling points
-    std::size_t getNPoints() const {return _n_sampl_pt;}
+    std::size_t getNumberOfPoints() const {return _n_sampl_pt;}
 
     /**
      * get coordinates of a integration point
@@ -94,7 +94,7 @@ public:
      * @return the number of points
      */
     static std::size_t
-    getNPoints(std::size_t order)
+    getNumberOfPoints(std::size_t order)
     {
         if (order==2) return 6;
         return 0;

--- a/NumLib/Fem/Integration/IntegrationGaussPyramid.h
+++ b/NumLib/Fem/Integration/IntegrationGaussPyramid.h
@@ -38,14 +38,14 @@ public:
     void setIntegrationOrder(std::size_t order)
     {
         _order = order;
-        _n_sampl_pt = getNPoints(_order);
+        _n_sampl_pt = getNumberOfPoints(_order);
     }
 
     /// return current integration order.
     std::size_t getIntegrationOrder() const {return _order;}
 
     /// return the number of sampling points
-    std::size_t getNPoints() const {return _n_sampl_pt;}
+    std::size_t getNumberOfPoints() const {return _n_sampl_pt;}
 
     /**
      * get coordinates of a integration point
@@ -92,7 +92,7 @@ public:
      * @return the number of points
      */
     static std::size_t
-    getNPoints(std::size_t order)
+    getNumberOfPoints(std::size_t order)
     {
         switch (order)
         {

--- a/NumLib/Fem/Integration/IntegrationGaussRegular.h
+++ b/NumLib/Fem/Integration/IntegrationGaussRegular.h
@@ -53,7 +53,7 @@ public:
     std::size_t getIntegrationOrder() const {return _order;}
 
     /// return the number of sampling points
-    std::size_t getNPoints() const {return _n_sampl_pt;}
+    std::size_t getNumberOfPoints() const {return _n_sampl_pt;}
 
     /// Get coordinates of the integration point.
     ///

--- a/NumLib/Fem/Integration/IntegrationGaussTet.h
+++ b/NumLib/Fem/Integration/IntegrationGaussTet.h
@@ -38,14 +38,14 @@ public:
     void setIntegrationOrder(std::size_t order)
     {
         _order = order;
-        _n_sampl_pt = getNPoints(order);
+        _n_sampl_pt = getNumberOfPoints(order);
     }
 
     /// return current integration order.
     std::size_t getIntegrationOrder() const {return _order;}
 
     /// return the number of sampling points
-    std::size_t getNPoints() const {return _n_sampl_pt;}
+    std::size_t getNumberOfPoints() const {return _n_sampl_pt;}
 
     /**
      * get coordinates of a integration point
@@ -92,7 +92,7 @@ public:
      * @return the number of points
      */
     static std::size_t
-    getNPoints(std::size_t order)
+    getNumberOfPoints(std::size_t order)
     {
         switch (order)
         {

--- a/NumLib/Fem/Integration/IntegrationGaussTri.h
+++ b/NumLib/Fem/Integration/IntegrationGaussTri.h
@@ -54,14 +54,14 @@ public:
     void setIntegrationOrder(std::size_t order)
     {
         _order = order;
-        _n_sampl_pt = getNPoints(order);
+        _n_sampl_pt = getNumberOfPoints(order);
     }
 
     /// return current integration order.
     std::size_t getIntegrationOrder() const {return _order;}
 
     /// return the number of sampling points
-    std::size_t getNPoints() const {return _n_sampl_pt;}
+    std::size_t getNumberOfPoints() const {return _n_sampl_pt;}
 
     /**
      * get coordinates of a integration point
@@ -108,7 +108,7 @@ public:
      * @return the number of points
      */
     static std::size_t
-    getNPoints(std::size_t order)
+    getNumberOfPoints(std::size_t order)
     {
         switch (order)
         {

--- a/NumLib/Fem/Integration/IntegrationPoint.h
+++ b/NumLib/Fem/Integration/IntegrationPoint.h
@@ -38,7 +38,7 @@ public:
     }
 
     /// Return the number of sampling points.
-    std::size_t getNPoints() const
+    std::size_t getNumberOfPoints() const
     {
         return 1;
     }
@@ -73,7 +73,7 @@ public:
     ///
     /// \param order    the number of integration points
     /// \return the number of points.
-    static std::size_t getNPoints(std::size_t /* order */)
+    static std::size_t getNumberOfPoints(std::size_t /* order */)
     {
         return 1;
     }

--- a/NumLib/ODESolver/NonlinearSolver-impl.h
+++ b/NumLib/ODESolver/NonlinearSolver-impl.h
@@ -263,11 +263,11 @@ createNonlinearSolver(MathLib::LinearSolver<Matrix, Vector>& linear_solver,
     using AbstractNLS = NonlinearSolverBase<Matrix, Vector>;
 
     //! \ogs_file_param{prj__nonlinear_solvers__nonlinear_solver__type}
-    auto const type      = config.getConfParam<std::string>("type");
+    auto const type      = config.getParameter<std::string>("type");
     //! \ogs_file_param{prj__nonlinear_solvers__nonlinear_solver__tol}
-    auto const tol       = config.getConfParam<double>("tol");
+    auto const tol       = config.getParameter<double>("tol");
     //! \ogs_file_param{prj__nonlinear_solvers__nonlinear_solver__max_iter}
-    auto const max_iter  = config.getConfParam<unsigned>("max_iter");
+    auto const max_iter  = config.getParameter<unsigned>("max_iter");
 
     if (type == "Picard")
     {

--- a/NumLib/ODESolver/NonlinearSolver-impl.h
+++ b/NumLib/ODESolver/NonlinearSolver-impl.h
@@ -263,11 +263,11 @@ createNonlinearSolver(MathLib::LinearSolver<Matrix, Vector>& linear_solver,
     using AbstractNLS = NonlinearSolverBase<Matrix, Vector>;
 
     //! \ogs_file_param{prj__nonlinear_solvers__nonlinear_solver__type}
-    auto const type      = config.getParameter<std::string>("type");
+    auto const type      = config.getConfigParameter<std::string>("type");
     //! \ogs_file_param{prj__nonlinear_solvers__nonlinear_solver__tol}
-    auto const tol       = config.getParameter<double>("tol");
+    auto const tol       = config.getConfigParameter<double>("tol");
     //! \ogs_file_param{prj__nonlinear_solvers__nonlinear_solver__max_iter}
-    auto const max_iter  = config.getParameter<unsigned>("max_iter");
+    auto const max_iter  = config.getConfigParameter<unsigned>("max_iter");
 
     if (type == "Picard")
     {

--- a/NumLib/ODESolver/TimeDiscretizationBuilder.h
+++ b/NumLib/ODESolver/TimeDiscretizationBuilder.h
@@ -25,7 +25,7 @@ createTimeDiscretization(BaseLib::ConfigTree const& config)
     using T = std::unique_ptr<TimeDiscretization<Vector> >;
 
     //! \ogs_file_param{process__time_discretization__type}
-    auto const type = config.getConfParam<std::string>("type");
+    auto const type = config.getParameter<std::string>("type");
 
     if (type == "BackwardEuler") {
         using ConcreteTD = BackwardEuler<Vector>;
@@ -35,12 +35,12 @@ createTimeDiscretization(BaseLib::ConfigTree const& config)
         return T(new ConcreteTD);
     } else if (type == "CrankNicolson") {
         //! \ogs_file_param{process__time_discretization__CrankNicolson__theta}
-        auto const theta = config.getConfParam<double>("theta");
+        auto const theta = config.getParameter<double>("theta");
         using ConcreteTD = CrankNicolson<Vector>;
         return T(new ConcreteTD(theta));
     } else if (type == "BackwardDifferentiationFormula") {
         //! \ogs_file_param{process__time_discretization__BackwardDifferentiationFormula__order}
-        auto const order = config.getConfParam<unsigned>("order");
+        auto const order = config.getParameter<unsigned>("order");
         using ConcreteTD = BackwardDifferentiationFormula<Vector>;
         return T(new ConcreteTD(order));
     } else {

--- a/NumLib/ODESolver/TimeDiscretizationBuilder.h
+++ b/NumLib/ODESolver/TimeDiscretizationBuilder.h
@@ -25,7 +25,7 @@ createTimeDiscretization(BaseLib::ConfigTree const& config)
     using T = std::unique_ptr<TimeDiscretization<Vector> >;
 
     //! \ogs_file_param{process__time_discretization__type}
-    auto const type = config.getParameter<std::string>("type");
+    auto const type = config.getConfigParameter<std::string>("type");
 
     if (type == "BackwardEuler") {
         using ConcreteTD = BackwardEuler<Vector>;
@@ -35,12 +35,12 @@ createTimeDiscretization(BaseLib::ConfigTree const& config)
         return T(new ConcreteTD);
     } else if (type == "CrankNicolson") {
         //! \ogs_file_param{process__time_discretization__CrankNicolson__theta}
-        auto const theta = config.getParameter<double>("theta");
+        auto const theta = config.getConfigParameter<double>("theta");
         using ConcreteTD = CrankNicolson<Vector>;
         return T(new ConcreteTD(theta));
     } else if (type == "BackwardDifferentiationFormula") {
         //! \ogs_file_param{process__time_discretization__BackwardDifferentiationFormula__order}
-        auto const order = config.getParameter<unsigned>("order");
+        auto const order = config.getConfigParameter<unsigned>("order");
         using ConcreteTD = BackwardDifferentiationFormula<Vector>;
         return T(new ConcreteTD(order));
     } else {

--- a/NumLib/TimeStepping/Algorithms/FixedTimeStepping.cpp
+++ b/NumLib/TimeStepping/Algorithms/FixedTimeStepping.cpp
@@ -36,14 +36,14 @@ std::unique_ptr<ITimeStepAlgorithm>
 FixedTimeStepping::newInstance(BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{prj__time_stepping__type}
-    config.checkConfParam("type", "FixedTimeStepping");
+    config.checkParameter("type", "FixedTimeStepping");
 
     //! \ogs_file_param{prj__time_stepping__FixedTimeStepping__t_initial}
-    auto const t_initial = config.getConfParam<double>("t_initial");
+    auto const t_initial = config.getParameter<double>("t_initial");
     //! \ogs_file_param{prj__time_stepping__FixedTimeStepping__t_end}
-    auto const t_end     = config.getConfParam<double>("t_end");
+    auto const t_end     = config.getParameter<double>("t_end");
     //! \ogs_file_param{prj__time_stepping__FixedTimeStepping__timesteps}
-    auto const delta_ts  = config.getConfSubtree("timesteps");
+    auto const delta_ts  = config.getSubtree("timesteps");
 
     std::vector<double> timesteps;
     double t_curr = t_initial;
@@ -51,7 +51,7 @@ FixedTimeStepping::newInstance(BaseLib::ConfigTree const& config)
 
     // TODO: consider adding call "listNonEmpty" to config tree
     //! \ogs_file_param{prj__time_stepping__FixedTimeStepping__timesteps__pair}
-    auto const range = delta_ts.getConfSubtreeList("pair");
+    auto const range = delta_ts.getSubtreeList("pair");
     if (range.begin() == range.end()) {
         ERR("no timesteps have been given");
         std::abort();
@@ -59,9 +59,9 @@ FixedTimeStepping::newInstance(BaseLib::ConfigTree const& config)
     for (auto const pair : range)
     {
         //! \ogs_file_param{prj__time_stepping__FixedTimeStepping__timesteps__pair__repeat}
-        auto const repeat = pair.getConfParam<std::size_t>("repeat");
+        auto const repeat = pair.getParameter<std::size_t>("repeat");
         //! \ogs_file_param{prj__time_stepping__FixedTimeStepping__timesteps__pair__delta_t}
-        delta_t           = pair.getConfParam<double>("delta_t");
+        delta_t           = pair.getParameter<double>("delta_t");
 
         if (repeat == 0) {
             ERR("<repeat> is zero.");

--- a/NumLib/TimeStepping/Algorithms/FixedTimeStepping.cpp
+++ b/NumLib/TimeStepping/Algorithms/FixedTimeStepping.cpp
@@ -36,14 +36,14 @@ std::unique_ptr<ITimeStepAlgorithm>
 FixedTimeStepping::newInstance(BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{prj__time_stepping__type}
-    config.checkParameter("type", "FixedTimeStepping");
+    config.checkConfigParameter("type", "FixedTimeStepping");
 
     //! \ogs_file_param{prj__time_stepping__FixedTimeStepping__t_initial}
-    auto const t_initial = config.getParameter<double>("t_initial");
+    auto const t_initial = config.getConfigParameter<double>("t_initial");
     //! \ogs_file_param{prj__time_stepping__FixedTimeStepping__t_end}
-    auto const t_end     = config.getParameter<double>("t_end");
+    auto const t_end     = config.getConfigParameter<double>("t_end");
     //! \ogs_file_param{prj__time_stepping__FixedTimeStepping__timesteps}
-    auto const delta_ts  = config.getSubtree("timesteps");
+    auto const delta_ts  = config.getConfigSubtree("timesteps");
 
     std::vector<double> timesteps;
     double t_curr = t_initial;
@@ -51,7 +51,7 @@ FixedTimeStepping::newInstance(BaseLib::ConfigTree const& config)
 
     // TODO: consider adding call "listNonEmpty" to config tree
     //! \ogs_file_param{prj__time_stepping__FixedTimeStepping__timesteps__pair}
-    auto const range = delta_ts.getSubtreeList("pair");
+    auto const range = delta_ts.getConfigSubtreeList("pair");
     if (range.begin() == range.end()) {
         ERR("no timesteps have been given");
         std::abort();
@@ -59,9 +59,9 @@ FixedTimeStepping::newInstance(BaseLib::ConfigTree const& config)
     for (auto const pair : range)
     {
         //! \ogs_file_param{prj__time_stepping__FixedTimeStepping__timesteps__pair__repeat}
-        auto const repeat = pair.getParameter<std::size_t>("repeat");
+        auto const repeat = pair.getConfigParameter<std::size_t>("repeat");
         //! \ogs_file_param{prj__time_stepping__FixedTimeStepping__timesteps__pair__delta_t}
-        delta_t           = pair.getParameter<double>("delta_t");
+        delta_t           = pair.getConfigParameter<double>("delta_t");
 
         if (repeat == 0) {
             ERR("<repeat> is zero.");

--- a/NumLib/TimeStepping/Algorithms/IterationNumberBasedAdaptiveTimeStepping.h
+++ b/NumLib/TimeStepping/Algorithms/IterationNumberBasedAdaptiveTimeStepping.h
@@ -107,7 +107,7 @@ public:
     void setNIterations(std::size_t n_itr) {this->_iter_times = n_itr;}
 
     /// return the number of repeated steps
-    std::size_t getNRepeatedSteps() const {return this->_n_rejected_steps;}
+    std::size_t getNumberOfRepeatedSteps() const {return this->_n_rejected_steps;}
 
 private:
     /// calculate the next time step size

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -83,7 +83,7 @@ public:
         _localRhs.setZero();
 
         IntegrationMethod integration_method(_integration_order);
-        unsigned const n_integration_points = integration_method.getNPoints();
+        unsigned const n_integration_points = integration_method.getNumberOfPoints();
 
         for (std::size_t ip(0); ip < n_integration_points; ip++)
         {

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -155,7 +155,7 @@ createGroundwaterFlowProcess(
     BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{process__type}
-    config.checkParameter("type", "GROUNDWATER_FLOW");
+    config.checkConfigParameter("type", "GROUNDWATER_FLOW");
 
     DBUG("Create GroundwaterFlowProcess.");
 
@@ -182,7 +182,7 @@ createGroundwaterFlowProcess(
 
     SecondaryVariableCollection<typename GlobalSetup::VectorType> secondary_variables {
         //! \ogs_file_param{process__secondary_variables}
-        config.getSubtreeOptional("secondary_variables"),
+        config.getConfigSubtreeOptional("secondary_variables"),
         {
             //! \ogs_file_param_special{process__GROUNDWATER_FLOW__secondary_variables__darcy_velocity_x}
             "darcy_velocity_x",
@@ -195,7 +195,7 @@ createGroundwaterFlowProcess(
 
     ProcessOutput<typename GlobalSetup::VectorType>
         //! \ogs_file_param{process__output}
-        process_output{config.getSubtree("output"),
+        process_output{config.getConfigSubtree("output"),
                 process_variables, secondary_variables};
 
     return std::unique_ptr<GroundwaterFlowProcess<GlobalSetup>>{

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -155,7 +155,7 @@ createGroundwaterFlowProcess(
     BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{process__type}
-    config.checkConfParam("type", "GROUNDWATER_FLOW");
+    config.checkParameter("type", "GROUNDWATER_FLOW");
 
     DBUG("Create GroundwaterFlowProcess.");
 
@@ -182,7 +182,7 @@ createGroundwaterFlowProcess(
 
     SecondaryVariableCollection<typename GlobalSetup::VectorType> secondary_variables {
         //! \ogs_file_param{process__secondary_variables}
-        config.getConfSubtreeOptional("secondary_variables"),
+        config.getSubtreeOptional("secondary_variables"),
         {
             //! \ogs_file_param_special{process__GROUNDWATER_FLOW__secondary_variables__darcy_velocity_x}
             "darcy_velocity_x",
@@ -195,7 +195,7 @@ createGroundwaterFlowProcess(
 
     ProcessOutput<typename GlobalSetup::VectorType>
         //! \ogs_file_param{process__output}
-        process_output{config.getConfSubtree("output"),
+        process_output{config.getSubtree("output"),
                 process_variables, secondary_variables};
 
     return std::unique_ptr<GroundwaterFlowProcess<GlobalSetup>>{

--- a/ProcessLib/InitialCondition.cpp
+++ b/ProcessLib/InitialCondition.cpp
@@ -24,10 +24,10 @@ std::unique_ptr<InitialCondition> createUniformInitialCondition(
     BaseLib::ConfigTree const& config, int const /*n_components*/)
 {
     //! \ogs_file_param{initial_condition__type}
-    config.checkConfParam("type", "Uniform");
+    config.checkParameter("type", "Uniform");
 
     //! \ogs_file_param{initial_condition__Uniform__value}
-    auto value = config.getConfParam<double>("value");
+    auto value = config.getParameter<double>("value");
     DBUG("Using value %g", value);
 
     return std::unique_ptr<InitialCondition>(
@@ -40,10 +40,10 @@ std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
     int const n_components)
 {
     //! \ogs_file_param{initial_condition__type}
-    config.checkConfParam("type", "MeshProperty");
+    config.checkParameter("type", "MeshProperty");
 
     //! \ogs_file_param{initial_condition__MeshProperty__field_name}
-    auto field_name = config.getConfParam<std::string>("field_name");
+    auto field_name = config.getParameter<std::string>("field_name");
     DBUG("Using field_name %s", field_name.c_str());
 
     if (!mesh.getProperties().hasPropertyVector(field_name))

--- a/ProcessLib/InitialCondition.cpp
+++ b/ProcessLib/InitialCondition.cpp
@@ -24,10 +24,10 @@ std::unique_ptr<InitialCondition> createUniformInitialCondition(
     BaseLib::ConfigTree const& config, int const /*n_components*/)
 {
     //! \ogs_file_param{initial_condition__type}
-    config.checkParameter("type", "Uniform");
+    config.checkConfigParameter("type", "Uniform");
 
     //! \ogs_file_param{initial_condition__Uniform__value}
-    auto value = config.getParameter<double>("value");
+    auto value = config.getConfigParameter<double>("value");
     DBUG("Using value %g", value);
 
     return std::unique_ptr<InitialCondition>(
@@ -40,10 +40,10 @@ std::unique_ptr<InitialCondition> createMeshPropertyInitialCondition(
     int const n_components)
 {
     //! \ogs_file_param{initial_condition__type}
-    config.checkParameter("type", "MeshProperty");
+    config.checkConfigParameter("type", "MeshProperty");
 
     //! \ogs_file_param{initial_condition__MeshProperty__field_name}
-    auto field_name = config.getParameter<std::string>("field_name");
+    auto field_name = config.getConfigParameter<std::string>("field_name");
     DBUG("Using field_name %s", field_name.c_str());
 
     if (!mesh.getProperties().hasPropertyVector(field_name))

--- a/ProcessLib/NeumannBcAssembler.h
+++ b/ProcessLib/NeumannBcAssembler.h
@@ -61,7 +61,7 @@ public:
 
         _integration_order = integration_order;
         IntegrationMethod_ integration_method(_integration_order);
-        std::size_t const n_integration_points = integration_method.getNPoints();
+        std::size_t const n_integration_points = integration_method.getNumberOfPoints();
 
         _shape_matrices.reserve(n_integration_points);
         for (std::size_t ip(0); ip < n_integration_points; ip++) {
@@ -85,7 +85,7 @@ public:
         _localRhs->setZero();
 
         IntegrationMethod_ integration_method(_integration_order);
-        std::size_t const n_integration_points = integration_method.getNPoints();
+        std::size_t const n_integration_points = integration_method.getNumberOfPoints();
 
         for (std::size_t ip(0); ip < n_integration_points; ip++) {
             auto const& sm = _shape_matrices[ip];

--- a/ProcessLib/NeumannBcConfig.h
+++ b/ProcessLib/NeumannBcConfig.h
@@ -49,10 +49,10 @@ public:
     {
         DBUG("Constructing NeumannBcConfig from config.");
         //! \ogs_file_param{boundary_condition__type}
-        config.checkConfParam("type", "UniformNeumann");
+        config.checkParameter("type", "UniformNeumann");
 
         //! \ogs_file_param{boundary_condition__UniformNeumann__value}
-        double const value = config.getConfParam<double>("value");
+        double const value = config.getParameter<double>("value");
         DBUG("Using value %g", value);
 
         _function = new MathLib::ConstantFunction<double>(value);

--- a/ProcessLib/NeumannBcConfig.h
+++ b/ProcessLib/NeumannBcConfig.h
@@ -49,10 +49,10 @@ public:
     {
         DBUG("Constructing NeumannBcConfig from config.");
         //! \ogs_file_param{boundary_condition__type}
-        config.checkParameter("type", "UniformNeumann");
+        config.checkConfigParameter("type", "UniformNeumann");
 
         //! \ogs_file_param{boundary_condition__UniformNeumann__value}
-        double const value = config.getParameter<double>("value");
+        double const value = config.getConfigParameter<double>("value");
         DBUG("Using value %g", value);
 
         _function = new MathLib::ConstantFunction<double>(value);

--- a/ProcessLib/Output.cpp
+++ b/ProcessLib/Output.cpp
@@ -84,7 +84,7 @@ newInstance(const BaseLib::ConfigTree &config, std::string const& output_directo
 
 template<typename GlobalSetup>
 void Output<GlobalSetup>::
-init(typename Output<GlobalSetup>::ProcessIter first,
+initialize(typename Output<GlobalSetup>::ProcessIter first,
      typename Output<GlobalSetup>::ProcessIter last)
 {
     for (unsigned pcs_idx = 0; first != last; ++first, ++pcs_idx)

--- a/ProcessLib/Output.cpp
+++ b/ProcessLib/Output.cpp
@@ -51,18 +51,18 @@ newInstance(const BaseLib::ConfigTree &config, std::string const& output_directo
     std::unique_ptr<Output> out{ new Output{
         BaseLib::joinPaths(output_directory,
             //! \ogs_file_param{prj__output__prefix}
-            config.getConfParam<std::string>("prefix"))}};
+            config.getParameter<std::string>("prefix"))}};
 
     //! \ogs_file_param{prj__output__timesteps}
-    if (auto const timesteps = config.getConfSubtreeOptional("timesteps"))
+    if (auto const timesteps = config.getSubtreeOptional("timesteps"))
     {
         //! \ogs_file_param{prj__output__timesteps__pair}
-        for (auto pair : timesteps->getConfSubtreeList("pair"))
+        for (auto pair : timesteps->getSubtreeList("pair"))
         {
             //! \ogs_file_param{prj__output__timesteps__pair__repeat}
-            auto repeat     = pair.getConfParam<unsigned>("repeat");
+            auto repeat     = pair.getParameter<unsigned>("repeat");
             //! \ogs_file_param{prj__output__timesteps__pair__each_steps}
-            auto each_steps = pair.getConfParam<unsigned>("each_steps");
+            auto each_steps = pair.getParameter<unsigned>("each_steps");
 
             assert(repeat != 0 && each_steps != 0);
             out->_repeats_each_steps.emplace_back(repeat, each_steps);

--- a/ProcessLib/Output.cpp
+++ b/ProcessLib/Output.cpp
@@ -51,18 +51,18 @@ newInstance(const BaseLib::ConfigTree &config, std::string const& output_directo
     std::unique_ptr<Output> out{ new Output{
         BaseLib::joinPaths(output_directory,
             //! \ogs_file_param{prj__output__prefix}
-            config.getParameter<std::string>("prefix"))}};
+            config.getConfigParameter<std::string>("prefix"))}};
 
     //! \ogs_file_param{prj__output__timesteps}
-    if (auto const timesteps = config.getSubtreeOptional("timesteps"))
+    if (auto const timesteps = config.getConfigSubtreeOptional("timesteps"))
     {
         //! \ogs_file_param{prj__output__timesteps__pair}
-        for (auto pair : timesteps->getSubtreeList("pair"))
+        for (auto pair : timesteps->getConfigSubtreeList("pair"))
         {
             //! \ogs_file_param{prj__output__timesteps__pair__repeat}
-            auto repeat     = pair.getParameter<unsigned>("repeat");
+            auto repeat     = pair.getConfigParameter<unsigned>("repeat");
             //! \ogs_file_param{prj__output__timesteps__pair__each_steps}
-            auto each_steps = pair.getParameter<unsigned>("each_steps");
+            auto each_steps = pair.getConfigParameter<unsigned>("each_steps");
 
             assert(repeat != 0 && each_steps != 0);
             out->_repeats_each_steps.emplace_back(repeat, each_steps);

--- a/ProcessLib/Output.h
+++ b/ProcessLib/Output.h
@@ -34,7 +34,7 @@ public:
                         ::const_iterator;
 
     //! Opens a PVD file for each process.
-    void init(ProcessIter first, ProcessIter last);
+    void initialize(ProcessIter first, ProcessIter last);
 
     //! Writes output for the given \c process if it should be written in the
     //! given \c timestep.

--- a/ProcessLib/Parameter.cpp
+++ b/ProcessLib/Parameter.cpp
@@ -20,9 +20,9 @@ std::unique_ptr<ParameterBase> createConstParameter(
     BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{parameter__type}
-    config.checkParameter("type", "Constant");
+    config.checkConfigParameter("type", "Constant");
     //! \ogs_file_param{parameter__Constant__value}
-    auto value = config.getParameter<double>("value");
+    auto value = config.getConfigParameter<double>("value");
     DBUG("Using value %g", value);
 
     return std::unique_ptr<ParameterBase>(new ConstParameter<double>(value));
@@ -32,9 +32,9 @@ std::unique_ptr<ParameterBase> createMeshPropertyParameter(
     BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh)
 {
     //! \ogs_file_param{parameter__type}
-    config.checkParameter("type", "MeshProperty");
+    config.checkConfigParameter("type", "MeshProperty");
     //! \ogs_file_param{parameter__MeshProperty__field_name}
-    auto field_name = config.getParameter<std::string>("field_name");
+    auto field_name = config.getConfigParameter<std::string>("field_name");
     DBUG("Using field_name %s", field_name.c_str());
 
     if (!mesh.getProperties().hasPropertyVector(field_name))

--- a/ProcessLib/Parameter.cpp
+++ b/ProcessLib/Parameter.cpp
@@ -20,9 +20,9 @@ std::unique_ptr<ParameterBase> createConstParameter(
     BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{parameter__type}
-    config.checkConfParam("type", "Constant");
+    config.checkParameter("type", "Constant");
     //! \ogs_file_param{parameter__Constant__value}
-    auto value = config.getConfParam<double>("value");
+    auto value = config.getParameter<double>("value");
     DBUG("Using value %g", value);
 
     return std::unique_ptr<ParameterBase>(new ConstParameter<double>(value));
@@ -32,9 +32,9 @@ std::unique_ptr<ParameterBase> createMeshPropertyParameter(
     BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh)
 {
     //! \ogs_file_param{parameter__type}
-    config.checkConfParam("type", "MeshProperty");
+    config.checkParameter("type", "MeshProperty");
     //! \ogs_file_param{parameter__MeshProperty__field_name}
-    auto field_name = config.getConfParam<std::string>("field_name");
+    auto field_name = config.getParameter<std::string>("field_name");
     DBUG("Using field_name %s", field_name.c_str());
 
     if (!mesh.getProperties().hasPropertyVector(field_name))

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -17,7 +17,7 @@ ProcessVariable& findProcessVariable(
 {
     // Find process variable name in process config.
     //! \ogs_file_special
-    std::string const name = pv_config.getConfParam<std::string>(tag);
+    std::string const name = pv_config.getParameter<std::string>(tag);
 
         // Find corresponding variable by name.
     auto variable = std::find_if(variables.cbegin(), variables.cend(),
@@ -51,7 +51,7 @@ findProcessVariables(
     vars.reserve(tag_names.size());
 
     //! \ogs_file_param{process__process_variables}
-    auto const pv_conf = process_config.getConfSubtree("process_variables");
+    auto const pv_conf = process_config.getSubtree("process_variables");
 
     for (auto const& tag : tag_names) {
         vars.emplace_back(findProcessVariable(variables, pv_conf, tag));

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -17,7 +17,7 @@ ProcessVariable& findProcessVariable(
 {
     // Find process variable name in process config.
     //! \ogs_file_special
-    std::string const name = pv_config.getParameter<std::string>(tag);
+    std::string const name = pv_config.getConfigParameter<std::string>(tag);
 
         // Find corresponding variable by name.
     auto variable = std::find_if(variables.cbegin(), variables.cend(),
@@ -51,7 +51,7 @@ findProcessVariables(
     vars.reserve(tag_names.size());
 
     //! \ogs_file_param{process__process_variables}
-    auto const pv_conf = process_config.getSubtree("process_variables");
+    auto const pv_conf = process_config.getConfigSubtree("process_variables");
 
     for (auto const& tag : tag_names) {
         vars.emplace_back(findProcessVariable(variables, pv_conf, tag));

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -373,7 +373,7 @@ Parameter<ParameterArgs...>& findParameter(
 {
     // Find parameter name in process config.
     //! \ogs_file_special
-    auto const name = process_config.getConfParam<std::string>(tag);
+    auto const name = process_config.getParameter<std::string>(tag);
 
     // Find corresponding parameter by name.
     auto const parameter_it =

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -240,7 +240,7 @@ private:
                               int const component_id,
                               GlobalVector& x)
     {
-        std::size_t const n_nodes = _mesh.getNNodes();
+        std::size_t const n_nodes = _mesh.getNumberOfNodes();
         for (std::size_t node_id = 0; node_id < n_nodes; ++node_id)
         {
             MeshLib::Location const l(_mesh.getID(),

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -373,7 +373,7 @@ Parameter<ParameterArgs...>& findParameter(
 {
     // Find parameter name in process config.
     //! \ogs_file_special
-    auto const name = process_config.getParameter<std::string>(tag);
+    auto const name = process_config.getConfigParameter<std::string>(tag);
 
     // Find corresponding parameter by name.
     auto const parameter_it =

--- a/ProcessLib/ProcessOutput.h
+++ b/ProcessLib/ProcessOutput.h
@@ -28,10 +28,10 @@ struct ProcessOutput final
                   SecondaryVariableCollection<GlobalVector> const& secondary_variables)
     {
         //! \ogs_file_param{process__output__variables}
-        auto const out_vars = output_config.getSubtree("variables");
+        auto const out_vars = output_config.getConfigSubtree("variables");
 
         //! \ogs_file_param{process__output__variables__variable}
-        for (auto out_var : out_vars.getParameterList<std::string>("variable"))
+        for (auto out_var : out_vars.getConfigParameterList<std::string>("variable"))
         {
             if (output_variables.find(out_var) != output_variables.cend())
             {
@@ -59,7 +59,7 @@ struct ProcessOutput final
             output_variables.insert(out_var);
         }
 
-        if (auto out_resid = output_config.getParameterOptional<bool>(
+        if (auto out_resid = output_config.getConfigParameterOptional<bool>(
                 "output_extrapolation_residuals")) {
             output_residuals = *out_resid;
         }
@@ -67,7 +67,7 @@ struct ProcessOutput final
         // debug output
         if (auto const param =
             //! \ogs_file_param{process__output__output_iteration_results}
-            output_config.getParameterOptional<bool>("output_iteration_results"))
+            output_config.getConfigParameterOptional<bool>("output_iteration_results"))
         {
             DBUG("output_iteration_results: %s", (*param) ? "true" : "false");
 

--- a/ProcessLib/ProcessOutput.h
+++ b/ProcessLib/ProcessOutput.h
@@ -112,7 +112,7 @@ void doProcessOutput(
 
     auto const& output_variables = process_output.output_variables;
 
-    std::size_t const n_nodes = mesh.getNNodes();
+    std::size_t const n_nodes = mesh.getNumberOfNodes();
     int global_component_offset = 0;
     int global_component_offset_next = 0;
 
@@ -157,8 +157,8 @@ void doProcessOutput(
         MeshLib::Mesh const& mesh, MeshLib::MeshItemType type) -> std::size_t
     {
         switch (type) {
-        case MeshLib::MeshItemType::Cell: return mesh.getNElements();
-        case MeshLib::MeshItemType::Node: return mesh.getNNodes();
+        case MeshLib::MeshItemType::Cell: return mesh.getNumberOfElements();
+        case MeshLib::MeshItemType::Node: return mesh.getNumberOfNodes();
         default: break; // avoid compiler warning
         }
         return 0;
@@ -198,14 +198,14 @@ void doProcessOutput(
 
             auto result = get_or_create_mesh_property(
                               output_name, MeshLib::MeshItemType::Node);
-            assert(result->size() == mesh.getNNodes());
+            assert(result->size() == mesh.getNumberOfNodes());
 
             std::unique_ptr<GlobalVector> result_cache;
             auto const& nodal_values =
                     var.fcts.eval_field(x, dof_table, result_cache);
 
             // Copy result
-            for (std::size_t i = 0; i < mesh.getNNodes(); ++i)
+            for (std::size_t i = 0; i < mesh.getNumberOfNodes(); ++i)
             {
                 assert(!std::isnan(nodal_values[i]));
                 (*result)[i] = nodal_values[i];
@@ -219,14 +219,14 @@ void doProcessOutput(
 
             auto result = get_or_create_mesh_property(
                               property_name_res, MeshLib::MeshItemType::Cell);
-            assert(result->size() == mesh.getNElements());
+            assert(result->size() == mesh.getNumberOfElements());
 
             std::unique_ptr<GlobalVector> result_cache;
             auto const& residuals =
                     var.fcts.eval_residuals(x, dof_table, result_cache);
 
             // Copy result
-            for (std::size_t i = 0; i < mesh.getNElements(); ++i)
+            for (std::size_t i = 0; i < mesh.getNumberOfElements(); ++i)
             {
                 assert(!std::isnan(residuals[i]));
                 (*result)[i] = residuals[i];

--- a/ProcessLib/ProcessOutput.h
+++ b/ProcessLib/ProcessOutput.h
@@ -28,10 +28,10 @@ struct ProcessOutput final
                   SecondaryVariableCollection<GlobalVector> const& secondary_variables)
     {
         //! \ogs_file_param{process__output__variables}
-        auto const out_vars = output_config.getConfSubtree("variables");
+        auto const out_vars = output_config.getSubtree("variables");
 
         //! \ogs_file_param{process__output__variables__variable}
-        for (auto out_var : out_vars.getConfParamList<std::string>("variable"))
+        for (auto out_var : out_vars.getParameterList<std::string>("variable"))
         {
             if (output_variables.find(out_var) != output_variables.cend())
             {
@@ -59,7 +59,7 @@ struct ProcessOutput final
             output_variables.insert(out_var);
         }
 
-        if (auto out_resid = output_config.getConfParamOptional<bool>(
+        if (auto out_resid = output_config.getParameterOptional<bool>(
                 "output_extrapolation_residuals")) {
             output_residuals = *out_resid;
         }
@@ -67,7 +67,7 @@ struct ProcessOutput final
         // debug output
         if (auto const param =
             //! \ogs_file_param{process__output__output_iteration_results}
-            output_config.getConfParamOptional<bool>("output_iteration_results"))
+            output_config.getParameterOptional<bool>("output_iteration_results"))
         {
             DBUG("output_iteration_results: %s", (*param) ? "true" : "false");
 

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -133,14 +133,14 @@ MeshLib::PropertyVector<double>& ProcessVariable::getOrCreateMeshProperty()
         result =
             _mesh.getProperties().template getPropertyVector<double>(_name);
         assert(result);
-        assert(result->size() == _mesh.getNNodes() * _n_components);
+        assert(result->size() == _mesh.getNumberOfNodes() * _n_components);
     }
     else
     {
         result = _mesh.getProperties().template createNewPropertyVector<double>(
             _name, MeshLib::MeshItemType::Node);
         assert(result);
-        result->resize(_mesh.getNNodes() * _n_components);
+        result->resize(_mesh.getNumberOfNodes() * _n_components);
     }
     return *result;
 }

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -23,19 +23,19 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
                                  GeoLib::GEOObjects const& geometries)
     :
     //! \ogs_file_param{prj__process_variables__process_variable__name}
-    _name(config.getParameter<std::string>("name")),
+    _name(config.getConfigParameter<std::string>("name")),
     _mesh(mesh),
     //! \ogs_file_param{prj__process_variables__process_variable__components}
-    _n_components(config.getParameter<int>("components"))
+    _n_components(config.getConfigParameter<int>("components"))
 {
     DBUG("Constructing process variable %s", this->_name.c_str());
 
     // Initial condition
     //! \ogs_file_param{prj__process_variables__process_variable__initial_condition}
-    if (auto ic_config = config.getSubtreeOptional("initial_condition"))
+    if (auto ic_config = config.getConfigSubtreeOptional("initial_condition"))
     {
         //! \ogs_file_param{initial_condition__type}
-        auto const type = ic_config->peekParameter<std::string>("type");
+        auto const type = ic_config->peekConfigParameter<std::string>("type");
         if (type == "Uniform")
         {
             _initial_condition =
@@ -58,18 +58,18 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
 
     // Boundary conditions
     //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions}
-    if (auto bcs_config = config.getSubtreeOptional("boundary_conditions"))
+    if (auto bcs_config = config.getConfigSubtreeOptional("boundary_conditions"))
     {
         for (auto bc_config :
              //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition}
-             bcs_config->getSubtreeList("boundary_condition"))
+             bcs_config->getConfigSubtreeList("boundary_condition"))
         {
             auto const geometrical_set_name =
                     //! \ogs_file_param{boundary_condition__geometrical_set}
-                    bc_config.getParameter<std::string>("geometrical_set");
+                    bc_config.getConfigParameter<std::string>("geometrical_set");
             auto const geometry_name =
                     //! \ogs_file_param{boundary_condition__geometry}
-                    bc_config.getParameter<std::string>("geometry");
+                    bc_config.getConfigParameter<std::string>("geometry");
 
             GeoLib::GeoObject const* const geometry =
                 geometries.getGeoObject(geometrical_set_name, geometry_name);
@@ -79,7 +79,7 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
 
             // Construct type dependent boundary condition
             //! \ogs_file_param{boundary_condition__type}
-            auto const type = bc_config.peekParameter<std::string>("type");
+            auto const type = bc_config.peekConfigParameter<std::string>("type");
 
             if (type == "UniformDirichlet")
             {
@@ -102,7 +102,7 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
     }
 
     // Source Terms
-    config.ignoreParameter("source_terms");
+    config.ignoreConfigParameter("source_terms");
 }
 
 ProcessVariable::ProcessVariable(ProcessVariable&& other)

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -23,19 +23,19 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
                                  GeoLib::GEOObjects const& geometries)
     :
     //! \ogs_file_param{prj__process_variables__process_variable__name}
-    _name(config.getConfParam<std::string>("name")),
+    _name(config.getParameter<std::string>("name")),
     _mesh(mesh),
     //! \ogs_file_param{prj__process_variables__process_variable__components}
-    _n_components(config.getConfParam<int>("components"))
+    _n_components(config.getParameter<int>("components"))
 {
     DBUG("Constructing process variable %s", this->_name.c_str());
 
     // Initial condition
     //! \ogs_file_param{prj__process_variables__process_variable__initial_condition}
-    if (auto ic_config = config.getConfSubtreeOptional("initial_condition"))
+    if (auto ic_config = config.getSubtreeOptional("initial_condition"))
     {
         //! \ogs_file_param{initial_condition__type}
-        auto const type = ic_config->peekConfParam<std::string>("type");
+        auto const type = ic_config->peekParameter<std::string>("type");
         if (type == "Uniform")
         {
             _initial_condition =
@@ -58,18 +58,18 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
 
     // Boundary conditions
     //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions}
-    if (auto bcs_config = config.getConfSubtreeOptional("boundary_conditions"))
+    if (auto bcs_config = config.getSubtreeOptional("boundary_conditions"))
     {
         for (auto bc_config :
              //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition}
-             bcs_config->getConfSubtreeList("boundary_condition"))
+             bcs_config->getSubtreeList("boundary_condition"))
         {
             auto const geometrical_set_name =
                     //! \ogs_file_param{boundary_condition__geometrical_set}
-                    bc_config.getConfParam<std::string>("geometrical_set");
+                    bc_config.getParameter<std::string>("geometrical_set");
             auto const geometry_name =
                     //! \ogs_file_param{boundary_condition__geometry}
-                    bc_config.getConfParam<std::string>("geometry");
+                    bc_config.getParameter<std::string>("geometry");
 
             GeoLib::GeoObject const* const geometry =
                 geometries.getGeoObject(geometrical_set_name, geometry_name);
@@ -79,7 +79,7 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
 
             // Construct type dependent boundary condition
             //! \ogs_file_param{boundary_condition__type}
-            auto const type = bc_config.peekConfParam<std::string>("type");
+            auto const type = bc_config.peekParameter<std::string>("type");
 
             if (type == "UniformDirichlet")
             {
@@ -102,7 +102,7 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
     }
 
     // Source Terms
-    config.ignoreConfParam("source_terms");
+    config.ignoreParameter("source_terms");
 }
 
 ProcessVariable::ProcessVariable(ProcessVariable&& other)

--- a/ProcessLib/SecondaryVariable.h
+++ b/ProcessLib/SecondaryVariable.h
@@ -116,7 +116,7 @@ public:
         // read which variables are defined in the config
         for (auto const& tag_name : tag_names) {
             //! \ogs_file_special
-            if (auto var_name = config->getConfParamOptional<std::string>(tag_name))
+            if (auto var_name = config->getParameterOptional<std::string>(tag_name))
             {
                 // TODO check primary vars, too
                 BaseLib::insertIfKeyValueUniqueElseError(

--- a/ProcessLib/SecondaryVariable.h
+++ b/ProcessLib/SecondaryVariable.h
@@ -116,7 +116,7 @@ public:
         // read which variables are defined in the config
         for (auto const& tag_name : tag_names) {
             //! \ogs_file_special
-            if (auto var_name = config->getParameterOptional<std::string>(tag_name))
+            if (auto var_name = config->getConfigParameterOptional<std::string>(tag_name))
             {
                 // TODO check primary vars, too
                 BaseLib::insertIfKeyValueUniqueElseError(

--- a/ProcessLib/TES/TESLocalAssembler-impl.h
+++ b/ProcessLib/TES/TESLocalAssembler-impl.h
@@ -142,7 +142,7 @@ void TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalMatrix,
     _local_b.setZero();
 
     IntegrationMethod_ integration_method(_integration_order);
-    unsigned const n_integration_points = integration_method.getNPoints();
+    unsigned const n_integration_points = integration_method.getNumberOfPoints();
 
     _d.preEachAssemble();
 

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -103,7 +103,7 @@ TESProcess<GlobalSetup>::TESProcess(
 
         for (auto const& p : params)
         {
-            if (auto const par = config.getConfParamOptional<double>(p.first))
+            if (auto const par = config.getParameterOptional<double>(p.first))
             {
                 DBUG("setting parameter `%s' to value `%g'", p.first.c_str(),
                      *par);
@@ -121,7 +121,7 @@ TESProcess<GlobalSetup>::TESProcess(
 
         for (auto const& p : params)
         {
-            if (auto const par = config.getConfParamOptional<double>(p.first))
+            if (auto const par = config.getParameterOptional<double>(p.first))
             {
                 INFO("setting parameter `%s' to value `%g'", p.first.c_str(),
                      *par);
@@ -132,7 +132,7 @@ TESProcess<GlobalSetup>::TESProcess(
 
     // permeability
     if (auto par =
-            config.getConfParamOptional<double>("solid_hydraulic_permeability"))
+            config.getParameterOptional<double>("solid_hydraulic_permeability"))
     {
         DBUG(
             "setting parameter `solid_hydraulic_permeability' to isotropic "
@@ -145,11 +145,11 @@ TESProcess<GlobalSetup>::TESProcess(
 
     // reactive system
     _assembly_params.react_sys = Adsorption::AdsorptionReaction::newInstance(
-        config.getConfSubtree("reactive_system"));
+        config.getSubtree("reactive_system"));
 
     // debug output
     if (auto const param =
-            config.getConfParamOptional<bool>("output_element_matrices"))
+            config.getParameterOptional<bool>("output_element_matrices"))
     {
         DBUG("output_element_matrices: %s", (*param) ? "true" : "false");
 
@@ -159,7 +159,7 @@ TESProcess<GlobalSetup>::TESProcess(
     // TODO somewhere else
     /*
     if (auto const param =
-    config.getConfParamOptional<bool>("output_global_matrix"))
+    config.getParameterOptional<bool>("output_global_matrix"))
     {
         DBUG("output_global_matrix: %s", (*param) ? "true" : "false");
 

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -103,7 +103,7 @@ TESProcess<GlobalSetup>::TESProcess(
 
         for (auto const& p : params)
         {
-            if (auto const par = config.getParameterOptional<double>(p.first))
+            if (auto const par = config.getConfigParameterOptional<double>(p.first))
             {
                 DBUG("setting parameter `%s' to value `%g'", p.first.c_str(),
                      *par);
@@ -121,7 +121,7 @@ TESProcess<GlobalSetup>::TESProcess(
 
         for (auto const& p : params)
         {
-            if (auto const par = config.getParameterOptional<double>(p.first))
+            if (auto const par = config.getConfigParameterOptional<double>(p.first))
             {
                 INFO("setting parameter `%s' to value `%g'", p.first.c_str(),
                      *par);
@@ -132,7 +132,7 @@ TESProcess<GlobalSetup>::TESProcess(
 
     // permeability
     if (auto par =
-            config.getParameterOptional<double>("solid_hydraulic_permeability"))
+            config.getConfigParameterOptional<double>("solid_hydraulic_permeability"))
     {
         DBUG(
             "setting parameter `solid_hydraulic_permeability' to isotropic "
@@ -145,11 +145,11 @@ TESProcess<GlobalSetup>::TESProcess(
 
     // reactive system
     _assembly_params.react_sys = Adsorption::AdsorptionReaction::newInstance(
-        config.getSubtree("reactive_system"));
+        config.getConfigSubtree("reactive_system"));
 
     // debug output
     if (auto const param =
-            config.getParameterOptional<bool>("output_element_matrices"))
+            config.getConfigParameterOptional<bool>("output_element_matrices"))
     {
         DBUG("output_element_matrices: %s", (*param) ? "true" : "false");
 
@@ -159,7 +159,7 @@ TESProcess<GlobalSetup>::TESProcess(
     // TODO somewhere else
     /*
     if (auto const param =
-    config.getParameterOptional<bool>("output_global_matrix"))
+    config.getConfigParameterOptional<bool>("output_global_matrix"))
     {
         DBUG("output_global_matrix: %s", (*param) ? "true" : "false");
 

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -354,7 +354,7 @@ TESProcess<GlobalSetup>::computeVapourPartialPressure(
          dof_table_single.dofSizeWithoutGhosts(),
          &dof_table_single.getGhostIndices(), nullptr});
 
-    GlobalIndexType nnodes = this->_mesh.getNNodes();
+    GlobalIndexType nnodes = this->_mesh.getNumberOfNodes();
 
     for (GlobalIndexType node_id = 0; node_id < nnodes; ++node_id)
     {
@@ -388,7 +388,7 @@ TESProcess<GlobalSetup>::computeRelativeHumidity(
          dof_table_single.dofSizeWithoutGhosts(),
          &dof_table_single.getGhostIndices(), nullptr});
 
-    GlobalIndexType nnodes = this->_mesh.getNNodes();
+    GlobalIndexType nnodes = this->_mesh.getNumberOfNodes();
 
     for (GlobalIndexType node_id = 0; node_id < nnodes; ++node_id)
     {
@@ -427,7 +427,7 @@ TESProcess<GlobalSetup>::computeEquilibriumLoading(
          dof_table_single.dofSizeWithoutGhosts(),
          &dof_table_single.getGhostIndices(), nullptr});
 
-    GlobalIndexType nnodes = this->_mesh.getNNodes();
+    GlobalIndexType nnodes = this->_mesh.getNumberOfNodes();
 
     for (GlobalIndexType node_id = 0; node_id < nnodes; ++node_id)
     {

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -116,7 +116,7 @@ std::unique_ptr<TESProcess<GlobalSetup>> createTESProcess(
     std::vector<std::unique_ptr<ParameterBase>> const& /*parameters*/,
     BaseLib::ConfigTree const& config)
 {
-    config.checkConfParam("type", "TES");
+    config.checkParameter("type", "TES");
 
     DBUG("Create TESProcess.");
 
@@ -126,14 +126,14 @@ std::unique_ptr<TESProcess<GlobalSetup>> createTESProcess(
 
     SecondaryVariableCollection<typename GlobalSetup::VectorType>
         secondary_variables{
-            config.getConfSubtreeOptional("secondary_variables"),
+            config.getSubtreeOptional("secondary_variables"),
             {"solid_density", "reaction_rate", "velocity_x", "velocity_y",
              "velocity_z", "loading", "reaction_damping_factor",
              "vapour_partial_pressure", "relative_humidity",
              "equilibrium_loading"}};
 
     ProcessOutput<typename GlobalSetup::VectorType> process_output{
-        config.getConfSubtree("output"), process_variables,
+        config.getSubtree("output"), process_variables,
         secondary_variables};
 
     return std::unique_ptr<TESProcess<GlobalSetup>>{new TESProcess<GlobalSetup>{

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -116,7 +116,7 @@ std::unique_ptr<TESProcess<GlobalSetup>> createTESProcess(
     std::vector<std::unique_ptr<ParameterBase>> const& /*parameters*/,
     BaseLib::ConfigTree const& config)
 {
-    config.checkParameter("type", "TES");
+    config.checkConfigParameter("type", "TES");
 
     DBUG("Create TESProcess.");
 
@@ -126,14 +126,14 @@ std::unique_ptr<TESProcess<GlobalSetup>> createTESProcess(
 
     SecondaryVariableCollection<typename GlobalSetup::VectorType>
         secondary_variables{
-            config.getSubtreeOptional("secondary_variables"),
+            config.getConfigSubtreeOptional("secondary_variables"),
             {"solid_density", "reaction_rate", "velocity_x", "velocity_y",
              "velocity_z", "loading", "reaction_damping_factor",
              "vapour_partial_pressure", "relative_humidity",
              "equilibrium_loading"}};
 
     ProcessOutput<typename GlobalSetup::VectorType> process_output{
-        config.getSubtree("output"), process_variables,
+        config.getConfigSubtree("output"), process_variables,
         secondary_variables};
 
     return std::unique_ptr<TESProcess<GlobalSetup>>{new TESProcess<GlobalSetup>{

--- a/ProcessLib/UniformDirichletBoundaryCondition.h
+++ b/ProcessLib/UniformDirichletBoundaryCondition.h
@@ -43,10 +43,10 @@ public:
     {
         DBUG("Constructing UniformDirichletBoundaryCondition from config.");
         //! \ogs_file_param{boundary_condition__type}
-        config.checkParameter("type", "UniformDirichlet");
+        config.checkConfigParameter("type", "UniformDirichlet");
 
         //! \ogs_file_param{boundary_condition__UniformDirichlet__value}
-        _value = config.getParameter<double>("value");
+        _value = config.getConfigParameter<double>("value");
         DBUG("Using value %g", _value);
     }
 

--- a/ProcessLib/UniformDirichletBoundaryCondition.h
+++ b/ProcessLib/UniformDirichletBoundaryCondition.h
@@ -43,10 +43,10 @@ public:
     {
         DBUG("Constructing UniformDirichletBoundaryCondition from config.");
         //! \ogs_file_param{boundary_condition__type}
-        config.checkConfParam("type", "UniformDirichlet");
+        config.checkParameter("type", "UniformDirichlet");
 
         //! \ogs_file_param{boundary_condition__UniformDirichlet__value}
-        _value = config.getConfParam<double>("value");
+        _value = config.getParameter<double>("value");
         DBUG("Using value %g", _value);
     }
 

--- a/ProcessLib/Utils/InitShapeMatrices.h
+++ b/ProcessLib/Utils/InitShapeMatrices.h
@@ -32,7 +32,7 @@ initShapeMatrices(MeshLib::Element const& e, unsigned integration_order)
     FemType fe(*static_cast<const typename ShapeFunction::MeshElement*>(&e));
 
     IntegrationMethod integration_method(integration_order);
-    std::size_t const n_integration_points = integration_method.getNPoints();
+    std::size_t const n_integration_points = integration_method.getNumberOfPoints();
 
     shape_matrices.reserve(n_integration_points);
     for (std::size_t ip = 0; ip < n_integration_points; ++ip) {

--- a/SimpleTests/MatrixTests/DenseGaussEliminationChecker.cpp
+++ b/SimpleTests/MatrixTests/DenseGaussEliminationChecker.cpp
@@ -49,8 +49,8 @@ int main(int argc, char *argv[])
     in >> n_rows;
     in >> n_cols;
     MathLib::DenseMatrix<double, std::size_t> mat(n_rows, n_cols);
-    for (std::size_t i(0); i<mat.getNRows(); ++i) {
-        for (std::size_t j(0); j<mat.getNCols(); ++j) {
+    for (std::size_t i(0); i<mat.getNumberOfRows(); ++i) {
+        for (std::size_t j(0); j<mat.getNumberOfColumns(); ++j) {
             in >> mat(i,j);
         }
     }

--- a/SimpleTests/MeshTests/MPI/NodePartitionedMeshTester.cpp
+++ b/SimpleTests/MeshTests/MPI/NodePartitionedMeshTester.cpp
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
     // Output nodes
     os.setf(std::ios::scientific, std::ios::floatfield);
     std::setprecision(10);
-    const std::size_t nn = mesh->getNNodes();
+    const std::size_t nn = mesh->getNumberOfNodes();
     for(std::size_t i=0; i<nn; i++)
     {
         const double *x = mesh->getNode(i)->getCoords();
@@ -87,13 +87,13 @@ int main(int argc, char *argv[])
     os.flush();
 
     // Output elements
-    const std::size_t ne = mesh->getNElements();
+    const std::size_t ne = mesh->getNumberOfElements();
     for(std::size_t i=0; i<ne; i++)
     {
         const Element *elem = mesh->getElement(i);
         Node* const* ele_nodes = elem->getNodes();
 
-        for(unsigned j=0; j<elem->getNNodes(); j++)
+        for(unsigned j=0; j<elem->getNumberOfNodes(); j++)
         {
             os << ele_nodes[j]->getID() << " ";
         }

--- a/SimpleTests/MeshTests/MeshRead.cpp
+++ b/SimpleTests/MeshTests/MeshRead.cpp
@@ -69,8 +69,8 @@ int main(int argc, char *argv[])
 /*
     unsigned elem_id = 25000;
     const MeshLib::Element* e = mesh->getElement(elem_id);
-    const std::size_t nElems = mesh->getNElements();
-    for (unsigned i=0; i< e->getNNeighbors(); i++)
+    const std::size_t nElems = mesh->getNumberOfElements();
+    for (unsigned i=0; i< e->getNumberOfNeighbors(); i++)
     {
         for (unsigned j=0; j< nElems; j++)
             if (mesh->getElement(j) == e->getNeighbor(i))

--- a/Tests/BaseLib/TestConfigTree.cpp
+++ b/Tests/BaseLib/TestConfigTree.cpp
@@ -126,108 +126,108 @@ TEST(BaseLibConfigTree, Get)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        EXPECT_EQ(5.6e-4, conf.getParameter<double>("double")); // read certain types
+        EXPECT_EQ(5.6e-4, conf.getConfigParameter<double>("double")); // read certain types
         EXPECT_ERR_WARN(cbs, false, false);
-        EXPECT_TRUE(conf.getParameter<bool>("bool"));
+        EXPECT_TRUE(conf.getConfigParameter<bool>("bool"));
         EXPECT_ERR_WARN(cbs, false, false);
-        EXPECT_EQ(5, conf.getParameter<int>("int"));
+        EXPECT_EQ(5, conf.getConfigParameter<int>("int"));
         EXPECT_ERR_WARN(cbs, false, false);
 
-        EXPECT_EQ(8, conf.getParameter<int>("intx", 8)); // reading with default value
+        EXPECT_EQ(8, conf.getConfigParameter<int>("intx", 8)); // reading with default value
         EXPECT_ERR_WARN(cbs, false, false);
 
 
         // Testing subtree
         {
-            auto sub = conf.getSubtree("sub");
+            auto sub = conf.getConfigSubtree("sub");
             EXPECT_ERR_WARN(cbs, false, false);
 
-            EXPECT_EQ(6.1f, sub.getParameter<float>("float"));
+            EXPECT_EQ(6.1f, sub.getConfigParameter<float>("float"));
             EXPECT_ERR_WARN(cbs, false, false);
 
-            if (auto f2 = sub.getParameterOptional<float>("float2")) { // read optional value
+            if (auto f2 = sub.getConfigParameterOptional<float>("float2")) { // read optional value
                 EXPECT_EQ(0.1f, *f2);
             }
             EXPECT_ERR_WARN(cbs, false, false);
 
-            auto f3 = sub.getParameterOptional<float>("float3"); // optional value not existent
+            auto f3 = sub.getConfigParameterOptional<float>("float3"); // optional value not existent
             ASSERT_FALSE(f3);
             EXPECT_ERR_WARN(cbs, false, false);
 
 
-            // Testing the getParameter...() (non-template) / getValue() combination
+            // Testing the getConfigParameter...() (non-template) / getValue() combination
 
-            auto bool1 = sub.getSubtree("bool1");
+            auto bool1 = sub.getConfigSubtree("bool1");
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_FALSE(bool1.getValue<bool>());
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_ANY_THROW(bool1.getValue<bool>()); // getting data twice
             EXPECT_ERR_WARN(cbs, true, false);
 
-            if (auto bool2 = sub.getSubtreeOptional("bool2")) {
+            if (auto bool2 = sub.getConfigSubtreeOptional("bool2")) {
                 EXPECT_ERR_WARN(cbs, false, false);
                 EXPECT_FALSE(bool2->getValue<bool>());
             }
             EXPECT_ERR_WARN(cbs, false, false);
 
-            if (auto bool3 = sub.getSubtreeOptional("bool3")) {
+            if (auto bool3 = sub.getConfigSubtreeOptional("bool3")) {
                 EXPECT_ERR_WARN(cbs, false, false);
                 EXPECT_ANY_THROW(bool3->getValue<bool>());
                 EXPECT_ERR_WARN(cbs, true, false); // error because of no data
             }
             EXPECT_ERR_WARN(cbs, false, false);
 
-            EXPECT_FALSE(sub.getSubtreeOptional("bool4")); // optional value not existent
+            EXPECT_FALSE(sub.getConfigSubtreeOptional("bool4")); // optional value not existent
             EXPECT_ERR_WARN(cbs, false, false);
 
 
             // Testing ignore
 
-            sub.ignoreParameter("ignored");
+            sub.ignoreConfigParameter("ignored");
             EXPECT_ERR_WARN(cbs, false, false);
-            sub.ignoreParameterAll("ignored2");
+            sub.ignoreConfigParameterAll("ignored2");
             EXPECT_ERR_WARN(cbs, false, false);
-            sub.ignoreParameterAll("ignored4"); // I can ignore nonexistent stuff
+            sub.ignoreConfigParameterAll("ignored4"); // I can ignore nonexistent stuff
             EXPECT_ERR_WARN(cbs, false, false);
 
             // I can not ignore stuff that I already read
             // this also makes sure that the subtree inherits the callbacks properly
-            EXPECT_ANY_THROW(sub.ignoreParameter("float"));
+            EXPECT_ANY_THROW(sub.ignoreConfigParameter("float"));
             EXPECT_ERR_WARN(cbs, true, false);
         }
         for (int i : {0, 1, 2}) {
             (void) i;
-            EXPECT_EQ("Y", conf.peekParameter<std::string>("x"));
+            EXPECT_EQ("Y", conf.peekConfigParameter<std::string>("x"));
             EXPECT_ERR_WARN(cbs, false, false);
         }
-        conf.checkParameter<std::string>("x", "Y");
+        conf.checkConfigParameter<std::string>("x", "Y");
         EXPECT_ERR_WARN(cbs, false, false);
 
 
         // Testing attributes
         {
-            auto z = conf.getSubtree("z");
+            auto z = conf.getConfigSubtree("z");
             EXPECT_ERR_WARN(cbs, false, false);
-            EXPECT_EQ(0.5, z.getAttribute<double>("attr"));
+            EXPECT_EQ(0.5, z.getConfigAttribute<double>("attr"));
             EXPECT_ERR_WARN(cbs, false, false);
-            EXPECT_ANY_THROW(z.getAttribute<double>("attr")); // getting attribute twice
+            EXPECT_ANY_THROW(z.getConfigAttribute<double>("attr")); // getting attribute twice
             EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(z.getAttribute<double>("not_an_attr")); // nonexistent attribute
+            EXPECT_ANY_THROW(z.getConfigAttribute<double>("not_an_attr")); // nonexistent attribute
             EXPECT_ERR_WARN(cbs, true, false);
             EXPECT_EQ(32.0, z.getValue<double>());
             EXPECT_ERR_WARN(cbs, false, false);
-            auto const opt = z.getAttributeOptional<bool>("optattr");
+            auto const opt = z.getConfigAttributeOptional<bool>("optattr");
             EXPECT_TRUE(!!opt); EXPECT_FALSE(*opt);
             EXPECT_ERR_WARN(cbs, false, false);
-            EXPECT_ANY_THROW(z.getAttributeOptional<bool>("optattr")); // getting attribute twice
+            EXPECT_ANY_THROW(z.getConfigAttributeOptional<bool>("optattr")); // getting attribute twice
             EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_FALSE(z.getAttributeOptional<bool>("also_not_an_attr")); // nonexisting attribute
+            EXPECT_FALSE(z.getConfigAttributeOptional<bool>("also_not_an_attr")); // nonexisting attribute
             EXPECT_ERR_WARN(cbs, false, false);
         }
 
         // Testing vector
         {
-            auto v = conf.getParameter<std::vector<int>>("vector");
+            auto v = conf.getConfigParameter<std::vector<int>>("vector");
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_EQ(5u, v.size());
             std::vector<int> expected_vector(5);
@@ -235,10 +235,10 @@ TEST(BaseLibConfigTree, Get)
             EXPECT_TRUE(std::equal(expected_vector.begin(),
                                    expected_vector.end(), v.begin()));
             EXPECT_ANY_THROW(
-                conf.getParameter<std::vector<int>>("vector_bad1"));
+                conf.getConfigParameter<std::vector<int>>("vector_bad1"));
             EXPECT_ERR_WARN(cbs, true, false);
             EXPECT_ANY_THROW(
-                conf.getParameter<std::vector<int>>("vector_bad2"));
+                conf.getConfigParameter<std::vector<int>>("vector_bad2"));
             EXPECT_ERR_WARN(cbs, true, false);
         }
         EXPECT_ERR_WARN(cbs, false, false);
@@ -262,20 +262,20 @@ TEST(BaseLibConfigTree, IncompleteParse)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        EXPECT_EQ(5.6, conf.getParameter<double>("double"));
+        EXPECT_EQ(5.6, conf.getConfigParameter<double>("double"));
         EXPECT_ERR_WARN(cbs, false, false);
 
-        conf.getSubtree("tag");
+        conf.getConfigSubtree("tag");
         EXPECT_ERR_WARN(cbs, false, true); // data of <tag> has not been read
 
-        EXPECT_EQ(1, conf.getParameter<int>("pt"));
+        EXPECT_EQ(1, conf.getConfigParameter<int>("pt"));
         EXPECT_ERR_WARN(cbs, false, true); // attribute "x" has not been read
 
         {
-            auto pt2 = conf.getSubtree("pt2");
-            EXPECT_EQ(0.5, pt2.getAttribute<double>("x"));
+            auto pt2 = conf.getConfigSubtree("pt2");
+            EXPECT_EQ(0.5, pt2.getConfigAttribute<double>("x"));
             EXPECT_ERR_WARN(cbs, false, false);
-            EXPECT_EQ(1.0, pt2.getAttribute<double>("y"));
+            EXPECT_EQ(1.0, pt2.getConfigAttribute<double>("y"));
             EXPECT_ERR_WARN(cbs, false, false);
 
             BaseLib::checkAndInvalidate(pt2);
@@ -305,7 +305,7 @@ TEST(BaseLibConfigTree, CheckRange)
 
         {
             // check that std::distance can be computed twice in a row
-            auto list = conf.getSubtreeList("val");
+            auto list = conf.getConfigSubtreeList("val");
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_EQ(3, std::distance(list.begin(), list.end()));
             EXPECT_ERR_WARN(cbs, false, false);
@@ -315,7 +315,7 @@ TEST(BaseLibConfigTree, CheckRange)
 
         {
             // check that std::distance can be computed twice in a row
-            auto list = conf.getParameterList<int>("int");
+            auto list = conf.getConfigParameterList<int>("int");
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_EQ(3, std::distance(list.begin(), list.end()));
             EXPECT_ERR_WARN(cbs, false, false);
@@ -342,7 +342,7 @@ TEST(BaseLibConfigTree, GetSubtreeList)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        for (auto p : conf.getSubtreeList("nonexistent_list"))
+        for (auto p : conf.getConfigSubtreeList("nonexistent_list"))
         {
             (void) p;
             FAIL() << "Expected empty list";
@@ -350,9 +350,9 @@ TEST(BaseLibConfigTree, GetSubtreeList)
         EXPECT_ERR_WARN(cbs, false, false);
 
         int i = 0;
-        for (auto ct : conf.getSubtreeList("val"))
+        for (auto ct : conf.getConfigSubtreeList("val"))
         {
-            EXPECT_EQ(i, ct.getParameter<int>("int"));
+            EXPECT_EQ(i, ct.getConfigParameter<int>("int"));
             EXPECT_ERR_WARN(cbs, false, false);
             ++i;
         }
@@ -374,7 +374,7 @@ TEST(BaseLibConfigTree, GetParamList)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        for (auto p : conf.getParameterList("nonexistent_list"))
+        for (auto p : conf.getConfigParameterList("nonexistent_list"))
         {
             (void) p;
             FAIL() << "Expected empty list";
@@ -382,14 +382,14 @@ TEST(BaseLibConfigTree, GetParamList)
         EXPECT_ERR_WARN(cbs, false, false);
 
         int i = 0;
-        for (auto p : conf.getParameterList("int"))
+        for (auto p : conf.getConfigParameterList("int"))
         {
             EXPECT_EQ(i, p.getValue<int>());
             EXPECT_ERR_WARN(cbs, false, false);
             ++i;
         }
 
-        for (auto p : conf.getParameterList("int2"))
+        for (auto p : conf.getConfigParameterList("int2"))
         {
             EXPECT_EQ(i, p.getValue<int>());
             EXPECT_ERR_WARN(cbs, false, false);
@@ -398,7 +398,7 @@ TEST(BaseLibConfigTree, GetParamList)
         EXPECT_ERR_WARN(cbs, false, true); // attribute "a" not read
 
         {
-            auto range = conf.getParameterList("int3");
+            auto range = conf.getConfigParameterList("int3");
             EXPECT_ERR_WARN(cbs, false, false);
 
             EXPECT_ANY_THROW(*range.begin());
@@ -425,7 +425,7 @@ TEST(BaseLibConfigTree, GetValueList)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        for (auto p : conf.getParameterList<int>("nonexistent_list"))
+        for (auto p : conf.getConfigParameterList<int>("nonexistent_list"))
         {
             (void) p;
             FAIL() << "Expected empty list";
@@ -433,7 +433,7 @@ TEST(BaseLibConfigTree, GetValueList)
         EXPECT_ERR_WARN(cbs, false, false);
 
         int n = 0;
-        for (auto i : conf.getParameterList<int>("int"))
+        for (auto i : conf.getConfigParameterList<int>("int"))
         {
             EXPECT_EQ(n, i);
             EXPECT_ERR_WARN(cbs, false, false);
@@ -460,39 +460,39 @@ TEST(BaseLibConfigTree, NoConversion)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        EXPECT_ANY_THROW(conf.getParameter<int>("int"));
+        EXPECT_ANY_THROW(conf.getConfigParameter<int>("int"));
         EXPECT_ERR_WARN(cbs, true, false);
-        EXPECT_ANY_THROW(conf.ignoreParameter("int")); // after failure I also cannot ignore something
+        EXPECT_ANY_THROW(conf.ignoreConfigParameter("int")); // after failure I also cannot ignore something
         EXPECT_ERR_WARN(cbs, true, false);
 
-        EXPECT_ANY_THROW(conf.getParameter<double>("double"));
+        EXPECT_ANY_THROW(conf.getConfigParameter<double>("double"));
         EXPECT_ERR_WARN(cbs, true, false);
 
         // peek value existent but not convertible
-        EXPECT_ANY_THROW(conf.peekParameter<double>("non_double"));
+        EXPECT_ANY_THROW(conf.peekConfigParameter<double>("non_double"));
         EXPECT_ERR_WARN(cbs, true, false);
 
         // optional value existent but not convertible
         EXPECT_ANY_THROW(
-            auto d = conf.getParameterOptional<double>("non_double");
+            auto d = conf.getConfigParameterOptional<double>("non_double");
             ASSERT_FALSE(d);
         );
         EXPECT_ERR_WARN(cbs, true, false);
 
         // assert that I can only ignore something once
-        conf.ignoreParameter("ign");
+        conf.ignoreConfigParameter("ign");
         EXPECT_ERR_WARN(cbs, false, false);
-        EXPECT_ANY_THROW(conf.ignoreParameter("ign"));
+        EXPECT_ANY_THROW(conf.ignoreConfigParameter("ign"));
         EXPECT_ERR_WARN(cbs, true, false);
-        conf.ignoreParameterAll("ign2");
+        conf.ignoreConfigParameterAll("ign2");
         EXPECT_ERR_WARN(cbs, false, false);
-        EXPECT_ANY_THROW(conf.ignoreParameterAll("ign2"));
+        EXPECT_ANY_THROW(conf.ignoreConfigParameterAll("ign2"));
         EXPECT_ERR_WARN(cbs, true, false);
 
         // assert that I cannot read a parameter twice
-        conf.getParameter<bool>("bool");
+        conf.getConfigParameter<bool>("bool");
         EXPECT_ERR_WARN(cbs, false, false);
-        EXPECT_ANY_THROW(conf.getParameter<bool>("bool"));
+        EXPECT_ANY_THROW(conf.getConfigParameter<bool>("bool"));
         EXPECT_ERR_WARN(cbs, true, false);
 
     } // ConfigTree destroyed here
@@ -514,28 +514,28 @@ TEST(BaseLibConfigTree, BadKeynames)
 
         for (auto tag : { "<", "Z", ".", "$", "0", "", "/", "_", "a__" })
         {
-            EXPECT_ANY_THROW(conf.getParameter<int>(tag));
+            EXPECT_ANY_THROW(conf.getConfigParameter<int>(tag));
             EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(conf.getParameter<int>(tag, 500));
+            EXPECT_ANY_THROW(conf.getConfigParameter<int>(tag, 500));
             EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(conf.getParameterOptional<int>(tag));
+            EXPECT_ANY_THROW(conf.getConfigParameterOptional<int>(tag));
             EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(conf.getParameterList<int>(tag));
-            EXPECT_ERR_WARN(cbs, true, false);
-
-            EXPECT_ANY_THROW(conf.peekParameter<int>(tag));
-            EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(conf.checkParameter<int>(tag, 500));
+            EXPECT_ANY_THROW(conf.getConfigParameterList<int>(tag));
             EXPECT_ERR_WARN(cbs, true, false);
 
-            EXPECT_ANY_THROW(conf.getSubtree(tag));
+            EXPECT_ANY_THROW(conf.peekConfigParameter<int>(tag));
             EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(conf.getSubtreeOptional(tag));
-            EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(conf.getSubtreeList(tag));
+            EXPECT_ANY_THROW(conf.checkConfigParameter<int>(tag, 500));
             EXPECT_ERR_WARN(cbs, true, false);
 
-            EXPECT_ANY_THROW(conf.getAttribute<int>(tag));
+            EXPECT_ANY_THROW(conf.getConfigSubtree(tag));
+            EXPECT_ERR_WARN(cbs, true, false);
+            EXPECT_ANY_THROW(conf.getConfigSubtreeOptional(tag));
+            EXPECT_ERR_WARN(cbs, true, false);
+            EXPECT_ANY_THROW(conf.getConfigSubtreeList(tag));
+            EXPECT_ERR_WARN(cbs, true, false);
+
+            EXPECT_ANY_THROW(conf.getConfigAttribute<int>(tag));
             EXPECT_ERR_WARN(cbs, true, false);
         }
 
@@ -556,14 +556,14 @@ TEST(BaseLibConfigTree, StringLiterals)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        EXPECT_EQ("test", conf.getParameter<std::string>("s", "XX"));
+        EXPECT_EQ("test", conf.getConfigParameter<std::string>("s", "XX"));
         EXPECT_ERR_WARN(cbs, false, false);
 
         // <n> not present in the XML, so return the default value
-        EXPECT_EQ("XX",   conf.getParameter<std::string>("n", "XX"));
+        EXPECT_EQ("XX",   conf.getConfigParameter<std::string>("n", "XX"));
         EXPECT_ERR_WARN(cbs, false, false);
 
-        conf.checkParameter("t", "Test");
+        conf.checkConfigParameter("t", "Test");
         EXPECT_ERR_WARN(cbs, false, false);
     } // ConfigTree destroyed here
     EXPECT_ERR_WARN(cbs, false, false);
@@ -582,10 +582,10 @@ TEST(BaseLibConfigTree, MoveConstruct)
     {
         auto conf = makeConfigTree(ptree, cbs);
 
-        EXPECT_EQ("test", conf.getParameter<std::string>("s", "XX"));
+        EXPECT_EQ("test", conf.getConfigParameter<std::string>("s", "XX"));
         EXPECT_ERR_WARN(cbs, false, false);
 
-        auto u = conf.getSubtree("u");
+        auto u = conf.getConfigSubtree("u");
         EXPECT_ERR_WARN(cbs, false, false);
 
         EXPECT_EQ("data", u.getValue<std::string>());
@@ -601,10 +601,10 @@ TEST(BaseLibConfigTree, MoveConstruct)
         // test that read status of children is transferred in move construction
         BaseLib::ConfigTree conf2(std::move(conf));
 
-        EXPECT_EQ("XX",   conf2.getParameter<std::string>("n", "XX"));
+        EXPECT_EQ("XX",   conf2.getConfigParameter<std::string>("n", "XX"));
         EXPECT_ERR_WARN(cbs, false, false);
 
-        conf2.checkParameter("t", "Test");
+        conf2.checkConfigParameter("t", "Test");
         EXPECT_ERR_WARN(cbs, false, false);
 
         BaseLib::checkAndInvalidate(conf2);
@@ -626,10 +626,10 @@ TEST(BaseLibConfigTree, MoveAssign)
     {
         auto conf = makeConfigTree(ptree, cbs);
 
-        EXPECT_EQ("test", conf.getParameter<std::string>("s", "XX"));
+        EXPECT_EQ("test", conf.getConfigParameter<std::string>("s", "XX"));
         EXPECT_ERR_WARN(cbs, false, false);
 
-        auto u = conf.getSubtree("u");
+        auto u = conf.getConfigSubtree("u");
         EXPECT_ERR_WARN(cbs, false, false);
 
         EXPECT_EQ("data", u.getValue<std::string>());
@@ -653,10 +653,10 @@ TEST(BaseLibConfigTree, MoveAssign)
             // entirely before assignment.
             EXPECT_ERR_WARN(cbs, false, true);
 
-            EXPECT_EQ("XX",   conf2.getParameter<std::string>("n", "XX"));
+            EXPECT_EQ("XX",   conf2.getConfigParameter<std::string>("n", "XX"));
             EXPECT_ERR_WARN(cbs, false, false);
 
-            conf2.checkParameter("t", "Test");
+            conf2.checkConfigParameter("t", "Test");
             EXPECT_ERR_WARN(cbs, false, false);
         }
         EXPECT_ERR_WARN(cbs, false, false);

--- a/Tests/BaseLib/TestConfigTree.cpp
+++ b/Tests/BaseLib/TestConfigTree.cpp
@@ -157,27 +157,27 @@ TEST(BaseLibConfigTree, Get)
 
             // Testing the getConfParam...() (non-template) / getValue() combination
 
-            auto bool1 = sub.getConfParam("bool1");
+            auto bool1 = sub.getConfSubtree("bool1");
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_FALSE(bool1.getValue<bool>());
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_ANY_THROW(bool1.getValue<bool>()); // getting data twice
             EXPECT_ERR_WARN(cbs, true, false);
 
-            if (auto bool2 = sub.getConfParamOptional("bool2")) {
+            if (auto bool2 = sub.getConfSubtreeOptional("bool2")) {
                 EXPECT_ERR_WARN(cbs, false, false);
                 EXPECT_FALSE(bool2->getValue<bool>());
             }
             EXPECT_ERR_WARN(cbs, false, false);
 
-            if (auto bool3 = sub.getConfParamOptional("bool3")) {
+            if (auto bool3 = sub.getConfSubtreeOptional("bool3")) {
                 EXPECT_ERR_WARN(cbs, false, false);
                 EXPECT_ANY_THROW(bool3->getValue<bool>());
                 EXPECT_ERR_WARN(cbs, true, false); // error because of no data
             }
             EXPECT_ERR_WARN(cbs, false, false);
 
-            EXPECT_FALSE(sub.getConfParamOptional("bool4")); // optional value not existent
+            EXPECT_FALSE(sub.getConfSubtreeOptional("bool4")); // optional value not existent
             EXPECT_ERR_WARN(cbs, false, false);
 
 
@@ -206,7 +206,7 @@ TEST(BaseLibConfigTree, Get)
 
         // Testing attributes
         {
-            auto z = conf.getConfParam("z");
+            auto z = conf.getConfSubtree("z");
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_EQ(0.5, z.getConfAttribute<double>("attr"));
             EXPECT_ERR_WARN(cbs, false, false);
@@ -272,7 +272,7 @@ TEST(BaseLibConfigTree, IncompleteParse)
         EXPECT_ERR_WARN(cbs, false, true); // attribute "x" has not been read
 
         {
-            auto pt2 = conf.getConfParam("pt2");
+            auto pt2 = conf.getConfSubtree("pt2");
             EXPECT_EQ(0.5, pt2.getConfAttribute<double>("x"));
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_EQ(1.0, pt2.getConfAttribute<double>("y"));
@@ -521,11 +521,6 @@ TEST(BaseLibConfigTree, BadKeynames)
             EXPECT_ANY_THROW(conf.getConfParamOptional<int>(tag));
             EXPECT_ERR_WARN(cbs, true, false);
             EXPECT_ANY_THROW(conf.getConfParamList<int>(tag));
-            EXPECT_ERR_WARN(cbs, true, false);
-
-            EXPECT_ANY_THROW(conf.getConfParam(tag));
-            EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(conf.getConfParamOptional(tag));
             EXPECT_ERR_WARN(cbs, true, false);
 
             EXPECT_ANY_THROW(conf.peekConfParam<int>(tag));

--- a/Tests/BaseLib/TestConfigTree.cpp
+++ b/Tests/BaseLib/TestConfigTree.cpp
@@ -126,108 +126,108 @@ TEST(BaseLibConfigTree, Get)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        EXPECT_EQ(5.6e-4, conf.getConfParam<double>("double")); // read certain types
+        EXPECT_EQ(5.6e-4, conf.getParameter<double>("double")); // read certain types
         EXPECT_ERR_WARN(cbs, false, false);
-        EXPECT_TRUE(conf.getConfParam<bool>("bool"));
+        EXPECT_TRUE(conf.getParameter<bool>("bool"));
         EXPECT_ERR_WARN(cbs, false, false);
-        EXPECT_EQ(5, conf.getConfParam<int>("int"));
+        EXPECT_EQ(5, conf.getParameter<int>("int"));
         EXPECT_ERR_WARN(cbs, false, false);
 
-        EXPECT_EQ(8, conf.getConfParam<int>("intx", 8)); // reading with default value
+        EXPECT_EQ(8, conf.getParameter<int>("intx", 8)); // reading with default value
         EXPECT_ERR_WARN(cbs, false, false);
 
 
         // Testing subtree
         {
-            auto sub = conf.getConfSubtree("sub");
+            auto sub = conf.getSubtree("sub");
             EXPECT_ERR_WARN(cbs, false, false);
 
-            EXPECT_EQ(6.1f, sub.getConfParam<float>("float"));
+            EXPECT_EQ(6.1f, sub.getParameter<float>("float"));
             EXPECT_ERR_WARN(cbs, false, false);
 
-            if (auto f2 = sub.getConfParamOptional<float>("float2")) { // read optional value
+            if (auto f2 = sub.getParameterOptional<float>("float2")) { // read optional value
                 EXPECT_EQ(0.1f, *f2);
             }
             EXPECT_ERR_WARN(cbs, false, false);
 
-            auto f3 = sub.getConfParamOptional<float>("float3"); // optional value not existent
+            auto f3 = sub.getParameterOptional<float>("float3"); // optional value not existent
             ASSERT_FALSE(f3);
             EXPECT_ERR_WARN(cbs, false, false);
 
 
-            // Testing the getConfParam...() (non-template) / getValue() combination
+            // Testing the getParameter...() (non-template) / getValue() combination
 
-            auto bool1 = sub.getConfSubtree("bool1");
+            auto bool1 = sub.getSubtree("bool1");
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_FALSE(bool1.getValue<bool>());
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_ANY_THROW(bool1.getValue<bool>()); // getting data twice
             EXPECT_ERR_WARN(cbs, true, false);
 
-            if (auto bool2 = sub.getConfSubtreeOptional("bool2")) {
+            if (auto bool2 = sub.getSubtreeOptional("bool2")) {
                 EXPECT_ERR_WARN(cbs, false, false);
                 EXPECT_FALSE(bool2->getValue<bool>());
             }
             EXPECT_ERR_WARN(cbs, false, false);
 
-            if (auto bool3 = sub.getConfSubtreeOptional("bool3")) {
+            if (auto bool3 = sub.getSubtreeOptional("bool3")) {
                 EXPECT_ERR_WARN(cbs, false, false);
                 EXPECT_ANY_THROW(bool3->getValue<bool>());
                 EXPECT_ERR_WARN(cbs, true, false); // error because of no data
             }
             EXPECT_ERR_WARN(cbs, false, false);
 
-            EXPECT_FALSE(sub.getConfSubtreeOptional("bool4")); // optional value not existent
+            EXPECT_FALSE(sub.getSubtreeOptional("bool4")); // optional value not existent
             EXPECT_ERR_WARN(cbs, false, false);
 
 
             // Testing ignore
 
-            sub.ignoreConfParam("ignored");
+            sub.ignoreParameter("ignored");
             EXPECT_ERR_WARN(cbs, false, false);
-            sub.ignoreConfParamAll("ignored2");
+            sub.ignoreParameterAll("ignored2");
             EXPECT_ERR_WARN(cbs, false, false);
-            sub.ignoreConfParamAll("ignored4"); // I can ignore nonexistent stuff
+            sub.ignoreParameterAll("ignored4"); // I can ignore nonexistent stuff
             EXPECT_ERR_WARN(cbs, false, false);
 
             // I can not ignore stuff that I already read
             // this also makes sure that the subtree inherits the callbacks properly
-            EXPECT_ANY_THROW(sub.ignoreConfParam("float"));
+            EXPECT_ANY_THROW(sub.ignoreParameter("float"));
             EXPECT_ERR_WARN(cbs, true, false);
         }
         for (int i : {0, 1, 2}) {
             (void) i;
-            EXPECT_EQ("Y", conf.peekConfParam<std::string>("x"));
+            EXPECT_EQ("Y", conf.peekParameter<std::string>("x"));
             EXPECT_ERR_WARN(cbs, false, false);
         }
-        conf.checkConfParam<std::string>("x", "Y");
+        conf.checkParameter<std::string>("x", "Y");
         EXPECT_ERR_WARN(cbs, false, false);
 
 
         // Testing attributes
         {
-            auto z = conf.getConfSubtree("z");
+            auto z = conf.getSubtree("z");
             EXPECT_ERR_WARN(cbs, false, false);
-            EXPECT_EQ(0.5, z.getConfAttribute<double>("attr"));
+            EXPECT_EQ(0.5, z.getAttribute<double>("attr"));
             EXPECT_ERR_WARN(cbs, false, false);
-            EXPECT_ANY_THROW(z.getConfAttribute<double>("attr")); // getting attribute twice
+            EXPECT_ANY_THROW(z.getAttribute<double>("attr")); // getting attribute twice
             EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(z.getConfAttribute<double>("not_an_attr")); // nonexistent attribute
+            EXPECT_ANY_THROW(z.getAttribute<double>("not_an_attr")); // nonexistent attribute
             EXPECT_ERR_WARN(cbs, true, false);
             EXPECT_EQ(32.0, z.getValue<double>());
             EXPECT_ERR_WARN(cbs, false, false);
-            auto const opt = z.getConfAttributeOptional<bool>("optattr");
+            auto const opt = z.getAttributeOptional<bool>("optattr");
             EXPECT_TRUE(!!opt); EXPECT_FALSE(*opt);
             EXPECT_ERR_WARN(cbs, false, false);
-            EXPECT_ANY_THROW(z.getConfAttributeOptional<bool>("optattr")); // getting attribute twice
+            EXPECT_ANY_THROW(z.getAttributeOptional<bool>("optattr")); // getting attribute twice
             EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_FALSE(z.getConfAttributeOptional<bool>("also_not_an_attr")); // nonexisting attribute
+            EXPECT_FALSE(z.getAttributeOptional<bool>("also_not_an_attr")); // nonexisting attribute
             EXPECT_ERR_WARN(cbs, false, false);
         }
 
         // Testing vector
         {
-            auto v = conf.getConfParam<std::vector<int>>("vector");
+            auto v = conf.getParameter<std::vector<int>>("vector");
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_EQ(5u, v.size());
             std::vector<int> expected_vector(5);
@@ -235,10 +235,10 @@ TEST(BaseLibConfigTree, Get)
             EXPECT_TRUE(std::equal(expected_vector.begin(),
                                    expected_vector.end(), v.begin()));
             EXPECT_ANY_THROW(
-                conf.getConfParam<std::vector<int>>("vector_bad1"));
+                conf.getParameter<std::vector<int>>("vector_bad1"));
             EXPECT_ERR_WARN(cbs, true, false);
             EXPECT_ANY_THROW(
-                conf.getConfParam<std::vector<int>>("vector_bad2"));
+                conf.getParameter<std::vector<int>>("vector_bad2"));
             EXPECT_ERR_WARN(cbs, true, false);
         }
         EXPECT_ERR_WARN(cbs, false, false);
@@ -262,20 +262,20 @@ TEST(BaseLibConfigTree, IncompleteParse)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        EXPECT_EQ(5.6, conf.getConfParam<double>("double"));
+        EXPECT_EQ(5.6, conf.getParameter<double>("double"));
         EXPECT_ERR_WARN(cbs, false, false);
 
-        conf.getConfSubtree("tag");
+        conf.getSubtree("tag");
         EXPECT_ERR_WARN(cbs, false, true); // data of <tag> has not been read
 
-        EXPECT_EQ(1, conf.getConfParam<int>("pt"));
+        EXPECT_EQ(1, conf.getParameter<int>("pt"));
         EXPECT_ERR_WARN(cbs, false, true); // attribute "x" has not been read
 
         {
-            auto pt2 = conf.getConfSubtree("pt2");
-            EXPECT_EQ(0.5, pt2.getConfAttribute<double>("x"));
+            auto pt2 = conf.getSubtree("pt2");
+            EXPECT_EQ(0.5, pt2.getAttribute<double>("x"));
             EXPECT_ERR_WARN(cbs, false, false);
-            EXPECT_EQ(1.0, pt2.getConfAttribute<double>("y"));
+            EXPECT_EQ(1.0, pt2.getAttribute<double>("y"));
             EXPECT_ERR_WARN(cbs, false, false);
 
             BaseLib::checkAndInvalidate(pt2);
@@ -305,7 +305,7 @@ TEST(BaseLibConfigTree, CheckRange)
 
         {
             // check that std::distance can be computed twice in a row
-            auto list = conf.getConfSubtreeList("val");
+            auto list = conf.getSubtreeList("val");
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_EQ(3, std::distance(list.begin(), list.end()));
             EXPECT_ERR_WARN(cbs, false, false);
@@ -315,7 +315,7 @@ TEST(BaseLibConfigTree, CheckRange)
 
         {
             // check that std::distance can be computed twice in a row
-            auto list = conf.getConfParamList<int>("int");
+            auto list = conf.getParameterList<int>("int");
             EXPECT_ERR_WARN(cbs, false, false);
             EXPECT_EQ(3, std::distance(list.begin(), list.end()));
             EXPECT_ERR_WARN(cbs, false, false);
@@ -342,7 +342,7 @@ TEST(BaseLibConfigTree, GetSubtreeList)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        for (auto p : conf.getConfSubtreeList("nonexistent_list"))
+        for (auto p : conf.getSubtreeList("nonexistent_list"))
         {
             (void) p;
             FAIL() << "Expected empty list";
@@ -350,9 +350,9 @@ TEST(BaseLibConfigTree, GetSubtreeList)
         EXPECT_ERR_WARN(cbs, false, false);
 
         int i = 0;
-        for (auto ct : conf.getConfSubtreeList("val"))
+        for (auto ct : conf.getSubtreeList("val"))
         {
-            EXPECT_EQ(i, ct.getConfParam<int>("int"));
+            EXPECT_EQ(i, ct.getParameter<int>("int"));
             EXPECT_ERR_WARN(cbs, false, false);
             ++i;
         }
@@ -374,7 +374,7 @@ TEST(BaseLibConfigTree, GetParamList)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        for (auto p : conf.getConfParamList("nonexistent_list"))
+        for (auto p : conf.getParameterList("nonexistent_list"))
         {
             (void) p;
             FAIL() << "Expected empty list";
@@ -382,14 +382,14 @@ TEST(BaseLibConfigTree, GetParamList)
         EXPECT_ERR_WARN(cbs, false, false);
 
         int i = 0;
-        for (auto p : conf.getConfParamList("int"))
+        for (auto p : conf.getParameterList("int"))
         {
             EXPECT_EQ(i, p.getValue<int>());
             EXPECT_ERR_WARN(cbs, false, false);
             ++i;
         }
 
-        for (auto p : conf.getConfParamList("int2"))
+        for (auto p : conf.getParameterList("int2"))
         {
             EXPECT_EQ(i, p.getValue<int>());
             EXPECT_ERR_WARN(cbs, false, false);
@@ -398,7 +398,7 @@ TEST(BaseLibConfigTree, GetParamList)
         EXPECT_ERR_WARN(cbs, false, true); // attribute "a" not read
 
         {
-            auto range = conf.getConfParamList("int3");
+            auto range = conf.getParameterList("int3");
             EXPECT_ERR_WARN(cbs, false, false);
 
             EXPECT_ANY_THROW(*range.begin());
@@ -425,7 +425,7 @@ TEST(BaseLibConfigTree, GetValueList)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        for (auto p : conf.getConfParamList<int>("nonexistent_list"))
+        for (auto p : conf.getParameterList<int>("nonexistent_list"))
         {
             (void) p;
             FAIL() << "Expected empty list";
@@ -433,7 +433,7 @@ TEST(BaseLibConfigTree, GetValueList)
         EXPECT_ERR_WARN(cbs, false, false);
 
         int n = 0;
-        for (auto i : conf.getConfParamList<int>("int"))
+        for (auto i : conf.getParameterList<int>("int"))
         {
             EXPECT_EQ(n, i);
             EXPECT_ERR_WARN(cbs, false, false);
@@ -460,39 +460,39 @@ TEST(BaseLibConfigTree, NoConversion)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        EXPECT_ANY_THROW(conf.getConfParam<int>("int"));
+        EXPECT_ANY_THROW(conf.getParameter<int>("int"));
         EXPECT_ERR_WARN(cbs, true, false);
-        EXPECT_ANY_THROW(conf.ignoreConfParam("int")); // after failure I also cannot ignore something
+        EXPECT_ANY_THROW(conf.ignoreParameter("int")); // after failure I also cannot ignore something
         EXPECT_ERR_WARN(cbs, true, false);
 
-        EXPECT_ANY_THROW(conf.getConfParam<double>("double"));
+        EXPECT_ANY_THROW(conf.getParameter<double>("double"));
         EXPECT_ERR_WARN(cbs, true, false);
 
         // peek value existent but not convertible
-        EXPECT_ANY_THROW(conf.peekConfParam<double>("non_double"));
+        EXPECT_ANY_THROW(conf.peekParameter<double>("non_double"));
         EXPECT_ERR_WARN(cbs, true, false);
 
         // optional value existent but not convertible
         EXPECT_ANY_THROW(
-            auto d = conf.getConfParamOptional<double>("non_double");
+            auto d = conf.getParameterOptional<double>("non_double");
             ASSERT_FALSE(d);
         );
         EXPECT_ERR_WARN(cbs, true, false);
 
         // assert that I can only ignore something once
-        conf.ignoreConfParam("ign");
+        conf.ignoreParameter("ign");
         EXPECT_ERR_WARN(cbs, false, false);
-        EXPECT_ANY_THROW(conf.ignoreConfParam("ign"));
+        EXPECT_ANY_THROW(conf.ignoreParameter("ign"));
         EXPECT_ERR_WARN(cbs, true, false);
-        conf.ignoreConfParamAll("ign2");
+        conf.ignoreParameterAll("ign2");
         EXPECT_ERR_WARN(cbs, false, false);
-        EXPECT_ANY_THROW(conf.ignoreConfParamAll("ign2"));
+        EXPECT_ANY_THROW(conf.ignoreParameterAll("ign2"));
         EXPECT_ERR_WARN(cbs, true, false);
 
         // assert that I cannot read a parameter twice
-        conf.getConfParam<bool>("bool");
+        conf.getParameter<bool>("bool");
         EXPECT_ERR_WARN(cbs, false, false);
-        EXPECT_ANY_THROW(conf.getConfParam<bool>("bool"));
+        EXPECT_ANY_THROW(conf.getParameter<bool>("bool"));
         EXPECT_ERR_WARN(cbs, true, false);
 
     } // ConfigTree destroyed here
@@ -514,28 +514,28 @@ TEST(BaseLibConfigTree, BadKeynames)
 
         for (auto tag : { "<", "Z", ".", "$", "0", "", "/", "_", "a__" })
         {
-            EXPECT_ANY_THROW(conf.getConfParam<int>(tag));
+            EXPECT_ANY_THROW(conf.getParameter<int>(tag));
             EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(conf.getConfParam<int>(tag, 500));
+            EXPECT_ANY_THROW(conf.getParameter<int>(tag, 500));
             EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(conf.getConfParamOptional<int>(tag));
+            EXPECT_ANY_THROW(conf.getParameterOptional<int>(tag));
             EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(conf.getConfParamList<int>(tag));
-            EXPECT_ERR_WARN(cbs, true, false);
-
-            EXPECT_ANY_THROW(conf.peekConfParam<int>(tag));
-            EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(conf.checkConfParam<int>(tag, 500));
+            EXPECT_ANY_THROW(conf.getParameterList<int>(tag));
             EXPECT_ERR_WARN(cbs, true, false);
 
-            EXPECT_ANY_THROW(conf.getConfSubtree(tag));
+            EXPECT_ANY_THROW(conf.peekParameter<int>(tag));
             EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(conf.getConfSubtreeOptional(tag));
-            EXPECT_ERR_WARN(cbs, true, false);
-            EXPECT_ANY_THROW(conf.getConfSubtreeList(tag));
+            EXPECT_ANY_THROW(conf.checkParameter<int>(tag, 500));
             EXPECT_ERR_WARN(cbs, true, false);
 
-            EXPECT_ANY_THROW(conf.getConfAttribute<int>(tag));
+            EXPECT_ANY_THROW(conf.getSubtree(tag));
+            EXPECT_ERR_WARN(cbs, true, false);
+            EXPECT_ANY_THROW(conf.getSubtreeOptional(tag));
+            EXPECT_ERR_WARN(cbs, true, false);
+            EXPECT_ANY_THROW(conf.getSubtreeList(tag));
+            EXPECT_ERR_WARN(cbs, true, false);
+
+            EXPECT_ANY_THROW(conf.getAttribute<int>(tag));
             EXPECT_ERR_WARN(cbs, true, false);
         }
 
@@ -556,14 +556,14 @@ TEST(BaseLibConfigTree, StringLiterals)
     {
         auto const conf = makeConfigTree(ptree, cbs);
 
-        EXPECT_EQ("test", conf.getConfParam<std::string>("s", "XX"));
+        EXPECT_EQ("test", conf.getParameter<std::string>("s", "XX"));
         EXPECT_ERR_WARN(cbs, false, false);
 
         // <n> not present in the XML, so return the default value
-        EXPECT_EQ("XX",   conf.getConfParam<std::string>("n", "XX"));
+        EXPECT_EQ("XX",   conf.getParameter<std::string>("n", "XX"));
         EXPECT_ERR_WARN(cbs, false, false);
 
-        conf.checkConfParam("t", "Test");
+        conf.checkParameter("t", "Test");
         EXPECT_ERR_WARN(cbs, false, false);
     } // ConfigTree destroyed here
     EXPECT_ERR_WARN(cbs, false, false);
@@ -582,10 +582,10 @@ TEST(BaseLibConfigTree, MoveConstruct)
     {
         auto conf = makeConfigTree(ptree, cbs);
 
-        EXPECT_EQ("test", conf.getConfParam<std::string>("s", "XX"));
+        EXPECT_EQ("test", conf.getParameter<std::string>("s", "XX"));
         EXPECT_ERR_WARN(cbs, false, false);
 
-        auto u = conf.getConfSubtree("u");
+        auto u = conf.getSubtree("u");
         EXPECT_ERR_WARN(cbs, false, false);
 
         EXPECT_EQ("data", u.getValue<std::string>());
@@ -601,10 +601,10 @@ TEST(BaseLibConfigTree, MoveConstruct)
         // test that read status of children is transferred in move construction
         BaseLib::ConfigTree conf2(std::move(conf));
 
-        EXPECT_EQ("XX",   conf2.getConfParam<std::string>("n", "XX"));
+        EXPECT_EQ("XX",   conf2.getParameter<std::string>("n", "XX"));
         EXPECT_ERR_WARN(cbs, false, false);
 
-        conf2.checkConfParam("t", "Test");
+        conf2.checkParameter("t", "Test");
         EXPECT_ERR_WARN(cbs, false, false);
 
         BaseLib::checkAndInvalidate(conf2);
@@ -626,10 +626,10 @@ TEST(BaseLibConfigTree, MoveAssign)
     {
         auto conf = makeConfigTree(ptree, cbs);
 
-        EXPECT_EQ("test", conf.getConfParam<std::string>("s", "XX"));
+        EXPECT_EQ("test", conf.getParameter<std::string>("s", "XX"));
         EXPECT_ERR_WARN(cbs, false, false);
 
-        auto u = conf.getConfSubtree("u");
+        auto u = conf.getSubtree("u");
         EXPECT_ERR_WARN(cbs, false, false);
 
         EXPECT_EQ("data", u.getValue<std::string>());
@@ -653,10 +653,10 @@ TEST(BaseLibConfigTree, MoveAssign)
             // entirely before assignment.
             EXPECT_ERR_WARN(cbs, false, true);
 
-            EXPECT_EQ("XX",   conf2.getConfParam<std::string>("n", "XX"));
+            EXPECT_EQ("XX",   conf2.getParameter<std::string>("n", "XX"));
             EXPECT_ERR_WARN(cbs, false, false);
 
-            conf2.checkConfParam("t", "Test");
+            conf2.checkParameter("t", "Test");
             EXPECT_ERR_WARN(cbs, false, false);
         }
         EXPECT_ERR_WARN(cbs, false, false);

--- a/Tests/FileIO/TestGmlInterface.h
+++ b/Tests/FileIO/TestGmlInterface.h
@@ -188,7 +188,7 @@ public:
         {
             auto const& sfc_vec = *(sfcs.getVector());
             auto const& sfc = *(sfc_vec[sfc_id]);
-            EXPECT_EQ(tri_ids.size(), sfc.getNTriangles());
+            EXPECT_EQ(tri_ids.size(), sfc.getNumberOfTriangles());
             for (std::size_t k(0); k<tri_ids.size(); ++k)
                 checkTriangleIDs(*(sfc[k]), tri_ids[k]);
 

--- a/Tests/FileIO/TestGmsInterface.cpp
+++ b/Tests/FileIO/TestGmsInterface.cpp
@@ -22,8 +22,8 @@ TEST(FileIO, TestGmsInterface)
     std::string const file_name (BaseLib::BuildInfo::data_path + "/FileIO/3DMeshData.3dm");
     std::unique_ptr<MeshLib::Mesh> mesh (FileIO::GMSInterface::readGMS3DMMesh(file_name));
     ASSERT_TRUE(mesh != nullptr);
-    ASSERT_EQ(11795, mesh->getNNodes());
-    ASSERT_EQ(19885, mesh->getNElements());
+    ASSERT_EQ(11795, mesh->getNumberOfNodes());
+    ASSERT_EQ(19885, mesh->getNumberOfElements());
 
     std::array<unsigned, 7> types (MeshLib::MeshInformation::getNumberOfElementTypes(*mesh));
     ASSERT_EQ(1456,  types[3]);    // tets

--- a/Tests/FileIO/TestTetGenInterface.cpp
+++ b/Tests/FileIO/TestTetGenInterface.cpp
@@ -39,8 +39,8 @@ TEST(FileIO, TetGenSmeshReader)
     ASSERT_EQ(744, pnts.size());
     std::vector<GeoLib::Surface*> const& sfcs (*geo_objects.getSurfaceVec("twolayermdl"));
     ASSERT_EQ(5, sfcs.size());
-    ASSERT_EQ(468, sfcs[2]->getNTriangles());
-    ASSERT_EQ(191, sfcs[3]->getNTriangles());
+    ASSERT_EQ(468, sfcs[2]->getNumberOfTriangles());
+    ASSERT_EQ(191, sfcs[3]->getNumberOfTriangles());
 }
 
 // existing mesh to TetGen geometry
@@ -76,7 +76,7 @@ TEST(FileIO, DISABLED_TetGenSmeshInterface)
     ASSERT_EQ(ref_sfc.size(), new_sfc.size());
 
     for (std::size_t i=0; i<ref_sfc.size(); ++i)
-        ASSERT_EQ(ref_sfc[i]->getNTriangles(), new_sfc[i]->getNTriangles());
+        ASSERT_EQ(ref_sfc[i]->getNumberOfTriangles(), new_sfc[i]->getNumberOfTriangles());
 
     std::remove(output_name.c_str());
 }
@@ -89,8 +89,8 @@ TEST(FileIO, TetGenMeshReaderWithMaterials)
     FileIO::TetGenInterface tgi;
     std::unique_ptr<MeshLib::Mesh> mesh (tgi.readTetGenMesh(node_name, ele_name));
     ASSERT_TRUE(mesh != nullptr);
-    ASSERT_EQ(1378, mesh->getNNodes());
-    ASSERT_EQ(5114, mesh->getNElements());
+    ASSERT_EQ(1378, mesh->getNumberOfNodes());
+    ASSERT_EQ(5114, mesh->getNumberOfElements());
 
     std::pair<int, int> bounds (MeshLib::MeshInformation::getValueBounds<int>(*mesh, "MaterialIDs"));
     ASSERT_EQ(-20, bounds.first);
@@ -105,8 +105,8 @@ TEST(FileIO, TetGenMeshReaderWithoutMaterials)
     FileIO::TetGenInterface tgi;
     std::unique_ptr<MeshLib::Mesh> mesh (tgi.readTetGenMesh(node_name, ele_name));
     ASSERT_TRUE(mesh != nullptr);
-    ASSERT_EQ(202, mesh->getNNodes());
-    ASSERT_EQ(650, mesh->getNElements());
+    ASSERT_EQ(202, mesh->getNumberOfNodes());
+    ASSERT_EQ(650, mesh->getNumberOfElements());
 
     std::pair<int, int> bounds (MeshLib::MeshInformation::getValueBounds<int>(*mesh, "MaterialIDs"));
     ASSERT_EQ(std::numeric_limits<int>::max(), bounds.first);

--- a/Tests/GeoLib/IO/TestGLIReader.cpp
+++ b/Tests/GeoLib/IO/TestGLIReader.cpp
@@ -64,7 +64,7 @@ TEST_F(OGSIOVer4InterfaceTest, SimpleTIN)
         sfcs(geometries.getSurfaceVec(geometry_name));
     ASSERT_TRUE(sfcs != nullptr);
     ASSERT_EQ(1u, geometries.getSurfaceVec(geometry_name)->size());
-    ASSERT_EQ(2u, (*geometries.getSurfaceVec(geometry_name))[0]->getNTriangles());
+    ASSERT_EQ(2u, (*geometries.getSurfaceVec(geometry_name))[0]->getNumberOfTriangles());
 
     std::remove(tin_fname.c_str());
 }
@@ -87,7 +87,7 @@ TEST_F(OGSIOVer4InterfaceTest, StillCorrectTINWihtAdditionalValueAtEndOfLine)
         sfcs(geometries.getSurfaceVec(geometry_name));
     ASSERT_TRUE(sfcs != nullptr);
     ASSERT_EQ(1u, geometries.getSurfaceVec(geometry_name)->size());
-    ASSERT_EQ(2u, (*geometries.getSurfaceVec(geometry_name))[0]->getNTriangles());
+    ASSERT_EQ(2u, (*geometries.getSurfaceVec(geometry_name))[0]->getNumberOfTriangles());
 
     std::remove(tin_fname.c_str());
 }
@@ -196,7 +196,7 @@ TEST_F(OGSIOVer4InterfaceTest, SimpleTIN_AdditionalEmptyLinesAtEnd)
         sfcs(geometries.getSurfaceVec(geometry_name));
     ASSERT_TRUE(sfcs != nullptr);
     ASSERT_EQ(1u, geometries.getSurfaceVec(geometry_name)->size());
-    ASSERT_EQ(2u, (*geometries.getSurfaceVec(geometry_name))[0]->getNTriangles());
+    ASSERT_EQ(2u, (*geometries.getSurfaceVec(geometry_name))[0]->getNumberOfTriangles());
 
     std::remove(tin_fname.c_str());
 }

--- a/Tests/GeoLib/TestSimplePolygonTree.cpp
+++ b/Tests/GeoLib/TestSimplePolygonTree.cpp
@@ -140,7 +140,7 @@ TEST_F(CreatePolygonTreesTest, P0AndP1AndP2)
 
     createPolygonTrees(pt_list);
     ASSERT_EQ(1u, pt_list.size());
-    ASSERT_EQ(2u, (*(pt_list.begin()))->getNChildren());
+    ASSERT_EQ(2u, (*(pt_list.begin()))->getNumberOfChildren());
     std::for_each(pt_list.begin(), pt_list.end(), std::default_delete<GeoLib::SimplePolygonTree>());
 }
 
@@ -169,7 +169,7 @@ TEST_F(CreatePolygonTreesTest, P0AndP1AndP2AndP3)
 
     createPolygonTrees(pt_list);
     ASSERT_EQ(1u, pt_list.size());
-    ASSERT_EQ(2u, (*(pt_list.begin()))->getNChildren());
+    ASSERT_EQ(2u, (*(pt_list.begin()))->getNumberOfChildren());
     std::for_each(pt_list.begin(), pt_list.end(), std::default_delete<GeoLib::SimplePolygonTree>());
 }
 

--- a/Tests/GeoLib/TestSurfaceIsPointInSurface.cpp
+++ b/Tests/GeoLib/TestSurfaceIsPointInSurface.cpp
@@ -146,7 +146,7 @@ TEST(GeoLib, SurfaceIsPointInSurface)
             EXPECT_FALSE(sfc->isPntInSfc(q));
         }
         // test edge middle points of the triangles
-        for (std::size_t k(0); k<sfc->getNTriangles(); ++k) {
+        for (std::size_t k(0); k<sfc->getNumberOfTriangles(); ++k) {
             MathLib::Point3d p, q, r;
             std::tie(p,q,r) = getEdgeMiddlePoints(*(*sfc)[k]);
             EXPECT_TRUE(sfc->isPntInSfc(p));

--- a/Tests/MathLib/TestDenseMatrix.cpp
+++ b/Tests/MathLib/TestDenseMatrix.cpp
@@ -20,48 +20,48 @@ TEST(MathLib, DenseMatrixTransposeInPlace)
     // square matrix
     DenseMatrix<double> m1(3,3);
     unsigned cnt = 0;
-    for (unsigned i=0; i<m1.getNRows(); i++)
-        for (unsigned j=0; j<m1.getNCols(); j++)
+    for (unsigned i=0; i<m1.getNumberOfRows(); i++)
+        for (unsigned j=0; j<m1.getNumberOfColumns(); j++)
             m1(i,j) = cnt++;
     double expected_m1[] = {0, 1, 2, 3, 4, 5, 6, 7, 8};
-    ASSERT_EQ(3u, m1.getNRows());
-    ASSERT_EQ(3u, m1.getNCols());
+    ASSERT_EQ(3u, m1.getNumberOfRows());
+    ASSERT_EQ(3u, m1.getNumberOfColumns());
     ASSERT_ARRAY_NEAR(expected_m1, m1.data(), m1.size(), eps);
     m1.transposeInPlace();
-    ASSERT_EQ(3u, m1.getNRows());
-    ASSERT_EQ(3u, m1.getNCols());
+    ASSERT_EQ(3u, m1.getNumberOfRows());
+    ASSERT_EQ(3u, m1.getNumberOfColumns());
     double expected_m1t[] = {0, 3, 6, 1, 4, 7, 2, 5, 8};
     ASSERT_ARRAY_NEAR(expected_m1t, m1.data(), m1.size(), eps);
 
     // non-square matrix 1
     DenseMatrix<double> m2(2,3);
     cnt = 0;
-    for (unsigned i=0; i<m2.getNRows(); i++)
-        for (unsigned j=0; j<m2.getNCols(); j++)
+    for (unsigned i=0; i<m2.getNumberOfRows(); i++)
+        for (unsigned j=0; j<m2.getNumberOfColumns(); j++)
             m2(i,j) = cnt++;
-    ASSERT_EQ(2u, m2.getNRows());
-    ASSERT_EQ(3u, m2.getNCols());
+    ASSERT_EQ(2u, m2.getNumberOfRows());
+    ASSERT_EQ(3u, m2.getNumberOfColumns());
     double expected_m2[] = {0, 1, 2, 3, 4, 5};
     ASSERT_ARRAY_NEAR(expected_m2, m2.data(), m2.size(), eps);
     m2.transposeInPlace();
-    ASSERT_EQ(3u, m2.getNRows());
-    ASSERT_EQ(2u, m2.getNCols());
+    ASSERT_EQ(3u, m2.getNumberOfRows());
+    ASSERT_EQ(2u, m2.getNumberOfColumns());
     double expected_m2t[] = {0, 3, 1, 4, 2, 5};
     ASSERT_ARRAY_NEAR(expected_m2t, m2.data(), m2.size(), eps);
 
     // non-square matrix 2
     DenseMatrix<double> m3(3,2);
     cnt = 0;
-    for (unsigned i=0; i<m3.getNRows(); i++)
-        for (unsigned j=0; j<m3.getNCols(); j++)
+    for (unsigned i=0; i<m3.getNumberOfRows(); i++)
+        for (unsigned j=0; j<m3.getNumberOfColumns(); j++)
             m3(i,j) = cnt++;
-    ASSERT_EQ(3u, m3.getNRows());
-    ASSERT_EQ(2u, m3.getNCols());
+    ASSERT_EQ(3u, m3.getNumberOfRows());
+    ASSERT_EQ(2u, m3.getNumberOfColumns());
     double expected_m3[] = {0, 1, 2, 3, 4, 5};
     ASSERT_ARRAY_NEAR(expected_m3, m3.data(), m3.size(), eps);
     m3.transposeInPlace();
-    ASSERT_EQ(2u, m3.getNRows());
-    ASSERT_EQ(3u, m3.getNCols());
+    ASSERT_EQ(2u, m3.getNumberOfRows());
+    ASSERT_EQ(3u, m3.getNumberOfColumns());
     double expected_m3t[] = {0, 2, 4, 1, 3, 5};
     ASSERT_ARRAY_NEAR(expected_m3t, m3.data(), m3.size(), eps);
 }

--- a/Tests/MathLib/TestGlobalMatrixInterface.cpp
+++ b/Tests/MathLib/TestGlobalMatrixInterface.cpp
@@ -36,8 +36,8 @@ namespace
 template <class T_MATRIX>
 void checkGlobalMatrixInterface(T_MATRIX &m)
 {
-    ASSERT_EQ(10u, m.getNRows());
-    ASSERT_EQ(10u, m.getNCols());
+    ASSERT_EQ(10u, m.getNumberOfRows());
+    ASSERT_EQ(10u, m.getNumberOfColumns());
     ASSERT_EQ(0u,  m.getRangeBegin());
     ASSERT_EQ(10u, m.getRangeEnd());
 
@@ -64,17 +64,17 @@ void checkGlobalMatrixInterfaceMPI(T_MATRIX &m, T_VECTOR &v)
     MPI_Comm_rank(PETSC_COMM_WORLD, &mrank);
 
     ASSERT_EQ(3u, msize);
-    ASSERT_EQ(m.getRangeEnd()-m.getRangeBegin(), m.getNLocalRows());
+    ASSERT_EQ(m.getRangeEnd()-m.getRangeBegin(), m.getNumberOfLocalRows());
 
     int gathered_rows;
-    int local_rows = m.getNLocalRows();
+    int local_rows = m.getNumberOfLocalRows();
     MPI_Allreduce(&local_rows, &gathered_rows, 1, MPI_INT, MPI_SUM, PETSC_COMM_WORLD);
-    ASSERT_EQ(m.getNRows(), gathered_rows);
+    ASSERT_EQ(m.getNumberOfRows(), gathered_rows);
 
     int gathered_cols;
-    int local_cols = m.getNLocalColumns();
+    int local_cols = m.getNumberOfLocalColumns();
     MPI_Allreduce(&local_cols, &gathered_cols, 1, MPI_INT, MPI_SUM, PETSC_COMM_WORLD);
-    ASSERT_EQ(m.getNCols(), gathered_cols);
+    ASSERT_EQ(m.getNumberOfColumns(), gathered_cols);
 
     // Add entries
     MathLib::DenseMatrix<double> loc_m(2, 2);
@@ -121,17 +121,17 @@ void checkGlobalRectangularMatrixInterfaceMPI(T_MATRIX &m, T_VECTOR &v)
     int mrank;
     MPI_Comm_rank(PETSC_COMM_WORLD, &mrank);
 
-    ASSERT_EQ(m.getRangeEnd()-m.getRangeBegin(), m.getNLocalRows());
+    ASSERT_EQ(m.getRangeEnd()-m.getRangeBegin(), m.getNumberOfLocalRows());
 
     int gathered_rows;
-    int local_rows = m.getNLocalRows();
+    int local_rows = m.getNumberOfLocalRows();
     MPI_Allreduce(&local_rows, &gathered_rows, 1, MPI_INT, MPI_SUM, PETSC_COMM_WORLD);
-    ASSERT_EQ(m.getNRows(), gathered_rows);
+    ASSERT_EQ(m.getNumberOfRows(), gathered_rows);
 
     int gathered_cols;
-    int local_cols = m.getNLocalColumns();
+    int local_cols = m.getNumberOfLocalColumns();
     MPI_Allreduce(&local_cols, &gathered_cols, 1, MPI_INT, MPI_SUM, PETSC_COMM_WORLD);
-    ASSERT_EQ(m.getNCols(), gathered_cols);
+    ASSERT_EQ(m.getNumberOfColumns(), gathered_cols);
 
     // Add entries
     MathLib::DenseMatrix<double> loc_m(2, 3);
@@ -156,7 +156,7 @@ void checkGlobalRectangularMatrixInterfaceMPI(T_MATRIX &m, T_VECTOR &v)
 
     // Multiply by a vector
     v = 1.;
-    T_VECTOR y(m.getNRows());
+    T_VECTOR y(m.getNumberOfRows());
     m.multiply(v, y);
 
     ASSERT_NEAR(6.*sqrt(6.), y.getNorm(), 1.e-10);

--- a/Tests/MathLib/TestNonlinearPicard.cpp
+++ b/Tests/MathLib/TestNonlinearPicard.cpp
@@ -88,13 +88,13 @@ TEST(MathLib, NonlinearPicard_double)
     picard.setAbsTolerance(1e-5);
     picard.setRelTolerance(std::numeric_limits<double>::max());
     ASSERT_FALSE(picard.solve(f1, x0, x));
-    ASSERT_EQ(3u, picard.getNIterations());
+    ASSERT_EQ(3u, picard.getNumberOfIterations());
 
     // abs tol, converge
     picard.setMaxIterations(10);
     ASSERT_TRUE(picard.solve(f1, x0, x));
     ASSERT_NEAR(2.0, x, 1e-5);
-    ASSERT_EQ(5u, picard.getNIterations());
+    ASSERT_EQ(5u, picard.getNumberOfIterations());
 
     // rel tol, converge
     picard.setMaxIterations(100);
@@ -102,7 +102,7 @@ TEST(MathLib, NonlinearPicard_double)
     picard.setRelTolerance(1e-5);
     ASSERT_TRUE(picard.solve(f1, x0, x));
     ASSERT_NEAR(2.0, x, 1e-5);
-    ASSERT_EQ(5u, picard.getNIterations());
+    ASSERT_EQ(5u, picard.getNumberOfIterations());
 }
 
 TEST(MathLib, NonlinearPicard_vector_x0)

--- a/Tests/MeshLib/MeshSubsets.cpp
+++ b/Tests/MeshLib/MeshSubsets.cpp
@@ -54,7 +54,7 @@ TEST(MeshLibMeshSubsets, GetIntersectionByNodes)
         {all_nodes_mesh_subset.getIntersectionByNodes(some_nodes)};
 
     // Check sizes.
-    ASSERT_EQ(some_nodes.size(), some_nodes_mesh_subset->getNNodes());
+    ASSERT_EQ(some_nodes.size(), some_nodes_mesh_subset->getNumberOfNodes());
 
     // Check ids.
     std::size_t nnodes = some_nodes.size();

--- a/Tests/MeshLib/TestAddLayerToMesh.cpp
+++ b/Tests/MeshLib/TestAddLayerToMesh.cpp
@@ -38,7 +38,7 @@ namespace AddLayerValidation
 
     void testZCoords2D(MeshLib::Mesh const& input, MeshLib::Mesh const& output, double height)
     {
-        std::size_t const nNodes (input.getNNodes());
+        std::size_t const nNodes (input.getNumberOfNodes());
         for (std::size_t i=0; i<nNodes; ++i)
         {
             ASSERT_EQ((*input.getNode(i))[2], (*output.getNode(i))[2]);
@@ -48,7 +48,7 @@ namespace AddLayerValidation
 
     void testZCoords3D(MeshLib::Mesh const& input, MeshLib::Mesh const& output, double height)
     {
-        std::size_t const nNodes (input.getNNodes());
+        std::size_t const nNodes (input.getNumberOfNodes());
         for (std::size_t i=0; i<nNodes; ++i)
             ASSERT_EQ((*input.getNode(i))[2] + height, (*output.getNode(i))[2]);
     }
@@ -60,8 +60,8 @@ TEST(MeshLib, AddTopLayerToLineMesh)
     double const height (1);
     std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", true));
 
-    ASSERT_EQ(2*mesh->getNNodes(), result->getNNodes());
-    ASSERT_EQ(2*mesh->getNElements(), result->getNElements());
+    ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
+    ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
 
     std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
     ASSERT_EQ(5, n_elems[0]); // tests if 5 lines are present
@@ -77,8 +77,8 @@ TEST(MeshLib, AddBottomLayerToLineMesh)
     double const height (1);
     std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", false));
 
-    ASSERT_EQ(2*mesh->getNNodes(), result->getNNodes());
-    ASSERT_EQ(2*mesh->getNElements(), result->getNElements());
+    ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
+    ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
 
     std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
     ASSERT_EQ(5, n_elems[0]); // tests if 5 lines are present
@@ -96,33 +96,33 @@ TEST(MeshLib, AddTopLayerToTriMesh)
         mesh->getProperties().createNewPropertyVector<int>(mat_name, MeshLib::MeshItemType::Cell);
     if (mats)
     {
-        mats->resize(mesh->getNElements());
-        std::fill_n(mats->begin(), mesh->getNElements(), 0);
+        mats->resize(mesh->getNumberOfElements());
+        std::fill_n(mats->begin(), mesh->getNumberOfElements(), 0);
     }
     boost::optional<MeshLib::PropertyVector<double>&> test =
         mesh->getProperties().createNewPropertyVector<double>("test", MeshLib::MeshItemType::Cell);
     if (test)
     {
-        test->resize(mesh->getNElements());
-        std::fill_n(test->begin(), mesh->getNElements(), 0.1);
+        test->resize(mesh->getNumberOfElements());
+        std::fill_n(test->begin(), mesh->getNumberOfElements(), 0.1);
     }
     ASSERT_EQ(2, mesh->getProperties().getPropertyVectorNames().size());
     double const height (1);
     std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", true));
 
-    ASSERT_EQ(2*mesh->getNNodes(), result->getNNodes());
-    ASSERT_EQ(2*mesh->getNElements(), result->getNElements());
+    ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
+    ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
 
     std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
-    ASSERT_EQ(mesh->getNElements(), n_elems[1]); // tests if 50 tris are present
-    ASSERT_EQ(mesh->getNElements(), n_elems[6]); // tests if 50 prisms are present
+    ASSERT_EQ(mesh->getNumberOfElements(), n_elems[1]); // tests if 50 tris are present
+    ASSERT_EQ(mesh->getNumberOfElements(), n_elems[6]); // tests if 50 prisms are present
 
     ASSERT_EQ(1, result->getProperties().getPropertyVectorNames().size());
     boost::optional<MeshLib::PropertyVector<int>&> new_mats =
         result->getProperties().getPropertyVector<int>(mat_name);
-    ASSERT_EQ(result->getNElements(), new_mats->size());
-    ASSERT_EQ(mesh->getNElements(), std::count(new_mats->cbegin(), new_mats->cend(), 0));
-    ASSERT_EQ(mesh->getNElements(), std::count(new_mats->cbegin(), new_mats->cend(), 1));
+    ASSERT_EQ(result->getNumberOfElements(), new_mats->size());
+    ASSERT_EQ(mesh->getNumberOfElements(), std::count(new_mats->cbegin(), new_mats->cend(), 0));
+    ASSERT_EQ(mesh->getNumberOfElements(), std::count(new_mats->cbegin(), new_mats->cend(), 1));
     AddLayerValidation::testZCoords2D(*mesh, *result, height);
     AddLayerValidation::validate(*result, true);
 }
@@ -133,8 +133,8 @@ TEST(MeshLib, AddBottomLayerToTriMesh)
     double const height (1);
     std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", false));
 
-    ASSERT_EQ(2*mesh->getNNodes(), result->getNNodes());
-    ASSERT_EQ(2*mesh->getNElements(), result->getNElements());
+    ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
+    ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
 
     std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
     ASSERT_EQ(50, n_elems[1]); // tests if 50 tris are present
@@ -150,8 +150,8 @@ TEST(MeshLib, AddTopLayerToQuadMesh)
     double const height (1);
     std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", true));
 
-    ASSERT_EQ(2*mesh->getNNodes(), result->getNNodes());
-    ASSERT_EQ(2*mesh->getNElements(), result->getNElements());
+    ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
+    ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
 
     std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
     ASSERT_EQ(25, n_elems[2]); // tests if 25 quads are present
@@ -167,8 +167,8 @@ TEST(MeshLib, AddBottomLayerToQuadMesh)
     double const height (1);
     std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", false));
 
-    ASSERT_EQ(2*mesh->getNNodes(), result->getNNodes());
-    ASSERT_EQ(2*mesh->getNElements(), result->getNElements());
+    ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
+    ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
 
     std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
     ASSERT_EQ(25, n_elems[2]); // tests if 25 quads are present
@@ -184,8 +184,8 @@ TEST(MeshLib, AddTopLayerToHexMesh)
     double const height (1);
     std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", true));
 
-    ASSERT_EQ(mesh->getNNodes(), result->getNNodes()-36);
-    ASSERT_EQ(mesh->getNElements(), result->getNElements()-25);
+    ASSERT_EQ(mesh->getNumberOfNodes(), result->getNumberOfNodes()-36);
+    ASSERT_EQ(mesh->getNumberOfElements(), result->getNumberOfElements()-25);
 
     std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
     ASSERT_EQ(150, n_elems[4]); // tests if 150 hexes are present
@@ -205,8 +205,8 @@ TEST(MeshLib, AddBottomLayerToHexMesh)
     double const height (1);
     std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", false));
 
-    ASSERT_EQ(mesh->getNNodes(), result->getNNodes()-36);
-    ASSERT_EQ(mesh->getNElements(), result->getNElements()-25);
+    ASSERT_EQ(mesh->getNumberOfNodes(), result->getNumberOfNodes()-36);
+    ASSERT_EQ(mesh->getNumberOfElements(), result->getNumberOfElements()-25);
 
     std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
     ASSERT_EQ(150, n_elems[4]); // tests if 150 hexes are present
@@ -227,8 +227,8 @@ TEST(MeshLib, AddTopLayerToPrismMesh)
     double const height (1);
     std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh2, height, "mesh", true));
 
-    ASSERT_EQ(mesh2->getNNodes()/2.0 * 3, result->getNNodes());
-    ASSERT_EQ(mesh2->getNElements()/2.0 * 3, result->getNElements());
+    ASSERT_EQ(mesh2->getNumberOfNodes()/2.0 * 3, result->getNumberOfNodes());
+    ASSERT_EQ(mesh2->getNumberOfElements()/2.0 * 3, result->getNumberOfElements());
 
     std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
     ASSERT_EQ(50, n_elems[1]); // tests if 50 tris are present
@@ -253,23 +253,23 @@ TEST(MeshLib, AddBottomLayerToPrismMesh)
         mesh2->getProperties().createNewPropertyVector<int>(mat_name, MeshLib::MeshItemType::Cell);
     if (mats)
     {
-        mats->resize(mesh2->getNElements());
-        std::fill_n(mats->begin(), mesh2->getNElements(), 0);
+        mats->resize(mesh2->getNumberOfElements());
+        std::fill_n(mats->begin(), mesh2->getNumberOfElements(), 0);
     }
 
     std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh2, height, "mesh", false));
-    ASSERT_EQ(mesh2->getNNodes()/2.0 * 3, result->getNNodes());
-    ASSERT_EQ(mesh2->getNElements()/2.0 * 3, result->getNElements());
+    ASSERT_EQ(mesh2->getNumberOfNodes()/2.0 * 3, result->getNumberOfNodes());
+    ASSERT_EQ(mesh2->getNumberOfElements()/2.0 * 3, result->getNumberOfElements());
 
     std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
-    ASSERT_EQ(mesh->getNElements(), n_elems[1]); // tests if 50 tris are present
-    ASSERT_EQ(2 * mesh->getNElements(), n_elems[6]); // tests if 50 prisms are present
+    ASSERT_EQ(mesh->getNumberOfElements(), n_elems[1]); // tests if 50 tris are present
+    ASSERT_EQ(2 * mesh->getNumberOfElements(), n_elems[6]); // tests if 50 prisms are present
     ASSERT_EQ(1, result->getProperties().getPropertyVectorNames().size());
     boost::optional<MeshLib::PropertyVector<int>&> new_mats =
         result->getProperties().getPropertyVector<int>(mat_name);
-    ASSERT_EQ(result->getNElements(), new_mats->size());
-    ASSERT_EQ(mesh2->getNElements(), std::count(new_mats->cbegin(), new_mats->cend(), 0));
-    ASSERT_EQ(mesh->getNElements(), std::count(new_mats->cbegin(), new_mats->cend(), 1));
+    ASSERT_EQ(result->getNumberOfElements(), new_mats->size());
+    ASSERT_EQ(mesh2->getNumberOfElements(), std::count(new_mats->cbegin(), new_mats->cend(), 0));
+    ASSERT_EQ(mesh->getNumberOfElements(), std::count(new_mats->cbegin(), new_mats->cend(), 1));
 
     MathLib::Vector3 const dir(0, 0, 1);
     std::unique_ptr<MeshLib::Mesh> test_input (

--- a/Tests/MeshLib/TestBoundaryElementSearch.cpp
+++ b/Tests/MeshLib/TestBoundaryElementSearch.cpp
@@ -89,22 +89,22 @@ TEST_F(MeshLibBoundaryElementSearchInSimpleQuadMesh, PolylineSearch)
     for (unsigned i=0; i<n_eles_per_dir; i++) {
         // edge found on a bottom line
         auto* edge0 = found_edges_ply0[i];
-        ASSERT_EQ(2u, edge0->getNBaseNodes());
+        ASSERT_EQ(2u, edge0->getNumberOfBaseNodes());
         ASSERT_EQ(i, edge0->getNodeIndex(0));
         ASSERT_EQ(i+1, edge0->getNodeIndex(1));
         // edge found on a right line
         auto* edge1 = found_edges_ply0[i+n_eles_per_dir];
-        ASSERT_EQ(2u, edge1->getNBaseNodes());
+        ASSERT_EQ(2u, edge1->getNumberOfBaseNodes());
         ASSERT_EQ(n_nodes_per_dir*i+n_nodes_per_dir-1, edge1->getNodeIndex(0));
         ASSERT_EQ(n_nodes_per_dir*(i+1)+n_nodes_per_dir-1, edge1->getNodeIndex(1));
         // edge found on a top line
         auto* edge2 = found_edges_ply0[i+n_eles_per_dir*2];
-        ASSERT_EQ(2u, edge2->getNBaseNodes());
+        ASSERT_EQ(2u, edge2->getNumberOfBaseNodes());
         ASSERT_EQ(n_nodes_per_dir*n_nodes_per_dir-1-i, edge2->getNodeIndex(0));
         ASSERT_EQ(n_nodes_per_dir*n_nodes_per_dir-1-(i+1), edge2->getNodeIndex(1));
         // edge found on a left line
         auto* edge3 = found_edges_ply0[i+n_eles_per_dir*3];
-        ASSERT_EQ(2u, edge3->getNBaseNodes());
+        ASSERT_EQ(2u, edge3->getNumberOfBaseNodes());
         ASSERT_EQ(n_nodes_per_dir*(n_nodes_per_dir-1)-n_nodes_per_dir*i, edge3->getNodeIndex(0));
         ASSERT_EQ(n_nodes_per_dir*(n_nodes_per_dir-1)-n_nodes_per_dir*(i+1), edge3->getNodeIndex(1));
     }

--- a/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
+++ b/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
@@ -124,15 +124,15 @@ void debugOutput(MeshLib::Element *ele, MeshLib::ElementCoordinatesMappingLocal 
 {
     std::cout.precision(12);
     std::cout << "original" << std::endl;
-    for (unsigned i=0; i<ele->getNNodes(); i++)
+    for (unsigned i=0; i<ele->getNumberOfNodes(); i++)
         std::cout << *ele->getNode(i) << std::endl;
     std::cout << "local coords=" << std::endl;
-    for (unsigned i=0; i<ele->getNNodes(); i++)
+    for (unsigned i=0; i<ele->getNumberOfNodes(); i++)
         std::cout << *mapping.getMappedCoordinates(i) << std::endl;
     std::cout << "R=\n" << mapping.getRotationMatrixToGlobal() << std::endl;
     auto matR(mapping.getRotationMatrixToGlobal());
     std::cout << "global coords=" << std::endl;
-    for (unsigned i=0; i<ele->getNNodes(); i++) {
+    for (unsigned i=0; i<ele->getNumberOfNodes(); i++) {
         double* raw = const_cast<double*>(&(*mapping.getMappedCoordinates(i))[0]);
         Eigen::Map<Eigen::Vector3d> v(raw);
         std::cout << (matR*v).transpose() << std::endl;
@@ -142,7 +142,7 @@ void debugOutput(MeshLib::Element *ele, MeshLib::ElementCoordinatesMappingLocal 
 
 // check if using the rotation matrix results in the original coordinates
 #define CHECK_COORDS(ele, mapping)\
-    for (unsigned ii=0; ii<ele->getNNodes(); ii++) {\
+    for (unsigned ii=0; ii<ele->getNumberOfNodes(); ii++) {\
         MathLib::Point3d global(matR*mapping.getMappedCoordinates(ii));\
         const double eps(std::numeric_limits<double>::epsilon());\
         ASSERT_ARRAY_NEAR(&(*ele->getNode(ii))[0], global.getCoords(), 3u, eps);\
@@ -164,7 +164,7 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimLineY)
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
 
-    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+    for (std::size_t n = 0; n < ele->getNumberOfNodes(); ++n)
         delete ele->getNode(n);
 }
 
@@ -181,7 +181,7 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimLineZ)
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
 
-    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+    for (std::size_t n = 0; n < ele->getNumberOfNodes(); ++n)
         delete ele->getNode(n);
 }
 
@@ -199,7 +199,7 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimLineXY)
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
 
-    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+    for (std::size_t n = 0; n < ele->getNumberOfNodes(); ++n)
         delete ele->getNode(n);
 }
 
@@ -217,7 +217,7 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimLineXYZ)
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
 
-    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+    for (std::size_t n = 0; n < ele->getNumberOfNodes(); ++n)
         delete ele->getNode(n);
 }
 
@@ -237,7 +237,7 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadXZ)
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
 
-    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+    for (std::size_t n = 0; n < ele->getNumberOfNodes(); ++n)
         delete ele->getNode(n);
 }
 
@@ -257,7 +257,7 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadYZ)
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
 
-    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+    for (std::size_t n = 0; n < ele->getNumberOfNodes(); ++n)
         delete ele->getNode(n);
 }
 
@@ -277,7 +277,7 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadXYZ)
     ASSERT_ARRAY_NEAR(exp_R, matR.data(), matR.size(), eps);
     CHECK_COORDS(ele,mapping);
 
-    for (std::size_t n = 0; n < ele->getNNodes(); ++n)
+    for (std::size_t n = 0; n < ele->getNumberOfNodes(); ++n)
         delete ele->getNode(n);
 }
 

--- a/Tests/MeshLib/TestDuplicate.cpp
+++ b/Tests/MeshLib/TestDuplicate.cpp
@@ -34,14 +34,14 @@ TEST(MeshLib, Duplicate)
 
     MeshLib::Mesh new_mesh ("new", new_nodes, new_elements);
 
-    ASSERT_EQ (mesh->getNElements(), new_mesh.getNElements());
-    ASSERT_EQ (mesh->getNNodes(), new_mesh.getNNodes());
+    ASSERT_EQ (mesh->getNumberOfElements(), new_mesh.getNumberOfElements());
+    ASSERT_EQ (mesh->getNumberOfNodes(), new_mesh.getNumberOfNodes());
 
     std::vector<std::size_t> del_idx(1,1);
     std::unique_ptr<MeshLib::Mesh> mesh2(MeshLib::removeNodes(*mesh, del_idx, "mesh2"));
 
-    ASSERT_EQ (mesh2->getNElements(), new_mesh.getNElements()-2);
-    ASSERT_EQ (mesh2->getNNodes(), new_mesh.getNNodes()-2);
+    ASSERT_EQ (mesh2->getNumberOfElements(), new_mesh.getNumberOfElements()-2);
+    ASSERT_EQ (mesh2->getNumberOfNodes(), new_mesh.getNumberOfNodes()-2);
 
     ASSERT_DOUBLE_EQ (4.0, MathLib::sqrDist(*mesh2->getNode(0), *new_mesh.getNode(0)));
     ASSERT_DOUBLE_EQ (0.0, MathLib::sqrDist(*mesh2->getNode(0), *new_mesh.getNode(2)));

--- a/Tests/MeshLib/TestElementConstants.cpp
+++ b/Tests/MeshLib/TestElementConstants.cpp
@@ -28,8 +28,8 @@ TEST(MeshLib, ElementConstantsQuad4)
     Quad quad(nodes);
 
     ASSERT_EQ(2u, quad.getDimension());
-    ASSERT_EQ(4u, quad.getNNodes());
-    ASSERT_EQ(4u, quad.getNBaseNodes());
+    ASSERT_EQ(4u, quad.getNumberOfNodes());
+    ASSERT_EQ(4u, quad.getNumberOfBaseNodes());
 
     for (auto n : nodes)
         delete n;
@@ -55,8 +55,8 @@ TEST(MeshLib, ElementConstantsQuad8)
     Quad8 quad8(nodes);
 
     ASSERT_EQ(2u, quad8.getDimension());
-    ASSERT_EQ(8u, quad8.getNNodes());
-    ASSERT_EQ(4u, quad8.getNBaseNodes());
+    ASSERT_EQ(8u, quad8.getNumberOfNodes());
+    ASSERT_EQ(4u, quad8.getNumberOfBaseNodes());
 
     for (auto n : nodes)
         delete n;
@@ -83,8 +83,8 @@ TEST(MeshLib, ElementConstantsQuad9)
     Quad9 quad9(nodes);
 
     ASSERT_EQ(2u, quad9.getDimension());
-    ASSERT_EQ(9u, quad9.getNNodes());
-    ASSERT_EQ(4u, quad9.getNBaseNodes());
+    ASSERT_EQ(9u, quad9.getNumberOfNodes());
+    ASSERT_EQ(4u, quad9.getNumberOfBaseNodes());
 
     for (auto n : nodes)
         delete n;
@@ -108,8 +108,8 @@ TEST(MeshLib, ElementConstantsHex8)
     Hex ele(nodes);
 
     ASSERT_EQ(3u, ele.getDimension());
-    ASSERT_EQ(8u, ele.getNNodes());
-    ASSERT_EQ(8u, ele.getNBaseNodes());
+    ASSERT_EQ(8u, ele.getNumberOfNodes());
+    ASSERT_EQ(8u, ele.getNumberOfBaseNodes());
 
     for (auto n : nodes)
         delete n;
@@ -145,8 +145,8 @@ TEST(MeshLib, ElementConstantsHex20)
     Hex20 ele(nodes);
 
     ASSERT_EQ( 3u, ele.getDimension());
-    ASSERT_EQ(20u, ele.getNNodes());
-    ASSERT_EQ( 8u, ele.getNBaseNodes());
+    ASSERT_EQ(20u, ele.getNumberOfNodes());
+    ASSERT_EQ( 8u, ele.getNumberOfBaseNodes());
 
     for (auto n : nodes)
         delete n;
@@ -166,8 +166,8 @@ TEST(MeshLib, ElementConstantsTet4)
     Tet ele(nodes);
 
     ASSERT_EQ(3u, ele.getDimension());
-    ASSERT_EQ(4u, ele.getNNodes());
-    ASSERT_EQ(4u, ele.getNBaseNodes());
+    ASSERT_EQ(4u, ele.getNumberOfNodes());
+    ASSERT_EQ(4u, ele.getNumberOfBaseNodes());
 
     for (auto n : nodes)
         delete n;
@@ -194,8 +194,8 @@ TEST(MeshLib, ElementConstantsTet10)
     Tet10 ele(nodes);
 
     ASSERT_EQ( 3u, ele.getDimension());
-    ASSERT_EQ(10u, ele.getNNodes());
-    ASSERT_EQ( 4u, ele.getNBaseNodes());
+    ASSERT_EQ(10u, ele.getNumberOfNodes());
+    ASSERT_EQ( 4u, ele.getNumberOfBaseNodes());
 
     for (auto n : nodes)
         delete n;

--- a/Tests/MeshLib/TestElementStatus.cpp
+++ b/Tests/MeshLib/TestElementStatus.cpp
@@ -34,7 +34,7 @@ TEST(MeshLib, ElementStatus)
                                                            MeshLib::MeshItemType::Cell)
     );
     ASSERT_TRUE(bool(material_id_properties));
-    (*material_id_properties).resize(mesh->getNElements());
+    (*material_id_properties).resize(mesh->getNumberOfElements());
 
     const std::vector<MeshLib::Element*> elements (mesh->getElements());
 
@@ -47,29 +47,29 @@ TEST(MeshLib, ElementStatus)
     {
         // all elements and nodes active
         MeshLib::ElementStatus status(mesh.get());
-        ASSERT_EQ (elements.size(), status.getNActiveElements());
-        ASSERT_EQ (mesh->getNNodes(), status.getNActiveNodes());
+        ASSERT_EQ (elements.size(), status.getNumberOfActiveElements());
+        ASSERT_EQ (mesh->getNumberOfNodes(), status.getNumberOfActiveNodes());
     }
 
     {
         // set material 1 to false
         std::vector<int> inactiveMat{1};
         MeshLib::ElementStatus status(mesh.get(), inactiveMat);
-        ASSERT_EQ (elements.size()-elements_per_side, status.getNActiveElements());
+        ASSERT_EQ (elements.size()-elements_per_side, status.getNumberOfActiveElements());
     }
 
     {
         // set material 0 and 1 to false
         std::vector<int> inactiveMat{0, 1};
         MeshLib::ElementStatus status(mesh.get(), inactiveMat);
-        ASSERT_EQ (elements.size()-(2*elements_per_side), status.getNActiveElements());
+        ASSERT_EQ (elements.size()-(2*elements_per_side), status.getNumberOfActiveElements());
 
         // active elements
         auto &active_elements (status.getActiveElements());
-        ASSERT_EQ (active_elements.size(), status.getNActiveElements());
+        ASSERT_EQ (active_elements.size(), status.getNumberOfActiveElements());
 
         // active nodes
         auto& active_nodes (status.getActiveNodes());
-        ASSERT_EQ (active_nodes.size(), status.getNActiveNodes());
+        ASSERT_EQ (active_nodes.size(), status.getNumberOfActiveNodes());
     }
 }

--- a/Tests/MeshLib/TestFlipElements.cpp
+++ b/Tests/MeshLib/TestFlipElements.cpp
@@ -22,9 +22,9 @@ TEST(MeshLib, FlipLineMesh)
     std::unique_ptr<MeshLib::Mesh> mesh (MeshLib::MeshGenerator::generateLineMesh(1.0, 5));
     std::unique_ptr<MeshLib::Mesh> result (MeshLib::createFlippedMesh(*mesh));
 
-    ASSERT_EQ(mesh->getNNodes(), result->getNNodes());
-    ASSERT_EQ(mesh->getNElements(), result->getNElements());
-    for (std::size_t i=0; i<result->getNElements(); ++i)
+    ASSERT_EQ(mesh->getNumberOfNodes(), result->getNumberOfNodes());
+    ASSERT_EQ(mesh->getNumberOfElements(), result->getNumberOfElements());
+    for (std::size_t i=0; i<result->getNumberOfElements(); ++i)
     {
         ASSERT_EQ(mesh->getElement(i)->getNode(0)->getID(),
                   result->getElement(i)->getNode(1)->getID());
@@ -38,9 +38,9 @@ TEST(MeshLib, FlipTriMesh)
     std::unique_ptr<MeshLib::Mesh> mesh (MeshLib::MeshGenerator::generateRegularTriMesh(5, 5));
     std::unique_ptr<MeshLib::Mesh> result (MeshLib::createFlippedMesh(*mesh));
 
-    ASSERT_EQ(mesh->getNNodes(), result->getNNodes());
-    ASSERT_EQ(mesh->getNElements(), result->getNElements());
-    for (std::size_t i=0; i<result->getNElements(); ++i)
+    ASSERT_EQ(mesh->getNumberOfNodes(), result->getNumberOfNodes());
+    ASSERT_EQ(mesh->getNumberOfElements(), result->getNumberOfElements());
+    for (std::size_t i=0; i<result->getNumberOfElements(); ++i)
     {
         ASSERT_EQ(mesh->getElement(i)->getNode(0)->getID(),
                   result->getElement(i)->getNode(1)->getID());
@@ -57,9 +57,9 @@ TEST(MeshLib, FlipQuadMesh)
     std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::MeshGenerator::generateRegularQuadMesh(5, 5));
     std::unique_ptr<MeshLib::Mesh> result (MeshLib::createFlippedMesh(*mesh));
 
-    ASSERT_EQ(mesh->getNNodes(), result->getNNodes());
-    ASSERT_EQ(mesh->getNElements(), result->getNElements());
-    for (std::size_t i=0; i<result->getNElements(); ++i)
+    ASSERT_EQ(mesh->getNumberOfNodes(), result->getNumberOfNodes());
+    ASSERT_EQ(mesh->getNumberOfElements(), result->getNumberOfElements());
+    for (std::size_t i=0; i<result->getNumberOfElements(); ++i)
     {
         ASSERT_EQ(mesh->getElement(i)->getNode(0)->getID(),
                   result->getElement(i)->getNode(1)->getID());
@@ -80,7 +80,7 @@ TEST(MeshLib, FlipHexMesh)
 
     ASSERT_EQ(nullptr, result);
     std::vector<MeshLib::Node*> nodes;
-    for (std::size_t i=0; i<mesh->getNNodes(); ++i)
+    for (std::size_t i=0; i<mesh->getNumberOfNodes(); ++i)
         nodes.push_back(new MeshLib::Node(*mesh->getNode(i)));
     std::unique_ptr<MeshLib::Element> elem (MeshLib::createFlippedElement(*mesh->getElement(0), nodes));
     ASSERT_EQ(nullptr, elem);
@@ -94,9 +94,9 @@ TEST(MeshLib, DoubleFlipQuadMesh)
     std::unique_ptr<MeshLib::Mesh> result (MeshLib::createFlippedMesh(*mesh));
     std::unique_ptr<MeshLib::Mesh> result2 (MeshLib::createFlippedMesh(*result));
 
-    ASSERT_EQ(mesh->getNNodes(), result2->getNNodes());
-    ASSERT_EQ(mesh->getNElements(), result2->getNElements());
-    for (std::size_t i=0; i<result2->getNElements(); ++i)
+    ASSERT_EQ(mesh->getNumberOfNodes(), result2->getNumberOfNodes());
+    ASSERT_EQ(mesh->getNumberOfElements(), result2->getNumberOfElements());
+    for (std::size_t i=0; i<result2->getNumberOfElements(); ++i)
         for (std::size_t j=0; j<4; ++j)
             ASSERT_EQ(mesh->getElement(i)->getNode(j)->getID(),
                       result2->getElement(i)->getNode(j)->getID());

--- a/Tests/MeshLib/TestLineMesh.cpp
+++ b/Tests/MeshLib/TestLineMesh.cpp
@@ -37,15 +37,15 @@ TEST_F(MeshLibLineMesh, Construction)
     ASSERT_TRUE(mesh != nullptr);
 
     // There are mesh_size elements in the mesh.
-    ASSERT_EQ(mesh_size, mesh->getNElements());
+    ASSERT_EQ(mesh_size, mesh->getNumberOfElements());
 
     // There are mesh_size+1 nodes in the mesh.
-    ASSERT_EQ(mesh_size+1, mesh->getNNodes());
+    ASSERT_EQ(mesh_size+1, mesh->getNumberOfNodes());
 
     // All elements have maximum two neighbors.
     std::vector<MeshLib::Element*> const& elements = mesh->getElements();
     for (auto e : elements)
-        ASSERT_EQ(2u, e->getNNeighbors());
+        ASSERT_EQ(2u, e->getNumberOfNeighbors());
 }
 
 TEST_F(MeshLibLineMesh, ElementNeigbors)
@@ -83,7 +83,7 @@ TEST_F(MeshLibLineMesh, ElementToNodeConnectivity)
     for (std::size_t i = 0; i < elements.size(); ++i)
     {
         // An element consists of two nodes n and n+1
-        ASSERT_EQ(2u, elements[i]->getNBaseNodes());
+        ASSERT_EQ(2u, elements[i]->getNumberOfBaseNodes());
         ASSERT_EQ(i, elements[i]->getNode(0)->getID());
         ASSERT_EQ(i+1, elements[i]->getNode(1)->getID());
     }
@@ -96,15 +96,15 @@ TEST_F(MeshLibLineMesh, NodeToElementConnectivity)
 
     // Each node n of the line mesh is connected to two elements n-1 and n,
     // except the first and last nodes.
-    ASSERT_EQ(1u, nodes.front()->getNElements());
+    ASSERT_EQ(1u, nodes.front()->getNumberOfElements());
     ASSERT_EQ(elements[0], nodes.front()->getElement(0));
 
-    ASSERT_EQ(1u, nodes.back()->getNElements());
+    ASSERT_EQ(1u, nodes.back()->getNumberOfElements());
     ASSERT_EQ(elements.back(), nodes.back()->getElement(0));
 
     for (std::size_t i = 1; i < nodes.size() - 1; ++i)
     {
-        ASSERT_EQ(2u, nodes[i]->getNElements());
+        ASSERT_EQ(2u, nodes[i]->getNumberOfElements());
         ASSERT_EQ(elements[i-1], nodes[i]->getElement(0));
         ASSERT_EQ(elements[i], nodes[i]->getElement(1));
     }

--- a/Tests/MeshLib/TestMeshGenerator.cpp
+++ b/Tests/MeshLib/TestMeshGenerator.cpp
@@ -27,14 +27,14 @@ TEST(MeshLib, MeshGeneratorRegularHex)
     const double dL = L / static_cast<double>(n_subdivisions);
     std::unique_ptr<Mesh> msh(MeshGenerator::generateRegularHexMesh(L, n_subdivisions));
 
-    ASSERT_EQ(std::pow(n_subdivisions, 3), msh->getNElements());
-    ASSERT_EQ(std::pow(n_subdivisions+1, 3), msh->getNNodes());
+    ASSERT_EQ(std::pow(n_subdivisions, 3), msh->getNumberOfElements());
+    ASSERT_EQ(std::pow(n_subdivisions+1, 3), msh->getNumberOfNodes());
 
     // check nodes
     const Node& node0 = *msh->getNode(0);
     const Node& node1 = *msh->getNode(1);
-    const Node& node_n = *msh->getNode(msh->getNNodes()-2);
-    const Node& node_n1 = *msh->getNode(msh->getNNodes()-1);
+    const Node& node_n = *msh->getNode(msh->getNumberOfNodes()-2);
+    const Node& node_n1 = *msh->getNode(msh->getNumberOfNodes()-1);
     ASSERT_DOUBLE_EQ(.0, node0[0]);
     ASSERT_DOUBLE_EQ(.0, node0[1]);
     ASSERT_DOUBLE_EQ(.0, node0[2]);
@@ -50,7 +50,7 @@ TEST(MeshLib, MeshGeneratorRegularHex)
 
     // check elements
     const Element& ele0 = *msh->getElement(0);
-    const Element& ele_n = *msh->getElement(msh->getNElements()-1);
+    const Element& ele_n = *msh->getElement(msh->getNumberOfElements()-1);
     const std::size_t offset_y0 = (n_subdivisions+1);
     const std::size_t offset_z0 = (n_subdivisions+1)*(n_subdivisions+1);
     ASSERT_EQ(0u, ele0.getNodeIndex(0));
@@ -75,17 +75,17 @@ TEST(MeshLib, MeshGeneratorRegularHex)
     ASSERT_EQ(offset_zn1+offset_yn1+n_subdivisions-1, ele_n.getNodeIndex(7));
 
     std::unique_ptr<Mesh> msh2 (MeshGenerator::generateRegularHexMesh(n_subdivisions, n_subdivisions, n_subdivisions, L/n_subdivisions));
-    ASSERT_EQ(msh->getNNodes(), msh2->getNNodes());
-    ASSERT_DOUBLE_EQ(0, MathLib::sqrDist(*(msh->getNode(msh->getNNodes()-1)), *(msh2->getNode(msh->getNNodes()-1))));
+    ASSERT_EQ(msh->getNumberOfNodes(), msh2->getNumberOfNodes());
+    ASSERT_DOUBLE_EQ(0, MathLib::sqrDist(*(msh->getNode(msh->getNumberOfNodes()-1)), *(msh2->getNode(msh->getNumberOfNodes()-1))));
 
     unsigned n_x (10);
     unsigned n_y (5);
     unsigned n_z (2);
     double delta (1.2);
     std::unique_ptr<Mesh> hex_mesh (MeshGenerator::generateRegularHexMesh(n_x, n_y, n_z, delta));
-    ASSERT_EQ(n_x * n_y * n_z, hex_mesh->getNElements());
-    ASSERT_EQ((n_x+1) * (n_y+1) * (n_z+1), hex_mesh->getNNodes());
-    const MeshLib::Node* node (hex_mesh->getNode(hex_mesh->getNNodes()-1));
+    ASSERT_EQ(n_x * n_y * n_z, hex_mesh->getNumberOfElements());
+    ASSERT_EQ((n_x+1) * (n_y+1) * (n_z+1), hex_mesh->getNumberOfNodes());
+    const MeshLib::Node* node (hex_mesh->getNode(hex_mesh->getNumberOfNodes()-1));
     ASSERT_DOUBLE_EQ(n_x*delta, (*node)[0]);
     ASSERT_DOUBLE_EQ(n_y*delta, (*node)[1]);
     ASSERT_DOUBLE_EQ(n_z*delta, (*node)[2]);
@@ -97,9 +97,9 @@ TEST(MeshLib, MeshGeneratorRegularQuad)
     unsigned n_y (5);
     double delta (1.2);
     std::unique_ptr<Mesh> quad_mesh (MeshGenerator::generateRegularQuadMesh(n_x, n_y,delta));
-    ASSERT_EQ(n_x * n_y, quad_mesh->getNElements());
-    ASSERT_EQ((n_x+1) * (n_y+1), quad_mesh->getNNodes());
-    const MeshLib::Node* node (quad_mesh->getNode(quad_mesh->getNNodes()-1));
+    ASSERT_EQ(n_x * n_y, quad_mesh->getNumberOfElements());
+    ASSERT_EQ((n_x+1) * (n_y+1), quad_mesh->getNumberOfNodes());
+    const MeshLib::Node* node (quad_mesh->getNode(quad_mesh->getNumberOfNodes()-1));
     ASSERT_DOUBLE_EQ(n_x*delta, (*node)[0]);
     ASSERT_DOUBLE_EQ(n_y*delta, (*node)[1]);
     ASSERT_DOUBLE_EQ(0, (*node)[2]);
@@ -107,8 +107,8 @@ TEST(MeshLib, MeshGeneratorRegularQuad)
     const double L = 10.0;
     const std::size_t n_subdivisions = 9;
     std::unique_ptr<Mesh> quad_mesh2(MeshGenerator::generateRegularQuadMesh(L, n_subdivisions));
-    ASSERT_EQ(n_subdivisions * n_subdivisions, quad_mesh2->getNElements());
-    node = quad_mesh2->getNode(quad_mesh2->getNNodes()-1);
+    ASSERT_EQ(n_subdivisions * n_subdivisions, quad_mesh2->getNumberOfElements());
+    node = quad_mesh2->getNode(quad_mesh2->getNumberOfNodes()-1);
     ASSERT_DOUBLE_EQ(L, (*node)[0]);
     ASSERT_DOUBLE_EQ(L, (*node)[1]);
 }
@@ -122,8 +122,8 @@ TEST(MeshLib, MeshGeneratorRegularPrism)
     unsigned n_y (5);
     unsigned n_z (4);
     std::unique_ptr<Mesh> mesh (MeshGenerator::generateRegularPrismMesh(l_x, l_y, l_z, n_x, n_y, n_z));
-    ASSERT_EQ(2 * n_x * n_y * n_z, mesh->getNElements());
-    ASSERT_EQ((n_x+1) * (n_y+1) * (n_z+1), mesh->getNNodes());
+    ASSERT_EQ(2 * n_x * n_y * n_z, mesh->getNumberOfElements());
+    ASSERT_EQ((n_x+1) * (n_y+1) * (n_z+1), mesh->getNumberOfNodes());
 
     std::size_t count (0);
     for (std::size_t k=0; k<(n_z+1); ++k)

--- a/Tests/MeshLib/TestMeshNodeSearch.cpp
+++ b/Tests/MeshLib/TestMeshNodeSearch.cpp
@@ -241,7 +241,7 @@ TEST_F(MeshLibMeshNodeSearchInSimpleQuadMesh, SurfaceSearch)
 
     std::vector<std::size_t> const& found_ids_sfc0(mesh_node_searcher.getMeshNodeIDsAlongSurface(*sfc0));
 
-    ASSERT_EQ(_quad_mesh->getNNodes(), found_ids_sfc0.size());
+    ASSERT_EQ(_quad_mesh->getNumberOfNodes(), found_ids_sfc0.size());
     for (std::size_t k(0); k<found_ids_sfc0.size(); k++)
         ASSERT_EQ(k, found_ids_sfc0[k]);
 
@@ -256,7 +256,7 @@ TEST_F(MeshLibMeshNodeSearchInSimpleQuadMesh, SurfaceSearch)
 
     std::vector<std::size_t> const& found_ids_sfc1(mesh_node_searcher.getMeshNodeIDsAlongSurface(*sfc1));
 
-    ASSERT_EQ(_quad_mesh->getNNodes()/2, found_ids_sfc1.size());
+    ASSERT_EQ(_quad_mesh->getNumberOfNodes()/2, found_ids_sfc1.size());
     for (std::size_t k(0); k<found_ids_sfc1.size(); k++)
         ASSERT_EQ(k, found_ids_sfc1[k]);
 

--- a/Tests/MeshLib/TestMeshRevision.cpp
+++ b/Tests/MeshLib/TestMeshRevision.cpp
@@ -43,13 +43,13 @@ TEST(MeshEditing, Tri)
 
     ASSERT_EQ(MeshLib::MeshElemType::LINE, result->getElement(0)->getGeomType());
     ASSERT_EQ(1, result->getElement(0)->getContent());
-    ASSERT_EQ(2u, result->getNNodes());
+    ASSERT_EQ(2u, result->getNumberOfNodes());
     delete result;
 
     result = rev.simplifyMesh("new_mesh", 0.0999);
     ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, result->getElement(0)->getGeomType());
     ASSERT_EQ(0.05, result->getElement(0)->getContent());
-    ASSERT_EQ(3u, result->getNNodes());
+    ASSERT_EQ(3u, result->getNumberOfNodes());
     delete result;
 }
 
@@ -69,7 +69,7 @@ TEST(MeshEditing, NonPlanarQuad)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(2u, result->getNElements());
+    ASSERT_EQ(2u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, result->getElement(1)->getGeomType());
 
     delete result;
@@ -94,7 +94,7 @@ TEST(MeshEditing, Quad2Line)
 
     ASSERT_EQ(MeshLib::MeshElemType::LINE, result->getElement(0)->getGeomType());
     ASSERT_NEAR(1.414213562373095, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
-    ASSERT_EQ(2u, result->getNNodes());
+    ASSERT_EQ(2u, result->getNumberOfNodes());
 
     delete result;
 }
@@ -118,7 +118,7 @@ TEST(MeshEditing, Quad2Tri)
 
     ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, result->getElement(0)->getGeomType());
     ASSERT_NEAR(0.5049752469181039, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
-    ASSERT_EQ(3u, result->getNNodes());
+    ASSERT_EQ(3u, result->getNumberOfNodes());
 
     delete result;
 }
@@ -144,7 +144,7 @@ TEST(MeshEditing, NonPlanarHex)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(6u, result->getNElements());
+    ASSERT_EQ(6u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(4)->getGeomType());
     ASSERT_NEAR(0.25, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
     ASSERT_NEAR(0.1666666666666667, result->getElement(5)->getContent(), std::numeric_limits<double>::epsilon());
@@ -173,7 +173,7 @@ TEST(MeshEditing, Hex2PyramidPrism)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(2u, result->getNElements());
+    ASSERT_EQ(2u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::PYRAMID, result->getElement(0)->getGeomType());
     ASSERT_EQ(MeshLib::MeshElemType::PRISM, result->getElement(1)->getGeomType());
     ASSERT_NEAR(0.3333333333333333, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
@@ -203,7 +203,7 @@ TEST(MeshEditing, Hex2FourTets)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(4u, result->getNElements());
+    ASSERT_EQ(4u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(1)->getGeomType());
     ASSERT_NEAR(0.1666666666666667, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
     ASSERT_NEAR(0.1666666666666667, result->getElement(1)->getContent(), std::numeric_limits<double>::epsilon());
@@ -234,7 +234,7 @@ TEST(MeshEditing, Hex2TwoTets)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(2u, result->getNElements());
+    ASSERT_EQ(2u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(1)->getGeomType());
     ASSERT_NEAR(0.1666666666666667, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
     ASSERT_NEAR(0.1666666666666667, result->getElement(1)->getContent(), std::numeric_limits<double>::epsilon());
@@ -260,7 +260,7 @@ TEST(MeshEditing, NonPlanarPyramid)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(2u, result->getNElements());
+    ASSERT_EQ(2u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(1)->getGeomType());
     ASSERT_NEAR(0.25, result->getElement(0)->getContent(),  std::numeric_limits<double>::epsilon());
     ASSERT_NEAR(0.1666666666666667, result->getElement(1)->getContent(), std::numeric_limits<double>::epsilon());
@@ -286,7 +286,7 @@ TEST(MeshEditing, Pyramid2Tet)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(1u, result->getNElements());
+    ASSERT_EQ(1u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(0)->getGeomType());
     ASSERT_NEAR(0.16666666666666666, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 
@@ -311,7 +311,7 @@ TEST(MeshEditing, Pyramid2Quad)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(1u, result->getNElements());
+    ASSERT_EQ(1u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::QUAD, result->getElement(0)->getGeomType());
     ASSERT_NEAR(1, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 
@@ -336,8 +336,8 @@ TEST(MeshEditing, Pyramid2Tri)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(3u, result->getNNodes());
-    ASSERT_EQ(1u, result->getNElements());
+    ASSERT_EQ(3u, result->getNumberOfNodes());
+    ASSERT_EQ(1u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, result->getElement(0)->getGeomType());
     ASSERT_NEAR(0.5, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 
@@ -363,7 +363,7 @@ TEST(MeshEditing, NonPlanarPrism)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(3u, result->getNElements());
+    ASSERT_EQ(3u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(2)->getGeomType());
     ASSERT_NEAR(0.1666666666666667, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 
@@ -389,8 +389,8 @@ TEST(MeshEditing, Prism2TwoTets)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(5u, result->getNNodes());
-    ASSERT_EQ(2u, result->getNElements());
+    ASSERT_EQ(5u, result->getNumberOfNodes());
+    ASSERT_EQ(2u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(1)->getGeomType());
     ASSERT_NEAR(0.1666666666666667, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
     ASSERT_NEAR(0.15, result->getElement(1)->getContent(), std::numeric_limits<double>::epsilon());
@@ -417,7 +417,7 @@ TEST(MeshEditing, Prism2Quad)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(1u, result->getNElements());
+    ASSERT_EQ(1u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::QUAD, result->getElement(0)->getGeomType());
     ASSERT_NEAR(1.345362404707371, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 
@@ -443,7 +443,7 @@ TEST(MeshEditing, Prism2Tet)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(1u, result->getNElements());
+    ASSERT_EQ(1u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::TETRAHEDRON, result->getElement(0)->getGeomType());
     ASSERT_NEAR(0.1666666666666667, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 
@@ -469,7 +469,7 @@ TEST(MeshEditing, Prism2Tri)
     MeshLib::MeshRevision rev(mesh);
     MeshLib::Mesh* result = rev.simplifyMesh("new_mesh", 0.2);
 
-    ASSERT_EQ(1u, result->getNElements());
+    ASSERT_EQ(1u, result->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, result->getElement(0)->getGeomType());
     ASSERT_NEAR(0.5, result->getElement(0)->getContent(), std::numeric_limits<double>::epsilon());
 

--- a/Tests/MeshLib/TestNodeAdjacencyTable.cpp
+++ b/Tests/MeshLib/TestNodeAdjacencyTable.cpp
@@ -27,16 +27,16 @@ TEST(MeshLib, CreateNodeAdjacencyTable1D)
     NodeAdjacencyTable table(mesh->getNodes());
 
     // There must be as many entries as there are nodes in the mesh.
-    ASSERT_EQ(mesh->getNNodes(), table.size());
+    ASSERT_EQ(mesh->getNumberOfNodes(), table.size());
 
     // Minimum connectivity for line mesh is 2 for boundary nodes,
     // and the maximum is 3 for interior nodes.
-    std::size_t const nnodes = mesh->getNNodes();
+    std::size_t const nnodes = mesh->getNumberOfNodes();
     for (std::size_t i = 0; i < nnodes; ++i)
     {
         std::size_t const n_connections = table.getNodeDegree(i);
 
-        std::size_t const n_elements = mesh->getNode(i)->getNElements();
+        std::size_t const n_elements = mesh->getNode(i)->getNumberOfElements();
         switch (n_elements)
         {
         case 1: // a corner node has 2 adjacent nodes.
@@ -63,14 +63,14 @@ TEST(MeshLib, CreateNodeAdjacencyTable2D)
     NodeAdjacencyTable table(mesh->getNodes());
 
     // There must be as many entries as there are nodes in the mesh.
-    ASSERT_EQ(mesh->getNNodes(), table.size());
+    ASSERT_EQ(mesh->getNumberOfNodes(), table.size());
 
-    std::size_t const nnodes = mesh->getNNodes();
+    std::size_t const nnodes = mesh->getNumberOfNodes();
     for (std::size_t i = 0; i < nnodes; ++i)
     {
         std::size_t const n_connections = table.getNodeDegree(i);
 
-        std::size_t const n_elements = mesh->getNode(i)->getNElements();
+        std::size_t const n_elements = mesh->getNode(i)->getNumberOfElements();
         switch (n_elements)
         {
         case 1: // a corner node has 4 adjacent nodes.
@@ -101,14 +101,14 @@ TEST(MeshLib, CreateNodeAdjacencyTable3D)
     NodeAdjacencyTable table(mesh->getNodes());
 
     // There must be as many entries as there are nodes in the mesh.
-    ASSERT_EQ(mesh->getNNodes(), table.size());
+    ASSERT_EQ(mesh->getNumberOfNodes(), table.size());
 
-    std::size_t const nnodes = mesh->getNNodes();
+    std::size_t const nnodes = mesh->getNumberOfNodes();
     for (std::size_t i = 0; i < nnodes; ++i)
     {
         std::size_t const n_connections = table.getNodeDegree(i);
 
-        std::size_t const n_elements = mesh->getNode(i)->getNElements();
+        std::size_t const n_elements = mesh->getNode(i)->getNumberOfElements();
         switch (n_elements)
         {
         case 1: // a corner node has 8 adjacent nodes.

--- a/Tests/MeshLib/TestProjectMeshOnPlane.cpp
+++ b/Tests/MeshLib/TestProjectMeshOnPlane.cpp
@@ -46,7 +46,7 @@ protected:
 TEST_F(ProjectionTest, ProjectToXY)
 {
     MathLib::Vector3 normal (0,0,1);
-    std::size_t const n_nodes (_mesh->getNNodes());
+    std::size_t const n_nodes (_mesh->getNumberOfNodes());
     for (std::size_t p=0; p<10; p++)
     {
         MathLib::Point3d origin (std::array<double,3>{{0,0,static_cast<double>(p)}});
@@ -61,7 +61,7 @@ TEST_F(ProjectionTest, ProjectToXY)
 TEST_F(ProjectionTest, ProjectToXZ)
 {
     MathLib::Vector3 normal (0,1,0);
-    std::size_t const n_nodes (_mesh->getNNodes());
+    std::size_t const n_nodes (_mesh->getNumberOfNodes());
     for (std::size_t p=0; p<10; p++)
     {
         MathLib::Point3d origin (std::array<double,3>{{0,static_cast<double>(p),0}});
@@ -76,7 +76,7 @@ TEST_F(ProjectionTest, ProjectToXZ)
 TEST_F(ProjectionTest, ProjectToYZ)
 {
     MathLib::Vector3 normal (1,0,0);
-    std::size_t const n_nodes (_mesh->getNNodes());
+    std::size_t const n_nodes (_mesh->getNumberOfNodes());
     for (std::size_t p=0; p<10; p++)
     {
         MathLib::Point3d origin (std::array<double,3>{{static_cast<double>(p),0,0}});
@@ -92,7 +92,7 @@ TEST_F(ProjectionTest, NormalDirection)
 {
     MathLib::Vector3 normal_p (0,0,1);
     MathLib::Vector3 normal_n (0,0,-1);
-    std::size_t const n_nodes (_mesh->getNNodes());
+    std::size_t const n_nodes (_mesh->getNumberOfNodes());
     MathLib::Point3d origin (std::array<double,3>{{0,0,0}});
     MeshLib::Mesh* result_p = MeshLib::projectMeshOntoPlane(*_mesh, origin, normal_p);
     MeshLib::Mesh* result_n = MeshLib::projectMeshOntoPlane(*_mesh, origin, normal_n);
@@ -107,7 +107,7 @@ TEST_F(ProjectionTest, NormalLength)
 {
     MathLib::Point3d origin (std::array<double,3>{{0,0,0}});
     MathLib::Vector3 normal (0,0,1);
-    std::size_t const n_nodes (_mesh->getNNodes());
+    std::size_t const n_nodes (_mesh->getNumberOfNodes());
     MeshLib::Mesh* result = MeshLib::projectMeshOntoPlane(*_mesh, origin, normal);
     for (std::size_t p=2; p<10; p++)
     {

--- a/Tests/MeshLib/TestQuadMesh.cpp
+++ b/Tests/MeshLib/TestQuadMesh.cpp
@@ -157,15 +157,15 @@ TEST_F(MeshLibQuadMesh, Construction)
     ASSERT_TRUE(mesh != nullptr);
 
     // There are n_elements^2 elements in the mesh.
-    ASSERT_EQ(n_elements * n_elements, mesh->getNElements());
+    ASSERT_EQ(n_elements * n_elements, mesh->getNumberOfElements());
 
     // There are n_nodes^2 nodes in the mesh.
-    ASSERT_EQ(n_nodes*n_nodes, mesh->getNNodes());
+    ASSERT_EQ(n_nodes*n_nodes, mesh->getNumberOfNodes());
 
     // All elements have maximum four neighbors.
     testAllElements([](MeshLib::Element const* const e, ...)
         {
-            ASSERT_EQ(4u, e->getNNeighbors());
+            ASSERT_EQ(4u, e->getNumberOfNeighbors());
         });
 }
 
@@ -252,7 +252,7 @@ TEST_F(MeshLibQuadMesh, ElementToNodeConnectivity)
         std::size_t const i,
         std::size_t const j)
         {
-            EXPECT_EQ(4u, e->getNBaseNodes());
+            EXPECT_EQ(4u, e->getNumberOfBaseNodes());
             EXPECT_EQ(getNode(i,   j),   e->getNode(0));
             EXPECT_EQ(getNode(i,   j+1), e->getNode(1));
             EXPECT_EQ(getNode(i+1, j+1), e->getNode(2));
@@ -269,7 +269,7 @@ TEST_F(MeshLibQuadMesh, NodeToElementConnectivity)
             std::size_t i,
             std::size_t j)
         {
-            EXPECT_EQ(1u, node->getNElements());
+            EXPECT_EQ(1u, node->getNumberOfElements());
 
             if (i == nodes_stride)
                 i--;
@@ -284,7 +284,7 @@ TEST_F(MeshLibQuadMesh, NodeToElementConnectivity)
         std::size_t i,
         std::size_t j)
         {
-            EXPECT_EQ(2u, node->getNElements());
+            EXPECT_EQ(2u, node->getNumberOfElements());
 
             if (i == 0)
             {
@@ -314,7 +314,7 @@ TEST_F(MeshLibQuadMesh, NodeToElementConnectivity)
         std::size_t const i,
         std::size_t const j)
         {
-            EXPECT_EQ(4u, node->getNElements());
+            EXPECT_EQ(4u, node->getNumberOfElements());
 
             EXPECT_EQ(getElement(i-1, j-1), node->getElement(0));
             EXPECT_EQ(getElement(i-1, j  ), node->getElement(1));

--- a/Tests/MeshLib/TestRemove.cpp
+++ b/Tests/MeshLib/TestRemove.cpp
@@ -36,10 +36,10 @@ TEST(MeshLib, RemoveNodes)
     auto new_mesh = std::unique_ptr<MeshLib::Mesh>{
         MeshLib::removeNodes(*mesh, removed_node_ids, "")};
 
-    ASSERT_EQ(5u, new_mesh->getNNodes());
-    ASSERT_EQ(5u, new_mesh->getNBaseNodes());
-    ASSERT_EQ(4u, new_mesh->getNElements());
-    for (std::size_t i=0; i<new_mesh->getNNodes(); i++)
+    ASSERT_EQ(5u, new_mesh->getNumberOfNodes());
+    ASSERT_EQ(5u, new_mesh->getNumberOfBaseNodes());
+    ASSERT_EQ(4u, new_mesh->getNumberOfElements());
+    for (std::size_t i=0; i<new_mesh->getNumberOfNodes(); i++)
         ASSERT_TRUE(*mesh->getNode(5+i) == *new_mesh->getNode(i));
 }
 
@@ -55,9 +55,9 @@ TEST(MeshLib, RemoveElements)
     auto new_mesh = std::unique_ptr<MeshLib::Mesh>{
         MeshLib::removeElements(*mesh, removed_ele_ids, "")};
 
-    ASSERT_EQ(5u, new_mesh->getNNodes());
-    ASSERT_EQ(5u, new_mesh->getNBaseNodes());
-    ASSERT_EQ(4u, new_mesh->getNElements());
-    for (std::size_t i=0; i<new_mesh->getNNodes(); i++)
+    ASSERT_EQ(5u, new_mesh->getNumberOfNodes());
+    ASSERT_EQ(5u, new_mesh->getNumberOfBaseNodes());
+    ASSERT_EQ(4u, new_mesh->getNumberOfElements());
+    for (std::size_t i=0; i<new_mesh->getNumberOfNodes(); i++)
         ASSERT_TRUE(*mesh->getNode(5+i) == *new_mesh->getNode(i));
 }

--- a/Tests/MeshLib/TestTriLineMesh.cpp
+++ b/Tests/MeshLib/TestTriLineMesh.cpp
@@ -77,28 +77,28 @@ class MeshLibTriLineMesh : public ::testing::Test
 TEST_F(MeshLibTriLineMesh, Construction)
 {
     ASSERT_TRUE(mesh != nullptr);
-    ASSERT_EQ(3u, mesh->getNElements());
+    ASSERT_EQ(3u, mesh->getNumberOfElements());
     ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, elements[0]->getGeomType());
     ASSERT_EQ(MeshLib::MeshElemType::TRIANGLE, elements[1]->getGeomType());
     ASSERT_EQ(MeshLib::MeshElemType::LINE, elements[2]->getGeomType());
-    ASSERT_EQ(4u, mesh->getNNodes());
+    ASSERT_EQ(4u, mesh->getNumberOfNodes());
 }
 
 TEST_F(MeshLibTriLineMesh, NodeToElementConnectivity)
 {
     // Nodes 0 and 3 are connected only to triangles.
-    EXPECT_EQ(1u, nodes[0]->getNElements());
-    EXPECT_EQ(1u, nodes[3]->getNElements());
+    EXPECT_EQ(1u, nodes[0]->getNumberOfElements());
+    EXPECT_EQ(1u, nodes[3]->getNumberOfElements());
     EXPECT_EQ(elements[0], nodes[0]->getElement(0));
     EXPECT_EQ(elements[1], nodes[3]->getElement(0));
 
     // Nodes 1 and 2 are connected to all elements.
-    EXPECT_EQ(3u, nodes[1]->getNElements());
+    EXPECT_EQ(3u, nodes[1]->getNumberOfElements());
     EXPECT_TRUE(isConnectedToNode(1, 0));
     EXPECT_TRUE(isConnectedToNode(1, 1));
     EXPECT_TRUE(isConnectedToNode(1, 2));
 
-    EXPECT_EQ(3u, nodes[2]->getNElements());
+    EXPECT_EQ(3u, nodes[2]->getNumberOfElements());
     EXPECT_TRUE(isConnectedToNode(2, 0));
     EXPECT_TRUE(isConnectedToNode(2, 1));
     EXPECT_TRUE(isConnectedToNode(2, 2));

--- a/Tests/MeshLib/TestVtkMappedMeshSource.cpp
+++ b/Tests/MeshLib/TestVtkMappedMeshSource.cpp
@@ -49,7 +49,7 @@ class InSituMesh : public ::testing::Test
             mesh->getProperties().createNewPropertyVector<double>(point_prop_name,
                 MeshLib::MeshItemType::Node)
         );
-        (*point_double_properties).resize(mesh->getNNodes());
+        (*point_double_properties).resize(mesh->getNumberOfNodes());
         std::iota((*point_double_properties).begin(), (*point_double_properties).end(), 1);
 
         std::string const cell_prop_name("CellDoubleProperty");
@@ -57,7 +57,7 @@ class InSituMesh : public ::testing::Test
             mesh->getProperties().createNewPropertyVector<double>(cell_prop_name,
                 MeshLib::MeshItemType::Cell)
         );
-        (*cell_double_properties).resize(mesh->getNElements());
+        (*cell_double_properties).resize(mesh->getNumberOfElements());
         std::iota((*cell_double_properties).begin(), (*cell_double_properties).end(), 1);
 
         std::string const point_int_prop_name("PointIntProperty");
@@ -65,7 +65,7 @@ class InSituMesh : public ::testing::Test
             mesh->getProperties().createNewPropertyVector<int>(point_int_prop_name,
                 MeshLib::MeshItemType::Node)
         );
-        (*point_int_properties).resize(mesh->getNNodes());
+        (*point_int_properties).resize(mesh->getNumberOfNodes());
         std::iota((*point_int_properties).begin(), (*point_int_properties).end(), 1);
 
         std::string const cell_int_prop_name("CellIntProperty");
@@ -73,7 +73,7 @@ class InSituMesh : public ::testing::Test
             mesh->getProperties().createNewPropertyVector<int>(cell_int_prop_name,
                 MeshLib::MeshItemType::Cell)
         );
-        (*cell_int_properties).resize(mesh->getNElements());
+        (*cell_int_properties).resize(mesh->getNumberOfElements());
         std::iota((*cell_int_properties).begin(), (*cell_int_properties).end(), 1);
 
         std::string const point_unsigned_prop_name("PointUnsignedProperty");
@@ -81,7 +81,7 @@ class InSituMesh : public ::testing::Test
             mesh->getProperties().createNewPropertyVector<unsigned>(point_unsigned_prop_name,
                 MeshLib::MeshItemType::Node)
         );
-        (*point_unsigned_properties).resize(mesh->getNNodes());
+        (*point_unsigned_properties).resize(mesh->getNumberOfNodes());
         std::iota((*point_unsigned_properties).begin(), (*point_unsigned_properties).end(), 1);
 
         std::string const cell_unsigned_prop_name("CellUnsignedProperty");
@@ -89,7 +89,7 @@ class InSituMesh : public ::testing::Test
             mesh->getProperties().createNewPropertyVector<unsigned>(cell_unsigned_prop_name,
                 MeshLib::MeshItemType::Cell)
         );
-        (*cell_unsigned_properties).resize(mesh->getNElements());
+        (*cell_unsigned_properties).resize(mesh->getNumberOfElements());
         std::iota((*cell_unsigned_properties).begin(), (*cell_unsigned_properties).end(), 1);
 
         std::string const material_ids_name("MaterialIDs");
@@ -97,7 +97,7 @@ class InSituMesh : public ::testing::Test
             mesh->getProperties().createNewPropertyVector<int>(material_ids_name,
                 MeshLib::MeshItemType::Cell)
         );
-        (*material_id_properties).resize(mesh->getNElements());
+        (*material_id_properties).resize(mesh->getNumberOfElements());
         std::iota((*material_id_properties).begin(), (*material_id_properties).end(), 1);
     }
 
@@ -117,7 +117,7 @@ class InSituMesh : public ::testing::Test
 TEST_F(InSituMesh, Construction)
 {
     ASSERT_TRUE(mesh != nullptr);
-    ASSERT_EQ((subdivisions+1)*(subdivisions+1)*(subdivisions+1), mesh->getNNodes());
+    ASSERT_EQ((subdivisions+1)*(subdivisions+1)*(subdivisions+1), mesh->getNumberOfNodes());
 }
 
 // Maps the mesh into a vtkUnstructuredGrid-equivalent
@@ -164,47 +164,47 @@ TEST_F(InSituMesh, DISABLED_MappedMeshSourceRoundtrip)
 
     // Point data arrays
     vtkDataArray* pointDoubleArray = output->GetPointData()->GetScalars("PointDoubleProperty");
-    ASSERT_EQ(pointDoubleArray->GetSize(), mesh->getNNodes());
+    ASSERT_EQ(pointDoubleArray->GetSize(), mesh->getNumberOfNodes());
     ASSERT_EQ(pointDoubleArray->GetComponent(0, 0), 1.0);
     double* range = pointDoubleArray->GetRange(0);
     ASSERT_EQ(range[0], 1.0);
-    ASSERT_EQ(range[1], 1.0 + mesh->getNNodes() - 1.0);
+    ASSERT_EQ(range[1], 1.0 + mesh->getNumberOfNodes() - 1.0);
 
     vtkDataArray* pointIntArray = output->GetPointData()->GetScalars("PointIntProperty");
-    ASSERT_EQ(pointIntArray->GetSize(), mesh->getNNodes());
+    ASSERT_EQ(pointIntArray->GetSize(), mesh->getNumberOfNodes());
     ASSERT_EQ(pointIntArray->GetComponent(0, 0), 1.0);
     range = pointIntArray->GetRange(0);
     ASSERT_EQ(range[0], 1.0);
-    ASSERT_EQ(range[1], 1 + mesh->getNNodes() - 1);
+    ASSERT_EQ(range[1], 1 + mesh->getNumberOfNodes() - 1);
 
     vtkDataArray* pointUnsignedArray = output->GetPointData()->GetScalars("PointUnsignedProperty");
-    ASSERT_EQ(pointUnsignedArray->GetSize(), mesh->getNNodes());
+    ASSERT_EQ(pointUnsignedArray->GetSize(), mesh->getNumberOfNodes());
     ASSERT_EQ(pointUnsignedArray->GetComponent(0, 0), 1.0);
     range = pointUnsignedArray->GetRange(0);
     ASSERT_EQ(range[0], 1.0);
-    ASSERT_EQ(range[1], 1 + mesh->getNNodes() - 1);
+    ASSERT_EQ(range[1], 1 + mesh->getNumberOfNodes() - 1);
 
     // Cell data arrays
     vtkDataArray* cellDoubleArray = output->GetCellData()->GetScalars("CellDoubleProperty");
-    ASSERT_EQ(cellDoubleArray->GetSize(), mesh->getNElements());
+    ASSERT_EQ(cellDoubleArray->GetSize(), mesh->getNumberOfElements());
     ASSERT_EQ(cellDoubleArray->GetComponent(0, 0), 1.0);
     range = cellDoubleArray->GetRange(0);
     ASSERT_EQ(range[0], 1.0);
-    ASSERT_EQ(range[1], 1.0 + mesh->getNElements() - 1.0);
+    ASSERT_EQ(range[1], 1.0 + mesh->getNumberOfElements() - 1.0);
 
     vtkDataArray* cellIntArray = output->GetCellData()->GetScalars("CellIntProperty");
-    ASSERT_EQ(cellIntArray->GetSize(), mesh->getNElements());
+    ASSERT_EQ(cellIntArray->GetSize(), mesh->getNumberOfElements());
     ASSERT_EQ(cellIntArray->GetComponent(0, 0), 1.0);
     range = cellIntArray->GetRange(0);
     ASSERT_EQ(range[0], 1.0);
-    ASSERT_EQ(range[1], 1 + mesh->getNElements() - 1);
+    ASSERT_EQ(range[1], 1 + mesh->getNumberOfElements() - 1);
 
     vtkDataArray* cellUnsignedArray = output->GetCellData()->GetScalars("CellUnsignedProperty");
-    ASSERT_EQ(cellUnsignedArray->GetSize(), mesh->getNElements());
+    ASSERT_EQ(cellUnsignedArray->GetSize(), mesh->getNumberOfElements());
     ASSERT_EQ(cellUnsignedArray->GetComponent(0, 0), 1.0);
     range = cellUnsignedArray->GetRange(0);
     ASSERT_EQ(range[0], 1.0);
-    ASSERT_EQ(range[1], 1 + mesh->getNElements() - 1);
+    ASSERT_EQ(range[1], 1 + mesh->getNumberOfElements() - 1);
 
     // -- Write VTK mesh to file (in all combinations of binary, appended and compressed)
     // atm vtkXMLWriter::Appended does not work, see http://www.paraview.org/Bug/view.php?id=13382
@@ -242,8 +242,8 @@ TEST_F(InSituMesh, DISABLED_MappedMeshSourceRoundtrip)
 
             // Both OGS meshes should be identical
             auto newMesh = std::unique_ptr<MeshLib::Mesh>{MeshLib::VtkMeshConverter::convertUnstructuredGrid(vtkMesh)};
-            ASSERT_EQ(mesh->getNNodes(), newMesh->getNNodes());
-            ASSERT_EQ(mesh->getNElements(), newMesh->getNElements());
+            ASSERT_EQ(mesh->getNumberOfNodes(), newMesh->getNumberOfNodes());
+            ASSERT_EQ(mesh->getNumberOfElements(), newMesh->getNumberOfElements());
 
             // Both properties should be identical
             auto meshProperties = mesh->getProperties();

--- a/Tests/MeshLib/TestVtkMappedPropertyVector.cpp
+++ b/Tests/MeshLib/TestVtkMappedPropertyVector.cpp
@@ -49,7 +49,7 @@ TEST(MeshLibMappedPropertyVector, Double)
     ASSERT_EQ(dataArray->GetValueReference(0), 1.0);
     double* range = dataArray->GetRange(0);
     ASSERT_EQ(range[0], 1.0);
-    ASSERT_EQ(range[1], 1.0 + mesh->getNElements() - 1.0);
+    ASSERT_EQ(range[1], 1.0 + mesh->getNumberOfElements() - 1.0);
 
     delete mesh;
 }
@@ -81,7 +81,7 @@ TEST(MeshLibMappedPropertyVector, Int)
     ASSERT_EQ(dataArray->GetValueReference(0), -5);
     double* range = dataArray->GetRange(0);
     ASSERT_EQ(-5.0, range[0]);
-    ASSERT_EQ(-5.0 + static_cast<double>(mesh->getNElements()) - 1.0, range[1]);
+    ASSERT_EQ(-5.0 + static_cast<double>(mesh->getNumberOfElements()) - 1.0, range[1]);
 
     delete mesh;
 }
@@ -113,7 +113,7 @@ TEST(MeshLibMappedPropertyVector, Unsigned)
     ASSERT_EQ(dataArray->GetValueReference(0), 0);
     double* range = dataArray->GetRange(0);
     ASSERT_EQ(range[0], 0);
-    ASSERT_EQ(range[1], 0 + mesh->getNElements() - 1);
+    ASSERT_EQ(range[1], 0 + mesh->getNumberOfElements() - 1);
 
     delete mesh;
 }

--- a/Tests/MeshLib/TestVtkMeshConverter.cpp
+++ b/Tests/MeshLib/TestVtkMeshConverter.cpp
@@ -95,8 +95,8 @@ TEST_F(TestVtkMeshConverter, Conversion)
 {
     auto mesh = std::unique_ptr<MeshLib::Mesh>(
         MeshLib::VtkMeshConverter::convertUnstructuredGrid(vtu));
-    ASSERT_EQ(mesh->getNNodes(), vtu->GetNumberOfPoints());
-    ASSERT_EQ(mesh->getNElements(), vtu->GetNumberOfCells());
+    ASSERT_EQ(mesh->getNumberOfNodes(), vtu->GetNumberOfPoints());
+    ASSERT_EQ(mesh->getNumberOfElements(), vtu->GetNumberOfCells());
     ASSERT_EQ(mesh->getElement(0)->getCellType(), MeshLib::CellType::HEX8);
 
     auto meshProperties = mesh->getProperties();

--- a/Tests/NumLib/LocalToGlobalIndexMap.cpp
+++ b/Tests/NumLib/LocalToGlobalIndexMap.cpp
@@ -62,7 +62,7 @@ TEST_F(NumLibLocalToGlobalIndexMapTest, DISABLED_NumberOfRowsByComponent)
 
     // There must be as many rows as nodes in the input times the number of
     // components.
-    ASSERT_EQ(mesh->getNNodes() * components_size, dof_map->dofSizeWithGhosts());
+    ASSERT_EQ(mesh->getNumberOfNodes() * components_size, dof_map->dofSizeWithGhosts());
 }
 
 #ifndef USE_PETSC
@@ -80,7 +80,7 @@ TEST_F(NumLibLocalToGlobalIndexMapTest, DISABLED_NumberOfRowsByLocation)
 
     // There must be as many rows as nodes in the input times the number of
     // components.
-    ASSERT_EQ(mesh->getNNodes() * components_size, dof_map->dofSizeWithGhosts());
+    ASSERT_EQ(mesh->getNumberOfNodes() * components_size, dof_map->dofSizeWithGhosts());
 }
 
 #ifndef USE_PETSC

--- a/Tests/NumLib/LocalToGlobalIndexMapMultiComponent.cpp
+++ b/Tests/NumLib/LocalToGlobalIndexMapMultiComponent.cpp
@@ -152,7 +152,7 @@ void NumLibLocalToGlobalIndexMapMultiDOFTest::test(
     initComponents(num_components, selected_component, ComponentOrder);
 
     ASSERT_EQ(dof_map->getNumComponents(), num_components);
-    ASSERT_EQ(dof_map->size(), mesh->getNElements());
+    ASSERT_EQ(dof_map->size(), mesh->getNumberOfElements());
 
     ASSERT_EQ(dof_map_boundary->getNumComponents(), 1);
     ASSERT_EQ(dof_map_boundary->size(), boundary_elements.size());
@@ -160,7 +160,7 @@ void NumLibLocalToGlobalIndexMapMultiDOFTest::test(
     // check mesh elements
     for (unsigned e=0; e<dof_map->size(); ++e)
     {
-        auto const element_nodes_size = mesh->getElement(e)->getNNodes();
+        auto const element_nodes_size = mesh->getElement(e)->getNumberOfNodes();
         auto const ptr_element_nodes = mesh->getElement(e)->getNodes();
 
         for (unsigned c=0; c<dof_map->getNumComponents(); ++c)

--- a/Tests/NumLib/TestCoordinatesMapping.cpp
+++ b/Tests/NumLib/TestCoordinatesMapping.cpp
@@ -75,7 +75,7 @@ public:
         vec_eles.push_back(clockwiseEle);
         vec_eles.push_back(zeroVolumeEle);
         for (auto e : vec_eles)
-            for (unsigned i=0; i<e->getNNodes(); i++)
+            for (unsigned i=0; i<e->getNumberOfNodes(); i++)
                 vec_nodes.push_back(e->getNode(i));
     }
 
@@ -305,7 +305,7 @@ TEST(NumLib, FemNaturalCoordinatesMappingLineY)
     double exp_dNdx[2*e_nnodes] = {0, 0, -0.5, 0.5};
     ASSERT_ARRAY_NEAR(exp_dNdx, shape.dNdx.data(), shape.dNdx.size(), eps);
 
-    for (auto n = 0u; n < line->getNNodes(); ++n)
+    for (auto n = 0u; n < line->getNumberOfNodes(); ++n)
         delete line->getNode(n);
     delete line;
 }

--- a/Tests/NumLib/TestDistribution.cpp
+++ b/Tests/NumLib/TestDistribution.cpp
@@ -203,8 +203,8 @@ TEST_F(NumLibDistributionQuad, InterpolationSurface)
 {
     const std::vector<std::size_t> vec_point_ids = {{0, 1, 2, 3}};
     const std::vector<double> vec_point_values = {{0., 100., 100., 0.}};
-    std::vector<double> expected(_msh->getNNodes());
-    for (std::size_t i=0; i<_msh->getNNodes(); i++) {
+    std::vector<double> expected(_msh->getNumberOfNodes());
+    for (std::size_t i=0; i<_msh->getNumberOfNodes(); i++) {
         expected[i] = static_cast<double>((i%(_number_of_subdivisions_per_direction+1)) * 10);
     }
 

--- a/Tests/NumLib/TestExtrapolation.cpp
+++ b/Tests/NumLib/TestExtrapolation.cpp
@@ -242,7 +242,7 @@ private:
             LocalAssembler, LocalAssemblerData,
             GlobalMatrix, GlobalVector, GlobalDim>;
 
-        _local_assemblers.resize(mesh.getNElements());
+        _local_assemblers.resize(mesh.getNumberOfElements());
 
         LocalDataInitializer initializer(*_dof_table);
 
@@ -330,8 +330,8 @@ TEST(NumLib, DISABLED_Extrapolation)
                     MeshLib::MeshGenerator::generateRegularHexMesh(
                         mesh_length, mesh_elements_in_each_direction));
 
-        auto const nnodes    = mesh->getNNodes();
-        auto const nelements = mesh->getNElements();
+        auto const nnodes    = mesh->getNumberOfNodes();
+        auto const nelements = mesh->getNumberOfElements();
         DBUG("number of nodes: %lu, number of elements: %lu", nnodes, nelements);
 
         TestProcess<GlobalSetup> pcs(*mesh, integration_order);

--- a/Tests/NumLib/TestFe.cpp
+++ b/Tests/NumLib/TestFe.cpp
@@ -131,7 +131,7 @@ class NumLibFemIsoTest : public ::testing::Test, public T::TestFeType
         // for destructor
         vec_eles.push_back(mesh_element);
         for (auto e : vec_eles)
-            for (unsigned i=0; i<e->getNNodes(); i++)
+            for (unsigned i=0; i<e->getNumberOfNodes(); i++)
                 vec_nodes.push_back(e->getNode(i));
     }
 
@@ -194,7 +194,7 @@ TYPED_TEST(NumLibFemIsoTest, CheckMassMatrix)
     NodalMatrix M(this->e_nnodes, this->e_nnodes);
     M.setZero();
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    for (std::size_t i=0; i < this->integration_method.getNPoints(); i++) {
+    for (std::size_t i=0; i < this->integration_method.getNumberOfPoints(); i++) {
         shape.setZero();
         auto wp = this->integration_method.getWeightedPoint(i);
         fe.template computeShapeFunctions<ShapeMatrixType::N_J>(wp.getCoords(), shape);
@@ -218,7 +218,7 @@ TYPED_TEST(NumLibFemIsoTest, CheckLaplaceMatrix)
     NodalMatrix K(this->e_nnodes, this->e_nnodes);
     K.setZero();
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    for (std::size_t i=0; i < this->integration_method.getNPoints(); i++) {
+    for (std::size_t i=0; i < this->integration_method.getNumberOfPoints(); i++) {
         shape.setZero();
         auto wp = this->integration_method.getWeightedPoint(i);
         fe.template computeShapeFunctions<ShapeMatrixType::DNDX>(wp.getCoords(), shape);
@@ -244,7 +244,7 @@ TYPED_TEST(NumLibFemIsoTest, CheckMassLaplaceMatrices)
     NodalMatrix K(this->e_nnodes, this->e_nnodes);
     K.setZero();
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    for (std::size_t i=0; i < this->integration_method.getNPoints(); i++) {
+    for (std::size_t i=0; i < this->integration_method.getNumberOfPoints(); i++) {
         shape.setZero();
         auto wp = this->integration_method.getWeightedPoint(i);
         fe.computeShapeFunctions(wp.getCoords(), shape);
@@ -271,8 +271,8 @@ TYPED_TEST(NumLibFemIsoTest, CheckGaussIntegrationLevel)
     NodalMatrix M(this->e_nnodes, this->e_nnodes);
     M.setZero();
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    ASSERT_EQ(TestFixture::n_sample_pt_order2, this->integration_method.getNPoints());
-    for (std::size_t i=0; i < this->integration_method.getNPoints(); i++) {
+    ASSERT_EQ(TestFixture::n_sample_pt_order2, this->integration_method.getNumberOfPoints());
+    for (std::size_t i=0; i < this->integration_method.getNumberOfPoints(); i++) {
         shape.setZero();
         auto wp = this->integration_method.getWeightedPoint(i);
         fe.computeShapeFunctions(wp.getCoords(), shape);
@@ -284,8 +284,8 @@ TYPED_TEST(NumLibFemIsoTest, CheckGaussIntegrationLevel)
     // Change gauss quadrature level to 3
     this->integration_method.setIntegrationOrder(3);
     M *= .0;
-    ASSERT_EQ(TestFixture::n_sample_pt_order3, this->integration_method.getNPoints());
-    for (std::size_t i=0; i < this->integration_method.getNPoints(); i++) {
+    ASSERT_EQ(TestFixture::n_sample_pt_order3, this->integration_method.getNumberOfPoints());
+    for (std::size_t i=0; i < this->integration_method.getNumberOfPoints(); i++) {
         shape.setZero();
         auto wp = this->integration_method.getWeightedPoint(i);
         fe.computeShapeFunctions(wp.getCoords(), shape);

--- a/Tests/NumLib/TestFemIntegration.cpp
+++ b/Tests/NumLib/TestFemIntegration.cpp
@@ -118,16 +118,16 @@ TEST(NumLib, FemIntegrationGaussRegular)
     // check other member functions
     IntegrationGaussRegular<1> q1;
     ASSERT_EQ(2u, q1.getIntegrationOrder());
-    ASSERT_EQ(2u, q1.getNPoints());
+    ASSERT_EQ(2u, q1.getNumberOfPoints());
     q1.setIntegrationOrder(3u);
     ASSERT_EQ(3u, q1.getIntegrationOrder());
-    ASSERT_EQ(3u, q1.getNPoints());
+    ASSERT_EQ(3u, q1.getNumberOfPoints());
     IntegrationGaussRegular<2> q2;
     ASSERT_EQ(2u, q2.getIntegrationOrder());
-    ASSERT_EQ(4u, q2.getNPoints());
+    ASSERT_EQ(4u, q2.getNumberOfPoints());
     IntegrationGaussRegular<3> q3;
     ASSERT_EQ(2u, q3.getIntegrationOrder());
-    ASSERT_EQ(8u, q3.getNPoints());
+    ASSERT_EQ(8u, q3.getNumberOfPoints());
 }
 
 

--- a/Tests/NumLib/TestMeshComponentMap.cpp
+++ b/Tests/NumLib/TestMeshComponentMap.cpp
@@ -79,7 +79,7 @@ TEST_F(NumLibMeshComponentMapTest, DISABLED_CheckOrderByComponent)
     cmap = new MeshComponentMap(components,
         NumLib::ComponentOrder::BY_COMPONENT);
 
-    ASSERT_EQ(2 * mesh->getNNodes(), cmap->dofSizeWithGhosts());
+    ASSERT_EQ(2 * mesh->getNumberOfNodes(), cmap->dofSizeWithGhosts());
     for (std::size_t i = 0; i < mesh_size; i++)
     {
         // Test global indices for the different components of the node.
@@ -107,7 +107,7 @@ TEST_F(NumLibMeshComponentMapTest, DISABLED_CheckOrderByLocation)
     cmap = new MeshComponentMap(components,
         NumLib::ComponentOrder::BY_LOCATION);
 
-    ASSERT_EQ(2 * mesh->getNNodes(), cmap->dofSizeWithGhosts());
+    ASSERT_EQ(2 * mesh->getNumberOfNodes(), cmap->dofSizeWithGhosts());
     for (std::size_t i = 0; i < mesh_size; i++)
     {
         // Test global indices for the different components of the node.

--- a/Tests/NumLib/TestSerialLinearSolver.cpp
+++ b/Tests/NumLib/TestSerialLinearSolver.cpp
@@ -79,7 +79,7 @@ TEST(NumLibSerialLinearSolver, Steady2DdiffusionQuadElem)
     using LocalAssembler = Example::LocalAssemblerData<GlobalMatrix, GlobalVector>;
     // Initializer of the local assembler data.
     std::vector<LocalAssembler*> local_assembler_data;
-    local_assembler_data.resize(ex1.msh->getNElements());
+    local_assembler_data.resize(ex1.msh->getNumberOfElements());
 
     auto local_asm_builder =
         [&](std::size_t const id,

--- a/Tests/NumLib/TestTimeSteppingIterationNumber.cpp
+++ b/Tests/NumLib/TestTimeSteppingIterationNumber.cpp
@@ -121,6 +121,6 @@ TEST(NumLib, TimeSteppingIterationNumberBased2)
     //std::cout << vec_t;
 
     ASSERT_EQ(expected_vec_t.size(), vec_t.size());
-    ASSERT_EQ(1u, alg.getNRepeatedSteps());
+    ASSERT_EQ(1u, alg.getNumberOfRepeatedSteps());
     ASSERT_ARRAY_NEAR(expected_vec_t, vec_t, expected_vec_t.size(), std::numeric_limits<double>::epsilon());
 }

--- a/Tests/NumLib/TestVectorMatrixBuilder.cpp
+++ b/Tests/NumLib/TestVectorMatrixBuilder.cpp
@@ -87,8 +87,8 @@ TYPED_TEST_P(NumLibVectorMatrixBuilder, DISABLED_createMatrix)
     M* m = Builder::createMatrix(this->cmap->dofSizeWithGhosts());
 
     ASSERT_TRUE(m != nullptr);
-    ASSERT_EQ(this->cmap->dofSizeWithGhosts(), m->getNRows());
-    ASSERT_EQ(this->cmap->dofSizeWithGhosts(), m->getNCols());
+    ASSERT_EQ(this->cmap->dofSizeWithGhosts(), m->getNumberOfRows());
+    ASSERT_EQ(this->cmap->dofSizeWithGhosts(), m->getNumberOfColumns());
 
     delete m;
 }

--- a/scripts/doc/get-project-params.sh
+++ b/scripts/doc/get-project-params.sh
@@ -27,13 +27,13 @@ cat <<"EOF" \
 ^\s*//! \\ogs_file_\(param\|attr\){[A-Za-z_0-9]\+}\( \\todo .*\)\?$
 ^\s*//! \\ogs_file_special$
 ^\s*//! \\ogs_file_\(param\|attr\)_special{[A-Za-z_0-9]\+}\( \\todo .*\)\?$
-checkParameter.*)
-getAttribute.*)
-getParameter.*)
-getSubtree.*)
-ignoreAttribute.*)
-ignoreParameter.*)
-peekParameter.*)
+checkConfigParameter.*)
+getConfigAttribute.*)
+getConfigParameter.*)
+getConfigSubtree.*)
+ignoreConfigAttribute.*)
+ignoreConfigParameter.*)
+peekConfigParameter.*)
 EOF
 
 # format as table:

--- a/scripts/doc/get-project-params.sh
+++ b/scripts/doc/get-project-params.sh
@@ -27,13 +27,13 @@ cat <<"EOF" \
 ^\s*//! \\ogs_file_\(param\|attr\){[A-Za-z_0-9]\+}\( \\todo .*\)\?$
 ^\s*//! \\ogs_file_special$
 ^\s*//! \\ogs_file_\(param\|attr\)_special{[A-Za-z_0-9]\+}\( \\todo .*\)\?$
-checkConfParam.*)
-getConfAttribute.*)
-getConfParam.*)
-getConfSubtree.*)
-ignoreConfAttribute.*)
-ignoreConfParam.*)
-peekConfParam.*)
+checkParameter.*)
+getAttribute.*)
+getParameter.*)
+getSubtree.*)
+ignoreAttribute.*)
+ignoreParameter.*)
+peekParameter.*)
 EOF
 
 # format as table:

--- a/scripts/doc/normalize-param-cache.py
+++ b/scripts/doc/normalize-param-cache.py
@@ -19,11 +19,11 @@ comment = re.compile(r"^//! \\ogs_file_(param|attr)\{([A-Za-z_0-9]+)\}( \\todo .
 comment_special = re.compile(r"^//! \\ogs_file(_param|_attr)?_special(\{[A-Za-z_0-9]+\})?( \\todo .*)?$")
 
 # capture #5 is the parameter name
-getter = re.compile(r'^(get|check|ignore|peek)Conf(Param|Attribute|Subtree)(List|Optional|All)?'
+getter = re.compile(r'^(get|check|ignore|peek)Config(Parameter|Attribute|Subtree)(List|Optional|All)?'
                    +r'(<.*>)?'
                    +r'\("([a-zA-Z_0-9:]+)"[,)]')
 
-getter_special = re.compile(r'^(get|check|ignore|peek)Conf(Param|Attribute|Subtree)(List|Optional|All)?'
+getter_special = re.compile(r'^(get|check|ignore|peek)Config(Parameter|Attribute|Subtree)(List|Optional|All)?'
                            +r'(<.*>)?\(')
 
 state = "getter"
@@ -78,7 +78,7 @@ for inline in sys.stdin:
     if m:
         param = m.group(5)
         paramtype = m.group(4)[1:-1] if m.group(4) else ""
-        method = m.group(1) + "Conf" + m.group(2) + (m.group(3) or "")
+        method = m.group(1) + "Config" + m.group(2) + (m.group(3) or "")
 
         if state != "comment" or oldpath != path:
             write_out("NODOC", path, lineno, "NONE", param, paramtype, method)
@@ -93,7 +93,7 @@ for inline in sys.stdin:
                 debug("error: the associated comment is not on the line preceding this one."
                         + " line numbers {0} vs. {1}".format(oldlineno, lineno))
                 write_out("NODOC", path, lineno, tag_path_comment, param, paramtype, method)
-            elif param_or_attr_comment == "param" and m.group(2) != "Param" and m.group(2) != "Subtree":
+            elif param_or_attr_comment == "param" and m.group(2) != "Parameter" and m.group(2) != "Subtree":
                 debug("error: comment says param but code says different.")
                 write_out("NODOC", path, lineno, tag_path_comment, param, paramtype, method)
             elif param_or_attr_comment == "attr" and m.group(2) != "Attribute":
@@ -111,7 +111,7 @@ for inline in sys.stdin:
     m = getter_special.match(line)
     if m:
         paramtype = m.group(4)[1:-1] if m.group(4) else ""
-        method = m.group(1) + "Conf" + m.group(2) + (m.group(3) or "")
+        method = m.group(1) + "Config" + m.group(2) + (m.group(3) or "")
 
         if state != "comment" or oldpath != path:
             write_out("NODOC", path, lineno, "NONE", "UNKNOWN", paramtype, method)


### PR DESCRIPTION
As written in #1220. Let me know if there is something else to be renamed
- use only getNumberOfXXX() instead of getN, getNum
- use only initialize() instead of init() (private methods are not subject of this change)
- no use of short names in ConfigTree 
