### PR TITLE
Fixing namespaces and removing Mat/Vec templates in NumLib/DOF

### DIFF
--- a/Applications/ApplicationsLib/LinearSolverLibrarySetup.h
+++ b/Applications/ApplicationsLib/LinearSolverLibrarySetup.h
@@ -37,7 +37,7 @@ struct LinearSolverLibrarySetup final
 
     ~LinearSolverLibrarySetup()
     {
-        MathLib::cleanupGlobalMatrixProviders();
+        NumLib::cleanupGlobalMatrixProviders();
         PetscFinalize();
         MPI_Finalize();
     }
@@ -56,7 +56,7 @@ struct LinearSolverLibrarySetup final
 
     ~LinearSolverLibrarySetup()
     {
-        MathLib::cleanupGlobalMatrixProviders();
+        NumLib::cleanupGlobalMatrixProviders();
         lis_finalize();
     }
 };
@@ -69,7 +69,7 @@ struct LinearSolverLibrarySetup final
     LinearSolverLibrarySetup(int /*argc*/, char* /*argv*/[]) {}
     ~LinearSolverLibrarySetup()
     {
-        MathLib::cleanupGlobalMatrixProviders();
+        NumLib::cleanupGlobalMatrixProviders();
     }
 };
 }    // ApplicationsLib

--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.cpp
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.cpp
@@ -83,7 +83,7 @@ void UncoupledProcessesTimeLoop::setInitialConditions(
 
         // append a solution vector of suitable size
         _process_solutions.emplace_back(
-            &MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+            &NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
                 ode_sys.getMatrixSpecifications()));
 
         auto& x0 = *_process_solutions[pcs_idx];
@@ -235,7 +235,7 @@ bool UncoupledProcessesTimeLoop::loop(ProjectData& project)
 UncoupledProcessesTimeLoop::~UncoupledProcessesTimeLoop()
 {
     for (auto* x : _process_solutions)
-        MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(*x);
+        NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(*x);
 }
 
 }  // namespace ApplicationsLib

--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.cpp
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.cpp
@@ -83,7 +83,7 @@ void UncoupledProcessesTimeLoop::setInitialConditions(
 
         // append a solution vector of suitable size
         _process_solutions.emplace_back(
-            &NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+            &NumLib::GlobalVectorProvider::provider.getVector(
                 ode_sys.getMatrixSpecifications()));
 
         auto& x0 = *_process_solutions[pcs_idx];
@@ -235,7 +235,7 @@ bool UncoupledProcessesTimeLoop::loop(ProjectData& project)
 UncoupledProcessesTimeLoop::~UncoupledProcessesTimeLoop()
 {
     for (auto* x : _process_solutions)
-        NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(*x);
+        NumLib::GlobalVectorProvider::provider.releaseVector(*x);
 }
 
 }  // namespace ApplicationsLib

--- a/NumLib/DOF/GlobalMatrixProviders.cpp
+++ b/NumLib/DOF/GlobalMatrixProviders.cpp
@@ -18,10 +18,10 @@
 // Initializes the static members of the structs in the header file
 // associated with this file.
 #define INITIALIZE_GLOBAL_MATRIX_VECTOR_PROVIDER(MAT, VEC, VARNAME) \
-    static std::unique_ptr<MathLib::SimpleMatrixVectorProvider<MAT, VEC>> VARNAME{ \
-        new MathLib::SimpleMatrixVectorProvider<MAT, VEC>}; \
+    static std::unique_ptr<NumLib::SimpleMatrixVectorProvider<MAT, VEC>> VARNAME{ \
+        new NumLib::SimpleMatrixVectorProvider<MAT, VEC>}; \
     \
