### PR TITLE
[PL] Add multicomponent boundary conditions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 # 6.0.7 (in preparation)
 
 ### Features:
+ - Finalize support for multicomponent boundary conditions adding configuration
+   parser. #1343
 
 ### Infrastructure
 

--- a/Documentation/ProjectFile/boundary_condition/t_component.md
+++ b/Documentation/ProjectFile/boundary_condition/t_component.md
@@ -1,0 +1,3 @@
+For the multi-component process variables specifies the component of the
+boundary condition. The component ids start with 0. For single-component
+variables this is optional and defaults to 0.

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -86,8 +86,25 @@ ProcessVariable::ProcessVariable(BaseLib::ConfigTree const& config,
                 "Found geometry type \"%s\"",
                 GeoLib::convertGeoTypeToString(geometry->getGeoType()).c_str());
 
-            // TODO, the 0 is the component_id. Need parser.
-            _bc_configs.emplace_back(std::move(bc_config), *geometry, 0);
+            auto component_id =
+                //! \ogs_file_param{boundary_condition__component}
+                bc_config.getConfigParameterOptional<int>("component");
+
+            if (!component_id)
+            {
+                if (_n_components == 1)
+                    // default value for single component vars.
+                    component_id = 0;
+                else
+                    OGS_FATAL(
+                        "The <component> tag could not be found for the "
+                        "multi-component boundary condition of the process "
+                        "variable `%s'.",
+                        _name.c_str());
+            }
+
+            _bc_configs.emplace_back(std::move(bc_config), *geometry,
+                                     *component_id);
         }
     } else {
         INFO("No boundary conditions found.");


### PR DESCRIPTION
The main work was done before, but the parser was missing.

The default value for the component is 0 such that there is no need to add <component> for single component variables.

TODO:
 - [x] Documentation of the config param.
 - [x] Changelog