### PR TITLE
Use mesh subsets instead of mesh nodes

### DIFF
--- a/MeshLib/MeshSubset.h
+++ b/MeshLib/MeshSubset.h
@@ -125,6 +125,12 @@ public:
         return _msh.getElements().cend();
     }
 
+    std::vector<Node*> const& getNodes() const
+    {
+        assert(_nodes);
+        return *_nodes;
+    }
+
     /// Constructs a new mesh subset which is a set intersection of the current
     /// nodes and the provided vector of nodes.
     /// An empty mesh subset may be returned, not a nullptr, in case of empty

--- a/NumLib/DOF/LocalToGlobalIndexMap.h
+++ b/NumLib/DOF/LocalToGlobalIndexMap.h
@@ -130,6 +130,7 @@ private:
     template <typename ElementIterator>
     void
     findGlobalIndices(ElementIterator first, ElementIterator last,
+        std::vector<MeshLib::Node*> const& nodes,
         std::size_t const mesh_id,
         const unsigned component_id, const unsigned comp_id_write);
 


### PR DESCRIPTION
When creating dof table, setting initial conditions, creating boundary conditions, and in output
currently all nodes of the mesh are involved. If the underlying mesh subsets do not consist of all nodes (e.g. only base nodes) then the mentioned algorithms do return wrong results.

Maybe there are more places with similar patterns, please tell me then.