-    namespace MathLib { \
+    namespace NumLib { \
     template<> \
     VectorProvider<VEC>& GlobalVectorProvider<VEC>::provider = *(VARNAME); \
     \
@@ -42,7 +42,7 @@ INITIALIZE_GLOBAL_MATRIX_VECTOR_PROVIDER(GlobalMatrix, GlobalVector,
                                          globalSetupGlobalMatrixVectorProvider)
 
 
-namespace MathLib
+namespace NumLib
 {
 void cleanupGlobalMatrixProviders()
 {

--- a/NumLib/DOF/GlobalMatrixProviders.cpp
+++ b/NumLib/DOF/GlobalMatrixProviders.cpp
@@ -22,21 +22,10 @@
         new NumLib::SimpleMatrixVectorProvider<MAT, VEC>}; \
     \
     namespace NumLib { \
-    template<> \
-    VectorProvider<VEC>& GlobalVectorProvider<VEC>::provider = *(VARNAME); \
+    VectorProvider<VEC>& GlobalVectorProvider::provider = *(VARNAME); \
     \
-    template<> \
-    MatrixProvider<MAT>& GlobalMatrixProvider<MAT>::provider = *(VARNAME); \
+    MatrixProvider<MAT>& GlobalMatrixProvider::provider = *(VARNAME); \
     }
-
-
-#ifdef OGS_USE_EIGEN
-
-INITIALIZE_GLOBAL_MATRIX_VECTOR_PROVIDER(Eigen::MatrixXd, Eigen::VectorXd,
-                                         eigenGlobalMatrixVectorProvider)
-
-#endif
-
 
 INITIALIZE_GLOBAL_MATRIX_VECTOR_PROVIDER(GlobalMatrix, GlobalVector,
                                          globalSetupGlobalMatrixVectorProvider)
@@ -46,7 +35,6 @@ namespace NumLib
 {
 void cleanupGlobalMatrixProviders()
 {
-    eigenGlobalMatrixVectorProvider.reset();
     globalSetupGlobalMatrixVectorProvider.reset();
 }
 }

--- a/NumLib/DOF/GlobalMatrixProviders.cpp
+++ b/NumLib/DOF/GlobalMatrixProviders.cpp
@@ -7,28 +7,26 @@
  *
  */
 
+#include "GlobalMatrixProviders.h"
+
 #include <memory>
 
-#include "NumLib/NumericsConfig.h"
-
-#include "GlobalMatrixProviders.h"
 #include "SimpleMatrixVectorProvider.h"
 
 
 // Initializes the static members of the structs in the header file
 // associated with this file.
-#define INITIALIZE_GLOBAL_MATRIX_VECTOR_PROVIDER(MAT, VEC, VARNAME) \
-    static std::unique_ptr<NumLib::SimpleMatrixVectorProvider<MAT, VEC>> VARNAME{ \
-        new NumLib::SimpleMatrixVectorProvider<MAT, VEC>}; \
+#define INITIALIZE_GLOBAL_MATRIX_VECTOR_PROVIDER(VARNAME) \
+    static std::unique_ptr<NumLib::SimpleMatrixVectorProvider> VARNAME{ \
+        new NumLib::SimpleMatrixVectorProvider}; \
     \
     namespace NumLib { \
-    VectorProvider<VEC>& GlobalVectorProvider::provider = *(VARNAME); \
+    VectorProvider& GlobalVectorProvider::provider = *(VARNAME); \
     \
-    MatrixProvider<MAT>& GlobalMatrixProvider::provider = *(VARNAME); \
+    MatrixProvider& GlobalMatrixProvider::provider = *(VARNAME); \
     }
 
-INITIALIZE_GLOBAL_MATRIX_VECTOR_PROVIDER(GlobalMatrix, GlobalVector,
-                                         globalSetupGlobalMatrixVectorProvider)
+INITIALIZE_GLOBAL_MATRIX_VECTOR_PROVIDER(globalSetupGlobalMatrixVectorProvider)
 
 
 namespace NumLib

--- a/NumLib/DOF/GlobalMatrixProviders.h
+++ b/NumLib/DOF/GlobalMatrixProviders.h
@@ -14,17 +14,14 @@
 
 namespace NumLib
 {
-
-template<typename Vector>
 struct GlobalVectorProvider
 {
-    static VectorProvider<Vector>& provider;
+    static VectorProvider<GlobalVector>& provider;
 };
 
-template<typename Matrix>
 struct GlobalMatrixProvider
 {
-    static MatrixProvider<Matrix>& provider;
+    static MatrixProvider<GlobalMatrix>& provider;
 };
 
 void cleanupGlobalMatrixProviders();

--- a/NumLib/DOF/GlobalMatrixProviders.h
+++ b/NumLib/DOF/GlobalMatrixProviders.h
@@ -7,12 +7,12 @@
  *
  */
 
-#ifndef MATHLIB_GLOBAL_MATRIX_PROVIDERS
-#define MATHLIB_GLOBAL_MATRIX_PROVIDERS
+#ifndef NUMLIB_GLOBAL_MATRIX_PROVIDERS
+#define NUMLIB_GLOBAL_MATRIX_PROVIDERS
 
 #include "MatrixProviderUser.h"
 
-namespace MathLib
+namespace NumLib
 {
 
 template<typename Vector>
@@ -31,4 +31,4 @@ void cleanupGlobalMatrixProviders();
 
 } // MathLib
 
-#endif // MATHLIB_GLOBAL_MATRIX_PROVIDERS
+#endif // NUMLIB_GLOBAL_MATRIX_PROVIDERS

--- a/NumLib/DOF/GlobalMatrixProviders.h
+++ b/NumLib/DOF/GlobalMatrixProviders.h
@@ -16,12 +16,12 @@ namespace NumLib
 {
 struct GlobalVectorProvider
 {
-    static VectorProvider<GlobalVector>& provider;
+    static VectorProvider& provider;
 };
 
 struct GlobalMatrixProvider
 {
-    static MatrixProvider<GlobalMatrix>& provider;
+    static MatrixProvider& provider;
 };
 
 void cleanupGlobalMatrixProviders();

--- a/NumLib/DOF/MatrixProviderUser.h
+++ b/NumLib/DOF/MatrixProviderUser.h
@@ -7,20 +7,20 @@
  *
  */
 
-#ifndef MATHLIB_MATRIX_PROVIDER_USER_H
-#define MATHLIB_MATRIX_PROVIDER_USER_H
+#ifndef NUMLIB_MATRIX_PROVIDER_USER_H
+#define NUMLIB_MATRIX_PROVIDER_USER_H
 
 #include <cstddef>
 
 #include "MathLib/LinAlg/MatrixSpecifications.h"
 
-namespace MathLib
+namespace NumLib
 {
 
 class MatrixSpecificationsProvider
 {
 public:
-    virtual MatrixSpecifications getMatrixSpecifications() const = 0;
+    virtual MathLib::MatrixSpecifications getMatrixSpecifications() const = 0;
 
     virtual ~MatrixSpecificationsProvider() = default;
 };
@@ -67,11 +67,11 @@ public:
     virtual Vector& getVector(Vector const& x, std::size_t& id) = 0;
 
     //! Get a vector according to the given specifications.
-    virtual Vector& getVector(MatrixSpecifications const& ms) = 0;
+    virtual Vector& getVector(MathLib::MatrixSpecifications const& ms) = 0;
 
     //! Get a vector according to the given specifications in the storage
     //! of the vector with the given \c id.
-    virtual Vector& getVector(MatrixSpecifications const& ms, std::size_t& id) = 0;
+    virtual Vector& getVector(MathLib::MatrixSpecifications const& ms, std::size_t& id) = 0;
 
     //! Release the given vector.
     //!
@@ -103,11 +103,11 @@ public:
     virtual Matrix& getMatrix(Matrix const& A, std::size_t& id) = 0;
 
     //! Get a matrix according to the given specifications.
-    virtual Matrix& getMatrix(MatrixSpecifications const& ms) = 0;
+    virtual Matrix& getMatrix(MathLib::MatrixSpecifications const& ms) = 0;
 
     //! Get a matrix according to the given specifications in the storage
     //! of the matrix with the given \c id.
-    virtual Matrix& getMatrix(MatrixSpecifications const& ms, std::size_t& id) = 0;
+    virtual Matrix& getMatrix(MathLib::MatrixSpecifications const& ms, std::size_t& id) = 0;
 
     //! Release the given matrix.
     //!
@@ -118,6 +118,6 @@ public:
     virtual ~MatrixProvider() = default;
 };
 
-} // namespace MathLib
+} // namespace NumLib
 
-#endif // MATHLIB_MATRIX_PROVIDER_USER_H
+#endif // NUMLIB_MATRIX_PROVIDER_USER_H

--- a/NumLib/DOF/MatrixProviderUser.h
+++ b/NumLib/DOF/MatrixProviderUser.h
@@ -50,34 +50,33 @@ public:
  * has to be initialized with zero. The respective method then will set the \c id
  * to the specific \c id of the returned vector.
  */
-template<typename Vector>
 class VectorProvider
 {
 public:
     //! Get an uninitialized vector.
-    virtual Vector& getVector() = 0;
+    virtual GlobalVector& getVector() = 0;
 
     //! Get an uninitialized vector with the given \c id.
-    virtual Vector& getVector(std::size_t& id) = 0;
+    virtual GlobalVector& getVector(std::size_t& id) = 0;
 
     //! Get a copy of \c x.
-    virtual Vector& getVector(Vector const& x) = 0;
+    virtual GlobalVector& getVector(GlobalVector const& x) = 0;
 
     //! Get a copy of \c x in the storage of the vector with the given \c id.
-    virtual Vector& getVector(Vector const& x, std::size_t& id) = 0;
+    virtual GlobalVector& getVector(GlobalVector const& x, std::size_t& id) = 0;
 
     //! Get a vector according to the given specifications.
-    virtual Vector& getVector(MathLib::MatrixSpecifications const& ms) = 0;
+    virtual GlobalVector& getVector(MathLib::MatrixSpecifications const& ms) = 0;
 
     //! Get a vector according to the given specifications in the storage
     //! of the vector with the given \c id.
-    virtual Vector& getVector(MathLib::MatrixSpecifications const& ms, std::size_t& id) = 0;
+    virtual GlobalVector& getVector(MathLib::MatrixSpecifications const& ms, std::size_t& id) = 0;
 
     //! Release the given vector.
     //!
     //! \pre \c x must have been acquired before, i.e., you must not call this
     //! method twice in a row in the same \c x!
-    virtual void releaseVector(Vector const& x) = 0;
+    virtual void releaseVector(GlobalVector const& x) = 0;
 
     virtual ~VectorProvider() = default;
 };
@@ -86,34 +85,33 @@ public:
  *
  * This the matrix-analog of VectorProvider. The same notes apply to this class.
  */
-template<typename Matrix>
 class MatrixProvider
 {
 public:
     //! Get an uninitialized matrix.
-    virtual Matrix& getMatrix() = 0;
+    virtual GlobalMatrix& getMatrix() = 0;
 
     //! Get an uninitialized matrix with the given \c id.
-    virtual Matrix& getMatrix(std::size_t& id) = 0;
+    virtual GlobalMatrix& getMatrix(std::size_t& id) = 0;
 
     //! Get a copy of \c A.
-    virtual Matrix& getMatrix(Matrix const& A) = 0;
+    virtual GlobalMatrix& getMatrix(GlobalMatrix const& A) = 0;
 
     //! Get a copy of \c A in the storage of the matrix with the given \c id.
-    virtual Matrix& getMatrix(Matrix const& A, std::size_t& id) = 0;
+    virtual GlobalMatrix& getMatrix(GlobalMatrix const& A, std::size_t& id) = 0;
 
     //! Get a matrix according to the given specifications.
-    virtual Matrix& getMatrix(MathLib::MatrixSpecifications const& ms) = 0;
+    virtual GlobalMatrix& getMatrix(MathLib::MatrixSpecifications const& ms) = 0;
 
     //! Get a matrix according to the given specifications in the storage
     //! of the matrix with the given \c id.
-    virtual Matrix& getMatrix(MathLib::MatrixSpecifications const& ms, std::size_t& id) = 0;
+    virtual GlobalMatrix& getMatrix(MathLib::MatrixSpecifications const& ms, std::size_t& id) = 0;
 
     //! Release the given matrix.
     //!
     //! \pre \c A must have been acquired before, i.e., you must not call this
     //! method twice in a row in the same \c A!
-    virtual void releaseMatrix(Matrix const& A) = 0;
+    virtual void releaseMatrix(GlobalMatrix const& A) = 0;
 
     virtual ~MatrixProvider() = default;
 };

--- a/NumLib/DOF/SimpleMatrixVectorProvider-impl.h
+++ b/NumLib/DOF/SimpleMatrixVectorProvider-impl.h
@@ -15,6 +15,8 @@
 #include "MathLib/LinAlg/MatrixVectorTraits.h"
 #include "SimpleMatrixVectorProvider.h"
 
+namespace LinAlg = MathLib::LinAlg;
+
 namespace detail
 {
 
@@ -51,7 +53,7 @@ transfer(std::map<MatVec*, std::size_t>& from_used,
 } // detail
 
 
-namespace MathLib
+namespace NumLib
 {
 
 template<typename Matrix, typename Vector>
@@ -80,7 +82,7 @@ get_(std::size_t& id,
     // not searched or not found, so create a new one
     id = _next_id++;
     auto res = used_map.emplace(
-        MatrixVectorTraits<MatVec>::newInstance(std::forward<Args>(args)...).release(),
+        MathLib::MatrixVectorTraits<MatVec>::newInstance(std::forward<Args>(args)...).release(),
         id);
     assert(res.second && "Emplacement failed.");
     return { res.first->first, true };
@@ -116,7 +118,7 @@ getMatrix(std::size_t& id)
 template<typename Matrix, typename Vector>
 Matrix&
 SimpleMatrixVectorProvider<Matrix, Vector>::
-getMatrix(MatrixSpecifications const& ms)
+getMatrix(MathLib::MatrixSpecifications const& ms)
 {
     std::size_t id = 0u;
     return *getMatrix_<false>(id, ms).first;
@@ -126,7 +128,7 @@ getMatrix(MatrixSpecifications const& ms)
 template<typename Matrix, typename Vector>
 Matrix&
 SimpleMatrixVectorProvider<Matrix, Vector>::
-getMatrix(MatrixSpecifications const& ms, std::size_t& id)
+getMatrix(MathLib::MatrixSpecifications const& ms, std::size_t& id)
 {
     return *getMatrix_<true>(id, ms).first;
     // TODO assert that the returned object always is of the right size
@@ -198,7 +200,7 @@ getVector(std::size_t& id)
 template<typename Matrix, typename Vector>
 Vector&
 SimpleMatrixVectorProvider<Matrix, Vector>::
-getVector(MatrixSpecifications const& ms)
+getVector(MathLib::MatrixSpecifications const& ms)
 {
     std::size_t id = 0u;
     return *getVector_<false>(id, ms).first;
@@ -208,7 +210,7 @@ getVector(MatrixSpecifications const& ms)
 template<typename Matrix, typename Vector>
 Vector&
 SimpleMatrixVectorProvider<Matrix, Vector>::
-getVector(MatrixSpecifications const& ms, std::size_t& id)
+getVector(MathLib::MatrixSpecifications const& ms, std::size_t& id)
 {
     return *getVector_<true>(id, ms).first;
     // TODO assert that the returned object always is of the right size

--- a/NumLib/DOF/SimpleMatrixVectorProvider.cpp
+++ b/NumLib/DOF/SimpleMatrixVectorProvider.cpp
@@ -7,13 +7,14 @@
  *
  */
 
+#include "SimpleMatrixVectorProvider.h"
+
 #include <cassert>
 #include <logog/include/logog.hpp>
 
 #include "BaseLib/Error.h"
 #include "MathLib/LinAlg/LinAlg.h"
 #include "MathLib/LinAlg/MatrixVectorTraits.h"
-#include "SimpleMatrixVectorProvider.h"
 
 namespace LinAlg = MathLib::LinAlg;
 
@@ -56,10 +57,9 @@ transfer(std::map<MatVec*, std::size_t>& from_used,
 namespace NumLib
 {
 
-template<typename Matrix, typename Vector>
 template<bool do_search, typename MatVec, typename... Args>
 std::pair<MatVec*, bool>
-SimpleMatrixVectorProvider<Matrix, Vector>::
+SimpleMatrixVectorProvider::
 get_(std::size_t& id,
      std::map<std::size_t, MatVec*>& unused_map,
      std::map<MatVec*, std::size_t>& used_map,
@@ -88,36 +88,32 @@ get_(std::size_t& id,
     return { res.first->first, true };
 }
 
-template<typename Matrix, typename Vector>
 template<bool do_search, typename... Args>
-std::pair<Matrix*, bool>
-SimpleMatrixVectorProvider<Matrix, Vector>::
+std::pair<GlobalMatrix*, bool>
+SimpleMatrixVectorProvider::
 getMatrix_(std::size_t& id, Args&&... args)
 {
     return get_<do_search>(id, _unused_matrices, _used_matrices, std::forward<Args>(args)...);
 }
 
 
-template<typename Matrix, typename Vector>
-Matrix&
-SimpleMatrixVectorProvider<Matrix, Vector>::
+GlobalMatrix&
+SimpleMatrixVectorProvider::
 getMatrix()
 {
     std::size_t id = 0u;
     return *getMatrix_<false>(id).first;
 }
 
-template<typename Matrix, typename Vector>
-Matrix&
-SimpleMatrixVectorProvider<Matrix, Vector>::
+GlobalMatrix&
+SimpleMatrixVectorProvider::
 getMatrix(std::size_t& id)
 {
     return *getMatrix_<true>(id).first;
 }
 
-template<typename Matrix, typename Vector>
-Matrix&
-SimpleMatrixVectorProvider<Matrix, Vector>::
+GlobalMatrix&
+SimpleMatrixVectorProvider::
 getMatrix(MathLib::MatrixSpecifications const& ms)
 {
     std::size_t id = 0u;
@@ -125,19 +121,17 @@ getMatrix(MathLib::MatrixSpecifications const& ms)
     // TODO assert that the returned object always is of the right size
 }
 
-template<typename Matrix, typename Vector>
-Matrix&
-SimpleMatrixVectorProvider<Matrix, Vector>::
+GlobalMatrix&
+SimpleMatrixVectorProvider::
 getMatrix(MathLib::MatrixSpecifications const& ms, std::size_t& id)
 {
     return *getMatrix_<true>(id, ms).first;
     // TODO assert that the returned object always is of the right size
 }
 
-template<typename Matrix, typename Vector>
-Matrix&
-SimpleMatrixVectorProvider<Matrix, Vector>::
-getMatrix(Matrix const& A)
+GlobalMatrix&
+SimpleMatrixVectorProvider::
+getMatrix(GlobalMatrix const& A)
 {
     std::size_t id = 0u;
     auto const& res = getMatrix_<false>(id, A);
@@ -146,10 +140,9 @@ getMatrix(Matrix const& A)
     return *res.first;
 }
 
-template<typename Matrix, typename Vector>
-Matrix&
-SimpleMatrixVectorProvider<Matrix, Vector>::
-getMatrix(Matrix const& A, std::size_t& id)
+GlobalMatrix&
+SimpleMatrixVectorProvider::
+getMatrix(GlobalMatrix const& A, std::size_t& id)
 {
     auto const& res = getMatrix_<true>(id, A);
     if (!res.second) // no new object has been created
@@ -157,12 +150,11 @@ getMatrix(Matrix const& A, std::size_t& id)
     return *res.first;
 }
 
-template<typename Matrix, typename Vector>
 void
-SimpleMatrixVectorProvider<Matrix, Vector>::
-releaseMatrix(Matrix const& A)
+SimpleMatrixVectorProvider::
+releaseMatrix(GlobalMatrix const& A)
 {
-    auto it = _used_matrices.find(const_cast<Matrix*>(&A));
+    auto it = _used_matrices.find(const_cast<GlobalMatrix*>(&A));
     if (it == _used_matrices.end()) {
         OGS_FATAL("The given matrix has not been found. Cannot release it. Aborting.");
     } else {
@@ -170,36 +162,32 @@ releaseMatrix(Matrix const& A)
     }
 }
 
-template<typename Matrix, typename Vector>
 template<bool do_search, typename... Args>
-std::pair<Vector*, bool>
-SimpleMatrixVectorProvider<Matrix, Vector>::
+std::pair<GlobalVector*, bool>
+SimpleMatrixVectorProvider::
 getVector_(std::size_t& id, Args&&... args)
 {
     return get_<do_search>(id, _unused_vectors, _used_vectors, std::forward<Args>(args)...);
 }
 
 
-template<typename Matrix, typename Vector>
-Vector&
-SimpleMatrixVectorProvider<Matrix, Vector>::
+GlobalVector&
+SimpleMatrixVectorProvider::
 getVector()
 {
     std::size_t id = 0u;
     return *getVector_<false>(id).first;
 }
 
-template<typename Matrix, typename Vector>
-Vector&
-SimpleMatrixVectorProvider<Matrix, Vector>::
+GlobalVector&
+SimpleMatrixVectorProvider::
 getVector(std::size_t& id)
 {
     return *getVector_<true>(id).first;
 }
 
-template<typename Matrix, typename Vector>
-Vector&
-SimpleMatrixVectorProvider<Matrix, Vector>::
+GlobalVector&
+SimpleMatrixVectorProvider::
 getVector(MathLib::MatrixSpecifications const& ms)
 {
     std::size_t id = 0u;
@@ -207,19 +195,17 @@ getVector(MathLib::MatrixSpecifications const& ms)
     // TODO assert that the returned object always is of the right size
 }
 
-template<typename Matrix, typename Vector>
-Vector&
-SimpleMatrixVectorProvider<Matrix, Vector>::
+GlobalVector&
+SimpleMatrixVectorProvider::
 getVector(MathLib::MatrixSpecifications const& ms, std::size_t& id)
 {
     return *getVector_<true>(id, ms).first;
     // TODO assert that the returned object always is of the right size
 }
 
-template<typename Matrix, typename Vector>
-Vector&
-SimpleMatrixVectorProvider<Matrix, Vector>::
-getVector(Vector const& x)
+GlobalVector&
+SimpleMatrixVectorProvider::
+getVector(GlobalVector const& x)
 {
     std::size_t id = 0u;
     auto const& res = getVector_<false>(id, x);
@@ -228,10 +214,9 @@ getVector(Vector const& x)
     return *res.first;
 }
 
-template<typename Matrix, typename Vector>
-Vector&
-SimpleMatrixVectorProvider<Matrix, Vector>::
-getVector(Vector const& x, std::size_t& id)
+GlobalVector&
+SimpleMatrixVectorProvider::
+getVector(GlobalVector const& x, std::size_t& id)
 {
     auto const& res = getVector_<true>(id, x);
     if (!res.second) // no new object has been created
@@ -239,12 +224,11 @@ getVector(Vector const& x, std::size_t& id)
     return *res.first;
 }
 
-template<typename Matrix, typename Vector>
 void
-SimpleMatrixVectorProvider<Matrix, Vector>::
-releaseVector(Vector const& x)
+SimpleMatrixVectorProvider::
+releaseVector(GlobalVector const& x)
 {
-    auto it = _used_vectors.find(const_cast<Vector*>(&x));
+    auto it = _used_vectors.find(const_cast<GlobalVector*>(&x));
     if (it == _used_vectors.end()) {
         OGS_FATAL("The given vector has not been found. Cannot release it. Aborting.");
     } else {
@@ -252,8 +236,7 @@ releaseVector(Vector const& x)
     }
 }
 
-template<typename Matrix, typename Vector>
-SimpleMatrixVectorProvider<Matrix, Vector>::
+SimpleMatrixVectorProvider::
 ~SimpleMatrixVectorProvider()
 {
     if ((!_used_matrices.empty()) || (!_used_vectors.empty())) {

--- a/NumLib/DOF/SimpleMatrixVectorProvider.h
+++ b/NumLib/DOF/SimpleMatrixVectorProvider.h
@@ -7,15 +7,15 @@
  *
  */
 
-#ifndef MATHLIB_SIMPLE_MATRIX_PROVIDER_H
-#define MATHLIB_SIMPLE_MATRIX_PROVIDER_H
+#ifndef NUMLIB_SIMPLE_MATRIX_PROVIDER_H
+#define NUMLIB_SIMPLE_MATRIX_PROVIDER_H
 
-#include<map>
-#include<memory>
+#include <map>
+#include <memory>
 
 #include "MatrixProviderUser.h"
 
-namespace MathLib
+namespace NumLib
 {
 
 /*! Manages storage for matrices and vectors.
@@ -43,8 +43,8 @@ public:
     Vector& getVector(Vector const& x) override;
     Vector& getVector(Vector const& x, std::size_t& id) override;
 
-    Vector& getVector(MatrixSpecifications const& ms) override;
-    Vector& getVector(MatrixSpecifications const& ms, std::size_t& id) override;
+    Vector& getVector(MathLib::MatrixSpecifications const& ms) override;
+    Vector& getVector(MathLib::MatrixSpecifications const& ms, std::size_t& id) override;
 
     void releaseVector(Vector const& x) override;
 
@@ -54,8 +54,8 @@ public:
     Matrix& getMatrix(Matrix const& A) override;
     Matrix& getMatrix(Matrix const& A, std::size_t& id) override;
 
-    Matrix& getMatrix(MatrixSpecifications const& ms) override;
-    Matrix& getMatrix(MatrixSpecifications const& ms, std::size_t& id) override;
+    Matrix& getMatrix(MathLib::MatrixSpecifications const& ms) override;
+    Matrix& getMatrix(MathLib::MatrixSpecifications const& ms, std::size_t& id) override;
 
     void releaseMatrix(Matrix const& A) override;
 
@@ -88,8 +88,8 @@ private:
 
 
 
-} // namespace MathLib
+} // namespace NumLib
 
 #include "SimpleMatrixVectorProvider-impl.h"
 
-#endif // MATHLIB_SIMPLE_MATRIX_PROVIDER_H
+#endif // NUMLIB_SIMPLE_MATRIX_PROVIDER_H

--- a/NumLib/DOF/SimpleMatrixVectorProvider.h
+++ b/NumLib/DOF/SimpleMatrixVectorProvider.h
@@ -25,10 +25,9 @@ namespace NumLib
  * It is simple insofar it does not reuse released matrices/vectors, but keeps them in
  * memory until they are acquired again by the user.
  */
-template<typename Matrix, typename Vector>
 class SimpleMatrixVectorProvider final
-        : public MatrixProvider<Matrix>
-        , public VectorProvider<Vector>
+        : public MatrixProvider
+        , public VectorProvider
 {
 public:
     SimpleMatrixVectorProvider() = default;
@@ -37,36 +36,36 @@ public:
     SimpleMatrixVectorProvider(SimpleMatrixVectorProvider const&) = delete;
     SimpleMatrixVectorProvider& operator=(SimpleMatrixVectorProvider const&) = delete;
 
-    Vector& getVector() override;
-    Vector& getVector(std::size_t& id) override;
+    GlobalVector& getVector() override;
+    GlobalVector& getVector(std::size_t& id) override;
 
-    Vector& getVector(Vector const& x) override;
-    Vector& getVector(Vector const& x, std::size_t& id) override;
+    GlobalVector& getVector(GlobalVector const& x) override;
+    GlobalVector& getVector(GlobalVector const& x, std::size_t& id) override;
 
-    Vector& getVector(MathLib::MatrixSpecifications const& ms) override;
-    Vector& getVector(MathLib::MatrixSpecifications const& ms, std::size_t& id) override;
+    GlobalVector& getVector(MathLib::MatrixSpecifications const& ms) override;
+    GlobalVector& getVector(MathLib::MatrixSpecifications const& ms, std::size_t& id) override;
 
-    void releaseVector(Vector const& x) override;
+    void releaseVector(GlobalVector const& x) override;
 
-    Matrix& getMatrix() override;
-    Matrix& getMatrix(std::size_t& id) override;
+    GlobalMatrix& getMatrix() override;
+    GlobalMatrix& getMatrix(std::size_t& id) override;
 
-    Matrix& getMatrix(Matrix const& A) override;
-    Matrix& getMatrix(Matrix const& A, std::size_t& id) override;
+    GlobalMatrix& getMatrix(GlobalMatrix const& A) override;
+    GlobalMatrix& getMatrix(GlobalMatrix const& A, std::size_t& id) override;
 
-    Matrix& getMatrix(MathLib::MatrixSpecifications const& ms) override;
-    Matrix& getMatrix(MathLib::MatrixSpecifications const& ms, std::size_t& id) override;
+    GlobalMatrix& getMatrix(MathLib::MatrixSpecifications const& ms) override;
+    GlobalMatrix& getMatrix(MathLib::MatrixSpecifications const& ms, std::size_t& id) override;
 
-    void releaseMatrix(Matrix const& A) override;
+    void releaseMatrix(GlobalMatrix const& A) override;
 
     ~SimpleMatrixVectorProvider();
 
 private:
     template<bool do_search, typename... Args>
-    std::pair<Matrix*, bool> getMatrix_(std::size_t& id, Args&&... args);
+    std::pair<GlobalMatrix*, bool> getMatrix_(std::size_t& id, Args&&... args);
 
     template<bool do_search, typename... Args>
-    std::pair<Vector*, bool> getVector_(std::size_t& id, Args&&... args);
+    std::pair<GlobalVector*, bool> getVector_(std::size_t& id, Args&&... args);
 
     // returns a pair with the pointer to the matrix/vector and
     // a boolean indicating if a new object has been built (then true else false)
@@ -79,17 +78,15 @@ private:
 
     std::size_t _next_id = 1;
 
-    std::map<std::size_t, Matrix*> _unused_matrices;
-    std::map<Matrix*, std::size_t> _used_matrices;
+    std::map<std::size_t, GlobalMatrix*> _unused_matrices;
+    std::map<GlobalMatrix*, std::size_t> _used_matrices;
 
-    std::map<std::size_t, Vector*> _unused_vectors;
-    std::map<Vector*, std::size_t> _used_vectors;
+    std::map<std::size_t, GlobalVector*> _unused_vectors;
+    std::map<GlobalVector*, std::size_t> _used_vectors;
 };
 
 
 
 } // namespace NumLib
-
-#include "SimpleMatrixVectorProvider-impl.h"
 
 #endif // NUMLIB_SIMPLE_MATRIX_PROVIDER_H

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
@@ -53,7 +53,7 @@ public:
         MathLib::MatrixSpecifications const& matrix_specs,
         NumLib::LocalToGlobalIndexMap const& dof_table)
         : _nodal_values(
-              NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+              NumLib::GlobalVectorProvider::provider.getVector(
                   matrix_specs))
 #ifndef USE_PETSC
           ,
@@ -102,7 +102,7 @@ public:
 
     ~LocalLinearLeastSquaresExtrapolator()
     {
-        NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(
+        NumLib::GlobalVectorProvider::provider.releaseVector(
             _nodal_values);
     }
 

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
@@ -53,7 +53,7 @@ public:
         MathLib::MatrixSpecifications const& matrix_specs,
         NumLib::LocalToGlobalIndexMap const& dof_table)
         : _nodal_values(
-              MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+              NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
                   matrix_specs))
 #ifndef USE_PETSC
           ,
@@ -102,7 +102,7 @@ public:
 
     ~LocalLinearLeastSquaresExtrapolator()
     {
-        MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(
+        NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(
             _nodal_values);
     }
 

--- a/NumLib/ODESolver/EquationSystem.h
+++ b/NumLib/ODESolver/EquationSystem.h
@@ -28,7 +28,7 @@ enum class IterationResult : char
 /*! Collection of basic methods every equation system must provide.
  *
  */
-class EquationSystem : public MathLib::MatrixSpecificationsProvider
+class EquationSystem : public NumLib::MatrixSpecificationsProvider
 {
 public:
     /*! Check whether this is actually a linear equation system.

--- a/NumLib/ODESolver/MatrixTranslator.cpp
+++ b/NumLib/ODESolver/MatrixTranslator.cpp
@@ -32,13 +32,13 @@ void MatrixTranslatorGeneral<ODESystemTag::FirstOrderImplicitQuasilinear>::
 {
     namespace LinAlg = MathLib::LinAlg;
 
-    auto& tmp = MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_tmp_id);
+    auto& tmp = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_tmp_id);
     _time_disc.getWeightedOldX(tmp);
 
     // rhs = M * weighted_old_x + b
     LinAlg::matMultAdd(M, tmp, b, rhs);
 
-    MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(tmp);
+    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(tmp);
 }
 
 void MatrixTranslatorGeneral<ODESystemTag::FirstOrderImplicitQuasilinear>::
@@ -84,7 +84,7 @@ void MatrixTranslatorForwardEuler<ODESystemTag::FirstOrderImplicitQuasilinear>::
 {
     namespace LinAlg = MathLib::LinAlg;
 
-    auto& tmp = MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_tmp_id);
+    auto& tmp = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_tmp_id);
     _fwd_euler.getWeightedOldX(tmp);
 
     auto const& x_old = _fwd_euler.getXOld();
@@ -94,7 +94,7 @@ void MatrixTranslatorForwardEuler<ODESystemTag::FirstOrderImplicitQuasilinear>::
     LinAlg::aypx(rhs, -1.0, b);            // rhs = b - K * x_old
     LinAlg::matMultAdd(M, tmp, rhs, rhs);  // rhs += M * weighted_old_x
 
-    MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(tmp);
+    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(tmp);
 }
 
 void MatrixTranslatorForwardEuler<ODESystemTag::FirstOrderImplicitQuasilinear>::
@@ -145,7 +145,7 @@ void MatrixTranslatorCrankNicolson<
 {
     namespace LinAlg = MathLib::LinAlg;
 
-    auto& tmp = MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_tmp_id);
+    auto& tmp = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_tmp_id);
     _crank_nicolson.getWeightedOldX(tmp);
 
     auto const theta = _crank_nicolson.getTheta();
@@ -158,7 +158,7 @@ void MatrixTranslatorCrankNicolson<
     LinAlg::matMultAdd(_M_bar, tmp, rhs, rhs);  // rhs += _M_bar * weighted_old_x
     LinAlg::axpy(rhs, -1.0, _b_bar);            // rhs -= b
 
-    MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(tmp);
+    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(tmp);
 }
 
 void MatrixTranslatorCrankNicolson<

--- a/NumLib/ODESolver/MatrixTranslator.cpp
+++ b/NumLib/ODESolver/MatrixTranslator.cpp
@@ -32,13 +32,13 @@ void MatrixTranslatorGeneral<ODESystemTag::FirstOrderImplicitQuasilinear>::
 {
     namespace LinAlg = MathLib::LinAlg;
 
-    auto& tmp = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_tmp_id);
+    auto& tmp = NumLib::GlobalVectorProvider::provider.getVector(_tmp_id);
     _time_disc.getWeightedOldX(tmp);
 
     // rhs = M * weighted_old_x + b
     LinAlg::matMultAdd(M, tmp, b, rhs);
 
-    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(tmp);
+    NumLib::GlobalVectorProvider::provider.releaseVector(tmp);
 }
 
 void MatrixTranslatorGeneral<ODESystemTag::FirstOrderImplicitQuasilinear>::
@@ -84,7 +84,7 @@ void MatrixTranslatorForwardEuler<ODESystemTag::FirstOrderImplicitQuasilinear>::
 {
     namespace LinAlg = MathLib::LinAlg;
 
-    auto& tmp = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_tmp_id);
+    auto& tmp = NumLib::GlobalVectorProvider::provider.getVector(_tmp_id);
     _fwd_euler.getWeightedOldX(tmp);
 
     auto const& x_old = _fwd_euler.getXOld();
@@ -94,7 +94,7 @@ void MatrixTranslatorForwardEuler<ODESystemTag::FirstOrderImplicitQuasilinear>::
     LinAlg::aypx(rhs, -1.0, b);            // rhs = b - K * x_old
     LinAlg::matMultAdd(M, tmp, rhs, rhs);  // rhs += M * weighted_old_x
 
-    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(tmp);
+    NumLib::GlobalVectorProvider::provider.releaseVector(tmp);
 }
 
 void MatrixTranslatorForwardEuler<ODESystemTag::FirstOrderImplicitQuasilinear>::
@@ -145,7 +145,7 @@ void MatrixTranslatorCrankNicolson<
 {
     namespace LinAlg = MathLib::LinAlg;
 
-    auto& tmp = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_tmp_id);
+    auto& tmp = NumLib::GlobalVectorProvider::provider.getVector(_tmp_id);
     _crank_nicolson.getWeightedOldX(tmp);
 
     auto const theta = _crank_nicolson.getTheta();
@@ -158,7 +158,7 @@ void MatrixTranslatorCrankNicolson<
     LinAlg::matMultAdd(_M_bar, tmp, rhs, rhs);  // rhs += _M_bar * weighted_old_x
     LinAlg::axpy(rhs, -1.0, _b_bar);            // rhs -= b
 
-    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(tmp);
+    NumLib::GlobalVectorProvider::provider.releaseVector(tmp);
 }
 
 void MatrixTranslatorCrankNicolson<

--- a/NumLib/ODESolver/MatrixTranslator.h
+++ b/NumLib/ODESolver/MatrixTranslator.h
@@ -218,18 +218,18 @@ public:
      */
     MatrixTranslatorCrankNicolson(CrankNicolson const& timeDisc)
         : _crank_nicolson(timeDisc),
-          _M_bar(MathLib::GlobalMatrixProvider<GlobalMatrix>::provider
+          _M_bar(NumLib::GlobalMatrixProvider<GlobalMatrix>::provider
                      .getMatrix()),
           _b_bar(
-              MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector())
+              NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector())
     {
     }
 
     ~MatrixTranslatorCrankNicolson()
     {
-        MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(
+        NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(
             _M_bar);
-        MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(
+        NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(
             _b_bar);
     }
 

--- a/NumLib/ODESolver/MatrixTranslator.h
+++ b/NumLib/ODESolver/MatrixTranslator.h
@@ -218,18 +218,18 @@ public:
      */
     MatrixTranslatorCrankNicolson(CrankNicolson const& timeDisc)
         : _crank_nicolson(timeDisc),
-          _M_bar(NumLib::GlobalMatrixProvider<GlobalMatrix>::provider
+          _M_bar(NumLib::GlobalMatrixProvider::provider
                      .getMatrix()),
           _b_bar(
-              NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector())
+              NumLib::GlobalVectorProvider::provider.getVector())
     {
     }
 
     ~MatrixTranslatorCrankNicolson()
     {
-        NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(
+        NumLib::GlobalMatrixProvider::provider.releaseMatrix(
             _M_bar);
-        NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(
+        NumLib::GlobalVectorProvider::provider.releaseVector(
             _b_bar);
     }
 

--- a/NumLib/ODESolver/NonlinearSolver.cpp
+++ b/NumLib/ODESolver/NonlinearSolver.cpp
@@ -36,11 +36,11 @@ bool NonlinearSolver<NonlinearSolverTag::Picard>::solve(
     auto& sys = *_equation_system;
 
     auto& A =
-        NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(_A_id);
-    auto& rhs = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+        NumLib::GlobalMatrixProvider::provider.getMatrix(_A_id);
+    auto& rhs = NumLib::GlobalVectorProvider::provider.getVector(
         _rhs_id);
     auto& x_new =
-        NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+        NumLib::GlobalVectorProvider::provider.getVector(
             _x_new_id);
 
     bool error_norms_met = false;
@@ -136,9 +136,9 @@ bool NonlinearSolver<NonlinearSolverTag::Picard>::solve(
             _maxiter);
     }
 
-    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(A);
-    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(rhs);
-    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(x_new);
+    NumLib::GlobalMatrixProvider::provider.releaseMatrix(A);
+    NumLib::GlobalVectorProvider::provider.releaseVector(rhs);
+    NumLib::GlobalVectorProvider::provider.releaseVector(x_new);
 
     return error_norms_met;
 }
@@ -159,13 +159,13 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
     namespace LinAlg = MathLib::LinAlg;
     auto& sys = *_equation_system;
 
-    auto& res = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+    auto& res = NumLib::GlobalVectorProvider::provider.getVector(
         _res_id);
     auto& minus_delta_x =
-        NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+        NumLib::GlobalVectorProvider::provider.getVector(
             _minus_delta_x_id);
     auto& J =
-        NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(_J_id);
+        NumLib::GlobalMatrixProvider::provider.getMatrix(_J_id);
 
     bool error_norms_met = false;
 
@@ -202,7 +202,7 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
             // cf.
             // http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Vec/VecWAXPY.html
             auto& x_new =
-                NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+                NumLib::GlobalVectorProvider::provider.getVector(
                     x, _x_new_id);
             LinAlg::axpy(x_new, -_alpha, minus_delta_x);
 
@@ -224,7 +224,7 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
                         "iteration"
                         " has to be repeated.");
                     // TODO introduce some onDestroy hook.
-                    NumLib::GlobalVectorProvider<GlobalVector>::provider
+                    NumLib::GlobalVectorProvider::provider
                         .releaseVector(x_new);
                     continue;  // That throws the iteration result away.
             }
@@ -232,7 +232,7 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
             // TODO could be done via swap. Note: that also requires swapping
             // the ids. Same for the Picard scheme.
             LinAlg::copy(x_new, x);  // copy new solution to x
-            NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(
+            NumLib::GlobalVectorProvider::provider.releaseVector(
                 x_new);
         }
 
@@ -271,9 +271,9 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
             _maxiter);
     }
 
-    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(J);
-    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(res);
-    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(
+    NumLib::GlobalMatrixProvider::provider.releaseMatrix(J);
+    NumLib::GlobalVectorProvider::provider.releaseVector(res);
+    NumLib::GlobalVectorProvider::provider.releaseVector(
         minus_delta_x);
 
     return error_norms_met;

--- a/NumLib/ODESolver/NonlinearSolver.cpp
+++ b/NumLib/ODESolver/NonlinearSolver.cpp
@@ -36,11 +36,11 @@ bool NonlinearSolver<NonlinearSolverTag::Picard>::solve(
     auto& sys = *_equation_system;
 
     auto& A =
-        MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(_A_id);
-    auto& rhs = MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+        NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(_A_id);
+    auto& rhs = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
         _rhs_id);
     auto& x_new =
-        MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+        NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
             _x_new_id);
 
     bool error_norms_met = false;
@@ -136,9 +136,9 @@ bool NonlinearSolver<NonlinearSolverTag::Picard>::solve(
             _maxiter);
     }
 
-    MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(A);
-    MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(rhs);
-    MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(x_new);
+    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(A);
+    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(rhs);
+    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(x_new);
 
     return error_norms_met;
 }
@@ -159,13 +159,13 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
     namespace LinAlg = MathLib::LinAlg;
     auto& sys = *_equation_system;
 
-    auto& res = MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+    auto& res = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
         _res_id);
     auto& minus_delta_x =
-        MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+        NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
             _minus_delta_x_id);
     auto& J =
-        MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(_J_id);
+        NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(_J_id);
 
     bool error_norms_met = false;
 
@@ -202,7 +202,7 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
             // cf.
             // http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Vec/VecWAXPY.html
             auto& x_new =
-                MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+                NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
                     x, _x_new_id);
             LinAlg::axpy(x_new, -_alpha, minus_delta_x);
 
@@ -224,7 +224,7 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
                         "iteration"
                         " has to be repeated.");
                     // TODO introduce some onDestroy hook.
-                    MathLib::GlobalVectorProvider<GlobalVector>::provider
+                    NumLib::GlobalVectorProvider<GlobalVector>::provider
                         .releaseVector(x_new);
                     continue;  // That throws the iteration result away.
             }
@@ -232,7 +232,7 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
             // TODO could be done via swap. Note: that also requires swapping
             // the ids. Same for the Picard scheme.
             LinAlg::copy(x_new, x);  // copy new solution to x
-            MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(
+            NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(
                 x_new);
         }
 
@@ -271,9 +271,9 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
             _maxiter);
     }
 
-    MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(J);
-    MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(res);
-    MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(
+    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(J);
+    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(res);
+    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(
         minus_delta_x);
 
     return error_norms_met;

--- a/NumLib/ODESolver/TimeDiscretization.h
+++ b/NumLib/ODESolver/TimeDiscretization.h
@@ -208,13 +208,13 @@ class BackwardEuler final : public TimeDiscretization
 {
 public:
     BackwardEuler()
-        : _x_old(MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector())
+        : _x_old(NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector())
     {
     }
 
     ~BackwardEuler()
     {
-        MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(_x_old);
+        NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(_x_old);
     }
 
     void setInitialState(const double t0, GlobalVector const& x0) override
@@ -257,13 +257,13 @@ class ForwardEuler final : public TimeDiscretization
 {
 public:
     ForwardEuler()
-        : _x_old(MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector())
+        : _x_old(NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector())
     {
     }
 
     ~ForwardEuler()
     {
-        MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(_x_old);
+        NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(_x_old);
     }
 
     void setInitialState(const double t0, GlobalVector const& x0) override
@@ -332,13 +332,13 @@ public:
      */
     explicit CrankNicolson(const double theta)
         : _theta(theta),
-          _x_old(MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector())
+          _x_old(NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector())
     {
     }
 
     ~CrankNicolson()
     {
-        MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(_x_old);
+        NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(_x_old);
     }
 
     void setInitialState(const double t0, GlobalVector const& x0) override
@@ -426,14 +426,14 @@ public:
     ~BackwardDifferentiationFormula()
     {
         for (auto* x : _xs_old)
-            MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(*x);
+            NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(*x);
     }
 
     void setInitialState(const double t0, GlobalVector const& x0) override
     {
         _t = t0;
         _xs_old.push_back(
-            &MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(x0));
+            &NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(x0));
     }
 
     void pushState(const double, GlobalVector const& x,
@@ -446,7 +446,7 @@ public:
         if (_xs_old.size() < _num_steps)
         {
             _xs_old.push_back(
-                &MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(x));
+                &NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(x));
         }
         else
         {

--- a/NumLib/ODESolver/TimeDiscretization.h
+++ b/NumLib/ODESolver/TimeDiscretization.h
@@ -208,13 +208,13 @@ class BackwardEuler final : public TimeDiscretization
 {
 public:
     BackwardEuler()
-        : _x_old(NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector())
+        : _x_old(NumLib::GlobalVectorProvider::provider.getVector())
     {
     }
 
     ~BackwardEuler()
     {
-        NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(_x_old);
+        NumLib::GlobalVectorProvider::provider.releaseVector(_x_old);
     }
 
     void setInitialState(const double t0, GlobalVector const& x0) override
@@ -257,13 +257,13 @@ class ForwardEuler final : public TimeDiscretization
 {
 public:
     ForwardEuler()
-        : _x_old(NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector())
+        : _x_old(NumLib::GlobalVectorProvider::provider.getVector())
     {
     }
 
     ~ForwardEuler()
     {
-        NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(_x_old);
+        NumLib::GlobalVectorProvider::provider.releaseVector(_x_old);
     }
 
     void setInitialState(const double t0, GlobalVector const& x0) override
@@ -332,13 +332,13 @@ public:
      */
     explicit CrankNicolson(const double theta)
         : _theta(theta),
-          _x_old(NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector())
+          _x_old(NumLib::GlobalVectorProvider::provider.getVector())
     {
     }
 
     ~CrankNicolson()
     {
-        NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(_x_old);
+        NumLib::GlobalVectorProvider::provider.releaseVector(_x_old);
     }
 
     void setInitialState(const double t0, GlobalVector const& x0) override
@@ -426,14 +426,14 @@ public:
     ~BackwardDifferentiationFormula()
     {
         for (auto* x : _xs_old)
-            NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(*x);
+            NumLib::GlobalVectorProvider::provider.releaseVector(*x);
     }
 
     void setInitialState(const double t0, GlobalVector const& x0) override
     {
         _t = t0;
         _xs_old.push_back(
-            &NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(x0));
+            &NumLib::GlobalVectorProvider::provider.getVector(x0));
     }
 
     void pushState(const double, GlobalVector const& x,
@@ -446,7 +446,7 @@ public:
         if (_xs_old.size() < _num_steps)
         {
             _xs_old.push_back(
-                &NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(x));
+                &NumLib::GlobalVectorProvider::provider.getVector(x));
         }
         else
         {

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
@@ -44,13 +44,13 @@ TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
       _time_disc(time_discretization),
       _mat_trans(createMatrixTranslator<ODETag>(time_discretization))
 {
-    _Jac = &NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
+    _Jac = &NumLib::GlobalMatrixProvider::provider.getMatrix(
         _ode.getMatrixSpecifications(), _Jac_id);
-    _M = &NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
+    _M = &NumLib::GlobalMatrixProvider::provider.getMatrix(
         _ode.getMatrixSpecifications(), _M_id);
-    _K = &NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
+    _K = &NumLib::GlobalMatrixProvider::provider.getMatrix(
         _ode.getMatrixSpecifications(), _K_id);
-    _b = &NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+    _b = &NumLib::GlobalVectorProvider::provider.getVector(
         _ode.getMatrixSpecifications(), _b_id);
 }
 
@@ -58,10 +58,10 @@ TimeDiscretizedODESystem<
     ODESystemTag::FirstOrderImplicitQuasilinear,
     NonlinearSolverTag::Newton>::~TimeDiscretizedODESystem()
 {
-    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_Jac);
-    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_M);
-    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_K);
-    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(*_b);
+    NumLib::GlobalMatrixProvider::provider.releaseMatrix(*_Jac);
+    NumLib::GlobalMatrixProvider::provider.releaseMatrix(*_M);
+    NumLib::GlobalMatrixProvider::provider.releaseMatrix(*_K);
+    NumLib::GlobalVectorProvider::provider.releaseVector(*_b);
 }
 
 void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
@@ -95,7 +95,7 @@ void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
     auto const dxdot_dx = _time_disc.getNewXWeight();
     auto const dx_dx = _time_disc.getDxDx();
 
-    auto& xdot = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_xdot_id);
+    auto& xdot = NumLib::GlobalVectorProvider::provider.getVector(_xdot_id);
     _time_disc.getXdot(x_new_timestep, xdot);
 
     _Jac->setZero();
@@ -104,7 +104,7 @@ void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
 
     MathLib::LinAlg::finalizeAssembly(*_Jac);
 
-    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(xdot);
+    NumLib::GlobalVectorProvider::provider.releaseVector(xdot);
 }
 
 void TimeDiscretizedODESystem<
@@ -115,12 +115,12 @@ void TimeDiscretizedODESystem<
     // TODO Maybe the duplicate calculation of xdot here and in assembleJacobian
     //      can be optimuized. However, that would make the interface a bit more
     //      fragile.
-    auto& xdot = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_xdot_id);
+    auto& xdot = NumLib::GlobalVectorProvider::provider.getVector(_xdot_id);
     _time_disc.getXdot(x_new_timestep, xdot);
 
     _mat_trans->computeResidual(*_M, *_K, *_b, x_new_timestep, xdot, res);
 
-    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(xdot);
+    NumLib::GlobalVectorProvider::provider.releaseVector(xdot);
 }
 
 void TimeDiscretizedODESystem<
@@ -169,11 +169,11 @@ TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
       _time_disc(time_discretization),
       _mat_trans(createMatrixTranslator<ODETag>(time_discretization))
 {
-    _M = &NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
+    _M = &NumLib::GlobalMatrixProvider::provider.getMatrix(
         ode.getMatrixSpecifications(), _M_id);
-    _K = &NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
+    _K = &NumLib::GlobalMatrixProvider::provider.getMatrix(
         ode.getMatrixSpecifications(), _K_id);
-    _b = &NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+    _b = &NumLib::GlobalVectorProvider::provider.getVector(
         ode.getMatrixSpecifications(), _b_id);
 }
 
@@ -181,9 +181,9 @@ TimeDiscretizedODESystem<
     ODESystemTag::FirstOrderImplicitQuasilinear,
     NonlinearSolverTag::Picard>::~TimeDiscretizedODESystem()
 {
-    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_M);
-    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_K);
-    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(*_b);
+    NumLib::GlobalMatrixProvider::provider.releaseMatrix(*_M);
+    NumLib::GlobalMatrixProvider::provider.releaseMatrix(*_K);
+    NumLib::GlobalVectorProvider::provider.releaseVector(*_b);
 }
 
 void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
@@ -44,13 +44,13 @@ TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
       _time_disc(time_discretization),
       _mat_trans(createMatrixTranslator<ODETag>(time_discretization))
 {
-    _Jac = &MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
+    _Jac = &NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
         _ode.getMatrixSpecifications(), _Jac_id);
-    _M = &MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
+    _M = &NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
         _ode.getMatrixSpecifications(), _M_id);
