### PR TITLE
Fix pvtu name

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -168,9 +168,9 @@ else()
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
-        quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1.000000_0.vtu pressure pressure
-        quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1.000000_1.vtu pressure pressure
-        quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1.000000_2.vtu pressure pressure
+        quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_0.vtu pressure pressure
+        quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_1.vtu pressure pressure
+        quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_2.vtu pressure pressure
     )
 
     AddTest(
@@ -182,9 +182,9 @@ else()
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
-        cube_1e3_pcs_0_ts_1_t_1.000000_0.vtu pressure pressure
-        cube_1e3_pcs_0_ts_1_t_1.000000_1.vtu pressure pressure
-        cube_1e3_pcs_0_ts_1_t_1.000000_2.vtu pressure pressure
+        cube_1e3_pcs_0_ts_1_t_1_000000_0.vtu pressure pressure
+        cube_1e3_pcs_0_ts_1_t_1_000000_1.vtu pressure pressure
+        cube_1e3_pcs_0_ts_1_t_1_000000_2.vtu pressure pressure
     )
 
     AddTest(
@@ -196,9 +196,9 @@ else()
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
-        cube_1e3_neumann_pcs_0_ts_1_t_1.000000_0.vtu pressure pressure
-        cube_1e3_neumann_pcs_0_ts_1_t_1.000000_1.vtu pressure pressure
-        cube_1e3_neumann_pcs_0_ts_1_t_1.000000_2.vtu pressure pressure
+        cube_1e3_neumann_pcs_0_ts_1_t_1_000000_0.vtu pressure pressure
+        cube_1e3_neumann_pcs_0_ts_1_t_1_000000_1.vtu pressure pressure
+        cube_1e3_neumann_pcs_0_ts_1_t_1_000000_2.vtu pressure pressure
     )
 
     # Single core
@@ -212,7 +212,7 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-15 RELTOL 1e-15
-            DIFF_DATA cube_${mesh_size}_pcs_0_ts_1_t_1_0.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA cube_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -223,7 +223,7 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-1 RELTOL 1e-1
-            DIFF_DATA cube_${mesh_size}_neumann_pcs_0_ts_1_t_1_0.vtu D1_left_front_N1_right pressure
+            DIFF_DATA cube_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_front_N1_right pressure
         )
     endforeach()
 
@@ -237,7 +237,7 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-7 RELTOL 1e-7
-            DIFF_DATA cube_${mesh_size}_pcs_0_ts_1_t_1_0.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA cube_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -248,7 +248,7 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-2 RELTOL 1e-2
-            DIFF_DATA cube_${mesh_size}_neumann_pcs_0_ts_1_t_1_0.vtu D1_left_front_N1_right pressure
+            DIFF_DATA cube_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_front_N1_right pressure
         )
     endforeach()
 
@@ -262,7 +262,7 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-13 RELTOL 1e-13
-            DIFF_DATA square_${mesh_size}_pcs_0_ts_1_t_1_0.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA square_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -273,7 +273,7 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-1 RELTOL 1e-1
-            DIFF_DATA square_${mesh_size}_neumann_pcs_0_ts_1_t_1_0.vtu D1_left_bottom_N1_right pressure
+            DIFF_DATA square_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_bottom_N1_right pressure
         )
     endforeach()
 
@@ -286,7 +286,7 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-7 RELTOL 1e-7
-            DIFF_DATA square_${mesh_size}_pcs_0_ts_1_t_1_0.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA square_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -297,7 +297,7 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-02 RELTOL 1e-02
-            DIFF_DATA square_${mesh_size}_neumann_pcs_0_ts_1_t_1_0.vtu D1_left_bottom_N1_right pressure
+            DIFF_DATA square_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_bottom_N1_right pressure
         )
     endforeach()
 
@@ -311,7 +311,7 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-15 RELTOL 1e-15
-            DIFF_DATA line_${mesh_size}_pcs_0_ts_1_t_1_0.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA line_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -322,7 +322,7 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-14 RELTOL 1e-14
-            DIFF_DATA line_${mesh_size}_neumann_pcs_0_ts_1_t_1_0.vtu D1_left_N1_right pressure
+            DIFF_DATA line_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_N1_right pressure
         )
         endforeach()
 
@@ -335,9 +335,9 @@ else()
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
-        tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000_0.vtu pressure pressure
-        tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000_0.vtu temperature temperature
-        tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000_0.vtu v_mass_frac v_mass_frac
+        tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu pressure pressure
+        tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu temperature temperature
+        tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu v_mass_frac v_mass_frac
 #        tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000_0.vtu solid_density solid_density
     )
 
@@ -350,9 +350,9 @@ else()
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000_0.vtu pressure pressure
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000_0.vtu temperature temperature
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000_0.vtu v_mass_frac v_mass_frac
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu pressure pressure
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu temperature temperature
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu v_mass_frac v_mass_frac
 #        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_0.vtu solid_density solid_density
     )
 endif()

--- a/MeshLib/IO/VtkIO/VtuInterface.cpp
+++ b/MeshLib/IO/VtkIO/VtuInterface.cpp
@@ -77,7 +77,10 @@ bool VtuInterface::writeToFile(std::string const &file_name)
     // and PETSC_COMM_WORLD should be replaced with the argument.
     int mpi_rank;
     MPI_Comm_rank(PETSC_COMM_WORLD, &mpi_rank);
-    const std::string file_name_base = boost::erase_last_copy(file_name, ".vtu");
+    std::string file_name_base = boost::erase_last_copy(file_name, ".vtu");
+
+    // Since the pvtu writing function drops all letters from the letter of '.'.
+    std::replace(file_name_base.begin(), file_name_base.end(), '.', '_');
 
     const std::string file_name_rank = file_name_base + "_"
                                        + std::to_string(mpi_rank) + ".vtu";


### PR DESCRIPTION
Since SetFileName of ``vtkSmartPointer<UnstructuredGridWriter>`` drops characters starting from '.' in a string, the previous changes in the output file names cause a problem in writing a correct pvtu file. This PR fixes the problem, meanwhile it removes some compilation warnings. 