### PR TITLE
Added flexible nonlinear solver convergence criteria

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -24,6 +24,7 @@
 #include "MeshLib/Mesh.h"
 
 #include "NumLib/ODESolver/TimeDiscretizationBuilder.h"
+#include "NumLib/ODESolver/ConvergenceCriterion.h"
 
 // FileIO
 #include "GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.h"
@@ -169,6 +170,10 @@ void ProjectData::buildProcesses()
             //! \ogs_file_param{process__time_discretization}
             pc.getConfigSubtree("time_discretization"));
 
+        auto conv_crit = NumLib::createConvergenceCriterion(
+            //! \ogs_file_param{process__convergence_criterion}
+            pc.getConfigSubtree("convergence_criterion"));
+
         if (type == "GROUNDWATER_FLOW")
         {
             // The existence check of the in the configuration referenced
@@ -179,13 +184,13 @@ void ProjectData::buildProcesses()
             _processes.emplace_back(
                 ProcessLib::GroundwaterFlow::createGroundwaterFlowProcess(
                     *_mesh_vec[0], *nl_slv, std::move(time_disc),
-                    _process_variables, _parameters, pc));
+                    std::move(conv_crit), _process_variables, _parameters, pc));
         }
         else if (type == "TES")
         {
             _processes.emplace_back(ProcessLib::TES::createTESProcess(
                 *_mesh_vec[0], *nl_slv, std::move(time_disc),
-                _process_variables, _parameters, pc));
+                std::move(conv_crit), _process_variables, _parameters, pc));
         }
         else
         {

--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.cpp
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.cpp
@@ -98,8 +98,9 @@ void UncoupledProcessesTimeLoop::setInitialConditions(
         {
             auto& nonlinear_solver = ppd.nonlinear_solver;
             auto& mat_strg = ppd.mat_strg;
+            auto& conv_crit = pcs.getConvergenceCriterion();
 
-            setEquationSystem(nonlinear_solver, ode_sys, nl_tag);
+            setEquationSystem(nonlinear_solver, ode_sys, conv_crit, nl_tag);
             nonlinear_solver.assemble(x0);
             time_disc.pushState(
                 t0, x0, mat_strg);  // TODO: that might do duplicate work
@@ -117,11 +118,12 @@ solveOneTimeStepOneProcess(
         ProcessLib::Output const& output_control)
 {
     auto& time_disc = process.getTimeDiscretization();
+    auto& conv_crit = process.getConvergenceCriterion();
     auto& ode_sys = *process_data.tdisc_ode_sys;
     auto& nonlinear_solver = process_data.nonlinear_solver;
     auto const nl_tag = process_data.nonlinear_solver_tag;
 
-    setEquationSystem(nonlinear_solver, ode_sys, nl_tag);
+    setEquationSystem(nonlinear_solver, ode_sys, conv_crit, nl_tag);
 
     // Note: Order matters!
     // First advance to the next timestep, then set known solutions at that

--- a/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
+++ b/Applications/ApplicationsLib/UncoupledProcessesTimeLoop.h
@@ -162,7 +162,8 @@ private:
     //! which is Picard or Newton depending on the NLTag.
     template <NumLib::NonlinearSolverTag NLTag>
     static void setEquationSystem(AbstractNLSolver& nonlinear_solver,
-                                  EquationSystem& eq_sys)
+                                  EquationSystem& eq_sys,
+                                  NumLib::ConvergenceCriterion& conv_crit)
     {
         using Solver = NumLib::NonlinearSolver<NLTag>;
         using EqSys = NumLib::NonlinearSystem<NLTag>;
@@ -173,23 +174,26 @@ private:
         auto& nl_solver_ = static_cast<Solver&>(nonlinear_solver);
         auto& eq_sys_ = static_cast<EqSys&>(eq_sys);
 
-        nl_solver_.setEquationSystem(eq_sys_);
+        nl_solver_.setEquationSystem(eq_sys_, conv_crit);
     }
 
     //! Sets the EquationSystem for the given nonlinear solver,
     //! transparently both for Picard and Newton solvers.
     static void setEquationSystem(AbstractNLSolver& nonlinear_solver,
                                   EquationSystem& eq_sys,
+                                  NumLib::ConvergenceCriterion& conv_crit,
                                   NumLib::NonlinearSolverTag nl_tag)
     {
         using Tag = NumLib::NonlinearSolverTag;
         switch (nl_tag)
         {
             case Tag::Picard:
-                setEquationSystem<Tag::Picard>(nonlinear_solver, eq_sys);
+                setEquationSystem<Tag::Picard>(nonlinear_solver, eq_sys,
+                                               conv_crit);
                 break;
             case Tag::Newton:
-                setEquationSystem<Tag::Newton>(nonlinear_solver, eq_sys);
+                setEquationSystem<Tag::Newton>(nonlinear_solver, eq_sys,
+                                               conv_crit);
                 break;
         }
     }

--- a/NumLib/ODESolver/ConvergenceCriterion.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterion.cpp
@@ -12,6 +12,7 @@
 #include "BaseLib/Error.h"
 
 #include "ConvergenceCriterionDeltaX.h"
+#include "ConvergenceCriterionResidual.h"
 #include "ConvergenceCriterionPerComponentDeltaX.h"
 
 namespace NumLib
@@ -24,6 +25,8 @@ std::unique_ptr<ConvergenceCriterion> createConvergenceCriterion(
 
     if (type == "DeltaX") {
         return createConvergenceCriterionDeltaX(config);
+    } else if (type == "Residual") {
+        return createConvergenceCriterionResidual(config);
     } else if (type == "PerComponentDeltaX") {
         return createConvergenceCriterionPerComponentDeltaX(config);
     }

--- a/NumLib/ODESolver/ConvergenceCriterion.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterion.cpp
@@ -1,0 +1,34 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "ConvergenceCriterion.h"
+#include "BaseLib/ConfigTree.h"
+#include "BaseLib/Error.h"
+
+#include "ConvergenceCriterionDeltaX.h"
+#include "ConvergenceCriterionPerComponentDeltaX.h"
+
+namespace NumLib
+{
+std::unique_ptr<ConvergenceCriterion> createConvergenceCriterion(
+    const BaseLib::ConfigTree& config)
+{
+    //! \ogs_file_param{process__convergence_criterion__type}
+    auto const type = config.peekConfigParameter<std::string>("type");
+
+    if (type == "DeltaX") {
+        return createConvergenceCriterionDeltaX(config);
+    } else if (type == "PerComponentDeltaX") {
+        return createConvergenceCriterionPerComponentDeltaX(config);
+    }
+
+    OGS_FATAL("There is no convergence criterion of type `%s'.", type.c_str());
+}
+
+}  // NumLib

--- a/NumLib/ODESolver/ConvergenceCriterion.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterion.cpp
@@ -14,6 +14,7 @@
 #include "ConvergenceCriterionDeltaX.h"
 #include "ConvergenceCriterionResidual.h"
 #include "ConvergenceCriterionPerComponentDeltaX.h"
+#include "ConvergenceCriterionPerComponentResidual.h"
 
 namespace NumLib
 {
@@ -29,6 +30,8 @@ std::unique_ptr<ConvergenceCriterion> createConvergenceCriterion(
         return createConvergenceCriterionResidual(config);
     } else if (type == "PerComponentDeltaX") {
         return createConvergenceCriterionPerComponentDeltaX(config);
+    } else if (type == "PerComponentResidual") {
+        return createConvergenceCriterionPerComponentResidual(config);
     }
 
     OGS_FATAL("There is no convergence criterion of type `%s'.", type.c_str());

--- a/NumLib/ODESolver/ConvergenceCriterion.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterion.cpp
@@ -37,4 +37,12 @@ std::unique_ptr<ConvergenceCriterion> createConvergenceCriterion(
     OGS_FATAL("There is no convergence criterion of type `%s'.", type.c_str());
 }
 
+bool checkRelativeTolerance(const double reltol, const double numerator,
+                            const double denominator)
+{
+    auto const eps = std::numeric_limits<double>::epsilon();
+    return std::abs(numerator) <
+           std::abs(reltol) * (std::abs(denominator) + eps);
+}
+
 }  // NumLib

--- a/NumLib/ODESolver/ConvergenceCriterion.h
+++ b/NumLib/ODESolver/ConvergenceCriterion.h
@@ -19,10 +19,11 @@ class ConfigTree;
 
 namespace NumLib
 {
-/*! Convergence criterion for nonlinear solvers.
+/*! Convergence criterion for iterative algorithms, like nonlinear solvers.
  *
  * It is able to check the difference of the solution vector between iterations
- * and the residual of the nonlinear equation system.
+ * and the residual of the equation being solved (e.g. the nonlinear equation
+ * system).
  */
 class ConvergenceCriterion
 {

--- a/NumLib/ODESolver/ConvergenceCriterion.h
+++ b/NumLib/ODESolver/ConvergenceCriterion.h
@@ -77,6 +77,13 @@ public:
 std::unique_ptr<ConvergenceCriterion> createConvergenceCriterion(
     BaseLib::ConfigTree const& config);
 
+//! Returns if |numerator/denominator| < |reltol|.
+//! This method copes with the case that denominator = 0 by always adding
+//! epsilon to the denominator.
+bool checkRelativeTolerance(double const reltol,
+                            double const numerator,
+                            double const denominator);
+
 } // namespace NumLib
 
 #endif  // NUMLIB_CONVERGENCECRITERION_H

--- a/NumLib/ODESolver/ConvergenceCriterion.h
+++ b/NumLib/ODESolver/ConvergenceCriterion.h
@@ -53,6 +53,10 @@ public:
     //! Check if the residual satisfies the convergence criterion.
     virtual void checkResidual(GlobalVector const& residual) = 0;
 
+    //! Tell the ConvergenceCriterion that it is called for the first time now
+    //! (while solving a specific nonlinear system).
+    virtual void preFirstIteration() {}
+
     //! Indicate that a new iteration now starts.
     //!
     //! A concrete implementation of ConvergenceCriterion might want to check

--- a/NumLib/ODESolver/ConvergenceCriterion.h
+++ b/NumLib/ODESolver/ConvergenceCriterion.h
@@ -54,6 +54,12 @@ public:
     virtual void checkResidual(GlobalVector const& residual) = 0;
 
     //! Indicate that a new iteration now starts.
+    //!
+    //! A concrete implementation of ConvergenceCriterion might want to check
+    //! both delta x and the residual. I.e., in a new iteration both checks have
+    //! to be done anew. This method will make the ConvergenceCriterion forget
+    //! the result of all checks already done, s.t. all necessary checks will
+    //! have to be repeated in order to satisfy the ConvergenceCriterion.
     virtual void reset() = 0;
 
     //! Tell if the convergence criterion is satisfied.

--- a/NumLib/ODESolver/ConvergenceCriterion.h
+++ b/NumLib/ODESolver/ConvergenceCriterion.h
@@ -1,0 +1,71 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef NUMLIB_CONVERGENCECRITERION_H
+#define NUMLIB_CONVERGENCECRITERION_H
+
+#include <memory>
+#include "NumLib/NumericsConfig.h"
+
+namespace BaseLib {
+class ConfigTree;
+}  // BaseLib
+
+namespace NumLib
+{
+/*! Convergence criterion for nonlinear solvers.
+ *
+ * It is able to check the difference of the solution vector between iterations
+ * and the residual of the nonlinear equation system.
+ */
+class ConvergenceCriterion
+{
+public:
+    //! Tells if the change of the solution between iterations is checked.
+    //!
+    //! \remark
+    //! This method allows to save some computations if no such check will be
+    //! done.
+    virtual bool hasDeltaXCheck() const = 0;
+
+    //! Tells if the residual is checked.
+    //!
+    //! \remark
+    //! This method allows to save some computations if no such check will be
+    //! done.
+    virtual bool hasResidualCheck() const = 0;
+
+    //! Check if the change of the solution between iterations satisfies the
+    //! convergence criterion.
+    //!
+    //! \remark
+    //! The Newton-Raphson solver computes \c minus_delta_x. \c x is needed for
+    //! relative tolerances.
+    virtual void checkDeltaX(GlobalVector const& minus_delta_x,
+                             GlobalVector const& x) = 0;
+
+    //! Check if the residual satisfies the convergence criterion.
+    virtual void checkResidual(GlobalVector const& residual) = 0;
+
+    //! Indicate that a new iteration now starts.
+    virtual void reset() = 0;
+
+    //! Tell if the convergence criterion is satisfied.
+    virtual bool isSatisfied() const = 0;
+
+    ~ConvergenceCriterion() = default;
+};
+
+//! Creates a convergence criterion from the given configuration.
+std::unique_ptr<ConvergenceCriterion> createConvergenceCriterion(
+    BaseLib::ConfigTree const& config);
+
+} // namespace NumLib
+
+#endif  // NUMLIB_CONVERGENCECRITERION_H

--- a/NumLib/ODESolver/ConvergenceCriterionDeltaX.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionDeltaX.cpp
@@ -45,7 +45,7 @@ void ConvergenceCriterionDeltaX::checkDeltaX(const GlobalVector& minus_delta_x,
         satisfied_abs = error_dx < *_abstol;
     }
     if (_reltol) {
-        satisfied_rel = error_dx < *_reltol * norm_x;
+        satisfied_rel = checkRelativeTolerance(*_reltol, error_dx, norm_x);
     }
 
     _satisfied = _satisfied && (satisfied_abs || satisfied_rel);

--- a/NumLib/ODESolver/ConvergenceCriterionDeltaX.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionDeltaX.cpp
@@ -1,0 +1,73 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "ConvergenceCriterionDeltaX.h"
+#include <logog/include/logog.hpp>
+
+#include "BaseLib/ConfigTree.h"
+#include "MathLib/LinAlg/LinAlg.h"
+
+namespace NumLib
+{
+ConvergenceCriterionDeltaX::ConvergenceCriterionDeltaX(
+    boost::optional<double>&& absolute_tolerance,
+    boost::optional<double>&& relative_tolerance,
+    MathLib::VecNormType norm_type)
+    : _abstol(std::move(absolute_tolerance)),
+      _reltol(std::move(relative_tolerance)),
+      _norm_type(norm_type)
+{
+    if ((!_abstol) && (!_reltol))
+        OGS_FATAL(
+            "At least one of absolute or relative tolerance has to be "
+            "specified.");
+}
+
+void ConvergenceCriterionDeltaX::checkDeltaX(const GlobalVector& minus_delta_x,
+                                             GlobalVector const& x)
+{
+    auto error_dx = MathLib::LinAlg::norm(minus_delta_x, _norm_type);
+    auto norm_x = MathLib::LinAlg::norm(x, _norm_type);
+
+    INFO("Convergence criterion: |dx|=%.4e, |x|=%.4e, |dx|/|x|=%.4e", error_dx,
+         norm_x, error_dx / norm_x);
+
+    bool satisfied_abs = false;
+    bool satisfied_rel = false;
+
+    if (_abstol) {
+        satisfied_abs = error_dx < *_abstol;
+    }
+    if (_reltol) {
+        satisfied_rel = error_dx < *_reltol * norm_x;
+    }
+
+    _satisfied = _satisfied && (satisfied_abs || satisfied_rel);
+}
+
+std::unique_ptr<ConvergenceCriterionDeltaX> createConvergenceCriterionDeltaX(
+    const BaseLib::ConfigTree& config)
+{
+    config.checkConfigParameter("type", "DeltaX");
+
+    auto abstol = config.getConfigParameterOptional<double>("abstol");
+    auto reltol = config.getConfigParameterOptional<double>("reltol");
+    auto const norm_type_str =
+        config.getConfigParameter<std::string>("norm_type");
+    auto const norm_type = MathLib::convertStringToVecNormType(norm_type_str);
+
+    if (norm_type == MathLib::VecNormType::INVALID)
+        OGS_FATAL("Unknown vector norm type `%s'.", norm_type_str.c_str());
+
+    return std::unique_ptr<ConvergenceCriterionDeltaX>(
+        new ConvergenceCriterionDeltaX(std::move(abstol), std::move(reltol),
+                                       norm_type));
+}
+
+}  // NumLib

--- a/NumLib/ODESolver/ConvergenceCriterionDeltaX.h
+++ b/NumLib/ODESolver/ConvergenceCriterionDeltaX.h
@@ -16,6 +16,12 @@
 
 namespace NumLib
 {
+//! Convergence criterion applying a single absolute or relative tolerance to
+//! the whole solution increment vector.
+//!
+//! A residual check is not done.
+//! If both an absolute and a relative tolerance are specified, at least one of
+//! them has to be satisfied.
 class ConvergenceCriterionDeltaX final : public ConvergenceCriterion
 {
 public:

--- a/NumLib/ODESolver/ConvergenceCriterionDeltaX.h
+++ b/NumLib/ODESolver/ConvergenceCriterionDeltaX.h
@@ -19,7 +19,7 @@ namespace NumLib
 class ConvergenceCriterionDeltaX final : public ConvergenceCriterion
 {
 public:
-    explicit ConvergenceCriterionDeltaX(
+    ConvergenceCriterionDeltaX(
         boost::optional<double>&& absolute_tolerance,
         boost::optional<double>&& relative_tolerance,
         MathLib::VecNormType norm_type);

--- a/NumLib/ODESolver/ConvergenceCriterionDeltaX.h
+++ b/NumLib/ODESolver/ConvergenceCriterionDeltaX.h
@@ -1,0 +1,48 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef NUMLIB_CONVERGENCECRITERIONDELTAX_H
+#define NUMLIB_CONVERGENCECRITERIONDELTAX_H
+
+#include <boost/optional.hpp>
+#include "ConvergenceCriterion.h"
+#include "MathLib/LinAlg/LinAlgEnums.h"
+
+namespace NumLib
+{
+class ConvergenceCriterionDeltaX final : public ConvergenceCriterion
+{
+public:
+    explicit ConvergenceCriterionDeltaX(
+        boost::optional<double>&& absolute_tolerance,
+        boost::optional<double>&& relative_tolerance,
+        MathLib::VecNormType norm_type);
+
+    bool hasDeltaXCheck() const override { return true; }
+    bool hasResidualCheck() const override { return false; }
+
+    void checkDeltaX(const GlobalVector& minus_delta_x,
+                     GlobalVector const& x) override;
+    void checkResidual(const GlobalVector& /*residual*/) override {}
+
+    void reset() override { _satisfied = true; }
+    bool isSatisfied() const { return _satisfied; }
+private:
+    const boost::optional<double> _abstol;
+    const boost::optional<double> _reltol;
+    const MathLib::VecNormType _norm_type;
+    bool _satisfied = true;
+};
+
+std::unique_ptr<ConvergenceCriterionDeltaX> createConvergenceCriterionDeltaX(
+    BaseLib::ConfigTree const& config);
+
+}  // NumLib
+
+#endif  // NUMLIB_CONVERGENCECRITERIONDELTAX_H

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponent.h
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponent.h
@@ -1,0 +1,33 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef NUMLIB_CONVERGENCECRITERIONPERCOMPONENT_H
+#define NUMLIB_CONVERGENCECRITERIONPERCOMPONENT_H
+
+#include "ConvergenceCriterion.h"
+
+namespace MeshLib
+{
+class Mesh;
+}  // namespace MeshLib
+
+namespace NumLib
+{
+class LocalToGlobalIndexMap;
+
+class ConvergenceCriterionPerComponent : public ConvergenceCriterion
+{
+public:
+    virtual void setDOFTable(NumLib::LocalToGlobalIndexMap const& dof_table,
+                             MeshLib::Mesh const& mesh) = 0;
+};
+
+}  // namespace NumLib
+
+#endif  // NUMLIB_CONVERGENCECRITERIONPERCOMPONENT_H

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponent.h
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponent.h
@@ -21,9 +21,13 @@ namespace NumLib
 {
 class LocalToGlobalIndexMap;
 
+//! Interface for applying a convergence criterion individually to each
+//! component of a multi-component solution or residual vector.
+//! Component here means sub-vector, not single scalar vector entry.
 class ConvergenceCriterionPerComponent : public ConvergenceCriterion
 {
 public:
+    //! Sets the d.o.f. table used to extract data for a specific component.
     virtual void setDOFTable(NumLib::LocalToGlobalIndexMap const& dof_table,
                              MeshLib::Mesh const& mesh) = 0;
 };

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentDeltaX.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentDeltaX.cpp
@@ -58,7 +58,8 @@ void ConvergenceCriterionPerComponentDeltaX::checkDeltaX(
 
         satisfied_abs = satisfied_abs && error_dx < _abstols[global_component];
         satisfied_rel =
-            satisfied_rel && error_dx < _reltols[global_component] * norm_x;
+            satisfied_rel && checkRelativeTolerance(_reltols[global_component],
+                                                    error_dx, norm_x);
     }
 
     _satisfied = _satisfied && (satisfied_abs || satisfied_rel);

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentDeltaX.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentDeltaX.cpp
@@ -1,0 +1,108 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "ConvergenceCriterionPerComponentDeltaX.h"
+#include <logog/include/logog.hpp>
+
+#include "BaseLib/ConfigTree.h"
+#include "NumLib/DOF/LocalToGlobalIndexMap.h"
+#include "NumLib/DOF/DOFTableUtil.h"
+
+namespace NumLib
+{
+ConvergenceCriterionPerComponentDeltaX::ConvergenceCriterionPerComponentDeltaX(
+    std::vector<double>&& absolute_tolerances,
+    std::vector<double>&& relative_tolerances,
+    MathLib::VecNormType norm_type)
+    : _abstols(std::move(absolute_tolerances)),
+      _reltols(std::move(relative_tolerances)),
+      _norm_type(norm_type)
+{
+    if (_abstols.size() != _reltols.size())
+        OGS_FATAL(
+            "The number of absolute and relative tolerances given must be the "
+            "same.");
+}
+
+void ConvergenceCriterionPerComponentDeltaX::checkDeltaX(
+    const GlobalVector& minus_delta_x, GlobalVector const& x)
+{
+    if ((!_dof_table) || (!_mesh))
+        OGS_FATAL("D.o.f. table or mesh have not been set.");
+
+    bool satisfied_abs = true;
+    bool satisfied_rel = true;
+
+    for (unsigned global_component = 0; global_component < _abstols.size();
+         ++global_component)
+    {
+        // TODO short cut if tol <= 0.0
+        auto error_dx = norm(minus_delta_x, global_component, _norm_type,
+                             *_dof_table, *_mesh);
+        auto norm_x =
+            norm(x, global_component, _norm_type, *_dof_table, *_mesh);
+
+        INFO(
+            "Convergence criterion, component %u: |dx|=%.4e, |x|=%.4e, "
+            "|dx|/|x|=%.4e",
+            error_dx, global_component, norm_x, error_dx / norm_x);
+
+        satisfied_abs = satisfied_abs && error_dx < _abstols[global_component];
+        satisfied_rel =
+            satisfied_rel && error_dx < _reltols[global_component] * norm_x;
+    }
+
+    _satisfied = _satisfied && (satisfied_abs || satisfied_rel);
+}
+
+void ConvergenceCriterionPerComponentDeltaX::setDOFTable(
+    const LocalToGlobalIndexMap& dof_table, MeshLib::Mesh const& mesh)
+{
+    _dof_table = &dof_table;
+    _mesh = &mesh;
+
+    if (_dof_table->getNumberOfComponents() != _abstols.size())
+        OGS_FATAL(
+            "The number of components in the DOF table and the number of "
+            "tolerances given do not match.");
+}
+
+std::unique_ptr<ConvergenceCriterionPerComponentDeltaX>
+createConvergenceCriterionPerComponentDeltaX(const BaseLib::ConfigTree& config)
+{
+    config.checkConfigParameter("type", "PerComponentDeltaX");
+
+    auto abstols =
+        config.getConfigParameterOptional<std::vector<double>>("abstols");
+    auto reltols =
+        config.getConfigParameterOptional<std::vector<double>>("reltols");
+    auto const norm_type_str =
+        config.getConfigParameter<std::string>("norm_type");
+
+    if ((!abstols) && (!reltols))
+        OGS_FATAL(
+            "At least one of absolute or relative tolerance has to be "
+            "specified.");
+    if (!abstols) {
+        abstols = std::vector<double>(reltols->size());
+    } else if (!reltols) {
+        reltols = std::vector<double>(abstols->size());
+    }
+
+    auto const norm_type = MathLib::convertStringToVecNormType(norm_type_str);
+
+    if (norm_type == MathLib::VecNormType::INVALID)
+        OGS_FATAL("Unknown vector norm type `%s'.", norm_type_str.c_str());
+
+    return std::unique_ptr<ConvergenceCriterionPerComponentDeltaX>(
+        new ConvergenceCriterionPerComponentDeltaX(
+            std::move(*abstols), std::move(*reltols), norm_type));
+}
+
+}  // NumLib

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentDeltaX.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentDeltaX.cpp
@@ -28,6 +28,9 @@ ConvergenceCriterionPerComponentDeltaX::ConvergenceCriterionPerComponentDeltaX(
         OGS_FATAL(
             "The number of absolute and relative tolerances given must be the "
             "same.");
+
+    if (_abstols.empty())
+        OGS_FATAL("The given tolerances vector is empty.");
 }
 
 void ConvergenceCriterionPerComponentDeltaX::checkDeltaX(

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentDeltaX.h
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentDeltaX.h
@@ -1,0 +1,56 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef NUMLIB_CONVERGENCECRITERIONPERCOMPONENTDELTAX_H
+#define NUMLIB_CONVERGENCECRITERIONPERCOMPONENTDELTAX_H
+
+#include "MathLib/LinAlg/LinAlgEnums.h"
+#include "ConvergenceCriterionPerComponent.h"
+
+namespace NumLib
+{
+class LocalToGlobalIndexMap;
+
+class ConvergenceCriterionPerComponentDeltaX
+    : public ConvergenceCriterionPerComponent
+{
+public:
+    explicit ConvergenceCriterionPerComponentDeltaX(
+        std::vector<double>&& absolute_tolerances,
+        std::vector<double>&& relative_tolerances,
+        MathLib::VecNormType norm_type);
+
+    bool hasDeltaXCheck() const override { return true; }
+    bool hasResidualCheck() const override { return false; }
+
+    void checkDeltaX(const GlobalVector& minus_delta_x,
+                     GlobalVector const& x) override;
+    void checkResidual(const GlobalVector& /*residual*/) override {}
+
+    void reset() override { _satisfied = true; }
+    bool isSatisfied() const override { return _satisfied; }
+
+    void setDOFTable(const LocalToGlobalIndexMap& dof_table,
+                     MeshLib::Mesh const& mesh) override;
+
+private:
+    const std::vector<double> _abstols;
+    const std::vector<double> _reltols;
+    const MathLib::VecNormType _norm_type;
+    bool _satisfied = true;
+    LocalToGlobalIndexMap const* _dof_table = nullptr;
+    MeshLib::Mesh const* _mesh = nullptr;
+};
+
+std::unique_ptr<ConvergenceCriterionPerComponentDeltaX>
+createConvergenceCriterionPerComponentDeltaX(BaseLib::ConfigTree const& config);
+
+}  // namespace NumLib
+
+#endif  // NUMLIB_CONVERGENCECRITERIONPERCOMPONENTDELTAX_H

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentDeltaX.h
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentDeltaX.h
@@ -17,6 +17,12 @@ namespace NumLib
 {
 class LocalToGlobalIndexMap;
 
+//! Convergence criterion applying absolute or relative tolerances individually
+//! to each component of the whole solution increment vector.
+//!
+//! A residual check is not done.
+//! If both an absolute and a relative tolerances are specified, at least one of
+//! them has to be satisfied.
 class ConvergenceCriterionPerComponentDeltaX
     : public ConvergenceCriterionPerComponent
 {

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentDeltaX.h
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentDeltaX.h
@@ -21,7 +21,7 @@ class ConvergenceCriterionPerComponentDeltaX
     : public ConvergenceCriterionPerComponent
 {
 public:
-    explicit ConvergenceCriterionPerComponentDeltaX(
+    ConvergenceCriterionPerComponentDeltaX(
         std::vector<double>&& absolute_tolerances,
         std::vector<double>&& relative_tolerances,
         MathLib::VecNormType norm_type);

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.cpp
@@ -1,0 +1,121 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "ConvergenceCriterionPerComponentResidual.h"
+#include <logog/include/logog.hpp>
+
+#include "BaseLib/ConfigTree.h"
+#include "NumLib/DOF/DOFTableUtil.h"
+#include "NumLib/DOF/LocalToGlobalIndexMap.h"
+
+namespace NumLib
+{
+ConvergenceCriterionPerComponentResidual::
+    ConvergenceCriterionPerComponentResidual(
+        std::vector<double>&& absolute_tolerances,
+        std::vector<double>&& relative_tolerances,
+        MathLib::VecNormType norm_type)
+    : _abstols(std::move(absolute_tolerances)),
+      _reltols(std::move(relative_tolerances)),
+      _norm_type(norm_type),
+      _residual_norms_0(_abstols.size())
+{
+    if (_abstols.size() != _reltols.size())
+        OGS_FATAL(
+            "The number of absolute and relative tolerances given must be the "
+            "same.");
+
+    if (_abstols.empty())
+        OGS_FATAL("The given tolerances vector is empty.");
+}
+
+void ConvergenceCriterionPerComponentResidual::checkResidual(
+    const GlobalVector& residual)
+{
+    if ((!_dof_table) || (!_mesh))
+        OGS_FATAL("D.o.f. table or mesh have not been set.");
+
+    bool satisfied_abs = true;
+    // Make sure that in the first iteration the relative residual tolerance is
+    // not satisfied.
+    bool satisfied_rel = _is_first_iteration ? false : true;
+
+    for (unsigned global_component = 0; global_component < _abstols.size();
+         ++global_component)
+    {
+        // TODO short cut if tol <= 0.0
+        auto norm_res = norm(residual, global_component, _norm_type,
+                             *_dof_table, *_mesh);
+
+        if (_is_first_iteration) {
+            INFO("Convergence criterion: |r0|=%.4e", norm_res);
+            _residual_norms_0[global_component] = norm_res;
+        } else {
+            auto const norm_res0 = _residual_norms_0[global_component];
+            INFO(
+                "Convergence criterion, component %u: |r|=%.4e, |r0|=%.4e, "
+                "|r|/|r0|=%.4e",
+                norm_res, global_component, norm_res0, norm_res / norm_res0);
+        }
+
+        satisfied_abs = satisfied_abs && norm_res < _abstols[global_component];
+        satisfied_rel = satisfied_rel &&
+                        norm_res < _reltols[global_component] *
+                                       _residual_norms_0[global_component];
+    }
+
+    _satisfied = _satisfied && (satisfied_abs || satisfied_rel);
+}
+
+void ConvergenceCriterionPerComponentResidual::setDOFTable(
+    const LocalToGlobalIndexMap& dof_table, MeshLib::Mesh const& mesh)
+{
+    _dof_table = &dof_table;
+    _mesh = &mesh;
+
+    if (_dof_table->getNumberOfComponents() != _abstols.size())
+        OGS_FATAL(
+            "The number of components in the DOF table and the number of "
+            "tolerances given do not match.");
+}
+
+std::unique_ptr<ConvergenceCriterionPerComponentResidual>
+createConvergenceCriterionPerComponentResidual(
+    const BaseLib::ConfigTree& config)
+{
+    config.checkConfigParameter("type", "PerComponentResidual");
+
+    auto abstols =
+        config.getConfigParameterOptional<std::vector<double>>("abstols");
+    auto reltols =
+        config.getConfigParameterOptional<std::vector<double>>("reltols");
+    auto const norm_type_str =
+        config.getConfigParameter<std::string>("norm_type");
+
+    if ((!abstols) && (!reltols))
+        OGS_FATAL(
+            "At least one of absolute or relative tolerance has to be "
+            "specified.");
+    if (!abstols) {
+        abstols = std::vector<double>(reltols->size());
+    } else if (!reltols) {
+        reltols = std::vector<double>(abstols->size());
+    }
+
+    auto const norm_type = MathLib::convertStringToVecNormType(norm_type_str);
+
+    if (norm_type == MathLib::VecNormType::INVALID)
+        OGS_FATAL("Unknown vector norm type `%s'.", norm_type_str.c_str());
+
+    return std::unique_ptr<ConvergenceCriterionPerComponentResidual>(
+        new ConvergenceCriterionPerComponentResidual(
+            std::move(*abstols), std::move(*reltols), norm_type));
+}
+
+}  // NumLib

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.cpp
@@ -65,9 +65,10 @@ void ConvergenceCriterionPerComponentResidual::checkResidual(
         }
 
         satisfied_abs = satisfied_abs && norm_res < _abstols[global_component];
-        satisfied_rel = satisfied_rel &&
-                        norm_res < _reltols[global_component] *
-                                       _residual_norms_0[global_component];
+        satisfied_rel =
+            satisfied_rel &&
+            checkRelativeTolerance(_reltols[global_component], norm_res,
+                                   _residual_norms_0[global_component]);
     }
 
     _satisfied = _satisfied && (satisfied_abs || satisfied_rel);

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.h
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.h
@@ -1,0 +1,61 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef NUMLIB_CONVERGENCECRITERIONPERCOMPONENTRESIDUAL_H
+#define NUMLIB_CONVERGENCECRITERIONPERCOMPONENTRESIDUAL_H
+
+#include <vector>
+#include "MathLib/LinAlg/LinAlgEnums.h"
+#include "ConvergenceCriterionPerComponent.h"
+
+namespace NumLib
+{
+class LocalToGlobalIndexMap;
+
+class ConvergenceCriterionPerComponentResidual
+    : public ConvergenceCriterionPerComponent
+{
+public:
+    explicit ConvergenceCriterionPerComponentResidual(
+        std::vector<double>&& absolute_tolerances,
+        std::vector<double>&& relative_tolerances,
+        MathLib::VecNormType norm_type);
+
+    bool hasDeltaXCheck() const override { return false; }
+    bool hasResidualCheck() const override { return true; }
+
+    void checkDeltaX(const GlobalVector& /*minus_delta_x*/,
+                     GlobalVector const& /*x*/) override {}
+    void checkResidual(const GlobalVector& residual) override;
+
+    void preFirstIteration() override { _is_first_iteration = true; }
+    void reset() override { _satisfied = true; _is_first_iteration = false; }
+    bool isSatisfied() const override { return _satisfied; }
+
+    void setDOFTable(const LocalToGlobalIndexMap& dof_table,
+                     MeshLib::Mesh const& mesh) override;
+
+private:
+    const std::vector<double> _abstols;
+    const std::vector<double> _reltols;
+    const MathLib::VecNormType _norm_type;
+    bool _satisfied = true;
+    LocalToGlobalIndexMap const* _dof_table = nullptr;
+    MeshLib::Mesh const* _mesh = nullptr;
+    bool _is_first_iteration = true;
+    std::vector<double> _residual_norms_0;
+};
+
+std::unique_ptr<ConvergenceCriterionPerComponentResidual>
+createConvergenceCriterionPerComponentResidual(
+    BaseLib::ConfigTree const& config);
+
+}  // namespace NumLib
+
+#endif  // NUMLIB_CONVERGENCECRITERIONPERCOMPONENTRESIDUAL_H

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.h
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.h
@@ -18,6 +18,12 @@ namespace NumLib
 {
 class LocalToGlobalIndexMap;
 
+//! Convergence criterion applying absolute or relative tolerances individually
+//! to each component of the whole residual vector.
+//!
+//! A check of the solution increment is not done.
+//! If both an absolute and a relative tolerances are specified, at least one of
+//! them has to be satisfied.
 class ConvergenceCriterionPerComponentResidual
     : public ConvergenceCriterionPerComponent
 {

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.h
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.h
@@ -22,7 +22,7 @@ class ConvergenceCriterionPerComponentResidual
     : public ConvergenceCriterionPerComponent
 {
 public:
-    explicit ConvergenceCriterionPerComponentResidual(
+    ConvergenceCriterionPerComponentResidual(
         std::vector<double>&& absolute_tolerances,
         std::vector<double>&& relative_tolerances,
         MathLib::VecNormType norm_type);

--- a/NumLib/ODESolver/ConvergenceCriterionResidual.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionResidual.cpp
@@ -1,0 +1,76 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "ConvergenceCriterionResidual.h"
+#include <logog/include/logog.hpp>
+
+#include "BaseLib/ConfigTree.h"
+#include "MathLib/LinAlg/LinAlg.h"
+
+namespace NumLib
+{
+ConvergenceCriterionResidual::ConvergenceCriterionResidual(
+    boost::optional<double>&& absolute_tolerance,
+    boost::optional<double>&& relative_tolerance,
+    MathLib::VecNormType norm_type)
+    : _abstol(std::move(absolute_tolerance)),
+      _reltol(std::move(relative_tolerance)),
+      _norm_type(norm_type)
+{
+    if ((!_abstol) && (!_reltol))
+        OGS_FATAL(
+            "At least one of absolute or relative tolerance has to be "
+            "specified.");
+}
+
+void ConvergenceCriterionResidual::checkResidual(const GlobalVector& residual)
+{
+    auto norm_res = MathLib::LinAlg::norm(residual, _norm_type);
+
+    if (_is_first_iteration) {
+        INFO("Convergence criterion: |r0|=%.4e", norm_res);
+        _residual_norm_0 = norm_res;
+    } else {
+        INFO("Convergence criterion: |r|=%.4e |r0|=%.4e |r|/|r0|=%.4e",
+             norm_res, _residual_norm_0, norm_res / _residual_norm_0);
+    }
+
+    bool satisfied_abs = false;
+    bool satisfied_rel = false;
+
+    if (_abstol) {
+        satisfied_abs = norm_res < *_abstol;
+    }
+    if (_reltol && !_is_first_iteration) {
+        satisfied_rel = norm_res < *_reltol * _residual_norm_0;
+    }
+
+    _satisfied = _satisfied && (satisfied_abs || satisfied_rel);
+}
+
+std::unique_ptr<ConvergenceCriterionResidual>
+createConvergenceCriterionResidual(const BaseLib::ConfigTree& config)
+{
+    config.checkConfigParameter("type", "Residual");
+
+    auto abstol = config.getConfigParameterOptional<double>("abstol");
+    auto reltol = config.getConfigParameterOptional<double>("reltol");
+    auto const norm_type_str =
+        config.getConfigParameter<std::string>("norm_type");
+    auto const norm_type = MathLib::convertStringToVecNormType(norm_type_str);
+
+    if (norm_type == MathLib::VecNormType::INVALID)
+        OGS_FATAL("Unknown vector norm type `%s'.", norm_type_str.c_str());
+
+    return std::unique_ptr<ConvergenceCriterionResidual>(
+        new ConvergenceCriterionResidual(std::move(abstol), std::move(reltol),
+                                         norm_type));
+}
+
+}  // NumLib

--- a/NumLib/ODESolver/ConvergenceCriterionResidual.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionResidual.cpp
@@ -48,7 +48,8 @@ void ConvergenceCriterionResidual::checkResidual(const GlobalVector& residual)
         satisfied_abs = norm_res < *_abstol;
     }
     if (_reltol && !_is_first_iteration) {
-        satisfied_rel = norm_res < *_reltol * _residual_norm_0;
+        satisfied_rel =
+            checkRelativeTolerance(*_reltol, norm_res, _residual_norm_0);
     }
 
     _satisfied = _satisfied && (satisfied_abs || satisfied_rel);

--- a/NumLib/ODESolver/ConvergenceCriterionResidual.h
+++ b/NumLib/ODESolver/ConvergenceCriterionResidual.h
@@ -19,7 +19,7 @@ namespace NumLib
 class ConvergenceCriterionResidual final : public ConvergenceCriterion
 {
 public:
-    explicit ConvergenceCriterionResidual(
+    ConvergenceCriterionResidual(
         boost::optional<double>&& absolute_tolerance,
         boost::optional<double>&& relative_tolerance,
         MathLib::VecNormType norm_type);

--- a/NumLib/ODESolver/ConvergenceCriterionResidual.h
+++ b/NumLib/ODESolver/ConvergenceCriterionResidual.h
@@ -16,6 +16,12 @@
 
 namespace NumLib
 {
+//! Convergence criterion applying a single absolute or relative tolerance to
+//! the whole residual vector.
+//!
+//! A check of the solution increment is not done.
+//! If both an absolute and a relative tolerance are specified, at least one of
+//! them has to be satisfied.
 class ConvergenceCriterionResidual final : public ConvergenceCriterion
 {
 public:

--- a/NumLib/ODESolver/ConvergenceCriterionResidual.h
+++ b/NumLib/ODESolver/ConvergenceCriterionResidual.h
@@ -1,0 +1,51 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef NUMLIB_CONVERGENCECRITERIONRESIDUAL_H
+#define NUMLIB_CONVERGENCECRITERIONRESIDUAL_H
+
+#include <boost/optional.hpp>
+#include "ConvergenceCriterion.h"
+#include "MathLib/LinAlg/LinAlgEnums.h"
+
+namespace NumLib
+{
+class ConvergenceCriterionResidual final : public ConvergenceCriterion
+{
+public:
+    explicit ConvergenceCriterionResidual(
+        boost::optional<double>&& absolute_tolerance,
+        boost::optional<double>&& relative_tolerance,
+        MathLib::VecNormType norm_type);
+
+    bool hasDeltaXCheck() const override { return false; }
+    bool hasResidualCheck() const override { return true; }
+
+    void checkDeltaX(const GlobalVector& /*minus_delta_x*/,
+                     GlobalVector const& /*x*/) override {}
+    void checkResidual(const GlobalVector& residual) override;
+
+    void preFirstIteration() override { _is_first_iteration = true; }
+    void reset() override { _satisfied = true; _is_first_iteration = false; }
+    bool isSatisfied() const { return _satisfied; }
+private:
+    const boost::optional<double> _abstol;
+    const boost::optional<double> _reltol;
+    const MathLib::VecNormType _norm_type;
+    bool _satisfied = true;
+    bool _is_first_iteration = true;
+    double _residual_norm_0;
+};
+
+std::unique_ptr<ConvergenceCriterionResidual> createConvergenceCriterionResidual(
+    BaseLib::ConfigTree const& config);
+
+}  // NumLib
+
+#endif  // NUMLIB_CONVERGENCECRITERIONRESIDUAL_H

--- a/NumLib/ODESolver/NonlinearSolver.cpp
+++ b/NumLib/ODESolver/NonlinearSolver.cpp
@@ -72,7 +72,7 @@ bool NonlinearSolver<NonlinearSolverTag::Picard>::solve(
         sys.applyKnownSolutionsPicard(A, rhs, x_new);
         INFO("[time] Applying Dirichlet BCs took %g s.", time_dirichlet.elapsed());
 
-        if (_convergence_criterion->hasResidualCheck()) {
+        if (!sys.isLinear() && _convergence_criterion->hasResidualCheck()) {
             GlobalVector res;
             LinAlg::matMult(A, x_new, res); // res = A * x_new
             LinAlg::axpy(res, -1.0, rhs);   // res -= rhs
@@ -215,7 +215,7 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
         sys.applyKnownSolutionsNewton(J, res, minus_delta_x);
         INFO("[time] Applying Dirichlet BCs took %g s.", time_dirichlet.elapsed());
 
-        if (_convergence_criterion->hasResidualCheck())
+        if (!sys.isLinear() && _convergence_criterion->hasResidualCheck())
             _convergence_criterion->checkResidual(res);
 
         BaseLib::RunTime time_linear_solver;

--- a/NumLib/ODESolver/NonlinearSolver.cpp
+++ b/NumLib/ODESolver/NonlinearSolver.cpp
@@ -48,12 +48,12 @@ bool NonlinearSolver<NonlinearSolverTag::Picard>::solve(
 
     LinAlg::copy(x, x_new);  // set initial guess, TODO save the copy
 
+    _convergence_criterion->preFirstIteration();
 
     unsigned iteration = 1;
-    for (; iteration <= _maxiter; ++iteration)
+    for (; iteration <= _maxiter;
+         ++iteration, _convergence_criterion->reset())
     {
-        _convergence_criterion->reset();
-
         BaseLib::RunTime time_iteration;
         time_iteration.start();
 
@@ -192,11 +192,12 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
     LinAlg::copy(x, minus_delta_x);
     minus_delta_x.setZero();
 
-    unsigned iteration = 1;
-    for (; iteration <= _maxiter; ++iteration)
-    {
-        _convergence_criterion->reset();
+    _convergence_criterion->preFirstIteration();
 
+    unsigned iteration = 1;
+    for (; iteration <= _maxiter;
+         ++iteration, _convergence_criterion->reset())
+    {
         BaseLib::RunTime time_iteration;
         time_iteration.start();
 

--- a/NumLib/ODESolver/NonlinearSolver.h
+++ b/NumLib/ODESolver/NonlinearSolver.h
@@ -14,6 +14,7 @@
 #include <utility>
 #include <logog/include/logog.hpp>
 
+#include "ConvergenceCriterion.h"
 #include "NonlinearSystem.h"
 #include "Types.h"
 
@@ -88,14 +89,21 @@ public:
      * \param maxiter the maximum number of iterations used to solve the
      *                equation.
      */
-    explicit NonlinearSolver(GlobalLinearSolver& linear_solver, double const tol,
-                             const unsigned maxiter)
-        : _linear_solver(linear_solver), _tol(tol), _maxiter(maxiter)
+    explicit NonlinearSolver(
+        GlobalLinearSolver& linear_solver,
+        const unsigned maxiter)
+        : _linear_solver(linear_solver),
+          _maxiter(maxiter)
     {
     }
 
     //! Set the nonlinear equation system that will be solved.
-    void setEquationSystem(System& eq) { _equation_system = &eq; }
+    //! TODO doc
+    void setEquationSystem(System& eq, ConvergenceCriterion& conv_crit)
+    {
+        _equation_system = &eq;
+        _convergence_criterion = &conv_crit;
+    }
     void assemble(GlobalVector const& x) const override;
 
     bool solve(GlobalVector& x,
@@ -106,7 +114,8 @@ private:
     GlobalLinearSolver& _linear_solver;
     System* _equation_system = nullptr;
 
-    const double _tol;        //!< tolerance of the solver
+    // TODO doc
+    ConvergenceCriterion* _convergence_criterion = nullptr;
     const unsigned _maxiter;  //!< maximum number of iterations
 
     double const _alpha =
@@ -139,14 +148,19 @@ public:
      * \param maxiter the maximum number of iterations used to solve the
      *                equation.
      */
-    explicit NonlinearSolver(GlobalLinearSolver& linear_solver, double const tol,
+    explicit NonlinearSolver(GlobalLinearSolver& linear_solver,
                              const unsigned maxiter)
-        : _linear_solver(linear_solver), _tol(tol), _maxiter(maxiter)
+        : _linear_solver(linear_solver), _maxiter(maxiter)
     {
     }
 
     //! Set the nonlinear equation system that will be solved.
-    void setEquationSystem(System& eq) { _equation_system = &eq; }
+    //! TODO doc
+    void setEquationSystem(System& eq, ConvergenceCriterion& conv_crit)
+    {
+        _equation_system = &eq;
+        _convergence_criterion = &conv_crit;
+    }
     void assemble(GlobalVector const& x) const override;
 
     bool solve(GlobalVector& x,
@@ -157,7 +171,8 @@ private:
     GlobalLinearSolver& _linear_solver;
     System* _equation_system = nullptr;
 
-    const double _tol;        //!< tolerance of the solver
+    // TODO doc
+    ConvergenceCriterion* _convergence_criterion = nullptr;
     const unsigned _maxiter;  //!< maximum number of iterations
 
     std::size_t _A_id = 0u;      //!< ID of the \f$ A \f$ matrix.

--- a/NumLib/ODESolver/TimeLoopSingleODE.h
+++ b/NumLib/ODESolver/TimeLoopSingleODE.h
@@ -36,13 +36,18 @@ public:
      * \param linear_solver the linear solver used to solve the linearized ODE
      *                      system.
      * \param nonlinear_solver The solver to be used to resolve nonlinearities.
+     * \param convergence_criterion The convergence criterion used by the
+     * nonlinear solver.
      */
-    TimeLoopSingleODE(TDiscODESys& ode_sys,
-                               std::unique_ptr<GlobalLinearSolver>&& linear_solver,
-                               std::unique_ptr<NLSolver>&& nonlinear_solver)
+    TimeLoopSingleODE(
+        TDiscODESys& ode_sys,
+        std::unique_ptr<GlobalLinearSolver>&& linear_solver,
+        std::unique_ptr<NLSolver>&& nonlinear_solver,
+        std::unique_ptr<ConvergenceCriterion>&& convergence_criterion)
         : _ode_sys(ode_sys),
           _linear_solver(std::move(linear_solver)),
-          _nonlinear_solver(std::move(nonlinear_solver))
+          _nonlinear_solver(std::move(nonlinear_solver)),
+          _convergence_criterion(std::move(convergence_criterion))
     {
     }
 
@@ -69,6 +74,7 @@ private:
     TDiscODESys& _ode_sys;
     std::unique_ptr<GlobalLinearSolver> _linear_solver;
     std::unique_ptr<NLSolver> _nonlinear_solver;
+    std::unique_ptr<ConvergenceCriterion> _convergence_criterion;
 };
 
 //! @}
@@ -87,7 +93,7 @@ bool TimeLoopSingleODE<NLTag>::loop(const double t0, GlobalVector const& x0,
 
     time_disc.setInitialState(t0, x0);  // push IC
 
-    _nonlinear_solver->setEquationSystem(_ode_sys);
+    _nonlinear_solver->setEquationSystem(_ode_sys, *_convergence_criterion);
 
     if (time_disc.needsPreload())
     {

--- a/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
@@ -21,6 +21,7 @@ std::unique_ptr<Process> createGroundwaterFlowProcess(
     MeshLib::Mesh& mesh,
     Process::NonlinearSolver& nonlinear_solver,
     std::unique_ptr<Process::TimeDiscretization>&& time_discretization,
+    std::unique_ptr<NumLib::ConvergenceCriterion>&& convergence_criterion,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
     BaseLib::ConfigTree const& config)
@@ -62,9 +63,9 @@ std::unique_ptr<Process> createGroundwaterFlowProcess(
 
     return std::unique_ptr<Process>{new GroundwaterFlowProcess{
         mesh, nonlinear_solver, std::move(time_discretization),
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(process_output),
-        std::move(named_function_caller)}};
+        std::move(convergence_criterion), std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(process_output), std::move(named_function_caller)}};
 }
 
 }  // namespace GroundwaterFlow

--- a/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.h
@@ -18,12 +18,11 @@ namespace ProcessLib
 {
 namespace GroundwaterFlow
 {
-
-std::unique_ptr<Process>
-createGroundwaterFlowProcess(
+std::unique_ptr<Process> createGroundwaterFlowProcess(
     MeshLib::Mesh& mesh,
     Process::NonlinearSolver& nonlinear_solver,
     std::unique_ptr<Process::TimeDiscretization>&& time_discretization,
+    std::unique_ptr<NumLib::ConvergenceCriterion>&& convergence_criterion,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
     BaseLib::ConfigTree const& config);

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -21,14 +21,16 @@ GroundwaterFlowProcess::GroundwaterFlowProcess(
     MeshLib::Mesh& mesh,
     Base::NonlinearSolver& nonlinear_solver,
     std::unique_ptr<Base::TimeDiscretization>&& time_discretization,
+    std::unique_ptr<NumLib::ConvergenceCriterion>&& convergence_criterion,
     std::vector<std::reference_wrapper<ProcessVariable>>&& process_variables,
     GroundwaterFlowProcessData&& process_data,
     SecondaryVariableCollection&& secondary_variables,
     ProcessOutput&& process_output,
     NumLib::NamedFunctionCaller&& named_function_caller)
     : Process(mesh, nonlinear_solver, std::move(time_discretization),
-              std::move(process_variables), std::move(secondary_variables),
-              std::move(process_output), std::move(named_function_caller)),
+              std::move(convergence_criterion), std::move(process_variables),
+              std::move(secondary_variables), std::move(process_output),
+              std::move(named_function_caller)),
       _process_data(std::move(process_data))
 {
     if (dynamic_cast<NumLib::ForwardEuler*>(

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -29,6 +29,7 @@ public:
         MeshLib::Mesh& mesh,
         Base::NonlinearSolver& nonlinear_solver,
         std::unique_ptr<Base::TimeDiscretization>&& time_discretization,
+        std::unique_ptr<NumLib::ConvergenceCriterion>&& convergence_criterion,
         std::vector<std::reference_wrapper<ProcessVariable>>&&
             process_variables,
         GroundwaterFlowProcessData&& process_data,

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -38,14 +38,16 @@ public:
     using NonlinearSolver = NumLib::NonlinearSolverBase;
     using TimeDiscretization = NumLib::TimeDiscretization;
 
-    Process(MeshLib::Mesh& mesh,
-            NonlinearSolver& nonlinear_solver,
-            std::unique_ptr<TimeDiscretization>&& time_discretization,
-            std::vector<std::reference_wrapper<ProcessVariable>>&&
-                process_variables,
-            SecondaryVariableCollection&& secondary_variables,
-            ProcessOutput&& process_output,
-            NumLib::NamedFunctionCaller&& named_function_caller);
+    Process(
+        MeshLib::Mesh& mesh,
+        NonlinearSolver& nonlinear_solver,
+        std::unique_ptr<TimeDiscretization>&& time_discretization,
+        std::unique_ptr<NumLib::ConvergenceCriterion>&& convergence_criterion,
+        std::vector<std::reference_wrapper<ProcessVariable>>&&
+            process_variables,
+        SecondaryVariableCollection&& secondary_variables,
+        ProcessOutput&& process_output,
+        NumLib::NamedFunctionCaller&& named_function_caller);
 
     /// Preprocessing before starting assembly for new timestep.
     virtual void preTimestep(GlobalVector const& /*x*/, const double /*t*/,
@@ -94,6 +96,11 @@ public:
     TimeDiscretization& getTimeDiscretization() const
     {
         return *_time_discretization;
+    }
+
+    NumLib::ConvergenceCriterion& getConvergenceCriterion() const
+    {
+        return *_convergence_criterion;
     }
 
 protected:
@@ -172,6 +179,7 @@ private:
 
     NonlinearSolver& _nonlinear_solver;
     std::unique_ptr<TimeDiscretization> _time_discretization;
+    std::unique_ptr<NumLib::ConvergenceCriterion> _convergence_criterion;
 
     /// Variables used by this process.
     std::vector<std::reference_wrapper<ProcessVariable>> _process_variables;

--- a/ProcessLib/TES/CreateTESProcess.cpp
+++ b/ProcessLib/TES/CreateTESProcess.cpp
@@ -15,11 +15,11 @@ namespace ProcessLib
 {
 namespace TES
 {
-
 std::unique_ptr<Process> createTESProcess(
     MeshLib::Mesh& mesh,
     Process::NonlinearSolver& nonlinear_solver,
     std::unique_ptr<Process::TimeDiscretization>&& time_discretization,
+    std::unique_ptr<NumLib::ConvergenceCriterion>&& convergence_criterion,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& /*parameters*/,
     BaseLib::ConfigTree const& config)
@@ -46,8 +46,9 @@ std::unique_ptr<Process> createTESProcess(
 
     return std::unique_ptr<Process>{new TESProcess{
         mesh, nonlinear_solver, std::move(time_discretization),
-        std::move(process_variables), std::move(secondary_variables),
-        std::move(process_output), std::move(named_function_caller), config}};
+        std::move(convergence_criterion), std::move(process_variables),
+        std::move(secondary_variables), std::move(process_output),
+        std::move(named_function_caller), config}};
 }
 
 }  // namespace TES

--- a/ProcessLib/TES/CreateTESProcess.h
+++ b/ProcessLib/TES/CreateTESProcess.h
@@ -17,12 +17,11 @@ namespace ProcessLib
 {
 namespace TES
 {
-
 std::unique_ptr<Process> createTESProcess(
     MeshLib::Mesh& mesh,
     Process::NonlinearSolver& nonlinear_solver,
-    std::unique_ptr<Process::TimeDiscretization>&&
-        time_discretization,
+    std::unique_ptr<Process::TimeDiscretization>&& time_discretization,
+    std::unique_ptr<NumLib::ConvergenceCriterion>&& convergence_criterion,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& /*parameters*/,
     BaseLib::ConfigTree const& config);

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -56,18 +56,17 @@ namespace TES
 TESProcess::TESProcess(
     MeshLib::Mesh& mesh,
     Process::NonlinearSolver& nonlinear_solver,
-    std::unique_ptr<Process::TimeDiscretization>&&
-        time_discretization,
+    std::unique_ptr<Process::TimeDiscretization>&& time_discretization,
+    std::unique_ptr<NumLib::ConvergenceCriterion>&& convergence_criterion,
     std::vector<std::reference_wrapper<ProcessVariable>>&& process_variables,
     SecondaryVariableCollection&& secondary_variables,
     ProcessOutput&& process_output,
     NumLib::NamedFunctionCaller&& named_function_caller,
     const BaseLib::ConfigTree& config)
-    : Process(
-          mesh, nonlinear_solver, std::move(time_discretization),
-          std::move(process_variables), std::move(secondary_variables),
-          std::move(process_output),
-          std::move(named_function_caller))
+    : Process(mesh, nonlinear_solver, std::move(time_discretization),
+              std::move(convergence_criterion), std::move(process_variables),
+              std::move(secondary_variables), std::move(process_output),
+              std::move(named_function_caller))
 {
     DBUG("Create TESProcess.");
 

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -35,6 +35,7 @@ public:
         MeshLib::Mesh& mesh,
         Process::NonlinearSolver& nonlinear_solver,
         std::unique_ptr<Process::TimeDiscretization>&& time_discretization,
+        std::unique_ptr<NumLib::ConvergenceCriterion>&& convergence_criterion,
         std::vector<std::reference_wrapper<ProcessVariable>>&&
             process_variables,
         SecondaryVariableCollection&& secondary_variables,

--- a/Tests/NumLib/TestODEInt.cpp
+++ b/Tests/NumLib/TestODEInt.cpp
@@ -16,8 +16,9 @@
 #include <logog/include/logog.hpp>
 
 #include "BaseLib/BuildInfo.h"
-#include "NumLib/ODESolver/TimeLoopSingleODE.h"
 #include "NumLib/NumericsConfig.h"
+#include "NumLib/ODESolver/TimeLoopSingleODE.h"
+#include "NumLib/ODESolver/ConvergenceCriterionDeltaX.h"
 #include "ODEs.h"
 
 using GMatrix = GlobalMatrix;
@@ -52,11 +53,15 @@ public:
 
         auto linear_solver = std::unique_ptr<GlobalLinearSolver>{
             new GlobalLinearSolver{"", nullptr}};
+        auto conv_crit = std::unique_ptr<NumLib::ConvergenceCriterion>(
+            new NumLib::ConvergenceCriterionDeltaX(
+                _tol, boost::none, MathLib::VecNormType::NORM2));
         std::unique_ptr<NLSolver> nonlinear_solver(
-                    new NLSolver(*linear_solver, _tol, _maxiter));
+            new NLSolver(*linear_solver, _maxiter));
 
         NumLib::TimeLoopSingleODE<NLTag> loop(ode_sys, std::move(linear_solver),
-                                              std::move(nonlinear_solver));
+                                              std::move(nonlinear_solver),
+                                              std::move(conv_crit));
 
         const double t0      = ODET::t0;
         const double t_end   = ODET::t_end;


### PR DESCRIPTION
~~Follow-up of #1315 and of #1349.~~
Closes #1339.

Core things:
* The [ConvergenceCriterion](https://github.com/chleh/ogs6/blob/conv-crit/NumLib/ODESolver/ConvergenceCriterion.h) interface
* Its usage in the [nonlinear solvers](https://github.com/ufz/ogs/pull/1342/files#diff-bf2c8423f053d67a6d9d9a91d8ac0a87) 
* The changes to the input files ufz/ogs-data#17

TODO
* [x] squash
* [x] docu

For later:
* There is currently no residual-norm check class implemented. I think that an be done later on as soon as it is needed.