### PR TITLE
Tag names of secondary variables better checked

### DIFF
--- a/ProcessLib/ProcessOutput.h
+++ b/ProcessLib/ProcessOutput.h
@@ -234,13 +234,12 @@ void doProcessOutput(
         }
     };
 
-    for (auto const& var : secondary_variables)
+    for (auto const& elem : secondary_variables)
     {
-        auto const var_name = secondary_variables.getMappedName(var.name);
-        if (output_variables.find(var_name)
-            != output_variables.cend())
+        auto const& var_name = elem.first;
+        if (output_variables.find(var_name) != output_variables.cend())
         {
-            add_secondary_var(var, var_name);
+            add_secondary_var(elem.second, var_name);
         }
     }
 

--- a/ProcessLib/SecondaryVariable.h
+++ b/ProcessLib/SecondaryVariable.h
@@ -115,10 +115,8 @@ public:
 
         // read which variables are defined in the config
         for (auto const& tag_name : tag_names) {
-            if (!_all_secondary_variables.insert(tag_name).second)
-            {
-                ERR("Tag name <%s> has been specified twice as a secondary variable.");
-                std::abort();
+            if (!_all_secondary_variables.insert(tag_name).second) {
+                OGS_FATAL("Tag name <%s> has been specified twice as a secondary variable.");
             }
 
             //! \ogs_file_special
@@ -179,19 +177,17 @@ public:
                              var_name, num_components, std::move(fcts)}))
                      .second)
             {
-                ERR("The secondary variable with name `%s' has already been "
-                    "set up.",
-                    var_name.c_str());
-                std::abort();
+                OGS_FATAL("The secondary variable with name `%s' has already been "
+                          "set up.",
+                          var_name.c_str());
             }
         }
         else if (_all_secondary_variables.find(tag_name) ==
                  _all_secondary_variables.end())
         {
-            ERR("The tag <%s> has not been registered to mark a secondary "
-                "variable.",
-                tag_name.c_str());
-            std::abort();
+            OGS_FATAL("The tag <%s> has not been registered to mark a secondary "
+                      "variable.",
+                      tag_name.c_str());
         }
     }
 


### PR DESCRIPTION
Thus it will be less likely to configure them wrong in custom processes.

The underlying "problem" is that the tag name has to be written twice in the source code in order to set up one secondary variable. Cf.
https://github.com/ufz/ogs/blob/master/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h#L108
and
https://github.com/ufz/ogs/blob/master/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h#L188