### PR TITLE
Fix AddTest

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -13,7 +13,8 @@ if(NOT OGS_USE_MPI)
             WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-15 RELTOL 1e-15
-            DIFF_DATA cube_${mesh_size}_pcs_0_ts_1_t_1.000000.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA
+            cube_1x1x1_hex_${mesh_size}.vtu cube_${mesh_size}_pcs_0_ts_1_t_1.000000.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -24,7 +25,8 @@ if(NOT OGS_USE_MPI)
             WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-1 RELTOL 1e-1
-            DIFF_DATA cube_${mesh_size}_neumann_pcs_0_ts_1_t_1.000000.vtu D1_left_front_N1_right pressure
+            DIFF_DATA
+            cube_1x1x1_hex_${mesh_size}.vtu cube_${mesh_size}_neumann_pcs_0_ts_1_t_1.000000.vtu D1_left_front_N1_right pressure
         )
     endforeach()
 
@@ -37,7 +39,8 @@ if(NOT OGS_USE_MPI)
             WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-13 RELTOL 1e-13
-            DIFF_DATA cube_${mesh_size}_pcs_0_ts_1_t_1.000000.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA
+            cube_1x1x1_hex_${mesh_size}.vtu cube_${mesh_size}_pcs_0_ts_1_t_1.000000.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -48,7 +51,8 @@ if(NOT OGS_USE_MPI)
             WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-2 RELTOL 1e-2
-            DIFF_DATA cube_${mesh_size}_neumann_pcs_0_ts_1_t_1.000000.vtu D1_left_front_N1_right pressure
+            DIFF_DATA
+            cube_1x1x1_hex_${mesh_size}.vtu cube_${mesh_size}_neumann_pcs_0_ts_1_t_1.000000.vtu D1_left_front_N1_right pressure
         )
     endforeach()
 
@@ -62,7 +66,8 @@ if(NOT OGS_USE_MPI)
             WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-13 RELTOL 1e-13
-            DIFF_DATA square_${mesh_size}_pcs_0_ts_1_t_1.000000.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA
+            square_1x1_quad_${mesh_size}.vtu square_${mesh_size}_pcs_0_ts_1_t_1.000000.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -73,7 +78,8 @@ if(NOT OGS_USE_MPI)
             WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-1 RELTOL 1e-1
-            DIFF_DATA square_${mesh_size}_neumann_pcs_0_ts_1_t_1.000000.vtu D1_left_bottom_N1_right pressure
+            DIFF_DATA
+            square_1x1_quad_${mesh_size}.vtu square_${mesh_size}_neumann_pcs_0_ts_1_t_1.000000.vtu D1_left_bottom_N1_right pressure
         )
     endforeach()
 
@@ -86,7 +92,8 @@ if(NOT OGS_USE_MPI)
             WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-12 RELTOL 1e-16
-            DIFF_DATA square_${mesh_size}_pcs_0_ts_1_t_1.000000.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA
+            square_1x1_quad_${mesh_size}.vtu square_${mesh_size}_pcs_0_ts_1_t_1.000000.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -97,7 +104,8 @@ if(NOT OGS_USE_MPI)
             WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-02 RELTOL 1e-02
-            DIFF_DATA square_${mesh_size}_neumann_pcs_0_ts_1_t_1.000000.vtu D1_left_bottom_N1_right pressure
+            DIFF_DATA
+            square_1x1_quad_${mesh_size}.vtu square_${mesh_size}_neumann_pcs_0_ts_1_t_1.000000.vtu D1_left_bottom_N1_right pressure
         )
     endforeach()
 
@@ -111,7 +119,8 @@ if(NOT OGS_USE_MPI)
             WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-15 RELTOL 1e-15
-            DIFF_DATA line_${mesh_size}_pcs_0_ts_1_t_1.000000.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA
+            line_1_line_${mesh_size}.vtu line_${mesh_size}_pcs_0_ts_1_t_1.000000.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -122,9 +131,10 @@ if(NOT OGS_USE_MPI)
             WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-14 RELTOL 1e-14
