### PR TITLE
Fix surfaces lying in x-y-plane

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -124,9 +124,31 @@ if(NOT OGS_USE_MPI)
             ABSTOL 1e-14 RELTOL 1e-14
             DIFF_DATA line_${mesh_size}_neumann_pcs_0_ts_1_t_1.000000.vtu D1_left_N1_right pressure
         )
-        endforeach()
+    endforeach()
 
+    # Some Neumann BC tests
+    AddTest(
+        NAME GroundWaterFlowProcess_cube_top
+        PATH Elliptic/cube_1x1x1_GroundWaterFlow
+        EXECUTABLE ogs
+        EXECUTABLE_ARGS cube_1e3_top_neumann.prj
+        WRAPPER time
+        TESTER vtkdiff
+        ABSTOL 1e-16 RELTOL 1e-16
+        DIFF_DATA cube_1e3_top_neumann_pcs_0_ts_1_t_1.000000.vtu pressure pressure
+    )
+    AddTest(
+        NAME GroundWaterFlowProcess_cube_bottom
+        PATH Elliptic/cube_1x1x1_GroundWaterFlow
+        EXECUTABLE ogs
+        EXECUTABLE_ARGS cube_1e3_bottom_neumann.prj
+        WRAPPER time
+        TESTER vtkdiff
+        ABSTOL 1e-16 RELTOL 1e-16
+        DIFF_DATA cube_1e3_bottom_neumann_pcs_0_ts_1_t_1.000000.vtu pressure pressure
+    )
 
