### PR TITLE
[GL] Correctly setting point names

### DIFF
--- a/GeoLib/PointVec.cpp
+++ b/GeoLib/PointVec.cpp
@@ -243,4 +243,10 @@ std::string const& PointVec::getItemNameByID(std::size_t id) const
     return _id_to_name_map[id];
 }
 
+void PointVec::setNameForElement(std::size_t id, std::string const& name)
+{
+    TemplateVec::setNameForElement(id, name);
+    _id_to_name_map[id] = name;
+}
+
 }  // end namespace

--- a/GeoLib/PointVec.h
+++ b/GeoLib/PointVec.h
@@ -101,6 +101,8 @@ public:
 
     std::string const& getItemNameByID(std::size_t id) const;
 
+    void setNameForElement(std::size_t id, std::string const& name) override;
+
 private:
     /**
      * After the point set is modified (for example by makePntsUnique()) the mapping has to be corrected.

--- a/GeoLib/TemplateVec.h
+++ b/GeoLib/TemplateVec.h
@@ -195,7 +195,7 @@ public:
     }
 
     /// Sets the given name for the element of the given ID.
-    void setNameForElement(std::size_t id, std::string const& name)
+    virtual void setNameForElement(std::size_t id, std::string const& name)
     {
         // Erase id if found in map.
         auto it = findFirstElementByID(id);


### PR DESCRIPTION
This fixes an issue where point names would get lost when merging or saving geometries.