### PR TITLE
Fix an issue in `BaseLib::copyPathToFileName`

### DIFF
--- a/BaseLib/FileTools.cpp
+++ b/BaseLib/FileTools.cpp
@@ -123,6 +123,13 @@ bool hasFileExtension(std::string const& extension, std::string const& filename)
     return boost::iequals(extension, getFileExtension(filename));
 }
 
+static const char pathSeparator =
+#ifdef _WIN32
+                            '\\';
+#else
+                            '/';
+#endif
+
 std::string copyPathToFileName(const std::string &file_name,
                                const std::string &source)
 {
@@ -131,6 +138,10 @@ std::string copyPathToFileName(const std::string &file_name,
     if (pos != std::string::npos)
         return file_name;
 
+    if (source.empty())
+        return file_name;
+    if (source.back() != pathSeparator)
+        return BaseLib::extractPath(source + pathSeparator).append(file_name);
     return BaseLib::extractPath(source).append(file_name);
 }
 
@@ -141,12 +152,6 @@ std::string extractPath(std::string const& pathname)
         return "";
     return pathname.substr(0, pos + 1);
 }
-static const char pathSeparator =
-#ifdef _WIN32
-                            '\\';
-#else
-                            '/';
-#endif
 
 std::string appendPathSeparator(std::string const& path)
 {

--- a/Tests/BaseLib/TestFilePathStringManipulation.cpp
+++ b/Tests/BaseLib/TestFilePathStringManipulation.cpp
@@ -146,29 +146,35 @@ TEST(BaseLib, getFileExtensionUnix)
     ASSERT_EQ ( BaseLib::getFileExtension("/path.wrong0/path.wrong/path.ext/"), "" );
 }
 
+#ifdef _WIN32
 TEST(BaseLib, CopyPathToFileNameWin)
 {
-    ASSERT_EQ ( BaseLib::copyPathToFileName("file", "extend"), "file" );
-    ASSERT_EQ ( BaseLib::copyPathToFileName("path\\file", "extend"), "path\\file" );
-
-    ASSERT_EQ ( BaseLib::copyPathToFileName("file", "extend\\"), "extend\\file" );
-    ASSERT_EQ ( BaseLib::copyPathToFileName("path\\file", "extend\\"), "path\\file" );
-
-    ASSERT_EQ ( BaseLib::copyPathToFileName("file", "extend\\smth"), "extend\\file" );
-    ASSERT_EQ ( BaseLib::copyPathToFileName("path\\file", "extend\\smth"), "path\\file" );
+    ASSERT_EQ("extend\\file", BaseLib::copyPathToFileName("file", "extend"));
+    ASSERT_EQ("path\\file",
+              BaseLib::copyPathToFileName("path\\file", "extend"));
+    ASSERT_EQ("extend\\file", BaseLib::copyPathToFileName("file", "extend\\"));
+    ASSERT_EQ("path\\file",
+              BaseLib::copyPathToFileName("path\\file", "extend\\"));
+    ASSERT_EQ("extend\\smth\\file",
+              BaseLib::copyPathToFileName("file", "extend\\smth"));
+    ASSERT_EQ("path\\file",
+              BaseLib::copyPathToFileName("path\\file", "extend\\smth"));
 }
-
+#else
 TEST(BaseLib, CopyPathToFileNameUnix)
 {
-    ASSERT_EQ ( BaseLib::copyPathToFileName("file", "extend"), "file" );
-    ASSERT_EQ ( BaseLib::copyPathToFileName("path/file", "extend"), "path/file" );
+    ASSERT_EQ("extend/file", BaseLib::copyPathToFileName("file", "extend"));
+    ASSERT_EQ("path/file",
+              BaseLib::copyPathToFileName("path/file", "extend"));
+    ASSERT_EQ("extend/file", BaseLib::copyPathToFileName("file", "extend/"));
+    ASSERT_EQ("path/file", BaseLib::copyPathToFileName("path/file", "extend/"));
 
-    ASSERT_EQ ( BaseLib::copyPathToFileName("file", "extend/"), "extend/file" );
-    ASSERT_EQ ( BaseLib::copyPathToFileName("path/file", "extend/"), "path/file" );
-
-    ASSERT_EQ ( BaseLib::copyPathToFileName("file", "extend/smth"), "extend/file" );
-    ASSERT_EQ ( BaseLib::copyPathToFileName("path/file", "extend/smth"), "path/file" );
+    ASSERT_EQ("extend/smth/file",
+              BaseLib::copyPathToFileName("file", "extend/smth"));
+    ASSERT_EQ("path/file",
+              BaseLib::copyPathToFileName("path/file", "extend/smth"));
 }
+#endif
 
 TEST(BaseLib, ExtractPathWin)
 {


### PR DESCRIPTION
I had to activate the windows tests only for windows since at one place a path separator is added. In general in my opinion we should switch to something like [boost::filesystem](http://www.boost.org/doc/libs/1_61_0/libs/filesystem/doc/index.htm).

**update**
`BaseLib::copyPathToFileName` takes two arguments: a file name and a path. The method puts them together. If the given `path` argument does not end with a path separator the previous version removed the part of the path from the last path separator till the end, i.e., for example `path/smth` was reduced to the path `path/`. This behaviour is changed with this PR. Now a path separator will be appended, i.e., the path will be modified: `path/smth/`.