### PR TITLE
Removing circular dependency with XmlLutReader

### DIFF
--- a/Applications/DataExplorer/Base/CMakeLists.txt
+++ b/Applications/DataExplorer/Base/CMakeLists.txt
@@ -7,10 +7,8 @@ set(SOURCES
     TreeModel.cpp
     ColorPickerPushButton.cpp
     TreeModelIterator.cpp
-    # modeltest.cpp # Not needed
     CheckboxDelegate.cpp
     QValueTooltipSlider.cpp
-    Color.cpp
 )
 
 # Header files
@@ -24,7 +22,6 @@ set(HEADERS
     RecentFiles.h
     TreeModel.h
     ColorPickerPushButton.h
-    # modeltest.h # Not needed
     CheckboxDelegate.h
     QValueTooltipSlider.h
 )

--- a/Applications/DataExplorer/DataView/ColorTableModel.cpp
+++ b/Applications/DataExplorer/DataView/ColorTableModel.cpp
@@ -14,7 +14,7 @@
 
 #include "ColorTableModel.h"
 
-ColorTableModel::ColorTableModel( const std::map<std::string, GeoLib::Color*> &colorLookupTable,
+ColorTableModel::ColorTableModel( const std::map<std::string, DataHolderLib::Color*> &colorLookupTable,
                                   QObject* parent /*= 0*/ )
 {
     Q_UNUSED(parent)
@@ -77,12 +77,12 @@ QVariant ColorTableModel::data( const QModelIndex& index, int role ) const
     return QVariant();
 }
 
-bool ColorTableModel::buildTable(const std::map<std::string, GeoLib::Color*> &colorLookupTable)
+bool ColorTableModel::buildTable(const std::map<std::string, DataHolderLib::Color*> &colorLookupTable)
 {
     int count = 0;
     beginInsertRows(QModelIndex(), 0, colorLookupTable.size() - 1);
 
-    for (std::map<std::string, GeoLib::Color*>::const_iterator it = colorLookupTable.begin();
+    for (std::map<std::string, DataHolderLib::Color*>::const_iterator it = colorLookupTable.begin();
          it != colorLookupTable.end(); ++it)
     {
         QColor color((*(it->second))[0], (*(it->second))[1], (*(it->second))[2]);

--- a/Applications/DataExplorer/DataView/ColorTableModel.h
+++ b/Applications/DataExplorer/DataView/ColorTableModel.h
@@ -15,9 +15,10 @@
 #ifndef COLORTABLEMODEL_H
 #define COLORTABLEMODEL_H
 
-#include "Color.h"
 #include <QAbstractTableModel>
 #include <QColor>
+
+#include "Applications/DataHolderLib/Color.h"
 
 /**
  * The PolylinesModel is a Qt model which represents Polylines.
@@ -27,7 +28,7 @@ class ColorTableModel : public QAbstractTableModel
     Q_OBJECT
 
 public:
-    ColorTableModel( const std::map<std::string, GeoLib::Color*> &colorLookupTable,
+    ColorTableModel( const std::map<std::string, DataHolderLib::Color*> &colorLookupTable,
                      QObject* parent = 0 );
     ~ColorTableModel();
 
@@ -45,7 +46,7 @@ public:
                          int role /*= Qt::DisplayRole*/ ) const;
 
 private:
-    bool buildTable( const std::map<std::string, GeoLib::Color*> &colorLookupTable );
+    bool buildTable( const std::map<std::string, DataHolderLib::Color*> &colorLookupTable );
 
     QList< QPair<QString, QColor> > _listOfPairs;
 };

--- a/Applications/DataExplorer/DataView/DiagramView/DetailWindow.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/DetailWindow.cpp
@@ -12,11 +12,12 @@
  *
  */
 
+#include "DetailWindow.h"
+
 #include <QFileDialog>
 #include <QSettings>
 
 #include "Applications/DataHolderLib/Color.h"
-#include "DetailWindow.h"
 #include "DiagramPrefsDialog.h"
 
 DetailWindow::DetailWindow(QWidget* parent) : QWidget(parent)

--- a/Applications/DataExplorer/DataView/DiagramView/DetailWindow.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/DetailWindow.cpp
@@ -12,12 +12,12 @@
  *
  */
 
-#include "Color.h"
-#include "DetailWindow.h"
-#include "DiagramPrefsDialog.h"
-
 #include <QFileDialog>
 #include <QSettings>
+
+#include "Applications/DataHolderLib/Color.h"
+#include "DetailWindow.h"
+#include "DiagramPrefsDialog.h"
 
 DetailWindow::DetailWindow(QWidget* parent) : QWidget(parent)
 {
@@ -124,7 +124,7 @@ void DetailWindow::resizeWindow()
 
 void DetailWindow::addList(DiagramList* list)
 {
-    GeoLib::Color const c = GeoLib::getRandomColor();
+    DataHolderLib::Color const c = DataHolderLib::getRandomColor();
     QColor colour(c[0], c[1], c[2]);
     this->addList(list, colour);
     resizeWindow();

--- a/Applications/DataExplorer/DataView/StationTreeView.cpp
+++ b/Applications/DataExplorer/DataView/StationTreeView.cpp
@@ -144,7 +144,7 @@ void StationTreeView::displayStratigraphy()
     static_cast<StationTreeModel*>(model())->stationFromIndex(
             this->selectionModel()->currentIndex(), temp_name);
     // get color table (horrible way to do it but there you go ...)
-    std::map<std::string, GeoLib::Color> colorLookupTable =
+    std::map<std::string, DataHolderLib::Color> colorLookupTable =
         static_cast<VtkStationSource*>(static_cast<StationTreeModel*>
             (model())->vtkSource(temp_name.toStdString()))->getColorLookupTable();
     StratWindow* stratView = new StratWindow(static_cast<GeoLib::StationBorehole*>
@@ -237,7 +237,7 @@ void StationTreeView::showDiagramPrefsDialog()
 
 void StationTreeView::writeStratigraphiesAsImages(QString listName)
 {
-    std::map<std::string, GeoLib::Color> colorLookupTable =
+    std::map<std::string, DataHolderLib::Color> colorLookupTable =
         static_cast<VtkStationSource*>(static_cast<StationTreeModel*>
             (model())->vtkSource(listName.toStdString()))->getColorLookupTable();
     std::vector<ModelTreeItem*> lists = static_cast<StationTreeModel*>(model())->getLists();

--- a/Applications/DataExplorer/DataView/StratView/StratBar.cpp
+++ b/Applications/DataExplorer/DataView/StratView/StratBar.cpp
@@ -16,7 +16,7 @@
 #include <QPainter>
 
 StratBar::StratBar(GeoLib::StationBorehole* station,
-                   std::map<std::string, GeoLib::Color>* stratColors,
+                   std::map<std::string, DataHolderLib::Color>* stratColors,
                    QGraphicsItem* parent) :
     QGraphicsItem(parent), _station(station)
 {
@@ -61,7 +61,7 @@ void StratBar::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, 
         top += height;
         height = logHeight(((*(profile[i - 1]))[2] - (*(profile[i]))[2]));
         QRectF layer(0, top, BARWIDTH, height);
-        GeoLib::Color const& c (GeoLib::getColor(soilNames[i], _stratColors));
+        DataHolderLib::Color const& c (DataHolderLib::getColor(soilNames[i], _stratColors));
         QBrush brush(QColor((int)c[0], (int)c[1], (int)c[2], 127), Qt::SolidPattern);
         painter->setBrush(brush);
 

--- a/Applications/DataExplorer/DataView/StratView/StratBar.h
+++ b/Applications/DataExplorer/DataView/StratView/StratBar.h
@@ -15,11 +15,12 @@
 #ifndef STRATBAR_H
 #define STRATBAR_H
 
-#include "StationBorehole.h"
-#include "Color.h"
-#include <QGraphicsItem>
 #include <cmath>
 
+#include <QGraphicsItem>
+
+#include "StationBorehole.h"
+#include "Applications/DataHolderLib/Color.h"
 
 /**
  * \brief A 2D bar visualisation of a borehole stratigraphy.
@@ -36,7 +37,7 @@ public:
      * \param parent The parent QGraphicsItem.
      */
     StratBar(GeoLib::StationBorehole* station,
-             std::map<std::string, GeoLib::Color>* stratColors = nullptr,
+             std::map<std::string, DataHolderLib::Color>* stratColors = nullptr,
              QGraphicsItem* parent = 0);
     ~StratBar();
 
@@ -60,7 +61,7 @@ private:
     static const int BARWIDTH = 50;
 
     GeoLib::StationBorehole* _station;
-    std::map<std::string, GeoLib::Color> _stratColors;
+    std::map<std::string, DataHolderLib::Color> _stratColors;
 };
 
 #endif //STRATBAR_H

--- a/Applications/DataExplorer/DataView/StratView/StratScene.cpp
+++ b/Applications/DataExplorer/DataView/StratView/StratScene.cpp
@@ -23,7 +23,7 @@
 #include "StratScene.h"
 
 StratScene::StratScene(GeoLib::StationBorehole* station,
-                       std::map<std::string, GeoLib::Color>* stratColors,
+                       std::map<std::string, DataHolderLib::Color>* stratColors,
                        QObject* parent) : QGraphicsScene(parent)
 {
     QRectF textBounds;
@@ -115,7 +115,7 @@ void StratScene::addSoilNameLabels(std::vector<std::string> soilNames,
 }
 
 StratBar* StratScene::addStratBar(GeoLib::StationBorehole* station,
-                                  std::map<std::string, GeoLib::Color>* stratColors)
+                                  std::map<std::string, DataHolderLib::Color>* stratColors)
 {
     StratBar* b = new StratBar(station, stratColors);
     addItem(b);

--- a/Applications/DataExplorer/DataView/StratView/StratScene.h
+++ b/Applications/DataExplorer/DataView/StratView/StratScene.h
@@ -15,9 +15,10 @@
 #ifndef STRATSCENE_H
 #define STRATSCENE_H
 
-#include "StationBorehole.h"
-#include "Color.h"
 #include <QGraphicsScene>
+
+#include "StationBorehole.h"
+#include "Applications/DataHolderLib/Color.h"
 
 class StratBar;
 class QNonScalableGraphicsTextItem;
@@ -30,7 +31,7 @@ class StratScene : public QGraphicsScene
 public:
     /// Constructor
     StratScene(GeoLib::StationBorehole* station,
-               std::map<std::string, GeoLib::Color>* stratColors = nullptr,
+               std::map<std::string, DataHolderLib::Color>* stratColors = nullptr,
                QObject* parent = 0);
     ~StratScene();
 
@@ -52,7 +53,7 @@ private:
 
     /// Add a stratigraphy-bar to the scene.
     StratBar* addStratBar(GeoLib::StationBorehole* station,
-                          std::map<std::string, GeoLib::Color>* stratColors = nullptr);
+                          std::map<std::string, DataHolderLib::Color>* stratColors = nullptr);
 };
 
 #endif //STRATSCENE_H

--- a/Applications/DataExplorer/DataView/StratView/StratView.cpp
+++ b/Applications/DataExplorer/DataView/StratView/StratView.cpp
@@ -22,7 +22,7 @@ StratView::~StratView()
 }
 
 void StratView::setStation(GeoLib::StationBorehole* station,
-                           std::map<std::string, GeoLib::Color>* stratColors)
+                           std::map<std::string, DataHolderLib::Color>* stratColors)
 {
     _scene = new StratScene(station, stratColors);
     setScene(_scene);

--- a/Applications/DataExplorer/DataView/StratView/StratView.h
+++ b/Applications/DataExplorer/DataView/StratView/StratView.h
@@ -39,7 +39,7 @@ public:
 
     /// Sets the Borehole whose data should be visualised.
     void setStation(GeoLib::StationBorehole* station,
-                    std::map<std::string, GeoLib::Color>* stratColors = nullptr);
+                    std::map<std::string, DataHolderLib::Color>* stratColors = nullptr);
 
     /// Returns the height of the bounding rectangle of all objects within the scene.
     int getHeight() { return static_cast<int>((_scene->itemsBoundingRect()).height()); }

--- a/Applications/DataExplorer/DataView/StratView/StratWindow.cpp
+++ b/Applications/DataExplorer/DataView/StratView/StratWindow.cpp
@@ -16,7 +16,7 @@
 #include "StratWindow.h"
 
 StratWindow::StratWindow(GeoLib::StationBorehole* station,
-                         std::map<std::string, GeoLib::Color>* stratColors,
+                         std::map<std::string, DataHolderLib::Color>* stratColors,
                          QWidget* parent) : QWidget(parent)
 {
     setupUi(this);

--- a/Applications/DataExplorer/DataView/StratView/StratWindow.h
+++ b/Applications/DataExplorer/DataView/StratView/StratWindow.h
@@ -38,7 +38,7 @@ public:
      * \param parent The parent QWidget.
      */
     StratWindow(GeoLib::StationBorehole* station,
-                std::map<std::string, GeoLib::Color>* stratColors = nullptr,
+                std::map<std::string, DataHolderLib::Color>* stratColors = nullptr,
                 QWidget* parent = 0);
     ~StratWindow(void) { this->destroy(); }
 

--- a/Applications/DataExplorer/VtkVis/VtkAlgorithmProperties.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkAlgorithmProperties.cpp
@@ -88,6 +88,8 @@ void VtkAlgorithmProperties::SetLookUpTable(const QString &array_name, const QSt
         colorLookupTable->setLookupTable(lut);
         SetLookUpTable(array_name, colorLookupTable);
     }
+    else
+        ERR ("Error reading color look-up table.");
 }
 
 void VtkAlgorithmProperties::SetScalarVisibility(bool on)

--- a/Applications/DataExplorer/VtkVis/VtkAlgorithmProperties.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkAlgorithmProperties.cpp
@@ -20,6 +20,7 @@
 #include <vtkProperty.h>
 #include <vtkTexture.h>
 
+#include "Applications/DataHolderLib/ColorLookupTable.h"
 #include "VtkColorLookupTable.h"
 #include "XmlIO/Qt/XmlLutReader.h"
 
@@ -80,8 +81,13 @@ void VtkAlgorithmProperties::SetLookUpTable(const QString &array_name, vtkLookup
 
 void VtkAlgorithmProperties::SetLookUpTable(const QString &array_name, const QString &filename)
 {
-    VtkColorLookupTable* colorLookupTable = FileIO::XmlLutReader::readFromFile(filename);
-    SetLookUpTable(array_name, colorLookupTable);
+    DataHolderLib::ColorLookupTable lut;
+    if (FileIO::XmlLutReader::readFromFile(filename, lut))
+    {
+        VtkColorLookupTable* colorLookupTable = VtkColorLookupTable::New();
+        colorLookupTable->setLookupTable(lut);
+        SetLookUpTable(array_name, colorLookupTable);
+    }
 }
 
 void VtkAlgorithmProperties::SetScalarVisibility(bool on)

--- a/Applications/DataExplorer/VtkVis/VtkColorLookupTable.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkColorLookupTable.cpp
@@ -19,8 +19,9 @@
 
 #include <logog/include/logog.hpp>
 
-#include <Color.h>
 #include <vtkObjectFactory.h>
+
+#include "Applications/DataHolderLib/Color.h"
 
 vtkStandardNewMacro(VtkColorLookupTable);
 

--- a/Applications/DataExplorer/VtkVis/VtkColorLookupTable.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkColorLookupTable.cpp
@@ -26,7 +26,7 @@
 vtkStandardNewMacro(VtkColorLookupTable);
 
 VtkColorLookupTable::VtkColorLookupTable()
-    : _type(VtkColorLookupTable::LUTType::LINEAR)
+: _type(DataHolderLib::LUTType::LINEAR)
 {
 }
 
@@ -79,10 +79,10 @@ void VtkColorLookupTable::Build()
                     unsigned char int_rgba[4];
                     double pos = (i - lastValue.first) / (static_cast<double>(nextIndex - lastValue.first));
 
-                    if (_type == VtkColorLookupTable::LUTType::LINEAR)
+                    if (_type == DataHolderLib::LUTType::LINEAR)
                         for (std::size_t j = 0; j < 4; j++)
                             int_rgba[j] = linInterpolation( (lastValue.second)[j], (it->second)[j], pos);
-                    else if (_type == VtkColorLookupTable::LUTType::EXPONENTIAL)
+                    else if (_type == DataHolderLib::LUTType::EXPONENTIAL)
                         for (std::size_t j = 0; j < 4; j++)
                             int_rgba[j] = expInterpolation((lastValue.second)[j], (it->second)[j], 0.2, pos);
                     else // no interpolation
@@ -98,6 +98,17 @@ void VtkColorLookupTable::Build()
     }
     else
         vtkLookupTable::Build();
+}
+
+void VtkColorLookupTable::setLookupTable(DataHolderLib::ColorLookupTable const& lut)
+{
+    std::size_t const n_colors (lut.size());
+    for (std::size_t i=0; i<n_colors; ++i)
+        setColor(std::get<0>(lut[i]), std::get<1>(lut[i]));
+    setInterpolationType(lut.getInterpolationType());
+    auto const range (lut.getTableRange());
+    SetTableRange(range.first, range.second);
+    Build();
 }
 
 void VtkColorLookupTable::writeToFile(const std::string &filename)
@@ -137,11 +148,11 @@ void VtkColorLookupTable::GetTableValue(vtkIdType idx, unsigned char rgba[4])
         rgba[i] = value[i]*255.0;
 }
 
-void VtkColorLookupTable::setColor(double pos, unsigned char rgba[4])
+void VtkColorLookupTable::setColor(double pos, DataHolderLib::Color const& color)
 {
     unsigned char* dict_rgba = new unsigned char[4];
     for (std::size_t i = 0; i < 4; i++)
-        dict_rgba[i] = rgba[i];
+        dict_rgba[i] = color[i];
     _dict.insert( std::pair<double, unsigned char*>(pos, dict_rgba) );
 }
 

--- a/Applications/DataExplorer/VtkVis/VtkColorLookupTable.h
+++ b/Applications/DataExplorer/VtkVis/VtkColorLookupTable.h
@@ -21,6 +21,8 @@
 #include <vector>
 #include <vtkLookupTable.h>
 
+#include "Applications/DataHolderLib/ColorLookupTable.h"
+
 /**
  * \brief Calculates and stores a colour lookup table.
  *
@@ -33,14 +35,6 @@
 class VtkColorLookupTable : public vtkLookupTable
 {
 public:
-    /// Interpolation methods
-    enum class LUTType {
-        NONE = 0,
-        LINEAR = 1,
-        EXPONENTIAL = 2,
-        SIGMOID = 3 // not yet implemented
-    };
-
     static const int DEFAULTMINVALUE = -9999;
     static const int DEFAULTMAXVALUE =  9999;
 
@@ -58,7 +52,7 @@ public:
      * relative position, i.e. pos in (0,1). The actual position of that colour in the table is dependent on the number of entries set
      * the SetRange() method.
      */
-    void setColor(double pos, unsigned char rgba[4]);
+    void setColor(double pos, DataHolderLib::Color const& color);
 
     /* \brief Returns the colour at the given index from the colour lookup table.
      * The colour will be interpolated from the colour-dictionary entries before and after this index.
@@ -67,10 +61,13 @@ public:
     void getColor(vtkIdType indx, unsigned char rgba[4]) const;
 
     /// Returns the type of interpolation used.
-    VtkColorLookupTable::LUTType getInterpolationType() const { return _type; }
+    DataHolderLib::LUTType getInterpolationType() const { return _type; }
 
     /// Sets the type of interpolation.
-    void setInterpolationType(VtkColorLookupTable::LUTType type) { _type = type; }
+    void setInterpolationType(DataHolderLib::LUTType type) { _type = type; }
+
+    /// Imports settings of OGS lookup table class
+    void setLookupTable(DataHolderLib::ColorLookupTable const& lut);
 
     /// Exports a color table to a file.
     void writeToFile(const std::string &filename);
@@ -93,11 +90,10 @@ private:
     unsigned char linInterpolation(unsigned char a, unsigned char b, double p) const;
 
     /// Interpolates values exponentially. gamma should roughly be in [0,4), for gamma=1 interpolation is linear.
-    unsigned char expInterpolation(unsigned char a, unsigned char b, double gamma,
-                                   double p) const;
+    unsigned char expInterpolation(unsigned char a, unsigned char b, double gamma, double p) const;
 
     std::map<double, unsigned char*> _dict;
-    LUTType _type;
+    DataHolderLib::LUTType _type;
 };
 
 #endif // VTKCOLORLOOKUPTABLE_H

--- a/Applications/DataExplorer/VtkVis/VtkCompositeColorByHeightFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeColorByHeightFilter.cpp
@@ -44,13 +44,13 @@ void VtkCompositeColorByHeightFilter::init()
     else
         heightFilter->SetInputConnection(_inputAlgorithm->GetOutputPort());
 
-    unsigned char a[4] = { 0, 0, 255, 255 }; // blue
-    unsigned char b[4] = { 0, 255, 0, 255 }; // green
-    unsigned char c[4] = { 255, 255, 0, 255 }; // yellow
-    unsigned char d[4] = { 155, 100, 50, 255 }; // brown
-    unsigned char e[4] = { 255, 0, 0, 255 }; // red
+    DataHolderLib::Color a = { 0, 0, 255, 255 }; // blue
+    DataHolderLib::Color b = { 0, 255, 0, 255 }; // green
+    DataHolderLib::Color c = { 255, 255, 0, 255 }; // yellow
+    DataHolderLib::Color d = { 155, 100, 50, 255 }; // brown
+    DataHolderLib::Color e = { 255, 0, 0, 255 }; // red
     VtkColorLookupTable* ColorLookupTable = heightFilter->GetColorLookupTable();
-    ColorLookupTable->setInterpolationType(VtkColorLookupTable::LUTType::LINEAR);
+    ColorLookupTable->setInterpolationType(DataHolderLib::LUTType::LINEAR);
     ColorLookupTable->setColor(-50, a);
     ColorLookupTable->setColor(0, a);
     ColorLookupTable->setColor(1, b);   // instant change at 0m a.s.l.

--- a/Applications/DataExplorer/VtkVis/VtkCompositeColormapToImageFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeColormapToImageFilter.cpp
@@ -42,7 +42,7 @@ void VtkCompositeColormapToImageFilter::init()
     this->_inputDataObjectType = VTK_IMAGE_DATA;
     this->_outputDataObjectType = VTK_IMAGE_DATA;
 
-    vtkSmartPointer<VtkColorLookupTable> colormap;
+    vtkSmartPointer<VtkColorLookupTable> colormap = vtkSmartPointer<VtkColorLookupTable>::New();
 
     QWidget* parent = 0;
     QSettings settings;
@@ -52,14 +52,14 @@ void VtkCompositeColormapToImageFilter::init()
     double range[2];
     dynamic_cast<vtkImageAlgorithm*>(_inputAlgorithm)->GetOutput()->GetPointData()->GetScalars()->GetRange(range);
 
-    if (fileName.length() > 0)
+    DataHolderLib::ColorLookupTable lut;
+    if (FileIO::XmlLutReader::readFromFile(fileName, lut))
     {
-        colormap = FileIO::XmlLutReader::readFromFile(fileName);
+        colormap->setLookupTable(lut);
         settings.setValue("lastOpenedLookupTableFileDirectory", fileName);
     }
     else
     {
-        colormap = vtkSmartPointer<VtkColorLookupTable>::New();
         colormap->SetTableRange(range[0], range[1]);
         colormap->SetHueRange(0.0, 0.666);
     }

--- a/Applications/DataExplorer/VtkVis/VtkCompositeElementSelectionFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeElementSelectionFilter.cpp
@@ -94,10 +94,10 @@ VtkColorLookupTable* VtkCompositeElementSelectionFilter::GetLookupTable()
 {
     VtkColorLookupTable* lut = VtkColorLookupTable::New();
     lut->SetTableRange(0,1);
-    unsigned char a[4] = { 0, 0, 255, 255 }; // blue
-    unsigned char b[4] = { 0, 255, 0, 255 }; // green
-    unsigned char c[4] = { 255, 255, 0, 255 }; // yellow
-    unsigned char d[4] = { 255, 0, 0, 255 }; // red
+    DataHolderLib::Color a = { 0, 0, 255, 255 }; // blue
+    DataHolderLib::Color b = { 0, 255, 0, 255 }; // green
+    DataHolderLib::Color c = { 255, 255, 0, 255 }; // yellow
+    DataHolderLib::Color d = { 255, 0, 0, 255 }; // red
     lut->setColor(1.0, a);
     lut->setColor(0.5, b);
     lut->setColor(0.25, c);

--- a/Applications/DataExplorer/VtkVis/VtkPointsSource.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkPointsSource.cpp
@@ -12,10 +12,6 @@
  *
  */
 
-// ** INCLUDES **
-// GeoLib
-#include "Color.h"
-
 #include "VtkPointsSource.h"
 
 #include <logog/include/logog.hpp>
@@ -32,6 +28,8 @@
 #include <vtkCellData.h>
 #include <vtkProperty.h>
 
+#include "Applications/DataHolderLib/Color.h"
+
 vtkStandardNewMacro(VtkPointsSource);
 
 VtkPointsSource::VtkPointsSource()
@@ -40,7 +38,7 @@ VtkPointsSource::VtkPointsSource()
     _removable = false; // From VtkAlgorithmProperties
     this->SetNumberOfInputPorts(0);
 
-    const GeoLib::Color c = GeoLib::getRandomColor();
+    const DataHolderLib::Color c = DataHolderLib::getRandomColor();
     GetProperties()->SetColor(c[0] / 255.0,c[1] / 255.0,c[2] / 255.0);
 }
 