-            DIFF_DATA line_${mesh_size}_neumann_pcs_0_ts_1_t_1.000000.vtu D1_left_N1_right pressure
+            DIFF_DATA
+            line_1_line_${mesh_size}.vtu line_${mesh_size}_neumann_pcs_0_ts_1_t_1.000000.vtu D1_left_N1_right pressure
         )
-    endforeach()
+        endforeach()
 
     # Some Neumann BC tests
     AddTest(
@@ -135,7 +145,8 @@ if(NOT OGS_USE_MPI)
         WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
-        DIFF_DATA cube_1e3_top_neumann_pcs_0_ts_1_t_1.000000.vtu pressure pressure
+        DIFF_DATA
+        cube_1e3_bottom_neumann_pcs_0_ts_1_t_1.000000.vtu cube_1e3_top_neumann_pcs_0_ts_1_t_1.000000.vtu pressure pressure
     )
     AddTest(
         NAME GroundWaterFlowProcess_cube_bottom
@@ -145,7 +156,8 @@ if(NOT OGS_USE_MPI)
         WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
-        DIFF_DATA cube_1e3_bottom_neumann_pcs_0_ts_1_t_1.000000.vtu pressure pressure
+        DIFF_DATA
+        cube_1e3_bottom_neumann_pcs_0_ts_1_t_1.000000.vtu cube_1e3_bottom_neumann_pcs_0_ts_1_t_1.000000.vtu pressure pressure
     )
 
     # TES tests
@@ -158,10 +170,11 @@ if(NOT OGS_USE_MPI)
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
-        tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu pressure pressure
-        tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu temperature temperature
-        tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu v_mass_frac v_mass_frac
-        tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu solid_density solid_density
+        tes_zeolite_discharge_small_ts_19_t_0.100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu pressure pressure
+        tes_zeolite_discharge_small_ts_19_t_0.100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu temperature temperature
+        tes_zeolite_discharge_small_ts_19_t_0.100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu vapour_partial_pressure vapour_partial_pressure
+        tes_zeolite_discharge_small_ts_19_t_0.100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu solid_density solid_density
+        tes_zeolite_discharge_small_ts_19_t_0.100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu solid_density fct_solid_density
     )
 
     AddTest(
@@ -173,10 +186,11 @@ if(NOT OGS_USE_MPI)
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu pressure pressure
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu temperature temperature
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu v_mass_frac v_mass_frac
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu solid_density solid_density
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu tes_zeolite_discharge_large_pcs_0_ts_25_t_1.000000.vtu pressure pressure
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu tes_zeolite_discharge_large_pcs_0_ts_25_t_1.000000.vtu temperature temperature
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu tes_zeolite_discharge_large_pcs_0_ts_25_t_1.000000.vtu vapour_partial_pressure vapour_partial_pressure
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu tes_zeolite_discharge_large_pcs_0_ts_25_t_1.000000.vtu solid_density solid_density
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu tes_zeolite_discharge_large_pcs_0_ts_25_t_1.000000.vtu solid_density fct_solid_density
     )
 
 else()