+    # TES tests
     AddTest(
         NAME TES_zeolite_discharge_small
         PATH Parabolic/TES/1D

--- a/GeoLib/AnalyticalGeometry-impl.h
+++ b/GeoLib/AnalyticalGeometry-impl.h
@@ -119,30 +119,25 @@ void computeRotationMatrixToXY(MathLib::Vector3 const& n,
 {
     // check if normal points already in the right direction
     if (n[0] == 0 && n[1] == 0) {
+        rot_mat(0,1) = 0.0;
+        rot_mat(0,2) = 0.0;
+        rot_mat(1,0) = 0.0;
+        rot_mat(1,1) = 1.0;
+        rot_mat(1,2) = 0.0;
+        rot_mat(2,0) = 0.0;
+        rot_mat(2,1) = 0.0;
+
         if (n[2] > 0) {
+            // identity matrix
             rot_mat(0,0) = 1.0;
-            rot_mat(0,1) = 0.0;
-            rot_mat(0,2) = 0.0;
-            rot_mat(1,0) = 0.0;
-            rot_mat(1,1) = 1.0;
-            rot_mat(1,2) = 0.0;
-            rot_mat(2,0) = 0.0;
-            rot_mat(2,1) = 0.0;
             rot_mat(2,2) = 1.0;
-            return;
         } else {
             // rotate by pi about the y-axis
             rot_mat(0,0) = -1.0;
-            rot_mat(0,1) = 0.0;
-            rot_mat(0,2) = 0.0;
-            rot_mat(1,0) = 0.0;
-            rot_mat(1,1) = 1.0;
-            rot_mat(1,2) = 0.0;
-            rot_mat(2,0) = 0.0;
-            rot_mat(2,1) = 0.0;
             rot_mat(2,2) = -1.0;
-            return;
         }
+
+        return;
     }
 
     // sqrt (n_1^2 + n_3^2)

--- a/GeoLib/AnalyticalGeometry-impl.h
+++ b/GeoLib/AnalyticalGeometry-impl.h
@@ -118,17 +118,31 @@ void computeRotationMatrixToXY(MathLib::Vector3 const& n,
         T_MATRIX & rot_mat)
 {
     // check if normal points already in the right direction
-    if (sqrt(n[0]*n[0]+n[1]*n[1]) == 0) {
-        rot_mat(0,0) = 1.0;
-        rot_mat(0,1) = 0.0;
-        rot_mat(0,2) = 0.0;
-        rot_mat(1,0) = 0.0;
-        rot_mat(1,1) = 1.0;
-        rot_mat(1,2) = 0.0;
-        rot_mat(2,0) = 0.0;
-        rot_mat(2,1) = 0.0;
-        rot_mat(2,2) = 1.0;
-        return;
+    if (n[0] == 0 && n[1] == 0) {
+        if (n[2] > 0) {
+            rot_mat(0,0) = 1.0;
+            rot_mat(0,1) = 0.0;
+            rot_mat(0,2) = 0.0;
+            rot_mat(1,0) = 0.0;
+            rot_mat(1,1) = 1.0;
+            rot_mat(1,2) = 0.0;
+            rot_mat(2,0) = 0.0;
+            rot_mat(2,1) = 0.0;
+            rot_mat(2,2) = 1.0;
+            return;
+        } else {
+            // rotate by pi about the y-axis
+            rot_mat(0,0) = -1.0;
+            rot_mat(0,1) = 0.0;
+            rot_mat(0,2) = 0.0;
+            rot_mat(1,0) = 0.0;
+            rot_mat(1,1) = 1.0;
+            rot_mat(1,2) = 0.0;
+            rot_mat(2,0) = 0.0;
+            rot_mat(2,1) = 0.0;
+            rot_mat(2,2) = -1.0;
+            return;
+        }
     }
 
     // sqrt (n_1^2 + n_3^2)

--- a/MeshLib/ElementCoordinatesMappingLocal.cpp
+++ b/MeshLib/ElementCoordinatesMappingLocal.cpp
@@ -68,24 +68,23 @@ namespace MeshLib
 
 ElementCoordinatesMappingLocal::ElementCoordinatesMappingLocal(
     const Element& e,
-    const CoordinateSystem &global_coords)
-: _coords(global_coords), _matR2global(3,3)
+        const unsigned global_dim)
+: _global_dim(global_dim), _matR2global(3,3)
 {
-    assert(e.getDimension() <= global_coords.getDimension());
+    assert(e.getDimension() <= global_dim);
     _points.reserve(e.getNumberOfNodes());
     for(unsigned i = 0; i < e.getNumberOfNodes(); i++)
         _points.emplace_back(*(e.getNode(i)));
 
-    auto const element_dimension = e.getDimension();
-    auto const global_dimension = global_coords.getDimension();
+    auto const element_dim = e.getDimension();
 
-    if (global_dimension == element_dimension)
+    if (global_dim == element_dim)
     {
         _matR2global.setIdentity();
         return;
     }
 
-    detail::getRotationMatrixToGlobal(element_dimension, global_dimension, _points, _matR2global);
+    detail::getRotationMatrixToGlobal(element_dim, global_dim, _points, _matR2global);
     detail::rotateToLocal(_matR2global.transpose(), _points);
 }
 

--- a/MeshLib/ElementCoordinatesMappingLocal.h
+++ b/MeshLib/ElementCoordinatesMappingLocal.h
@@ -37,10 +37,10 @@ public:
      * \param e                     Mesh element whose node coordinates are mapped
      * \param global_coord_system   Global coordinate system
      */
-    ElementCoordinatesMappingLocal(const Element &e, const CoordinateSystem &global_coord_system);
+    ElementCoordinatesMappingLocal(const Element &e, const unsigned global_dim);
 
     /// return the global coordinate system
-    const CoordinateSystem getGlobalCoordinateSystem() const { return _coords; }
+    unsigned getGlobalDimension() const { return _global_dim; }
 
     /// return mapped coordinates of the node
     MathLib::Point3d const& getMappedCoordinates(std::size_t node_id) const
@@ -52,7 +52,7 @@ public:
     const RotationMatrix& getRotationMatrixToGlobal() const {return _matR2global;}
 
 private:
-    const CoordinateSystem _coords;
+    const unsigned _global_dim;
     std::vector<MathLib::Point3d> _points;
     RotationMatrix _matR2global;
 };

--- a/MeshLib/ElementCoordinatesMappingLocal.h
+++ b/MeshLib/ElementCoordinatesMappingLocal.h
@@ -10,12 +10,8 @@
 #define ELEMENTCOORDINATESMAPPINGLOCAL_H_
 
 #include <vector>
-
 #include <Eigen/Eigen>
-
 #include "MathLib/Point3d.h"
-
-#include "MeshLib/CoordinateSystem.h"
 
 namespace MeshLib
 {
@@ -34,12 +30,12 @@ class ElementCoordinatesMappingLocal final
 public:
     /**
      * Constructor
-     * \param e                     Mesh element whose node coordinates are mapped
-     * \param global_coord_system   Global coordinate system
+     * \param e          Mesh element whose node coordinates are mapped
+     * \param global_dim Global dimension
      */
     ElementCoordinatesMappingLocal(const Element &e, const unsigned global_dim);
 
-    /// return the global coordinate system
+    /// return the global dimension
     unsigned getGlobalDimension() const { return _global_dim; }
 
     /// return mapped coordinates of the node

--- a/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.cpp
+++ b/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.cpp
@@ -10,14 +10,10 @@
 #include "NaturalCoordinatesMapping.h"
 
 #include <cassert>
-
 #include <logog/include/logog.hpp>
 
 #include "MeshLib/ElementCoordinatesMappingLocal.h"
-#include "MeshLib/CoordinateSystem.h"
-
 #include "MeshLib/Elements/TemplateElement.h"
-
 #include "MeshLib/Elements/HexRule20.h"
 #include "MeshLib/Elements/HexRule8.h"
 #include "MeshLib/Elements/LineRule2.h"
@@ -51,9 +47,9 @@
 #include "NumLib/Fem/ShapeFunction/ShapePrism15.h"
 #include "NumLib/Fem/ShapeFunction/ShapePyra5.h"
 #include "NumLib/Fem/ShapeFunction/ShapePyra13.h"
+#include "NumLib/Fem/ShapeMatrixPolicy.h"
 
 #include "ShapeMatrices.h"
-#include "NumLib/Fem/ShapeMatrixPolicy.h"
 
 namespace NumLib
 {

--- a/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.cpp
+++ b/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.cpp
@@ -129,6 +129,7 @@ computeMappingMatrices(
     shapemat.detJ = shapemat.J.determinant();
 
 #ifndef NDEBUG
+    // TODO make fatal?
     if (shapemat.detJ<=.0)
         ERR("det|J|=%e is not positive.\n", shapemat.detJ);
 #endif
@@ -180,7 +181,7 @@ computeMappingMatrices(
         auto const nnodes(shapemat.dNdr.cols());
         auto const ele_dim(shapemat.dNdr.rows());
         assert(shapemat.dNdr.rows()==ele.getDimension());
-        const unsigned global_dim(ele_local_coord.getGlobalCoordinateSystem().getDimension());
+        const unsigned global_dim = ele_local_coord.getGlobalDimension();
         if (global_dim==ele_dim) {
             shapemat.dNdx.topLeftCorner(ele_dim, nnodes).noalias() = shapemat.invJ * shapemat.dNdr;
         } else {
@@ -226,10 +227,10 @@ template <class T_MESH_ELEMENT,
           ShapeMatrixType T_SHAPE_MATRIX_TYPE>
 void naturalCoordinatesMappingComputeShapeMatrices(const T_MESH_ELEMENT& ele,
                                                    const double* natural_pt,
-                                                   T_SHAPE_MATRICES& shapemat)
+                                                   T_SHAPE_MATRICES& shapemat,
+                                                   const unsigned global_dim)
 {
-    const MeshLib::CoordinateSystem coords(ele);
-    const MeshLib::ElementCoordinatesMappingLocal ele_local_coord(ele, coords);
+    const MeshLib::ElementCoordinatesMappingLocal ele_local_coord(ele, global_dim);
 
     detail::computeMappingMatrices<
         T_MESH_ELEMENT,
@@ -251,7 +252,8 @@ void naturalCoordinatesMappingComputeShapeMatrices(const T_MESH_ELEMENT& ele,
         ShapeMatrixType::WHICHPART>(                             \
         MeshLib::TemplateElement<MeshLib::RULE> const&,          \
         double const*,                                           \
-        SHAPEMATRIXPOLICY<NumLib::SHAPE, DIM>::ShapeMatrices&)
+        SHAPEMATRIXPOLICY<NumLib::SHAPE, DIM>::ShapeMatrices&,   \
+        const unsigned global_dim)
 
 #define OGS_INSTANTIATE_NATURAL_COORDINATES_MAPPING_DYN(RULE, SHAPE) \
     OGS_INSTANTIATE_NATURAL_COORDINATES_MAPPING_PART(                \

--- a/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.h
+++ b/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.h
@@ -52,6 +52,7 @@ struct NaturalCoordinatesMapping
      * @param ele               Mesh element object
      * @param natural_pt        Location in natural coordinates (r,s,t)
      * @param shapemat          Shape matrix data where calculated shape functions are stored
+     * @param global_dim        Global dimension
      */
     static void computeShapeMatrices(const T_MESH_ELEMENT& ele,
                                      const double* natural_pt,
@@ -70,6 +71,7 @@ struct NaturalCoordinatesMapping
      * @param natural_pt            Location in natural coordinates (r,s,t)
      * @param shapemat              Shape matrix data where calculated shape
      * functions are stored
+     * @param global_dim            Global dimension
      */
     template <ShapeMatrixType T_SHAPE_MATRIX_TYPE>
     static void computeShapeMatrices(const T_MESH_ELEMENT& ele,

--- a/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.h
+++ b/NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.h
@@ -28,7 +28,8 @@ template <class T_MESH_ELEMENT,
           ShapeMatrixType T_SHAPE_MATRIX_TYPE>
 void naturalCoordinatesMappingComputeShapeMatrices(const T_MESH_ELEMENT& ele,
                                                    const double* natural_pt,
-                                                   T_SHAPE_MATRICES& shapemat);
+                                                   T_SHAPE_MATRICES& shapemat,
+                                                   const unsigned global_dim);
 }  // namespace detail
 
 /**
@@ -54,9 +55,10 @@ struct NaturalCoordinatesMapping
      */
     static void computeShapeMatrices(const T_MESH_ELEMENT& ele,
                                      const double* natural_pt,
-                                     T_SHAPE_MATRICES& shapemat)
+                                     T_SHAPE_MATRICES& shapemat,
+                                     const unsigned global_dim)
     {
-        computeShapeMatrices<ShapeMatrixType::ALL>(ele, natural_pt, shapemat);
+        computeShapeMatrices<ShapeMatrixType::ALL>(ele, natural_pt, shapemat, global_dim);
     }
 
     /**
@@ -72,13 +74,14 @@ struct NaturalCoordinatesMapping
     template <ShapeMatrixType T_SHAPE_MATRIX_TYPE>
     static void computeShapeMatrices(const T_MESH_ELEMENT& ele,
                                      const double* natural_pt,
-                                     T_SHAPE_MATRICES& shapemat)
+                                     T_SHAPE_MATRICES& shapemat,
+                                     const unsigned global_dim)
     {
         detail::naturalCoordinatesMappingComputeShapeMatrices<
             T_MESH_ELEMENT,
             T_SHAPE_FUNC,
             T_SHAPE_MATRICES,
-            T_SHAPE_MATRIX_TYPE>(ele, natural_pt, shapemat);
+            T_SHAPE_MATRIX_TYPE>(ele, natural_pt, shapemat, global_dim);
     }
 };
 

--- a/NumLib/Fem/FiniteElement/TemplateIsoparametric.h
+++ b/NumLib/Fem/FiniteElement/TemplateIsoparametric.h
@@ -82,6 +82,7 @@ public:
      *
      * @param natural_pt    position in natural coordinates
      * @param shape         evaluated shape function matrices
+     * @param global_dim    global dimension
      */
     void computeShapeFunctions(const double* natural_pt, ShapeMatrices& shape,
                                const unsigned global_dim) const
@@ -96,6 +97,7 @@ public:
      * @tparam T_SHAPE_MATRIX_TYPE  shape matrix types to be calculated
      * @param natural_pt            position in natural coordinates
      * @param shape                 evaluated shape function matrices
+     * @param global_dim            global dimension
      */
     template <ShapeMatrixType T_SHAPE_MATRIX_TYPE>
     void computeShapeFunctions(const double* natural_pt, ShapeMatrices& shape,

--- a/NumLib/Fem/FiniteElement/TemplateIsoparametric.h
+++ b/NumLib/Fem/FiniteElement/TemplateIsoparametric.h
@@ -77,16 +77,17 @@ public:
     {
         this->_ele = &e;
     }
-
     /**
      * compute shape functions
      *
      * @param natural_pt    position in natural coordinates
      * @param shape         evaluated shape function matrices
      */
-    void computeShapeFunctions(const double *natural_pt, ShapeMatrices &shape) const
+    void computeShapeFunctions(const double* natural_pt, ShapeMatrices& shape,
+                               const unsigned global_dim) const
     {
-        NaturalCoordsMappingType::computeShapeMatrices(*_ele, natural_pt, shape);
+        NaturalCoordsMappingType::computeShapeMatrices(*_ele, natural_pt, shape,
+                                                       global_dim);
     }
 
     /**
@@ -97,11 +98,12 @@ public:
      * @param shape                 evaluated shape function matrices
      */
     template <ShapeMatrixType T_SHAPE_MATRIX_TYPE>
-    void computeShapeFunctions(const double *natural_pt, ShapeMatrices &shape) const
+    void computeShapeFunctions(const double* natural_pt, ShapeMatrices& shape,
+                               const unsigned global_dim) const
     {
-        NaturalCoordsMappingType::template computeShapeMatrices<T_SHAPE_MATRIX_TYPE>(*_ele, natural_pt, shape);
+        NaturalCoordsMappingType::template computeShapeMatrices<
+            T_SHAPE_MATRIX_TYPE>(*_ele, natural_pt, shape, global_dim);
     }
-
 
 private:
     const MeshElementType* _ele;

--- a/ProcessLib/NeumannBcAssembler.h
+++ b/ProcessLib/NeumannBcAssembler.h
@@ -66,7 +66,7 @@ public:
                                          ShapeFunction::NPOINTS);
             fe.computeShapeFunctions(
                     integration_method.getWeightedPoint(ip).getCoords(),
-                    _shape_matrices[ip]);
+                    _shape_matrices[ip], GlobalDim);
         }
 
         _neumann_bc_value = value_lookup(e);

--- a/ProcessLib/Utils/InitShapeMatrices.h
+++ b/ProcessLib/Utils/InitShapeMatrices.h
@@ -40,7 +40,7 @@ initShapeMatrices(MeshLib::Element const& e, unsigned integration_order)
                                      ShapeFunction::NPOINTS);
         fe.computeShapeFunctions(
                 integration_method.getWeightedPoint(ip).getCoords(),
-                shape_matrices[ip]);
+                shape_matrices[ip], GlobalDim);
     }
 
     return shape_matrices;

--- a/Tests/MathLib/TestIntegration.cpp
+++ b/Tests/MathLib/TestIntegration.cpp
@@ -36,11 +36,15 @@ TEST(MathLib, IntegrationGaussLegendre)
     EXPECT_NEAR(2./3, MathLib::WeightedSum<MathLib::GaussLegendre<4>>::add(square),
             eps);
 
-    auto const& cube = [](double const x){ return x*x*x; };
-    EXPECT_EQ(0.0, MathLib::WeightedSum<MathLib::GaussLegendre<1>>::add(cube));
-    EXPECT_EQ(0.0, MathLib::WeightedSum<MathLib::GaussLegendre<2>>::add(cube));
-    EXPECT_EQ(0.0, MathLib::WeightedSum<MathLib::GaussLegendre<3>>::add(cube));
-    EXPECT_EQ(0.0, MathLib::WeightedSum<MathLib::GaussLegendre<4>>::add(cube));
+    auto const& cube = [](double const x) { return x * x * x; };
+    EXPECT_NEAR(0.0, MathLib::WeightedSum<MathLib::GaussLegendre<1>>::add(cube),
+                eps);
+    EXPECT_NEAR(0.0, MathLib::WeightedSum<MathLib::GaussLegendre<2>>::add(cube),
+                eps);
+    EXPECT_NEAR(0.0, MathLib::WeightedSum<MathLib::GaussLegendre<3>>::add(cube),
+                eps);
+    EXPECT_NEAR(0.0, MathLib::WeightedSum<MathLib::GaussLegendre<4>>::add(cube),
+                eps);
 }
 
 

--- a/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
+++ b/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
@@ -19,13 +19,14 @@
 #include "GeoLib/AnalyticalGeometry.h"
 #include "MathLib/LinAlg/Dense/DenseMatrix.h"
 
+#include "MeshLib/CoordinateSystem.h"
 #include "MeshLib/Node.h"
 #include "MeshLib/Elements/Element.h"
 #include "MeshLib/Elements/Line.h"
 #include "MeshLib/Elements/Quad.h"
 #include "MeshLib/ElementCoordinatesMappingLocal.h"
 
-#include "../TestTools.h"
+#include "Tests/TestTools.h"
 
 
 namespace

--- a/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
+++ b/Tests/MeshLib/TestCoordinatesMappingLocal.cpp
@@ -153,7 +153,9 @@ void debugOutput(MeshLib::Element *ele, MeshLib::ElementCoordinatesMappingLocal 
 TEST(MeshLib, CoordinatesMappingLocalLowerDimLineY)
 {
     auto ele = TestLine2::createY();
-    MeshLib::ElementCoordinatesMappingLocal mapping(*ele, MeshLib::CoordinateSystem(MeshLib::CoordinateSystemType::Y));
+    MeshLib::ElementCoordinatesMappingLocal mapping(
+        *ele, MeshLib::CoordinateSystem(MeshLib::CoordinateSystemType::Y)
+                  .getDimension());
     auto matR(mapping.getRotationMatrixToGlobal());
     //debugOutput(ele, mapping);
 
@@ -171,8 +173,10 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimLineY)
 TEST(MeshLib, CoordinatesMappingLocalLowerDimLineZ)
 {
     auto ele = TestLine2::createZ();
-    MeshLib::ElementCoordinatesMappingLocal mapping(*ele,
-            MeshLib::CoordinateSystem(MeshLib::CoordinateSystemType::Z));
+    MeshLib::ElementCoordinatesMappingLocal mapping(
+        *ele,
+        MeshLib::CoordinateSystem(MeshLib::CoordinateSystemType::Z)
+            .getDimension());
     auto matR(mapping.getRotationMatrixToGlobal());
     //debugOutput(ele, mapping);
 
@@ -188,7 +192,8 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimLineZ)
 TEST(MeshLib, CoordinatesMappingLocalLowerDimLineXY)
 {
     auto ele = TestLine2::createXY();
-    MeshLib::ElementCoordinatesMappingLocal mapping(*ele, MeshLib::CoordinateSystem(*ele));
+    MeshLib::ElementCoordinatesMappingLocal mapping(
+        *ele, MeshLib::CoordinateSystem(*ele).getDimension());
     auto matR(mapping.getRotationMatrixToGlobal());
     //debugOutput(ele, mapping);
 
@@ -206,7 +211,8 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimLineXY)
 TEST(MeshLib, CoordinatesMappingLocalLowerDimLineXYZ)
 {
     auto ele = TestLine2::createXYZ();
-    MeshLib::ElementCoordinatesMappingLocal mapping(*ele, MeshLib::CoordinateSystem(*ele));
+    MeshLib::ElementCoordinatesMappingLocal mapping(
+        *ele, MeshLib::CoordinateSystem(*ele).getDimension());
     auto matR(mapping.getRotationMatrixToGlobal());
     //debugOutput(ele, mapping);
 
@@ -224,7 +230,8 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimLineXYZ)
 TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadXZ)
 {
     auto ele = TestQuad4::createXZ();
-    MeshLib::ElementCoordinatesMappingLocal mapping(*ele, MeshLib::CoordinateSystem(*ele));
+    MeshLib::ElementCoordinatesMappingLocal mapping(
+        *ele, MeshLib::CoordinateSystem(*ele).getDimension());
     auto matR(mapping.getRotationMatrixToGlobal());
     //debugOutput(ele, mapping);
 
@@ -244,7 +251,8 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadXZ)
 TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadYZ)
 {
     auto ele = TestQuad4::createYZ();
-    MeshLib::ElementCoordinatesMappingLocal mapping(*ele, MeshLib::CoordinateSystem(*ele));
+    MeshLib::ElementCoordinatesMappingLocal mapping(
+        *ele, MeshLib::CoordinateSystem(*ele).getDimension());
     auto matR(mapping.getRotationMatrixToGlobal());
     //debugOutput(ele, mapping);
 
@@ -264,7 +272,8 @@ TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadYZ)
 TEST(MeshLib, CoordinatesMappingLocalLowerDimQuadXYZ)
 {
     auto ele = TestQuad4::createXYZ();
-    MeshLib::ElementCoordinatesMappingLocal mapping(*ele, MeshLib::CoordinateSystem(*ele));
+    MeshLib::ElementCoordinatesMappingLocal mapping(
+        *ele, MeshLib::CoordinateSystem(*ele).getDimension());
     auto matR(mapping.getRotationMatrixToGlobal());
     //debugOutput(ele, mapping);
 

--- a/Tests/NumLib/TestCoordinatesMapping.cpp
+++ b/Tests/NumLib/TestCoordinatesMapping.cpp
@@ -245,18 +245,9 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckClockwise)
 
     // clockwise node ordering, which is invalid)
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    NaturalCoordsMappingType::computeShapeMatrices(*this->clockwiseEle, this->r, shape, this->global_dim);
-    //std::cout <<  std::setprecision(16) << shape;
-    // Inverse of the Jacobian matrix doesn't exist
-    double exp_invJ[TestFixture::dim*TestFixture::dim]= {0.0};
-    double exp_dNdx[TestFixture::dim*TestFixture::e_nnodes]= {0.0};
 
-    ASSERT_ARRAY_NEAR(this->nat_exp_N, shape.N.data(), shape.N.size(), this->eps);
-    ASSERT_ARRAY_NEAR(this->nat_exp_dNdr, shape.dNdr.data(), shape.dNdr.size(), this->eps);
-    ASSERT_ARRAY_NEAR(this->cl_exp_J, shape.J.data(), shape.J.size(), this->eps);
-    ASSERT_NEAR(this->cl_exp_detJ, shape.detJ, this->eps);
-    ASSERT_ARRAY_NEAR(exp_invJ, shape.invJ.data(), shape.invJ.size(), this->eps);
-    ASSERT_ARRAY_NEAR(exp_dNdx, shape.dNdx.data(), shape.dNdx.size(), this->eps);
+    EXPECT_ANY_THROW(NaturalCoordsMappingType::computeShapeMatrices(
+        *this->clockwiseEle, this->r, shape, this->global_dim));
 }
 
 TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckZeroVolume)
