### PR TITLE
New tool convertGEO and some minor fixes

### DIFF
--- a/Applications/Utils/FileConverter/CMakeLists.txt
+++ b/Applications/Utils/FileConverter/CMakeLists.txt
@@ -43,6 +43,12 @@ set_target_properties(TIN2VTK PROPERTIES FOLDER Utilities)
 target_link_libraries(TIN2VTK MeshLib)
 ADD_VTK_DEPENDENCY(TIN2VTK)
 
+if (QT4_FOUND)
+    add_executable(convertGEO convertGEO.cpp)
+    set_target_properties(convertGEO PROPERTIES FOLDER Utilities)
+    target_link_libraries(convertGEO GeoLib)
+endif()
+
 ####################
 ### Installation ###
 ####################

--- a/Applications/Utils/FileConverter/CMakeLists.txt
+++ b/Applications/Utils/FileConverter/CMakeLists.txt
@@ -56,8 +56,8 @@ install(TARGETS generateMatPropsFromMatID GMSH2OGS OGS2VTK VTK2OGS VTK2TIN
     RUNTIME DESTINATION bin COMPONENT ogs_converter)
 
 if(QT4_FOUND)
-    install(TARGETS ConvertSHPToGLI
-        FEFLOW2OGS RUNTIME DESTINATION bin COMPONENT ogs_converter)
+    install(TARGETS ConvertSHPToGLI FEFLOW2OGS convertGEO
+        RUNTIME DESTINATION bin COMPONENT ogs_converter)
 endif()
 
 cpack_add_component(ogs_converter

--- a/Applications/Utils/FileConverter/convertGEO.cpp
+++ b/Applications/Utils/FileConverter/convertGEO.cpp
@@ -1,0 +1,46 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include <string>
+#include <vector>
+
+#include <tclap/CmdLine.h>
+
+#include "Applications/ApplicationsLib/LogogSetup.h"
+
+#include "GeoLib/IO/readGeometryFromFile.h"
+#include "GeoLib/IO/writeGeometryToFile.h"
+#include "GeoLib/GEOObjects.h"
+
+
+int main (int argc, char* argv[])
+{
+    ApplicationsLib::LogogSetup logog_setup;
+
+    TCLAP::CmdLine cmd("Converts OGS geometric file into another file format.", ' ', "0.1");
+    TCLAP::ValueArg<std::string> argInputFileName("i", "input-file",
+                                         "the name of the gli file to be converted", true,
+                                         "", "file name");
+    cmd.add(argInputFileName);
+    TCLAP::ValueArg<std::string> argOutputFileName("o", "output-file",
+                                          "the name of the new gml file", true,
+                                          "", "file name");
+    cmd.add(argOutputFileName);
+    cmd.parse(argc, argv);
+
+    GeoLib::GEOObjects geoObjects;
+    GeoLib::IO::readGeometryFromFile(argInputFileName.getValue(), geoObjects);
+    std::vector<std::string> geo_names;
+    geoObjects.getGeometryNames(geo_names);
+    assert(geo_names.size() == 1);
+
+    GeoLib::IO::writeGeometryToFile(geo_names[0], geoObjects, argOutputFileName.getValue());
+
+    return EXIT_SUCCESS;
+}

--- a/Applications/Utils/FileConverter/convertGEO.cpp
+++ b/Applications/Utils/FileConverter/convertGEO.cpp
@@ -25,13 +25,15 @@ int main (int argc, char* argv[])
 {
     ApplicationsLib::LogogSetup logog_setup;
 
-    TCLAP::CmdLine cmd("Converts OGS geometric file into another file format.", ' ', BaseLib::BuildInfo::git_describe);
+    TCLAP::CmdLine cmd("Converts OGS geometry file into another file format. "
+                       "Currently *.gml (OGS6 XML-based format) and *.gli (OGS5 format) formats are supported.",
+                       ' ', BaseLib::BuildInfo::git_describe);
     TCLAP::ValueArg<std::string> argInputFileName("i", "input-file",
-                                         "the name of the gli file to be converted", true,
+                                         "the name of the geometry file to be converted", true,
                                          "", "file name");
     cmd.add(argInputFileName);
     TCLAP::ValueArg<std::string> argOutputFileName("o", "output-file",
-                                          "the name of the new gml file", true,
+                                          "the name of the new geometry file whose file format is guessed from its file extension", true,
                                           "", "file name");
     cmd.add(argOutputFileName);
     cmd.parse(argc, argv);

--- a/Applications/Utils/FileConverter/convertGEO.cpp
+++ b/Applications/Utils/FileConverter/convertGEO.cpp
@@ -12,6 +12,8 @@
 
 #include <tclap/CmdLine.h>
 
+#include "BaseLib/BuildInfo.h"
+
 #include "Applications/ApplicationsLib/LogogSetup.h"
 
 #include "GeoLib/IO/readGeometryFromFile.h"
@@ -23,7 +25,7 @@ int main (int argc, char* argv[])
 {
     ApplicationsLib::LogogSetup logog_setup;
 
-    TCLAP::CmdLine cmd("Converts OGS geometric file into another file format.", ' ', "0.1");
+    TCLAP::CmdLine cmd("Converts OGS geometric file into another file format.", ' ', BaseLib::BuildInfo::git_describe);
     TCLAP::ValueArg<std::string> argInputFileName("i", "input-file",
                                          "the name of the gli file to be converted", true,
                                          "", "file name");

--- a/Applications/Utils/MeshEdit/appendLinesAlongPolyline.cpp
+++ b/Applications/Utils/MeshEdit/appendLinesAlongPolyline.cpp
@@ -14,7 +14,7 @@
 
 #include "GeoLib/GEOObjects.h"
 #include "GeoLib/PolylineVec.h"
-#include "GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.h"
+#include "GeoLib/IO/readGeometryFromFile.h"
 
 #include "MeshGeoToolsLib/AppendLinesAlongPolyline.h"
 
@@ -44,8 +44,7 @@ int main (int argc, char* argv[])
 
     // read GEO objects
     GeoLib::GEOObjects geo_objs;
-    GeoLib::IO::BoostXmlGmlInterface xml(geo_objs);
-    xml.readFile(geoFileArg.getValue());
+    GeoLib::IO::readGeometryFromFile(geoFileArg.getValue(), geo_objs);
 
     std::vector<std::string> geo_names;
     geo_objs.getGeometryNames (geo_names);

--- a/GeoLib/IO/readGeometryFromFile.cpp
+++ b/GeoLib/IO/readGeometryFromFile.cpp
@@ -31,7 +31,7 @@ readGeometryFromFile(std::string const& fname, GeoLib::GEOObjects & geo_objs)
         xml.readFile(fname);
     } else {
         std::vector<std::string> errors;
-        std::string geo_name(BaseLib::extractBaseNameWithoutExtension(fname));
+        std::string geo_name; // geo_name is output of the reading function
         GeoLib::IO::Legacy::readGLIFileV4(fname, geo_objs, geo_name, errors);
     }
 }

--- a/GeoLib/IO/readGeometryFromFile.cpp
+++ b/GeoLib/IO/readGeometryFromFile.cpp
@@ -12,6 +12,7 @@
 
 #include <vector>
 
+#include "BaseLib/Error.h"
 #include "BaseLib/FileTools.h"
 
 #include "GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.h"
@@ -33,6 +34,13 @@ readGeometryFromFile(std::string const& fname, GeoLib::GEOObjects & geo_objs)
         std::vector<std::string> errors;
         std::string geo_name; // geo_name is output of the reading function
         GeoLib::IO::Legacy::readGLIFileV4(fname, geo_objs, geo_name, errors);
+    }
+
+    std::vector<std::string> geo_names;
+    geo_objs.getGeometryNames(geo_names);
+    if (geo_names.empty()) {
+        OGS_FATAL("GEOObjects has no geometry name after reading the geometry file. "
+                  "Something is wrong in the reading function.");
     }
 }
 }


### PR DESCRIPTION
This PR includes 
- add a new CLI tool (`convertGEO`) for geometric file conversion, e.g. *.gli -> *.gml 
- support all geometric file formats in `appendLinesAlongPolyline` tool
- fix misleading variable setting in readGeometryFromFile.cpp