### PR TITLE
make Line elements return an edge

### DIFF
--- a/MeshGeoToolsLib/BoundaryElementsAlongPolyline.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsAlongPolyline.cpp
@@ -35,6 +35,9 @@ BoundaryElementsAlongPolyline::BoundaryElementsAlongPolyline(MeshLib::Mesh const
     // check all edges of the elements near the polyline
     for (auto ele_id : ele_ids_near_ply) {
         auto* e = _mesh.getElement(ele_id);
+        // skip line elements
+        if (e->getDimension() == 1)
+            continue;
         // skip internal elements
         if (!e->isBoundaryElement())
             continue;

--- a/MeshLib/Elements/EdgeRule.h
+++ b/MeshLib/Elements/EdgeRule.h
@@ -25,7 +25,7 @@ public:
     static const unsigned n_faces = 0;
 
     /// Constant: The number of edges
-    static const unsigned n_edges = 0;
+    static const unsigned n_edges = 1;
 
     /// Returns the i-th face of the element.
     static const Element* getFace(const Element* /*e*/, unsigned /*i*/) { return nullptr; }

--- a/MeshLib/Elements/LineRule2.h
+++ b/MeshLib/Elements/LineRule2.h
@@ -39,9 +39,6 @@ public:
     /// Constant: The FEM type of the element
     static const CellType cell_type = CellType::LINE2;
 
-    /// Constant: The number of edges
-    static const unsigned n_edges = 1;
-
     /// Constant: The number of neighbors
     static const unsigned n_neighbors = 2;
 
@@ -49,7 +46,7 @@ public:
     static const unsigned edge_nodes[1][2];
 
     /// Edge rule
-    typedef NoEdgeReturn EdgeReturn;
+    typedef LinearEdgeReturn EdgeReturn;
 
     /**
      * Checks if a point is inside the element.

--- a/MeshLib/Elements/LineRule3.h
+++ b/MeshLib/Elements/LineRule3.h
@@ -30,6 +30,9 @@ public:
 
     /// Constant: The FEM type of the element
     static const CellType cell_type = CellType::LINE3;
+
+    /// Edge rule
+    typedef QuadraticEdgeReturn EdgeReturn;
 }; /* class */
 
 } /* namespace */


### PR DESCRIPTION
fix #1419 

To keep the same behavior as before, I also changed `BoundaryElementsAlongPolyline` class ignores line elements.