### PR TITLE
Preparations for the BalanceProcess

### DIFF
--- a/Applications/Utils/MeshEdit/ExtractSurface.cpp
+++ b/Applications/Utils/MeshEdit/ExtractSurface.cpp
@@ -53,6 +53,26 @@ int main (int argc, char* argv[])
     TCLAP::ValueArg<double> z("z", "z-component", "z component of the normal",
                               false, -1.0, "floating point value");
     cmd.add(z);
+
+    TCLAP::ValueArg<std::string> node_prop_name(
+        "n", "node-property-name",
+        "the name of the data array the subsurface/bulk node id will be stored "
+        "to",
+        false, "OriginalSubsurfaceNodeIDs", "string");
+    cmd.add(node_prop_name);
+    TCLAP::ValueArg<std::string> element_prop_name(
+        "e", "element-property-name",
+        "the name of the data array the subsurface/bulk element id will be "
+        "stored to",
+        false, "OriginalSubsurfaceElementIDs", "string");
+    cmd.add(element_prop_name);
+    TCLAP::ValueArg<std::string> face_prop_name(
+        "f", "face-property-name",
+        "the name of the data array the surface face id of the subsurface/bulk "
+        "element will be stored to",
+        false, "OriginalFaceIDs", "string");
+    cmd.add(face_prop_name);
+
     TCLAP::ValueArg<double> angle_arg(
         "a", "angle", "angle between given normal and element normal", false,
         90, "floating point value");
@@ -62,14 +82,16 @@ int main (int argc, char* argv[])
 
     std::unique_ptr<MeshLib::Mesh const> mesh(
         MeshLib::IO::readMeshFromFile(mesh_in.getValue()));
-    INFO("Mesh read: %u nodes, %u elements.", mesh->getNumberOfNodes(), mesh->getNumberOfElements());
+    INFO("Mesh read: %u nodes, %u elements.", mesh->getNumberOfNodes(),
+         mesh->getNumberOfElements());
 
     // extract surface
     MathLib::Vector3 const dir(x.getValue(), y.getValue(), z.getValue());
     double const angle(angle_arg.getValue());
     std::unique_ptr<MeshLib::Mesh> surface_mesh(
         MeshLib::MeshSurfaceExtraction::getMeshSurface(
-            *mesh, dir, angle, "OriginalSubsurfaceNodeIDs"));
+            *mesh, dir, angle, node_prop_name.getValue(),
+            element_prop_name.getValue(), face_prop_name.getValue()));
 
     std::string out_fname(mesh_out.getValue());
     if (out_fname.empty())

--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "BaseLib/Counter.h"
+#include "BaseLib/Error.h"
 
 #include "MeshEnums.h"
 #include "Properties.h"
@@ -171,6 +172,47 @@ protected:
 void scaleMeshPropertyVector(MeshLib::Mesh& mesh,
                              std::string const& property_name,
                              double factor);
