### PR TITLE
[NL] Unify unsigned type usage in shape functions.

### DIFF
--- a/NumLib/Fem/ShapeFunction/ShapeHex20.h
+++ b/NumLib/Fem/ShapeFunction/ShapeHex20.h
@@ -41,8 +41,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Hex20;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapeHex8.h
+++ b/NumLib/Fem/ShapeFunction/ShapeHex8.h
@@ -59,8 +59,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Hex;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapeLine2.h
+++ b/NumLib/Fem/ShapeFunction/ShapeLine2.h
@@ -45,8 +45,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Line;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapeLine3.h
+++ b/NumLib/Fem/ShapeFunction/ShapeLine3.h
@@ -40,8 +40,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Line3;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapePoint1.h
+++ b/NumLib/Fem/ShapeFunction/ShapePoint1.h
@@ -26,8 +26,8 @@ public:
     static void computeShapeFunction(const T_X& r, T_N& N);
 
     using MeshElement = MeshLib::Point;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 }
 

--- a/NumLib/Fem/ShapeFunction/ShapePrism15.h
+++ b/NumLib/Fem/ShapeFunction/ShapePrism15.h
@@ -41,8 +41,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Prism15;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapePrism6.h
+++ b/NumLib/Fem/ShapeFunction/ShapePrism6.h
@@ -41,8 +41,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Prism;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapePyra13.h
+++ b/NumLib/Fem/ShapeFunction/ShapePyra13.h
@@ -41,8 +41,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Pyramid13;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapePyra5.h
+++ b/NumLib/Fem/ShapeFunction/ShapePyra5.h
@@ -41,8 +41,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Pyramid;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapeQuad4.h
+++ b/NumLib/Fem/ShapeFunction/ShapeQuad4.h
@@ -53,8 +53,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Quad;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapeQuad8.h
+++ b/NumLib/Fem/ShapeFunction/ShapeQuad8.h
@@ -40,8 +40,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Quad8;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapeQuad9.h
+++ b/NumLib/Fem/ShapeFunction/ShapeQuad9.h
@@ -40,8 +40,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Quad9;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapeStaticConsts.cpp
+++ b/NumLib/Fem/ShapeFunction/ShapeStaticConsts.cpp
@@ -22,8 +22,8 @@
  * | sort \
  * | while read f; do
  *     c="${f%.h}";
- *     echo "const std::size_t $c::DIM;";
- *     echo "const std::size_t $c::NPOINTS;";
+ *     echo "const unsigned $c::DIM;";
+ *     echo "const unsigned $c::NPOINTS;";
  * done >ShapeStaticConsts.cpp
  * \endcode
  */
@@ -48,44 +48,44 @@
 namespace NumLib
 {
 
-const std::size_t ShapeHex20::DIM;
-const std::size_t ShapeHex20::NPOINTS;
-const std::size_t ShapeHex8::DIM;
-const std::size_t ShapeHex8::NPOINTS;
+const unsigned ShapeHex20::DIM;
+const unsigned ShapeHex20::NPOINTS;
+const unsigned ShapeHex8::DIM;
+const unsigned ShapeHex8::NPOINTS;
 
-const std::size_t ShapeLine2::DIM;
-const std::size_t ShapeLine2::NPOINTS;
-const std::size_t ShapeLine3::DIM;
-const std::size_t ShapeLine3::NPOINTS;
+const unsigned ShapeLine2::DIM;
+const unsigned ShapeLine2::NPOINTS;
+const unsigned ShapeLine3::DIM;
+const unsigned ShapeLine3::NPOINTS;
 
-const std::size_t ShapePoint1::DIM;
-const std::size_t ShapePoint1::NPOINTS;
+const unsigned ShapePoint1::DIM;
+const unsigned ShapePoint1::NPOINTS;
 
-const std::size_t ShapePrism15::DIM;
-const std::size_t ShapePrism15::NPOINTS;
-const std::size_t ShapePrism6::DIM;
-const std::size_t ShapePrism6::NPOINTS;
+const unsigned ShapePrism15::DIM;
+const unsigned ShapePrism15::NPOINTS;
+const unsigned ShapePrism6::DIM;
+const unsigned ShapePrism6::NPOINTS;
 
-const std::size_t ShapePyra13::DIM;
-const std::size_t ShapePyra13::NPOINTS;
-const std::size_t ShapePyra5::DIM;
-const std::size_t ShapePyra5::NPOINTS;
+const unsigned ShapePyra13::DIM;
+const unsigned ShapePyra13::NPOINTS;
+const unsigned ShapePyra5::DIM;
+const unsigned ShapePyra5::NPOINTS;
 
-const std::size_t ShapeQuad4::DIM;
-const std::size_t ShapeQuad4::NPOINTS;
-const std::size_t ShapeQuad8::DIM;
-const std::size_t ShapeQuad8::NPOINTS;
-const std::size_t ShapeQuad9::DIM;
-const std::size_t ShapeQuad9::NPOINTS;
+const unsigned ShapeQuad4::DIM;
+const unsigned ShapeQuad4::NPOINTS;
+const unsigned ShapeQuad8::DIM;
+const unsigned ShapeQuad8::NPOINTS;
+const unsigned ShapeQuad9::DIM;
+const unsigned ShapeQuad9::NPOINTS;
 
-const std::size_t ShapeTet10::DIM;
-const std::size_t ShapeTet10::NPOINTS;
-const std::size_t ShapeTet4::DIM;
-const std::size_t ShapeTet4::NPOINTS;
+const unsigned ShapeTet10::DIM;
+const unsigned ShapeTet10::NPOINTS;
+const unsigned ShapeTet4::DIM;
+const unsigned ShapeTet4::NPOINTS;
 
-const std::size_t ShapeTri3::DIM;
-const std::size_t ShapeTri3::NPOINTS;
-const std::size_t ShapeTri6::DIM;
-const std::size_t ShapeTri6::NPOINTS;
+const unsigned ShapeTri3::DIM;
+const unsigned ShapeTri3::NPOINTS;
+const unsigned ShapeTri6::DIM;
+const unsigned ShapeTri6::NPOINTS;
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapeTet10.h
+++ b/NumLib/Fem/ShapeFunction/ShapeTet10.h
@@ -41,8 +41,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Tet10;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapeTet4.h
+++ b/NumLib/Fem/ShapeFunction/ShapeTet4.h
@@ -41,8 +41,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Tet;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapeTri3.h
+++ b/NumLib/Fem/ShapeFunction/ShapeTri3.h
@@ -54,8 +54,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Tri;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }

--- a/NumLib/Fem/ShapeFunction/ShapeTri6.h
+++ b/NumLib/Fem/ShapeFunction/ShapeTri6.h
@@ -42,8 +42,8 @@ public:
     static void computeGradShapeFunction(const T_X &r, T_N &dN);
 
     using MeshElement = MeshLib::Tri6;
-    static const std::size_t DIM = MeshElement::dimension;
-    static const std::size_t NPOINTS = MeshElement::n_all_nodes;
+    static const unsigned DIM = MeshElement::dimension;
+    static const unsigned NPOINTS = MeshElement::n_all_nodes;
 };
 
 }


### PR DESCRIPTION
The elements' dimensions (DIM and NPOINTS) are declared
'unsigned' is the MeshLib (MeshElement::dimension and
MeshElement::n_all_nodes) and should be of the same
type for the shape functions.

This is automated change with sed.