@@ -265,19 +256,9 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckZeroVolume)
     typedef typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
 
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    NaturalCoordsMappingType::computeShapeMatrices(
-        *this->zeroVolumeEle, this->r, shape, this->global_dim);
-    // std::cout <<  std::setprecision(16) << shape;
-    // Inverse of the Jacobian matrix doesn't exist
-    double exp_invJ[TestFixture::dim*TestFixture::dim]= {0.0};
-    double exp_dNdx[TestFixture::dim*TestFixture::e_nnodes]= {0.0};
 
-    ASSERT_ARRAY_NEAR(this->nat_exp_N, shape.N.data(), shape.N.size(), this->eps);
-    ASSERT_ARRAY_NEAR(this->nat_exp_dNdr, shape.dNdr.data(), shape.dNdr.size(), this->eps);
-    ASSERT_ARRAY_NEAR(this->ze_exp_J, shape.J.data(), shape.J.size(), this->eps);
-    ASSERT_NEAR(0.0, shape.detJ, this->eps);
-    ASSERT_ARRAY_NEAR(exp_invJ, shape.invJ.data(), shape.invJ.size(), this->eps);
-    ASSERT_ARRAY_NEAR(exp_dNdx, shape.dNdx.data(), shape.dNdx.size(), this->eps);
+    EXPECT_ANY_THROW(NaturalCoordsMappingType::computeShapeMatrices(
+        *this->zeroVolumeEle, this->r, shape, this->global_dim));
 }
 
 TEST(NumLib, FemNaturalCoordinatesMappingLineY)