+
+/// Creates a new \c PropertyVector in the given mesh and initializes it with
+/// the given data. A \c PropertyVector with the same name must not exist.
+/// \param mesh A \c Mesh the new \c ProperyVector will be created in.
+/// \param name A string that contains the name of the new \c PropertyVector.
+/// \param item_type One of the values \c MeshLib::MeshItemType::Cell or \c
+/// \c MeshLib::MeshItemType::Node that shows the association of the property
+/// values either to \c Element's / cells or \c Node's
+/// \param number_of_components the number of components of a property
+/// \param values A vector containing the values that are used for
+/// initialization.
+template <typename T>
+void addPropertyToMesh(MeshLib::Mesh& mesh, std::string const& name,
+                       MeshLib::MeshItemType item_type,
+                       std::size_t number_of_components,
+                       std::vector<T> const& values)
+{
+    if (item_type == MeshLib::MeshItemType::Node)
+        if (mesh.getNumberOfNodes() != values.size() / number_of_components)
+            OGS_FATAL(
+                "Error number of nodes (%u) does not match the number of "
+                "tuples (%u).",
+                mesh.getNumberOfNodes(), values.size() / number_of_components);
+    if (item_type == MeshLib::MeshItemType::Cell)
+        if (mesh.getNumberOfElements() != values.size() / number_of_components)
+            OGS_FATAL(
+                "Error number of elements (%u) does not match the number of "
+                "tuples (%u).",
+                mesh.getNumberOfElements(),
+                values.size() / number_of_components);
+
+    boost::optional<MeshLib::PropertyVector<T>&> property(
+        mesh.getProperties().createNewPropertyVector<T>(name, item_type,
+                                                        number_of_components));
+    if (!property)
+    {
+        OGS_FATAL("Error while creating PropertyVector \"%s\".", name.c_str());
+    }
+    property->reserve(values.size());
+    std::copy(values.cbegin(), values.cend(), std::back_inserter(*property));
+}
 
 } /* namespace */
 

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -203,9 +203,9 @@ void MeshSurfaceExtraction::get2DSurfaceElements(
     double const cos_theta(std::cos(angle * pi / 180.0));
     MathLib::Vector3 const norm_dir(dir.getNormalizedVector());
 
-    for (auto elem = all_elements.cbegin(); elem != all_elements.cend(); ++elem)
+    for (auto const* elem : all_elements)
     {
-        const unsigned element_dimension((*elem)->getDimension());
+        const unsigned element_dimension(elem->getDimension());
         if (element_dimension < mesh_dimension)
             continue;
 
@@ -213,7 +213,7 @@ void MeshSurfaceExtraction::get2DSurfaceElements(
         {
             if (!complete_surface)
             {
-                MeshLib::Element* face = *elem;
+                auto const* face = elem;
                 if (MathLib::scalarProduct(
                         FaceRule::getSurfaceNormal(face).getNormalizedVector(),
                         norm_dir) > cos_theta)
@@ -225,16 +225,16 @@ void MeshSurfaceExtraction::get2DSurfaceElements(
         }
         else
         {
-            if (!(*elem)->isBoundaryElement())
+            if (!elem->isBoundaryElement())
                 continue;
-            const unsigned nFaces((*elem)->getNumberOfFaces());
+            const unsigned nFaces(elem->getNumberOfFaces());
             for (unsigned j = 0; j < nFaces; ++j)
             {
-                if ((*elem)->getNeighbor(j) != nullptr)
+                if (elem->getNeighbor(j) != nullptr)
                     continue;
 
-                auto const face = std::unique_ptr<MeshLib::Element const>{
-                    (*elem)->getFace(j)};
+                auto const face =
+                    std::unique_ptr<MeshLib::Element const>{elem->getFace(j)};
                 if (!complete_surface)
                 {
                     if (MathLib::scalarProduct(

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -67,8 +67,10 @@ std::vector<double> MeshSurfaceExtraction::getSurfaceAreaForNodes(const MeshLib:
 }
 
 MeshLib::Mesh* MeshSurfaceExtraction::getMeshSurface(
-    const MeshLib::Mesh& mesh, const MathLib::Vector3& dir, double angle,
-    std::string const& subsfc_node_id_backup_prop_name)
+    const MeshLib::Mesh& subsfc_mesh, const MathLib::Vector3& dir, double angle,
+    std::string const& subsfc_node_id_prop_name,
+    std::string const& subsfc_element_id_prop_name,
+    std::string const& face_id_prop_name)
 {
     // allow slightly greater angles than 90 degrees for numerical errors
     if (angle < 0 || angle > 91)
@@ -79,14 +81,19 @@ MeshLib::Mesh* MeshSurfaceExtraction::getMeshSurface(
 
     INFO ("Extracting mesh surface...");
     std::vector<MeshLib::Element*> sfc_elements;
-    get2DSurfaceElements(mesh.getElements(), sfc_elements, dir, angle, mesh.getDimension());
+    std::vector<std::size_t> element_ids_map;
+    std::vector<std::size_t> face_ids_map;
+    get2DSurfaceElements(subsfc_mesh.getElements(), sfc_elements,
+                         element_ids_map, face_ids_map, dir, angle,
+                         subsfc_mesh.getDimension());
 
     if (sfc_elements.empty())
         return nullptr;
 
     std::vector<MeshLib::Node*> sfc_nodes;
-    std::vector<std::size_t> node_id_map(mesh.getNumberOfNodes());
-    get2DSurfaceNodes(sfc_nodes, mesh.getNumberOfNodes(), sfc_elements, node_id_map);
+    std::vector<std::size_t> node_id_map(subsfc_mesh.getNumberOfNodes());
+    get2DSurfaceNodes(sfc_nodes, subsfc_mesh.getNumberOfNodes(), sfc_elements,
+                      node_id_map);
 
     // create new elements vector with newly created nodes
     std::vector<MeshLib::Element*> new_elements;
@@ -107,23 +114,36 @@ MeshLib::Mesh* MeshSurfaceExtraction::getMeshSurface(
     }
 
     std::vector<std::size_t> id_map;
-    if (!subsfc_node_id_backup_prop_name.empty())
+    if (!subsfc_node_id_prop_name.empty())
     {
         id_map.reserve(sfc_nodes.size());
-        for (auto node = sfc_nodes.cbegin(); node != sfc_nodes.cend(); ++node)
-            id_map.push_back((*node)->getID());
+        for (auto const* node : sfc_nodes)
+            id_map.push_back(node->getID());
     }
-    MeshLib::Mesh* result (new Mesh(mesh.getName()+"-Surface", sfc_nodes, new_elements));
+    MeshLib::Mesh* result(
+        new Mesh(subsfc_mesh.getName() + "-Surface", sfc_nodes, new_elements));
+
     // transmit the original node ids of the subsurface mesh as a property
-    if (!subsfc_node_id_backup_prop_name.empty()) {
-        boost::optional<MeshLib::PropertyVector<std::size_t>&> orig_node_ids(
-            result->getProperties().createNewPropertyVector<std::size_t>(
-                subsfc_node_id_backup_prop_name , MeshLib::MeshItemType::Node, 1));
-        if (orig_node_ids) {
-            orig_node_ids->resize(id_map.size());
-            std::copy(id_map.cbegin(), id_map.cend(), orig_node_ids->begin());
-        }
+    if (!subsfc_node_id_prop_name.empty())
+    {
+        MeshLib::addPropertyToMesh(*result, subsfc_node_id_prop_name,
+                                   MeshLib::MeshItemType::Node, 1, id_map);
     }
+
+    // transmit the original subsurface element ids as a property
+    if (!subsfc_element_id_prop_name.empty()) {
+        MeshLib::addPropertyToMesh(*result, subsfc_element_id_prop_name,
+                                   MeshLib::MeshItemType::Cell, 1,
+                                   element_ids_map);
+    }
+
+    // transmit the face id of the original subsurface element as a property
+    if (!face_id_prop_name.empty()) {
+        MeshLib::addPropertyToMesh(*result, face_id_prop_name,
+                                   MeshLib::MeshItemType::Cell, 1,
+                                   face_ids_map);
+    }
+
     return result;
 }
 
@@ -167,20 +187,25 @@ MeshLib::Mesh* MeshSurfaceExtraction::getMeshBoundary(const MeshLib::Mesh &mesh)
     }
 }
 
-void MeshSurfaceExtraction::get2DSurfaceElements(const std::vector<MeshLib::Element*> &all_elements, std::vector<MeshLib::Element*> &sfc_elements, const MathLib::Vector3 &dir, double angle, unsigned mesh_dimension)
+void MeshSurfaceExtraction::get2DSurfaceElements(
+    const std::vector<MeshLib::Element*>& all_elements,
+    std::vector<MeshLib::Element*>& sfc_elements,
+    std::vector<std::size_t>& element_to_bulk_element_id_map,
+    std::vector<std::size_t>& element_to_bulk_face_id_map,
+    const MathLib::Vector3& dir, double angle, unsigned mesh_dimension)
 {
-    if (mesh_dimension<2 || mesh_dimension>3)
+    if (mesh_dimension < 2 || mesh_dimension > 3)
         ERR("Cannot handle meshes of dimension %i", mesh_dimension);
 
     bool const complete_surface = (MathLib::scalarProduct(dir, dir) == 0);
 
-    double const pi (boost::math::constants::pi<double>());
-    double const cos_theta (std::cos(angle * pi / 180.0));
-    MathLib::Vector3 const norm_dir (dir.getNormalizedVector());
+    double const pi(boost::math::constants::pi<double>());
+    double const cos_theta(std::cos(angle * pi / 180.0));
+    MathLib::Vector3 const norm_dir(dir.getNormalizedVector());
 
     for (auto elem = all_elements.cbegin(); elem != all_elements.cend(); ++elem)
     {
-        const unsigned element_dimension ((*elem)->getDimension());
+        const unsigned element_dimension((*elem)->getDimension());
         if (element_dimension < mesh_dimension)
             continue;
 
@@ -189,33 +214,45 @@ void MeshSurfaceExtraction::get2DSurfaceElements(const std::vector<MeshLib::Elem
             if (!complete_surface)
             {
                 MeshLib::Element* face = *elem;
-                if (MathLib::scalarProduct(FaceRule::getSurfaceNormal(face).getNormalizedVector(), norm_dir) > cos_theta)
+                if (MathLib::scalarProduct(
+                        FaceRule::getSurfaceNormal(face).getNormalizedVector(),
+                        norm_dir) > cos_theta)
                     continue;
             }
-            sfc_elements.push_back(*elem);
+            sfc_elements.push_back(elem->clone());
+            element_to_bulk_element_id_map.push_back(elem->getID());
+            element_to_bulk_face_id_map.push_back(0);
         }
         else
         {
             if (!(*elem)->isBoundaryElement())
                 continue;
-            const unsigned nFaces ((*elem)->getNumberOfFaces());
-            for (unsigned j=0; j<nFaces; ++j)
+            const unsigned nFaces((*elem)->getNumberOfFaces());
+            for (unsigned j = 0; j < nFaces; ++j)
             {
                 if ((*elem)->getNeighbor(j) != nullptr)
                     continue;
 
-                auto const face = std::unique_ptr<MeshLib::Element const>{(*elem)->getFace(j)};
+                auto const face = std::unique_ptr<MeshLib::Element const>{
+                    (*elem)->getFace(j)};
                 if (!complete_surface)
                 {
-                    if (MathLib::scalarProduct(FaceRule::getSurfaceNormal(face.get()).getNormalizedVector(), norm_dir) < cos_theta)
+                    if (MathLib::scalarProduct(
+                            FaceRule::getSurfaceNormal(face.get())
+                                .getNormalizedVector(),
+                            norm_dir) < cos_theta)
                     {
                         continue;
                     }
                 }
                 if (face->getGeomType() == MeshElemType::TRIANGLE)
-                    sfc_elements.push_back(new MeshLib::Tri(*static_cast<const MeshLib::Tri*>(face.get())));
+                    sfc_elements.push_back(new MeshLib::Tri(
+                        *static_cast<const MeshLib::Tri*>(face.get())));
                 else
-                    sfc_elements.push_back(new MeshLib::Quad(*static_cast<const MeshLib::Quad*>(face.get())));
+                    sfc_elements.push_back(new MeshLib::Quad(
+                        *static_cast<const MeshLib::Quad*>(face.get())));
+                element_to_bulk_element_id_map.push_back(elem->getID());
+                element_to_bulk_face_id_map.push_back(j);
             }
         }
     }
@@ -251,8 +288,11 @@ std::vector<MeshLib::Node*> MeshSurfaceExtraction::getSurfaceNodes(
 {
     INFO ("Extracting surface nodes...");
     std::vector<MeshLib::Element*> sfc_elements;
-    get2DSurfaceElements(mesh.getElements(), sfc_elements, dir, angle,
-                         mesh.getDimension());
+    std::vector<std::size_t> element_to_bulk_element_id_map;
+    std::vector<std::size_t> element_to_bulk_face_id_map;
+    get2DSurfaceElements(
+        mesh.getElements(), sfc_elements, element_to_bulk_element_id_map,
+        element_to_bulk_face_id_map, dir, angle, mesh.getDimension());
 
     std::vector<MeshLib::Node*> sfc_nodes;
     std::vector<std::size_t> node_id_map(mesh.getNumberOfNodes());

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -41,22 +41,30 @@ public:
 
     /**
      * Returns the 2d-element mesh representing the surface of the given mesh.
-     * \param mesh                The original mesh
-     * \param dir                 The direction in which face normals have to
+     * \param subsfc_mesh The original mesh
+     * \param dir The direction in which face normals have to
      * point to be considered surface elements
-     * \param angle               The angle of the allowed deviation from the
+     * \param angle The angle of the allowed deviation from the
      * given direction (0 <= angle <= 90 degrees)
-     * \param subsfc_node_id_backup_prop_name Name of the property in the
-     * surface mesh the subsurface node ids are stored to. This is a mapping
-     * surface node -> subsurface node which is needed from some applications.
-     * If the string is empty, there isn't a backup created.
+     * \param subsfc_node_id_prop_name The name of the \c PropertyVector in
+     * the surface mesh the subsurface mesh node ids are stored to. If the
+     * string is empty, there won't be such a \c PropertyVector.
+     * \param subsfc_element_id_prop_name The name of the PropertyVector in
+     * the surface mesh that stores the subsurface element ids. If the string
+     * is empty, there won't be such a \c PropertyVector.
+     * \param face_id_prop_name The name of the \c PropertyVector in the surface
+     * mesh that stores the face number of the subsurface element that belongs
+     * to the boundary. If the string is empty, there won't be such a \c
+     * PropertyVector.
      * \return A 2D mesh representing the surface in direction dir
      */
     static MeshLib::Mesh* getMeshSurface(
-        const MeshLib::Mesh& mesh,
+        const MeshLib::Mesh& subsfc_mesh,
         const MathLib::Vector3& dir,
         double angle,
-        std::string const& subsfc_node_id_backup_prop_name = "");
+        std::string const& subsfc_node_id_prop_name = "",
+        std::string const& subsfc_element_id_prop_name = "",
+        std::string const& face_id_prop_name = "");
 
     /**
      * Returns the boundary of mesh, i.e. lines for 2D meshes and surfaces for 3D meshes.
@@ -72,6 +80,8 @@ private:
     static void get2DSurfaceElements(
         const std::vector<MeshLib::Element*>& all_elements,
         std::vector<MeshLib::Element*>& sfc_elements,
+        std::vector<std::size_t>& element_to_bulk_element_id_map,
+        std::vector<std::size_t>& element_to_bulk_face_id_map,
         const MathLib::Vector3& dir,
         double angle,
         unsigned mesh_dimension);


### PR DESCRIPTION
The class `MeshSurfaceExtraction` extracts the surface of a subsurface mesh. For the balance process it is also important to know the subsurface element id and the number of the face of the subsurface element that belongs to the surface. 

The PR adds the possibility to write subsurface/bulk element ids and face ids to the mesh.