### PR TITLE
Classes for fluid density models

### DIFF
--- a/MaterialLib/CMakeLists.txt
+++ b/MaterialLib/CMakeLists.txt
@@ -1,8 +1,12 @@
-GET_SOURCE_FILES(SOURCES)
-APPEND_SOURCE_FILES(SOURCES Adsorption)
-APPEND_SOURCE_FILES(SOURCES SolidModels)
+# Source files
+get_source_files(SOURCES)
+append_source_files(SOURCES Adsorption)
+append_source_files(SOURCES SolidModels)
 
-add_library(MaterialLib ${SOURCES})
+append_source_files(SOURCES Fluid)
+append_source_files(SOURCES Fluid/Density)
+
+add_library(MaterialLib ${SOURCES} )
 target_link_libraries(MaterialLib
     BaseLib
 )

--- a/MaterialLib/Fluid/ConstantFluidProperty.h
+++ b/MaterialLib/Fluid/ConstantFluidProperty.h
@@ -19,35 +19,43 @@ namespace MaterialLib
 {
 namespace Fluid
 {
-/// Constant fluid density properties
-class ConstantFluidProperty : public FluidProperty
+/// Constant fluid properties
+class ConstantFluidProperty final : public FluidProperty
 {
 public:
-    ConstantFluidProperty(const double value) : FluidProperty(), _value(value)
+    explicit ConstantFluidProperty(const double value) : FluidProperty(),_value(value)
     {
     }
 
     /// Get model name.
-    virtual std::string getName() const final { return "constant"; }
+    std::string getName() const override
+    {
+        return "Constant";
+    }
+
     /// Get property value.
     /// \param var_vals Variable values in an array. The order of its elements
     ///                 is given in enum class PropertyVariable.
-    virtual double getValue(const double /* var_vals*/[]) const final
+    double getValue(const double var_vals[]) const override
     {
+        (void) var_vals;
         return _value;
     }
 
     /// Get the partial differential of the property value
     /// \param var_vals  Variable values  in an array. The order of its elements
-    ///                   is given in enum class PropertyVariable.
-    virtual double getdValue(const double /* var_vals*/[],
-                             const PropertyVariable /* var */) const final
+    ///                  is given in enum class PropertyVariable.
+    /// \param var       Variable type.
+    double getdValue(const double var_vals[],
+            const PropertyVariable var) const override
     {
+        (void) var_vals;
+        (void) var;
         return 0.;
     }
 
 private:
-    double _value;
+    const double _value;
 };
 
 }  // end namespace

--- a/MaterialLib/Fluid/ConstantFluidProperty.h
+++ b/MaterialLib/Fluid/ConstantFluidProperty.h
@@ -1,0 +1,55 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * \file:   ConstantFluidProperty.h
+ *
+ * Created on August 15, 2016, 12:11 PM
+ */
+
+#ifndef CONSTANTFLUIDPROPERTY_H
+#define CONSTANTFLUIDPROPERTY_H
+
+#include "FluidProperty.h"
+
+namespace MaterialLib
+{
+namespace Fluid
+{
+/// Constant fluid density properties
+class ConstantFluidProperty : public FluidProperty
+{
+public:
+    ConstantFluidProperty(const double value) : FluidProperty(), _value(value)
+    {
+    }
+
+    /// Get model name.
+    virtual std::string getName() const final { return "constant"; }
+    /// Get property value.
+    /// \param var_vals Variable values in an array. The order of its elements
+    ///                 is given in enum class PropertyVariable.
+    virtual double getValue(const double /* var_vals*/[]) const final
+    {
+        return _value;
+    }
+
+    /// Get the partial differential of the property value
+    /// \param var_vals  Variable values  in an array. The order of its elements
+    ///                   is given in enum class PropertyVariable.
+    virtual double getdValue(const double /* var_vals*/[],
+                             const PropertyVariable /* var */) const final
+    {
+        return 0.;
+    }
+
+private:
+    double _value;
+};
+
+}  // end namespace
+}  // end namespace
+#endif /* CONSTANTFLUIDPROPERTY_H */

--- a/MaterialLib/Fluid/ConstantFluidProperty.h
+++ b/MaterialLib/Fluid/ConstantFluidProperty.h
@@ -23,22 +23,19 @@ namespace Fluid
 class ConstantFluidProperty final : public FluidProperty
 {
 public:
-    explicit ConstantFluidProperty(const double value) : FluidProperty(),_value(value)
+    explicit ConstantFluidProperty(const double value)
+        : FluidProperty(), _value(value)
     {
     }
 
     /// Get model name.
-    std::string getName() const override
-    {
-        return "Constant";
-    }
-
+    std::string getName() const override { return "Constant"; }
     /// Get property value.
     /// \param var_vals Variable values in an array. The order of its elements
     ///                 is given in enum class PropertyVariableType.
     double getValue(const ArrayType& var_vals) const override
     {
-        (void) var_vals;
+        (void)var_vals;
         return _value;
     }
 
@@ -47,10 +44,10 @@ public:
     ///                  is given in enum class PropertyVariableType.
     /// \param var       Variable type.
     double getdValue(const ArrayType& var_vals,
-            const PropertyVariableType var) const override
+                     const PropertyVariableType var) const override
     {
-        (void) var_vals;
-        (void) var;
+        (void)var_vals;
+        (void)var;
         return 0.;
     }
 

--- a/MaterialLib/Fluid/ConstantFluidProperty.h
+++ b/MaterialLib/Fluid/ConstantFluidProperty.h
@@ -35,8 +35,8 @@ public:
 
     /// Get property value.
     /// \param var_vals Variable values in an array. The order of its elements
-    ///                 is given in enum class PropertyVariable.
-    double getValue(const double var_vals[]) const override
+    ///                 is given in enum class PropertyVariableType.
+    double getValue(const ArrayType& var_vals) const override
     {
         (void) var_vals;
         return _value;
@@ -44,10 +44,10 @@ public:
 
     /// Get the partial differential of the property value
     /// \param var_vals  Variable values  in an array. The order of its elements
-    ///                  is given in enum class PropertyVariable.
+    ///                  is given in enum class PropertyVariableType.
     /// \param var       Variable type.
-    double getdValue(const double var_vals[],
-            const PropertyVariable var) const override
+    double getdValue(const ArrayType& var_vals,
+            const PropertyVariableType var) const override
     {
         (void) var_vals;
         (void) var;

--- a/MaterialLib/Fluid/Density/IdealGasLaw.h
+++ b/MaterialLib/Fluid/Density/IdealGasLaw.h
@@ -61,7 +61,7 @@ public:
     {
         assert(var == PropertyVariableType::T || var == PropertyVariableType::pg);
 
-        const int func_id = (var == PropertyVariableType::T) ? 0 : 1;
+        const int func_id = static_cast<int> (var);
         return (this->*_derivative_functions[func_id])(
                 var_vals[static_cast<int> (PropertyVariableType::T)],
                 var_vals[static_cast<int> (PropertyVariableType::pg)]);
@@ -91,11 +91,12 @@ private:
                                                      const double) const;
 
     /// An array of pointers to derivative functions.
-    static DerivativeFunctionPointer _derivative_functions[2];
+      static DerivativeFunctionPointer _derivative_functions[PropertyVariableNumber];
 };
 
-IdealGasLaw::DerivativeFunctionPointer IdealGasLaw::_derivative_functions[2]
-        = {&IdealGasLaw::dIdealGasLaw_dT,&IdealGasLaw::dIdealGasLaw_dp};
+    IdealGasLaw::DerivativeFunctionPointer IdealGasLaw
+            ::_derivative_functions[PropertyVariableNumber]
+            = {&IdealGasLaw::dIdealGasLaw_dT, nullptr, &IdealGasLaw::dIdealGasLaw_dp};
 }  // end namespace
 }  // end namespace
 #endif

