### PR TITLE
Newton-Raphson for dense systems

### DIFF
--- a/MaterialLib/SolidModels/NewtonRaphson.h
+++ b/MaterialLib/SolidModels/NewtonRaphson.h
@@ -1,0 +1,99 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef MATERIALLIB_SOLIDMODELS_NEWTONRAPHSON_H_
+#define MATERIALLIB_SOLIDMODELS_NEWTONRAPHSON_H_
+
+#include <boost/optional.hpp>
+#include <logog/include/logog.hpp>
+
+#include <Eigen/Dense>
+
+namespace MaterialLib
+{
+namespace Solids
+{
+/// Newton-Raphson solver for system of equations using an Eigen linear solvers
+/// library.
+/// The current implementation does not update the solution itself, but calls a
+/// function for the solution's update with the current increment.
+template <typename LinearSolver, typename JacobianMatrix,
+          typename JacobianMatrixUpdate, typename ResidualVector,
+          typename ResidualUpdate, typename SolutionUpdate>
+class NewtonRaphson final
+{
+public:
+    NewtonRaphson(LinearSolver& linear_solver,
+                  JacobianMatrixUpdate jacobian_update,
+                  ResidualUpdate residual_update,
+                  SolutionUpdate solution_update, int const maximum_iterations,
+                  double const tolerance)
+        : _linear_solver(linear_solver),
+          _jacobian_update(jacobian_update),
+          _residual_update(residual_update),
+          _solution_update(solution_update),
+          _maximum_iterations(maximum_iterations),
+          _tolerance_squared(tolerance * tolerance)
+    {
+    }
+
+    /// Returns true and the iteration number if succeeded, otherwise false and
+    /// an undefined value for the number of iterations.
+    boost::optional<int> solve(JacobianMatrix& jacobian) const
+    {
+        int iteration = 0;
+        ResidualVector increment;
+        ResidualVector residual;
+        do
+        {
+            // The jacobian and the residual are updated simulataniously to keep
+            // consistency. The jacobian is used after the non-linear solver
+            // onward.
+            _jacobian_update(jacobian);
+            _residual_update(residual);
+
+            if (residual.squaredNorm() < _tolerance_squared)
+                break;  // convergence criteria fulfilled.
+
+            increment.noalias() =
+                _linear_solver.compute(jacobian).solve(-residual);
+            // DBUG("Local linear solver accuracy |J dx - r| = %g",
+            //      (jacobian * increment + residual).norm());
+
+            _solution_update(increment);
+
+            // DBUG("Local Newton: Iteration #%d |dx| = %g, |r| = %g",
+            //      iteration, increment.norm(), residual.norm());
+        } while (iteration++ < _maximum_iterations);
+
+        if (iteration > _maximum_iterations)
+        {
+            ERR("The local Newton method did not converge within the given "
+                "number of iterations. Iteration: %d, increment %g, residual: "
+                "%g",
+                iteration - 1, increment.norm(), residual.norm());
+            return {};
+        }
+
+        return iteration;
+    };
+
+private:
+    LinearSolver& _linear_solver;
+    JacobianMatrixUpdate _jacobian_update;
+    ResidualUpdate _residual_update;
+    SolutionUpdate _solution_update;
+    const int _maximum_iterations;
+    const double _tolerance_squared;
+};
+
+}  // namespace Solids
+}  // namespace MaterialLib
+
+#endif  // MATERIALLIB_SOLIDMODELS_NEWTONRAPHSON_H_

--- a/Tests/MaterialLib/NewtonRaphson.cpp
+++ b/Tests/MaterialLib/NewtonRaphson.cpp
@@ -1,0 +1,54 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ */
+
+#include <gtest/gtest.h>
+#include <limits>
+
+#include "MaterialLib/SolidModels/NewtonRaphson.h"
+
+TEST(MaterialLibNewtonRaphson, Sqrt3)
+{
+    static const int N = 1;  // Problem's size.
+
+    using LocalJacobianMatrix = Eigen::Matrix<double, N, N, Eigen::RowMajor>;
+    using LocalResidualVector = Eigen::Matrix<double, N, 1>;
+
+    Eigen::PartialPivLU<LocalJacobianMatrix> linear_solver(N);
+    LocalJacobianMatrix jacobian;
+
+    const int maximum_iterations = 5;
+    const double tolerance = 1e-15;
+
+    // Solve f(x) = x^2 - S == 0, where S = 3.
+    //
+    // Initial value
+    double state = 1;
+
+    auto const update_jacobian = [&state](LocalJacobianMatrix& jacobian) {
+        jacobian(0, 0) = 2 * state;
+    };
+
+    auto const update_residual = [&state](LocalResidualVector& residual) {
+        residual[0] = state * state - 3;
+    };
+
+    auto const update_solution = [&state](
+        LocalResidualVector const& increment) { state += increment[0]; };
+
+    auto const newton_solver = MaterialLib::Solids::NewtonRaphson<
+        decltype(linear_solver), LocalJacobianMatrix, decltype(update_jacobian),
+        LocalResidualVector, decltype(update_residual),
+        decltype(update_solution)>(linear_solver, update_jacobian,
+                                   update_residual, update_solution,
+                                   maximum_iterations, tolerance);
+    auto const success_iterations = newton_solver.solve(jacobian);
+
+    EXPECT_TRUE(static_cast<bool>(success_iterations));
+    EXPECT_LE(*success_iterations, maximum_iterations);
+    ASSERT_LE(state - std::sqrt(3), std::numeric_limits<double>::epsilon());
+}


### PR DESCRIPTION
A very simple abstraction of the named method required in the current visco-elastic Burgers material model (#1391) and in the following single surface yield function material model (currently in development).

~~I put it into NumLib/NewtonMethods for now, but if this is not general enough (and you don't want extend it), it can be~~ It is placed near the material models implementations, where it is used.

No aspect of the solver can be configured by input files.