### PR TITLE
Another implementation of material ID dependent parameter

### DIFF
--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -138,7 +138,7 @@ public:
     ~PropertyVector()
     {
         for (auto v : _values)
-            delete v;
+            delete [] v;
     }
 
     /// The operator[] uses the item to group property map to access to the
@@ -155,13 +155,16 @@ public:
 
     void initPropertyValue(std::size_t group_id, T const& value)
     {
-        _values[group_id] = new T(value);
+        T* p = new T[1];
+        p[0] = value;
+        _values[group_id] = p;
     }
 
     std::size_t getNumberOfTuples() const
     {
         return std::vector<std::size_t>::size();
     }
+
     /// Method returns the number of tuples times the number of tuple components.
     std::size_t size() const
     {

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+#include "BaseLib/Error.h"
 #include "BaseLib/excludeObjectCopy.h"
 #include "Location.h"
 
@@ -186,6 +187,20 @@ public:
             t->initPropertyValue(j, *(_values[j]));
         }
         return t;
+    }
+
+    //! Returns the value for the given component stored in the given tuple.
+    T const& getComponent(std::size_t tuple_index,
+                                      std::size_t component) const
+    {
+        assert(component < _n_components);
+        assert(tuple_index < getNumberOfTuples());
+        const double* p = this->operator[](tuple_index);
+        if (p==nullptr)
+            OGS_FATAL("No data found in the property vector %s "
+                      "for the tuple index %d and component %d",
+                      getPropertyName().c_str(), tuple_index, component);
+        return p[component];
     }
 
 #ifndef NDEBUG

--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -161,6 +161,14 @@ public:
         _values[group_id] = p;
     }
 