--- a/Applications/DataExplorer/VtkVis/VtkPolylinesSource.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkPolylinesSource.cpp
@@ -17,10 +17,6 @@
 
 #include <logog/include/logog.hpp>
 
-// GeoLib
-#include "Color.h"
-#include "Polyline.h"
-
 #include <vtkCellArray.h>
 #include <vtkCellData.h>
 #include <vtkInformation.h>
@@ -33,6 +29,11 @@
 #include <vtkSmartPointer.h>
 #include <vtkStreamingDemandDrivenPipeline.h>
 
+#include "Polyline.h"
+
+#include "Applications/DataHolderLib/Color.h"
+
+
 vtkStandardNewMacro(VtkPolylinesSource);
 
 VtkPolylinesSource::VtkPolylinesSource()
@@ -41,7 +42,7 @@ VtkPolylinesSource::VtkPolylinesSource()
     _removable = false; // From VtkAlgorithmProperties
     this->SetNumberOfInputPorts(0);
 
-    const GeoLib::Color c = GeoLib::getRandomColor();
+    const DataHolderLib::Color c = DataHolderLib::getRandomColor();
     GetProperties()->SetColor(c[0] / 255.0, c[1] / 255.0, c[2] / 255.0);
 }
 

--- a/Applications/DataExplorer/VtkVis/VtkStationSource.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkStationSource.cpp
@@ -41,7 +41,7 @@ VtkStationSource::VtkStationSource()
     _removable = false; // From VtkAlgorithmProperties
     this->SetNumberOfInputPorts(0);
 
