### PR TITLE
[NL] Fix Newton max iterations counter comparison.

### DIFF
--- a/NumLib/ODESolver/NonlinearSolver.cpp
+++ b/NumLib/ODESolver/NonlinearSolver.cpp
@@ -189,7 +189,7 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
     minus_delta_x.setZero();
 
     unsigned iteration = 1;
-    for (; iteration < _maxiter; ++iteration)
+    for (; iteration <= _maxiter; ++iteration)
     {
         BaseLib::RunTime time_iteration;
         time_iteration.start();


### PR DESCRIPTION
Otherwise it behaves different than the Picard iterations: [NonlinearSolver.cpp, Picard solve method](https://github.com/ufz/ogs/blob/master/NumLib/ODESolver/NonlinearSolver.cpp#L53)