@@ -190,9 +204,9 @@ else()
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
-        quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_0.vtu pressure pressure
-        quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_1.vtu pressure pressure
-        quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_2.vtu pressure pressure
+        quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_0.vtu quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_0.vtu pressure pressure
+        quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_1.vtu quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_1.vtu pressure pressure
+        quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_2.vtu quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_2.vtu pressure pressure
     )
 
     AddTest(
@@ -204,9 +218,9 @@ else()
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
-        cube_1e3_pcs_0_ts_1_t_1_000000_0.vtu pressure pressure
-        cube_1e3_pcs_0_ts_1_t_1_000000_1.vtu pressure pressure
-        cube_1e3_pcs_0_ts_1_t_1_000000_2.vtu pressure pressure
+        cube_1e3_pcs_0_ts_1_t_1_000000_0.vtu cube_1e3_pcs_0_ts_1_t_1_000000_0.vtu pressure pressure
+        cube_1e3_pcs_0_ts_1_t_1_000000_1.vtu cube_1e3_pcs_0_ts_1_t_1_000000_1.vtu pressure pressure
+        cube_1e3_pcs_0_ts_1_t_1_000000_2.vtu cube_1e3_pcs_0_ts_1_t_1_000000_2.vtu pressure pressure
     )
 
     AddTest(
@@ -218,9 +232,9 @@ else()
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
-        cube_1e3_neumann_pcs_0_ts_1_t_1_000000_0.vtu pressure pressure
-        cube_1e3_neumann_pcs_0_ts_1_t_1_000000_1.vtu pressure pressure
-        cube_1e3_neumann_pcs_0_ts_1_t_1_000000_2.vtu pressure pressure
+        cube_1e3_neumann_pcs_0_ts_1_t_1_000000_0.vtu cube_1e3_neumann_pcs_0_ts_1_t_1_000000_0.vtu pressure pressure
+        cube_1e3_neumann_pcs_0_ts_1_t_1_000000_1.vtu cube_1e3_neumann_pcs_0_ts_1_t_1_000000_1.vtu pressure pressure
+        cube_1e3_neumann_pcs_0_ts_1_t_1_000000_2.vtu cube_1e3_neumann_pcs_0_ts_1_t_1_000000_2.vtu pressure pressure
     )
 
     # Single core
@@ -234,7 +248,8 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-15 RELTOL 1e-15
-            DIFF_DATA cube_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA
+            cube_1x1x1_hex_${mesh_size}.vtu cube_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -245,7 +260,8 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-1 RELTOL 1e-1
-            DIFF_DATA cube_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_front_N1_right pressure
+            DIFF_DATA
+            cube_1x1x1_hex_${mesh_size}.vtu cube_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_front_N1_right pressure
         )
     endforeach()
 
@@ -259,7 +275,8 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-7 RELTOL 1e-7
-            DIFF_DATA cube_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA
+            cube_1x1x1_hex_${mesh_size}.vtu cube_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -270,7 +287,8 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-2 RELTOL 1e-2
-            DIFF_DATA cube_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_front_N1_right pressure
+            DIFF_DATA
+            cube_1x1x1_hex_${mesh_size}.vtu cube_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_front_N1_right pressure
         )
     endforeach()
 
@@ -284,7 +302,8 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-13 RELTOL 1e-13
-            DIFF_DATA square_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA
+            square_1x1_quad_${mesh_size}.vtu square_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -295,7 +314,8 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-1 RELTOL 1e-1
-            DIFF_DATA square_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_bottom_N1_right pressure
+            DIFF_DATA
+            square_1x1_quad_${mesh_size}.vtu square_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_bottom_N1_right pressure
         )
     endforeach()
 
@@ -308,7 +328,8 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-7 RELTOL 1e-7
-            DIFF_DATA square_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA
+            square_1x1_quad_${mesh_size}.vtu square_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -319,7 +340,8 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-02 RELTOL 1e-02
-            DIFF_DATA square_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_bottom_N1_right pressure
+            DIFF_DATA
+            square_1x1_quad_${mesh_size}.vtu square_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_bottom_N1_right pressure
         )
     endforeach()
 
@@ -333,7 +355,8 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-15 RELTOL 1e-15
-            DIFF_DATA line_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
+            DIFF_DATA
+            line_1_line_${mesh_size}.vtu line_${mesh_size}_pcs_0_ts_1_t_1_000000_0.vtu Linear_1_to_minus1 pressure
         )
 
         AddTest(
@@ -344,7 +367,8 @@ else()
             WRAPPER_ARGS -np 1
             TESTER vtkdiff
             ABSTOL 1e-14 RELTOL 1e-14
-            DIFF_DATA line_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_N1_right pressure
+            DIFF_DATA
+            line_1_line_${mesh_size}.vtu line_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_N1_right pressure
         )
         endforeach()
 