-    const GeoLib::Color c = GeoLib::getRandomColor();
+    const DataHolderLib::Color c = DataHolderLib::getRandomColor();
     GetProperties()->SetColor(c[0] / 255.0, c[1] / 255.0, c[2] / 255.0);
 }
 

--- a/Applications/DataExplorer/VtkVis/VtkStationSource.h
+++ b/Applications/DataExplorer/VtkVis/VtkStationSource.h
@@ -15,13 +15,11 @@
 #ifndef VTKSTATIONSOURCE_H
 #define VTKSTATIONSOURCE_H
 
-// ** INCLUDES **
-#include "VtkAlgorithmProperties.h"
 #include <vtkPolyDataAlgorithm.h>
 
-// GeoLib
-#include "Color.h"
 #include "Station.h"
+#include "Applications/DataHolderLib/Color.h"
+#include "VtkAlgorithmProperties.h"
 
 /**
  * \brief VTK source object for the visualisation of station data (including boreholes)
@@ -36,7 +34,7 @@ public:
 
     /// Returns the colour lookup table generated for boreholes.
     /// This method should only be called after the colour lookup table has actually been build (via RequestData() or setColorLookupTable()).
-    const std::map<std::string, GeoLib::Color>& getColorLookupTable() const
+    const std::map<std::string, DataHolderLib::Color>& getColorLookupTable() const
         { return _colorLookupTable; }
 
     /// Returns the type of observation site represented in this source object
@@ -44,8 +42,8 @@ public:
         { return static_cast<GeoLib::Station*>((*_stations)[0])->type(); };
 
     /// Sets a predefined color lookup table for the colouring of borehole stratigraphies
-    int setColorLookupTable(const std::string &filename)
-        { return GeoLib::readColorLookupTable(_colorLookupTable, filename); }
+//    int setColorLookupTable(const std::string &filename)
+//        { return GeoLib::readColorLookupTable(_colorLookupTable, filename); }
 
     /// Sets the stations as a vector
     void setStations(const std::vector<GeoLib::Point*>* stations) { _stations = stations; }
@@ -72,7 +70,7 @@ protected:
 
     /// The colour table for stratigraphic data. This table is either set using the setColorLookupTable() method or is generated
     /// automatically with random colours while creating the VtkStationSource-object.
-    std::map<std::string, GeoLib::Color> _colorLookupTable;
+    std::map<std::string, DataHolderLib::Color> _colorLookupTable;
 
 private:
     std::size_t GetIndexByName( std::string const& name );

--- a/Applications/DataExplorer/VtkVis/VtkSurfacesSource.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkSurfacesSource.cpp
@@ -27,8 +27,8 @@
 #include <vtkStreamingDemandDrivenPipeline.h>
 #include <vtkProperty.h>
 
-#include "Applications/DataExplorer/Base/Color.h"
 #include "GeoLib/Triangle.h"
+#include "Applications/DataHolderLib/Color.h"
 
 vtkStandardNewMacro(VtkSurfacesSource);
 
@@ -39,7 +39,7 @@ VtkSurfacesSource::VtkSurfacesSource()
     this->SetNumberOfInputPorts(0);
     //this->SetColorBySurface(true);
 
-    const GeoLib::Color c = GeoLib::getRandomColor();
+    const DataHolderLib::Color c = DataHolderLib::getRandomColor();
     vtkProperty* vtkProps = GetProperties();
     vtkProps->SetColor(c[0] / 255.0,c[1] / 255.0,c[2] / 255.0);
     vtkProps->SetEdgeVisibility(0);

--- a/Applications/DataExplorer/VtkVis/VtkVisPipeline.h
+++ b/Applications/DataExplorer/VtkVis/VtkVisPipeline.h
@@ -18,7 +18,6 @@
 #include <QMap>
 #include <QVector>
 
-#include "BaseLib/Histogram.h"
 #include "GeoType.h"
 #include "MeshEnums.h"
 #include "Point.h"

--- a/Applications/DataExplorer/VtkVis/VtkVisPipeline.h
+++ b/Applications/DataExplorer/VtkVis/VtkVisPipeline.h
@@ -15,17 +15,15 @@
 #ifndef VTKVISPIPELINE_H
 #define VTKVISPIPELINE_H
 
-// ** INCLUDES **
-#include "BaseLib/Histogram.h"
+#include <QMap>
+#include <QVector>
 
-#include "Color.h"
+#include "BaseLib/Histogram.h"
 #include "GeoType.h"
 #include "MeshEnums.h"
 #include "Point.h"
 #include "TreeModel.h"
-
-#include <QMap>
-#include <QVector>
+#include "Applications/DataHolderLib/Color.h"
 
 class vtkAlgorithm;
 class vtkDataSet;

--- a/Applications/DataHolderLib/Color.cpp
+++ b/Applications/DataHolderLib/Color.cpp
@@ -23,6 +23,16 @@
 
 namespace DataHolderLib {
 
+Color createColor(unsigned char r, unsigned char g, unsigned char b)
+{
+    return Color{{r,g,b,255}};
+}
+
+Color createColor(unsigned char r, unsigned char g, unsigned char b, unsigned char a)
+{
+    return Color{{r,g,b,a}};
+}
+
 Color getRandomColor()
 {
     Color col;

--- a/Applications/DataHolderLib/Color.cpp
+++ b/Applications/DataHolderLib/Color.cpp
@@ -21,7 +21,7 @@
 
 #include "BaseLib/StringTools.h"
 
-namespace GeoLib {
+namespace DataHolderLib {
 
 Color getRandomColor()
 {
@@ -31,7 +31,7 @@ Color getRandomColor()
     col[2] = static_cast<unsigned char>((rand()%5)*50);
     return col;
 }
-
+/*
 int readColorLookupTable(std::map<std::string, Color> &colors, const std::string &filename)
 {
     std::ifstream in( filename.c_str() );
@@ -63,7 +63,7 @@ int readColorLookupTable(std::map<std::string, Color> &colors, const std::string
 
     return 1;
 }
-
+*/
 Color const getColor(const std::string &id, std::map<std::string, Color> &colors)
 {
     for (std::map<std::string, Color>::const_iterator it=colors.begin(); it !=colors.end(); ++it)

--- a/Applications/DataHolderLib/Color.cpp
+++ b/Applications/DataHolderLib/Color.cpp
@@ -41,39 +41,7 @@ Color getRandomColor()
     col[2] = static_cast<unsigned char>((rand()%5)*50);
     return col;
 }
