### PR TITLE
[GL] Add override specifier to one of push_backs.

### DIFF
--- a/GeoLib/PointVec.h
+++ b/GeoLib/PointVec.h
@@ -87,7 +87,7 @@ public:
      * @param pnt a pointer to the point, PointVec takes ownership of the point
      * @param name the name of the point
      */
-    virtual void push_back (Point* pnt, std::string const*const name);
+    void push_back (Point* pnt, std::string const*const name) override;
 
     /**
      * get the type of Point, this can be either POINT or STATION


### PR DESCRIPTION
Removes the warning: 'push_back' overrides a member function but is not marked 'override'.