### PR TITLE
Moving CSV-/Raster-interface back to FileIO

### DIFF
--- a/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
+++ b/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
@@ -20,7 +20,7 @@
 
 #include "DirectConditionGenerator.h"
 
-#include "GeoLib/IO/AsciiRasterInterface.h"
+#include "Applications/FileIO/AsciiRasterInterface.h"
 
 #include "Raster.h"
 #include "MeshSurfaceExtraction.h"
@@ -37,7 +37,7 @@ DirectConditionGenerator::directToSurfaceNodes(const MeshLib::Mesh& mesh,
     if (_direct_values.empty())
     {
         GeoLib::Raster* raster(
-            GeoLib::IO::AsciiRasterInterface::readRaster(filename));
+            FileIO::AsciiRasterInterface::readRaster(filename));
         if (!raster)
         {
             ERR("Error in DirectConditionGenerator::directToSurfaceNodes() - "
@@ -72,17 +72,15 @@ DirectConditionGenerator::directToSurfaceNodes(const MeshLib::Mesh& mesh,
 const std::vector< std::pair<std::size_t,double> >& DirectConditionGenerator::directWithSurfaceIntegration(MeshLib::Mesh &mesh, const std::string &filename, double scaling)
 {
     if (!_direct_values.empty()) {
-        ERR(
-            "Error in DirectConditionGenerator::directWithSurfaceIntegration()"
+        ERR("Error in DirectConditionGenerator::directWithSurfaceIntegration()"
             "- Data vector contains outdated values...");
         return _direct_values;
     }
 
     std::unique_ptr<GeoLib::Raster> raster(
-        GeoLib::IO::AsciiRasterInterface::readRaster(filename));
+        FileIO::AsciiRasterInterface::readRaster(filename));
     if (!raster) {
-        ERR(
-            "Error in DirectConditionGenerator::directWithSurfaceIntegration()"
+        ERR("Error in DirectConditionGenerator::directWithSurfaceIntegration()"
             "- could not load raster file.");
         return _direct_values;
     }

--- a/Applications/DataExplorer/DataView/MeshLayerEditDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshLayerEditDialog.cpp
@@ -22,7 +22,7 @@
 #include "StringTools.h"
 #include "Mesh.h"
 
-#include "GeoLib/IO/AsciiRasterInterface.h"
+#include "Applications/FileIO/AsciiRasterInterface.h"
 #include "TetGenInterface.h"
 
 #include <QCheckBox>
@@ -190,7 +190,7 @@ MeshLib::Mesh* MeshLayerEditDialog::createPrismMesh()
         for (int i=nLayers; i>=0; --i)
             raster_paths.push_back(this->_edits[i]->text().toStdString());
 
-        auto const rasters = GeoLib::IO::readRasters(raster_paths);
+        auto const rasters = FileIO::readRasters(raster_paths);
         if (rasters && mapper.createLayers(*_msh, *rasters, minimum_thickness))
         {
             INFO("Mesh construction time: %d ms.", myTimer0.elapsed());
@@ -231,7 +231,7 @@ MeshLib::Mesh* MeshLayerEditDialog::createTetMesh()
             raster_paths.push_back(this->_edits[i]->text().toStdString());
         LayeredVolume lv;
 
-        auto const rasters = GeoLib::IO::readRasters(raster_paths);
+        auto const rasters = FileIO::readRasters(raster_paths);
         if (rasters && lv.createLayers(*_msh, *rasters, minimum_thickness))
             tg_mesh = lv.getMesh("SubsurfaceMesh").release();
 

--- a/Applications/DataExplorer/DataView/MshView.cpp
+++ b/Applications/DataExplorer/DataView/MshView.cpp
@@ -25,7 +25,7 @@
 
 #include "SHPInterface.h"
 #include "TetGenInterface.h"
-#include "GeoLib/IO/AsciiRasterInterface.h"
+#include "Applications/FileIO/AsciiRasterInterface.h"
 
 #include "MeshLib/Mesh.h"
 #include "MeshLib/Node.h"
@@ -166,7 +166,7 @@ void MshView::openMap2dMeshDialog()
     if (dlg.useRasterMapping())
     {
         std::unique_ptr<GeoLib::Raster> raster{
-            GeoLib::IO::AsciiRasterInterface::readRaster(dlg.getRasterPath())};
+            FileIO::AsciiRasterInterface::readRaster(dlg.getRasterPath())};
         if (!raster)
         {
             OGSError::box(QString::fromStdString(

--- a/Applications/DataExplorer/VtkVis/VtkRaster.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkRaster.cpp
@@ -35,7 +35,7 @@
 #include <memory>
 #include <logog/include/logog.hpp>
 
-#include "GeoLib/IO/AsciiRasterInterface.h"
+#include "Applications/FileIO/AsciiRasterInterface.h"
 #include "GeoLib/Raster.h"
 
 
@@ -47,9 +47,9 @@ vtkImageAlgorithm* VtkRaster::loadImage(const std::string &fileName,
 
     std::unique_ptr<GeoLib::Raster> raster(nullptr);
     if (fileInfo.suffix().toLower() == "asc")
-        raster.reset(GeoLib::IO::AsciiRasterInterface::getRasterFromASCFile(fileName));
+        raster.reset(FileIO::AsciiRasterInterface::getRasterFromASCFile(fileName));
     else if (fileInfo.suffix().toLower() == "grd")
-        raster.reset(GeoLib::IO::AsciiRasterInterface::getRasterFromSurferFile(fileName));
+        raster.reset(FileIO::AsciiRasterInterface::getRasterFromSurferFile(fileName));
     if (raster)
         return VtkRaster::loadImageFromArray(raster->begin(), raster->getHeader());
     else if ((fileInfo.suffix().toLower() == "tif") || (fileInfo.suffix().toLower() == "tiff"))

--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -65,9 +65,10 @@
 #include "MeshLib/IO/Legacy/MeshIO.h"
 #include "MeshLib/IO/readMeshFromFile.h"
 #include "MeshLib/IO/GmshReader.h"
-#include "TetGenInterface.h"
-#include "PetrelInterface.h"
-#include "XmlIO/Qt/XmlGspInterface.h"
+#include "Applications/FileIO/AsciiRasterInterface.h"
+#include "Applications/FileIO/PetrelInterface.h"
+#include "Applications/FileIO/TetGenInterface.h"
+#include "Applications/FileIO/XmlIO/Qt/XmlGspInterface.h"
 #include "GeoLib/IO/GMSHInterface.h"
 #include "Applications/FileIO/FEFLOW/FEFLOWGeoInterface.h"
 #include "GeoLib/IO/XmlIO/Qt/XmlGmlInterface.h"
@@ -829,7 +830,12 @@ void MainWindow::mapGeometry(const std::string &geo_name)
     {
         if (fi.suffix().toLower() == "asc" || fi.suffix().toLower() == "grd")
         {
-            geo_mapper.mapOnDEM(file_name.toStdString());
+            std::unique_ptr<GeoLib::Raster> raster (
+                FileIO::AsciiRasterInterface::getRasterFromASCFile(file_name.toStdString()));
+            if (raster)
+                geo_mapper.mapOnDEM(raster.get());
+            else
+                OGSError::box("Error reading raster file.");
             _geo_model->updateGeometry(geo_name);
         }
         else

--- a/Applications/FileIO/AsciiRasterInterface.cpp
+++ b/Applications/FileIO/AsciiRasterInterface.cpp
@@ -21,9 +21,7 @@
 
 #include "GeoLib/Raster.h"
 
-namespace GeoLib
-{
-namespace IO
+namespace FileIO
 {
 
 GeoLib::Raster* AsciiRasterInterface::readRaster(std::string const& fname)
@@ -241,8 +239,7 @@ boost::optional<std::vector<GeoLib::Raster const*>> readRasters(
     std::vector<GeoLib::Raster const*> rasters;
     rasters.reserve(raster_paths.size());
     for (auto const& path : raster_paths)
-        rasters.push_back(GeoLib::IO::AsciiRasterInterface::readRaster(path));
+        rasters.push_back(FileIO::AsciiRasterInterface::readRaster(path));
     return boost::make_optional(rasters);
 }
-} // end namespace IO
-} // end namespace GeoLib
+} // end namespace FileIO

--- a/Applications/FileIO/AsciiRasterInterface.h
+++ b/Applications/FileIO/AsciiRasterInterface.h
@@ -21,9 +21,7 @@
 
 #include "GeoLib/Raster.h"
 
-namespace GeoLib
-{
-namespace IO
+namespace FileIO
 {
 /**
  * Interface for reading and writing a number of ASCII raster formats.
@@ -58,7 +56,6 @@ private:
 /// otherwise the returned vector contains pointers to the read rasters.
 boost::optional<std::vector<GeoLib::Raster const*>> readRasters(
     std::vector<std::string> const& raster_paths);
-} // end namespace IO
-} // end namespace GeoLib
+} // end namespace FileIO
 
 #endif /* ASCIIRASTERINTERFACE_H_ */

--- a/Applications/FileIO/CsvInterface.cpp
+++ b/Applications/FileIO/CsvInterface.cpp
@@ -18,8 +18,7 @@
 
 #include "GeoLib/Point.h"
 
-namespace GeoLib {
-namespace IO {
+namespace FileIO {
 
 int CsvInterface::readPoints(std::string const& fname, char delim,
                              std::vector<GeoLib::Point*> &points)
@@ -182,5 +181,4 @@ std::size_t CsvInterface::findColumn(std::string const& line, char delim, std::s
     return count;
 }
 
-} // end namespace IO
-} // end namespace GeoLib
+} // end namespace FileIO

--- a/Applications/FileIO/CsvInterface.h
+++ b/Applications/FileIO/CsvInterface.h
@@ -31,8 +31,7 @@ namespace GeoLib {
     class Point;
 }
 
-namespace GeoLib {
-namespace IO {
+namespace FileIO {
 
 /**
  * Interface for reading CSV file formats.
@@ -181,7 +180,6 @@ private:
     static std::size_t findColumn(std::string const& line, char delim, std::string const& column_name);
 };
 
-} // IO
-} // GeoLib
+} // FileIO
 
 #endif /* CSVINTERFACE_H_ */

--- a/Applications/Utils/MeshEdit/CMakeLists.txt
+++ b/Applications/Utils/MeshEdit/CMakeLists.txt
@@ -56,7 +56,10 @@ target_link_libraries(AddTopLayer MeshLib)
 set_target_properties(AddTopLayer PROPERTIES FOLDER Utilities)
 
 add_executable(createLayeredMeshFromRasters createLayeredMeshFromRasters.cpp)
-target_link_libraries(createLayeredMeshFromRasters MeshLib)
+target_link_libraries(createLayeredMeshFromRasters
+    MeshLib
+    ApplicationsFileIO
+)
 set_target_properties(createLayeredMeshFromRasters PROPERTIES FOLDER Utilities)
 
 add_executable(CreateBoundaryConditionsAlongPolylines

--- a/Applications/Utils/MeshEdit/createLayeredMeshFromRasters.cpp
+++ b/Applications/Utils/MeshEdit/createLayeredMeshFromRasters.cpp
@@ -23,8 +23,8 @@
 #include "BaseLib/FileTools.h"
 
 #include "MeshLib/IO/readMeshFromFile.h"
-#include "GeoLib/IO/AsciiRasterInterface.h"
 #include "MeshLib/IO/writeMeshToFile.h"
+#include "Applications/FileIO/AsciiRasterInterface.h"
 
 #include "MeshLib/Mesh.h"
 #include "MeshLib/MeshGenerators/MeshLayerMapper.h"
@@ -114,7 +114,7 @@ int main (int argc, char* argv[])
         return EXIT_FAILURE;
 
     MeshLib::MeshLayerMapper mapper;
-    if (auto rasters = GeoLib::IO::readRasters(raster_paths))
+    if (auto rasters = FileIO::readRasters(raster_paths))
     {
         if (!mapper.createLayers(*sfc_mesh, *rasters, min_thickness))
             return EXIT_FAILURE;

--- a/Applications/Utils/SimpleMeshCreation/CMakeLists.txt
+++ b/Applications/Utils/SimpleMeshCreation/CMakeLists.txt
@@ -2,7 +2,10 @@
 if(OGS_BUILD_GUI)
     add_executable(createMeshElemPropertiesFromASCRaster createMeshElemPropertiesFromASCRaster.cpp)
     set_target_properties(createMeshElemPropertiesFromASCRaster PROPERTIES FOLDER Utilities)
-    target_link_libraries(createMeshElemPropertiesFromASCRaster MeshLib)
+    target_link_libraries(createMeshElemPropertiesFromASCRaster
+        ApplicationsFileIO
+        MeshLib
+    )
     ADD_VTK_DEPENDENCY(createMeshElemPropertiesFromASCRaster)
 endif() # OGS_BUILD_GUI (VtkVis-target is existing)
 

--- a/Applications/Utils/SimpleMeshCreation/createMeshElemPropertiesFromASCRaster.cpp
+++ b/Applications/Utils/SimpleMeshCreation/createMeshElemPropertiesFromASCRaster.cpp
@@ -22,7 +22,7 @@
 
 #include "MeshLib/IO/readMeshFromFile.h"
 #include "MeshLib/IO/writeMeshToFile.h"
-#include "GeoLib/IO/AsciiRasterInterface.h"
+#include "Applications/FileIO/AsciiRasterInterface.h"
 
 #include "GeoLib/Raster.h"
 
@@ -127,7 +127,7 @@ int main (int argc, char* argv[])
 
     // read raster and if required manipulate it
     auto raster = std::unique_ptr<GeoLib::Raster>(
-        GeoLib::IO::AsciiRasterInterface::getRasterFromASCFile(raster_arg.getValue()));
+        FileIO::AsciiRasterInterface::getRasterFromASCFile(raster_arg.getValue()));
     GeoLib::RasterHeader header (raster->getHeader());
     if (refinement_arg.getValue() > 1) {
         raster->refineRaster(refinement_arg.getValue());
@@ -137,7 +137,7 @@ int main (int argc, char* argv[])
                                                   raster_arg.getValue()));
             new_raster_fname += "-" + std::to_string(header.n_rows) + "x" +
                                 std::to_string(header.n_cols) + ".asc";
-            GeoLib::IO::AsciiRasterInterface::writeRasterAsASC(*raster, new_raster_fname);
+            FileIO::AsciiRasterInterface::writeRasterAsASC(*raster, new_raster_fname);
         }
     }
 

--- a/MeshGeoToolsLib/GeoMapper.cpp
+++ b/MeshGeoToolsLib/GeoMapper.cpp
@@ -19,7 +19,7 @@
 
 #include <logog/include/logog.hpp>
 
-#include "GeoLib/IO/AsciiRasterInterface.h"
+#include "Applications/FileIO/AsciiRasterInterface.h"
 #include "MeshLib/IO/readMeshFromFile.h"
 
 #include "GeoLib/AABB.h"
@@ -50,7 +50,7 @@ GeoMapper::~GeoMapper()
 
 void GeoMapper::mapOnDEM(const std::string &file_name)
 {
-    _raster = GeoLib::IO::AsciiRasterInterface::getRasterFromASCFile(file_name);
+    _raster = FileIO::AsciiRasterInterface::getRasterFromASCFile(file_name);
     if (! _raster) {
         ERR("GeoMapper::mapOnDEM(): failed to load %s", file_name.c_str());
         return;

--- a/MeshGeoToolsLib/GeoMapper.cpp
+++ b/MeshGeoToolsLib/GeoMapper.cpp
@@ -19,9 +19,6 @@
 
 #include <logog/include/logog.hpp>
 
-#include "Applications/FileIO/AsciiRasterInterface.h"
-#include "MeshLib/IO/readMeshFromFile.h"
-
 #include "GeoLib/AABB.h"
 #include "GeoLib/AnalyticalGeometry.h"
 #include "GeoLib/GEOObjects.h"
@@ -33,6 +30,7 @@
 #include "MeshLib/Node.h"
 #include "MeshLib/MeshSurfaceExtraction.h"
 #include "MeshLib/MeshEditing/projectMeshOntoPlane.h"
+#include "MeshLib/IO/readMeshFromFile.h"
 
 namespace MeshGeoToolsLib {
 
@@ -48,19 +46,15 @@ GeoMapper::~GeoMapper()
     delete _raster;
 }
 
-void GeoMapper::mapOnDEM(const std::string &file_name)
+void GeoMapper::mapOnDEM(GeoLib::Raster *const raster)
 {
-    _raster = FileIO::AsciiRasterInterface::getRasterFromASCFile(file_name);
-    if (! _raster) {
-        ERR("GeoMapper::mapOnDEM(): failed to load %s", file_name.c_str());
-        return;
-    }
-
     std::vector<GeoLib::Point*> const* pnts(_geo_objects.getPointVec(_geo_name));
     if (! pnts) {
         ERR("Geometry \"%s\" does not exist.", _geo_name.c_str());
         return;
     }
+    _raster = raster;
+
     if (GeoLib::isStation((*pnts)[0])) {
         mapStationData(*pnts);
     } else {
@@ -68,14 +62,7 @@ void GeoMapper::mapOnDEM(const std::string &file_name)
     }
 }
 
-void GeoMapper::mapOnMesh(const std::string &file_name)
-{
-    MeshLib::Mesh *mesh (MeshLib::IO::readMeshFromFile(file_name));
-    mapOnMesh(mesh);
-    delete mesh;
-}
-
-void GeoMapper::mapOnMesh(const MeshLib::Mesh* mesh)
+void GeoMapper::mapOnMesh(MeshLib::Mesh const*const mesh)
 {
     std::vector<GeoLib::Point*> const* pnts(_geo_objects.getPointVec(_geo_name));
     if (! pnts) {

--- a/MeshGeoToolsLib/GeoMapper.h
+++ b/MeshGeoToolsLib/GeoMapper.h
@@ -44,16 +44,13 @@ public:
     ~GeoMapper();
 
     /// Maps geometry based on a raster file
-    void mapOnDEM(const std::string &file_name);
-
-    /// Maps geometry based on a mesh file
-    void mapOnMesh(const std::string &file_name);
+    void mapOnDEM(GeoLib::Raster *const raster);
 
     /**
      * Maps the geometry based on the given mesh file. The elevation value of all geometric
      * points are modified such that they are located on the mesh surface.
      */
-    void mapOnMesh(const MeshLib::Mesh* mesh);
+    void mapOnMesh(MeshLib::Mesh const*const mesh);
 
     /// Maps geometry to a constant elevation value
     void mapToConstantValue(double value);

--- a/Tests/FileIO/TestCsvReader.cpp
+++ b/Tests/FileIO/TestCsvReader.cpp
@@ -17,7 +17,7 @@
 #include "gtest/gtest.h"
 
 #include "BaseLib/BuildInfo.h"
-#include "GeoLib/IO/CsvInterface.h"
+#include "Applications/FileIO/CsvInterface.h"
 #include "GeoLib/Point.h"
 
 class CsvInterfaceTest : public ::testing::Test
@@ -56,9 +56,9 @@ TEST_F(CsvInterfaceTest, SimpleReadPoints)
 {
     std::vector<GeoLib::Point*> points;
     std::vector<GeoLib::Point*> points2;
-    _result = GeoLib::IO::CsvInterface::readPoints(_file_name, '\t', points);
+    _result = FileIO::CsvInterface::readPoints(_file_name, '\t', points);
     ASSERT_EQ(0, _result);
-    _result = GeoLib::IO::CsvInterface::readPoints(_file_name, '\t', points2, "x", "y", "z");
+    _result = FileIO::CsvInterface::readPoints(_file_name, '\t', points2, "x", "y", "z");
     ASSERT_EQ(0, _result);
     ASSERT_TRUE(points.size() == 10);
     ASSERT_TRUE(points2.size() == 10);
@@ -77,7 +77,7 @@ TEST_F(CsvInterfaceTest, SimpleReadPoints)
 TEST_F(CsvInterfaceTest, StringInPointColumn)
 {
     std::vector<GeoLib::Point*> points;
-    _result = GeoLib::IO::CsvInterface::readPoints(_file_name, '\t', points, "x", "y", "name");
+    _result = FileIO::CsvInterface::readPoints(_file_name, '\t', points, "x", "y", "name");
     ASSERT_EQ(10, _result);
     ASSERT_TRUE(points.empty());
 }
@@ -86,11 +86,11 @@ TEST_F(CsvInterfaceTest, StringInPointColumn)
 TEST_F(CsvInterfaceTest, WrongColumnName)
 {
     std::vector<GeoLib::Point*> points;
-    _result = GeoLib::IO::CsvInterface::readPoints(_file_name, '\t', points, "x", "y", "wrong_column_name");
+    _result = FileIO::CsvInterface::readPoints(_file_name, '\t', points, "x", "y", "wrong_column_name");
     ASSERT_EQ(-1, _result);
     ASSERT_TRUE(points.empty());
 
-    _result = GeoLib::IO::CsvInterface::readPoints(_file_name, '\t', points, "wrong_column_name", "y", "id");
+    _result = FileIO::CsvInterface::readPoints(_file_name, '\t', points, "wrong_column_name", "y", "id");
     ASSERT_EQ(-1, _result);
     ASSERT_TRUE(points.empty());
 }
@@ -99,7 +99,7 @@ TEST_F(CsvInterfaceTest, WrongColumnName)
 TEST_F(CsvInterfaceTest, MissingValues)
 {
     std::vector<GeoLib::Point*> points;
-    _result = GeoLib::IO::CsvInterface::readPoints(_file_name, '\t', points, "z", "value1", "value_two");
+    _result = FileIO::CsvInterface::readPoints(_file_name, '\t', points, "z", "value1", "value_two");
     ASSERT_EQ(3, _result);
     ASSERT_EQ(7, points.size());
     ASSERT_NEAR(437.539, (*points[4])[2], std::numeric_limits<double>::epsilon());
@@ -111,7 +111,7 @@ TEST_F(CsvInterfaceTest, MissingValues)
 TEST_F(CsvInterfaceTest, Points2D)
 {
     std::vector<GeoLib::Point*> points;
-    _result = GeoLib::IO::CsvInterface::readPoints(_file_name, '\t', points, "x", "y");
+    _result = FileIO::CsvInterface::readPoints(_file_name, '\t', points, "x", "y");
     ASSERT_EQ(0, _result);
     ASSERT_EQ(10, points.size());
     for (auto & point : points)
@@ -126,11 +126,11 @@ TEST_F(CsvInterfaceTest, CoordinateOrder)
     std::vector<GeoLib::Point*> points1;
     std::vector<GeoLib::Point*> points2;
     std::vector<GeoLib::Point*> points3;
-    _result = GeoLib::IO::CsvInterface::readPoints(_file_name, '\t', points1, "id", "y", "z");
+    _result = FileIO::CsvInterface::readPoints(_file_name, '\t', points1, "id", "y", "z");
     ASSERT_EQ(0, _result);
-    _result = GeoLib::IO::CsvInterface::readPoints(_file_name, '\t', points2, "id", "z", "y");
+    _result = FileIO::CsvInterface::readPoints(_file_name, '\t', points2, "id", "z", "y");
     ASSERT_EQ(0, _result);
-    _result = GeoLib::IO::CsvInterface::readPoints(_file_name, '\t', points3, "y", "id", "z");
+    _result = FileIO::CsvInterface::readPoints(_file_name, '\t', points3, "y", "id", "z");
     ASSERT_EQ(0, _result);
     ASSERT_EQ(10, points1.size());
     ASSERT_EQ(10, points2.size());
@@ -156,12 +156,12 @@ TEST_F(CsvInterfaceTest, CoordinateOrder)
 TEST_F(CsvInterfaceTest, GetColumn)
 {
     std::vector<std::string> names;
-    _result = GeoLib::IO::CsvInterface::readColumn<std::string>(_file_name, '\t', names, "name");
+    _result = FileIO::CsvInterface::readColumn<std::string>(_file_name, '\t', names, "name");
     ASSERT_EQ(0, _result);
     ASSERT_EQ(10, names.size());
 
     std::vector<double> values;
-    _result = GeoLib::IO::CsvInterface::readColumn<double>(_file_name, '\t', values, "value_two");
+    _result = FileIO::CsvInterface::readColumn<double>(_file_name, '\t', values, "value_two");
     ASSERT_EQ(2, _result);
     ASSERT_EQ(8, values.size());
 }
@@ -170,7 +170,7 @@ TEST_F(CsvInterfaceTest, GetColumn)
 TEST_F(CsvInterfaceTest, NonExistingColumn)
 {
     std::vector<double> values;
-    _result = GeoLib::IO::CsvInterface::readColumn<double>(_file_name, '\t', values, "value2");
+    _result = FileIO::CsvInterface::readColumn<double>(_file_name, '\t', values, "value2");
     ASSERT_EQ(-1, _result);
     ASSERT_TRUE(values.empty());
 }
@@ -179,12 +179,12 @@ TEST_F(CsvInterfaceTest, NonExistingColumn)
 TEST_F(CsvInterfaceTest, WrongDataType)
 {
     std::vector<double> values;
-    _result = GeoLib::IO::CsvInterface::readColumn<double>(_file_name, '\t', values, "name");
+    _result = FileIO::CsvInterface::readColumn<double>(_file_name, '\t', values, "name");
     ASSERT_EQ(10, _result);
     ASSERT_TRUE(values.empty());
 
     std::vector<std::string> names;
-    _result = GeoLib::IO::CsvInterface::readColumn<std::string>(_file_name, '\t', names, "value1");
+    _result = FileIO::CsvInterface::readColumn<std::string>(_file_name, '\t', names, "value1");
     ASSERT_EQ(2, _result);
     ASSERT_EQ(8, names.size());
 }


### PR DESCRIPTION
As discussed, interfaces for external file formats are moved back into Applications/FileIO.