### PR TITLE
Quickfix for confusing error messages from ConfigTree

### DIFF
--- a/BaseLib/ConfigTree.cpp
+++ b/BaseLib/ConfigTree.cpp
@@ -65,7 +65,8 @@ ConfigTree(ConfigTree && other)
 
 ConfigTree::~ConfigTree()
 {
-    checkAndInvalidate();
+    if (!std::uncaught_exception())
+        checkAndInvalidate();
 }
 
 ConfigTree&
@@ -194,6 +195,9 @@ void ConfigTree::ignoreConfigParameterAll(const std::string &param) const
 void ConfigTree::error(const std::string& message) const
 {
     _onerror(_filename, _path, message);
+    OGS_FATAL(
+        "ConfigTree: The error handler does not break out of the normal "
+        "control flow.");
 }
 
 void ConfigTree::warning(const std::string& message) const

--- a/Tests/BaseLib/TestConfigTree.cpp
+++ b/Tests/BaseLib/TestConfigTree.cpp
@@ -398,13 +398,13 @@ TEST(BaseLibConfigTree, GetParamList)
         EXPECT_ERR_WARN(cbs, false, true); // attribute "a" not read
 
         {
+            // get list of parameters, i.e., subtrees without children
             auto range = conf.getConfigParameterList("int3");
             EXPECT_ERR_WARN(cbs, false, false);
 
             EXPECT_ANY_THROW(*range.begin());
-            // Error because of child tag, raises exception, thus
-            // a temporary ConfigTree gets destroyed producing a warning.
-            EXPECT_ERR_WARN(cbs, true, true);
+            // error because of child tag <error/>
+            EXPECT_ERR_WARN(cbs, true, false);
         } // range destroyed here
         EXPECT_ERR_WARN(cbs, false, false);
 


### PR DESCRIPTION
The problem is the following:
1. Something goes wrong → exception thrown
2. stack unwinds
3. ConfigTree gets destroyed
4. The check detects that it has not been processed entirely → throws again, leading to an error message from a point that would have been OK if the (1.) would not have occured.

This PR fixes point no. (4.).