-/*
-int readColorLookupTable(std::map<std::string, Color> &colors, const std::string &filename)
-{
-    std::ifstream in( filename.c_str() );
 
-    if (!in)
-    {
-        WARN("Color::readLookupTable() - Could not open file %s.", filename.c_str());
-        return 0;
-    }
-
-    std::string id = "", line = "";
-    while ( getline(in, line) )
-    {
-        std::list<std::string> fields = BaseLib::splitString(line, '\t');
-
-        if (fields.size()>=4)
-        {
-            Color c;
-            id = fields.front();
-            fields.pop_front();
-            c[0] = std::atoi(fields.front().c_str());
-            fields.pop_front();
-            c[1] = std::atoi(fields.front().c_str());
-            fields.pop_front();
-            c[2] = std::atoi(fields.front().c_str());
-            colors.insert(std::pair<std::string, Color>(id, c));
-        }
-    }
-
-    return 1;
-}
-*/
 Color const getColor(const std::string &id, std::map<std::string, Color> &colors)
 {
     for (std::map<std::string, Color>::const_iterator it=colors.begin(); it !=colors.end(); ++it)

--- a/Applications/DataHolderLib/Color.h
+++ b/Applications/DataHolderLib/Color.h
@@ -20,22 +20,22 @@
 #include <map>
 #include <string>
 
-namespace GeoLib
+namespace DataHolderLib
 {
-using Color = std::array<unsigned char, 3>;
+using Color = std::array<unsigned char, 4>;
 
 /// Returns a random RGB colour.
 Color getRandomColor();
 
 /// Reads a color-lookup-table from a file and writes it to a map.
-int readColorLookupTable(std::map<std::string, GeoLib::Color> &colors, const std::string &filename);
+//int readColorLookupTable(std::map<std::string, GeoLib::Color> &colors, const std::string &filename);
 
 /// Uses a color-lookup-table (in form of a map) to return a colour for a specified name. If the name is not
 /// in the colortable a new entry is created with the new name and a random colour.
-Color const getColor(const std::string &id, std::map<std::string, GeoLib::Color> &colors);
+Color const getColor(const std::string &id, std::map<std::string, DataHolderLib::Color> &colors);
 
 /// Convenience function to use the getColor method with numbers as identifiers.
-Color const getColor(double id, std::map<std::string, GeoLib::Color> &colors);
+Color const getColor(double id, std::map<std::string, DataHolderLib::Color> &colors);
 } // namespace
 
 #endif /* COLOR_H_ */

--- a/Applications/DataHolderLib/Color.h
+++ b/Applications/DataHolderLib/Color.h
@@ -31,9 +31,6 @@ Color createColor(unsigned char r, unsigned char g, unsigned char b, unsigned ch
 /// Returns a random RGB colour.
 Color getRandomColor();
 
-/// Reads a color-lookup-table from a file and writes it to a map.
-//int readColorLookupTable(std::map<std::string, GeoLib::Color> &colors, const std::string &filename);
-
 /// Uses a color-lookup-table (in form of a map) to return a colour for a specified name. If the name is not
 /// in the colortable a new entry is created with the new name and a random colour.
 Color const getColor(const std::string &id, std::map<std::string, DataHolderLib::Color> &colors);

--- a/Applications/DataHolderLib/Color.h
+++ b/Applications/DataHolderLib/Color.h
@@ -24,6 +24,10 @@ namespace DataHolderLib
 {
 using Color = std::array<unsigned char, 4>;
 
+Color createColor(unsigned char r, unsigned char g, unsigned char b);
+
+Color createColor(unsigned char r, unsigned char g, unsigned char b, unsigned char a);
+
 /// Returns a random RGB colour.
 Color getRandomColor();
 

--- a/Applications/DataHolderLib/ColorLookupTable.cpp
+++ b/Applications/DataHolderLib/ColorLookupTable.cpp
@@ -1,0 +1,41 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "ColorLookupTable.h"
+
+#include <limits>
+
+namespace DataHolderLib
+{
+
+ColorLookupTable::ColorLookupTable()
+: _range(std::make_pair<double, double>(std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max())),
+  _type(DataHolderLib::LUTType::LINEAR)
+{}
+
+void ColorLookupTable::setTableRange(double min, double max)
+{
+    if (min<max)
+        _range = std::make_pair(min, max);
+}
+
+void ColorLookupTable::setColor(double id, DataHolderLib::Color color)
+{
+    if ((id>_range.first) && (id<_range.second))
+        _lut.push_back(std::make_tuple(id, color, ""));
+}
+
+void ColorLookupTable::setColor(std::string const& name, DataHolderLib::Color color)
+{
+    _lut.push_back(std::make_tuple(0, color, name));
+}
+
+
+
+} // namespace

--- a/Applications/DataHolderLib/ColorLookupTable.cpp
+++ b/Applications/DataHolderLib/ColorLookupTable.cpp
@@ -25,13 +25,13 @@ void ColorLookupTable::setTableRange(double min, double max)
         _range = std::make_pair(min, max);
 }
 
-void ColorLookupTable::setColor(double id, DataHolderLib::Color color)
+void ColorLookupTable::setColor(double id, DataHolderLib::Color const& color)
 {
     if ((id>_range.first) && (id<_range.second))
         _lut.push_back(std::make_tuple(id, color, ""));
 }
 
-void ColorLookupTable::setColor(std::string const& name, DataHolderLib::Color color)
+void ColorLookupTable::setColor(std::string const& name, DataHolderLib::Color const& color)
 {
     _lut.push_back(std::make_tuple(0, color, name));
 }

--- a/Applications/DataHolderLib/ColorLookupTable.h
+++ b/Applications/DataHolderLib/ColorLookupTable.h
@@ -1,0 +1,71 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef COLORLOOKUPTABLE_H
+#define COLORLOOKUPTABLE_H
+
+#include <cassert>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "Applications/DataHolderLib/Color.h"
+
+namespace DataHolderLib
+{
+
+/// Interpolation methods
+enum class LUTType {
+    NONE = 0,
+    LINEAR = 1,
+    EXPONENTIAL = 2,
+    SIGMOID = 3 // not yet implemented
+};
+
+/**
+ * A colour look-up table stored as a vector containing for each entry
+ *    id     - value for which the colour is stored
+ *    colour - RGBA value
+ *    name   - a name referencing the colour (such as a stratigraphic layer)
+ * Colours from the table can then be accessed using either id or name.
+ */
+class ColorLookupTable
+{
+public:
+    ColorLookupTable();
+
+    void setColor(double id, DataHolderLib::Color color);
+
+    void setColor(std::string const& name, DataHolderLib::Color color);
+
+    DataHolderLib::LUTType getInterpolationType() const { return _type; }
+
+    void setInterpolationType(LUTType type) { _type = type; }
+
+    std::size_t size() const { return _lut.size(); }
+
+    std::pair<double, double> getTableRange() const { return _range; }
+
+    void setTableRange(double min, double max);
+
+    std::tuple<double, Color, std::string> const& operator[](std::size_t i) const
+    {
+        assert (i < _lut.size());
+        return _lut[i];
+    }
+
+private:
+    std::vector< std::tuple<double, Color, std::string> > _lut;
+    LUTType _type;
+    std::pair<double, double> _range;
+};
+
+} // namespace
+
+#endif //COLORLOOKUPTABLE_H

--- a/Applications/DataHolderLib/ColorLookupTable.h
+++ b/Applications/DataHolderLib/ColorLookupTable.h
@@ -40,9 +40,9 @@ class ColorLookupTable
 public:
     ColorLookupTable();
 
-    void setColor(double id, DataHolderLib::Color color);
+    void setColor(double id, DataHolderLib::Color const& color);
 
-    void setColor(std::string const& name, DataHolderLib::Color color);
+    void setColor(std::string const& name, DataHolderLib::Color const& color);
 
     DataHolderLib::LUTType getInterpolationType() const { return _type; }
 


### PR DESCRIPTION
Moves Color to DataHolderLib, introduces a new data holder for lookup-tables and removes the circular dependency.