### PR TITLE
Read and write data arrays of type std::size_t under linux and windows in the vtu io.

### DIFF
--- a/MeshLib/MeshGenerators/VtkMeshConverter.cpp
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.cpp
@@ -26,6 +26,7 @@
 #include <vtkCharArray.h>
 #include <vtkUnsignedCharArray.h>
 #include <vtkUnsignedLongArray.h>
+#include <vtkUnsignedLongLongArray.h>
 #include <vtkDoubleArray.h>
 #include <vtkIntArray.h>
 
@@ -235,6 +236,13 @@ void VtkMeshConverter::convertArray(vtkDataArray &array, MeshLib::Properties &pr
     if (vtkUnsignedLongArray::SafeDownCast(&array))
     {
         VtkMeshConverter::convertTypedArray<unsigned long>(array, properties, type);
+        return;
+    }
+
+    if (vtkUnsignedLongLongArray::SafeDownCast(&array))
+    {
+        VtkMeshConverter::convertTypedArray<unsigned long long>(
+            array, properties, type);
         return;
     }
 


### PR DESCRIPTION
This makes it possible to read and write std::size_t under linux and windows.