### PR TITLE
Output iteration results

### DIFF
--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.cpp
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.cpp
@@ -108,7 +108,7 @@ setInitialConditions(ProjectData& project,
 bool
 UncoupledProcessesTimeLoop::
 solveOneTimeStepOneProcess(
-        GlobalVector& x, std::size_t timestep, double const t, double const delta_t,
+        GlobalVector& x, std::size_t const timestep, double const t, double const delta_t,
         SingleProcessData& process_data,
         UncoupledProcessesTimeLoop::Process& process,
         ProcessLib::Output const& output_control)
@@ -133,7 +133,7 @@ solveOneTimeStepOneProcess(
 
     auto const post_iteration_callback = [&](unsigned iteration,
                                              GlobalVector const& x) {
-        output_control.doOutputIteration(process, timestep, t, x, iteration);
+        output_control.doOutputNonlinearIteration(process, timestep, t, x, iteration);
     };
 
     bool nonlinear_solver_succeeded =

--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
@@ -155,7 +155,7 @@ private:
 
     //! Solves one timestep for the given \c process.
     bool solveOneTimeStepOneProcess(
-            GlobalVector& x, std::size_t timestep, double const t, double const delta_t,
+            GlobalVector& x, std::size_t const timestep, double const t, double const delta_t,
             SingleProcessData& process_data,
             Process& process, ProcessLib::Output const& output_control);
 

--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
@@ -155,9 +155,9 @@ private:
 
     //! Solves one timestep for the given \c process.
     bool solveOneTimeStepOneProcess(
-            GlobalVector& x, double const t, double const delta_t,
+            GlobalVector& x, std::size_t timestep, double const t, double const delta_t,
             SingleProcessData& process_data,
-            Process& process);
+            Process& process, ProcessLib::Output const& output_control);
 
     //! Sets the EquationSystem for the given nonlinear solver,
     //! which is Picard or Newton depending on the NLTag.

--- a/NumLib/ODESolver/NonlinearSolver-impl.h
+++ b/NumLib/ODESolver/NonlinearSolver-impl.h
@@ -32,10 +32,10 @@ assemble(Vector const& x) const
     _equation_system->assembleMatricesPicard(x);
 }
 
