### PR TITLE
Multi component ConstantParameter and Parameter access operators.

### DIFF
--- a/Documentation/ProjectFile/parameter/Constant/c_Constant.md
+++ b/Documentation/ProjectFile/parameter/Constant/c_Constant.md
@@ -1,1 +1,1 @@
-\ogs_missing_documentation
+A constant scalar value or tuple parameter.

--- a/Documentation/ProjectFile/parameter/Constant/t_value.md
+++ b/Documentation/ProjectFile/parameter/Constant/t_value.md
@@ -1,1 +1,3 @@
-\ogs_missing_documentation
+Single component constant parameter value.
+
+This is an alternative to the \ref ogs_file_param__parameter__Constant__values

--- a/Documentation/ProjectFile/parameter/Constant/t_values.md
+++ b/Documentation/ProjectFile/parameter/Constant/t_values.md
@@ -1,0 +1,1 @@
+Multi-component constant parameter values.

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
@@ -58,9 +58,8 @@ public:
             pos.setIntegrationPoint(ip);
             auto const& sm = Base::_shape_matrices[ip];
             auto const& wp = integration_method.getWeightedPoint(ip);
-            _local_rhs.noalias() +=
-                sm.N * _neumann_bc_parameter.getTuple(t, pos).front() *
-                sm.detJ * wp.getWeight();
+            _local_rhs.noalias() += sm.N * _neumann_bc_parameter(t, pos)[0] *
+                                    sm.detJ * wp.getWeight();
         }
 
         auto const indices = NumLib::getIndices(id, dof_table_boundary);

--- a/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
@@ -64,8 +64,8 @@ public:
             auto const& sm = Base::_shape_matrices[ip];
             auto const& wp = integration_method.getWeightedPoint(ip);
 
-            double const alpha = _data.alpha.getTuple(t, pos).front();
-            double const u_0 = _data.u_0.getTuple(t, pos).front();
+            double const alpha = _data.alpha(t, pos)[0];
+            double const u_0 = _data.u_0(t, pos)[0];
 
             // flux = alpha * ( u_0 - u )
             // adding a alpha term to the diagonal of the stiffness matrix

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -99,7 +99,7 @@ public:
             pos.setIntegrationPoint(ip);
             auto const& sm = _shape_matrices[ip];
             auto const& wp = integration_method.getWeightedPoint(ip);
-            auto const k = _process_data.hydraulic_conductivity.getTuple(t, pos).front();
+            auto const k = _process_data.hydraulic_conductivity(t, pos)[0];
 
             _localA.noalias() += sm.dNdx.transpose() * k * sm.dNdx *
                                  sm.detJ * wp.getWeight();

--- a/ProcessLib/Parameter/ConstantParameter.cpp
+++ b/ProcessLib/Parameter/ConstantParameter.cpp
@@ -10,6 +10,7 @@
 #include "ConstantParameter.h"
 #include <logog/include/logog.hpp>
 #include "BaseLib/ConfigTree.h"