--- a/Tests/NumLib/TestCoordinatesMapping.cpp
+++ b/Tests/NumLib/TestCoordinatesMapping.cpp
@@ -62,7 +62,7 @@ public:
 
 public:
     NumLibFemNaturalCoordinatesMappingTest()
-    : eps(std::numeric_limits<double>::epsilon())
+    : eps(2*std::numeric_limits<double>::epsilon())
     {
         // create four elements used for testing
         naturalEle   = this->createNaturalShape();
@@ -106,7 +106,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_N)
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
 
     //only N
-    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::N>(*this->naturalEle, this->r, shape);
+    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::N>(*this->naturalEle, this->r, shape, this->dim); // TODO check dim
     ASSERT_FALSE(shape.N.isZero());
     ASSERT_TRUE(shape.dNdr.isZero());
     ASSERT_TRUE(shape.J.isZero());
@@ -122,7 +122,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_DNDR)
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
 
     // dNdr
-    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::DNDR>(*this->naturalEle, this->r, shape);
+    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::DNDR>(*this->naturalEle, this->r, shape, this->dim); // TODO check dim
     ASSERT_TRUE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_TRUE(shape.J.isZero());
@@ -139,7 +139,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_N_J)
 
     // N_J
     shape.setZero();
-    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::N_J>(*this->naturalEle, this->r, shape);
+    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::N_J>(*this->naturalEle, this->r, shape, this->dim); // TODO check dim
     ASSERT_FALSE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_FALSE(shape.J.isZero());