-    _K = &MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
+    _K = &NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
         _ode.getMatrixSpecifications(), _K_id);
-    _b = &MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+    _b = &NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
         _ode.getMatrixSpecifications(), _b_id);
 }
 
@@ -58,10 +58,10 @@ TimeDiscretizedODESystem<
     ODESystemTag::FirstOrderImplicitQuasilinear,
     NonlinearSolverTag::Newton>::~TimeDiscretizedODESystem()
 {
-    MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_Jac);
-    MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_M);
-    MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_K);
-    MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(*_b);
+    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_Jac);
+    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_M);
+    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_K);
+    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(*_b);
 }
 
 void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
@@ -95,7 +95,7 @@ void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
     auto const dxdot_dx = _time_disc.getNewXWeight();
     auto const dx_dx = _time_disc.getDxDx();
 
-    auto& xdot = MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_xdot_id);
+    auto& xdot = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_xdot_id);
     _time_disc.getXdot(x_new_timestep, xdot);
 
     _Jac->setZero();
@@ -104,7 +104,7 @@ void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
 
     MathLib::LinAlg::finalizeAssembly(*_Jac);
 
-    MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(xdot);
+    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(xdot);
 }
 
 void TimeDiscretizedODESystem<
@@ -115,12 +115,12 @@ void TimeDiscretizedODESystem<
     // TODO Maybe the duplicate calculation of xdot here and in assembleJacobian
     //      can be optimuized. However, that would make the interface a bit more
     //      fragile.
