### PR TITLE
Fix LocalToGlobalIndexMap with mutliple variables and with multiple componets

### DIFF
--- a/NumLib/DOF/LocalToGlobalIndexMap.cpp
+++ b/NumLib/DOF/LocalToGlobalIndexMap.cpp
@@ -48,35 +48,54 @@ LocalToGlobalIndexMap::findGlobalIndices(
 LocalToGlobalIndexMap::LocalToGlobalIndexMap(
     std::vector<std::unique_ptr<MeshLib::MeshSubsets>>&& mesh_subsets,
     NumLib::ComponentOrder const order)
+    : LocalToGlobalIndexMap(std::move(mesh_subsets), std::vector<unsigned>(mesh_subsets.size(), 1), order)
+{
+}
+
+
+LocalToGlobalIndexMap::LocalToGlobalIndexMap(
+    std::vector<std::unique_ptr<MeshLib::MeshSubsets>>&& mesh_subsets,
+    std::vector<unsigned> const& vec_var_n_components,
+    NumLib::ComponentOrder const order)
     : _mesh_subsets(std::move(mesh_subsets)),
       _mesh_component_map(_mesh_subsets, order)
 {
+    // construct a mapping table to get a global component ID from a variableID & a variable comp ID
+    _map_varCompID_to_globalCompID.resize(vec_var_n_components.size());
+    {
+        unsigned global_component_ID = 0;
+        for (unsigned i=0; i<vec_var_n_components.size(); i++)
+            for (unsigned j=0; j<vec_var_n_components[i]; j++)
+                _map_varCompID_to_globalCompID[i].push_back(global_component_ID++);
+    }
+
     // For all MeshSubsets and each of their MeshSubset's and each element
     // of that MeshSubset save a line of global indices.
 
 
-    _variable_component_offsets.reserve(_mesh_subsets.size());
     std::size_t offset = 0;
-    for (int variable_id = 0; variable_id < static_cast<int>(_mesh_subsets.size());
+    for (int variable_id = 0; variable_id < static_cast<int>(vec_var_n_components.size());
          ++variable_id)
     {
-        _variable_component_offsets.push_back(offset);
-        auto const& mss = *_mesh_subsets[variable_id];
-        for (int component_id = 0; component_id < static_cast<int>(mss.size());
+        for (int component_id = 0; component_id < static_cast<int>(vec_var_n_components[variable_id]);
              ++component_id)
         {
-            MeshLib::MeshSubset const& ms = mss.getMeshSubset(component_id);
-            std::size_t const mesh_id = ms.getMeshID();
-
             auto const global_component_id =
                 getGlobalComponent(variable_id, component_id);
 
-            findGlobalIndices(ms.elementsBegin(), ms.elementsEnd(), ms.getNodes(),
-                              mesh_id, global_component_id, global_component_id);
-        }
+            auto const& mss = *_mesh_subsets[global_component_id];
+            for (int subset_id = 0; subset_id < static_cast<int>(mss.size());
+                 ++subset_id)
+            {
+                MeshLib::MeshSubset const& ms = mss.getMeshSubset(subset_id);
+                std::size_t const mesh_id = ms.getMeshID();
 
-        // increase by number of components of that variable
-        offset += mss.size();
+                findGlobalIndices(ms.elementsBegin(), ms.elementsEnd(), ms.getNodes(),
+                                  mesh_id, global_component_id, global_component_id);
+            }
+            // increase by number of components of that variable
+            offset += mss.size();
+        }
     }
 }
 
@@ -87,7 +106,7 @@ LocalToGlobalIndexMap::LocalToGlobalIndexMap(
     NumLib::MeshComponentMap&& mesh_component_map)
     : _mesh_subsets(std::move(mesh_subsets)),
       _mesh_component_map(std::move(mesh_component_map)),
-      _variable_component_offsets(1, 0) // Single variable only.
+      _map_varCompID_to_globalCompID(1, std::vector<int>(1, 0)) // Single variable only.
 {
     // There is only on mesh_subsets in the vector _mesh_subsets.
     assert(_mesh_subsets.size() == 1);

--- a/NumLib/DOF/LocalToGlobalIndexMap.cpp
+++ b/NumLib/DOF/LocalToGlobalIndexMap.cpp
@@ -116,7 +116,7 @@ LocalToGlobalIndexMap::LocalToGlobalIndexMap(
     NumLib::MeshComponentMap&& mesh_component_map)
     : _mesh_subsets(std::move(mesh_subsets)),
       _mesh_component_map(std::move(mesh_component_map)),
-      _variable_component_offsets{0, 1} // Single variable only.
+      _variable_component_offsets(to_cumulative(std::vector<unsigned>(1,1))) // Single variable only.
 {
     // There is only on mesh_subsets in the vector _mesh_subsets.
     assert(_mesh_subsets.size() == 1);

--- a/NumLib/DOF/LocalToGlobalIndexMap.cpp
+++ b/NumLib/DOF/LocalToGlobalIndexMap.cpp
@@ -9,24 +9,20 @@
 
 #include "LocalToGlobalIndexMap.h"
 
+#include <algorithm>
+
 namespace NumLib
 {
 
 namespace
 {
 
-// Make the cumulative sum of an array
+// Make the cumulative sum of an array, which starts with zero
 template <typename T>
 std::vector<T> to_cumulative(std::vector<T> const& vec)
 {
-    std::vector<T> result(vec.size() + 1);
-    T sum = 0;
-    for (std::size_t i=0; i<vec.size(); i++)
-    {
-        result[i] = sum;
-        sum += vec[i];
-    }
-    result[vec.size()] = sum;
+    std::vector<T> result(vec.size()+1, 0);
+    std::partial_sum(vec.begin(), vec.end(), result.begin()+1);
 
     return result;
 }

--- a/NumLib/DOF/LocalToGlobalIndexMap.h
+++ b/NumLib/DOF/LocalToGlobalIndexMap.h
@@ -89,9 +89,13 @@ public:
 
     std::size_t size() const;
 
-    std::size_t getNumberOfVariables() const { return _map_varCompID_to_globalCompID.size(); }
+    std::size_t getNumberOfVariables() const { return (_variable_component_offsets.size() - 1); }
 
-    std::size_t getNumberOfVariableComponents(int variable_id) const { return _map_varCompID_to_globalCompID[variable_id].size(); }
+    std::size_t getNumberOfVariableComponents(int variable_id) const
+    {
+        assert(static_cast<unsigned>(variable_id) < getNumberOfVariables());
+        return _variable_component_offsets[variable_id+1] - _variable_component_offsets[variable_id];
+    }
 
     std::size_t getNumberOfComponents() const { return _mesh_subsets.size(); }
 
@@ -159,7 +163,7 @@ private:
     std::size_t getGlobalComponent(int const variable_id,
                                    int const component_id) const
     {
-        return _map_varCompID_to_globalCompID[variable_id][component_id];
+        return _variable_component_offsets[variable_id] + component_id;
     }
 
 private:
@@ -176,7 +180,7 @@ private:
     /// \see _rows
     Table const& _columns = _rows;
 
-    std::vector<std::vector<int>> _map_varCompID_to_globalCompID;
+    std::vector<unsigned> const _variable_component_offsets;
 #ifndef NDEBUG
     /// Prints first rows of the table, every line, and the mesh component map.
     friend std::ostream& operator<<(std::ostream& os, LocalToGlobalIndexMap const& map);

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -154,8 +154,14 @@ void Process::constructDofTable()
             });
     }
 
+    // Create a vector of the number of variable components
+    std::vector<unsigned> vec_var_n_components;
+    for (ProcessVariable const& pv : _process_variables)
+        vec_var_n_components.push_back(pv.getNumberOfComponents());
+
     _local_to_global_index_map.reset(new NumLib::LocalToGlobalIndexMap(
-        std::move(all_mesh_subsets), NumLib::ComponentOrder::BY_LOCATION));
+        std::move(all_mesh_subsets), vec_var_n_components,
+        NumLib::ComponentOrder::BY_LOCATION));
 
 }
 

