### PR TITLE
Fix usage of optional<T const&>.

### DIFF
--- a/Applications/Utils/ModelPreparation/ComputeNodeAreasFromSurfaceMesh.cpp
+++ b/Applications/Utils/ModelPreparation/ComputeNodeAreasFromSurfaceMesh.cpp
@@ -83,7 +83,7 @@ int main (int argc, char* argv[])
     // ToDo check if mesh is read correct and if the mesh is a surface mesh
 
     // check if a node property containing the subsurface ids is available
-    boost::optional<MeshLib::PropertyVector<std::size_t> const&> orig_node_ids(
+    boost::optional<MeshLib::PropertyVector<std::size_t>&> orig_node_ids(
         surface_mesh->getProperties().getPropertyVector<std::size_t>(
             id_prop_name.getValue()));
     // if the node property is not available generate it

--- a/Applications/Utils/ModelPreparation/createNeumannBc.cpp
+++ b/Applications/Utils/ModelPreparation/createNeumannBc.cpp
@@ -131,8 +131,9 @@ int main(int argc, char* argv[])
         MeshLib::IO::readMeshFromFile(in_mesh.getValue()));
 
     std::string const prop_name("OriginalSubsurfaceNodeIDs");
-    boost::optional<MeshLib::PropertyVector<std::size_t> const&> node_id_pv(
-        surface_mesh->getProperties().getPropertyVector<std::size_t>(prop_name));
+    boost::optional<MeshLib::PropertyVector<std::size_t>&> const node_id_pv(
+        surface_mesh->getProperties().getPropertyVector<std::size_t>(
+            prop_name));
     if (!node_id_pv)
     {
         ERR(

--- a/MeshLib/MeshEditing/AddLayerToMesh.cpp
+++ b/MeshLib/MeshEditing/AddLayerToMesh.cpp
@@ -132,7 +132,7 @@ MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh, double thickness,
     std::size_t const n_sfc_nodes(sfc_nodes.size());
 
     // fetch subsurface node ids PropertyVector
-    boost::optional<MeshLib::PropertyVector<std::size_t> const&> opt_node_id_pv(
+    boost::optional<MeshLib::PropertyVector<std::size_t>&> const opt_node_id_pv(
         sfc_mesh->getProperties().getPropertyVector<std::size_t>(prop_name));
     if (!opt_node_id_pv) {
         ERR(

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -71,9 +71,9 @@ TEST_F(MeshLibProperties, AddDoubleProperties)
         ASSERT_EQ(static_cast<double>(k+1), (*double_properties)[k]);
     }
 
-    boost::optional<MeshLib::PropertyVector<double> const&>
-        double_properties_cpy(mesh->getProperties().getPropertyVector<double>(
-            prop_name));
+    boost::optional<MeshLib::PropertyVector<double>&> const
+    double_properties_cpy(
+        mesh->getProperties().getPropertyVector<double>(prop_name));
     ASSERT_FALSE(!double_properties_cpy);
 
     for (std::size_t k(0); k<size; k++) {
@@ -81,10 +81,9 @@ TEST_F(MeshLibProperties, AddDoubleProperties)
     }
 
     mesh->getProperties().removePropertyVector(prop_name);
-    boost::optional<MeshLib::PropertyVector<double> const&>
-        removed_double_properties(
-            mesh->getProperties().getPropertyVector<double>(prop_name)
-        );
+    boost::optional<MeshLib::PropertyVector<double>&> const
+    removed_double_properties(
+        mesh->getProperties().getPropertyVector<double>(prop_name));
 
     ASSERT_TRUE(!removed_double_properties);
 }
@@ -149,9 +148,9 @@ TEST_F(MeshLibProperties, AddDoublePointerProperties)
     // the mesh should have the property assigned to cells
     ASSERT_TRUE(mesh->getProperties().hasPropertyVector(prop_name));
     // fetch the properties from the container
-    boost::optional<MeshLib::PropertyVector<double*> const&>
-        group_properties_cpy(mesh->getProperties().getPropertyVector<double*>(
-            prop_name));
+    boost::optional<MeshLib::PropertyVector<double*>&> const
+    group_properties_cpy(
+        mesh->getProperties().getPropertyVector<double*>(prop_name));
     ASSERT_FALSE(!group_properties_cpy);
 
     for (std::size_t k(0); k<n_items; k++) {
@@ -159,9 +158,9 @@ TEST_F(MeshLibProperties, AddDoublePointerProperties)
     }
 
     mesh->getProperties().removePropertyVector(prop_name);
-    boost::optional<MeshLib::PropertyVector<double*> const&>
-        removed_group_properties(mesh->getProperties().getPropertyVector<double*>(
-            prop_name));
+    boost::optional<MeshLib::PropertyVector<double*>&> const
+    removed_group_properties(
+        mesh->getProperties().getPropertyVector<double*>(prop_name));
 
     ASSERT_TRUE(!removed_group_properties);
 }
@@ -229,10 +228,10 @@ TEST_F(MeshLibProperties, AddArrayPointerProperties)
         }
     }
 