+    void initPropertyValue(std::size_t group_id, std::vector<T> const& values)
+    {
+        T* p = new T[values.size()];
+        for (unsigned i=0; i<values.size(); i++)
+            p[i] = values[i];
+        _values[group_id] = p;
+    }
+
     std::size_t getNumberOfTuples() const
     {
         return std::vector<std::size_t>::size();

--- a/ProcessLib/Parameter/MaterialIDParameter.cpp
+++ b/ProcessLib/Parameter/MaterialIDParameter.cpp
@@ -1,0 +1,120 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "MaterialIDParameter.h"
+
+#include "BaseLib/ConfigTree.h"
+#include "BaseLib/Error.h"
+
+#include "MeshLib/Mesh.h"
+#include "MeshLib/Properties.h"
+#include "MeshLib/PropertyVector.h"
+
+#include "ProcessLib/Parameter/MeshElementParameter.h"
+
+namespace ProcessLib
+{
+std::unique_ptr<ParameterBase> createMaterialIDParameter(
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh)
+{
+    //! \ogs_file_param{parameter__type}
+    config.checkConfigParameter("type", "MaterialID");
+
+    // get a parameter name
+    //! \ogs_file_param{parameter_MaterialID__name}
+    std::string const parameter_name = config.getConfigParameter<std::string>("name");
+    DBUG("Using parameter name %s", parameter_name.c_str());
+
+    // get a property vector
+    //! \ogs_file_param{parameter_MaterialID__property_name}
+    std::string const index_property_name = config.getConfigParameter<std::string>("property_name");
+    DBUG("Using property_name %s", index_property_name.c_str());
+
+    auto const& index_property_vector =
+        mesh.getProperties().getPropertyVector<int>(index_property_name);
+    if (!index_property_vector) {
+        OGS_FATAL("The required property %s does not exist in the given mesh",
+                  index_property_name.c_str());
+    }
+
+    // parse mapping data
+    typedef std::vector<double> Values;
+    typedef std::pair<int, Values> Index_Values;
+    std::vector<Index_Values> vec_index_values;
+    //! \ogs_file_param{parameter_MaterialID__index_values}
+    for (auto p : config.getConfigSubtreeList("index_values"))
+    {
+        //! \ogs_file_param{parameter_MaterialID__index_values__index}
+        auto const index = p.getConfigParameter<int>("index");
+        {
+            //! \ogs_file_param{parameter_MaterialID__index_values__value}
+            auto const value = p.getConfigParameterOptional<double>("value");
+
+            if (value)
+            {
+                Values values(1, *value);
+                vec_index_values.push_back(Index_Values(index, values));
+                continue;
+            }
+        }
+
+        // Value tag not available; continue with required values tag.
+        //! \ogs_file_param{parameter_MaterialID__index_values__values}
+        Values const values = p.getConfigParameter<Values>("values");
+
+        if (values.empty())
+            OGS_FATAL("No value available for constant parameter.");
+
+        vec_index_values.push_back(Index_Values(index, values));
+    }
+
+    // check the input
+    unsigned n_values = vec_index_values.front().second.size();
+    for (auto p : vec_index_values)
+    {
+        auto itr = std::find(index_property_vector->begin(), index_property_vector->end(), p.first);
+        if (itr == index_property_vector->end())
+            OGS_FATAL("Specified property index %d does not exist in the property vector %s",
+                      p.first, index_property_name.c_str());
+
+        if (p.second.size() != n_values)
+            OGS_FATAL("The length of some values (%d) is different from the first one (%d). "
+                      "The length should be same for all index_values.",
+                      p.second.size(),  n_values);
+    }
+
+    // create a mapping table
+    const int max_index = *std::max_element(index_property_vector->begin(), index_property_vector->end());
+
+    std::vector<std::size_t> prop_item2group_mapping(max_index+1);
+    for (int i=0; i<max_index+1; i++)
+        prop_item2group_mapping[i] = i;
+
+    std::string prop_name = parameter_name;
+    if (mesh.getProperties().hasPropertyVector(prop_name))
+        prop_name += "_MaterialIDParameter";
+    boost::optional<MeshLib::PropertyVector<double*> &> group_properties(
+        const_cast<MeshLib::Mesh&>(mesh).getProperties().createNewPropertyVector<double*>(
+            prop_name, prop_item2group_mapping.size(), prop_item2group_mapping,
+            MeshLib::MeshItemType::Cell
+        )
+    );
+
+    if (!group_properties)
+        OGS_FATAL("Couldn't create a property vector in createMaterialIDParameter()");
+
+    for (auto p : vec_index_values)
+        (*group_properties).initPropertyValue(p.first, p.second);
+
+    return std::unique_ptr<ParameterBase>(
+        new MeshElementParameter<double*>(*group_properties));
+
+}
+
+}  // ProcessLib

--- a/ProcessLib/Parameter/MaterialIDParameter.h
+++ b/ProcessLib/Parameter/MaterialIDParameter.h
@@ -1,0 +1,31 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_MATERIALID_PARAMETER_H_
+#define PROCESSLIB_MATERIALID_PARAMETER_H_
+
+#include "Parameter.h"
+
+#include "MeshLib/PropertyVector.h"
+
+namespace MeshLib
+{
+template <typename T>
+class PropertyVector;
+}  // MeshLib
+
+namespace ProcessLib
+{
+
+std::unique_ptr<ParameterBase> createMaterialIDParameter(
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh);
+
+}  // ProcessLib
+
+#endif // PROCESSLIB_MATERIALID_PARAMETER_H_

--- a/ProcessLib/Parameter/MeshElementParameter.h
+++ b/ProcessLib/Parameter/MeshElementParameter.h
@@ -53,6 +53,38 @@ private:
     mutable std::vector<double> _cache;
 };
 
+template <typename T>
+struct MeshElementParameter<T*> final : public Parameter<T> {
+    MeshElementParameter(MeshLib::PropertyVector<T*> const& property)
+        : _property(property)
+        , _cache(_property.getNumberOfComponents())
+    {
+    }
+
+    bool isTimeDependent() const override { return false; }
+
+    unsigned getNumberOfComponents() const override
+    {
+        return _property.getNumberOfComponents();
+    }
+
+    std::vector<T> const& operator()(double const /*t*/,
+                                     SpatialPosition const& pos) const override
+    {
+        auto const e = pos.getElementID();
+        assert(e);
+        auto const num_comp = _property.getNumberOfComponents();
+        for (std::size_t c=0; c<num_comp; ++c) {
+            _cache[c] = _property.getComponent(*e, c);
+        }
+        return _cache;
+    }
+
+private:
+    MeshLib::PropertyVector<T*> const& _property;
+    mutable std::vector<double> _cache;
+};
+
 std::unique_ptr<ParameterBase> createMeshElementParameter(
     BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh);
 

