### PR TITLE
Extrapolation moved to base Process

### DIFF
--- a/NumLib/Extrapolation/ExtrapolatableElement.h
+++ b/NumLib/Extrapolation/ExtrapolatableElement.h
@@ -24,7 +24,7 @@ class ExtrapolatableElement
 {
 public:
     //! Provides the shape matrix at the given integration point.
-    virtual Eigen::Map<const Eigen::VectorXd> getShapeMatrix(
+    virtual Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         const unsigned integration_point) const = 0;
 
     virtual ~ExtrapolatableElement() = default;

--- a/NumLib/Extrapolation/ExtrapolatableElement.h
+++ b/NumLib/Extrapolation/ExtrapolatableElement.h
@@ -1,0 +1,33 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef NUMLIB_EXTRAPOLATION_EXTRAPOLATABLEELEMENT_H
+#define NUMLIB_EXTRAPOLATION_EXTRAPOLATABLEELEMENT_H
+
+namespace NumLib
+{
+/*! Interface for providing shape matrices and integration point values for
+ *  extrapolation,
+ *
+ * Local assemblers that want to have some integration point values extrapolated
+ * using an Extrapolator have to implement this interface.
+ */
+class ExtrapolatableElement
+{
+public:
+    //! Provides the shape matrix at the given integration point.
+    virtual Eigen::Map<const Eigen::VectorXd> getShapeMatrix(
+        const unsigned integration_point) const = 0;
+
+    virtual ~ExtrapolatableElement() = default;
+};
+
+}  // namespace NumLib
+
+#endif  // NUMLIB_EXTRAPOLATION_EXTRAPOLATABLEELEMENT_H

--- a/NumLib/Extrapolation/ExtrapolatableElement.h
+++ b/NumLib/Extrapolation/ExtrapolatableElement.h
@@ -10,6 +10,8 @@
 #ifndef NUMLIB_EXTRAPOLATION_EXTRAPOLATABLEELEMENT_H
 #define NUMLIB_EXTRAPOLATION_EXTRAPOLATABLEELEMENT_H
 
+#include <Eigen/Core>
+
 namespace NumLib
 {
 /*! Interface for providing shape matrices and integration point values for

--- a/NumLib/Extrapolation/ExtrapolatableElementCollection.h
+++ b/NumLib/Extrapolation/ExtrapolatableElementCollection.h
@@ -14,8 +14,12 @@
 
 namespace NumLib
 {
-//! Adaptor to get information needed by an Extrapolator from an "arbitrary"
-//! collection of elements (e.g., local assemblers).
+/*! Adaptor to get information needed by an Extrapolator from an "arbitrary"
+ * collection of elements (e.g., local assemblers).
+ *
+ * This is an interface class; suitable implementations have to be provided for
+ * concrete collections of extrapolatable elements.
+ */
 class ExtrapolatableElementCollection
 {
 public:
@@ -24,8 +28,27 @@ public:
     virtual Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         std::size_t const id, unsigned const integration_point) const = 0;
 
-    //! Returns integration point values of some property of the element with
-    //! the given \c id.
+    /*! Returns integration point values of some property of a specific element.
+     *
+     * \param id ID of the element of which the property is queried.
+     * \param cache Can be used to compute a property on-the-fly.
+     *
+     * \remark
+     * \parblock
+     * Since this method returns a reference, integration point values can not
+     * be computed locally and just returned.
+     *
+     * Instead, the vector \c cache can be used to store some derived quantities
+     * that should be used as integration point values. They can be written to
+     * the \c cache and a reference to the \c cache can then be returned by the
+     * implementation of this method. Ordinary integration point values can be
+     * returned directly (if they are stored in the local assembler), and the
+     * \c cache can be left untouched.
+     *
+     * For usage examples see the processes already implemented or the unit test
+     * in TestExtrapolation.cpp
+     * \endparblock
+     */
     virtual std::vector<double> const& getIntegrationPointValues(
         std::size_t const id, std::vector<double>& cache) const = 0;
 
@@ -51,21 +74,11 @@ public:
 
     /*! A method providing integration point values of some property.
      *
-     * \remark
-     * \parblock
-     * The vector \c cache can be used to store some derived quantities that
-     * should be used as integration point values. They can be written to the
-     * \c cache and a reference to the \c cache can then be returned by the
-     * implementation of this method.
-     * Ordinary integration point values can be returned directly (if they are
-     * stored in the local assembler), and the \c cache can be left untouched.
-     *
-     * For usage examples see the processes already implemented or the unit test
-     * in TestExtrapolation.cpp
-     * \endparblock
-     *
      * The method must return reference to a vector containing the integration
      * point values.
+     *
+     * For further information about the \c cache parameter see
+     * ExtrapolatableElementCollection::getIntegrationPointValues().
      */
     using IntegrationPointValuesMethod = std::vector<double> const& (
         LocalAssembler::*)(std::vector<double>& cache) const;

--- a/NumLib/Extrapolation/ExtrapolatableElementCollection.h
+++ b/NumLib/Extrapolation/ExtrapolatableElementCollection.h
@@ -70,7 +70,7 @@ public:
 
     static_assert(std::is_base_of<ExtrapolatableElement, LocalAssembler>::value,
                   "Local assemblers used for extrapolation must be derived "
-                  "from Extrapolatable.");
+                  "from ExtrapolatableElement.");
 
     /*! A method providing integration point values of some property.
      *

--- a/NumLib/Extrapolation/ExtrapolatableElementCollection.h
+++ b/NumLib/Extrapolation/ExtrapolatableElementCollection.h
@@ -21,7 +21,7 @@ class ExtrapolatableElementCollection
 public:
     //! Returns the shape matrix of the element with the given \c id at the
     //! given \c integration_point.
-    virtual Eigen::Map<const Eigen::VectorXd> getShapeMatrix(
+    virtual Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         std::size_t const id, unsigned const integration_point) const = 0;
 
     //! Returns integration point values of some property of the element with
@@ -85,7 +85,7 @@ public:
     {
     }
 
-    Eigen::Map<const Eigen::VectorXd> getShapeMatrix(
+    Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         std::size_t const id, unsigned const integration_point) const override
     {
         ExtrapolatableElement const& loc_asm = *_local_assemblers[id];

--- a/NumLib/Extrapolation/Extrapolator.h
+++ b/NumLib/Extrapolation/Extrapolator.h
@@ -18,60 +18,14 @@
 namespace NumLib
 {
 
-/*! Interface for providing shape matrices and integration point values for
- *  extrapolation,
- *
- * Local assemblers that want to have some integration point values extrapolated
- * using Extrapolator have to implement this interface.
- *
- * \tparam PropertyTag  type of the property used to query a specific kind of
- *                      integration point value, usually an enum.
- */
-template <typename PropertyTag>
-class Extrapolatable
-{
-public:
-    //! Provides the shape matrix at the given integration point.
-    virtual Eigen::Map<const Eigen::RowVectorXd>
-    getShapeMatrix(const unsigned integration_point) const = 0;
-
-    /*! Provides integration point values for the given property.
-     *
-     * \remark
-     * The vector \c cache can be used to store some derived quantities that
-     * should be used as integration point values. They can be written to the
-     * \c cache and a reference to the \c cache can then be returned by the
-     * implementation of this method.
-     * Ordinary integration point values can be returned directly (if they are
-     * stored in the local assembler), and the \c cache cen be left untouched.
-     *
-     * \returns a reference to a vector containing the integration point values.
-     */
-    virtual std::vector<double> const&
-    getIntegrationPointValues(PropertyTag const property,
-                              std::vector<double>& cache) const = 0;
-
-    virtual ~Extrapolatable() = default;
-};
-
-/*! Interface for classes that extrapolate integration point values to nodal
- *  values.
- *
- * \tparam PropertyTag    type of the property used to query a specific kind of
- *                        integration point value, usually an enum.
- * \tparam LocalAssembler type of the local assembler being queried for
- *                        integration point values.
- */
-template<typename PropertyTag, typename LocalAssembler>
+//! Interface for classes that extrapolate integration point values to nodal
+//! values.
 class Extrapolator
 {
 public:
-    //! Vector of local assemblers, the same as is used in the FEM process.
-    using LocalAssemblers = std::vector<std::unique_ptr<LocalAssembler>>;
-
     //! Extrapolates the given \c property from the given local assemblers.
     virtual void extrapolate(
-            LocalAssemblers const& loc_asms, PropertyTag const property) = 0;
+            ExtrapolatableElementCollection const& extrapolatables) = 0;
 
     /*! Computes residuals from the extrapolation of the given \c property.
      *
@@ -80,7 +34,7 @@ public:
      * \pre extrapolate() must have been called before with the same arguments.
      */
     virtual void calculateResiduals(
-            LocalAssemblers const& loc_asms, PropertyTag const property) = 0;
+            ExtrapolatableElementCollection const& extrapolatables) = 0;
 
     //! Returns the extrapolated nodal values.
     //! \todo Maybe write directly to a MeshProperty.

