### PR TITLE
Abort in OGS_FATAL()

### DIFF
--- a/BaseLib/Error.h
+++ b/BaseLib/Error.h
@@ -11,29 +11,30 @@
 #define BASELIB_ERROR_H
 
 #ifdef OGS_FATAL_ABORT
+
 #include <cstdlib>
-#endif
-#include <stdexcept>
-
-#ifdef OGS_FATAL_ABORT
 #include <logog/include/logog.hpp>
-#endif
-
 #include "StringTools.h"
-#include "FileTools.h"
 
-#define OGS_STR(x) #x
-#define OGS_STRINGIFY(x) OGS_STR(x)
-#define OGS_LOCATION " at " + BaseLib::extractBaseName(__FILE__) + ", line " OGS_STRINGIFY(__LINE__)
-#ifdef OGS_FATAL_ABORT
 #define OGS_FATAL(fmt, ...)\
     {\
     ERR("%s", BaseLib::format(fmt, ##__VA_ARGS__).data());\
     std::abort();\
     }
-#else
+
+#else // OGS_FATAL_ABORT
+
+#include <stdexcept>
+#include "FileTools.h"
+#include "StringTools.h"
+
+#define OGS_STR(x) #x
+#define OGS_STRINGIFY(x) OGS_STR(x)
+#define OGS_LOCATION " at " + BaseLib::extractBaseName(__FILE__) + ", line " OGS_STRINGIFY(__LINE__)
+
 #define OGS_FATAL(fmt, ...)\
     throw std::runtime_error(BaseLib::format(fmt, ##__VA_ARGS__) + OGS_LOCATION);
-#endif
+
+#endif // OGS_FATAL_ABORT
 
 #endif //BASELIB_ERROR_H

--- a/BaseLib/Error.h
+++ b/BaseLib/Error.h
@@ -10,7 +10,14 @@
 #ifndef BASELIB_ERROR_H
 #define BASELIB_ERROR_H
 
+#ifdef OGS_FATAL_ABORT
+#include <cstdlib>
+#endif
 #include <stdexcept>
+
+#ifdef OGS_FATAL_ABORT
+#include <logog/include/logog.hpp>
+#endif
 
 #include "StringTools.h"
 #include "FileTools.h"
@@ -18,7 +25,15 @@
 #define OGS_STR(x) #x
 #define OGS_STRINGIFY(x) OGS_STR(x)
 #define OGS_LOCATION " at " + BaseLib::extractBaseName(__FILE__) + ", line " OGS_STRINGIFY(__LINE__)
+#ifdef OGS_FATAL_ABORT
+#define OGS_FATAL(fmt, ...)\
+    {\
+    ERR("%s", BaseLib::format(fmt, ##__VA_ARGS__).data());\
+    std::abort();\
+    }
+#else
 #define OGS_FATAL(fmt, ...)\
     throw std::runtime_error(BaseLib::format(fmt, ##__VA_ARGS__) + OGS_LOCATION);
+#endif
 
 #endif //BASELIB_ERROR_H

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,9 @@ option(EIGEN_NO_DEBUG "Disables Eigen's assertions" OFF)
 # Logging
 option(OGS_DISABLE_LOGGING "Disables all logog messages." OFF)
 
+# Debug
+option(OGS_FATAL_ABORT "Abort in OGS_FATAL" OFF)
+
 # Compiler flags
 set(OGS_CXX_FLAGS "" CACHE STRING "Additional C++ compiler flags.")
 option(STL_NO_DEBUG "Disable STL debug in debug build" OFF)
@@ -152,6 +155,10 @@ endif()
 
 if(OGS_USE_EIGEN)
     add_definitions(-DOGS_USE_EIGEN)
+endif()
+
+if (OGS_FATAL_ABORT)
+    add_definitions(-DOGS_FATAL_ABORT)
 endif()
 
 if(OGS_BUILD_TESTS)


### PR DESCRIPTION
This PR adds a new CMake option `OGS_FATAL_ABORT` which enables calling `abort()` in `OGS_FATAL()` instead of throwing exceptions.  The changes is helpful in debugging because it stops at at abort() and can backtrace from there. 