--- a/MaterialLib/Fluid/Density/IdealGasLaw.h
+++ b/MaterialLib/Fluid/Density/IdealGasLaw.h
@@ -1,6 +1,6 @@
 /*!
    \file  IdealGasLow.h
-   \brief Declaration of class LIdealGasLow for fluid density by the ideal gas
+   \brief Declaration of class IdealGasLow for fluid density by the ideal gas
    law
           depending on one variable linearly.
 
@@ -26,17 +26,15 @@ namespace MaterialLib
 {
 namespace Fluid
 {
-/// Fluid density by ideal gas low
+/// Fluid density by ideal gas law
 
 class IdealGasLaw : public FluidProperty
 {
 public:
     ///   \param molar_mass Molar mass of the gas phase.
+
     IdealGasLaw(const double molar_mass)
-        : FluidProperty(),
-          _molar_mass(molar_mass),
-          _derivative_functions{&IdealGasLaw::dIdealGasLaw_dT,
-                                &IdealGasLaw::dIdealGasLaw_dp}
+    : FluidProperty(),_molar_mass(molar_mass)
     {
     }
 
@@ -92,8 +90,11 @@ private:
                                                      const double) const;
 
     /// An array of pointer to derivative functions.
-    DerivativeFunctionPointer _derivative_functions[2];
+    static DerivativeFunctionPointer _derivative_functions[2];
 };
+
+IdealGasLaw::DerivativeFunctionPointer IdealGasLaw::_derivative_functions[2]
+        = {&IdealGasLaw::dIdealGasLaw_dT,&IdealGasLaw::dIdealGasLaw_dp};
 }  // end namespace
 }  // end namespace
 #endif

--- a/MaterialLib/Fluid/Density/IdealGasLaw.h
+++ b/MaterialLib/Fluid/Density/IdealGasLaw.h
@@ -43,28 +43,28 @@ public:
 
     /// Get density value.
     /// \param var_vals Variable values in an array. The order of its elements
-    ///                 is given in enum class PropertyVariable.
-    double getValue(const double var_vals[]) const override
+    ///                 is given in enum class PropertyVariableType.
+    double getValue(const ArrayType& var_vals) const override
     {
-        return _molar_mass * var_vals[static_cast<int>(PropertyVariable::pg)] /
+        return _molar_mass * var_vals[static_cast<int> (PropertyVariableType::pg)] /
                (PhysicalConstant::IdealGasConstant *
-                var_vals[static_cast<int>(PropertyVariable::T)]);
+                var_vals[static_cast<int> (PropertyVariableType::T)]);
     }
 
     /// Get the partial differential of the density with respect to temperature
     /// or gas pressure.
     /// \param var_vals  Variable values  in an array. The order of its elements
-    ///                   is given in enum class PropertyVariable.
+    ///                   is given in enum class PropertyVariableType.
     /// \param var       Variable type.
-    double getdValue(const double var_vals[],
-            const PropertyVariable var) const override
+    double getdValue(const ArrayType& var_vals,
+            const PropertyVariableType var) const override
     {
-        assert(var == PropertyVariable::T || var == PropertyVariable::pg);
+        assert(var == PropertyVariableType::T || var == PropertyVariableType::pg);
 
-        const int func_id = (var == PropertyVariable::T) ? 0 : 1;
+        const int func_id = (var == PropertyVariableType::T) ? 0 : 1;
         return (this->*_derivative_functions[func_id])(
-            var_vals[static_cast<int>(PropertyVariable::T)],
-            var_vals[static_cast<int>(PropertyVariable::pg)]);
+                var_vals[static_cast<int> (PropertyVariableType::T)],
+                var_vals[static_cast<int> (PropertyVariableType::pg)]);
     }
 
 private:

--- a/MaterialLib/Fluid/Density/IdealGasLaw.h
+++ b/MaterialLib/Fluid/Density/IdealGasLaw.h
@@ -15,8 +15,8 @@
 #ifndef IDEAL_GAS_LAW_H_
 #define IDEAL_GAS_LAW_H_
 
-#include <string>
 #include <cassert>
+#include <string>
 
 #include "MaterialLib/Fluid/FluidProperty.h"
 #include "MaterialLib/PhysicalConstant.h"
@@ -31,24 +31,21 @@ class IdealGasLaw final : public FluidProperty
 public:
     ///   \param molar_mass Molar mass of the gas phase.
     explicit IdealGasLaw(const double molar_mass)
-    : FluidProperty(),_molar_mass(molar_mass)
+        : FluidProperty(), _molar_mass(molar_mass)
     {
     }
 
     /// Get density model name.
-    std::string getName() const override
-    {
-        return "Ideal gas law";
-    }
-
+    std::string getName() const override { return "Ideal gas law"; }
     /// Get density value.
     /// \param var_vals Variable values in an array. The order of its elements
     ///                 is given in enum class PropertyVariableType.
     double getValue(const ArrayType& var_vals) const override
     {
-        return _molar_mass * var_vals[static_cast<int> (PropertyVariableType::pg)] /
+        return _molar_mass *
+               var_vals[static_cast<int>(PropertyVariableType::pg)] /
                (PhysicalConstant::IdealGasConstant *
-                var_vals[static_cast<int> (PropertyVariableType::T)]);
+                var_vals[static_cast<int>(PropertyVariableType::T)]);
     }
 
     /// Get the partial differential of the density with respect to temperature
@@ -57,11 +54,12 @@ public:
     ///                   is given in enum class PropertyVariableType.
     /// \param var       Variable type.
     double getdValue(const ArrayType& var_vals,
-            const PropertyVariableType var) const override
+                     const PropertyVariableType var) const override
     {
-        const double T = var_vals[static_cast<int> (PropertyVariableType::T)];
-        const double p = var_vals[static_cast<int> (PropertyVariableType::pg)];
-        switch (var) {
+        const double T = var_vals[static_cast<int>(PropertyVariableType::T)];
+        const double p = var_vals[static_cast<int>(PropertyVariableType::pg)];
+        switch (var)
+        {
             case PropertyVariableType::T:
                 return dIdealGasLaw_dT(T, p);
             case PropertyVariableType::pg:
@@ -91,6 +89,6 @@ private:
         return _molar_mass / (PhysicalConstant::IdealGasConstant * T);
     }
 };
-} // end namespace
+}  // end namespace
 }  // end namespace
 #endif

--- a/MaterialLib/Fluid/Density/IdealGasLaw.h
+++ b/MaterialLib/Fluid/Density/IdealGasLaw.h
@@ -59,12 +59,16 @@ public:
     double getdValue(const ArrayType& var_vals,
             const PropertyVariableType var) const override
     {
-        assert(var == PropertyVariableType::T || var == PropertyVariableType::pg);
-
-        const int func_id = static_cast<int> (var);
-        return (this->*_derivative_functions[func_id])(
-                var_vals[static_cast<int> (PropertyVariableType::T)],
-                var_vals[static_cast<int> (PropertyVariableType::pg)]);
+        const double T = var_vals[static_cast<int> (PropertyVariableType::T)];
+        const double p = var_vals[static_cast<int> (PropertyVariableType::pg)];
+        switch (var) {
+            case PropertyVariableType::T:
+                return dIdealGasLaw_dT(T, p);
+            case PropertyVariableType::pg:
+                return dIdealGasLaw_dp(T, p);
+            default:
+                return 0.;
+        }
     }
 
 private:
@@ -86,17 +90,7 @@ private:
     {
         return _molar_mass / (PhysicalConstant::IdealGasConstant * T);
     }
-
-    typedef double (IdealGasLaw::*DerivativeFunctionPointer)(const double,
-                                                     const double) const;
-
-    /// An array of pointers to derivative functions.
-      static DerivativeFunctionPointer _derivative_functions[PropertyVariableNumber];
 };
-
-    IdealGasLaw::DerivativeFunctionPointer IdealGasLaw
-            ::_derivative_functions[PropertyVariableNumber]
-            = {&IdealGasLaw::dIdealGasLaw_dT, nullptr, &IdealGasLaw::dIdealGasLaw_dp};
-}  // end namespace
+} // end namespace
 }  // end namespace
 #endif

--- a/MaterialLib/Fluid/Density/IdealGasLaw.h
+++ b/MaterialLib/Fluid/Density/IdealGasLaw.h
@@ -1,0 +1,99 @@
+/*!
+   \file  IdealGasLow.h
+   \brief Declaration of class LIdealGasLow for fluid density by the ideal gas
+   law
+          depending on one variable linearly.
+
+   \author Wenqing Wang
+   \date Jan 2015
+
+   \copyright
+    Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+               Distributed under a Modified BSD License.
+               See accompanying file LICENSE.txt or
+               http://www.opengeosys.org/project/license
+ */
+#ifndef IDEAL_GAS_LAW_H_
+#define IDEAL_GAS_LAW_H_
+
+#include <string>
+#include <cassert>
+
+#include "MaterialLib/Fluid/FluidProperty.h"
+#include "MaterialLib/PhysicalConstant.h"
+
+namespace MaterialLib
+{
+namespace Fluid
+{
+/// Fluid density by ideal gas low
+
+class IdealGasLaw : public FluidProperty
+{
+public:
+    ///   \param molar_mass Molar mass of the gas phase.
+    IdealGasLaw(const double molar_mass)
+        : FluidProperty(),
+          _molar_mass(molar_mass),
+          _derivative_functions{&IdealGasLaw::dIdealGasLaw_dT,
+                                &IdealGasLaw::dIdealGasLaw_dp}
+    {
+    }
+
+    /// Get density model name.
+    virtual std::string getName() const final { return "Ideal gas law"; }
+    /// Get density value.
+    /// \param var_vals Variable values in an array. The order of its elements
+    ///                 is given in enum class PropertyVariable.
+    virtual double getValue(const double var_vals[]) const final
+    {
+        return _molar_mass * var_vals[static_cast<int>(PropertyVariable::pg)] /
+               (PhysicalConstant::IdealGasConstant *
+                var_vals[static_cast<int>(PropertyVariable::T)]);
+    }
+
+    /// Get the partial differential of the density with respect to temperature
+    /// or gas pressure.
+    /// \param var_vals  Variable values  in an array. The order of its elements
+    ///                   is given in enum class PropertyVariable.
+    virtual double getdValue(const double var_vals[],
+                             const PropertyVariable var) const final
+    {
+        assert(var == PropertyVariable::T || var == PropertyVariable::pg);
+
+        const int func_id = (var == PropertyVariable::T) ? 0 : 1;
+        return (this->*_derivative_functions[func_id])(
+            var_vals[static_cast<int>(PropertyVariable::T)],
+            var_vals[static_cast<int>(PropertyVariable::pg)]);
+    }
+
+private:
+    /// Molar mass of gas phase.
+    double _molar_mass;
+
+    /// Get the partial differential of density with the respect to temperature
+    /// \param T  Temperature in K.
+    /// \param pg Gas phase pressure in Pa.
+
+    double dIdealGasLaw_dT(const double T, const double pg) const
+    {
+        return -_molar_mass * pg / (PhysicalConstant::IdealGasConstant * T * T);
+    }
+
+    /// Get the partial differential of density with the respect to pressure
+    /// \param T  Temperature in K.
+    /// \param pg Gas phase pressure in Pa.
+    double dIdealGasLaw_dp(const double T, const double /* pg */) const
+    {
+        return _molar_mass / (PhysicalConstant::IdealGasConstant * T);
+    }
+
+    typedef double (IdealGasLaw::*DerivativeFunctionPointer)(const double,
+                                                     const double) const;
+
+    /// An array of pointer to derivative functions.
+    DerivativeFunctionPointer _derivative_functions[2];
+};
+}  // end namespace
+}  // end namespace
+#endif