-    boost::optional<MeshLib::PropertyVector<std::array<double,3>*> const&>
-        group_properties_cpy(
-            mesh->getProperties().getPropertyVector<std::array<double,3>*>(prop_name)
-        );
+    boost::optional<MeshLib::PropertyVector<std::array<double, 3>*>&> const
+    group_properties_cpy(
+        mesh->getProperties().getPropertyVector<std::array<double, 3>*>(
+            prop_name));
     ASSERT_FALSE(!group_properties_cpy);
 
     for (std::size_t k(0); k<n_items; k++) {
@@ -245,10 +244,10 @@ TEST_F(MeshLibProperties, AddArrayPointerProperties)
     }
 
     mesh->getProperties().removePropertyVector(prop_name);
-    boost::optional<MeshLib::PropertyVector<std::array<double, 3>*> const&>
-        removed_group_properties(
-            mesh->getProperties().getPropertyVector<std::array<double,3>*>(prop_name)
-        );
+    boost::optional<MeshLib::PropertyVector<std::array<double, 3>*>&> const
+    removed_group_properties(
+        mesh->getProperties().getPropertyVector<std::array<double, 3>*>(
+            prop_name));
 
     ASSERT_TRUE(!removed_group_properties);
 }
@@ -301,10 +300,10 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
     ASSERT_TRUE(mesh->getProperties().hasPropertyVector(prop_name));
 
     // fetch the vector filled with property values from mesh
-    boost::optional<MeshLib::PropertyVector<std::array<double,3>*> const&>
-        group_properties_cpy(
-            mesh->getProperties().getPropertyVector<std::array<double,3>*>(prop_name)
-        );
+    boost::optional<MeshLib::PropertyVector<std::array<double, 3>*>&> const
+    group_properties_cpy(
+        mesh->getProperties().getPropertyVector<std::array<double, 3>*>(
+            prop_name));
     ASSERT_FALSE(!group_properties_cpy);
     // compare the content
     const std::size_t n_elements(mesh_size*mesh_size*mesh_size);
@@ -344,7 +343,7 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
     ASSERT_TRUE(mesh->getProperties().hasPropertyVector(prop_name_2));
 
     // fetch the vector in order to compare the content
-    boost::optional<MeshLib::PropertyVector<std::array<float,9>> const&>
+    boost::optional<MeshLib::PropertyVector<std::array<float,9>> &>const
         array_properties_cpy(mesh->getProperties().getPropertyVector<std::array<float,9>>(
             prop_name_2)
     );
@@ -382,12 +381,12 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
     ASSERT_TRUE(mesh->getProperties().hasPropertyVector(prop_name_3));
 
     // fetch the vector in order to compare the content
-    boost::optional<
-        MeshLib::PropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>> const&
-    > matrix_properties_cpy(
-        mesh->getProperties().getPropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>>(
-            prop_name_3)
-    );
+    boost::optional<MeshLib::PropertyVector<
+        Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>&> const
+    matrix_properties_cpy(
+        mesh->getProperties()
+            .getPropertyVector<Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>(
+                prop_name_3));
     ASSERT_FALSE(!matrix_properties_cpy);
 
     // compare the values/matrices
@@ -443,9 +442,8 @@ TEST_F(MeshLibProperties, CopyConstructor)
     // check if the Properties have a PropertyVector with the correct name
     ASSERT_TRUE(properties_copy.hasPropertyVector(prop_name));
     // fetch the PropertyVector from the copy of the Properties object
-    boost::optional<MeshLib::PropertyVector<double*> const&>
-        group_properties_cpy(properties_copy.getPropertyVector<double*>(
-            prop_name));
+    boost::optional<MeshLib::PropertyVector<double*>&> const
+    group_properties_cpy(properties_copy.getPropertyVector<double*>(prop_name));
     ASSERT_FALSE(!group_properties_cpy);
 
     // check if the values in the PropertyVector of the copy of the Properties


### PR DESCRIPTION
The called `getPropertyVector<T>()` did not return an optional to a const reference (there are two versions of that function), but an `optional<T&>`.

With boost 1.61 this conversion is no longer possible.

Fixes #1383