### PR TITLE
small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ tags
 *.iml
 .idea
 
+# Visual Studio Code project files
+.vscode
+
 # Conan package manager
 conanbuildinfo.cmake
 conaninfo.txt

--- a/ProcessLib/CMakeLists.txt
+++ b/ProcessLib/CMakeLists.txt
@@ -6,6 +6,8 @@ APPEND_SOURCE_FILES(SOURCES)
 add_subdirectory(BoundaryCondition)
 APPEND_SOURCE_FILES(SOURCES BoundaryCondition)
 
+APPEND_SOURCE_FILES(SOURCES Deformation)
+
 add_subdirectory(Parameter)
 APPEND_SOURCE_FILES(SOURCES Parameter)
 


### PR DESCRIPTION
- ignore Visual Studio Code project files in git
- include ProcessLib/Deformation directory (so far header only) in CMake. Otherwise the dir is not shown in QtCreator.