-template<typename Matrix, typename Vector>
-bool
-NonlinearSolver<Matrix, Vector, NonlinearSolverTag::Picard>::
-solve(Vector &x)
+template <typename Matrix, typename Vector>
+bool NonlinearSolver<Matrix, Vector, NonlinearSolverTag::Picard>::solve(
+    Vector& x,
+    std::function<void(unsigned, Vector const&)> const& postIterationCallback)
 {
     namespace BLAS = MathLib::BLAS;
     auto& sys = *_equation_system;
@@ -71,6 +71,9 @@ solve(Vector &x)
         }
         else
         {
+            if (postIterationCallback)
+                postIterationCallback(iteration, x_new);
+
             switch(sys.postIteration(x_new))
             {
             case IterationResult::SUCCESS:
@@ -143,10 +146,10 @@ assemble(Vector const& x) const
     //      equation every time and could not forget it.
 }
 
-template<typename Matrix, typename Vector>
-bool
-NonlinearSolver<Matrix, Vector, NonlinearSolverTag::Newton>::
-solve(Vector &x)
+template <typename Matrix, typename Vector>
+bool NonlinearSolver<Matrix, Vector, NonlinearSolverTag::Newton>::solve(
+    Vector& x,
+    std::function<void(unsigned, Vector const&)> const& postIterationCallback)
 {
     namespace BLAS = MathLib::BLAS;
     auto& sys = *_equation_system;
@@ -194,6 +197,9 @@ solve(Vector &x)
             auto& x_new =
                     MathLib::GlobalVectorProvider<Vector>::provider.getVector(x, _x_new_id);
             BLAS::axpy(x_new, -_alpha, minus_delta_x);
+
+            if (postIterationCallback)
+                postIterationCallback(iteration, x_new);
 
             switch(sys.postIteration(x_new))
             {

--- a/NumLib/ODESolver/NonlinearSolver.h
+++ b/NumLib/ODESolver/NonlinearSolver.h
@@ -53,11 +53,14 @@ public:
     /*! Assemble and solve the equation system.
      *
      * \param x   in: the initial guess, out: the solution.
+     * \param postIterationCallback called after each iteration if set.
      *
      * \retval true if the equation system could be solved
      * \retval false otherwise
      */
-    virtual bool solve(Vector& x) = 0;
+    virtual bool solve(Vector& x,
+                       std::function<void(unsigned, Vector const&)> const&
+                           postIterationCallback) = 0;
 
     virtual ~NonlinearSolverBase() = default;
 };
@@ -108,7 +111,9 @@ public:
 
     void assemble(Vector const& x) const override;
 
-    bool solve(Vector& x) override;
+    bool solve(Vector& x,
+               std::function<void(unsigned, Vector const&)> const&
+                   postIterationCallback) override;
 
 private:
     LinearSolver& _linear_solver;
@@ -159,7 +164,9 @@ public:
 
     void assemble(Vector const& x) const override;
 
-    bool solve(Vector& x) override;
+    bool solve(Vector& x,
+               std::function<void(unsigned, Vector const&)> const&
+                   postIterationCallback) override;
 
 private:
     LinearSolver& _linear_solver;

--- a/NumLib/ODESolver/TimeLoopSingleODE.h
+++ b/NumLib/ODESolver/TimeLoopSingleODE.h
@@ -110,7 +110,7 @@ loop(const double t0, Vector const& x0, const double t_end, const double delta_t
         // INFO("time: %e, delta_t: %e", t, delta_t);
         time_disc.nextTimestep(t, delta_t);
 
-        nl_slv_succeeded = _nonlinear_solver->solve(x);
+        nl_slv_succeeded = _nonlinear_solver->solve(x, nullptr);
         if (!nl_slv_succeeded) break;
 
         time_disc.pushState(t, x, _ode_sys);

--- a/ProcessLib/Output.cpp
+++ b/ProcessLib/Output.cpp
@@ -142,11 +142,12 @@ doOutputLastTimestep(Process const& process,
         doOutputAlways(process, timestep, t, x);
 }
 
-void Output::doOutputIteration(
-    Process const& process, unsigned timestep, const double t,
-    GlobalVector const& x, const unsigned iteration) const
+void Output::doOutputNonlinearIteration(Process const& process,
+                                        const unsigned timestep, const double t,
+                                        GlobalVector const& x,
+                                        const unsigned iteration) const
 {
-    if (!_output_iteration_results) return;
+    if (!_output_nonlinear_iteration_results) return;
 
     auto spd_it = _single_process_data.find(&process);
     if (spd_it == _single_process_data.end()) {
@@ -159,7 +160,7 @@ void Output::doOutputIteration(
             _output_file_prefix + "_pcs_" + std::to_string(spd.process_index)
             + "_ts_" + std::to_string(timestep)
             + "_t_"  + std::to_string(t)
-            + "_iter_" + std::to_string(iteration)
+            + "_nliter_" + std::to_string(iteration)
             + ".vtu";
     DBUG("output iteration results to %s", output_file_name.c_str());
     process.output(output_file_name, timestep, x);

--- a/ProcessLib/Output.h
+++ b/ProcessLib/Output.h
@@ -58,6 +58,15 @@ public:
             const double t,
             GlobalVector const& x);
 
+    //! Writes output for the given \c process.
+    //! To be used for debug output after an iteration of the nonlinear solver.
+    void doOutputIteration(
+            Process<GlobalSetup> const& process, unsigned timestep,
+            const double t,
+            typename GlobalSetup::VectorType const& x,
+            const unsigned iteration) const;
+
+
     struct PairRepeatEachSteps
     {
         explicit PairRepeatEachSteps(unsigned c, unsigned e)
@@ -80,11 +89,13 @@ private:
         MeshLib::IO::PVDFile pvd_file;
     };
 
-    Output(std::string const& prefix)
+    Output(std::string const& prefix, bool output_iteration_results)
         : _output_file_prefix(prefix)
+        , _output_iteration_results(output_iteration_results)
     {}
 
-    std::string _output_file_prefix;
+    std::string const _output_file_prefix;
+    bool const _output_iteration_results;
 
     //! Describes after which timesteps to write output.
     std::vector<PairRepeatEachSteps> _repeats_each_steps;

--- a/ProcessLib/Output.h
+++ b/ProcessLib/Output.h
@@ -60,12 +60,10 @@ public:
 
     //! Writes output for the given \c process.
     //! To be used for debug output after an iteration of the nonlinear solver.
-    void doOutputIteration(
-            Process const& process, unsigned timestep,
-            const double t,
-            GlobalVector const& x,
-            const unsigned iteration) const;
-
+    void doOutputNonlinearIteration(Process const& process,
+                                    const unsigned timestep, const double t,
+                                    GlobalVector const& x,
+                                    const unsigned iteration) const;
 
     struct PairRepeatEachSteps
     {
@@ -89,13 +87,14 @@ private:
         MeshLib::IO::PVDFile pvd_file;
     };
 
-    Output(std::string const& prefix, bool output_iteration_results)
-        : _output_file_prefix(prefix)
-        , _output_iteration_results(output_iteration_results)
+    Output(std::string const& prefix, bool output_nonlinear_iteration_results)
+        : _output_file_prefix(prefix),
+          _output_nonlinear_iteration_results(
+              output_nonlinear_iteration_results)
     {}
 
     std::string const _output_file_prefix;
-    bool const _output_iteration_results;
+    bool const _output_nonlinear_iteration_results;
 
     //! Describes after which timesteps to write output.
     std::vector<PairRepeatEachSteps> _repeats_each_steps;

--- a/ProcessLib/Output.h
+++ b/ProcessLib/Output.h
@@ -61,9 +61,9 @@ public:
     //! Writes output for the given \c process.
     //! To be used for debug output after an iteration of the nonlinear solver.
     void doOutputIteration(
-            Process<GlobalSetup> const& process, unsigned timestep,
+            Process const& process, unsigned timestep,
             const double t,
-            typename GlobalSetup::VectorType const& x,
+            GlobalVector const& x,
             const unsigned iteration) const;
 
 


### PR DESCRIPTION
... after every iteration of the nonlinear solver.

This adds PR adds a callback to the nonlinear solvers' `solve()` method that can be used for output.
The output file name is the same as usual, but with `_iter_#ITER` appended.

The places in the code are not performance-critical, so it is runtime-checked if there shall be output. It can bve configured with the tag `<output_iteration_results>` in the output config.