### PR TITLE
fix internally setting BOOST_ROOT from env var

### DIFF
--- a/scripts/cmake/ExternalProjectBoost.cmake
+++ b/scripts/cmake/ExternalProjectBoost.cmake
@@ -13,7 +13,7 @@ if(Boost_FOUND)
 endif()
 
 if(NOT DEFINED BOOST_ROOT AND DEFINED ENV{BOOST_ROOT})
-    set(BOOST_ROOT $ENV{BOOST_ROOT} TRUE CACHE PATH "")
+    set(BOOST_ROOT $ENV{BOOST_ROOT} CACHE PATH "")
 endif()
 
 # First check for system boost


### PR DESCRIPTION
fix a problem that a environmental variable BOOST_ROOT doesn't work