### PR TITLE
[NL] Remove Eigen alignment from shape matrices.

### DIFF
--- a/NumLib/Fem/CoordinatesMapping/ShapeMatrices.h
+++ b/NumLib/Fem/CoordinatesMapping/ShapeMatrices.h
@@ -15,8 +15,6 @@
 
 #include <ostream>
 
-#include <Eigen/Eigen>
-
 namespace NumLib
 {
 
@@ -103,8 +101,6 @@ struct ShapeMatrices
      * @param out the output stream
      */
     void write (std::ostream& out) const;
-
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 }; // ShapeMatrices
 

--- a/Tests/NumLib/TestFe.cpp
+++ b/Tests/NumLib/TestFe.cpp
@@ -155,9 +155,6 @@ class NumLibFemIsoTest : public ::testing::Test, public T::TestFeType
     std::vector<const MeshLib::Node*> vec_nodes;
     std::vector<const MeshElementType*> vec_eles;
     MeshElementType* mesh_element;
-
- public:
-   EIGEN_MAKE_ALIGNED_OPERATOR_NEW // required to use fixed size Eigen matrices
 }; // NumLibFemIsoTest
 
 template <class T>


### PR DESCRIPTION
The Eigen alignment is not used anywhere else and so far the code runs fine w/o
this alignment.
Between the decisions to add Eigen alignment for all Eigen-containing structs
and containers or remove completely the latter is easier.

This is related to https://github.com/ufz/ogs/pull/1221.

Closes https://github.com/ufz/ogs/pull/1221.