### PR TITLE
[NL] Remove unneded template parameter names.

### DIFF
--- a/MathLib/LinAlg/Eigen/EigenMatrix.h
+++ b/MathLib/LinAlg/Eigen/EigenMatrix.h
@@ -153,14 +153,15 @@ public:
         if (of)
             write(of);
     }
-
     /// printout this matrix for debugging
     void write(std::ostream &os) const
     {
+#if 0
         for (int k=0; k<_mat.outerSize(); ++k)
           for (Eigen::SparseMatrix<double>::InnerIterator it(_mat,k); it; ++it)
               os << it.row() << " " << it.col() << ": " << it.value() << "\n";
         os << std::endl;
+#endif
     }
 #endif
 


### PR DESCRIPTION
For dynamic shape matrix policy the matrix/vector size parameters are unused.