### PR TITLE
Make MeshSurfaceExtraction independent from GeoLib

### DIFF
--- a/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
+++ b/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
@@ -49,14 +49,13 @@ DirectConditionGenerator::directToSurfaceNodes(const MeshLib::Mesh& mesh,
         const std::vector<MeshLib::Node*> surface_nodes(
             MeshLib::MeshSurfaceExtraction::getSurfaceNodes(mesh, dir, 90));
         const double no_data(raster->getHeader().no_data);
-        const std::size_t nNodes(surface_nodes.size());
-        _direct_values.reserve(nNodes);
-        for (std::size_t i = 0; i < nNodes; i++)
+        _direct_values.reserve(surface_nodes.size());
+        for (auto const* surface_node : surface_nodes)
         {
-            double val(raster->getValueAtPoint(*surface_nodes[i]));
+            double val(raster->getValueAtPoint(*surface_node));
             val = (val == no_data) ? 0 : val;
             _direct_values.push_back(
-                std::pair<std::size_t, double>(surface_nodes[i]->getID(), val));
+                std::make_pair(surface_node->getID(), val));
         }
         delete raster;
 

--- a/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
+++ b/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
@@ -30,27 +30,33 @@
 #include <cmath>
 #include <limits>
 
-const std::vector< std::pair<std::size_t,double> >& DirectConditionGenerator::directToSurfaceNodes(const MeshLib::Mesh &mesh, const std::string &filename)
+const std::vector<std::pair<std::size_t, double>>&
+DirectConditionGenerator::directToSurfaceNodes(const MeshLib::Mesh& mesh,
+                                               const std::string& filename)
 {
     if (_direct_values.empty())
     {
-        GeoLib::Raster* raster (GeoLib::IO::AsciiRasterInterface::readRaster(filename));
-        if (! raster) {
-            ERR("Error in DirectConditionGenerator::directToSurfaceNodes() - could not load raster file.");
+        GeoLib::Raster* raster(
+            GeoLib::IO::AsciiRasterInterface::readRaster(filename));
+        if (!raster)
+        {
+            ERR("Error in DirectConditionGenerator::directToSurfaceNodes() - "
+                "could not load raster file.");
             return _direct_values;
         }
 
-        const MathLib::Vector3 dir(0,0,-1);
+        const MathLib::Vector3 dir(0, 0, -1);
         const std::vector<MeshLib::Node*> surface_nodes(
             MeshLib::MeshSurfaceExtraction::getSurfaceNodes(mesh, dir, 90));
+        const double no_data(raster->getHeader().no_data);
         const std::size_t nNodes(surface_nodes.size());
-        const double no_data (raster->getHeader().no_data);
         _direct_values.reserve(nNodes);
-        for (std::size_t i=0; i<nNodes; i++)
+        for (std::size_t i = 0; i < nNodes; i++)
         {
-            double val (raster->getValueAtPoint(*surface_nodes[i]));
+            double val(raster->getValueAtPoint(*surface_nodes[i]));
             val = (val == no_data) ? 0 : val;
-            _direct_values.push_back (std::pair<std::size_t, double>(surface_nodes[i]->getID(), val));
+            _direct_values.push_back(
+                std::pair<std::size_t, double>(surface_nodes[i]->getID(), val));
         }
         delete raster;
 
@@ -58,11 +64,11 @@ const std::vector< std::pair<std::size_t,double> >& DirectConditionGenerator::di
                       std::default_delete<MeshLib::Node>());
     }
     else
-        ERR("Error in DirectConditionGenerator::directToSurfaceNodes() - Data vector contains outdated values.");
+        ERR("Error in DirectConditionGenerator::directToSurfaceNodes() - Data "
+            "vector contains outdated values.");
 
     return _direct_values;
 }
-
 
 const std::vector< std::pair<std::size_t,double> >& DirectConditionGenerator::directWithSurfaceIntegration(MeshLib::Mesh &mesh, const std::string &filename, double scaling)
 {

--- a/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
+++ b/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
@@ -41,7 +41,8 @@ const std::vector< std::pair<std::size_t,double> >& DirectConditionGenerator::di
         }
 
         const MathLib::Vector3 dir(0,0,-1);
-        const std::vector<GeoLib::Point*> surface_nodes(MeshLib::MeshSurfaceExtraction::getSurfaceNodes(mesh, dir, 90) );
+        const std::vector<MeshLib::Node*> surface_nodes(
+            MeshLib::MeshSurfaceExtraction::getSurfaceNodes(mesh, dir, 90));
         const std::size_t nNodes(surface_nodes.size());
         const double no_data (raster->getHeader().no_data);
         _direct_values.reserve(nNodes);

--- a/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
+++ b/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
@@ -53,6 +53,9 @@ const std::vector< std::pair<std::size_t,double> >& DirectConditionGenerator::di
             _direct_values.push_back (std::pair<std::size_t, double>(surface_nodes[i]->getID(), val));
         }
         delete raster;
+
+        std::for_each(surface_nodes.begin(), surface_nodes.end(),
+                      std::default_delete<MeshLib::Node>());
     }
     else
         ERR("Error in DirectConditionGenerator::directToSurfaceNodes() - Data vector contains outdated values.");