@@ -155,7 +155,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_DNDR_
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
 
     // dNdr, J
-    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::DNDR_J>(*this->naturalEle, this->r, shape);
+    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::DNDR_J>(*this->naturalEle, this->r, shape, this->dim); // TODO check dim
     ASSERT_TRUE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_FALSE(shape.J.isZero());
@@ -172,7 +172,9 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_DNDX)
 
     // DNDX
     shape.setZero();
-    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::DNDX>(*this->naturalEle, this->r, shape);
+    NaturalCoordsMappingType::template computeShapeMatrices<
+        ShapeMatrixType::DNDX>(*this->naturalEle, this->r, shape,
+                               this->dim);  // TODO check dim
     ASSERT_TRUE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_FALSE(shape.J.isZero());
@@ -189,7 +191,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_ALL)
 
     // ALL
     shape.setZero();
-    NaturalCoordsMappingType::computeShapeMatrices(*this->naturalEle, this->r, shape);
+    NaturalCoordsMappingType::computeShapeMatrices(*this->naturalEle, this->r, shape, this->dim); // TODO check dim
     ASSERT_FALSE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_FALSE(shape.J.isZero());
@@ -205,7 +207,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckNaturalShape)
 
     // identical to natural coordinates
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    NaturalCoordsMappingType::computeShapeMatrices(*this->naturalEle, this->r, shape);
+    NaturalCoordsMappingType::computeShapeMatrices(*this->naturalEle, this->r, shape, this->dim); // TODO check dim
     double exp_J[TestFixture::dim*TestFixture::dim]= {0.0};
     for (unsigned i=0; i<this->dim; i++)
         exp_J[i+this->dim*i] = 1.0;