--- a/Tests/NumLib/LocalToGlobalIndexMap.cpp
+++ b/Tests/NumLib/LocalToGlobalIndexMap.cpp
@@ -145,3 +145,32 @@ TEST_F(NumLibLocalToGlobalIndexMapTest, DISABLED_MultipleVariablesMultipleCompon
     ASSERT_EQ(10, dof_map->getGlobalIndex(l_node0, 1, 0));
     ASSERT_EQ(20, dof_map->getGlobalIndex(l_node0, 1, 1));
 }
+
+#ifndef USE_PETSC
+TEST_F(NumLibLocalToGlobalIndexMapTest, MultipleVariablesMultipleComponents2)
+#else
+TEST_F(NumLibLocalToGlobalIndexMapTest, DISABLED_MultipleVariablesMultipleComponents2)
+#endif
+{
+    // test 2 variables (1st variable with 2 component, 2nd variable with 1 components)
+    components.emplace_back(new MeshLib::MeshSubsets{nodesSubset.get()});
+
+    std::vector<unsigned> vec_var_n_components{2, 1};
+
+    dof_map.reset(new NumLib::LocalToGlobalIndexMap(
+                      std::move(components),
+                      vec_var_n_components,
+                      NumLib::ComponentOrder::BY_COMPONENT));
+
+    ASSERT_EQ(30, dof_map->dofSizeWithGhosts());
+    ASSERT_EQ(3u, dof_map->getNumberOfComponents());
+    ASSERT_EQ(2u, dof_map->getNumberOfVariables());
+    ASSERT_EQ(2u, dof_map->getNumberOfVariableComponents(0));
+    ASSERT_EQ(1u, dof_map->getNumberOfVariableComponents(1));
+
+    MeshLib::Location l_node0(mesh->getID(), MeshLib::MeshItemType::Node, 0);
+
+    ASSERT_EQ(0, dof_map->getGlobalIndex(l_node0, 0, 0));
+    ASSERT_EQ(10, dof_map->getGlobalIndex(l_node0, 0, 1));
+    ASSERT_EQ(20, dof_map->getGlobalIndex(l_node0, 1, 0));
+}

