### PR TITLE
Added finalizeAssembly(x) to avoid PETSc errors in the vector copying

### DIFF
--- a/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
@@ -32,6 +32,7 @@ void applyKnownSolutions(std::vector<Solutions> const* const known_solutions,
             MathLib::setVector(x, bc.ids[i], bc.values[i]);
         }
     }
+    MathLib::LinAlg::finalizeAssembly(x);
 }
 }
 


### PR DESCRIPTION
as titled. Although the results of the PETSc related tests are correct after introducing BLAS (now LinAlg), PETSc errors occur in the log file. This PR fixed the problem.