### PR TITLE
Nothrow ConfigTree destructor

### DIFF
--- a/BaseLib/ConfigTree.cpp
+++ b/BaseLib/ConfigTree.cpp
@@ -73,6 +73,7 @@ ConfigTree::~ConfigTree()
     try {
         checkAndInvalidate();
     } catch (std::exception& e) {
+        ERR("%s", e.what());
         configtree_destructor_error_messages.push_front(e.what());
     }
 }

--- a/BaseLib/ConfigTree.cpp
+++ b/BaseLib/ConfigTree.cpp
@@ -70,6 +70,13 @@ ConfigTree(ConfigTree && other)
 
 ConfigTree::~ConfigTree()
 {
+    if (std::uncaught_exception()) {
+        /* If the stack unwinds the check below shall be suppressed in order to
+         * not accumulate false-positive configuration errors.
+         */
+        return;
+    }
+
     try {
         checkAndInvalidate();
     } catch (std::exception& e) {

--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -493,6 +493,8 @@ public:
 
     //! The destructor performs the check if all nodes at the current level of the tree
     //! have been read.
+    //! Errors raised by the check are swallowed. Use assertNoSwallowedErrors()
+    //! manually to check for those.
     ~ConfigTree();
 
     //! Default error callback function
@@ -505,6 +507,9 @@ public:
     static void onwarning(std::string const& filename, std::string const& path,
                           std::string const& message);
 
+    //! Asserts that there have not been any errors reported in the destructor.
+    static void assertNoSwallowedErrors();
+
 private:
     //! Default implementation of reading a value of type T.
     template<typename T> boost::optional<T>
@@ -514,7 +519,6 @@ private:
     template<typename T> boost::optional<std::vector<T>>
     getConfigParameterOptionalImpl(std::string const& param, std::vector<T>*) const;
 
-private:
     struct CountType
     {
         int count;


### PR DESCRIPTION
With the default strict config checks, the dtor of ConfigTree threw exceptions. There are many problems with throwing dtors. This PR makes sure, `~ConfigTree()` won't throw.
The drawback is, that now we have to manually check from time to time if all config stuff went fine. (And I really like to keep the strict config checks.)