--- a/Tests/NumLib/LocalToGlobalIndexMap.cpp
+++ b/Tests/NumLib/LocalToGlobalIndexMap.cpp
@@ -107,8 +107,8 @@ TEST_F(NumLibLocalToGlobalIndexMapTest, DISABLED_SubsetByComponent)
         new MeshLib::MeshSubsets{selected_subset.get()}};
 
     auto dof_map_subset = std::unique_ptr<NumLib::LocalToGlobalIndexMap>{
-        dof_map->deriveBoundaryConstrainedMap(0,  // variable id
-                                              1,  // component id
+        dof_map->deriveBoundaryConstrainedMap(1,  // variable id
+                                              0,  // component id
                                               std::move(selected_component),
                                               some_elements)};
 

--- a/Tests/NumLib/LocalToGlobalIndexMap.cpp
+++ b/Tests/NumLib/LocalToGlobalIndexMap.cpp
@@ -116,3 +116,32 @@ TEST_F(NumLibLocalToGlobalIndexMapTest, DISABLED_SubsetByComponent)
     // components.
     ASSERT_EQ(selected_nodes.size(), dof_map_subset->dofSizeWithGhosts());
 }
+
+#ifndef USE_PETSC
+TEST_F(NumLibLocalToGlobalIndexMapTest, MultipleVariablesMultipleComponents)
+#else
+TEST_F(NumLibLocalToGlobalIndexMapTest, DISABLED_MultipleVariablesMultipleComponents)
+#endif
+{
+    // test 2 variables (1st variable with 1 component, 2nd variable with 2 components)
+    components.emplace_back(new MeshLib::MeshSubsets{nodesSubset.get()});
+
+    std::vector<unsigned> vec_var_n_components{1, 2};
+
+    dof_map.reset(new NumLib::LocalToGlobalIndexMap(
+                      std::move(components),
+                      vec_var_n_components,
+                      NumLib::ComponentOrder::BY_COMPONENT));
+
+    ASSERT_EQ(30, dof_map->dofSizeWithGhosts());
+    ASSERT_EQ(3u, dof_map->getNumberOfComponents());
+    ASSERT_EQ(2u, dof_map->getNumberOfVariables());
+    ASSERT_EQ(1u, dof_map->getNumberOfVariableComponents(0));
+    ASSERT_EQ(2u, dof_map->getNumberOfVariableComponents(1));
+
+    MeshLib::Location l_node0(mesh->getID(), MeshLib::MeshItemType::Node, 0);
+
+    ASSERT_EQ(0, dof_map->getGlobalIndex(l_node0, 0, 0));
+    ASSERT_EQ(10, dof_map->getGlobalIndex(l_node0, 1, 0));
+    ASSERT_EQ(20, dof_map->getGlobalIndex(l_node0, 1, 1));
+}

--- a/Tests/NumLib/LocalToGlobalIndexMapMultiComponent.cpp
+++ b/Tests/NumLib/LocalToGlobalIndexMapMultiComponent.cpp
@@ -88,8 +88,9 @@ public:
             components.emplace_back(
                 new MeL::MeshSubsets{mesh_items_all_nodes.get()});
         }
+        std::vector<unsigned> vec_var_n_components(1, num_components);
         dof_map.reset(
-            new NL::LocalToGlobalIndexMap(std::move(components), order));
+            new NL::LocalToGlobalIndexMap(std::move(components), vec_var_n_components, order));
 
         auto components_boundary = std::unique_ptr<MeshLib::MeshSubsets>{
             new MeL::MeshSubsets{mesh_items_boundary.get()}};


### PR DESCRIPTION
This PR fixes a problem that `LocalToGlobalIndexMap` cannot correctly handle multiple variables & multiple variable components cases (e.g. pressure and displacement vector in HM). Important changes to the interface is that you need to pass a vector of the number of variable components to `LocalToGlobalIndexMap` constructor, if you have any variables having more than one components. 