### PR TITLE
[scr] fixed format() for python 2.6 compatibilty

### DIFF
--- a/scripts/doc/check-project-params.py
+++ b/scripts/doc/check-project-params.py
@@ -15,12 +15,12 @@ def debug(msg):
     sys.stderr.write(msg+"\n")
 
 if len(sys.argv) != 3:
-    print_("USAGE: {} DOCAUXDIR SRCDIR".format(sys.argv[0]))
+    print_("USAGE: {0} DOCAUXDIR SRCDIR".format(sys.argv[0]))
     sys.exit(1)
 
 docauxdir = sys.argv[1]
 if not os.path.isdir(docauxdir):
-    print_("error: `{}' is not a directory".format(docauxdir))
+    print_("error: `{0}' is not a directory".format(docauxdir))
     sys.exit(1)
 
 doxdir = os.path.join(docauxdir, "dox", "ProjectFile")
@@ -67,7 +67,7 @@ with open(os.path.join(docauxdir, "documented-parameters-cache.txt")) as fh:
             debug("SPECIAL: " + " ".join(inline[1:])) # TODO implement proper handling
             # unneeded.append(inline[1:])
         else:
-            debug("ERROR: unrecognized status {}".format(status))
+            debug("ERROR: unrecognized status {0}".format(status))
             wrong_status = True
 
 
@@ -89,7 +89,7 @@ for (dirpath, _, filenames) in os.walk(srcdocdir):
             tagpath = os.path.join(reldirpath, f[2:-len(".md")])
             tag_or_attr = "attr"
         else:
-            debug("ERROR: Found md file with unrecognized name: {}"
+            debug("ERROR: Found md file with unrecognized name: {0}"
                     .format(filepath))
             continue
 
@@ -186,7 +186,7 @@ with open(os.path.join(docauxdir, "untested-parameters-cache.json")) as fh:
         print_("# Tags that do not occur in any CTest project file")
         for utag in sorted(utags):
             pagename = "ogs_file_param__" + utag.replace(".", "__")
-            print_(r'- \ref {} "{}"'.format(pagename, utag))
+            print_(r'- \ref {0} "{1}"'.format(pagename, utag))
 
     uattrs = [ ua for ua in untested_tags_attrs["attributes"] \
             if ua != "gml" and not ua.startswith("gml.") ]
@@ -196,7 +196,7 @@ with open(os.path.join(docauxdir, "untested-parameters-cache.json")) as fh:
         print_("# Attributes that do not occur in any CTest project file")
         for uattr in sorted(uattrs):
             pagename = "ogs_file_attr__" + uattr.replace(".", "__")
-            print_(r'- \ref {} "{}"'.format(pagename, uattr))
+            print_(r'- \ref {0} "{1}"'.format(pagename, uattr))
 
 # exit with error status if something was not documented/tested
 if qa_status_succeeded:

--- a/scripts/doc/linked-xml-file.py
+++ b/scripts/doc/linked-xml-file.py
@@ -45,9 +45,9 @@ indent = "&nbsp;"*2
 
 def format_if_documented(is_doc, fmt, fullpagename, tag_attr, *args):
     if is_doc:
-        tag_attr_formatted = r'\ref {} "{}"'.format(fullpagename, tag_attr)
+        tag_attr_formatted = r'\ref {0} "{1}"'.format(fullpagename, tag_attr)
     else:
-        tag_attr_formatted = r'<span style="color: red;" title="undocumented: {}">{}</span>'.format(fullpagename, tag_attr)
+        tag_attr_formatted = r'<span style="color: red;" title="undocumented: {0}">{1}</span>'.format(fullpagename, tag_attr)
 
     return fmt.format(tag_attr_formatted, tag_attr, *args)
 
@@ -232,12 +232,12 @@ for (dirpath, dirnames, filenames) in os.walk(datadir, topdown=False):
             pagetitle = "OGS CTests&mdash;Project Files"
 
         with open(os.path.join(outdirpath, "index.dox"), "w") as fh:
-            fh.write("""/*! \page {} {}
+            fh.write("""/*! \page {0} {1}
 
 """.format(pagename, pagetitle))
 
             for sp in sorted(subpages):
-                fh.write("- \\subpage {}\n".format(sp))
+                fh.write("- \\subpage {0}\n".format(sp))
 
             fh.write("""
 


### PR DESCRIPTION
Sorry for the change again.

This PR fixes the `ValueError: zero length field name in format` error.

This time I tried it on envinf1.