### PR TITLE
Make FileFinder general

### DIFF
--- a/Applications/FileIO/XmlIO/Qt/XmlGspInterface.cpp
+++ b/Applications/FileIO/XmlIO/Qt/XmlGspInterface.cpp
@@ -42,7 +42,7 @@ namespace FileIO
 {
 
 XmlGspInterface::XmlGspInterface(DataHolderLib::Project& project)
-: XMLInterface(), XMLQtInterface(BaseLib::FileFinder(BaseLib::BuildInfo::app_xml_schema_path).getPath("OpenGeoSysProject.xsd")),
+: XMLInterface(), XMLQtInterface(BaseLib::FileFinder({BaseLib::BuildInfo::app_xml_schema_path}).getPath("OpenGeoSysProject.xsd")),
   _project(project)
 {
 }

--- a/Applications/FileIO/XmlIO/Qt/XmlGspInterface.cpp
+++ b/Applications/FileIO/XmlIO/Qt/XmlGspInterface.cpp
@@ -18,29 +18,31 @@
 #include <vector>
 
 #include <logog/include/logog.hpp>
+#include <QFile>
+#include <QFileInfo>
+#include <QtXml/QDomDocument>
+
+#include "BaseLib/BuildInfo.h"
+#include "BaseLib/FileTools.h"
+#include "BaseLib/FileFinder.h"
+#include "BaseLib/IO/Writer.h"
 
 #include "GeoLib/GEOObjects.h"
 
 #include "GeoLib/IO/XmlIO/Qt/XmlGmlInterface.h"
 #include "GeoLib/IO/XmlIO/Qt/XmlStnInterface.h"
 
-#include "BaseLib/FileTools.h"
-#include "BaseLib/FileFinder.h"
-#include "BaseLib/IO/Writer.h"
 
 #include "MeshLib/IO/Legacy/MeshIO.h"
 #include "MeshLib/IO/readMeshFromFile.h"
 #include "MeshLib/Mesh.h"
 
-#include <QFile>
-#include <QFileInfo>
-#include <QtXml/QDomDocument>
 
 namespace FileIO
 {
 
 XmlGspInterface::XmlGspInterface(DataHolderLib::Project& project)
-: XMLInterface(), XMLQtInterface(BaseLib::FileFinder().getPath("OpenGeoSysProject.xsd")),
+: XMLInterface(), XMLQtInterface(BaseLib::FileFinder(BaseLib::BuildInfo::app_xml_schema_path).getPath("OpenGeoSysProject.xsd")),
   _project(project)
 {
 }

--- a/Applications/FileIO/XmlIO/Qt/XmlNumInterface.cpp
+++ b/Applications/FileIO/XmlIO/Qt/XmlNumInterface.cpp
@@ -27,7 +27,7 @@
 namespace FileIO
 {
 XmlNumInterface::XmlNumInterface() :
-    XMLInterface(), XMLQtInterface(BaseLib::FileFinder(BaseLib::BuildInfo::app_xml_schema_path).getPath("OpenGeoSysNUM.xsd"))
+XMLInterface(), XMLQtInterface(BaseLib::FileFinder({BaseLib::BuildInfo::app_xml_schema_path}).getPath("OpenGeoSysNUM.xsd"))
 {
 }
 

--- a/Applications/FileIO/XmlIO/Qt/XmlNumInterface.cpp
+++ b/Applications/FileIO/XmlIO/Qt/XmlNumInterface.cpp
@@ -20,13 +20,14 @@
 
 #include <logog/include/logog.hpp>
 
+#include "BaseLib/BuildInfo.h"
 #include "BaseLib/FileFinder.h"
 
 
 namespace FileIO
 {
 XmlNumInterface::XmlNumInterface() :
-    XMLInterface(), XMLQtInterface(BaseLib::FileFinder().getPath("OpenGeoSysNUM.xsd"))
+    XMLInterface(), XMLQtInterface(BaseLib::FileFinder(BaseLib::BuildInfo::app_xml_schema_path).getPath("OpenGeoSysNUM.xsd"))
 {
 }
 

--- a/BaseLib/BuildInfo.cpp.in
+++ b/BaseLib/BuildInfo.cpp.in
@@ -31,6 +31,8 @@ namespace BuildInfo
     const std::string ogs_version("@OGS_VERSION@");
 
     const std::string source_path("@CMAKE_CURRENT_SOURCE_DIR@");
+    const std::string geo_xml_schema_path("@CMAKE_CURRENT_SOURCE_DIR@/GeoLib/IO/XmlIO");
+    const std::string app_xml_schema_path("@CMAKE_CURRENT_SOURCE_DIR@/Applications/FileIO/XmlIO");
     const std::string data_path("@Data_SOURCE_DIR@");
     const std::string data_binary_path("@Data_BINARY_DIR@");
     const std::string tests_tmp_path("@PROJECT_BINARY_DIR@/Tests/");

--- a/BaseLib/BuildInfo.h
+++ b/BaseLib/BuildInfo.h
@@ -33,6 +33,8 @@ namespace BuildInfo
     extern const std::string ogs_version;
 
     extern const std::string source_path;
+    extern const std::string geo_xml_schema_path;
+    extern const std::string app_xml_schema_path;
     extern const std::string data_path;
     extern const std::string data_binary_path;
     extern const std::string tests_tmp_path;

--- a/BaseLib/FileFinder.cpp
+++ b/BaseLib/FileFinder.cpp
@@ -27,10 +27,11 @@ FileFinder::FileFinder()
     addDirectory(".");
 }
 
-FileFinder::FileFinder(std::string const& dir)
+FileFinder::FileFinder(std::initializer_list<std::string> dirs)
 {
     addDirectory(".");
-    addDirectory(dir);
+    for (auto const& dir : dirs)
+        addDirectory(dir);
 }
 
 void FileFinder::addDirectory(std::string const& dir)

--- a/BaseLib/FileFinder.cpp
+++ b/BaseLib/FileFinder.cpp
@@ -1,0 +1,66 @@
+/**
+ * \file
+ * \author Karsten Rink
+ * \date   2010-10-26
+ * \brief  Definition of the FileFinder class.
+ *
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "FileFinder.h"
+
+#include <fstream>
+
+#include <logog/include/logog.hpp>
+
+
+namespace BaseLib
+{
+
+FileFinder::FileFinder()
+{
+    addDirectory(".");
+}
+
+FileFinder::FileFinder(std::string const& dir)
+{
+    addDirectory(".");
+    addDirectory(dir);
+}
+
+void FileFinder::addDirectory(std::string const& dir)
+{
+    if (dir.empty())
+        return;
+
+    if (dir[dir.size() - 1] != '/')
+        _directories.push_back(std::string(dir + "/"));
+    else
+        _directories.push_back(dir);
+}
+
+std::string FileFinder::getPath(std::string const& filename) const
+{
+    if (_directories.empty())
+        ERR("FileFinder::getPath(): No directories set.");
+
+    for (auto const& dir : _directories)
+    {
+        std::string testDir(dir);
+        std::ifstream is(testDir.append(filename).c_str());
+        if (is.good())
+        {
+            is.close();
+            return testDir;
+        }
+    }
+    ERR("FileFinder::getPath(): File not found.");
+    return filename;
+}
+
+} // end namespace BaseLib

--- a/BaseLib/FileFinder.h
+++ b/BaseLib/FileFinder.h
@@ -15,12 +15,9 @@
 #ifndef FILEFINDER_H
 #define FILEFINDER_H
 
-#include <fstream>
 #include <string>
 #include <vector>
 
-#include "BuildInfo.h"
-#include <logog/include/logog.hpp>
 
 namespace BaseLib
 {
@@ -32,52 +29,28 @@ namespace BaseLib
 class FileFinder
 {
 public:
-    /// Constructor
-    FileFinder()
-    {
-        addDirectory(".");
-        addDirectory(BuildInfo::source_path + "/GeoLib/IO/XmlIO");
-        addDirectory(BuildInfo::source_path + "/Applications/FileIO/XmlIO");
-    }
+    /// Constructor having current directory as the search-space
+    FileFinder();
+
+    /**
+     * Construct with the given directory paths in addition to current directory
+     *
+     * @param dirs   a vector of directory paths to the search-space
+     */
+    explicit FileFinder(std::string const& dir);
 
     /**
      * \brief Adds another directory to the search-space.
      * If the given directory does not end with a slash one will be appended.
      */
-    void addDirectory(std::string const& dir)
-    {
-        if (dir.empty())
-            return;
-
-        if (dir[dir.size() - 1] != '/')
-            _directories.push_back(std::string(dir + "/"));
-        else
-            _directories.push_back(dir);
-    }
+    void addDirectory(std::string const& dir);
 
     /**
      * Given a filename, this method will return the complete path where this file can be found.
      * If the file is located in more than one of the directories in the search list, only the
      * first location will be returned.
      */
-    std::string getPath(std::string const& filename) const
-    {
-        if (_directories.empty())
-            ERR("FileFinder::getPath(): No directories set.");
-
-        for (auto it = _directories.begin(); it != _directories.end(); ++it)
-        {
-            std::string testDir(*it);
-            std::ifstream is(testDir.append(filename).c_str());
-            if (is.good())
-            {
-                is.close();
-                return testDir;
-            }
-        }
-        ERR("FileFinder::getPath(): File not found.");
-        return filename;
-    }
+    std::string getPath(std::string const& filename) const;
 
 private:
     std::vector<std::string> _directories;

--- a/BaseLib/FileFinder.h
+++ b/BaseLib/FileFinder.h
@@ -15,6 +15,7 @@
 #ifndef FILEFINDER_H
 #define FILEFINDER_H
 
+#include <initializer_list>
 #include <string>
 #include <vector>
 
@@ -29,15 +30,15 @@ namespace BaseLib
 class FileFinder
 {
 public:
-    /// Constructor having current directory as the search-space
+    /// Constructor having current directory (.) as the search-space
     FileFinder();
 
     /**
-     * Construct with the given directory paths in addition to current directory
+     * Construct with the given directory paths in addition to current directory (.)
      *
-     * @param dirs   a vector of directory paths to the search-space
+     * @param dirs   an initializer list of additional directory paths to the search-space
      */
-    explicit FileFinder(std::string const& dir);
+    FileFinder(std::initializer_list<std::string> dirs);
 
     /**
      * \brief Adds another directory to the search-space.

--- a/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
@@ -29,7 +29,7 @@ namespace GeoLib
 namespace IO
 {
 XmlGmlInterface::XmlGmlInterface(GeoLib::GEOObjects& geo_objs) :
-    XMLInterface(), XMLQtInterface(BaseLib::FileFinder(BaseLib::BuildInfo::geo_xml_schema_path).getPath("OpenGeoSysGLI.xsd")), _geo_objs(geo_objs)
+XMLInterface(), XMLQtInterface(BaseLib::FileFinder({BaseLib::BuildInfo::geo_xml_schema_path}).getPath("OpenGeoSysGLI.xsd")), _geo_objs(geo_objs)
 {
 }
 

--- a/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
@@ -20,6 +20,7 @@
 
 #include <logog/include/logog.hpp>
 
+#include "BaseLib/BuildInfo.h"
 #include "BaseLib/FileFinder.h"
 #include "GeoLib/Triangle.h"
 
@@ -28,7 +29,7 @@ namespace GeoLib
 namespace IO
 {
 XmlGmlInterface::XmlGmlInterface(GeoLib::GEOObjects& geo_objs) :
-    XMLInterface(), XMLQtInterface(BaseLib::FileFinder().getPath("OpenGeoSysGLI.xsd")), _geo_objs(geo_objs)
+    XMLInterface(), XMLQtInterface(BaseLib::FileFinder(BaseLib::BuildInfo::geo_xml_schema_path).getPath("OpenGeoSysGLI.xsd")), _geo_objs(geo_objs)
 {
 }
 

--- a/GeoLib/IO/XmlIO/Qt/XmlStnInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlStnInterface.cpp
@@ -21,6 +21,7 @@
 
 #include <logog/include/logog.hpp>
 
+#include "BaseLib/BuildInfo.h"
 #include "BaseLib/DateTools.h"
 #include "BaseLib/FileTools.h"
 #include "BaseLib/FileFinder.h"
@@ -33,7 +34,7 @@ namespace GeoLib
 namespace IO
 {
 XmlStnInterface::XmlStnInterface(GeoLib::GEOObjects& geo_objs) :
-    XMLInterface(), XMLQtInterface(BaseLib::FileFinder().getPath("OpenGeoSysSTN.xsd")), _geo_objs(geo_objs)
+    XMLInterface(), XMLQtInterface(BaseLib::FileFinder(BaseLib::BuildInfo::geo_xml_schema_path).getPath("OpenGeoSysSTN.xsd")), _geo_objs(geo_objs)
 {
 }
 

--- a/GeoLib/IO/XmlIO/Qt/XmlStnInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlStnInterface.cpp
@@ -34,7 +34,7 @@ namespace GeoLib
 namespace IO
 {
 XmlStnInterface::XmlStnInterface(GeoLib::GEOObjects& geo_objs) :
-    XMLInterface(), XMLQtInterface(BaseLib::FileFinder(BaseLib::BuildInfo::geo_xml_schema_path).getPath("OpenGeoSysSTN.xsd")), _geo_objs(geo_objs)
+XMLInterface(), XMLQtInterface(BaseLib::FileFinder({BaseLib::BuildInfo::geo_xml_schema_path}).getPath("OpenGeoSysSTN.xsd")), _geo_objs(geo_objs)
 {
 }
 


### PR DESCRIPTION
To get rid of specific directory paths in BaseLib/FileFinder and make it general, this PR introduces
- add new FileFinder constructor taking a directory search path
- add XML scheme paths to BaseLib::BuildInfo

and definitions of FileFinder were moved to cpp file.