@@ -357,9 +381,9 @@ else()
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
-        tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu pressure pressure
-        tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu temperature temperature
-        tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu v_mass_frac v_mass_frac
+        tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu pressure pressure
+        tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu temperature temperature
+        tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu v_mass_frac v_mass_frac
 #        tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000_0.vtu solid_density solid_density
     )
 
@@ -372,9 +396,9 @@ else()
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu pressure pressure
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu temperature temperature
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu v_mass_frac v_mass_frac
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu pressure pressure
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu temperature temperature
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu v_mass_frac v_mass_frac
 #        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_0.vtu solid_density solid_density
     )
 endif()

--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -134,7 +134,7 @@ if(NOT OGS_USE_MPI)
             DIFF_DATA
             line_1_line_${mesh_size}.vtu line_${mesh_size}_neumann_pcs_0_ts_1_t_1.000000.vtu D1_left_N1_right pressure
         )
-        endforeach()
+    endforeach()
 
     # Some Neumann BC tests
     AddTest(
@@ -144,9 +144,9 @@ if(NOT OGS_USE_MPI)
         EXECUTABLE_ARGS cube_1e3_top_neumann.prj
         WRAPPER time
         TESTER vtkdiff
-        ABSTOL 1e-16 RELTOL 1e-16
+        ABSTOL 1e-14 RELTOL 1e-14
         DIFF_DATA
-        cube_1e3_bottom_neumann_pcs_0_ts_1_t_1.000000.vtu cube_1e3_top_neumann_pcs_0_ts_1_t_1.000000.vtu pressure pressure
+        cube_1e3_top_neumann_pcs_0_ts_1_t_1.000000.vtu cube_1e3_top_neumann_pcs_0_ts_1_t_1.000000.vtu pressure pressure
     )
     AddTest(
         NAME GroundWaterFlowProcess_cube_bottom
@@ -155,7 +155,7 @@ if(NOT OGS_USE_MPI)
         EXECUTABLE_ARGS cube_1e3_bottom_neumann.prj
         WRAPPER time
         TESTER vtkdiff
-        ABSTOL 1e-16 RELTOL 1e-16
+        ABSTOL 1e-14 RELTOL 1e-14
         DIFF_DATA
         cube_1e3_bottom_neumann_pcs_0_ts_1_t_1.000000.vtu cube_1e3_bottom_neumann_pcs_0_ts_1_t_1.000000.vtu pressure pressure
     )
@@ -168,13 +168,12 @@ if(NOT OGS_USE_MPI)
         EXECUTABLE_ARGS tes-1D-zeolite-discharge-small.prj
         WRAPPER time
         TESTER vtkdiff
-        ABSTOL 1e-16 RELTOL 1e-16
+        ABSTOL 1e-7 RELTOL 1e-12
         DIFF_DATA
