### PR TITLE
Change Surface search tolerance.

### DIFF
--- a/GeoLib/Surface.cpp
+++ b/GeoLib/Surface.cpp
@@ -153,15 +153,14 @@ bool Surface::isPntInBoundingVolume(MathLib::Point3d const& pnt) const
     return _bounding_volume->containsPoint(pnt);
 }
 
-bool Surface::isPntInSfc(MathLib::Point3d const& pnt) const
+bool Surface::isPntInSfc(MathLib::Point3d const& pnt, double eps) const
 {
     // Mutable _surface_grid is constructed if method is called the first time.
     if (_surface_grid == nullptr)
     {
         _surface_grid.reset(new SurfaceGrid(this));
     }
-    return _surface_grid->isPointInSurface(
-        pnt, std::numeric_limits<double>::epsilon());
+    return _surface_grid->isPointInSurface(pnt, eps);
 }
 
 const Triangle* Surface::findTriangle(MathLib::Point3d const& pnt) const

--- a/GeoLib/Surface.h
+++ b/GeoLib/Surface.h
@@ -71,9 +71,10 @@ public:
     /**
      * is the given point pnt located in the surface
      * @param pnt the point
+     * @param eps geometric tolerance for the search
      * @return true if the point is contained in the surface
      */
-    bool isPntInSfc(MathLib::Point3d const& pnt) const;
+    bool isPntInSfc(MathLib::Point3d const& pnt, double eps) const;
 
     /**
      * find a triangle in which the given point is located

--- a/MeshGeoToolsLib/BoundaryElementsOnSurface.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsOnSurface.cpp
@@ -22,7 +22,7 @@ namespace MeshGeoToolsLib
 BoundaryElementsOnSurface::BoundaryElementsOnSurface(MeshLib::Mesh const& mesh, MeshNodeSearcher &mshNodeSearcher, GeoLib::Surface const& sfc)
 : _mesh(mesh), _sfc(sfc)
 {
-    // search elements near the polyline
+    // search elements near the surface
     auto node_ids_on_sfc = mshNodeSearcher.getMeshNodeIDsAlongSurface(sfc);
     MeshLib::ElementSearch es(_mesh);
     es.searchByNodeIDs(node_ids_on_sfc);

--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -42,7 +42,7 @@ MeshNodeSearcher::MeshNodeSearcher(MeshLib::Mesh const& mesh,
     DBUG("Constructing MeshNodeSearcher obj.");
     _search_length = search_length_algorithm.getSearchLength();
 
-    DBUG("Calculated search length for mesh \"%s\" is %e.",
+    INFO("Calculated search length for mesh \"%s\" is %e.",
         _mesh.getName().c_str(), _search_length);
 }
 
@@ -136,7 +136,7 @@ MeshNodesAlongSurface& MeshNodeSearcher::getMeshNodesAlongSurface(GeoLib::Surfac
 
     // compute nodes (and supporting points) along polyline
     _mesh_nodes_along_surfaces.push_back(
-            new MeshNodesAlongSurface(_mesh, sfc, _search_all_nodes));
+            new MeshNodesAlongSurface(_mesh, sfc, _search_length, _search_all_nodes));
     return *_mesh_nodes_along_surfaces.back();
 }
 

--- a/MeshGeoToolsLib/MeshNodesAlongSurface.cpp
+++ b/MeshGeoToolsLib/MeshNodesAlongSurface.cpp
@@ -26,6 +26,7 @@ namespace MeshGeoToolsLib
 MeshNodesAlongSurface::MeshNodesAlongSurface(
         MeshLib::Mesh const& mesh,
         GeoLib::Surface const& sfc,
+        double epsilon_radius,
         bool search_all_nodes) :
     _mesh(mesh), _sfc(sfc)
 {
@@ -36,7 +37,7 @@ MeshNodesAlongSurface::MeshNodesAlongSurface(
         auto* node = mesh_nodes[i];
         if (!sfc.isPntInBoundingVolume(*node))
             continue;
-        if (sfc.isPntInSfc(*node)) {
+        if (sfc.isPntInSfc(*node, epsilon_radius)) {
             _msh_node_ids.push_back(node->getID());
         }
     }

--- a/MeshGeoToolsLib/MeshNodesAlongSurface.h
+++ b/MeshGeoToolsLib/MeshNodesAlongSurface.h
@@ -38,6 +38,11 @@ public:
      * GeoLib::Surface object within a given search radius.
      * @param mesh_nodes Nodes the search will be performed on.
      * @param sfc Along the GeoLib::Surface sfc the mesh nodes are searched.
+     * @param epsilon Euclidean distance tolerance value. Is the distance
+     * between a mesh node and the surface smaller than that value it is a mesh
+     * node near the surface.
+     * @param search_all_nodes switch between searching all mesh nodes and
+     * searching the base nodes.
      */
     MeshNodesAlongSurface(MeshLib::Mesh const& mesh, GeoLib::Surface const& sfc,
                           double epsilon, bool search_all_nodes = true);