+#include "BaseLib/Error.h"
 
 namespace ProcessLib
 {
@@ -18,11 +19,39 @@ std::unique_ptr<ParameterBase> createConstantParameter(
 {
     //! \ogs_file_param{parameter__type}
     config.checkConfigParameter("type", "Constant");
-    //! \ogs_file_param{parameter__Constant__value}
-    auto const value = config.getConfigParameter<double>("value");
-    DBUG("Using value %g", value);
 
-    return std::unique_ptr<ParameterBase>(new ConstantParameter<double>(value));
+    // Optional case for single-component variables where the value can be used.
+    // If the 'value' tag is found, use it and return. Otherwise continue with
+    // then required tag 'values'.
+    {
+        //! \ogs_file_param{parameter__Constant__value}
+        auto const value = config.getConfigParameterOptional<double>("value");
+
+        if (value)
+        {
+            DBUG("Using value %g for constant parameter.", *value);
+            return std::unique_ptr<ParameterBase>(
+                new ConstantParameter<double>(*value));
+        }
+    }
+
+    // Value tag not available; continue with required values tag.
+    std::vector<double> const values =
+        //! \ogs_file_param{parameter__Constant__values}
+        config.getConfigParameter<std::vector<double>>("values");
+
+    if (values.empty())
+        OGS_FATAL("No value available for constant parameter.");
+
+    DBUG("Using following values for the constant parameter:");
+    for (double const v : values)
+    {
+        (void)v;  // unused value if building w/o DBUG output.
+        DBUG("\t%g", v);
+    }
+
+    return std::unique_ptr<ParameterBase>(
+        new ConstantParameter<double>(values));
 }
 
 }  // ProcessLib

--- a/ProcessLib/Parameter/ConstantParameter.h
+++ b/ProcessLib/Parameter/ConstantParameter.h
@@ -16,11 +16,20 @@ namespace ProcessLib
 {
 /// Single, constant value parameter.
 template <typename T>
-struct ConstantParameter final : public Parameter<T> {
+struct ConstantParameter final : public Parameter<T>
+{
+    /// Construction with single value.
     ConstantParameter(T const& value) : _value({value}) {}
-
-    // TODO allow for different sizes
-    unsigned getNumberOfComponents() const override { return 1; }
+    /// Construction with a tuple.
+    /// The given tuple must be non-empty.
+    ConstantParameter(std::vector<T> const& value) : _value(value)
+    {
+        assert(!value.empty());
+    }
+    unsigned getNumberOfComponents() const override
+    {
+        return static_cast<unsigned>(_value.size());
+    }
 
     std::vector<T> const& getTuple(
         double const /*t*/, SpatialPosition const& /*pos*/) const override

--- a/ProcessLib/Parameter/ConstantParameter.h
+++ b/ProcessLib/Parameter/ConstantParameter.h
@@ -31,7 +31,7 @@ struct ConstantParameter final : public Parameter<T>
         return static_cast<unsigned>(_value.size());
     }
 
-    std::vector<T> const& getTuple(
+    std::vector<T> const& operator()(
         double const /*t*/, SpatialPosition const& /*pos*/) const override
     {
         return _value;

--- a/ProcessLib/Parameter/MeshElementParameter.h
+++ b/ProcessLib/Parameter/MeshElementParameter.h
@@ -34,8 +34,8 @@ struct MeshElementParameter final : public Parameter<T> {
         return _property.getNumberOfComponents();
     }
 
-    std::vector<T> const& getTuple(double const /*t*/,
-                                   SpatialPosition const& pos) const override
+    std::vector<T> const& operator()(double const /*t*/,
+                                     SpatialPosition const& pos) const override
     {
         auto const e = pos.getElementID();
         assert(e);

--- a/ProcessLib/Parameter/MeshNodeParameter.h
+++ b/ProcessLib/Parameter/MeshNodeParameter.h
@@ -34,8 +34,8 @@ struct MeshNodeParameter final : public Parameter<T> {
         return _property.getNumberOfComponents();
     }
 
-    std::vector<T> const& getTuple(double const /*t*/,
-                                   SpatialPosition const& pos) const override
+    std::vector<T> const& operator()(double const /*t*/,
+                                     SpatialPosition const& pos) const override
     {
         auto const n = pos.getNodeID();
         assert(n);

--- a/ProcessLib/Parameter/Parameter.h
+++ b/ProcessLib/Parameter/Parameter.h
@@ -52,7 +52,7 @@ struct Parameter : public ParameterBase
     virtual unsigned getNumberOfComponents() const = 0;
 
     //! Returns the parameter value at the given time and position.
-    virtual std::vector<T> const& getTuple(
+    virtual std::vector<T> const& operator()(
         double const t, SpatialPosition const& pos) const = 0;
 };
 

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -93,7 +93,7 @@ void Process::setInitialConditions(double const t, GlobalVector& x)
                                       MeshLib::MeshItemType::Node, node_id);
 
             pos.setNodeID(node_id);
-            auto const& tup = ic.getTuple(t, pos);
+            auto const& ic_value = ic(t, pos);
 
             for (int comp_id = 0; comp_id < num_comp; ++comp_id)
             {
@@ -111,7 +111,7 @@ void Process::setInitialConditions(double const t, GlobalVector& x)
                 if (global_index == x.size())
                     global_index = 0;
 #endif
-                x.set(global_index, tup[comp_id]);
+                x.set(global_index, ic_value[comp_id]);
             }
         }
     }


### PR DESCRIPTION
 - Extend the ConstantParameter to read `<values>`. The `<value>` tag remains for scalar parameters.
   This is needed for the [Mechancis PR](https://github.com/ufz/ogs/pull/1340) where the initial conditions are multi-component, constants. Before we had multi-component InitialCondition, which is replaced by Parameter.
 - ~~Also add two Parameter::operator() for scalar and component-wise value access.~~
  Renames `getTuple(t,x)` into call operator. This is for convenience: `rho(t, x)[0]` for scalar parameter rho, or `K(t,x)[i]` for three-dim conductivity/permeability parameter K (accessing the i-th component) is much nicer/less noisier than `rho.getTuple(t,x)[0]` or `K.getTuple(t,x)[i]`.