-        tes_zeolite_discharge_small_ts_19_t_0.100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu pressure pressure
-        tes_zeolite_discharge_small_ts_19_t_0.100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu temperature temperature
-        tes_zeolite_discharge_small_ts_19_t_0.100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu vapour_partial_pressure vapour_partial_pressure
-        tes_zeolite_discharge_small_ts_19_t_0.100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu solid_density solid_density
-        tes_zeolite_discharge_small_ts_19_t_0.100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu solid_density fct_solid_density
+        tes_zeolite_discharge_small_ts_19_t_0_100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu pressure pressure
+        tes_zeolite_discharge_small_ts_19_t_0_100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu temperature temperature
+        tes_zeolite_discharge_small_ts_19_t_0_100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu vapour_partial_pressure vapour_partial_pressure
+        tes_zeolite_discharge_small_ts_19_t_0_100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu solid_density solid_density
     )
 
     AddTest(
@@ -184,13 +183,12 @@ if(NOT OGS_USE_MPI)
         EXECUTABLE_ARGS tes-1D-zeolite-discharge-large.prj
         WRAPPER time
         TESTER vtkdiff
-        ABSTOL 1e-16 RELTOL 1e-16
+        ABSTOL 1e-3 RELTOL 1e-4
         DIFF_DATA
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu tes_zeolite_discharge_large_pcs_0_ts_25_t_1.000000.vtu pressure pressure
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu tes_zeolite_discharge_large_pcs_0_ts_25_t_1.000000.vtu temperature temperature
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu tes_zeolite_discharge_large_pcs_0_ts_25_t_1.000000.vtu vapour_partial_pressure vapour_partial_pressure
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu tes_zeolite_discharge_large_pcs_0_ts_25_t_1.000000.vtu solid_density solid_density
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu tes_zeolite_discharge_large_pcs_0_ts_25_t_1.000000.vtu solid_density fct_solid_density
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu pressure pressure
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu temperature temperature
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu vapour_partial_pressure vapour_partial_pressure
+        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu solid_density solid_density
     )
 
 else()
@@ -202,7 +200,7 @@ else()
         WRAPPER mpirun
         WRAPPER_ARGS -np 3
         TESTER vtkdiff
-        ABSTOL 1e-16 RELTOL 1e-16
+        ABSTOL 1e-15 RELTOL 1e-14
         DIFF_DATA
         quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_0.vtu quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_0.vtu pressure pressure
         quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_1.vtu quad_20x10_GroundWaterFlow_result_pcs_0_ts_1_t_1_000000_1.vtu pressure pressure
@@ -216,7 +214,7 @@ else()
         WRAPPER mpirun
         WRAPPER_ARGS -np 3
         TESTER vtkdiff
-        ABSTOL 1e-16 RELTOL 1e-16
+        ABSTOL 1e-14 RELTOL 1e-6
         DIFF_DATA
         cube_1e3_pcs_0_ts_1_t_1_000000_0.vtu cube_1e3_pcs_0_ts_1_t_1_000000_0.vtu pressure pressure
         cube_1e3_pcs_0_ts_1_t_1_000000_1.vtu cube_1e3_pcs_0_ts_1_t_1_000000_1.vtu pressure pressure
@@ -230,7 +228,7 @@ else()
         WRAPPER mpirun
         WRAPPER_ARGS -np 3
         TESTER vtkdiff
-        ABSTOL 1e-16 RELTOL 1e-16
+        ABSTOL 1e-14 RELTOL 1e-14
         DIFF_DATA
         cube_1e3_neumann_pcs_0_ts_1_t_1_000000_0.vtu cube_1e3_neumann_pcs_0_ts_1_t_1_000000_0.vtu pressure pressure
         cube_1e3_neumann_pcs_0_ts_1_t_1_000000_1.vtu cube_1e3_neumann_pcs_0_ts_1_t_1_000000_1.vtu pressure pressure
@@ -370,7 +368,7 @@ else()
             DIFF_DATA
             line_1_line_${mesh_size}.vtu line_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_N1_right pressure
         )