--- a/MaterialLib/Fluid/Density/IdealGasLaw.h
+++ b/MaterialLib/Fluid/Density/IdealGasLaw.h
@@ -1,8 +1,7 @@
 /*!
    \file  IdealGasLow.h
    \brief Declaration of class IdealGasLow for fluid density by the ideal gas
-   law
-          depending on one variable linearly.
+          law depending on one variable linearly.
 
    \author Wenqing Wang
    \date Jan 2015
@@ -27,23 +26,25 @@ namespace MaterialLib
 namespace Fluid
 {
 /// Fluid density by ideal gas law
-
-class IdealGasLaw : public FluidProperty
+class IdealGasLaw final : public FluidProperty
 {
 public:
     ///   \param molar_mass Molar mass of the gas phase.
-
-    IdealGasLaw(const double molar_mass)
+    explicit IdealGasLaw(const double molar_mass)
     : FluidProperty(),_molar_mass(molar_mass)
     {
     }
 
     /// Get density model name.
-    virtual std::string getName() const final { return "Ideal gas law"; }
+    std::string getName() const override
+    {
+        return "Ideal gas law";
+    }
+
     /// Get density value.
     /// \param var_vals Variable values in an array. The order of its elements
     ///                 is given in enum class PropertyVariable.
-    virtual double getValue(const double var_vals[]) const final
+    double getValue(const double var_vals[]) const override
     {
         return _molar_mass * var_vals[static_cast<int>(PropertyVariable::pg)] /
                (PhysicalConstant::IdealGasConstant *
@@ -54,8 +55,9 @@ public:
     /// or gas pressure.
     /// \param var_vals  Variable values  in an array. The order of its elements
     ///                   is given in enum class PropertyVariable.
-    virtual double getdValue(const double var_vals[],
-                             const PropertyVariable var) const final
+    /// \param var       Variable type.
+    double getdValue(const double var_vals[],
+            const PropertyVariable var) const override
     {
         assert(var == PropertyVariable::T || var == PropertyVariable::pg);
 
@@ -67,12 +69,11 @@ public:
 
 private:
     /// Molar mass of gas phase.
-    double _molar_mass;
+    const double _molar_mass;
 
     /// Get the partial differential of density with the respect to temperature
     /// \param T  Temperature in K.
     /// \param pg Gas phase pressure in Pa.
-
     double dIdealGasLaw_dT(const double T, const double pg) const
     {
         return -_molar_mass * pg / (PhysicalConstant::IdealGasConstant * T * T);
@@ -89,7 +90,7 @@ private:
     typedef double (IdealGasLaw::*DerivativeFunctionPointer)(const double,
                                                      const double) const;
 
-    /// An array of pointer to derivative functions.
+    /// An array of pointers to derivative functions.
     static DerivativeFunctionPointer _derivative_functions[2];
 };
 

--- a/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
+++ b/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
@@ -28,7 +28,11 @@ namespace Fluid
 class LinearTemperatureDependentDensity final : public FluidProperty
 {
 public:
-    /// \param parameters An array contains the five parameters.
+    /** \param parameters An array contains the three parameters:
+     *                     [0] $f\rho_0$f
+     *                     [1] $fT_0$f
+     *                     [2] $f\beta$f
+     */
     explicit LinearTemperatureDependentDensity(std::array<double,3>& parameters)
     : _rho0(parameters[0]),_temperature0(parameters[1]),_beta(parameters[2])
     {

--- a/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
+++ b/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
@@ -25,13 +25,13 @@ namespace MaterialLib
 namespace Fluid
 {
 /// Linear temperature dependent density model.
-class LinearTemperatureDependentDensity : public FluidProperty
+class LinearTemperatureDependentDensity final : public FluidProperty
 {
 public:
     /// \param config  ConfigTree object which contains the input data
     ///                including <type>temperature_dependent</type> and it has
     ///                a tag of <density>
-    LinearTemperatureDependentDensity(BaseLib::ConfigTree const& config)
+    explicit LinearTemperatureDependentDensity(BaseLib::ConfigTree const& config)
         :  //! \ogs_file_param{material__fluid__density__linear_temperature__rho0}
     _rho0(config.getConfigParameter<double>("rho0")),
           //! \ogs_file_param{material__fluid__density__linear_temperature__temperature0}
@@ -42,7 +42,7 @@ public:
     }
 
     /// Get model name.
-    virtual std::string getName() const final
+    std::string getName() const override
     {
         return "Linear temperature dependent density";
     }
@@ -50,7 +50,7 @@ public:
     /// Get density value.
     /// \param var_vals Variable values in an array. The order of its elements
     ///                 is given in enum class PropertyVariable.
-    virtual double getValue(const double var_vals[]) const final
+    double getValue(const double var_vals[]) const override
     {
         const double T = var_vals[static_cast<int> (PropertyVariable::T)];
         return _rho0 * (1 + _beta * (T - _temperature0));
@@ -59,17 +59,19 @@ public:
     /// Get the partial differential of the density with respect to temperature.
     /// \param var_vals  Variable values  in an array. The order of its elements
     ///                   is given in enum class PropertyVariable.
-    virtual double getdValue(const double /* var_vals */[],
-                             const PropertyVariable /* var  */) const final
+    /// \param var       Variable type.
+    double getdValue(const double var_vals[],
+            const PropertyVariable var) const override
     {
+        (void) var_vals;
+        (void) var;
         return _rho0 * _beta;
-        ;
     }
 
 private:
-    double _rho0;          ///<  Reference density.
-    double _temperature0;  ///<  Reference temperature.
-    double _beta;          ///<  Parameter.
+    const double _rho0; ///<  Reference density.
+    const double _temperature0; ///<  Reference temperature.
+    const double _beta; ///<  Parameter.
 };
 
 }  // end namespace

--- a/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
+++ b/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
@@ -52,10 +52,8 @@ public:
     ///                 is given in enum class PropertyVariable.
     virtual double getValue(const double var_vals[]) const final
     {
-        return _rho0 *
-               (1 +
-                _beta * (var_vals[static_cast<int>(PropertyVariable::T)] -
-                         _temperature0));
+        const double T = var_vals[static_cast<int> (PropertyVariable::T)];
+        return _rho0 * (1 + _beta * (T - _temperature0));
     }
 
     /// Get the partial differential of the density with respect to temperature.

--- a/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
+++ b/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
@@ -1,0 +1,80 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * \file:   LinearTemperatureDependentDensity.h
+ * \author: wenqing
+ *
+ * Created on August 10, 2016, 11:34 AM
+ */
+
+#ifndef LINEARTEMPERATUREDEPENDENTDENSITY_H
+#define LINEARTEMPERATUREDEPENDENTDENSITY_H
+
+#include <string>
+
+#include "BaseLib/ConfigTree.h"
+
+#include "MaterialLib/Fluid/FluidProperty.h"
+
+namespace MaterialLib
+{
+namespace Fluid
+{
+/// Linear temperature dependent density model.
+class LinearTemperatureDependentDensity : public FluidProperty
+{
+public:
+    /// \param config  ConfigTree object which contains the input data
+    ///                including <type>temperature_dependent</type> and it has
+    ///                a tag of <density>
+    LinearTemperatureDependentDensity(BaseLib::ConfigTree const& config)
+        :  //! \ogs_file_param{material__fluid__density__linear_temperature__rho0}
+    _rho0(config.getConfigParameter<double>("rho0")),
+          //! \ogs_file_param{material__fluid__density__linear_temperature__temperature0}
+    _temperature0(config.getConfigParameter<double>("temperature0")),
+          //! \ogs_file_param{material__fluid__density__linear_temperature__beta}
+    _beta(config.getConfigParameter<double>("beta"))
+    {
+    }
+
+    /// Get model name.
+    virtual std::string getName() const final
+    {
+        return "Linear temperature dependent density";
+    }
+
+    /// Get density value.
+    /// \param var_vals Variable values in an array. The order of its elements
+    ///                 is given in enum class PropertyVariable.
+    virtual double getValue(const double var_vals[]) const final
+    {
+        return _rho0 *
+               (1 +
+                _beta * (var_vals[static_cast<int>(PropertyVariable::T)] -
+                         _temperature0));
+    }
+
+    /// Get the partial differential of the density with respect to temperature.
+    /// \param var_vals  Variable values  in an array. The order of its elements
+    ///                   is given in enum class PropertyVariable.
+    virtual double getdValue(const double /* var_vals */[],
+                             const PropertyVariable /* var  */) const final
+    {
+        return _rho0 * _beta;
+        ;
+    }
+
+private:
+    double _rho0;          ///<  Reference density.
+    double _temperature0;  ///<  Reference temperature.
+    double _beta;          ///<  Parameter.
+};
+
+}  // end namespace
+}  // end namespace
+
+#endif /* LINEARTEMPERATUREDEPENDENTDENSITY_H */

--- a/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
+++ b/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
@@ -33,8 +33,11 @@ public:
      *                     [1] $fT_0$f
      *                     [2] $f\beta$f
      */
-    explicit LinearTemperatureDependentDensity(std::array<double,3>& parameters)
-    : _rho0(parameters[0]),_temperature0(parameters[1]),_beta(parameters[2])
+    explicit LinearTemperatureDependentDensity(
+        std::array<double, 3>& parameters)
+        : _rho0(parameters[0]),
+          _temperature0(parameters[1]),
+          _beta(parameters[2])
     {
     }
 
@@ -49,7 +52,7 @@ public:
     ///                 is given in enum class PropertyVariableType.
     double getValue(const ArrayType& var_vals) const override
     {
-        const double T = var_vals[static_cast<int> (PropertyVariableType::T)];
+        const double T = var_vals[static_cast<int>(PropertyVariableType::T)];
         return _rho0 * (1 + _beta * (T - _temperature0));
     }
 
@@ -58,17 +61,17 @@ public:
     ///                   is given in enum class PropertyVariableType.
     /// \param var       Variable type.
     double getdValue(const ArrayType& var_vals,
-            const PropertyVariableType var) const override
+                     const PropertyVariableType var) const override
     {
-        (void) var_vals;
-        (void) var;
+        (void)var_vals;
+        (void)var;
         return _rho0 * _beta;
     }
 
 private:
-    const double _rho0; ///<  Reference density.
-    const double _temperature0; ///<  Reference temperature.
-    const double _beta; ///<  Parameter.
+    const double _rho0;          ///<  Reference density.
+    const double _temperature0;  ///<  Reference temperature.
+    const double _beta;          ///<  Parameter.
 };
 
 }  // end namespace

--- a/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
+++ b/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
@@ -34,7 +34,7 @@ public:
      *                     [2] $f\beta$f
      */
     explicit LinearTemperatureDependentDensity(
-        std::array<double, 3>& parameters)
+        std::array<double, 3> const& parameters)
         : _rho0(parameters[0]),
           _temperature0(parameters[1]),
           _beta(parameters[2])

--- a/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
+++ b/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
@@ -28,16 +28,9 @@ namespace Fluid
 class LinearTemperatureDependentDensity final : public FluidProperty
 {
 public:
-    /// \param config  ConfigTree object which contains the input data
-    ///                including <type>temperature_dependent</type> and it has
-    ///                a tag of <density>
-    explicit LinearTemperatureDependentDensity(BaseLib::ConfigTree const& config)
-        :  //! \ogs_file_param{material__fluid__density__linear_temperature__rho0}
-    _rho0(config.getConfigParameter<double>("rho0")),
-          //! \ogs_file_param{material__fluid__density__linear_temperature__temperature0}
-    _temperature0(config.getConfigParameter<double>("temperature0")),
-          //! \ogs_file_param{material__fluid__density__linear_temperature__beta}
-    _beta(config.getConfigParameter<double>("beta"))
+    /// \param parameters An array contains the five parameters.
+    explicit LinearTemperatureDependentDensity(std::array<double,3>& parameters)
+    : _rho0(parameters[0]),_temperature0(parameters[1]),_beta(parameters[2])
     {
     }
 

--- a/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
+++ b/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
@@ -49,19 +49,19 @@ public:
 
     /// Get density value.
     /// \param var_vals Variable values in an array. The order of its elements
-    ///                 is given in enum class PropertyVariable.
-    double getValue(const double var_vals[]) const override
+    ///                 is given in enum class PropertyVariableType.
+    double getValue(const ArrayType& var_vals) const override
     {
-        const double T = var_vals[static_cast<int> (PropertyVariable::T)];
+        const double T = var_vals[static_cast<int> (PropertyVariableType::T)];
         return _rho0 * (1 + _beta * (T - _temperature0));
     }
 
     /// Get the partial differential of the density with respect to temperature.
     /// \param var_vals  Variable values  in an array. The order of its elements
-    ///                   is given in enum class PropertyVariable.
+    ///                   is given in enum class PropertyVariableType.
     /// \param var       Variable type.
-    double getdValue(const double var_vals[],
-            const PropertyVariable var) const override
+    double getdValue(const ArrayType& var_vals,
+            const PropertyVariableType var) const override
     {
         (void) var_vals;
         (void) var;

--- a/MaterialLib/Fluid/Density/LiquidDensity.h
+++ b/MaterialLib/Fluid/Density/LiquidDensity.h
@@ -60,12 +60,9 @@ public:
      *                     [4] $f E_0 $f
      */
     explicit LiquidDensity(std::array<double,5>& parameters)
-    :
-    _beta(parameters[0]),
-    _rho0(parameters[1]),
-    _temperature0(parameters[2]),
-    _p0(parameters[3]),
-    _bulk_modulus(parameters[4])
+      : _beta (parameters[0]), _rho0 (parameters[1]),
+      _temperature0 (parameters[2]), _p0 (parameters[3]),
+      _bulk_modulus (parameters[4])
     {
     }
 
@@ -96,7 +93,7 @@ public:
     {
         assert(var == PropertyVariableType::T || var == PropertyVariableType::pl);
 
-        const int func_id = (var == PropertyVariableType::T) ? 0 : 1;
+        const int func_id = static_cast<int> (var);
         const double T = var_vals[static_cast<int> (PropertyVariableType::T)];
         const double p = var_vals[static_cast<int> (PropertyVariableType::pl)];
         return (this->*_derivative_functions[func_id])(T, p);
@@ -147,11 +144,12 @@ private:
                                                        const double) const;
 
     /// An array of pointers to derivative functions.
-    static DerivativeFunctionPointer _derivative_functions[2];
+      static DerivativeFunctionPointer _derivative_functions[PropertyVariableNumber];
 };
 
-LiquidDensity::DerivativeFunctionPointer LiquidDensity::_derivative_functions[2]
-        = {&LiquidDensity::dLiquidDensity_dT,&LiquidDensity::dLiquidDensity_dp};
+    LiquidDensity::DerivativeFunctionPointer LiquidDensity
+            ::_derivative_functions[PropertyVariableNumber]
+            = {&LiquidDensity::dLiquidDensity_dT, &LiquidDensity::dLiquidDensity_dp, nullptr};
 
 }  // end of namespace
 }  // end of namespace

