### PR TITLE
Fix dots in VTU file names

### DIFF
--- a/BaseLib/FileTools.cpp
+++ b/BaseLib/FileTools.cpp
@@ -141,11 +141,11 @@ std::string extractPath(std::string const& pathname)
         return "";
     return pathname.substr(0, pos + 1);
 }
-static const char * pathSeparator =
+static const char pathSeparator =
 #ifdef _WIN32
-                            "\\";
+                            '\\';
 #else
-                            "/";
+                            '/';
 #endif
 
 std::string appendPathSeparator(std::string const& path)
@@ -157,12 +157,18 @@ std::string appendPathSeparator(std::string const& path)
 
 std::string joinPaths(std::string const& pathA, std::string const& pathB)
 {
-    std::string tmpB(pathB);
-    if(tmpB.substr(0, 1) == ".")
-        tmpB = tmpB.substr(1);
-    if(tmpB.substr(0, 1) == pathSeparator)
-        tmpB = tmpB.substr(1);
-    return appendPathSeparator(pathA) + tmpB;
+    if (pathA.empty())
+        return pathB;
+
+    if (pathB.empty())
+        return pathA;
+
+    if (pathB.front() == pathSeparator) {
+        auto const tmpB = pathB.substr(1);
+        return appendPathSeparator(pathA) + tmpB;
+    } else {
+        return appendPathSeparator(pathA) + pathB;
+    }
 }
 
 } // end namespace BaseLib

--- a/Tests/BaseLib/TestFilePathStringManipulation.cpp
+++ b/Tests/BaseLib/TestFilePathStringManipulation.cpp
@@ -391,12 +391,13 @@ TEST(BaseLib, ExtractPathUnix)
 TEST(BaseLib, JoinPaths)
 {
 #if _WIN32
-    ASSERT_EQ ( "\\path\\path", BaseLib::joinPaths("\\path", "path") );
     ASSERT_EQ ( "\\path\\path", BaseLib::joinPaths("\\path", "\\path") );
-    ASSERT_EQ ( "\\path\\path", BaseLib::joinPaths("\\path", ".\\path") );
+    ASSERT_EQ ( "\\path\\path", BaseLib::joinPaths("\\path\\", "\\path") );
+    ASSERT_EQ ( "\\path\\.\\path", BaseLib::joinPaths("\\path", ".\\path") );
 #else
-    ASSERT_EQ ( "/path/path", BaseLib::joinPaths("/path", "path") );
     ASSERT_EQ ( "/path/path", BaseLib::joinPaths("/path", "/path") );
-    ASSERT_EQ ( "/path/path", BaseLib::joinPaths("/path", "./path") );
+    ASSERT_EQ ( "/path/path", BaseLib::joinPaths("/path/", "/path") );
+    ASSERT_EQ ( "/path/./path", BaseLib::joinPaths("/path", "./path") );
+    ASSERT_EQ ( "/path", BaseLib::joinPaths("/", "path") );
 #endif
 }


### PR DESCRIPTION
#1319 fixed pvtu file names. But the solution causes an issue if some directories in the file path contains dots in their name. This PR makes sure that only dots in the basename of the pvtu file are replaced. For the rest see the commit messages.