-        endforeach()
+    endforeach()
 
     AddTest(
         NAME TES_zeolite_discharge_small
@@ -379,12 +377,12 @@ else()
         WRAPPER mpirun
         WRAPPER_ARGS -np 1
         TESTER vtkdiff
-        ABSTOL 1e-16 RELTOL 1e-16
+        ABSTOL 1e-7 RELTOL 1e-12
         DIFF_DATA
-        tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu pressure pressure
-        tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu temperature temperature
-        tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu v_mass_frac v_mass_frac
-#        tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000_0.vtu solid_density solid_density
+        tes_zeolite_discharge_small_ts_19_t_0_100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu pressure pressure
+        tes_zeolite_discharge_small_ts_19_t_0_100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu temperature temperature
+        tes_zeolite_discharge_small_ts_19_t_0_100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0_100000_0.vtu v_mass_frac v_mass_frac
+#        tes_zeolite_discharge_small_ts_19_t_0.100000.vtu solid_density solid_density
     )
 
     AddTest(
@@ -396,9 +394,9 @@ else()
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu pressure pressure
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu temperature temperature
-        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu v_mass_frac v_mass_frac
-#        tes_zeolite_discharge_large_pcs_0_ts_28_t_1_0.vtu solid_density solid_density
+        tes_zeolite_discharge_large_ts_28_t_1_000000.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu pressure pressure
+        tes_zeolite_discharge_large_ts_28_t_1_000000.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu temperature temperature
+        tes_zeolite_discharge_large_ts_28_t_1_000000.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000_0.vtu v_mass_frac v_mass_frac
+#        tes_zeolite_discharge_large_ts_28_t_1_0.vtu solid_density solid_density
     )
 endif()

--- a/scripts/cmake/test/AddTest.cmake
+++ b/scripts/cmake/test/AddTest.cmake
@@ -130,20 +130,23 @@ function (AddTest)
         string(REPLACE ";" " && " TESTER_COMMAND "${TESTER_COMMAND}")
     elseif(AddTest_TESTER STREQUAL "vtkdiff")
         list(LENGTH AddTest_DIFF_DATA DiffDataLength)
-        math(EXPR DiffDataLengthMod3 "${DiffDataLength} % 3")
-        if (NOT ${DiffDataLengthMod3} EQUAL 0)
-            message(FATAL_ERROR "For vtkdiff tester the number of diff data arguments must be a multiple of three.")
+        math(EXPR DiffDataLengthMod4 "${DiffDataLength} % 4")
+        if (NOT ${DiffDataLengthMod4} EQUAL 0)
+            message(FATAL_ERROR "For vtkdiff tester the number of diff data arguments must be a multiple of four.")
         endif()
 
         math(EXPR DiffDataLastIndex "${DiffDataLength}-1")
-        foreach(DiffDataIndex RANGE 0 ${DiffDataLastIndex} 3)
-            list(GET AddTest_DIFF_DATA "${DiffDataIndex}" VTK_FILE)
+        foreach(DiffDataIndex RANGE 0 ${DiffDataLastIndex} 4)
+            list(GET AddTest_DIFF_DATA "${DiffDataIndex}" REFERENCE_VTK_FILE)
             math(EXPR DiffDataAuxIndex "${DiffDataIndex}+1")
-            list(GET AddTest_DIFF_DATA "${DiffDataAuxIndex}" NAME_A)
+            list(GET AddTest_DIFF_DATA "${DiffDataAuxIndex}" VTK_FILE)
             math(EXPR DiffDataAuxIndex "${DiffDataIndex}+2")
+            list(GET AddTest_DIFF_DATA "${DiffDataAuxIndex}" NAME_A)
+            math(EXPR DiffDataAuxIndex "${DiffDataIndex}+3")
             list(GET AddTest_DIFF_DATA "${DiffDataAuxIndex}" NAME_B)
 
             list(APPEND TESTER_COMMAND "${SELECTED_DIFF_TOOL_PATH} \
+                ${AddTest_SOURCE_PATH}/${REFERENCE_VTK_FILE} \
                 ${AddTest_BINARY_PATH}/${VTK_FILE} \
                 -a ${NAME_A} -b ${NAME_B} \
                 ${TESTER_ARGS}")


### PR DESCRIPTION
In #1239 I messed up the vtkdiff tests: One filename and two fieldnames are given, e.g.,
`tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu pressure pressure`.
If the two field names are equal, that field is compared to itself yielding zero error norms.

This PR fixes that.

~~TODO: Parallel PETSc tests.~~