@@ -225,7 +227,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckIrregularShape)
 
     // irregular shape
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    NaturalCoordsMappingType::computeShapeMatrices(*this->irregularEle, this->r, shape);
+    NaturalCoordsMappingType::computeShapeMatrices(*this->irregularEle, this->r, shape, this->dim); // TODO check dim
     //std::cout <<  std::setprecision(16) << shape;
 
     ASSERT_ARRAY_NEAR(this->nat_exp_N, shape.N.data(), shape.N.size(), this->eps);
@@ -243,7 +245,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckClockwise)
 
     // clockwise node ordering, which is invalid)
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    NaturalCoordsMappingType::computeShapeMatrices(*this->clockwiseEle, this->r, shape);
+    NaturalCoordsMappingType::computeShapeMatrices(*this->clockwiseEle, this->r, shape, this->dim); // TODO check dim
     //std::cout <<  std::setprecision(16) << shape;
     // Inverse of the Jacobian matrix doesn't exist
     double exp_invJ[TestFixture::dim*TestFixture::dim]= {0.0};
@@ -263,8 +265,9 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckZeroVolume)
     typedef typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
 
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    NaturalCoordsMappingType::computeShapeMatrices(*this->zeroVolumeEle, this->r, shape);
-    //std::cout <<  std::setprecision(16) << shape;
+    NaturalCoordsMappingType::computeShapeMatrices(
+        *this->zeroVolumeEle, this->r, shape, this->dim);  // TODO check dim
+    // std::cout <<  std::setprecision(16) << shape;
     // Inverse of the Jacobian matrix doesn't exist
     double exp_invJ[TestFixture::dim*TestFixture::dim]= {0.0};
     double exp_dNdx[TestFixture::dim*TestFixture::e_nnodes]= {0.0};
