### PR TITLE
small improvements of queryMesh 

### DIFF
--- a/Applications/Utils/MeshEdit/queryMesh.cpp
+++ b/Applications/Utils/MeshEdit/queryMesh.cpp
@@ -81,12 +81,16 @@ int main(int argc, char *argv[])
         out << std::scientific
             << std::setprecision(std::numeric_limits<double>::digits10);
         out << "--------------------------------------------------------" << std::endl;
-        auto* node = mesh->getNode(node_id);
+        MeshLib::Node const* node = mesh->getNode(node_id);
         out << "# Node" << node->getID() << std::endl;
         out << "Coordinates: " << *node << std::endl;
-        out << "Connected elements: " ;
-        for (unsigned i=0; i<node->getNumberOfElements(); i++)
-            out << node->getElement(i)->getID() << " ";
+        out << "Connected elements (" << node->getNumberOfElements() << "): ";
+        for (auto ele : node->getElements())
+            out << ele->getID() << " ";
+        out << std::endl;
+        out << "Connected nodes (" << node->getConnectedNodes().size() << "): ";
+        for (auto nd : node->getConnectedNodes())
+            out << nd->getID() << " ";
         out << std::endl;
         INFO("%s", out.str().c_str());
     }


### PR DESCRIPTION
This PR includes the following changes in queryMesh
- print a list of connected nodes (for the given node)
- add --show-node-with-max-elements option to print information about a node having the maximum number of connected elements in the given mesh