### PR TITLE
add missing dependency for dynamic linking

### DIFF
--- a/Applications/DataExplorer/Base/CMakeLists.txt
+++ b/Applications/DataExplorer/Base/CMakeLists.txt
@@ -41,7 +41,6 @@ add_library(QtBase
 
 target_link_libraries(QtBase
     Qt4::QtGui
-    logog
     GeoLib)
 
 set_property(TARGET QtBase PROPERTY FOLDER "DataExplorer")

--- a/Applications/DataExplorer/Base/CMakeLists.txt
+++ b/Applications/DataExplorer/Base/CMakeLists.txt
@@ -39,6 +39,9 @@ add_library(QtBase
     ${HEADERS}
 )
 
-target_link_libraries(QtBase PUBLIC Qt4::QtGui)
+target_link_libraries(QtBase
+    Qt4::QtGui
+    logog
+    GeoLib)
 
 set_property(TARGET QtBase PROPERTY FOLDER "DataExplorer")

--- a/Applications/DataExplorer/DataView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/CMakeLists.txt
@@ -121,7 +121,7 @@ if(GEOTIFF_FOUND)
     include_directories(${GEOTIFF_INCLUDE_DIRS})
 endif() # GEOTIFF_FOUND
 
-add_library(QtDataView
+add_library(QtDataView STATIC
     ${SOURCES}
     ${HEADERS}
     ${UIS}
@@ -133,6 +133,8 @@ target_link_libraries(QtDataView
     FileIO
     DataHolderLib
     QtBase
+    QtStratView
+    VtkVis
 )
 add_dependencies(QtDataView QtDiagramView QtStratView)
 

--- a/Applications/DataExplorer/DataView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/CMakeLists.txt
@@ -121,7 +121,7 @@ if(GEOTIFF_FOUND)
     include_directories(${GEOTIFF_INCLUDE_DIRS})
 endif() # GEOTIFF_FOUND
 
-add_library(QtDataView STATIC
+add_library(QtDataView
     ${SOURCES}
     ${HEADERS}
     ${UIS}
@@ -134,7 +134,6 @@ target_link_libraries(QtDataView
     DataHolderLib
     QtBase
     QtStratView
-    VtkVis
 )
 add_dependencies(QtDataView QtDiagramView QtStratView)
 

--- a/Applications/DataExplorer/DataView/DiagramView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/DiagramView/CMakeLists.txt
@@ -39,6 +39,12 @@ add_library(QtDiagramView
     ${UIS}
 )
 
-target_link_libraries(QtDiagramView Qt4::QtGui)
+target_link_libraries(QtDiagramView
+    Qt4::QtGui
+    logog
+    BaseLib
+    GeoLib
+    QtBase
+    )
 
 set_property(TARGET QtDiagramView PROPERTY FOLDER "DataExplorer")

--- a/Applications/DataExplorer/DataView/DiagramView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/DiagramView/CMakeLists.txt
@@ -41,8 +41,6 @@ add_library(QtDiagramView
 
 target_link_libraries(QtDiagramView
     Qt4::QtGui
-    logog
-    BaseLib
     GeoLib
     QtBase
     )

--- a/Applications/DataExplorer/VtkAct/CMakeLists.txt
+++ b/Applications/DataExplorer/VtkAct/CMakeLists.txt
@@ -25,7 +25,10 @@ add_library( VtkAct
 
 ADD_VTK_DEPENDENCY(VtkAct)
 
-target_link_libraries( VtkAct Qt4::QtCore )
-target_link_libraries( VtkAct ${VTK_LIBRARIES} )
+target_link_libraries( VtkAct
+    Qt4::QtCore
+    ${VTK_LIBRARIES}
+    logog
+    )
 
 set_property(TARGET VtkAct PROPERTY FOLDER "DataExplorer")

--- a/Applications/DataExplorer/VtkVis/CMakeLists.txt
+++ b/Applications/DataExplorer/VtkVis/CMakeLists.txt
@@ -114,7 +114,7 @@ include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}/../DataView
 )
 
-add_library(VtkVis STATIC
+add_library(VtkVis
     ${SOURCES}
     ${HEADERS}
     ${UIS}

--- a/Applications/DataExplorer/VtkVis/CMakeLists.txt
+++ b/Applications/DataExplorer/VtkVis/CMakeLists.txt
@@ -114,7 +114,7 @@ include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}/../DataView
 )
 
-add_library(VtkVis
+add_library(VtkVis STATIC
     ${SOURCES}
     ${HEADERS}
     ${UIS}

--- a/Applications/Utils/OGSFileConverter/CMakeLists.txt
+++ b/Applications/Utils/OGSFileConverter/CMakeLists.txt
@@ -34,7 +34,9 @@ add_library(OGSFileConverterLib
     ${HEADERS}
     ${UIS}
 )
-target_link_libraries(OGSFileConverterLib QtBase)
+target_link_libraries(OGSFileConverterLib
+    QtBase
+    MeshLib)
 
 add_executable(OGSFileConverter main.cpp)
 

--- a/MaterialsLib/CMakeLists.txt
+++ b/MaterialsLib/CMakeLists.txt
@@ -4,3 +4,7 @@ GET_SOURCE_FILES(SOURCES_ADSORPTION Adsorption)
 set(SOURCES ${SOURCES} ${SOURCES_ADSORPTION})
 
 add_library(MaterialsLib ${SOURCES} )
+target_link_libraries(MaterialsLib
+    logog
+    BaseLib
+)

--- a/MaterialsLib/CMakeLists.txt
+++ b/MaterialsLib/CMakeLists.txt
@@ -5,6 +5,5 @@ set(SOURCES ${SOURCES} ${SOURCES_ADSORPTION})
 
 add_library(MaterialsLib ${SOURCES} )
 target_link_libraries(MaterialsLib
-    logog
     BaseLib
 )


### PR DESCRIPTION
fix dynamic linking errors on mac. Note that STATIC is explicitly given to some DE libraries due to their circular dependency.