@@ -291,7 +294,7 @@ TEST(NumLib, FemNaturalCoordinatesMappingLineY)
     static const unsigned dim = 1;
     static const unsigned e_nnodes = 2;
     ShapeMatricesType shape(dim, 2, e_nnodes);
-    MappingType::computeShapeMatrices(*line, r, shape);
+    MappingType::computeShapeMatrices(*line, r, shape, 2);
 
     double exp_J[dim*dim]= {0.0};
     for (unsigned i=0; i<dim; i++)

--- a/Tests/NumLib/TestCoordinatesMapping.cpp
+++ b/Tests/NumLib/TestCoordinatesMapping.cpp
@@ -106,7 +106,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_N)
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
 
     //only N
-    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::N>(*this->naturalEle, this->r, shape, this->dim); // TODO check dim
+    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::N>(*this->naturalEle, this->r, shape, this->global_dim);
     ASSERT_FALSE(shape.N.isZero());
     ASSERT_TRUE(shape.dNdr.isZero());
     ASSERT_TRUE(shape.J.isZero());
@@ -122,7 +122,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_DNDR)
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
 
     // dNdr
-    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::DNDR>(*this->naturalEle, this->r, shape, this->dim); // TODO check dim
+    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::DNDR>(*this->naturalEle, this->r, shape, this->global_dim);
     ASSERT_TRUE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_TRUE(shape.J.isZero());
@@ -139,7 +139,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_N_J)
 
     // N_J
     shape.setZero();
-    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::N_J>(*this->naturalEle, this->r, shape, this->dim); // TODO check dim
+    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::N_J>(*this->naturalEle, this->r, shape, this->global_dim);
     ASSERT_FALSE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_FALSE(shape.J.isZero());
@@ -155,7 +155,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_DNDR_
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
 
     // dNdr, J
