### PR TITLE
[Jenkins] Exclude CLI from gcc Data Exlorer build.

### DIFF
--- a/scripts/jenkins/gcc.groovy
+++ b/scripts/jenkins/gcc.groovy
@@ -19,8 +19,8 @@ node('docker') {
 
         stage 'Data Explorer (Linux-Docker)'
         configure.linux 'build', "${defaultCMakeOptions} " +
-            '-DOGS_BUILD_GUI=ON -DOGS_BUILD_UTILS=ON -DOGS_BUILD_TESTS=OFF ' +
-            '-DOGS_BUILD_METIS=ON',
+            '-DOGS_BUILD_CLI=OFF -DOGS_BUILD_GUI=ON -DOGS_BUILD_UTILS=ON ' +
+            '-DOGS_BUILD_TESTS=OFF -DOGS_BUILD_METIS=ON',
             'Unix Makefiles', null, true
         build.linux 'build'
     }


### PR DESCRIPTION
Possibly fixing sporadic ldd errors. Closes #1416.