--- a/ProcessLib/Parameter/Parameter.cpp
+++ b/ProcessLib/Parameter/Parameter.cpp
@@ -12,9 +12,10 @@
 #include "BaseLib/Error.h"
 
 #include "ConstantParameter.h"
+#include "CurveScaledParameter.h"
+#include "MaterialIDParameter.h"
 #include "MeshElementParameter.h"
 #include "MeshNodeParameter.h"
-#include "CurveScaledParameter.h"
 
 namespace ProcessLib
 {
@@ -39,6 +40,20 @@ std::unique_ptr<ParameterBase> createParameter(
         param->name = name;
         return param;
     }
+    else if (type == "CurveScaled")
+    {
+        INFO("CurveScaledParameter: %s", name.c_str());
+        auto param = createCurveScaledParameter(config, curves);
+        param->name = name;
+        return param;
+    }
+    else if (type == "MaterialID")
+    {
+        INFO("MaterialIDParameter: %s", name.c_str());
+        auto param = createMaterialIDParameter(config, *meshes.front());
+        param->name = name;
+        return param;
+    }
     else if (type == "MeshElement")
     {
         INFO("MeshElementParameter: %s", name.c_str());
@@ -50,13 +65,6 @@ std::unique_ptr<ParameterBase> createParameter(
     {
         INFO("MeshElementParameter: %s", name.c_str());
         auto param = createMeshNodeParameter(config, *meshes.front());
-        param->name = name;
-        return param;
-    }
-    else if (type == "CurveScaled")
-    {
-        INFO("CurveScaledParameter: %s", name.c_str());
-        auto param = createCurveScaledParameter(config, curves);
         param->name = name;
         return param;
     }

--- a/Tests/ProcessLib/TestParameter.cpp
+++ b/Tests/ProcessLib/TestParameter.cpp
@@ -1,0 +1,60 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include <gtest/gtest.h>
+#include <logog/include/logog.hpp>
+
+#include <boost/property_tree/xml_parser.hpp>
+#include <numeric>
+#include <sstream>
+#include <vector>
+
+#include "BaseLib/ConfigTree.h"
+#include "Tests/TestTools.h"
+
+#include "MeshLib/Mesh.h"
+#include "MeshLib/PropertyVector.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
+
+#include "ProcessLib/Parameter/MaterialIDParameter.h"
+
+
+TEST(ProcessLib_Parameter, MaterialIDParameter)
+{
+    const char xml[] =
+            "<parameter>"
+            "<type>MaterialID</type>"
+            "<name>ParameterX</name>"
+            "<property_name>MaterialIDs</property_name>"
+            "<index_values><index>0</index><value>0</value></index_values>"
+            "<index_values><index>1</index><value>100</value></index_values>"
+            "<index_values><index>3</index><value>300</value></index_values>"
+            "</parameter>";
+    auto const ptree = readXml(xml);
+
+    std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::MeshGenerator::generateLineMesh(4u, 1.0));
+    std::vector<int> mat_ids({0,1,2,3});
+    MeshLib::addPropertyToMesh(*mesh, "MaterialIDs", MeshLib::MeshItemType::Cell, 1, mat_ids);
+
+    BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror, BaseLib::ConfigTree::onwarning);
+    std::unique_ptr<ProcessLib::ParameterBase> parameter_base
+            = ProcessLib::createMaterialIDParameter(conf.getConfigSubtree("parameter"), *mesh);
+
+    auto parameter = dynamic_cast<ProcessLib::Parameter<double>*>(parameter_base.get());
+    double t = 0;
+    ProcessLib::SpatialPosition x;
+    x.setElementID(0);
+    ASSERT_EQ(0.0, (*parameter)(t, x)[0]);
+    x.setElementID(1);
+    ASSERT_EQ(100.0, (*parameter)(t, x)[0]);
+    x.setElementID(2);
+    ASSERT_ANY_THROW((*parameter)(t, x));
+    x.setElementID(3);
+    ASSERT_EQ(300.0, (*parameter)(t, x)[0]);
+}


### PR DESCRIPTION
As suggested by @TomFischer in #1426. This PR uses/extends existing `PropertyVector<T*>` and `MeshElementParameter`. I had to modify `PropertyVector<T*>` to support multi-component values. 

Question is now which one, #1426 or this one, should we take? 