### PR TITLE
Unique data type for integer valued properties

### DIFF
--- a/Applications/Utils/ModelPreparation/ComputeNodeAreasFromSurfaceMesh.cpp
+++ b/Applications/Utils/ModelPreparation/ComputeNodeAreasFromSurfaceMesh.cpp
@@ -83,13 +83,13 @@ int main (int argc, char* argv[])
     // ToDo check if mesh is read correct and if the mesh is a surface mesh
 
     // check if a node property containing the subsurface ids is available
-    boost::optional<MeshLib::PropertyVector<std::size_t> const&> orig_node_ids(
-        surface_mesh->getProperties().getPropertyVector<std::size_t>(
+    boost::optional<MeshLib::PropertyVector<int> const&> orig_node_ids(
+        surface_mesh->getProperties().getPropertyVector<int>(
             id_prop_name.getValue()));
     // if the node property is not available generate it
     if (!orig_node_ids) {
-        boost::optional<MeshLib::PropertyVector<std::size_t>&> node_ids(
-            surface_mesh->getProperties().createNewPropertyVector<std::size_t>(
+        boost::optional<MeshLib::PropertyVector<int>&> node_ids(
+            surface_mesh->getProperties().createNewPropertyVector<int>(
                 id_prop_name.getValue(), MeshLib::MeshItemType::Node, 1));
         if (!node_ids) {
             ERR("Fatal error: could not create property.");

--- a/Applications/Utils/ModelPreparation/createNeumannBc.cpp
+++ b/Applications/Utils/ModelPreparation/createNeumannBc.cpp
@@ -131,8 +131,8 @@ int main(int argc, char* argv[])
         MeshLib::IO::readMeshFromFile(in_mesh.getValue()));
 
     std::string const prop_name("OriginalSubsurfaceNodeIDs");
-    boost::optional<MeshLib::PropertyVector<std::size_t> const&> node_id_pv(
-        surface_mesh->getProperties().getPropertyVector<std::size_t>(prop_name));
+    boost::optional<MeshLib::PropertyVector<int> const&> node_id_pv(
+        surface_mesh->getProperties().getPropertyVector<int>(prop_name));
     if (!node_id_pv)
     {
         ERR(

--- a/MeshLib/MeshEditing/AddLayerToMesh.cpp
+++ b/MeshLib/MeshEditing/AddLayerToMesh.cpp
@@ -46,7 +46,7 @@ namespace MeshLib
 */
 MeshLib::Element* extrudeElement(std::vector<MeshLib::Node*> const& subsfc_nodes,
     MeshLib::Element const& sfc_elem,
-    MeshLib::PropertyVector<std::size_t> const& sfc_to_subsfc_id_map,
+    MeshLib::PropertyVector<int> const& sfc_to_subsfc_id_map,
     std::map<std::size_t, std::size_t> const& subsfc_sfc_id_map)
 {
     if (sfc_elem.getDimension() > 2)
@@ -107,8 +107,8 @@ MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh, double thickness,
         sfc_mesh = (on_top) ? std::unique_ptr<MeshLib::Mesh>(new MeshLib::Mesh(mesh)) :
                               std::unique_ptr<MeshLib::Mesh>(MeshLib::createFlippedMesh(mesh));
         // add property storing node ids
-        boost::optional<MeshLib::PropertyVector<std::size_t>&> pv(
-            sfc_mesh->getProperties().createNewPropertyVector<std::size_t>(
+        boost::optional<MeshLib::PropertyVector<int>&> pv(
+            sfc_mesh->getProperties().createNewPropertyVector<int>(
                 prop_name, MeshLib::MeshItemType::Node, 1));
         if (pv) {
             pv->resize(sfc_mesh->getNumberOfNodes());
@@ -132,8 +132,8 @@ MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh, double thickness,
     std::size_t const n_sfc_nodes(sfc_nodes.size());
 
     // fetch subsurface node ids PropertyVector
-    boost::optional<MeshLib::PropertyVector<std::size_t> const&> opt_node_id_pv(
-        sfc_mesh->getProperties().getPropertyVector<std::size_t>(prop_name));
+    boost::optional<MeshLib::PropertyVector<int> const&> opt_node_id_pv(
+        sfc_mesh->getProperties().getPropertyVector<int>(prop_name));
     if (!opt_node_id_pv) {
         ERR(
             "Need subsurface node ids, but the property \"%s\" is not "
@@ -142,7 +142,7 @@ MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh, double thickness,
         return nullptr;
     }
 
-    MeshLib::PropertyVector<std::size_t> const& node_id_pv(*opt_node_id_pv);
+    MeshLib::PropertyVector<int> const& node_id_pv(*opt_node_id_pv);
     // *** copy sfc nodes to subsfc mesh node
     std::map<std::size_t, std::size_t> subsfc_sfc_id_map;
     for (std::size_t k(0); k<n_sfc_nodes; ++k) {

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -106,7 +106,7 @@ MeshLib::Mesh* MeshSurfaceExtraction::getMeshSurface(
         delete *elem;
     }
 
-    std::vector<std::size_t> id_map;
+    std::vector<int> id_map;
     if (!subsfc_node_id_backup_prop_name.empty())
     {
         id_map.reserve(sfc_nodes.size());
@@ -116,8 +116,8 @@ MeshLib::Mesh* MeshSurfaceExtraction::getMeshSurface(
     MeshLib::Mesh* result (new Mesh(mesh.getName()+"-Surface", sfc_nodes, new_elements));
     // transmit the original node ids of the subsurface mesh as a property
     if (!subsfc_node_id_backup_prop_name.empty()) {
-        boost::optional<MeshLib::PropertyVector<std::size_t>&> orig_node_ids(
-            result->getProperties().createNewPropertyVector<std::size_t>(
+        boost::optional<MeshLib::PropertyVector<int>&> orig_node_ids(
+            result->getProperties().createNewPropertyVector<int>(
                 subsfc_node_id_backup_prop_name , MeshLib::MeshItemType::Node, 1));
         if (orig_node_ids) {
             orig_node_ids->resize(id_map.size());


### PR DESCRIPTION
It seems that the handling within the Vtk io routines of the data type `std::size_t` depends on the operating system. For that reason I switched to the more common `int` data type for the `PropertyVector`. This works under arch linux as well as under windows (as reported by Eunseon).