--- a/MaterialLib/Fluid/Density/LiquidDensity.h
+++ b/MaterialLib/Fluid/Density/LiquidDensity.h
@@ -1,0 +1,157 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * \author wenqing
+ * \file   LiquidDensity.h
+ *
+ * Created on August 4, 2016, 10:15 AM
+ */
+
+#ifndef LIQUIDDENSITY_H
+#define LIQUIDDENSITY_H
+
+#include <vector>
+
+#include "BaseLib/Error.h"
+
+#include "BaseLib/ConfigTree.h"
+
+#include "MaterialLib/Fluid/FluidProperty.h"
+
+namespace MaterialLib
+{
+namespace Fluid
+{
+/**
+ *  Class of a generic density model for liquid fluids varying with temperature
+ *  or pressure.
+ *
+ *  The formula is given on
+ *  <a href="engineeringtoolbox">
+ * http://www.engineeringtoolbox.com/fluid-density-temperature-pressure-d_309.html</a>
+ *   which reads
+ *   \f[
+ *        \rho_l = \rho_0/(1+\beta(T-T_0))/(1-(p-p_0)/E)
+ *   \f]
+ *   where
+ *    \f{eqnarray*}{
+ *       &\rho_l:& \mbox{liquid density,}\\
+ *       &\rho_0:& \mbox{initial liquid density,}\\
+ *       &\beta: & \mbox{volumetric temperature expansion coefficient,}\\
+ *       &T:&      \mbox{temperature,}\\
+ *       &T_0:&    \mbox{initial temperature,}\\
+ *       &p:&      \mbox{pressure,}\\
+ *       &p_0:&    \mbox{initial pressure,}\\
+ *       &E:&      \mbox{bulk modulus fluid elasticity.}\\
+ *    \f}
+ */
+class LiquidDensity : public FluidProperty
+{
+public:
+    /// \param config  ConfigTree object which contains the input data
+    ///                 including  <type>fluid</type> and it has
+    ///                 a tag of <density>
+    LiquidDensity(BaseLib::ConfigTree const& config)
+        :  //! \ogs_file_param{material__fluid__density__liquid_density__beta}
+    _beta(config.getConfigParameter<double>("beta")),
+          //! \ogs_file_param{material__fluid__density__liquid_density__rho0}
+    _rho0(config.getConfigParameter<double>("rho0")),
+          //! \ogs_file_param{material__fluid__density__liquid_density__temperature0}
+    _temperature0(config.getConfigParameter<double>("temperature0")),
+          //! \ogs_file_param{material__fluid__density__liquid_density__p0}
+    _p0(config.getConfigParameter<double>("p0")),
+          //! \ogs_file_param{material__fluid__density__liquid_density__bulk_modulus}
+    _bulk_moudlus(config.getConfigParameter<double>("bulk_modulus")),
+          _derivative_functions{&LiquidDensity::dLiquidDensity_dT,
+                                &LiquidDensity::dLiquidDensity_dp}
+    {
+    }
+
+    /// Get density model name.
+    virtual std::string getName() const final
+    {
+        return "Temperature or pressure dependent liquid density";
+    }
+
+    /// Get density value.
+    /// \param var_vals Variable values in an array. The order of its elements
+    ///                 is given in enum class PropertyVariable.
+    virtual double getValue(const double var_vals[]) const final
+    {
+        const double T = var_vals[static_cast<int>(PropertyVariable::T)];
+        const double p = var_vals[static_cast<int>(PropertyVariable::pl)];
+        return _rho0 / (1. + _beta * (T - _temperature0)) /
+               (1. - (p - _p0) / _bulk_moudlus);
+    }
+
+    /// Get the partial differential of the density with respect to temperature
+    /// or liquid pressure.
+    /// \param var_vals  Variable values  in an array. The order of its elements
+    ///                   is given in enum class PropertyVariable.
+    virtual double getdValue(const double var_vals[],
+                             const PropertyVariable var) const final
+    {
+        assert(var == PropertyVariable::T || var == PropertyVariable::pl);
+
+        const int func_id = (var == PropertyVariable::T) ? 0 : 1;
+        const double T = var_vals[static_cast<int>(PropertyVariable::T)];
+        const double p = var_vals[static_cast<int>(PropertyVariable::pl)];
+        return (this->*_derivative_functions[func_id])(T, p);
+    }
+
+private:
+    /// Volumetric temperature expansion coefficient.
+    double _beta;
+
+    /// Initial density.
+    double _rho0;
+
+    /// Initial temperature.
+    double _temperature0;
+
+    /// Initial pressure.
+    double _p0;
+
+    /// Bulk modulus.
+    double _bulk_moudlus;
+
+    /**
+     *  Calculate the derivative of density of fluids with respect to
+     * temperature.
+     *   \param T    Temperature (K).
+     *   \param p    Pressure (Pa).
+     */
+    double dLiquidDensity_dT(const double T, const double p) const
+    {
+        const double fac_T = 1. + _beta * (T - _temperature0);
+        return -_beta * _rho0 / (fac_T * fac_T) /
+               (1. - (p - _p0) / _bulk_moudlus);
+    }
+
+    /**
+     *  Calculate the derivative of density of fluids with respect to pressure.
+     *   \param T    Temperature (K).
+     *   \param p    Pressure (Pa).
+     */
+    double dLiquidDensity_dp(const double T, const double p) const
+    {
+        const double fac_p = 1. - (p - _p0) / _bulk_moudlus;
+        return _rho0 / (1. + _beta * (T - _temperature0)) /
+               (fac_p * fac_p * _bulk_moudlus);
+    }
+
+    typedef double (LiquidDensity::*ptr2_derivative_f)(const double,
+                                                       const double) const;
+
+    /// An array of pointer to derivative functions.
+    ptr2_derivative_f _derivative_functions[2];
+};
+
+}  // end of namespace
+}  // end of namespace
+
+#endif /* LIQUIDDENSITY_H */

--- a/MaterialLib/Fluid/Density/LiquidDensity.h
+++ b/MaterialLib/Fluid/Density/LiquidDensity.h
@@ -49,13 +49,13 @@ namespace Fluid
  *       &E:&      \mbox{bulk modulus fluid elasticity.}\\
  *    \f}
  */
-class LiquidDensity : public FluidProperty
+class LiquidDensity final : public FluidProperty
 {
 public:
     /// \param config  ConfigTree object which contains the input data
     ///                 including  <type>fluid</type> and it has
     ///                 a tag of <density>
-    LiquidDensity(BaseLib::ConfigTree const& config)
+    explicit LiquidDensity(BaseLib::ConfigTree const& config)
         :  //! \ogs_file_param{material__fluid__density__liquid_density__beta}
     _beta(config.getConfigParameter<double>("beta")),
           //! \ogs_file_param{material__fluid__density__liquid_density__rho0}
@@ -70,7 +70,7 @@ public:
     }
 
     /// Get density model name.
-    virtual std::string getName() const final
+    std::string getName() const override
     {
         return "Temperature or pressure dependent liquid density";
     }
@@ -78,7 +78,7 @@ public:
     /// Get density value.
     /// \param var_vals Variable values in an array. The order of its elements
     ///                 is given in enum class PropertyVariable.