-    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::DNDR_J>(*this->naturalEle, this->r, shape, this->dim); // TODO check dim
+    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::DNDR_J>(*this->naturalEle, this->r, shape, this->global_dim);
     ASSERT_TRUE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_FALSE(shape.J.isZero());
@@ -174,7 +174,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_DNDX)
     shape.setZero();
     NaturalCoordsMappingType::template computeShapeMatrices<
         ShapeMatrixType::DNDX>(*this->naturalEle, this->r, shape,
-                               this->dim);  // TODO check dim
+                               this->dim);
     ASSERT_TRUE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_FALSE(shape.J.isZero());
@@ -191,7 +191,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_ALL)
 
     // ALL
     shape.setZero();
-    NaturalCoordsMappingType::computeShapeMatrices(*this->naturalEle, this->r, shape, this->dim); // TODO check dim
+    NaturalCoordsMappingType::computeShapeMatrices(*this->naturalEle, this->r, shape, this->global_dim);
     ASSERT_FALSE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_FALSE(shape.J.isZero());
@@ -207,7 +207,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckNaturalShape)
 
     // identical to natural coordinates
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    NaturalCoordsMappingType::computeShapeMatrices(*this->naturalEle, this->r, shape, this->dim); // TODO check dim
+    NaturalCoordsMappingType::computeShapeMatrices(*this->naturalEle, this->r, shape, this->global_dim);
     double exp_J[TestFixture::dim*TestFixture::dim]= {0.0};
     for (unsigned i=0; i<this->dim; i++)
         exp_J[i+this->dim*i] = 1.0;
@@ -227,7 +227,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckIrregularShape)
 
     // irregular shape
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    NaturalCoordsMappingType::computeShapeMatrices(*this->irregularEle, this->r, shape, this->dim); // TODO check dim
+    NaturalCoordsMappingType::computeShapeMatrices(*this->irregularEle, this->r, shape, this->global_dim);
     //std::cout <<  std::setprecision(16) << shape;
 
     ASSERT_ARRAY_NEAR(this->nat_exp_N, shape.N.data(), shape.N.size(), this->eps);
@@ -245,7 +245,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckClockwise)
 
     // clockwise node ordering, which is invalid)
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    NaturalCoordsMappingType::computeShapeMatrices(*this->clockwiseEle, this->r, shape, this->dim); // TODO check dim
+    NaturalCoordsMappingType::computeShapeMatrices(*this->clockwiseEle, this->r, shape, this->global_dim);
     //std::cout <<  std::setprecision(16) << shape;
     // Inverse of the Jacobian matrix doesn't exist
     double exp_invJ[TestFixture::dim*TestFixture::dim]= {0.0};
@@ -266,7 +266,7 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckZeroVolume)
 
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
     NaturalCoordsMappingType::computeShapeMatrices(
-        *this->zeroVolumeEle, this->r, shape, this->dim);  // TODO check dim
+        *this->zeroVolumeEle, this->r, shape, this->global_dim);
     // std::cout <<  std::setprecision(16) << shape;
     // Inverse of the Jacobian matrix doesn't exist
     double exp_invJ[TestFixture::dim*TestFixture::dim]= {0.0};

--- a/Tests/NumLib/TestFunctionInterpolation.cpp
+++ b/Tests/NumLib/TestFunctionInterpolation.cpp
@@ -71,7 +71,7 @@ TEST(NumLibFunctionInterpolationTest, Linear1DElement)
 
     finite_element.computeShapeFunctions(
             integration_method.getWeightedPoint(0).getCoords(),
-            shape_matrix);
+            shape_matrix, ShapeFunction::DIM); // TODO check DIM
     ASSERT_EQ(2, shape_matrix.N.size());
 
     // actual test

--- a/Tests/NumLib/TestFunctionInterpolation.cpp
+++ b/Tests/NumLib/TestFunctionInterpolation.cpp
@@ -71,7 +71,7 @@ TEST(NumLibFunctionInterpolationTest, Linear1DElement)
 
     finite_element.computeShapeFunctions(
             integration_method.getWeightedPoint(0).getCoords(),
-            shape_matrix, ShapeFunction::DIM); // TODO check DIM
+            shape_matrix, ShapeFunction::DIM);
     ASSERT_EQ(2, shape_matrix.N.size());
 
     // actual test


### PR DESCRIPTION
In our shape matrix computation routines there was some code detecting the special case when a 2D element lies in the x-y plane. This code led to Neumann BCs being added sign-flipped if the surface at which it was applied was in the x-y-plane with surface normal (0, 0, -1).

This PR fixes the special cases in the code. A small end-to-end test example has been added. Cf. image: Groundwaterflow process; upper row before the PR, lower row after the PR; one surface is kept at Dirichlet 1, the other has Neumann 1, i.e., the point at which the Neumann BC is applied must be the maximum over the entire z-axis; that did not always hold before this PR (upper right case).

![fixed-surface-orientation](https://cloud.githubusercontent.com/assets/10530151/16909336/675267aa-4cd2-11e6-8a55-abe2f2963c47.png)

Furthermore the det J > 0 check has been made strict in this PR. I.e., elements with zero volume or wrong orientation are disallowed now.