--- a/MeshGeoToolsLib/MeshNodesAlongSurface.h
+++ b/MeshGeoToolsLib/MeshNodesAlongSurface.h
@@ -39,7 +39,8 @@ public:
      * @param mesh_nodes Nodes the search will be performed on.
      * @param sfc Along the GeoLib::Surface sfc the mesh nodes are searched.
      */
-    MeshNodesAlongSurface(MeshLib::Mesh const& mesh, GeoLib::Surface const& sfc, bool search_all_nodes = true);
+    MeshNodesAlongSurface(MeshLib::Mesh const& mesh, GeoLib::Surface const& sfc,
+                          double epsilon, bool search_all_nodes = true);
 
     /// return the mesh object
     MeshLib::Mesh const& getMesh() const;

--- a/Tests/GeoLib/TestSurfaceIsPointInSurface.cpp
+++ b/Tests/GeoLib/TestSurfaceIsPointInSurface.cpp
@@ -128,8 +128,8 @@ TEST(GeoLib, SurfaceIsPointInSurface)
 
         MathLib::Vector3 const normal(0,0,1.0);
         MathLib::Vector3 const surface_normal(rot_mat * normal);
-        double const eps(1e-6);
-        MathLib::Vector3 const displacement(eps * surface_normal);
+        double const scaling(1e-6);
+        MathLib::Vector3 const displacement(scaling * surface_normal);
 
         GeoLib::GEOObjects geometries;
         MeshLib::convertMeshToGeo(*sfc_mesh, geometries);
@@ -137,21 +137,24 @@ TEST(GeoLib, SurfaceIsPointInSurface)
         std::vector<GeoLib::Surface*> const& sfcs(*geometries.getSurfaceVec(name));
         GeoLib::Surface const*const sfc(sfcs.front());
         std::vector<GeoLib::Point*> const& pnts(*geometries.getPointVec(name));
+
+        double const eps(std::numeric_limits<double>::epsilon());
+
         // test triangle edge point of the surface triangles
         for (auto const p : pnts) {
-            EXPECT_TRUE(sfc->isPntInSfc(*p));
+            EXPECT_TRUE(sfc->isPntInSfc(*p, eps));
             MathLib::Point3d q(*p);
             for (std::size_t k(0); k<3; ++k)
                 q[k] += displacement[k];
-            EXPECT_FALSE(sfc->isPntInSfc(q));
+            EXPECT_FALSE(sfc->isPntInSfc(q, eps));
         }
         // test edge middle points of the triangles
         for (std::size_t k(0); k<sfc->getNumberOfTriangles(); ++k) {
             MathLib::Point3d p, q, r;
             std::tie(p,q,r) = getEdgeMiddlePoints(*(*sfc)[k]);
-            EXPECT_TRUE(sfc->isPntInSfc(p));
-            EXPECT_TRUE(sfc->isPntInSfc(q));
-            EXPECT_TRUE(sfc->isPntInSfc(r));
+            EXPECT_TRUE(sfc->isPntInSfc(p, eps));
+            EXPECT_TRUE(sfc->isPntInSfc(q, eps));
+            EXPECT_TRUE(sfc->isPntInSfc(r, eps));
         }
     }
 }


### PR DESCRIPTION
Until now the default value of `std::numeric_limits<double>::epsilon()` was used. This PR changes the behaviour, i.e., the user can give some epsilon value different from the default value.