-    auto& xdot = MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_xdot_id);
+    auto& xdot = NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(_xdot_id);
     _time_disc.getXdot(x_new_timestep, xdot);
 
     _mat_trans->computeResidual(*_M, *_K, *_b, x_new_timestep, xdot, res);
 
-    MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(xdot);
+    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(xdot);
 }
 
 void TimeDiscretizedODESystem<
@@ -169,11 +169,11 @@ TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
       _time_disc(time_discretization),
       _mat_trans(createMatrixTranslator<ODETag>(time_discretization))
 {
-    _M = &MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
+    _M = &NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
         ode.getMatrixSpecifications(), _M_id);
-    _K = &MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
+    _K = &NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.getMatrix(
         ode.getMatrixSpecifications(), _K_id);
-    _b = &MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
+    _b = &NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(
         ode.getMatrixSpecifications(), _b_id);
 }
 
@@ -181,9 +181,9 @@ TimeDiscretizedODESystem<
     ODESystemTag::FirstOrderImplicitQuasilinear,
     NonlinearSolverTag::Picard>::~TimeDiscretizedODESystem()
 {
-    MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_M);
-    MathLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_K);
-    MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(*_b);
+    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_M);
+    NumLib::GlobalMatrixProvider<GlobalMatrix>::provider.releaseMatrix(*_K);
+    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(*_b);
 }
 
 void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,