-    virtual double getValue(const double var_vals[]) const final
+    double getValue(const double var_vals[]) const override
     {
         const double T = var_vals[static_cast<int>(PropertyVariable::T)];
         const double p = var_vals[static_cast<int>(PropertyVariable::pl)];
@@ -90,8 +90,9 @@ public:
     /// or liquid pressure.
     /// \param var_vals  Variable values  in an array. The order of its elements
     ///                   is given in enum class PropertyVariable.
-    virtual double getdValue(const double var_vals[],
-                             const PropertyVariable var) const final
+    /// \param var       Variable type.
+    double getdValue(const double var_vals[],
+            const PropertyVariable var) const override
     {
         assert(var == PropertyVariable::T || var == PropertyVariable::pl);
 
@@ -103,19 +104,19 @@ public:
 
 private:
     /// Volumetric temperature expansion coefficient.
-    double _beta;
+    const double _beta;
 
     /// Initial density.
-    double _rho0;
+    const double _rho0;
 
     /// Initial temperature.
-    double _temperature0;
+    const double _temperature0;
 
     /// Initial pressure.
-    double _p0;
+    const double _p0;
 
     /// Bulk modulus.
-    double _bulk_moudlus;
+    const double _bulk_moudlus;
 
     /**
      *  Calculate the derivative of density of fluids with respect to
@@ -145,7 +146,7 @@ private:
     typedef double (LiquidDensity::*DerivativeFunctionPointer)(const double,
                                                        const double) const;
 
-    /// An array of pointer to derivative functions.
+    /// An array of pointers to derivative functions.
     static DerivativeFunctionPointer _derivative_functions[2];
 };
 

--- a/MaterialLib/Fluid/Density/LiquidDensity.h
+++ b/MaterialLib/Fluid/Density/LiquidDensity.h
@@ -59,7 +59,7 @@ public:
      *                     [3] $f p_0 $f
      *                     [4] $f E_0 $f
      */
-    explicit LiquidDensity(std::array<double, 5>& parameters)
+    explicit LiquidDensity(std::array<double, 5> const& parameters)
         : _beta(parameters[0]),
           _rho0(parameters[1]),
           _temperature0(parameters[2]),

--- a/MaterialLib/Fluid/Density/LiquidDensity.h
+++ b/MaterialLib/Fluid/Density/LiquidDensity.h
@@ -52,7 +52,13 @@ namespace Fluid
 class LiquidDensity final : public FluidProperty
 {
 public:
-    /// \param parameters An array contains the five parameters.
+    /** \param parameters An array contains the five parameters:
+     *                     [0] $f \beta $f
+     *                     [1] $f \rho_0 $f
+     *                     [2] $f T_0 $f
+     *                     [3] $f p_0 $f
+     *                     [4] $f E_0 $f
+     */
     explicit LiquidDensity(std::array<double,5>& parameters)
     :
     _beta(parameters[0]),

--- a/MaterialLib/Fluid/Density/LiquidDensity.h
+++ b/MaterialLib/Fluid/Density/LiquidDensity.h
@@ -65,7 +65,7 @@ public:
           //! \ogs_file_param{material__fluid__density__liquid_density__p0}
     _p0(config.getConfigParameter<double>("p0")),
           //! \ogs_file_param{material__fluid__density__liquid_density__bulk_modulus}
-    _bulk_moudlus(config.getConfigParameter<double>("bulk_modulus"))
+    _bulk_modulus(config.getConfigParameter<double>("bulk_modulus"))
     {
     }
 
@@ -77,28 +77,28 @@ public:
 
     /// Get density value.
     /// \param var_vals Variable values in an array. The order of its elements
-    ///                 is given in enum class PropertyVariable.
-    double getValue(const double var_vals[]) const override
+    ///                 is given in enum class PropertyVariableType.
+    double getValue(const ArrayType& var_vals) const override
     {
-        const double T = var_vals[static_cast<int>(PropertyVariable::T)];
-        const double p = var_vals[static_cast<int>(PropertyVariable::pl)];
+        const double T = var_vals[static_cast<int> (PropertyVariableType::T)];
+        const double p = var_vals[static_cast<int> (PropertyVariableType::pl)];
         return _rho0 / (1. + _beta * (T - _temperature0)) /
-               (1. - (p - _p0) / _bulk_moudlus);
+                (1. - (p - _p0) / _bulk_modulus);
     }
 
     /// Get the partial differential of the density with respect to temperature
     /// or liquid pressure.
     /// \param var_vals  Variable values  in an array. The order of its elements
-    ///                   is given in enum class PropertyVariable.
+    ///                   is given in enum class PropertyVariableType.
     /// \param var       Variable type.
-    double getdValue(const double var_vals[],
-            const PropertyVariable var) const override
+    double getdValue(const ArrayType& var_vals,
+            const PropertyVariableType var) const override
     {
-        assert(var == PropertyVariable::T || var == PropertyVariable::pl);
+        assert(var == PropertyVariableType::T || var == PropertyVariableType::pl);
 
-        const int func_id = (var == PropertyVariable::T) ? 0 : 1;
-        const double T = var_vals[static_cast<int>(PropertyVariable::T)];
-        const double p = var_vals[static_cast<int>(PropertyVariable::pl)];
+        const int func_id = (var == PropertyVariableType::T) ? 0 : 1;
+        const double T = var_vals[static_cast<int> (PropertyVariableType::T)];
+        const double p = var_vals[static_cast<int> (PropertyVariableType::pl)];
         return (this->*_derivative_functions[func_id])(T, p);
     }
 
@@ -116,7 +116,7 @@ private:
     const double _p0;
 
     /// Bulk modulus.
-    const double _bulk_moudlus;
+    const double _bulk_modulus;
 
     /**
      *  Calculate the derivative of density of fluids with respect to
@@ -128,7 +128,7 @@ private:
     {
         const double fac_T = 1. + _beta * (T - _temperature0);
         return -_beta * _rho0 / (fac_T * fac_T) /
-               (1. - (p - _p0) / _bulk_moudlus);
+                (1. - (p - _p0) / _bulk_modulus);
     }
 
     /**
@@ -138,9 +138,9 @@ private:
      */
     double dLiquidDensity_dp(const double T, const double p) const
     {
-        const double fac_p = 1. - (p - _p0) / _bulk_moudlus;
+        const double fac_p = 1. - (p - _p0) / _bulk_modulus;
         return _rho0 / (1. + _beta * (T - _temperature0)) /
-               (fac_p * fac_p * _bulk_moudlus);
+                (fac_p * fac_p * _bulk_modulus);
     }
 
     typedef double (LiquidDensity::*DerivativeFunctionPointer)(const double,

--- a/MaterialLib/Fluid/Density/LiquidDensity.h
+++ b/MaterialLib/Fluid/Density/LiquidDensity.h
@@ -65,9 +65,7 @@ public:
           //! \ogs_file_param{material__fluid__density__liquid_density__p0}
     _p0(config.getConfigParameter<double>("p0")),
           //! \ogs_file_param{material__fluid__density__liquid_density__bulk_modulus}
-    _bulk_moudlus(config.getConfigParameter<double>("bulk_modulus")),
-          _derivative_functions{&LiquidDensity::dLiquidDensity_dT,
-                                &LiquidDensity::dLiquidDensity_dp}
+    _bulk_moudlus(config.getConfigParameter<double>("bulk_modulus"))
     {
     }
 
@@ -144,12 +142,15 @@ private:
                (fac_p * fac_p * _bulk_moudlus);
     }
 
-    typedef double (LiquidDensity::*ptr2_derivative_f)(const double,
+    typedef double (LiquidDensity::*DerivativeFunctionPointer)(const double,
                                                        const double) const;
 
     /// An array of pointer to derivative functions.
-    ptr2_derivative_f _derivative_functions[2];
+    static DerivativeFunctionPointer _derivative_functions[2];
 };
+
+LiquidDensity::DerivativeFunctionPointer LiquidDensity::_derivative_functions[2]
+        = {&LiquidDensity::dLiquidDensity_dT,&LiquidDensity::dLiquidDensity_dp};
 
 }  // end of namespace
 }  // end of namespace

--- a/MaterialLib/Fluid/Density/LiquidDensity.h
+++ b/MaterialLib/Fluid/Density/LiquidDensity.h
@@ -52,20 +52,14 @@ namespace Fluid
 class LiquidDensity final : public FluidProperty
 {
 public:
-    /// \param config  ConfigTree object which contains the input data
-    ///                 including  <type>fluid</type> and it has
-    ///                 a tag of <density>
-    explicit LiquidDensity(BaseLib::ConfigTree const& config)
-        :  //! \ogs_file_param{material__fluid__density__liquid_density__beta}
-    _beta(config.getConfigParameter<double>("beta")),
-          //! \ogs_file_param{material__fluid__density__liquid_density__rho0}
-    _rho0(config.getConfigParameter<double>("rho0")),
-          //! \ogs_file_param{material__fluid__density__liquid_density__temperature0}
-    _temperature0(config.getConfigParameter<double>("temperature0")),
-          //! \ogs_file_param{material__fluid__density__liquid_density__p0}
-    _p0(config.getConfigParameter<double>("p0")),
-          //! \ogs_file_param{material__fluid__density__liquid_density__bulk_modulus}
-    _bulk_modulus(config.getConfigParameter<double>("bulk_modulus"))
+    /// \param parameters An array contains the five parameters.
+    explicit LiquidDensity(std::array<double,5>& parameters)
+    :
+    _beta(parameters[0]),
+    _rho0(parameters[1]),
+    _temperature0(parameters[2]),
+    _p0(parameters[3]),
+    _bulk_modulus(parameters[4])
     {
     }
 

--- a/MaterialLib/Fluid/Density/LiquidDensity.h
+++ b/MaterialLib/Fluid/Density/LiquidDensity.h
@@ -59,10 +59,12 @@ public:
      *                     [3] $f p_0 $f
      *                     [4] $f E_0 $f
      */
-    explicit LiquidDensity(std::array<double,5>& parameters)
-      : _beta (parameters[0]), _rho0 (parameters[1]),
-      _temperature0 (parameters[2]), _p0 (parameters[3]),
-      _bulk_modulus (parameters[4])
+    explicit LiquidDensity(std::array<double, 5>& parameters)
+        : _beta(parameters[0]),
+          _rho0(parameters[1]),
+          _temperature0(parameters[2]),
+          _p0(parameters[3]),
+          _bulk_modulus(parameters[4])
     {
     }
 
@@ -77,10 +79,10 @@ public:
     ///                 is given in enum class PropertyVariableType.
     double getValue(const ArrayType& var_vals) const override
     {
-        const double T = var_vals[static_cast<int> (PropertyVariableType::T)];
-        const double p = var_vals[static_cast<int> (PropertyVariableType::pl)];
+        const double T = var_vals[static_cast<int>(PropertyVariableType::T)];
+        const double p = var_vals[static_cast<int>(PropertyVariableType::pl)];
         return _rho0 / (1. + _beta * (T - _temperature0)) /
-                (1. - (p - _p0) / _bulk_modulus);
+               (1. - (p - _p0) / _bulk_modulus);
     }
 
     /// Get the partial differential of the density with respect to temperature
@@ -89,11 +91,12 @@ public:
     ///                   is given in enum class PropertyVariableType.
     /// \param var       Variable type.
     double getdValue(const ArrayType& var_vals,
-            const PropertyVariableType var) const override
+                     const PropertyVariableType var) const override
     {
-        const double T = var_vals[static_cast<int> (PropertyVariableType::T)];
-        const double p = var_vals[static_cast<int> (PropertyVariableType::pl)];
-        switch (var) {
+        const double T = var_vals[static_cast<int>(PropertyVariableType::T)];
+        const double p = var_vals[static_cast<int>(PropertyVariableType::pl)];
+        switch (var)
+        {
             case PropertyVariableType::T:
                 return dLiquidDensity_dT(T, p);
             case PropertyVariableType::pl:
@@ -129,7 +132,7 @@ private:
     {
         const double fac_T = 1. + _beta * (T - _temperature0);
         return -_beta * _rho0 / (fac_T * fac_T) /
-                (1. - (p - _p0) / _bulk_modulus);
+               (1. - (p - _p0) / _bulk_modulus);
     }
 
     /**
@@ -141,7 +144,7 @@ private:
     {
         const double fac_p = 1. - (p - _p0) / _bulk_modulus;
         return _rho0 / (1. + _beta * (T - _temperature0)) /
-                (fac_p * fac_p * _bulk_modulus);
+               (fac_p * fac_p * _bulk_modulus);
     }
 };
 

--- a/MaterialLib/Fluid/Density/LiquidDensity.h
+++ b/MaterialLib/Fluid/Density/LiquidDensity.h
@@ -91,12 +91,16 @@ public:
     double getdValue(const ArrayType& var_vals,
             const PropertyVariableType var) const override
     {
-        assert(var == PropertyVariableType::T || var == PropertyVariableType::pl);
-
-        const int func_id = static_cast<int> (var);
         const double T = var_vals[static_cast<int> (PropertyVariableType::T)];
         const double p = var_vals[static_cast<int> (PropertyVariableType::pl)];
-        return (this->*_derivative_functions[func_id])(T, p);
+        switch (var) {
+            case PropertyVariableType::T:
+                return dLiquidDensity_dT(T, p);
+            case PropertyVariableType::pl:
+                return dLiquidDensity_dp(T, p);
+            default:
+                return 0.;
+        }
     }
 
 private:
@@ -139,17 +143,7 @@ private:
         return _rho0 / (1. + _beta * (T - _temperature0)) /
                 (fac_p * fac_p * _bulk_modulus);
     }
-
-    typedef double (LiquidDensity::*DerivativeFunctionPointer)(const double,
-                                                       const double) const;
-
-    /// An array of pointers to derivative functions.
-      static DerivativeFunctionPointer _derivative_functions[PropertyVariableNumber];
 };
-
-    LiquidDensity::DerivativeFunctionPointer LiquidDensity
-            ::_derivative_functions[PropertyVariableNumber]
-            = {&LiquidDensity::dLiquidDensity_dT, &LiquidDensity::dLiquidDensity_dp, nullptr};
 
 }  // end of namespace
 }  // end of namespace

--- a/MaterialLib/Fluid/Density/createFluidDensityModel.cpp
+++ b/MaterialLib/Fluid/Density/createFluidDensityModel.cpp
@@ -15,10 +15,10 @@
 
 #include "BaseLib/Error.h"
 
-#include "MaterialLib/Fluid/ConstantFluidProperty.h"
 #include "IdealGasLaw.h"
 #include "LinearTemperatureDependentDensity.h"
 #include "LiquidDensity.h"
+#include "MaterialLib/Fluid/ConstantFluidProperty.h"
 
 namespace MaterialLib
 {
@@ -29,7 +29,8 @@ namespace Fluid
                    including  <type>fluid</type> and it has
                    a tag of <density>
 */
-static std::unique_ptr<FluidProperty> createLiquidDensity(BaseLib::ConfigTree const& config)
+static std::unique_ptr<FluidProperty> createLiquidDensity(
+    BaseLib::ConfigTree const& config)
 {
     std::array<double, 5> parameters = {
         {//! \ogs_file_param{material__fluid__density__liquid_density__beta}
@@ -50,8 +51,8 @@ static std::unique_ptr<FluidProperty> createLiquidDensity(BaseLib::ConfigTree co
                    including  <type>fluid</type> and it has
                    a tag of <density>
 */
-static std::unique_ptr<FluidProperty> createLinearTemperatureDependentDensity
-                                     (BaseLib::ConfigTree const& config)
+static std::unique_ptr<FluidProperty> createLinearTemperatureDependentDensity(
+    BaseLib::ConfigTree const& config)
 {
     std::array<double, 3> parameters = {
         {//! \ogs_file_param{material__fluid__density__linear_temperature__rho0}
@@ -61,10 +62,11 @@ static std::unique_ptr<FluidProperty> createLinearTemperatureDependentDensity
          //! \ogs_file_param{material__fluid__density__linear_temperature__beta}
          config.getConfigParameter<double>("beta")}};
     return std::unique_ptr<FluidProperty>(
-            new LinearTemperatureDependentDensity(parameters));
+        new LinearTemperatureDependentDensity(parameters));
 }
 
-std::unique_ptr<FluidProperty> createFluidDensityModel(BaseLib::ConfigTree const& config)
+std::unique_ptr<FluidProperty> createFluidDensityModel(
+    BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{material__fluid__density__type}
     auto const type = config.getConfigParameter<std::string>("type");
@@ -73,7 +75,7 @@ std::unique_ptr<FluidProperty> createFluidDensityModel(BaseLib::ConfigTree const
     {
         return std::unique_ptr<FluidProperty>(new ConstantFluidProperty(
             //! \ogs_file_param{material__fluid__density__Constant_value}
-            config.getConfigParameter<double>("value")) );
+            config.getConfigParameter<double>("value")));
     }
     //! \ogs_file_param{material__fluid__density__LiquidDensity}
     else if (type == "LiquidDensity")
@@ -86,15 +88,16 @@ std::unique_ptr<FluidProperty> createFluidDensityModel(BaseLib::ConfigTree const
     else if (type == "IdealGasLaw")
     {
         //! \ogs_file_param{material__fluid__density__IdealGasLaw__molar_mass}
-        return std::unique_ptr<FluidProperty>(new IdealGasLaw(
-            config.getConfigParameter<double>("molar_mass")) );
+        return std::unique_ptr<FluidProperty>(
+            new IdealGasLaw(config.getConfigParameter<double>("molar_mass")));
     }
     else
     {
         OGS_FATAL(
             "The density type %s is unavailable.\n"
             "The available types are: \n\tConstant, \n\tLiquidDensity, "
-            "\n\tTemperatureDependent, \n\tIdealGasLaw.\n", type.data());
+            "\n\tTemperatureDependent, \n\tIdealGasLaw.\n",
+            type.data());
     }
 }
 

--- a/MaterialLib/Fluid/Density/createFluidDensityModel.cpp
+++ b/MaterialLib/Fluid/Density/createFluidDensityModel.cpp
@@ -9,6 +9,8 @@
                http://www.opengeosys.org/project/license
 */
 
+#include <array>
+
 #include "createFluidDensityModel.h"
 
 #include "BaseLib/Error.h"
@@ -22,6 +24,50 @@ namespace MaterialLib
 {
 namespace Fluid
 {
+/*
+    config  ConfigTree object which contains the input data
+                   including  <type>fluid</type> and it has
+                   a tag of <density>
+*/
+std::unique_ptr<FluidProperty> createLiquidDensity(BaseLib::ConfigTree const& config)
+{
+    std::array<double, 5> parameters =
+    {
+        //! \ogs_file_param{material__fluid__density__liquid_density__beta}
+        config.getConfigParameter<double>("beta"),
+        //! \ogs_file_param{material__fluid__density__liquid_density__rho0}
+        config.getConfigParameter<double>("rho0"),
+        //! \ogs_file_param{material__fluid__density__liquid_density__temperature0}
+        config.getConfigParameter<double>("temperature0"),
+        //! \ogs_file_param{material__fluid__density__liquid_density__p0}
+        config.getConfigParameter<double>("p0"),
+        //! \ogs_file_param{material__fluid__density__liquid_density__bulk_modulus}
+        config.getConfigParameter<double>("bulk_modulus")
+    };
+    return std::unique_ptr<FluidProperty>(new LiquidDensity(parameters));
+}
+
+/*
+    config  ConfigTree object which contains the input data
+                   including  <type>fluid</type> and it has
+                   a tag of <density>
+*/
+std::unique_ptr<FluidProperty> createLinearTemperatureDependentDensity
+                                     (BaseLib::ConfigTree const& config)
+{
+    std::array<double, 3> parameters =
+    {
+        //! \ogs_file_param{material__fluid__density__linear_temperature__rho0}
+        config.getConfigParameter<double>("rho0"),
+        //! \ogs_file_param{material__fluid__density__linear_temperature__temperature0}
+        config.getConfigParameter<double>("temperature0"),
+        //! \ogs_file_param{material__fluid__density__linear_temperature__beta}
+        config.getConfigParameter<double>("beta")
+    };
+    return std::unique_ptr<FluidProperty>(
+            new LinearTemperatureDependentDensity(parameters));
+}
+
 std::unique_ptr<FluidProperty> createFluidDensityModel(BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{material__fluid__density__type}
@@ -35,11 +81,11 @@ std::unique_ptr<FluidProperty> createFluidDensityModel(BaseLib::ConfigTree const
     }
     //! \ogs_file_param{material__fluid__density__LiquidDensity}
     else if (type == "LiquidDensity")
-        return std::unique_ptr<FluidProperty>(new LiquidDensity(config));
+        return createLiquidDensity(config);
+
     //! \ogs_file_param{material__fluid__density__TemperatureDependent}
     else if (type == "TemperatureDependent")
-        return std::unique_ptr<FluidProperty>(
-                new LinearTemperatureDependentDensity(config));
+        return createLinearTemperatureDependentDensity(config);
     //! \ogs_file_param{material__fluid__density__IdealGasLaw}
     else if (type == "IdealGasLaw")
     {
@@ -50,9 +96,9 @@ std::unique_ptr<FluidProperty> createFluidDensityModel(BaseLib::ConfigTree const
     else
     {
         OGS_FATAL(
-            "The density type %s is unavailable.\n", type.data(),
-            "The available types are Constant, LiquidDensity, "
-            "TemperatureDependent and IdealGasLaw");
+            "The density type %s is unavailable.\n"
+            "The available types are: \n\tConstant, \n\tLiquidDensity, "
+            "\n\tTemperatureDependent, \n\tIdealGasLaw.\n", type.data());
     }
 }
 

--- a/MaterialLib/Fluid/Density/createFluidDensityModel.cpp
+++ b/MaterialLib/Fluid/Density/createFluidDensityModel.cpp
@@ -27,10 +27,10 @@ std::unique_ptr<FluidProperty> createFluidDensityModel(BaseLib::ConfigTree const
     //! \ogs_file_param{material__fluid__density__type}
     auto const type = config.getConfigParameter<std::string>("type");
 
-    if (type == "constant")
+    if (type == "Constant")
     {
         return std::unique_ptr<FluidProperty>(new ConstantFluidProperty(
-            //! \ogs_file_param{material__fluid__density__constant_value}
+            //! \ogs_file_param{material__fluid__density__Constant_value}
             config.getConfigParameter<double>("value")) );
     }
     //! \ogs_file_param{material__fluid__density__LiquidDensity}
@@ -51,8 +51,8 @@ std::unique_ptr<FluidProperty> createFluidDensityModel(BaseLib::ConfigTree const
     {
         OGS_FATAL(
             "The density type %s is unavailable.\n", type.data(),
-            "The available types are liquid_density "
-            "temperature_dependent and ideal_gas_law");
+            "The available types are Constant, LiquidDensity, "
+            "TemperatureDependent and IdealGasLaw");
     }
 }
 

--- a/MaterialLib/Fluid/Density/createFluidDensityModel.cpp
+++ b/MaterialLib/Fluid/Density/createFluidDensityModel.cpp
@@ -1,0 +1,60 @@
+/*!
+   \file  createFluidDensityModel.cpp
+   \brief create an instance of a fluid density class.
+
+   \copyright
+    Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+               Distributed under a Modified BSD License.
+               See accompanying file LICENSE.txt or
+               http://www.opengeosys.org/project/license
+*/
+
+#include "createFluidDensityModel.h"
+
+#include "BaseLib/Error.h"
+
+#include "MaterialLib/Fluid/ConstantFluidProperty.h"
+#include "IdealGasLaw.h"
+#include "LinearTemperatureDependentDensity.h"
+#include "LiquidDensity.h"
+
+namespace MaterialLib
+{
+namespace Fluid
+{
+std::unique_ptr<FluidProperty> createFluidDensityModel(BaseLib::ConfigTree const& config)
+{
+    //! \ogs_file_param{material__fluid__density__type}
+    auto const type = config.getConfigParameter<std::string>("type");
+
+    if (type == "constant")
+    {
+        return std::unique_ptr<FluidProperty>(new ConstantFluidProperty(
+            //! \ogs_file_param{material__fluid__density__constant_value}
+            config.getConfigParameter<double>("value")) );
+    }
+    //! \ogs_file_param{material__fluid__density__LiquidDensity}
+    else if (type == "LiquidDensity")
+        return std::unique_ptr<FluidProperty>(new LiquidDensity(config));
+    //! \ogs_file_param{material__fluid__density__TemperatureDependent}
+    else if (type == "TemperatureDependent")
+        return std::unique_ptr<FluidProperty>(
+                new LinearTemperatureDependentDensity(config));
+    //! \ogs_file_param{material__fluid__density__IdealGasLaw}
+    else if (type == "IdealGasLaw")
+    {
+        //! \ogs_file_param{material__fluid__density__IdealGasLaw__molar_mass}
+        return std::unique_ptr<FluidProperty>(new IdealGasLaw(
+            config.getConfigParameter<double>("molar_mass")) );
+    }
+    else
+    {
+        OGS_FATAL(
+            "The density type %s is unavailable.\n", type.data(),
+            "The available types are liquid_density "
+            "temperature_dependent and ideal_gas_law");
+    }
+}
+
+}  // end namespace
+}  // end namespace

--- a/MaterialLib/Fluid/Density/createFluidDensityModel.cpp
+++ b/MaterialLib/Fluid/Density/createFluidDensityModel.cpp
@@ -24,12 +24,12 @@ namespace MaterialLib
 {
 namespace Fluid
 {
-/*
-    config  ConfigTree object which contains the input data
+/*!
+    \param config  ConfigTree object which contains the input data
                    including  <type>fluid</type> and it has
                    a tag of <density>
 */
-std::unique_ptr<FluidProperty> createLiquidDensity(BaseLib::ConfigTree const& config)
+static std::unique_ptr<FluidProperty> createLiquidDensity(BaseLib::ConfigTree const& config)
 {
     std::array<double, 5> parameters =
     {
@@ -47,12 +47,12 @@ std::unique_ptr<FluidProperty> createLiquidDensity(BaseLib::ConfigTree const& co
     return std::unique_ptr<FluidProperty>(new LiquidDensity(parameters));
 }
 
-/*
-    config  ConfigTree object which contains the input data
+/*!
+    \param config  ConfigTree object which contains the input data
                    including  <type>fluid</type> and it has
                    a tag of <density>
 */
-std::unique_ptr<FluidProperty> createLinearTemperatureDependentDensity
+static std::unique_ptr<FluidProperty> createLinearTemperatureDependentDensity
                                      (BaseLib::ConfigTree const& config)
 {
     std::array<double, 3> parameters =

--- a/MaterialLib/Fluid/Density/createFluidDensityModel.cpp
+++ b/MaterialLib/Fluid/Density/createFluidDensityModel.cpp
@@ -31,19 +31,17 @@ namespace Fluid
 */
 static std::unique_ptr<FluidProperty> createLiquidDensity(BaseLib::ConfigTree const& config)
 {
-    std::array<double, 5> parameters =
-    {
-        //! \ogs_file_param{material__fluid__density__liquid_density__beta}
-        config.getConfigParameter<double>("beta"),
-        //! \ogs_file_param{material__fluid__density__liquid_density__rho0}
-        config.getConfigParameter<double>("rho0"),
-        //! \ogs_file_param{material__fluid__density__liquid_density__temperature0}
-        config.getConfigParameter<double>("temperature0"),
-        //! \ogs_file_param{material__fluid__density__liquid_density__p0}
-        config.getConfigParameter<double>("p0"),
-        //! \ogs_file_param{material__fluid__density__liquid_density__bulk_modulus}
-        config.getConfigParameter<double>("bulk_modulus")
-    };
+    std::array<double, 5> parameters = {
+        {//! \ogs_file_param{material__fluid__density__liquid_density__beta}
+         config.getConfigParameter<double>("beta"),
+         //! \ogs_file_param{material__fluid__density__liquid_density__rho0}
+         config.getConfigParameter<double>("rho0"),
+         //! \ogs_file_param{material__fluid__density__liquid_density__temperature0}
+         config.getConfigParameter<double>("temperature0"),
+         //! \ogs_file_param{material__fluid__density__liquid_density__p0}
+         config.getConfigParameter<double>("p0"),
+         //! \ogs_file_param{material__fluid__density__liquid_density__bulk_modulus}
+         config.getConfigParameter<double>("bulk_modulus")}};
     return std::unique_ptr<FluidProperty>(new LiquidDensity(parameters));
 }
 
@@ -55,15 +53,13 @@ static std::unique_ptr<FluidProperty> createLiquidDensity(BaseLib::ConfigTree co
 static std::unique_ptr<FluidProperty> createLinearTemperatureDependentDensity
                                      (BaseLib::ConfigTree const& config)
 {
-    std::array<double, 3> parameters =
-    {
-        //! \ogs_file_param{material__fluid__density__linear_temperature__rho0}
-        config.getConfigParameter<double>("rho0"),
-        //! \ogs_file_param{material__fluid__density__linear_temperature__temperature0}
-        config.getConfigParameter<double>("temperature0"),
-        //! \ogs_file_param{material__fluid__density__linear_temperature__beta}
-        config.getConfigParameter<double>("beta")
-    };
+    std::array<double, 3> parameters = {
+        {//! \ogs_file_param{material__fluid__density__linear_temperature__rho0}
+         config.getConfigParameter<double>("rho0"),
+         //! \ogs_file_param{material__fluid__density__linear_temperature__temperature0}
+         config.getConfigParameter<double>("temperature0"),
+         //! \ogs_file_param{material__fluid__density__linear_temperature__beta}
+         config.getConfigParameter<double>("beta")}};
     return std::unique_ptr<FluidProperty>(
             new LinearTemperatureDependentDensity(parameters));
 }

--- a/MaterialLib/Fluid/Density/createFluidDensityModel.h
+++ b/MaterialLib/Fluid/Density/createFluidDensityModel.h
@@ -23,7 +23,8 @@ namespace Fluid
 {
 /// Create a density model
 /// \param config  ConfigTree object has a tag of <density>
-std::unique_ptr<FluidProperty> createFluidDensityModel(BaseLib::ConfigTree const& config);
+std::unique_ptr<FluidProperty> createFluidDensityModel(
+    BaseLib::ConfigTree const& config);
 }
 }  // end namespace
 #endif

--- a/MaterialLib/Fluid/Density/createFluidDensityModel.h
+++ b/MaterialLib/Fluid/Density/createFluidDensityModel.h
@@ -1,0 +1,29 @@
+/*!
+   \file  createFluidDensityModel.h
+   \brief create an instance of a fluid density class.
+
+   \copyright
+    Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+               Distributed under a Modified BSD License.
+               See accompanying file LICENSE.txt or
+               http://www.opengeosys.org/project/license
+*/
+#ifndef CREATE_FLUID_DENSITY_MODEL_H_
+#define CREATE_FLUID_DENSITY_MODEL_H_
+
+#include <memory>
+
+#include "BaseLib/ConfigTree.h"
+
+#include "MaterialLib/Fluid/FluidProperty.h"
+
+namespace MaterialLib
+{
+namespace Fluid
+{
+/// Create a density model
+/// \param config  ConfigTree object has a tag of <density>
+std::unique_ptr<FluidProperty> createFluidDensityModel(BaseLib::ConfigTree const& config);
+}
+}  // end namespace
+#endif

--- a/MaterialLib/Fluid/FluidProperty.h
+++ b/MaterialLib/Fluid/FluidProperty.h
@@ -14,23 +14,30 @@
 #define FLUIDPROPERTY_H
 
 #include <string>
+#include <array>
 
 namespace MaterialLib
 {
 namespace Fluid
 {
 /// Variable that determine the property.
-enum class PropertyVariable
+enum class PropertyVariableType
 {
-    T = 0,   ///< temperature
-    pl = 1,  ///< pressure of the liquid phase (1st phase for some cases))
-    pg = 2,  ///< pressure of the gas phase (2nd phase for some cases))
+    T = 0,///< temperature.
+    pl = 1,///< pressure of the liquid phase (1st phase for some cases).
+    pg = 2,///< pressure of the gas phase (2nd phase for some cases).
+    vars_num = 3 ///< Number of property variables.
 };
+
+const unsigned PropertyVariableNumber
+        = static_cast<unsigned> (PropertyVariableType::vars_num);
 
 /// Base class of fluid density properties
 class FluidProperty
 {
 public:
+
+    typedef std::array<double,PropertyVariableNumber> ArrayType;
 
     virtual ~FluidProperty()
     {
@@ -41,16 +48,16 @@ public:
 
     /// Get property value.
     /// The argument is an array of variables. The order of its elements
-    ///                 is given in enum class PropertyVariable.
-    virtual double getValue(const double /* var_vals*/[]) const = 0;
+    ///                 is given in enum class PropertyVariableType.
+    virtual double getValue(const ArrayType& /* var_vals*/) const = 0;
 
     /// Get the partial differential of the property value
     /// The first argument is an array of variables, and the order of the array
-    /// elements is given in enum class PropertyVariable.
+    /// elements is given in enum class PropertyVariableType.
     /// The second argument is the variable type indicating which partial derivative
     /// to be get.
-    virtual double getdValue(const double /* var_vals*/[],
-                             const PropertyVariable /* var */) const = 0;
+    virtual double getdValue(const ArrayType& /* var_vals*/,
+            const PropertyVariableType /* var */) const = 0;
 };
 
 }  // end namespace

--- a/MaterialLib/Fluid/FluidProperty.h
+++ b/MaterialLib/Fluid/FluidProperty.h
@@ -26,11 +26,11 @@ enum class PropertyVariableType
     T = 0,///< temperature.
     pl = 1,///< pressure of the liquid phase (1st phase for some cases).
     pg = 2,///< pressure of the gas phase (2nd phase for some cases).
-    vars_num = 3 ///< Number of property variables.
+    number_of_variables = 3 ///< Number of property variables.
 };
 
 const unsigned PropertyVariableNumber
-        = static_cast<unsigned> (PropertyVariableType::vars_num);
+        = static_cast<unsigned> (PropertyVariableType::number_of_variables);
 
 /// Base class of fluid density properties
 class FluidProperty
@@ -55,7 +55,7 @@ public:
     /// The first argument is an array of variables, and the order of the array
     /// elements is given in enum class PropertyVariableType.
     /// The second argument is the variable type indicating which partial derivative
-    /// to be get.
+    /// to be calculated.
     virtual double getdValue(const ArrayType& /* var_vals*/,
             const PropertyVariableType /* var */) const = 0;
 };

--- a/MaterialLib/Fluid/FluidProperty.h
+++ b/MaterialLib/Fluid/FluidProperty.h
@@ -32,17 +32,23 @@ class FluidProperty
 {
 public:
 
+    virtual ~FluidProperty()
+    {
+    }
+
     /// Get model name.
     virtual std::string getName() const = 0;
 
     /// Get property value.
-    /// \param var_vals Variable values in an array. The order of its elements
+    /// The argument is an array of variables. The order of its elements
     ///                 is given in enum class PropertyVariable.
     virtual double getValue(const double /* var_vals*/[]) const = 0;
 
     /// Get the partial differential of the property value
-    /// \param var_vals  Variable values  in an array. The order of its elements
-    ///                   is given in enum class PropertyVariable.
+    /// The first argument is an array of variables, and the order of the array
+    /// elements is given in enum class PropertyVariable.
+    /// The second argument is the variable type indicating which partial derivative
+    /// to be get.
     virtual double getdValue(const double /* var_vals*/[],
                              const PropertyVariable /* var */) const = 0;
 };

--- a/MaterialLib/Fluid/FluidProperty.h
+++ b/MaterialLib/Fluid/FluidProperty.h
@@ -13,8 +13,8 @@
 #ifndef FLUIDPROPERTY_H
 #define FLUIDPROPERTY_H
 
-#include <string>
 #include <array>
+#include <string>
 
 namespace MaterialLib
 {
@@ -23,26 +23,22 @@ namespace Fluid
 /// Variable that determine the property.
 enum class PropertyVariableType
 {
-    T = 0,///< temperature.
-    pl = 1,///< pressure of the liquid phase (1st phase for some cases).
-    pg = 2,///< pressure of the gas phase (2nd phase for some cases).
-    number_of_variables = 3 ///< Number of property variables.
+    T = 0,   ///< temperature.
+    pl = 1,  ///< pressure of the liquid phase (1st phase for some cases).
+    pg = 2,  ///< pressure of the gas phase (2nd phase for some cases).
+    number_of_variables = 3  ///< Number of property variables.
 };
 
-const unsigned PropertyVariableNumber
-        = static_cast<unsigned> (PropertyVariableType::number_of_variables);
+const unsigned PropertyVariableNumber =
+    static_cast<unsigned>(PropertyVariableType::number_of_variables);
 
 /// Base class of fluid density properties
 class FluidProperty
 {
 public:
+    typedef std::array<double, PropertyVariableNumber> ArrayType;
 
-    typedef std::array<double,PropertyVariableNumber> ArrayType;
-
-    virtual ~FluidProperty()
-    {
-    }
-
+    virtual ~FluidProperty() {}
     /// Get model name.
     virtual std::string getName() const = 0;
 
@@ -54,10 +50,10 @@ public:
     /// Get the partial differential of the property value
     /// The first argument is an array of variables, and the order of the array
     /// elements is given in enum class PropertyVariableType.
-    /// The second argument is the variable type indicating which partial derivative
-    /// to be calculated.
+    /// The second argument is the variable type indicating which partial
+    /// derivative to be calculated.
     virtual double getdValue(const ArrayType& /* var_vals*/,
-            const PropertyVariableType /* var */) const = 0;
+                             const PropertyVariableType /* var */) const = 0;
 };
 
 }  // end namespace

--- a/MaterialLib/Fluid/FluidProperty.h
+++ b/MaterialLib/Fluid/FluidProperty.h
@@ -1,0 +1,53 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * \file:   FluidProperty.h
+ *
+ * Created on August 12, 2016, 3:34 PM
+ */
+
+#ifndef FLUIDPROPERTY_H
+#define FLUIDPROPERTY_H
+
+#include <string>
+
+namespace MaterialLib
+{
+namespace Fluid
+{
+/// Variable that determine the property.
+enum class PropertyVariable
+{
+    T = 0,   ///< temperature
+    pl = 1,  ///< pressure of the liquid phase (1st phase for some cases))
+    pg = 2,  ///< pressure of the gas phase (2nd phase for some cases))
+};
+
+/// Base class of fluid density properties
+class FluidProperty
+{
+public:
+
+    /// Get model name.
+    virtual std::string getName() const = 0;
+
+    /// Get property value.
+    /// \param var_vals Variable values in an array. The order of its elements
+    ///                 is given in enum class PropertyVariable.
+    virtual double getValue(const double /* var_vals*/[]) const = 0;
+
+    /// Get the partial differential of the property value
+    /// \param var_vals  Variable values  in an array. The order of its elements
+    ///                   is given in enum class PropertyVariable.
+    virtual double getdValue(const double /* var_vals*/[],
+                             const PropertyVariable /* var */) const = 0;
+};
+
+}  // end namespace
+}  // end namespace
+
+#endif /* FLUIDPROPERTY_H */

--- a/MaterialLib/Fluid/FluidPropertyHeaders.h
+++ b/MaterialLib/Fluid/FluidPropertyHeaders.h
@@ -18,4 +18,3 @@
 #include "Viscosity/createViscosityModel.h"
 
 #endif /* FLUIDPROPERTYHEADERS_H */
-

--- a/MaterialLib/Fluid/FluidPropertyHeaders.h
+++ b/MaterialLib/Fluid/FluidPropertyHeaders.h
@@ -1,0 +1,21 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * File:   FluidPropertyHeaders.h
+ * Author: wenqing
+ *
+ * Created on August 18, 2016, 11:10 AM
+ */
+
+#ifndef FLUIDPROPERTYHEADERS_H
+#define FLUIDPROPERTYHEADERS_H
+
+#include "Density/createFluidDensityModel.h"
+#include "Viscosity/createViscosityModel.h"
+
+#endif /* FLUIDPROPERTYHEADERS_H */
+

--- a/Tests/MaterialLib/TestFluidDensity.cpp
+++ b/Tests/MaterialLib/TestFluidDensity.cpp
@@ -20,8 +20,6 @@
 #include "MaterialLib/Fluid/Density/createFluidDensityModel.h"
 #include "MaterialLib/PhysicalConstant.h"
 
-namespace
-{
 using namespace MaterialLib;
 using namespace MaterialLib::Fluid;
 
@@ -40,7 +38,7 @@ TEST(Material, checkConstantDensity)
 {
     const char xml[] =
         "<density>"
-        "   <type>constant</type>"
+        "   <type>Constant</type>"
         "   <value> 998.0 </value> "
         "</density>";
     const auto rho = createTestFluidDensityModel(xml);
@@ -129,6 +127,4 @@ TEST(Material, checkLiquidDensity)
     const double fac_p = 1. - (p - p0) / K;
     ASSERT_NEAR(rho0 / (1. + beta * (T - T0)) / (fac_p * fac_p * K),
                 rho->getdValue(vars, Fluid::PropertyVariable::pl), 1.e-10);
-}
-
 }

--- a/Tests/MaterialLib/TestFluidDensity.cpp
+++ b/Tests/MaterialLib/TestFluidDensity.cpp
@@ -64,7 +64,7 @@ TEST(Material, checkIdealGasLaw)
     const double p = 1.e+5;
     const double R = PhysicalConstant::IdealGasConstant;
     const double expected_air_dens = molar_air * p / (R * T);
-    ArrayType vars = {290, 0, 1.e+5};
+    ArrayType vars = {{290, 0, 1.e+5}};
     ASSERT_NEAR(expected_air_dens, rho->getValue(vars), 1.e-10);
 
     const double expected_d_air_dens_dT = -molar_air * p / (R * T * T);
@@ -109,7 +109,7 @@ TEST(Material, checkLiquidDensity)
         "</density>";
     const auto rho = createTestFluidDensityModel(xml);
 
-    const ArrayType vars = {273.15 + 60.0, 1.e+6, 0.};
+    const ArrayType vars = {{273.15 + 60.0, 1.e+6, 0.}};
     const double T0 = 273.15;
     const double p0 = 1.e+5;
     const double rho0 = 999.8;

--- a/Tests/MaterialLib/TestFluidDensity.cpp
+++ b/Tests/MaterialLib/TestFluidDensity.cpp
@@ -46,8 +46,9 @@ TEST(Material, checkConstantDensity)
 
     ArrayType dummy;
     ASSERT_EQ(998.0, rho->getValue(dummy));
-    ASSERT_EQ(0.0,
-              rho->getdValue(dummy, MaterialLib::Fluid::PropertyVariableType::T));
+    ASSERT_EQ(
+        0.0,
+        rho->getdValue(dummy, MaterialLib::Fluid::PropertyVariableType::T));
 }
 
 TEST(Material, checkIdealGasLaw)

--- a/Tests/MaterialLib/TestFluidDensity.cpp
+++ b/Tests/MaterialLib/TestFluidDensity.cpp
@@ -1,0 +1,134 @@
+/*!
+   \file  TestFluidDensity.cpp
+   \brief Test classes for fluid density models.
+
+   \author Wenqing Wang
+   \date Jan 2015
+
+   \copyright
+    Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+               Distributed under a Modified BSD License.
+               See accompanying file LICENSE.txt or
+               http://www.opengeosys.org/project/license
+*/
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "TestTools.h"
+
+#include "MaterialLib/Fluid/Density/createFluidDensityModel.h"
+#include "MaterialLib/PhysicalConstant.h"
+
+namespace
+{
+using namespace MaterialLib;
+using namespace MaterialLib::Fluid;
+
+//----------------------------------------------------------------------------
+// Test density models.
+std::unique_ptr<FluidProperty> createTestFluidDensityModel(const char xml[])
+{
+    auto const ptree = readXml(xml);
+    BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
+                             BaseLib::ConfigTree::onwarning);
+    auto const& sub_config = conf.getConfigSubtree("density");
+    return MaterialLib::Fluid::createFluidDensityModel(sub_config);
+}
+
+TEST(Material, checkConstantDensity)
+{
+    const char xml[] =
+        "<density>"
+        "   <type>constant</type>"
+        "   <value> 998.0 </value> "
+        "</density>";
+    const auto rho = createTestFluidDensityModel(xml);
+
+    ASSERT_EQ(998.0, rho->getValue(nullptr));
+    ASSERT_EQ(0.0,
+              rho->getdValue(nullptr, MaterialLib::Fluid::PropertyVariable::T));
+}
+
+TEST(Material, checkIdealGasLaw)
+{
+    const char xml[] =
+        "<density>"
+        "   <type>IdealGasLaw</type>"
+        "   <molar_mass> 28.96 </molar_mass> "
+        "</density>";
+    const auto rho = createTestFluidDensityModel(xml);
+
+    const double molar_air = 28.96;
+    const double T = 290.;
+    const double p = 1.e+5;
+    const double R = PhysicalConstant::IdealGasConstant;
+    const double expected_air_dens = molar_air * p / (R * T);
+    double vars[] = {290, 0, 1.e+5};
+    ASSERT_NEAR(expected_air_dens, rho->getValue(vars), 1.e-10);
+
+    const double expected_d_air_dens_dT = -molar_air * p / (R * T * T);
+    ASSERT_NEAR(expected_d_air_dens_dT,
+                rho->getdValue(vars, Fluid::PropertyVariable::T), 1.e-10);
+
+    const double expected_d_air_dens_dp = molar_air / (R * T);
+    ASSERT_NEAR(expected_d_air_dens_dp,
+                rho->getdValue(vars, Fluid::PropertyVariable::pg), 1.e-10);
+}
+
+TEST(Material, checkLinearTemperatureDependentDensity)
+{
+    const char xml[] =
+        "<density>"
+        "   <type>TemperatureDependent</type>"
+        "   <temperature0> 293.0 </temperature0> "
+        "   <beta> 4.3e-4 </beta> "
+        "   <rho0>1000.</rho0>"
+        "</density>";
+
+    const auto rho = createTestFluidDensityModel(xml);
+
+    double vars[] = {273.1 + 60.0};
+    ASSERT_NEAR(1000.0 * (1 + 4.3e-4 * (vars[0] - 293.0)), rho->getValue(vars),
+                1.e-10);
+    ASSERT_NEAR(1000.0 * 4.3e-4,
+                rho->getdValue(vars, Fluid::PropertyVariable::T), 1.e-10);
+}
+
+TEST(Material, checkLiquidDensity)
+{
+    const char xml[] =
+        "<density>"
+        "   <type>LiquidDensity</type>"
+        "   <temperature0> 273.15 </temperature0> "
+        "   <p0> 1.e+5 </p0> "
+        "   <bulk_modulus> 2.15e+9 </bulk_modulus> "
+        "   <beta> 2.0e-4 </beta> "
+        "   <rho0>999.8</rho0>"
+        "</density>";
+    const auto rho = createTestFluidDensityModel(xml);
+
+    const double vars[] = {273.15 + 60.0, 1.e+6};
+    const double T0 = 273.15;
+    const double p0 = 1.e+5;
+    const double rho0 = 999.8;
+    const double K = 2.15e+9;
+    const double beta = 2.e-4;
+    const double T = vars[0];
+    const double p = vars[1];
+
+    const double fac_T = 1. + beta * (T - T0);
+    ASSERT_NEAR(rho0 / fac_T / (1. - (p - p0) / K), rho->getValue(vars),
+                1.e-10);
+
+    // Test the derivative with respect to temperature.
+    ASSERT_NEAR(-beta * rho0 / (fac_T * fac_T) / (1. - (p - p0) / K),
+                rho->getdValue(vars, Fluid::PropertyVariable::T), 1.e-10);
+
+    // Test the derivative with respect to pressure.
+    const double fac_p = 1. - (p - p0) / K;
+    ASSERT_NEAR(rho0 / (1. + beta * (T - T0)) / (fac_p * fac_p * K),
+                rho->getdValue(vars, Fluid::PropertyVariable::pl), 1.e-10);
+}
+
+}


### PR DESCRIPTION
This PR is the fluid density part of PR #1365, which has been revised according to your comments and it is closed now. 

In this PR, class FluidProperty is the base class of the classes for fluid density models and viscosity models. 