### PR TITLE
Fix Jenkins python 2/3 compatibility

### DIFF
--- a/scripts/doc/append-xml-tags.py
+++ b/scripts/doc/append-xml-tags.py
@@ -14,7 +14,7 @@ import os
 import sys
 import xml.etree.cElementTree as ET
 import json
-from six import print_
+from print23 import print_
 
 github_src_url  = "https://github.com/ufz/ogs/tree/master"
 github_data_url = "https://github.com/ufz/ogs-data/tree/master"

--- a/scripts/doc/check-project-params.py
+++ b/scripts/doc/check-project-params.py
@@ -3,7 +3,7 @@
 # This script actually generates the QA page.
 # For its usage see generate-project-file-doc-qa.sh
 
-from six import print_
+from print23 import print_
 import sys
 import re
 import os.path

--- a/scripts/doc/linked-xml-file.py
+++ b/scripts/doc/linked-xml-file.py
@@ -15,7 +15,7 @@
 from signal import signal, SIGPIPE, SIG_DFL
 signal(SIGPIPE,SIG_DFL)
 
-from six import print_
+from print23 import print_
 import os
 import sys
 import xml.etree.cElementTree as ET

--- a/scripts/doc/normalize-param-cache.py
+++ b/scripts/doc/normalize-param-cache.py
@@ -4,6 +4,7 @@
 # and transforms it into a tabular representation for further
 # processing.
 
+from print23 import print_
 import sys
 import re
 import os.path
@@ -12,7 +13,7 @@ def debug(msg):
     sys.stderr.write(msg+"\n")
 
 def write_out(*args):
-    print("@@@".join([str(a) for a in args]))
+    print_("@@@".join(str(a) for a in args))
 
 # capture #2 is the parameter path
 comment = re.compile(r"//! \\ogs_file_(param|attr)\{([A-Za-z_0-9]+)\}( \\todo .*)?$")

--- a/scripts/doc/print23.py
+++ b/scripts/doc/print23.py
@@ -1,0 +1,6 @@
+#!/usr/bin/python
+
+# Print statement that behaves the same for python 2 and 3.
+# E,g, print_(1.0, 2, "5") will always print the string "1.0 2 5".
+def print_(*args):
+    print(" ".join(str(a) for a in args))


### PR DESCRIPTION
Jenkins' doc build failed because my new scripts used a non-standard python module. This PR fixes this.

Maybe it would be good to add `make internal_pre_doc_qa_page` to some of Jenkins' PR jobs in order to test the python and shell scripts?