--- a/NumLib/Extrapolation/Extrapolator.h
+++ b/NumLib/Extrapolation/Extrapolator.h
@@ -14,6 +14,7 @@
 
 #include <Eigen/Eigen>
 #include "NumLib/NumericsConfig.h"
+#include "ExtrapolatableElementCollection.h"
 
 namespace NumLib
 {

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.cpp
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.cpp
@@ -75,7 +75,7 @@ void LocalLinearLeastSquaresExtrapolator::calculateResiduals(
 
     auto const size = extrapolatables.size();
     for (std::size_t i=0; i<size; ++i) {
-        calculateResiudalElement(i, extrapolatables);
+        calculateResidualElement(i, extrapolatables);
     }
 }
 
@@ -136,7 +136,7 @@ void LocalLinearLeastSquaresExtrapolator::extrapolateElement(
     counts.add(global_indices, std::vector<double>(global_indices.size(), 1.0));
 }
 
-void LocalLinearLeastSquaresExtrapolator::calculateResiudalElement(
+void LocalLinearLeastSquaresExtrapolator::calculateResidualElement(
     std::size_t const element_index,
     ExtrapolatableElementCollection const& extrapolatables)
 {

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.cpp
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.cpp
@@ -22,6 +22,32 @@
 
 namespace NumLib
 {
+LocalLinearLeastSquaresExtrapolator::LocalLinearLeastSquaresExtrapolator(
+    NumLib::LocalToGlobalIndexMap const& dof_table)
+    : _nodal_values(NumLib::GlobalVectorProvider::provider.getVector(
+          MathLib::MatrixSpecifications(dof_table.dofSizeWithoutGhosts(),
+                                        dof_table.dofSizeWithoutGhosts(),
+                                        &dof_table.getGhostIndices(),
+                                        nullptr)))
+#ifndef USE_PETSC
+    , _residuals(dof_table.size())
+#else
+    , _residuals(dof_table.size(), false)
+#endif
+    , _local_to_global(dof_table)
+{
+    /* Note in case the following assertion fails:
+     * If you copied the extrapolation code, for your processes from
+     * somewhere, note that the code from the groundwater flow process might
+     * not suit your needs: It is a special case and is therefore most
+     * likely too simplistic. You better adapt the extrapolation code from
+     * some more advanced process, like the TES process.
+     */
+    assert(dof_table.getNumberOfComponents() == 1 &&
+           "The d.o.f. table passed must be for one variable that has "
+           "only one component!");
+}
+
 void LocalLinearLeastSquaresExtrapolator::extrapolate(
     ExtrapolatableElementCollection const& extrapolatables)
 {

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.cpp
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.cpp
@@ -22,7 +22,7 @@
 
 namespace NumLib
 {
-inline void LocalLinearLeastSquaresExtrapolator::extrapolate(
+void LocalLinearLeastSquaresExtrapolator::extrapolate(
     ExtrapolatableElementCollection const& extrapolatables)
 {
     _nodal_values.setZero();
@@ -41,7 +41,7 @@ inline void LocalLinearLeastSquaresExtrapolator::extrapolate(
     MathLib::LinAlg::componentwiseDivide(_nodal_values, _nodal_values, *counts);
 }
 
-inline void LocalLinearLeastSquaresExtrapolator::calculateResiduals(
+void LocalLinearLeastSquaresExtrapolator::calculateResiduals(
     ExtrapolatableElementCollection const& extrapolatables)
 {
     assert(static_cast<std::size_t>(_residuals.size()) ==
@@ -53,7 +53,7 @@ inline void LocalLinearLeastSquaresExtrapolator::calculateResiduals(
     }
 }
 
-inline void LocalLinearLeastSquaresExtrapolator::extrapolateElement(
+void LocalLinearLeastSquaresExtrapolator::extrapolateElement(
     std::size_t const element_index,
     ExtrapolatableElementCollection const& extrapolatables,
     GlobalVector& counts)
@@ -110,7 +110,7 @@ inline void LocalLinearLeastSquaresExtrapolator::extrapolateElement(
     counts.add(global_indices, std::vector<double>(global_indices.size(), 1.0));
 }
 
-inline void LocalLinearLeastSquaresExtrapolator::calculateResiudalElement(
+void LocalLinearLeastSquaresExtrapolator::calculateResiudalElement(
     std::size_t const element_index,
     ExtrapolatableElementCollection const& extrapolatables)
 {

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
@@ -38,39 +38,14 @@ namespace NumLib
 class LocalLinearLeastSquaresExtrapolator : public Extrapolator
 {
 public:
-    /*! Constructs a new instance
+    /*! Constructs a new instance.
      *
      * \note
-     * The \c dof_table of \c matrix_specs must be set, and it must point to a
-     * dof_table for one single component variable.
+     * The \c dof_table must point to a d.o.f. table for one single-component
+     * variable.
      */
     explicit LocalLinearLeastSquaresExtrapolator(
-        MathLib::MatrixSpecifications const& matrix_specs,
-        NumLib::LocalToGlobalIndexMap const& dof_table)
-        : _nodal_values(
-              NumLib::GlobalVectorProvider::provider.getVector(
-                  matrix_specs))
-#ifndef USE_PETSC
-          ,
-          _residuals(dof_table.size())
-#else
-          ,
-          _residuals(dof_table.size(), false)
-#endif
-          ,
-          _local_to_global(dof_table)
-    {
-        /* Note in case the following assertion fails.
-         * If you copied the extrapolation code, for your processes from
-         * somewhere, note that the code from the groundwater flow process might
-         * not suit your needs: It is a special case and is therefore most
-         * likely too simplistic. You better adapt the extrapolation code from
-         * some more advanced process, like the TES process.
-         */
-        assert(dof_table.getNumberOfComponents() == 1 &&
-               "The d.o.f. table passed must be for one variable that has "
-               "only one component!");
-    }
+        NumLib::LocalToGlobalIndexMap const& dof_table);
 
     void extrapolate(
             ExtrapolatableElementCollection const& extrapolatables) override;

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
@@ -84,7 +84,7 @@ private:
         GlobalVector& counts);
 
     //! Compute the residuals for one element
-    void calculateResiudalElement(
+    void calculateResidualElement(
         std::size_t const element_index,
         ExtrapolatableElementCollection const& extrapolatables);
 

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
@@ -35,14 +35,9 @@ namespace NumLib
  * system.
  * \endparblock
  */
-template <typename PropertyTag, typename LocalAssembler>
-class LocalLinearLeastSquaresExtrapolator
-    : public Extrapolator<PropertyTag, LocalAssembler>
+class LocalLinearLeastSquaresExtrapolator : public Extrapolator
 {
 public:
-    using LocalAssemblers =
-        typename Extrapolator<PropertyTag, LocalAssembler>::LocalAssemblers;
-
     /*! Constructs a new instance
      *
      * \note
@@ -77,8 +72,8 @@ public:
                "only one component!");
     }
 
-    void extrapolate(LocalAssemblers const& local_assemblers,
-                     PropertyTag const property) override;
+    void extrapolate(
+            ExtrapolatableElementCollection const& extrapolatables) override;
 
     /*! \copydoc Extrapolator::calculateResiduals()
      *
@@ -87,8 +82,8 @@ public:
      * extrapolation results when interpolated back to the integration points
      * again.
      */
-    void calculateResiduals(LocalAssemblers const& local_assemblers,
-                            PropertyTag const property) override;
+    void calculateResiduals(
+            ExtrapolatableElementCollection const& extrapolatables) override;
 
     GlobalVector const& getNodalValues() const override
     {
@@ -108,14 +103,15 @@ public:
 
 private:
     //! Extrapolate one element.
-    void extrapolateElement(std::size_t const element_index,
-                            LocalAssembler const& local_assembler,
-                            PropertyTag const property, GlobalVector& counts);
+    void extrapolateElement(
+        std::size_t const element_index,
+        ExtrapolatableElementCollection const& extrapolatables,
+        GlobalVector& counts);
 
     //! Compute the residuals for one element
-    void calculateResiudalElement(std::size_t const element_index,
-                                  LocalAssembler const& local_assembler,
-                                  PropertyTag const property);
+    void calculateResiudalElement(
+        std::size_t const element_index,
+        ExtrapolatableElementCollection const& extrapolatables);
 
     GlobalVector& _nodal_values;  //!< extrapolated nodal values
     GlobalVector _residuals;      //!< extrapolation residuals
@@ -129,8 +125,7 @@ private:
     //! Avoids frequent reallocations.
     std::vector<double> _integration_point_values_cache;
 };
-}
 
-#include "LocalLinearLeastSquaresExtrapolator-impl.h"
+}  // namespace NumLib
 
 #endif  // NUMLIB_LOCAL_LLSQ_EXTRAPOLATOR_H

--- a/ProcessLib/ExtrapolatorData.h
+++ b/ProcessLib/ExtrapolatorData.h
@@ -23,10 +23,20 @@ namespace ProcessLib
  * \todo Later on this struct shall be moved, e.g., be merged with the process
  * output class.
  */
-struct ExtrapolatorData
+class ExtrapolatorData
 {
+public:
     ExtrapolatorData() = default;
 
+    /*! Constructs a new instance.
+     *
+     * \param extrapolator the extrapolator managed by the instance being
+     * created
+     * \param dof_table_single_component the d.o.f. table used by the \c
+     * extrapolator
+     * \param manage_storage If true the memory of \c dof_table_single_component
+     * will be freed by the destructor of this class.
+     */
     ExtrapolatorData(
         std::unique_ptr<NumLib::Extrapolator>&& extrapolator,
         NumLib::LocalToGlobalIndexMap const* const dof_table_single_component,
@@ -66,15 +76,23 @@ struct ExtrapolatorData
     ~ExtrapolatorData() { cleanup(); }
 
 private:
+    //! Deletes the d.o.f table if it is allowed to do so.
     void cleanup()
     {
         if (_manage_storage) {
             delete _dof_table_single_component;
+            _dof_table_single_component = nullptr;
         }
     }
 
+    //! Extrapolator managed by the ExtrapolatorData instance.
     std::unique_ptr<NumLib::Extrapolator> _extrapolator;
+
+    //! D.o.f. table used by the extrapolator.
     NumLib::LocalToGlobalIndexMap const* _dof_table_single_component = nullptr;
+
+    //! If true, free storage of the d.o.f. table in the ExtrapolatorData
+    //! destructor.
     bool _manage_storage = false;
 };
 

--- a/ProcessLib/ExtrapolatorData.h
+++ b/ProcessLib/ExtrapolatorData.h
@@ -52,6 +52,8 @@ struct ExtrapolatorData
         _manage_storage = other._manage_storage;
         _dof_table_single_component = other._dof_table_single_component;
         _extrapolator = std::move(other._extrapolator);
+        other._dof_table_single_component = nullptr;
+        other._manage_storage = false;
         return *this;
     }
 

--- a/ProcessLib/ExtrapolatorData.h
+++ b/ProcessLib/ExtrapolatorData.h
@@ -28,17 +28,17 @@ struct ExtrapolatorData
     ExtrapolatorData() = default;
 
     ExtrapolatorData(
-        std::unique_ptr<NumLib::Extrapolator>&& extrapolator_,
+        std::unique_ptr<NumLib::Extrapolator>&& extrapolator,
         NumLib::LocalToGlobalIndexMap const* const dof_table_single_component,
         bool const manage_storage)
-        : extrapolator(std::move(extrapolator_))
+        : _extrapolator(std::move(extrapolator))
         , _dof_table_single_component(dof_table_single_component)
         , _manage_storage(manage_storage)
     {
     }
 
     ExtrapolatorData(ExtrapolatorData&& other)
-        : extrapolator(std::move(other.extrapolator))
+        : _extrapolator(std::move(other._extrapolator))
         , _dof_table_single_component(other._dof_table_single_component)
         , _manage_storage(other._manage_storage)
     {
@@ -51,12 +51,17 @@ struct ExtrapolatorData
         cleanup();
         _manage_storage = other._manage_storage;
         _dof_table_single_component = other._dof_table_single_component;
-        extrapolator = std::move(other.extrapolator);
+        _extrapolator = std::move(other._extrapolator);
         return *this;
     }
 
+    NumLib::LocalToGlobalIndexMap const& getDOFTable() const
+    {
+        return *_dof_table_single_component;
+    }
+    NumLib::Extrapolator& getExtrapolator() const { return *_extrapolator; }
+
     ~ExtrapolatorData() { cleanup(); }
-    std::unique_ptr<NumLib::Extrapolator> extrapolator;
 
 private:
     void cleanup()
@@ -66,6 +71,7 @@ private:
         }
     }
 
+    std::unique_ptr<NumLib::Extrapolator> _extrapolator;
     NumLib::LocalToGlobalIndexMap const* _dof_table_single_component = nullptr;
     bool _manage_storage = false;
 };

--- a/ProcessLib/ExtrapolatorData.h
+++ b/ProcessLib/ExtrapolatorData.h
@@ -1,0 +1,76 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_EXTRAPOLATORDATA_H
+#define PROCESSLIB_EXTRAPOLATORDATA_H
+
+#include <memory>
+#include "NumLib/DOF/LocalToGlobalIndexMap.h"
+#include "NumLib/Extrapolation/Extrapolator.h"
+
+namespace ProcessLib
+{
+/*! Helper struct containing an extrapolator and a single component DOF table.
+ *
+ * Storage for the DOF table is managed optionally.
+ *
+ * \todo Later on this struct shall be moved, e.g., be merged with the process
+ * output class.
+ */
+struct ExtrapolatorData
+{
+    ExtrapolatorData() = default;
+
+    ExtrapolatorData(
+        std::unique_ptr<NumLib::Extrapolator>&& extrapolator_,
+        NumLib::LocalToGlobalIndexMap const* const dof_table_single_component,
+        bool const manage_storage)
+        : extrapolator(std::move(extrapolator_))
+        , _dof_table_single_component(dof_table_single_component)
+        , _manage_storage(manage_storage)
+    {
+    }
+
+    ExtrapolatorData(ExtrapolatorData&& other)
+        : extrapolator(std::move(other.extrapolator))
+        , _dof_table_single_component(other._dof_table_single_component)
+        , _manage_storage(other._manage_storage)
+    {
+        other._manage_storage = false;
+        other._dof_table_single_component = nullptr;
+    }
+
+    ExtrapolatorData& operator=(ExtrapolatorData&& other)
+    {
+        cleanup();
+        _manage_storage = other._manage_storage;
+        _dof_table_single_component = other._dof_table_single_component;
+        extrapolator = std::move(other.extrapolator);
+        return *this;
+    }
+
+    ~ExtrapolatorData() { cleanup(); }
+    std::unique_ptr<NumLib::Extrapolator> extrapolator;
+
+private:
+    void cleanup()
+    {
+        if (_manage_storage) {
+            delete _dof_table_single_component;
+        }
+    }
+
+    NumLib::LocalToGlobalIndexMap const* _dof_table_single_component = nullptr;
+    bool _manage_storage = false;
+};
+
+} // namespace ProcessLib
+
+
+#endif // PROCESSLIB_EXTRAPOLATORDATA_H

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -125,19 +125,22 @@ public:
     std::vector<double> const&
     getIntPtDarcyVelocityX(std::vector<double>& /*cache*/) const override
     {
-            return _darcy_velocities[0];
+        assert(_darcy_velocities.size() > 1);
+        return _darcy_velocities[0];
     }
 
     std::vector<double> const&
     getIntPtDarcyVelocityY(std::vector<double>& /*cache*/) const override
     {
-            return _darcy_velocities[0];
+        assert(_darcy_velocities.size() > 1);
+        return _darcy_velocities[1];
     }
 
     std::vector<double> const&
     getIntPtDarcyVelocityZ(std::vector<double>& /*cache*/) const override
     {
-            return _darcy_velocities[0];
+        assert(_darcy_velocities.size() > 2);
+        return _darcy_velocities[2];
     }
 
 private:

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -12,6 +12,7 @@
 
 #include <vector>
 
+#include "NumLib/Extrapolation/ExtrapolatableElement.h"
 #include "NumLib/Fem/FiniteElement/TemplateIsoparametric.h"
 #include "NumLib/Fem/ShapeMatrixPolicy.h"
 #include "ProcessLib/LocalAssemblerInterface.h"

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -26,18 +26,22 @@ namespace ProcessLib
 namespace GroundwaterFlow
 {
 
-enum class IntegrationPointValue {
-    DarcyVelocityX,
-    DarcyVelocityY,
-    DarcyVelocityZ
-};
-
 const unsigned NUM_NODAL_DOF = 1;
 
 class GroundwaterFlowLocalAssemblerInterface
         : public ProcessLib::LocalAssemblerInterface
-        , public NumLib::Extrapolatable<IntegrationPointValue>
-{};
+        , public NumLib::ExtrapolatableElement
+{
+public:
+    virtual std::vector<double> const& getIntPtDarcyVelocityX(
+        std::vector<double>& /*cache*/) const = 0;
+
+    virtual std::vector<double> const& getIntPtDarcyVelocityY(
+        std::vector<double>& /*cache*/) const = 0;
+
+    virtual std::vector<double> const& getIntPtDarcyVelocityZ(
+        std::vector<double>& /*cache*/) const = 0;
+};
 
 template <typename ShapeFunction,
          typename IntegrationMethod,
@@ -118,22 +122,21 @@ public:
     }
 
     std::vector<double> const&
-    getIntegrationPointValues(IntegrationPointValue const property,
-                              std::vector<double>& /*cache*/) const override
+    getIntPtDarcyVelocityX(std::vector<double>& /*cache*/) const override
     {
-        switch (property)
-        {
-        case IntegrationPointValue::DarcyVelocityX:
             return _darcy_velocities[0];
-        case IntegrationPointValue::DarcyVelocityY:
-            assert(GlobalDim > 1);
-            return _darcy_velocities[1];
-        case IntegrationPointValue::DarcyVelocityZ:
-            assert(GlobalDim > 2);
-            return _darcy_velocities[2];
-        }
+    }
 
-        OGS_FATAL("");
+    std::vector<double> const&
+    getIntPtDarcyVelocityY(std::vector<double>& /*cache*/) const override
+    {
+            return _darcy_velocities[0];
+    }
+
+    std::vector<double> const&
+    getIntPtDarcyVelocityZ(std::vector<double>& /*cache*/) const override
+    {
+            return _darcy_velocities[0];
     }
 
 private:

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -53,27 +53,23 @@ void GroundwaterFlowProcess::initializeConcreteProcess(
         mesh.getDimension(), mesh.getElements(), dof_table, integration_order,
         _local_assemblers, _process_data);
 
-    // TODO Later on the DOF table can change during the simulation!
-    _extrapolator.reset(new ExtrapolatorImplementation(
-        Base::getMatrixSpecifications(), *Base::_local_to_global_index_map));
-
     _secondary_variables.addSecondaryVariable(
         "darcy_velocity_x", 1,
         makeExtrapolator(
-            *_extrapolator, _local_assemblers,
+            getExtrapolator(), _local_assemblers,
             &GroundwaterFlowLocalAssemblerInterface::getIntPtDarcyVelocityX));
 
     if (mesh.getDimension() > 1) {
         _secondary_variables.addSecondaryVariable(
             "darcy_velocity_y", 1,
-            makeExtrapolator(*_extrapolator, _local_assemblers,
+            makeExtrapolator(getExtrapolator(), _local_assemblers,
                              &GroundwaterFlowLocalAssemblerInterface::
                                  getIntPtDarcyVelocityY));
     }
     if (mesh.getDimension() > 2) {
         _secondary_variables.addSecondaryVariable(
             "darcy_velocity_z", 1,
-            makeExtrapolator(*_extrapolator, _local_assemblers,
+            makeExtrapolator(getExtrapolator(), _local_assemblers,
                              &GroundwaterFlowLocalAssemblerInterface::
                                  getIntPtDarcyVelocityZ));
     }

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -57,24 +57,25 @@ void GroundwaterFlowProcess::initializeConcreteProcess(
     _extrapolator.reset(new ExtrapolatorImplementation(
         Base::getMatrixSpecifications(), *Base::_local_to_global_index_map));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "darcy_velocity_x", 1,
-        makeExtrapolator(IntegrationPointValue::DarcyVelocityX, *_extrapolator,
-                         _local_assemblers));
+        makeExtrapolator(
+            *_extrapolator, _local_assemblers,
+            &GroundwaterFlowLocalAssemblerInterface::getIntPtDarcyVelocityX));
 
-    if (mesh.getDimension() > 1)
-    {
-        Base::_secondary_variables.addSecondaryVariable(
+    if (mesh.getDimension() > 1) {
+        _secondary_variables.addSecondaryVariable(
             "darcy_velocity_y", 1,
-            makeExtrapolator(IntegrationPointValue::DarcyVelocityY,
-                             *_extrapolator, _local_assemblers));
+            makeExtrapolator(*_extrapolator, _local_assemblers,
+                             &GroundwaterFlowLocalAssemblerInterface::
+                                 getIntPtDarcyVelocityY));
     }
-    if (mesh.getDimension() > 2)
-    {
-        Base::_secondary_variables.addSecondaryVariable(
+    if (mesh.getDimension() > 2) {
+        _secondary_variables.addSecondaryVariable(
             "darcy_velocity_z", 1,
-            makeExtrapolator(IntegrationPointValue::DarcyVelocityZ,
-                             *_extrapolator, _local_assemblers));
+            makeExtrapolator(*_extrapolator, _local_assemblers,
+                             &GroundwaterFlowLocalAssemblerInterface::
+                                 getIntPtDarcyVelocityZ));
     }
 }
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -42,11 +42,6 @@ public:
     //! @}
 
 private:
-    using ExtrapolatorInterface =
-        NumLib::Extrapolator;
-    using ExtrapolatorImplementation =
-        NumLib::LocalLinearLeastSquaresExtrapolator;
-
     void initializeConcreteProcess(
         NumLib::LocalToGlobalIndexMap const& dof_table,
         MeshLib::Mesh const& mesh,
@@ -60,8 +55,6 @@ private:
 
     std::vector<std::unique_ptr<GroundwaterFlowLocalAssemblerInterface>>
         _local_assemblers;
-
-    std::unique_ptr<ExtrapolatorInterface> _extrapolator;
 };
 
 }   // namespace GroundwaterFlow

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -43,11 +43,9 @@ public:
 
 private:
     using ExtrapolatorInterface =
-        NumLib::Extrapolator<IntegrationPointValue,
-                             GroundwaterFlowLocalAssemblerInterface>;
+        NumLib::Extrapolator;
     using ExtrapolatorImplementation =
-        NumLib::LocalLinearLeastSquaresExtrapolator<
-            IntegrationPointValue, GroundwaterFlowLocalAssemblerInterface>;
+        NumLib::LocalLinearLeastSquaresExtrapolator;
 
     void initializeConcreteProcess(
         NumLib::LocalToGlobalIndexMap const& dof_table,

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -199,15 +199,9 @@ void Process::initializeExtrapolator()
         manage_storage = true;
     }
 
-    MathLib::MatrixSpecifications mat_specs(
-        dof_table_single_component->dofSizeWithoutGhosts(),
-        dof_table_single_component->dofSizeWithoutGhosts(),
-        &dof_table_single_component->getGhostIndices(),
-        nullptr);
-
     std::unique_ptr<NumLib::Extrapolator> extrapolator(
         new NumLib::LocalLinearLeastSquaresExtrapolator(
-            mat_specs, *dof_table_single_component));
+            *dof_table_single_component));
 
     // TODO Later on the DOF table can change during the simulation!
     _extrapolator_data = ExtrapolatorData(

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -190,7 +190,7 @@ void Process::initializeExtrapolator()
         std::vector<std::unique_ptr<MeshLib::MeshSubsets>>
             all_mesh_subsets_single_component;
         all_mesh_subsets_single_component.emplace_back(
-            new MeshLib::MeshSubsets(this->_mesh_subset_all_nodes.get()));
+            new MeshLib::MeshSubsets(_mesh_subset_all_nodes.get()));
 
         dof_table_single_component = new NumLib::LocalToGlobalIndexMap(
             std::move(all_mesh_subsets_single_component),

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -87,9 +87,14 @@ public:
     }
 
 protected:
-    NumLib::Extrapolator& getExtrapolator()
+    NumLib::Extrapolator& getExtrapolator() const
     {
-        return *_extrapolator_data.extrapolator;
+        return _extrapolator_data.getExtrapolator();
+    }
+
+    NumLib::LocalToGlobalIndexMap const& getSingleComponentDOFTable() const
+    {
+        return _extrapolator_data.getDOFTable();
     }
 
 private:

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -14,6 +14,7 @@
 #include "NumLib/ODESolver/ODESystem.h"
 #include "NumLib/ODESolver/TimeDiscretization.h"
 
+#include "ExtrapolatorData.h"
 #include "Parameter.h"
 #include "ProcessOutput.h"
 #include "SecondaryVariable.h"
@@ -85,6 +86,12 @@ public:
         return *_time_discretization;
     }
 
+protected:
+    NumLib::Extrapolator& getExtrapolator()
+    {
+        return *_extrapolator_data.extrapolator;
+    }
+
 private:
     /// Process specific initialization called by initialize().
     virtual void initializeConcreteProcess(
@@ -103,6 +110,8 @@ private:
         GlobalMatrix const& /*K*/, GlobalMatrix& /*Jac*/);
 
     void constructDofTable();
+
+    void initializeExtrapolator();
 
     /// Sets the initial condition values in the solution vector x for a given
     /// process variable and component.
@@ -142,6 +151,8 @@ private:
 
     /// Variables used by this process.
     std::vector<std::reference_wrapper<ProcessVariable>> _process_variables;
+
+    ExtrapolatorData _extrapolator_data;
 };
 
 /// Find process variables in \c variables whose names match the settings under

--- a/ProcessLib/SecondaryVariable.h
+++ b/ProcessLib/SecondaryVariable.h
@@ -160,15 +160,23 @@ private:
     std::set<std::string> _all_secondary_variables;
 };
 
-
-//! Creates an object that computes a secondary variable via extrapolation
-//! of integration point values.
-template <typename LocalAssemblerCollection,
-          typename IntegrationPointValuesMethod>
+/*! Creates an object that computes a secondary variable via extrapolation of
+ * integration point values.
+ *
+ * \param extrapolator The extrapolator used for extrapolation.
+ * \param local_assemblers The collection of local assemblers whose integration
+ * point values will be extrapolated.
+ * \param integration_point_values_method The member function of the local
+ * assembler returning/computing the integration point values of the specific
+ * property being extrapolated.
+ */
+template <typename LocalAssemblerCollection>
 SecondaryVariableFunctions makeExtrapolator(
     NumLib::Extrapolator& extrapolator,
     LocalAssemblerCollection const& local_assemblers,
-    IntegrationPointValuesMethod integration_point_values_method)
+    typename NumLib::ExtrapolatableLocalAssemblerCollection<
+        LocalAssemblerCollection>::IntegrationPointValuesMethod
+        integration_point_values_method)
 {
     auto const eval_field = [&extrapolator, &local_assemblers,
                              integration_point_values_method](

--- a/ProcessLib/TES/TESLocalAssembler-impl.h
+++ b/ProcessLib/TES/TESLocalAssembler-impl.h
@@ -257,7 +257,7 @@ std::vector<double> const& TESLocalAssembler<
     ShapeFunction_, IntegrationMethod_,
     GlobalDim>::getIntPtDarcyVelocityY(std::vector<double>& /*cache*/) const
 {
-    assert(_d.getData().velocity.size() >= 2);
+    assert(_d.getData().velocity.size() > 1);
     return _d.getData().velocity[1];
 }
 
@@ -267,7 +267,7 @@ std::vector<double> const& TESLocalAssembler<
     ShapeFunction_, IntegrationMethod_,
     GlobalDim>::getIntPtDarcyVelocityZ(std::vector<double>& /*cache*/) const
 {
-    assert(_d.getData().velocity.size() >= 3);
+    assert(_d.getData().velocity.size() > 2);
     return _d.getData().velocity[2];
 }
 

--- a/ProcessLib/TES/TESLocalAssembler-impl.h
+++ b/ProcessLib/TES/TESLocalAssembler-impl.h
@@ -194,10 +194,47 @@ template <typename ShapeFunction_, typename IntegrationMethod_,
           unsigned GlobalDim>
 std::vector<double> const& TESLocalAssembler<
     ShapeFunction_, IntegrationMethod_,
-    GlobalDim>::getIntegrationPointValues(TESIntPtVariables const var,
-                                          std::vector<double>& cache) const
+    GlobalDim>::getIntPtSolidDensity(std::vector<double>& /*cache*/) const
 {
-    return _d.getIntegrationPointValues(var, cache);
+    return _d.getData().solid_density;
+}
+
+template <typename ShapeFunction_, typename IntegrationMethod_,
+          unsigned GlobalDim>
+std::vector<double> const& TESLocalAssembler<
+    ShapeFunction_, IntegrationMethod_,
+    GlobalDim>::getIntPtReactionRate(std::vector<double>& /*cache*/) const
+{
+    return _d.getData().reaction_rate;
+}
+
+template <typename ShapeFunction_, typename IntegrationMethod_,
+          unsigned GlobalDim>
+std::vector<double> const& TESLocalAssembler<
+    ShapeFunction_, IntegrationMethod_,
+    GlobalDim>::getIntPtDarcyVelocityX(std::vector<double>& /*cache*/) const
+{
+    return _d.getData().velocity[0];
+}
+
+template <typename ShapeFunction_, typename IntegrationMethod_,
+          unsigned GlobalDim>
+std::vector<double> const& TESLocalAssembler<
+    ShapeFunction_, IntegrationMethod_,
+    GlobalDim>::getIntPtDarcyVelocityY(std::vector<double>& /*cache*/) const
+{
+    assert(_d.getData().velocity.size() >= 2);
+    return _d.getData().velocity[1];
+}
+
+template <typename ShapeFunction_, typename IntegrationMethod_,
+          unsigned GlobalDim>
+std::vector<double> const& TESLocalAssembler<
+    ShapeFunction_, IntegrationMethod_,
+    GlobalDim>::getIntPtDarcyVelocityZ(std::vector<double>& /*cache*/) const
+{
+    assert(_d.getData().velocity.size() >= 3);
+    return _d.getData().velocity[2];
 }
 
 template <typename ShapeFunction_, typename IntegrationMethod_,

--- a/ProcessLib/TES/TESLocalAssembler-impl.h
+++ b/ProcessLib/TES/TESLocalAssembler-impl.h
@@ -203,6 +203,40 @@ template <typename ShapeFunction_, typename IntegrationMethod_,
           unsigned GlobalDim>
 std::vector<double> const& TESLocalAssembler<
     ShapeFunction_, IntegrationMethod_,
+    GlobalDim>::getIntPtLoading(std::vector<double>& cache) const
+{
+    auto const rho_SR = _d.getData().solid_density;
+    auto const rho_SR_dry = _d.getAssemblyParameters().rho_SR_dry;
+
+    cache.clear();
+    cache.reserve(rho_SR.size());
+
+    for (auto const rho : rho_SR) {
+        cache.push_back(rho/rho_SR_dry - 1.0);
+    }
+
+    return cache;
+}
+
+template <typename ShapeFunction_, typename IntegrationMethod_,
+          unsigned GlobalDim>
+std::vector<double> const&
+TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
+    getIntPtReactionDampingFactor(std::vector<double>& cache) const
+{
+    auto const fac = _d.getData().reaction_adaptor->getReactionDampingFactor();
+    auto const num_integration_points = _d.getData().solid_density.size();
+
+    cache.clear();
+    cache.resize(num_integration_points, fac);
+
+    return cache;
+}
+
+template <typename ShapeFunction_, typename IntegrationMethod_,
+          unsigned GlobalDim>
+std::vector<double> const& TESLocalAssembler<
+    ShapeFunction_, IntegrationMethod_,
     GlobalDim>::getIntPtReactionRate(std::vector<double>& /*cache*/) const
 {
     return _d.getData().reaction_rate;

--- a/ProcessLib/TES/TESLocalAssembler.h
+++ b/ProcessLib/TES/TESLocalAssembler.h
@@ -17,7 +17,7 @@
 #include "TESAssemblyParams.h"
 #include "TESLocalAssemblerInner-fwd.h"
 
-#include "NumLib/Extrapolation/Extrapolator.h"
+#include "NumLib/Extrapolation/ExtrapolatableElement.h"
 
 namespace ProcessLib
 {
@@ -25,13 +25,28 @@ namespace TES
 {
 class TESLocalAssemblerInterface
     : public ProcessLib::LocalAssemblerInterface,
-      public NumLib::Extrapolatable<TESIntPtVariables>
+      public NumLib::ExtrapolatableElement
 {
 public:
     virtual ~TESLocalAssemblerInterface() = default;
 
     virtual bool checkBounds(std::vector<double> const& local_x,
                              std::vector<double> const& local_x_prev_ts) = 0;
+
+    virtual std::vector<double> const& getIntPtSolidDensity(
+        std::vector<double>& /*cache*/) const = 0;
+
+    virtual std::vector<double> const& getIntPtReactionRate(
+        std::vector<double>& /*cache*/) const = 0;
+
+    virtual std::vector<double> const& getIntPtDarcyVelocityX(
+        std::vector<double>& /*cache*/) const = 0;
+
+    virtual std::vector<double> const& getIntPtDarcyVelocityY(
+        std::vector<double>& /*cache*/) const = 0;
+
+    virtual std::vector<double> const& getIntPtDarcyVelocityZ(
+        std::vector<double>& /*cache*/) const = 0;
 };
 
 template <typename ShapeFunction_, typename IntegrationMethod_,
@@ -66,9 +81,20 @@ public:
     bool checkBounds(std::vector<double> const& local_x,
                      std::vector<double> const& local_x_prev_ts) override;
 
-    std::vector<double> const& getIntegrationPointValues(
-        TESIntPtVariables const var, std::vector<double>& cache) const override;
+    std::vector<double> const& getIntPtSolidDensity(
+        std::vector<double>& /*cache*/) const override;
 
+    std::vector<double> const& getIntPtReactionRate(
+        std::vector<double>& /*cache*/) const override;
+
+    std::vector<double> const& getIntPtDarcyVelocityX(
+        std::vector<double>& /*cache*/) const override;
+
+    std::vector<double> const& getIntPtDarcyVelocityY(
+        std::vector<double>& /*cache*/) const override;
+
+    std::vector<double> const& getIntPtDarcyVelocityZ(
+        std::vector<double>& /*cache*/) const override;
 private:
     std::vector<ShapeMatrices> _shape_matrices;
 

--- a/ProcessLib/TES/TESLocalAssembler.h
+++ b/ProcessLib/TES/TESLocalAssembler.h
@@ -14,10 +14,9 @@
 #include <vector>
 
 #include "ProcessLib/LocalAssemblerInterface.h"
+#include "NumLib/Extrapolation/ExtrapolatableElement.h"
 #include "TESAssemblyParams.h"
 #include "TESLocalAssemblerInner-fwd.h"
-
-#include "NumLib/Extrapolation/ExtrapolatableElement.h"
 
 namespace ProcessLib
 {

--- a/ProcessLib/TES/TESLocalAssembler.h
+++ b/ProcessLib/TES/TESLocalAssembler.h
@@ -36,6 +36,12 @@ public:
     virtual std::vector<double> const& getIntPtSolidDensity(
         std::vector<double>& /*cache*/) const = 0;
 
+    virtual std::vector<double> const& getIntPtLoading(
+        std::vector<double>& cache) const = 0;
+
+    virtual std::vector<double> const& getIntPtReactionDampingFactor(
+        std::vector<double>& cache) const = 0;
+
     virtual std::vector<double> const& getIntPtReactionRate(
         std::vector<double>& /*cache*/) const = 0;
 
@@ -83,6 +89,12 @@ public:
 
     std::vector<double> const& getIntPtSolidDensity(
         std::vector<double>& /*cache*/) const override;
+
+    std::vector<double> const& getIntPtLoading(
+        std::vector<double>& cache) const override;
+
+    std::vector<double> const& getIntPtReactionDampingFactor(
+        std::vector<double>& cache) const override;
 
     std::vector<double> const& getIntPtReactionRate(
         std::vector<double>& /*cache*/) const override;

--- a/ProcessLib/TES/TESLocalAssemblerInner-impl.h
+++ b/ProcessLib/TES/TESLocalAssemblerInner-impl.h
@@ -219,57 +219,6 @@ void TESLocalAssemblerInner<Traits>::preEachAssembleIntegrationPoint(
 }
 
 template <typename Traits>
-std::vector<double> const&
-TESLocalAssemblerInner<Traits>::getIntegrationPointValues(
-    TESIntPtVariables const var, std::vector<double>& cache) const
-{
-    switch (var)
-    {
-        case TESIntPtVariables::REACTION_RATE:
-            return _d.reaction_rate;
-        case TESIntPtVariables::SOLID_DENSITY:
-            return _d.solid_density;
-        case TESIntPtVariables::VELOCITY_X:
-            return _d.velocity[0];
-        case TESIntPtVariables::VELOCITY_Y:
-            assert(_d.velocity.size() >= 2);
-            return _d.velocity[1];
-        case TESIntPtVariables::VELOCITY_Z:
-            assert(_d.velocity.size() >= 3);
-            return _d.velocity[2];
-
-        case TESIntPtVariables::LOADING:
-        {
-            auto& Cs = cache;
-            Cs.clear();
-            Cs.reserve(_d.solid_density.size());
-
-            for (auto rho_SR : _d.solid_density)
-            {
-                Cs.push_back(rho_SR / _d.ap.rho_SR_dry - 1.0);
-            }
-
-            return Cs;
-        }
-
-        // TODO that's an element value, ain't it?
-        case TESIntPtVariables::REACTION_DAMPING_FACTOR:
-        {
-            auto const num_integration_points = _d.solid_density.size();
-            auto& alphas = cache;
-            alphas.clear();
-            alphas.resize(num_integration_points,
-                          _d.reaction_adaptor->getReactionDampingFactor());
-
-            return alphas;
-        }
-    }
-
-    cache.clear();
-    return cache;
-}
-
-template <typename Traits>
 void TESLocalAssemblerInner<Traits>::assembleIntegrationPoint(
     unsigned integration_point,
     std::vector<double> const& localX,

--- a/ProcessLib/TES/TESLocalAssemblerInner.h
+++ b/ProcessLib/TES/TESLocalAssemblerInner.h
@@ -23,17 +23,6 @@ namespace ProcessLib
 {
 namespace TES
 {
-enum class TESIntPtVariables : unsigned
-{
-    SOLID_DENSITY,
-    REACTION_RATE,
-    VELOCITY_X,
-    VELOCITY_Y,
-    VELOCITY_Z,
-    LOADING,
-    REACTION_DAMPING_FACTOR
-};
-
 template <typename Traits>
 class TESLocalAssemblerInner
 {
@@ -55,9 +44,6 @@ public:
         typename Traits::LocalVector& local_b);
 
     void preEachAssemble();
-
-    std::vector<double> const& getIntegrationPointValues(
-        TESIntPtVariables const var, std::vector<double>& cache) const;
 
     // TODO better encapsulation
     AssemblyParams const& getAssemblyParameters() const { return _d.ap; }

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -204,22 +204,27 @@ void TESProcess::initializeConcreteProcess(
                                                         std::move(fcts));
     };
     auto makeEx =
-        [&](TESIntPtVariables var) -> SecondaryVariableFunctions {
-        return ProcessLib::makeExtrapolator(var, *_extrapolator,
-                                            _local_assemblers);
+        [&](std::vector<double> const& (TESLocalAssemblerInterface::*method)(
+            std::vector<double>&)const) -> SecondaryVariableFunctions {
+        return ProcessLib::makeExtrapolator(*_extrapolator, _local_assemblers,
+                                            method);
     };
 
-    add2nd("solid_density", 1, makeEx(TESIntPtVariables::SOLID_DENSITY));
-    add2nd("reaction_rate", 1, makeEx(TESIntPtVariables::REACTION_RATE));
-    add2nd("velocity_x", 1, makeEx(TESIntPtVariables::VELOCITY_X));
+    // add2nd("solid_density", 1, makeEx(TESIntPtVariables::SOLID_DENSITY));
+    add2nd("reaction_rate", 1,
+           makeEx(&TESLocalAssemblerInterface::getIntPtReactionRate));
+    add2nd("velocity_x", 1,
+           makeEx(&TESLocalAssemblerInterface::getIntPtDarcyVelocityX));
     if (mesh.getDimension() >= 2)
-        add2nd("velocity_y", 1, makeEx(TESIntPtVariables::VELOCITY_Y));
+        add2nd("velocity_y", 1,
+               makeEx(&TESLocalAssemblerInterface::getIntPtDarcyVelocityY));
     if (mesh.getDimension() >= 3)
-        add2nd("velocity_z", 1, makeEx(TESIntPtVariables::VELOCITY_Z));
+        add2nd("velocity_z", 1,
+               makeEx(&TESLocalAssemblerInterface::getIntPtDarcyVelocityZ));
 
-    add2nd("loading", 1, makeEx(TESIntPtVariables::LOADING));
+    /*add2nd("loading", 1, makeEx(TESIntPtVariables::LOADING));
     add2nd("reaction_damping_factor", 1,
-           makeEx(TESIntPtVariables::REACTION_DAMPING_FACTOR));
+           makeEx(TESIntPtVariables::REACTION_DAMPING_FACTOR));*/
 
     namespace PH = std::placeholders;
     using Self = TESProcess;

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -188,9 +188,11 @@ void TESProcess::initializeConcreteProcess(
                                             _local_assemblers, method);
     };
 
-    // add2nd("solid_density", 1, makeEx(TESIntPtVariables::SOLID_DENSITY));
+    add2nd("solid_density", 1,
+           makeEx(&TESLocalAssemblerInterface::getIntPtSolidDensity));
     add2nd("reaction_rate", 1,
            makeEx(&TESLocalAssemblerInterface::getIntPtReactionRate));
+
     add2nd("velocity_x", 1,
            makeEx(&TESLocalAssemblerInterface::getIntPtDarcyVelocityX));
     if (mesh.getDimension() >= 2)
@@ -200,9 +202,9 @@ void TESProcess::initializeConcreteProcess(
         add2nd("velocity_z", 1,
                makeEx(&TESLocalAssemblerInterface::getIntPtDarcyVelocityZ));
 
-    /*add2nd("loading", 1, makeEx(TESIntPtVariables::LOADING));
+    add2nd("loading", 1, makeEx(&TESLocalAssemblerInterface::getIntPtLoading));
     add2nd("reaction_damping_factor", 1,
-           makeEx(TESIntPtVariables::REACTION_DAMPING_FACTOR));*/
+           makeEx(&TESLocalAssemblerInterface::getIntPtReactionDampingFactor));
 
     namespace PH = std::placeholders;
     using Self = TESProcess;

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -323,7 +323,7 @@ TESProcess::computeVapourPartialPressure(
 {
     assert(&dof_table == this->_local_to_global_index_map.get());
 
-    auto const& dof_table_single = *_local_to_global_index_map_single_component;
+    auto const& dof_table_single = getSingleComponentDOFTable();
     result_cache = MathLib::MatrixVectorTraits<GlobalVector>::newInstance(
         {dof_table_single.dofSizeWithoutGhosts(),
          dof_table_single.dofSizeWithoutGhosts(),
@@ -356,7 +356,7 @@ TESProcess::computeRelativeHumidity(
 {
     assert(&dof_table == this->_local_to_global_index_map.get());
 
-    auto const& dof_table_single = *_local_to_global_index_map_single_component;
+    auto const& dof_table_single = getSingleComponentDOFTable();
     result_cache = MathLib::MatrixVectorTraits<GlobalVector>::newInstance(
         {dof_table_single.dofSizeWithoutGhosts(),
          dof_table_single.dofSizeWithoutGhosts(),
@@ -394,7 +394,7 @@ TESProcess::computeEquilibriumLoading(
 {
     assert(&dof_table == this->_local_to_global_index_map.get());
 
-    auto const& dof_table_single = *_local_to_global_index_map_single_component;
+    auto const& dof_table_single = getSingleComponentDOFTable();
     result_cache = MathLib::MatrixVectorTraits<GlobalVector>::newInstance(
         {dof_table_single.dofSizeWithoutGhosts(),
          dof_table_single.dofSizeWithoutGhosts(),

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -31,8 +31,6 @@ namespace TES
 {
 class TESProcess final : public Process
 {
-    using BP = Process;  //!< "Base Process"
-
 public:
     TESProcess(
         MeshLib::Mesh& mesh,
@@ -51,12 +49,8 @@ public:
     NumLib::IterationResult postIteration(GlobalVector const& x) override;
 
     bool isLinear() const override { return false; }
-private:
-    using ExtrapolatorInterface =
-        NumLib::Extrapolator;
-    using ExtrapolatorImplementation =
-        NumLib::LocalLinearLeastSquaresExtrapolator;
 
+private:
     void initializeConcreteProcess(
         NumLib::LocalToGlobalIndexMap const& dof_table,
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
@@ -86,8 +80,6 @@ private:
 
     std::unique_ptr<NumLib::LocalToGlobalIndexMap>
         _local_to_global_index_map_single_component;
-
-    std::unique_ptr<ExtrapolatorInterface> _extrapolator;
 
     // used for checkBounds()
     std::unique_ptr<GlobalVector> _x_previous_timestep;

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -78,9 +78,6 @@ private:
 
     AssemblyParams _assembly_params;
 
-    std::unique_ptr<NumLib::LocalToGlobalIndexMap>
-        _local_to_global_index_map_single_component;
-
     // used for checkBounds()
     std::unique_ptr<GlobalVector> _x_previous_timestep;
 };

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -53,10 +53,9 @@ public:
     bool isLinear() const override { return false; }
 private:
     using ExtrapolatorInterface =
-        NumLib::Extrapolator<TESIntPtVariables, TESLocalAssemblerInterface>;
+        NumLib::Extrapolator;
     using ExtrapolatorImplementation =
-        NumLib::LocalLinearLeastSquaresExtrapolator<
-            TESIntPtVariables, TESLocalAssemblerInterface>;
+        NumLib::LocalLinearLeastSquaresExtrapolator;
 
     void initializeConcreteProcess(
         NumLib::LocalToGlobalIndexMap const& dof_table,

--- a/Tests/NumLib/TestExtrapolation.cpp
+++ b/Tests/NumLib/TestExtrapolation.cpp
@@ -156,12 +156,7 @@ public:
 
         // Passing _dof_table works, because this process has only one variable
         // and the variable has exactly one component.
-        _extrapolator.reset(new ExtrapolatorImplementation(
-            MathLib::MatrixSpecifications{_dof_table->dofSizeWithoutGhosts(),
-                                          _dof_table->dofSizeWithoutGhosts(),
-                                          &_dof_table->getGhostIndices(),
-                                          nullptr},
-            *_dof_table));
+        _extrapolator.reset(new ExtrapolatorImplementation(*_dof_table));
 
         createAssemblers(mesh);
     }

--- a/Tests/NumLib/TestExtrapolation.cpp
+++ b/Tests/NumLib/TestExtrapolation.cpp
@@ -10,25 +10,25 @@
 #include <random>
 #include <gtest/gtest.h>
 
-#include "NumLib/DOF/MatrixProviderUser.h"
 #include "MathLib/LinAlg/MatrixVectorTraits.h"
 #include "MathLib/LinAlg/UnifiedMatrixSetters.h"
-
 #include "MathLib/LinAlg/LinAlg.h"
 
 #include "MeshLib/MeshGenerators/MeshGenerator.h"
 
 #include "NumLib/DOF/DOFTableUtil.h"
+#include "NumLib/DOF/MatrixProviderUser.h"
+#include "NumLib/Extrapolation/ExtrapolatableElementCollection.h"
 #include "NumLib/Extrapolation/Extrapolator.h"
 #include "NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h"
 #include "NumLib/Fem/FiniteElement/TemplateIsoparametric.h"
 #include "NumLib/Fem/ShapeMatrixPolicy.h"
-
+#include "NumLib/Function/Interpolation.h"
 #include "NumLib/NumericsConfig.h"
+
 #include "ProcessLib/Utils/LocalDataInitializer.h"
 #include "ProcessLib/Utils/CreateLocalAssemblers.h"
 #include "ProcessLib/Utils/InitShapeMatrices.h"
-
 
 namespace
 {
@@ -63,26 +63,25 @@ void fillVectorRandomly(Vector& x)
 
 }
 
-enum class IntegrationPointValue
-{
-    StoredQuantity, // some quantity acutally stored in the local assembler
-    DerivedQuantity // a quantity computed for each integration point on-the-fly
-};
-
-class LocalAssemblerDataInterface
-        : public NumLib::Extrapolatable<IntegrationPointValue>
+class LocalAssemblerDataInterface : public NumLib::ExtrapolatableElement
 {
 public:
     virtual void interpolateNodalValuesToIntegrationPoints(
-            std::vector<double> const& local_nodal_values,
-            IntegrationPointValue const property) = 0;
+        std::vector<double> const& local_nodal_values) = 0;
+
+    virtual std::vector<double> const& getStoredQuantity(
+        std::vector<double>& /*cache*/) const = 0;
+
+    virtual std::vector<double> const& getDerivedQuantity(
+        std::vector<double>& cache) const = 0;
 };
 
-template<typename ShapeFunction,
-         typename IntegrationMethod,
-         unsigned GlobalDim>
-class LocalAssemblerData
-        : public LocalAssemblerDataInterface
+using IntegrationPointValuesMethod = std::vector<double> const& (
+    LocalAssemblerDataInterface::*)(std::vector<double>&)const;
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          unsigned GlobalDim>
+class LocalAssemblerData : public LocalAssemblerDataInterface
 {
     using ShapeMatricesType = ShapeMatrixPolicyType<ShapeFunction, GlobalDim>;
     using ShapeMatrices = typename ShapeMatricesType::ShapeMatrices;
@@ -93,9 +92,11 @@ public:
                        unsigned const integration_order)
         : _shape_matrices(
               ProcessLib::initShapeMatrices<ShapeFunction, ShapeMatricesType,
-                  IntegrationMethod, GlobalDim>(e, integration_order))
+                                            IntegrationMethod, GlobalDim>(
+                  e, integration_order))
         , _int_pt_values(_shape_matrices.size())
-    {}
+    {
+    }
 
     Eigen::Map<const Eigen::RowVectorXd>
     getShapeMatrix(const unsigned integration_point) const override
@@ -106,42 +107,31 @@ public:
         return Eigen::Map<const Eigen::RowVectorXd>(N.data(), N.size());
     }
 
-    std::vector<double> const&
-    getIntegrationPointValues(IntegrationPointValue const property,
-                              std::vector<double>& cache) const override
+    std::vector<double> const& getStoredQuantity(
+        std::vector<double>& /*cache*/) const override
     {
-        switch (property)
-        {
-        case IntegrationPointValue::StoredQuantity:
-            return _int_pt_values;
-        case IntegrationPointValue::DerivedQuantity:
-            cache.clear();
-            for (auto value : _int_pt_values)
-                cache.push_back(2.0 * value);
-            return cache;
-        }
+        return _int_pt_values;
+    }
 
-        OGS_FATAL("");
+    std::vector<double> const& getDerivedQuantity(
+        std::vector<double>& cache) const override
+    {
+        cache.clear();
+        for (auto value : _int_pt_values)
+            cache.push_back(2.0 * value);
+        return cache;
     }
 
     void interpolateNodalValuesToIntegrationPoints(
-            std::vector<double> const& local_nodal_values,
-            IntegrationPointValue const property) override
+        std::vector<double> const& local_nodal_values) override
     {
-        switch (property)
-        {
-        case IntegrationPointValue::StoredQuantity:
-            ::interpolateNodalValuesToIntegrationPoints(
-                        local_nodal_values, _shape_matrices, _int_pt_values);
-            break;
-        case IntegrationPointValue::DerivedQuantity:
-            break;
-        }
+        ::interpolateNodalValuesToIntegrationPoints(
+            local_nodal_values, _shape_matrices, _int_pt_values);
     }
 
 private:
     std::vector<ShapeMatrices> _shape_matrices;
-    std::vector<double>        _int_pt_values;
+    std::vector<double> _int_pt_values;
 };
 
 class TestProcess
@@ -149,11 +139,9 @@ class TestProcess
 public:
     using LocalAssembler = LocalAssemblerDataInterface;
 
-    using ExtrapolatorInterface =
-        NumLib::Extrapolator<IntegrationPointValue, LocalAssembler>;
+    using ExtrapolatorInterface = NumLib::Extrapolator;
     using ExtrapolatorImplementation =
-        NumLib::LocalLinearLeastSquaresExtrapolator<
-            IntegrationPointValue, LocalAssembler>;
+        NumLib::LocalLinearLeastSquaresExtrapolator;
 
     TestProcess(MeshLib::Mesh const& mesh, unsigned const integration_order)
         : _integration_order(integration_order)
@@ -161,11 +149,10 @@ public:
     {
         std::vector<std::unique_ptr<MeshLib::MeshSubsets>> all_mesh_subsets;
         all_mesh_subsets.emplace_back(
-                    new MeshLib::MeshSubsets{&_mesh_subset_all_nodes});
+            new MeshLib::MeshSubsets{&_mesh_subset_all_nodes});
 
         _dof_table.reset(new NumLib::LocalToGlobalIndexMap(
-              std::move(all_mesh_subsets),
-              NumLib::ComponentOrder::BY_COMPONENT));
+            std::move(all_mesh_subsets), NumLib::ComponentOrder::BY_COMPONENT));
 
         // Passing _dof_table works, because this process has only one variable
         // and the variable has exactly one component.
@@ -180,32 +167,31 @@ public:
     }
 
     void interpolateNodalValuesToIntegrationPoints(
-            GlobalVector const& global_nodal_values,
-            IntegrationPointValue const property) const
+        GlobalVector const& global_nodal_values) const
     {
         auto cb = [](std::size_t id, LocalAssembler& loc_asm,
                      NumLib::LocalToGlobalIndexMap const& dof_table,
-                     GlobalVector const& x,
-                     IntegrationPointValue const property) {
+                     GlobalVector const& x) {
             auto const indices = NumLib::getIndices(id, dof_table);
             auto const local_x = x.get(indices);
 
-            loc_asm.interpolateNodalValuesToIntegrationPoints(local_x,
-                                                              property);
+            loc_asm.interpolateNodalValuesToIntegrationPoints(local_x);
         };
 
         GlobalExecutor::executeDereferenced(cb, _local_assemblers, *_dof_table,
-                                            global_nodal_values, property);
+                                            global_nodal_values);
     }
 
-    std::pair<GlobalVector const*, GlobalVector const*>
-    extrapolate(IntegrationPointValue const property) const
+    std::pair<GlobalVector const*, GlobalVector const*> extrapolate(
+        IntegrationPointValuesMethod method) const
     {
-        _extrapolator->extrapolate(_local_assemblers, property);
-        _extrapolator->calculateResiduals(_local_assemblers, property);
+        auto const extrapolatables =
+            NumLib::makeExtrapolatable(_local_assemblers, method);
+        _extrapolator->extrapolate(extrapolatables);
+        _extrapolator->calculateResiduals(extrapolatables);
 
-        return { &_extrapolator->getNodalValues(),
-                 &_extrapolator->getElementResiduals() };
+        return {&_extrapolator->getNodalValues(),
+                &_extrapolator->getElementResiduals()};
     }
 
 private:
@@ -249,11 +235,8 @@ private:
     std::unique_ptr<ExtrapolatorInterface> _extrapolator;
 };
 
-
-void extrapolate(TestProcess const& pcs,
-                 IntegrationPointValue property,
-                 GlobalVector const&
-                 expected_extrapolated_global_nodal_values,
+void extrapolate(TestProcess const& pcs, IntegrationPointValuesMethod method,
+                 GlobalVector const& expected_extrapolated_global_nodal_values,
                  std::size_t const nnodes, std::size_t const nelements)
 {
     namespace LinAlg = MathLib::LinAlg;
@@ -261,8 +244,8 @@ void extrapolate(TestProcess const& pcs,
     auto const tolerance_dx  = 20.0 * std::numeric_limits<double>::epsilon();
     auto const tolerance_res =  5.0 * std::numeric_limits<double>::epsilon();
 
-    auto const  result   = pcs.extrapolate(property);
-    auto const& x_extra  = *result.first;
+    auto const result = pcs.extrapolate(method);
+    auto const& x_extra = *result.first;
     auto const& residual = *result.second;
 
     ASSERT_EQ(nnodes,    x_extra.size());
@@ -322,20 +305,20 @@ TEST(NumLib, DISABLED_Extrapolation)
 
         fillVectorRandomly(*x);
 
-        pcs.interpolateNodalValuesToIntegrationPoints(
-                    *x, IntegrationPointValue::StoredQuantity);
+        pcs.interpolateNodalValuesToIntegrationPoints(*x);
 
-        // test extrapolation of a quantity that is stored in the local assembler
-        extrapolate(pcs, IntegrationPointValue::StoredQuantity,
-                    *x, nnodes, nelements);
+        // test extrapolation of a quantity that is stored in the local
+        // assembler
+        extrapolate(pcs, &LocalAssemblerDataInterface::getStoredQuantity, *x,
+                    nnodes, nelements);
 
         // expect 2*x as extraplation result for derived quantity
         auto two_x = MathLib::MatrixVectorTraits<GlobalVector>::newInstance(*x);
         LinAlg::axpy(*two_x, 1.0, *x); // two_x = x + x
 
-        // test extrapolation of a quantity that is derived from some integration
-        // point values
-        extrapolate(pcs, IntegrationPointValue::DerivedQuantity,
+        // test extrapolation of a quantity that is derived from some
+        // integration point values
+        extrapolate(pcs, &LocalAssemblerDataInterface::getDerivedQuantity,
                     *two_x, nnodes, nelements);
     }
 }


### PR DESCRIPTION
Follow-up of #1306.

* Core Extrapolation is now template-free
* there is an adaptor `ExtrapolatableElementCollection` passing information from local assemblers to the `Extrapolator`
* the `Extrapolator` is managed by the base `Process`, now
* there is no per-process enum telling what to extrapolate, anymore
* instead there has to be a member function for each property to be extrapolated.

The last point means somewhat more code is required. However, the other points save some code.
The introduced changes maka a better separation between individual processes and extrapolation. In the future the extrapolation logic maybe can be entirely moved to some output class.