--- a/NumLib/ODESolver/TimeLoopSingleODE.h
+++ b/NumLib/ODESolver/TimeLoopSingleODE.h
@@ -82,7 +82,7 @@ bool TimeLoopSingleODE<NLTag>::loop(const double t0, GlobalVector const& x0,
 {
     // solution vector
     GlobalVector& x =
-        NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(x0);
+        NumLib::GlobalVectorProvider::provider.getVector(x0);
 
     auto& time_disc = _ode_sys.getTimeDiscretization();
 
@@ -120,7 +120,7 @@ bool TimeLoopSingleODE<NLTag>::loop(const double t0, GlobalVector const& x0,
         post_timestep(t_cb, x_cb);
     }
 
-    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(x);
+    NumLib::GlobalVectorProvider::provider.releaseVector(x);
 
     if (!nl_slv_succeeded)
     {

--- a/NumLib/ODESolver/TimeLoopSingleODE.h
+++ b/NumLib/ODESolver/TimeLoopSingleODE.h
@@ -82,7 +82,7 @@ bool TimeLoopSingleODE<NLTag>::loop(const double t0, GlobalVector const& x0,
 {
     // solution vector
     GlobalVector& x =
-        MathLib::GlobalVectorProvider<GlobalVector>::provider.getVector(x0);
+        NumLib::GlobalVectorProvider<GlobalVector>::provider.getVector(x0);
 
     auto& time_disc = _ode_sys.getTimeDiscretization();
 
@@ -120,7 +120,7 @@ bool TimeLoopSingleODE<NLTag>::loop(const double t0, GlobalVector const& x0,
         post_timestep(t_cb, x_cb);
     }
 
-    MathLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(x);
+    NumLib::GlobalVectorProvider<GlobalVector>::provider.releaseVector(x);
 
     if (!nl_slv_succeeded)
     {


### PR DESCRIPTION
follow up of #1261

- fix that some classes in NumLib/DOF dir have MathLib namespace
- remove Mat/Vec templates in NumLib/DOF (i.e. GlobalMatrix/VectorProvider, Matrix/VectorProvider)