--- a/Applications/Utils/MeshGeoTools/ComputeSurfaceNodeIDsInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshGeoTools/ComputeSurfaceNodeIDsInPolygonalRegion.cpp
@@ -162,7 +162,8 @@ int main (int argc, char* argv[])
         writeToFile(id_and_area_fname, csv_fname, ids_and_areas, mesh_nodes);
     }
 
-    std::for_each(all_sfc_pnts.begin(), all_sfc_pnts.end(), std::default_delete<GeoLib::Point>());
+    std::for_each(all_sfc_nodes.begin(), all_sfc_nodes.end(),
+                  std::default_delete<MeshLib::Node>());
 
     return 0;
 }

--- a/Applications/Utils/MeshGeoTools/ComputeSurfaceNodeIDsInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshGeoTools/ComputeSurfaceNodeIDsInPolygonalRegion.cpp
@@ -110,11 +110,12 @@ int main (int argc, char* argv[])
     };
 
     std::vector<double> areas(computeElementTopSurfaceAreas(*mesh, dir, angle));
-    std::vector<GeoLib::Point*> all_sfc_pnts(
+    std::vector<MeshLib::Node*> all_sfc_nodes(
         MeshLib::MeshSurfaceExtraction::getSurfaceNodes(*mesh, dir, angle)
     );
 
-    std::for_each(all_sfc_pnts.begin(), all_sfc_pnts.end(), [](GeoLib::Point* p) { (*p)[2] = 0.0; });
+    std::for_each(all_sfc_nodes.begin(), all_sfc_nodes.end(),
+                  [](MeshLib::Node* p) { (*p)[2] = 0.0; });
 
     std::vector<MeshLib::Node*> const& mesh_nodes(mesh->getNodes());
     GeoLib::PolylineVec const* ply_vec(
@@ -134,9 +135,9 @@ int main (int argc, char* argv[])
         GeoLib::Polygon const& polygon(*(plys[j]));
         // ids of mesh nodes on surface that are within the given polygon
         std::vector<std::pair<std::size_t, double>> ids_and_areas;
-        for (std::size_t k(0); k<all_sfc_pnts.size(); k++) {
-            GeoLib::Point const& pnt(*(all_sfc_pnts[k]));
-            if (polygon.isPntInPolygon(pnt)) {
+        for (std::size_t k(0); k<all_sfc_nodes.size(); k++) {
+            MeshLib::Node const& pnt(*(all_sfc_nodes[k]));
+            if (polygon.isPntInPolygon(pnt[0], pnt[1], pnt[2])) {
                 ids_and_areas.push_back(std::make_pair(pnt.getID(), areas[k]));
             }
         }

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -18,8 +18,6 @@
 
 #include "logog/include/logog.hpp"
 
-#include "GeoLib/Point.h"
-
 #include "MeshLib/Mesh.h"
 #include "MeshLib/Elements/Line.h"
 #include "MeshLib/Elements/Tri.h"
@@ -228,14 +226,12 @@ void MeshSurfaceExtraction::get2DSurfaceNodes(
     const std::vector<MeshLib::Element*>& sfc_elements,
     std::vector<std::size_t>& node_id_map)
 {
-    const std::size_t nNewElements (sfc_elements.size());
     std::vector<const MeshLib::Node*> tmp_nodes(n_all_nodes, nullptr);
-    for (std::size_t i=0; i<nNewElements; ++i)
+    for (auto const* elem : sfc_elements)
     {
-        const MeshLib::Element* elem (sfc_elements[i]);
-        for (unsigned j=0; j<elem->getNumberOfBaseNodes(); ++j)
+        for (unsigned j = 0; j < elem->getNumberOfBaseNodes(); ++j)
         {
-            const MeshLib::Node* node (elem->getNode(j));
+            const MeshLib::Node* node(elem->getNode(j));
             tmp_nodes[node->getID()] = node;
         }
     }
@@ -245,12 +241,13 @@ void MeshSurfaceExtraction::get2DSurfaceNodes(
         if (tmp_nodes[i])
         {
             node_id_map[i] = sfc_nodes.size();
-            sfc_nodes.push_back(new MeshLib::Node(tmp_nodes[i]->getCoords(), tmp_nodes[i]->getID()));
+            sfc_nodes.push_back(new MeshLib::Node(*tmp_nodes[i]));
         }
     }
 }
 
-std::vector<GeoLib::Point*> MeshSurfaceExtraction::getSurfaceNodes(const MeshLib::Mesh &mesh, const MathLib::Vector3 &dir, double angle)
+std::vector<MeshLib::Node*> MeshSurfaceExtraction::getSurfaceNodes(
+    const MeshLib::Mesh& mesh, const MathLib::Vector3& dir, double angle)
 {
     INFO ("Extracting surface nodes...");
     std::vector<MeshLib::Element*> sfc_elements;
@@ -265,14 +262,7 @@ std::vector<GeoLib::Point*> MeshSurfaceExtraction::getSurfaceNodes(const MeshLib
     for (auto e : sfc_elements)
         delete e;
 
-    const std::size_t nNodes (sfc_nodes.size());
-    std::vector<GeoLib::Point*> surface_pnts(nNodes);
-    for (std::size_t i=0; i<nNodes; ++i)
-    {
-        surface_pnts[i] = new GeoLib::Point(*(sfc_nodes[i]), sfc_nodes[i]->getID());
-        delete sfc_nodes[i];
-    }
-    return surface_pnts;
+    return sfc_nodes;
 }
 
 } // end namespace MeshLib

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -223,7 +223,10 @@ void MeshSurfaceExtraction::get2DSurfaceElements(const std::vector<MeshLib::Elem
     }
 }
 
-void MeshSurfaceExtraction::get2DSurfaceNodes(std::vector<MeshLib::Node*> &sfc_nodes, std::size_t n_all_nodes, const std::vector<MeshLib::Element*> &sfc_elements, std::vector<std::size_t> &node_id_map)
+void MeshSurfaceExtraction::get2DSurfaceNodes(
+    std::vector<MeshLib::Node*>& sfc_nodes, std::size_t n_all_nodes,
+    const std::vector<MeshLib::Element*>& sfc_elements,
+    std::vector<std::size_t>& node_id_map)
 {
     const std::size_t nNewElements (sfc_elements.size());
     std::vector<const MeshLib::Node*> tmp_nodes(n_all_nodes, nullptr);
@@ -236,8 +239,8 @@ void MeshSurfaceExtraction::get2DSurfaceNodes(std::vector<MeshLib::Node*> &sfc_n
             tmp_nodes[node->getID()] = node;
         }
     }
-    const std::size_t nNodes (tmp_nodes.size());
-    for (unsigned i=0; i<nNodes; ++i)
+    const std::size_t nNodes(tmp_nodes.size());
+    for (unsigned i = 0; i < nNodes; ++i)
     {
         if (tmp_nodes[i])
         {
@@ -251,11 +254,13 @@ std::vector<GeoLib::Point*> MeshSurfaceExtraction::getSurfaceNodes(const MeshLib
 {
     INFO ("Extracting surface nodes...");
     std::vector<MeshLib::Element*> sfc_elements;
-    get2DSurfaceElements(mesh.getElements(), sfc_elements, dir, angle, mesh.getDimension());
+    get2DSurfaceElements(mesh.getElements(), sfc_elements, dir, angle,
+                         mesh.getDimension());
 
     std::vector<MeshLib::Node*> sfc_nodes;
     std::vector<std::size_t> node_id_map(mesh.getNumberOfNodes());
-    get2DSurfaceNodes(sfc_nodes, mesh.getNumberOfNodes(), sfc_elements, node_id_map);
+    get2DSurfaceNodes(sfc_nodes, mesh.getNumberOfNodes(), sfc_elements,
+                      node_id_map);
 
     for (auto e : sfc_elements)
         delete e;

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -72,10 +72,19 @@ public:
 
 private:
     /// Functionality needed for getSurfaceNodes() and getMeshSurface()
-    static void get2DSurfaceElements(const std::vector<MeshLib::Element*> &all_elements, std::vector<MeshLib::Element*> &sfc_elements, const MathLib::Vector3 &dir, double angle, unsigned mesh_dimension);
+    static void get2DSurfaceElements(
+        const std::vector<MeshLib::Element*>& all_elements,
+        std::vector<MeshLib::Element*>& sfc_elements,
+        const MathLib::Vector3& dir,
+        double angle,
+        unsigned mesh_dimension);
 
     /// Functionality needed for getSurfaceNodes() and getMeshSurface()
-    static void get2DSurfaceNodes(std::vector<MeshLib::Node*> &sfc_nodes, std::size_t n_all_nodes, const std::vector<MeshLib::Element*> &sfc_elements, std::vector<std::size_t> &node_id_map);
+    static void get2DSurfaceNodes(
+        std::vector<MeshLib::Node*>& sfc_nodes,
+        std::size_t n_all_nodes,
+        const std::vector<MeshLib::Element*>& sfc_elements,
+        std::vector<std::size_t>& node_id_map);
 };
 
 } // end namespace MeshLib

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -20,10 +20,6 @@
 
 #include "MathLib/Vector3.h"
 
-namespace GeoLib {
-    class Point;
-}
-
 namespace MeshLib {
 // forward declarations
 class Mesh;
@@ -40,7 +36,8 @@ public:
     static std::vector<double> getSurfaceAreaForNodes(const MeshLib::Mesh &mesh);
 
     /// Returns the surface nodes of a mesh.
-    static std::vector<GeoLib::Point*> getSurfaceNodes(const MeshLib::Mesh &mesh, const MathLib::Vector3 &dir, double angle);
+    static std::vector<MeshLib::Node*> getSurfaceNodes(
+        const MeshLib::Mesh& mesh, const MathLib::Vector3& dir, double angle);
 
     /**
      * Returns the 2d-element mesh representing the surface of the given mesh.


### PR DESCRIPTION
In the commits 04582f8, 3b57c33 and 38b2b67 main work is done, other two commits are only reformating. This is one of the steps to make `MeshLib` independent from `GeoLib`.