### PR TITLE
Solve Axially Symmetric Problems

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -416,6 +416,110 @@ if(NOT OGS_USE_MPI)
         cube_1e3_expected_pcs_0_ts_101_t_1.000000.vtu cube_1e3_pcs_0_ts_101_t_1.000000.vtu displacement displacement
     )
 
+    # SQUARE 1x1 GROUNDWATER FLOW TEST -- AXIALLY SYMMETRIC
+    # test results are compared to 3D simulation on a wedge-shaped domain
+    AddTest(
+        NAME GroundWaterFlowProcess_square_1x1_1e2_axi
+        PATH Elliptic/square_1x1_GroundWaterFlow
+        EXECUTABLE ogs
+        EXECUTABLE_ARGS square_1e2_axi.prj
+        WRAPPER time
+        TESTER vtkdiff
+        ABSTOL 1.6e-5 RELTOL 1e-5
+        DIFF_DATA
+        wedge-1e2-ang-0.02-surface.vtu square_1e2_axi_pcs_0_ts_1_t_1.000000.vtu temperature temperature
+    )
+    # # WEDGE 1x1 GROUNDWATER FLOW TEST -- computes reference results for the above test
+    # AddTest(
+    #     NAME GroundWaterFlowProcess_wedge_1e2_ang_0.02
+    #     PATH Elliptic/square_1x1_GroundWaterFlow
+    #     EXECUTABLE ogs
+    #     EXECUTABLE_ARGS wedge_1e2_axi_ang_0.02.prj
+    # )
+
+    # SQUARE 1x1 GROUNDWATER FLOW TEST -- AXIALLY SYMMETRIC
+    # test results are compared to 3D simulation on a wedge-shaped domain
+    AddTest(
+        NAME GroundWaterFlowProcess_square_1x1_1e4_axi_ang_0.02
+        PATH Elliptic/square_1x1_GroundWaterFlow
+        EXECUTABLE ogs
+        EXECUTABLE_ARGS square_1e4_axi.prj
+        WRAPPER time
+        TESTER vtkdiff
+        ABSTOL 1.6e-5 RELTOL 1e-5
+        DIFF_DATA
+        wedge-1e4-ang-0.02-surface.vtu square_1e4_axi_pcs_0_ts_1_t_1.000000.vtu temperature temperature
+    )
+    # # WEDGE 1x1 GROUNDWATER FLOW TEST -- computes reference results for the above test
+    # AddTest(
+    #     NAME GroundWaterFlowProcess_wedge_1e4_ang_0.02
+    #     PATH Elliptic/square_1x1_GroundWaterFlow
+    #     EXECUTABLE ogs
+    #     EXECUTABLE_ARGS wedge_1e4_axi_ang_0.02.prj
+    # )
+
+    # SMALL DEFORMATION TEST -- AXIALLY SYMMETRIC
+    AddTest(
+        NAME SmallDeformation_ring_plane_strain_axi
+        PATH Mechanics/Linear
+        EXECUTABLE ogs
+        EXECUTABLE_ARGS ring_plane_strain.prj
+        WRAPPER time
+        TESTER vtkdiff
+        ABSTOL 6e-4 RELTOL 1e-4
+        DIFF_DATA
+        ring_plane_strain_1e4_solution.vtu ring_plane_strain_pcs_0_ts_1_t_1.000000.vtu u displacement
+        ring_plane_strain_1e4_solution.vtu ring_plane_strain_pcs_0_ts_1_t_1.000000.vtu sigma_rr sigma_rr
+        ring_plane_strain_1e4_solution.vtu ring_plane_strain_pcs_0_ts_1_t_1.000000.vtu sigma_ff sigma_ff
+    )
+
+    # SQUARE 1x1 HEAT CONDUCTION TEST -- AXIALLY SYMMETRIC
+    # test results are compared to 3D simulation on a wedge-shaped domain
+    AddTest(
+         NAME 2D_HeatConduction_axi
+         PATH Parabolic/T/2D_axially_symmetric
+         EXECUTABLE ogs
+         EXECUTABLE_ARGS square_1e2_axi.prj
+         WRAPPER time
+         TESTER vtkdiff
+         ABSTOL 1.7e-5 RELTOL 1e-5
+         DIFF_DATA
+         wedge_1e2_axi_ang_0.02_t_2s_extracted_surface.vtu square_1e2_axi_pcs_0_ts_2_t_2.000000.vtu temperature temperature
+         wedge_1e2_axi_ang_0.02_t_2s_extracted_surface.vtu square_1e2_axi_pcs_0_ts_2_t_2.000000.vtu heat_flux_x heat_flux_x
+    )
+    # # WEDGE 1x1 HEATCONDUCTION TEST -- computes reference results for the above test
+    # AddTest(
+    #      NAME 2D_HeatConduction_wedge
+    #      PATH Parabolic/T/2D_axially_symmetric
+    #      EXECUTABLE ogs
+    #      EXECUTABLE_ARGS wedge_1e2_axi_ang_0.02.prj
+    # )
+
+    # SQUARE 1x1 TES TEST -- AXIALLY SYMMETRIC
+    # test results are compared to 3D simulation on a wedge-shaped domain
+    AddTest(
+        NAME LARGE_TES_inert_axi
+        PATH Parabolic/TES/2D
+        EXECUTABLE ogs
+        EXECUTABLE_ARGS tes-inert-axi.prj
+        WRAPPER time
+        TESTER vtkdiff
+        # Note: Since the temperature and pressure only vary by a factor of ~ 1.e-6 in x-direction
+        # the relative tolerance has to be much smaller than 1.e-6
+        ABSTOL 1e-12 RELTOL 2e-9
+        DIFF_DATA
+        inert-wedge-extracted-surface-t-1s.vtu tes_inert_axi_pcs_0_ts_4_t_1.000000.vtu pressure pressure
+        inert-wedge-extracted-surface-t-1s.vtu tes_inert_axi_pcs_0_ts_4_t_1.000000.vtu temperature temperature
+        inert-wedge-extracted-surface-t-1s.vtu tes_inert_axi_pcs_0_ts_4_t_1.000000.vtu v_mass_frac v_mass_frac
+    )
+    # # WEDGE 1x1 TES TEST -- computes reference results for the above test
+    # AddTest(
+    #     NAME TES_inert_wedge
+    #     PATH Parabolic/TES/2D
+    #     EXECUTABLE ogs
+    #     EXECUTABLE_ARGS tes-inert-wedge.prj
+    # )
+
 else()
     # MPI groundwater flow tests
     AddTest(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ for boundary conditions were generalized.
    ID dependent values. #1426
  - Added fluid property class and several fluid density and viscosity models
    based on it. #1398, #1435
+ - Enabled solving of axially symmetric problems on 2D meshes for all currently
+   implemented processes. #1443
 
 #### Utilities
  New utilities:

--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -125,6 +125,16 @@ public:
     MeshLib::Properties & getProperties() { return _properties; }
     MeshLib::Properties const& getProperties() const { return _properties; }
 
+    bool isAxiallySymmetric() const { return _is_axially_symmetric; }
+    void setAxiallySymmetric(bool is_axial_symmetric) {
+        _is_axially_symmetric = is_axial_symmetric;
+        if (_is_axially_symmetric && getDimension() != 2) {
+            OGS_FATAL(
+                "Axial symmetry is implemented only for two-dimensional "
+                "meshes.");
+        }
+    }
+
 protected:
     /// Set the minimum and maximum length over the edges of the mesh.
     void calcEdgeLengthRange();
@@ -163,6 +173,8 @@ protected:
     std::vector<Element*> _elements;
     std::size_t _n_base_nodes;
     Properties _properties;
+
+    bool _is_axially_symmetric = false;
 }; /* class */
 
 

--- a/NumLib/Fem/CoordinatesMapping/ShapeMatrices-impl.h
+++ b/NumLib/Fem/CoordinatesMapping/ShapeMatrices-impl.h
@@ -64,6 +64,7 @@ inline void setZero(ShapeMatrices<T_N, T_DNDR, T_J, T_DNDX> &shape, ShapeDataFie
     setZero(shape, ShapeDataFieldType<ShapeMatrixType::DNDR>());
     setMatrixZero(shape.J);
     shape.detJ = .0;
+    shape.integralMeasure = 0.0;
 }
 
 template <class T_N, class T_DNDR, class T_J, class T_DNDX>

--- a/NumLib/Fem/CoordinatesMapping/ShapeMatrices.h
+++ b/NumLib/Fem/CoordinatesMapping/ShapeMatrices.h
@@ -54,6 +54,7 @@ struct ShapeMatrices
     double detJ;        ///< Determinant of the Jacobian
     JacobianType invJ;  ///< Inverse matrix of the Jacobian
     DxShapeType dNdx;   ///< Matrix of gradient of shape functions in physical coordinates, dN(r)/dx
+    double integralMeasure;
 
     /** Not default constructible, dimensions always must be given.
      *
@@ -80,7 +81,8 @@ struct ShapeMatrices
           J(local_dim, local_dim),
           detJ(.0),
           invJ(local_dim, local_dim),
-          dNdx(global_dim, n_nodes)
+          dNdx(global_dim, n_nodes),
+          integralMeasure(0.0)
     {
         setZero();
     }

--- a/NumLib/Fem/FiniteElement/TemplateIsoparametric.h
+++ b/NumLib/Fem/FiniteElement/TemplateIsoparametric.h
@@ -85,10 +85,12 @@ public:
      * @param global_dim    global dimension
      */
     void computeShapeFunctions(const double* natural_pt, ShapeMatrices& shape,
-                               const unsigned global_dim) const
+                               const unsigned global_dim,
+                               bool is_axially_symmetric) const
     {
         NaturalCoordsMappingType::computeShapeMatrices(*_ele, natural_pt, shape,
                                                        global_dim);
+        computeIntegralMeasure(is_axially_symmetric, shape);
     }
 
     /**
@@ -101,13 +103,24 @@ public:
      */
     template <ShapeMatrixType T_SHAPE_MATRIX_TYPE>
     void computeShapeFunctions(const double* natural_pt, ShapeMatrices& shape,
-                               const unsigned global_dim) const
+                               const unsigned global_dim,
+                               bool is_axially_symmetric) const
     {
         NaturalCoordsMappingType::template computeShapeMatrices<
             T_SHAPE_MATRIX_TYPE>(*_ele, natural_pt, shape, global_dim);
+        computeIntegralMeasure(is_axially_symmetric, shape);
     }
 
 private:
+    void computeIntegralMeasure(bool is_axially_symmetric,
+                                ShapeMatrices& shape) const
+    {
+        if (!is_axially_symmetric) {
+            shape.integralMeasure = 1.0;
+            return;
+        }
+    }
+
     const MeshElementType* _ele;
 };
 

--- a/ProcessLib/BoundaryCondition/BoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/BoundaryCondition.cpp
@@ -85,15 +85,17 @@ std::unique_ptr<BoundaryCondition> BoundaryConditionBuilder::createBoundaryCondi
         return createNeumannBoundaryCondition(
             config.config,
             getClonedElements(boundary_element_searcher, config.geometry),
-            dof_table, variable_id, config.component_id, integration_order,
-            mesh.getDimension(), parameters);
+            dof_table, variable_id, config.component_id,
+            mesh.isAxiallySymmetric(), integration_order, mesh.getDimension(),
+            parameters);
     }
     else if (type == "Robin") {
         return createRobinBoundaryCondition(
             config.config,
             getClonedElements(boundary_element_searcher, config.geometry),
-            dof_table, variable_id, config.component_id, integration_order,
-            mesh.getDimension(), parameters);
+            dof_table, variable_id, config.component_id,
+            mesh.isAxiallySymmetric(), integration_order, mesh.getDimension(),
+            parameters);
     }
     else
     {

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
@@ -54,8 +54,8 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
         variable_id, component_id, std::move(all_mesh_subsets), _elements));
 
     createLocalAssemblers<LocalAssemblerImplementation>(
-        global_dim, _elements, *_dof_table_boundary, _integration_order,
-        _local_assemblers, _data);
+        global_dim, _elements, *_dof_table_boundary, _local_assemblers,
+        false /* TODO */, _integration_order, _data);
 }
 
 template <typename BoundaryConditionData,

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
@@ -24,11 +24,12 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
         typename std::enable_if<
             std::is_same<typename std::decay<BoundaryConditionData>::type,
                          typename std::decay<Data>::type>::value,
-            unsigned const>::type integration_order,
+            bool>::type is_axially_symmetric,
+        unsigned const integration_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
-        unsigned const global_dim,
-        std::vector<MeshLib::Element*>&& elements, Data&& data)
+        unsigned const global_dim, std::vector<MeshLib::Element*>&& elements,
+        Data&& data)
     : _data(std::forward<Data>(data)),
       _elements(std::move(elements)),
       _integration_order(integration_order)
@@ -55,7 +56,7 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
 
     createLocalAssemblers<LocalAssemblerImplementation>(
         global_dim, _elements, *_dof_table_boundary, _local_assemblers,
-        false /* TODO */, _integration_order, _data);
+        is_axially_symmetric, _integration_order, _data);
 }
 
 template <typename BoundaryConditionData,

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition.h
@@ -31,11 +31,12 @@ public:
         typename std::enable_if<
             std::is_same<typename std::decay<BoundaryConditionData>::type,
                          typename std::decay<Data>::type>::value,
-            unsigned const>::type integration_order,
+            bool>::type is_axially_symmetric,
+        unsigned const integration_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
-        unsigned const global_dim,
-        std::vector<MeshLib::Element*>&& elements, Data&& data);
+        unsigned const global_dim, std::vector<MeshLib::Element*>&& elements,
+        Data&& data);
 
     ~GenericNaturalBoundaryCondition() override;
 

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryConditionLocalAssembler.h
@@ -38,11 +38,12 @@ protected:
 
 public:
     GenericNaturalBoundaryConditionLocalAssembler(
-        MeshLib::Element const& e, unsigned const integration_order)
+        MeshLib::Element const& e, bool is_axially_symmetric,
+        unsigned const integration_order)
         : _integration_method(integration_order),
           _shape_matrices(initShapeMatrices<ShapeFunction, ShapeMatricesType,
                                             IntegrationMethod, GlobalDim>(
-              e, _integration_method))
+              e, is_axially_symmetric, _integration_method))
     {
     }
 

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.cpp
@@ -12,13 +12,12 @@
 
 namespace ProcessLib
 {
-std::unique_ptr<NeumannBoundaryCondition>
-createNeumannBoundaryCondition(
+std::unique_ptr<NeumannBoundaryCondition> createNeumannBoundaryCondition(
     BaseLib::ConfigTree const& config,
     std::vector<MeshLib::Element*>&& elements,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
-    int const component_id, unsigned const integration_order,
-    unsigned const global_dim,
+    int const component_id, bool is_axially_symmetric,
+    unsigned const integration_order, unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters)
 {
     DBUG("Constructing Neumann BC from config.");
@@ -32,9 +31,9 @@ createNeumannBoundaryCondition(
     auto const& param = findParameter<double>(param_name, parameters, 1);
 
     return std::unique_ptr<NeumannBoundaryCondition>(
-        new NeumannBoundaryCondition(
-            integration_order, dof_table, variable_id, component_id,
-            global_dim, std::move(elements), param));
+        new NeumannBoundaryCondition(is_axially_symmetric, integration_order,
+                                     dof_table, variable_id, component_id,
+                                     global_dim, std::move(elements), param));
 }
 
 }  // ProcessLib

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.h
@@ -19,13 +19,12 @@ namespace ProcessLib
 using NeumannBoundaryCondition = GenericNaturalBoundaryCondition<
     Parameter<double> const&, NeumannBoundaryConditionLocalAssembler>;
 
-std::unique_ptr<NeumannBoundaryCondition>
-createNeumannBoundaryCondition(
+std::unique_ptr<NeumannBoundaryCondition> createNeumannBoundaryCondition(
     BaseLib::ConfigTree const& config,
     std::vector<MeshLib::Element*>&& elements,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
-    int const component_id, unsigned const integration_order,
-    unsigned const global_dim,
+    int const component_id, bool is_axially_symmetric,
+    unsigned const integration_order, unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters);
 
 }  // ProcessLib

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
@@ -31,9 +31,10 @@ public:
     NeumannBoundaryConditionLocalAssembler(
         MeshLib::Element const& e,
         std::size_t const local_matrix_size,
+        bool is_axially_symmetric,
         unsigned const integration_order,
         Parameter<double> const& neumann_bc_parameter)
-        : Base(e, integration_order),
+        : Base(e, is_axially_symmetric, integration_order),
           _neumann_bc_parameter(neumann_bc_parameter),
           _local_rhs(local_matrix_size)
     {

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
@@ -59,7 +59,8 @@ public:
             auto const& sm = Base::_shape_matrices[ip];
             auto const& wp = Base::_integration_method.getWeightedPoint(ip);
             _local_rhs.noalias() += sm.N * _neumann_bc_parameter(t, pos)[0] *
-                                    sm.detJ * wp.getWeight();
+                                    sm.detJ * wp.getWeight() *
+                                    sm.integralMeasure;
         }
 
         auto const indices = NumLib::getIndices(id, dof_table_boundary);

--- a/ProcessLib/BoundaryCondition/RobinBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryCondition.cpp
@@ -16,8 +16,8 @@ std::unique_ptr<RobinBoundaryCondition> createRobinBoundaryCondition(
     BaseLib::ConfigTree const& config,
     std::vector<MeshLib::Element*>&& elements,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
-    int const component_id, unsigned const integration_order,
-    unsigned const global_dim,
+    int const component_id, bool is_axially_symmetric,
+    unsigned const integration_order, unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters)
 {
     DBUG("Constructing RobinBcConfig from config.");
@@ -32,11 +32,10 @@ std::unique_ptr<RobinBoundaryCondition> createRobinBoundaryCondition(
     auto const& alpha = findParameter<double>(alpha_name, parameters, 1);
     auto const& u_0 = findParameter<double>(u_0_name, parameters, 1);
 
-    return std::unique_ptr<RobinBoundaryCondition>(
-        new RobinBoundaryCondition(
-            integration_order, dof_table, variable_id, component_id, global_dim,
-            std::move(elements),
-            RobinBoundaryConditionData{alpha, u_0}));
+    return std::unique_ptr<RobinBoundaryCondition>(new RobinBoundaryCondition(
+        is_axially_symmetric, integration_order, dof_table, variable_id,
+        component_id, global_dim, std::move(elements),
+        RobinBoundaryConditionData{alpha, u_0}));
 }
 
 }  // ProcessLib

--- a/ProcessLib/BoundaryCondition/RobinBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryCondition.h
@@ -39,8 +39,8 @@ std::unique_ptr<RobinBoundaryCondition> createRobinBoundaryCondition(
     BaseLib::ConfigTree const& config,
     std::vector<MeshLib::Element*>&& elements,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
-    int const component_id, unsigned const integration_order,
-    unsigned const global_dim,
+    int const component_id, bool is_axially_symmetric,
+    unsigned const integration_order, unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters);
 
 }  // ProcessLib

--- a/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
@@ -71,9 +71,9 @@ public:
             // adding a alpha term to the diagonal of the stiffness matrix
             // and a alpha * u_0 term to the rhs vector
             _local_K.diagonal().noalias() +=
-                sm.N * alpha * sm.detJ * wp.getWeight();
-            _local_rhs.noalias() +=
-                sm.N * alpha * u_0 * sm.detJ * wp.getWeight();
+                sm.N * alpha * sm.detJ * wp.getWeight() * sm.integralMeasure;
+            _local_rhs.noalias() += sm.N * alpha * u_0 * sm.detJ *
+                                    wp.getWeight() * sm.integralMeasure;
         }
 
         auto const indices = NumLib::getIndices(id, dof_table_boundary);

--- a/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
@@ -31,11 +31,12 @@ class RobinBoundaryConditionLocalAssembler final
         ShapeFunction, IntegrationMethod, GlobalDim>;
 
 public:
-    RobinBoundaryConditionLocalAssembler(
-        MeshLib::Element const& e, std::size_t const local_matrix_size,
-        unsigned const integration_order,
-        RobinBoundaryConditionData const& data)
-        : Base(e, integration_order),
+    RobinBoundaryConditionLocalAssembler(MeshLib::Element const& e,
+                                         std::size_t const local_matrix_size,
+                                         bool is_axially_symmetric,
+                                         unsigned const integration_order,
+                                         RobinBoundaryConditionData const& data)
+        : Base(e, is_axially_symmetric, integration_order),
           _data(data),
           _local_K(local_matrix_size, local_matrix_size),
           _local_rhs(local_matrix_size)

--- a/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.cpp
+++ b/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.cpp
@@ -48,11 +48,12 @@ CalculateSurfaceFlux::CalculateSurfaceFlux(MeshLib::Mesh& boundary_mesh,
     boost::optional<MeshLib::PropertyVector<std::size_t> const&> bulk_face_ids(
         boundary_mesh.getProperties().template getPropertyVector<std::size_t>(
             "OriginalFaceIDs"));
-    const std::size_t integration_order = 2;
+    const unsigned integration_order = 2;
     ProcessLib::createLocalAssemblers<CalculateSurfaceFluxLocalAssembler>(
-        boundary_mesh.getDimension()+1, // or bulk_mesh.getDimension()?
-        boundary_mesh.getElements(), *dof_table, integration_order,
-        _local_assemblers, *bulk_element_ids, *bulk_face_ids);
+        boundary_mesh.getDimension() + 1,  // or bulk_mesh.getDimension()?
+        boundary_mesh.getElements(), *dof_table, _local_assemblers,
+        boundary_mesh.isAxiallySymmetric(), integration_order,
+        *bulk_element_ids, *bulk_face_ids);
 }
 
 void CalculateSurfaceFlux::integrate(GlobalVector const& x,

--- a/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
@@ -82,6 +82,9 @@ std::unique_ptr<Process> createGroundwaterFlowProcess(
             "\"%s\"\n\toutput to: \"%s\"",
             mesh_name.c_str(), balance_pv_name.c_str(),
             balance_out_fname.c_str());
+
+        // Surface mesh and bulk mesh must have equal axial symmetry flags!
+        surface_mesh->setAxiallySymmetric(mesh.isAxiallySymmetric());
     }
 
     return std::unique_ptr<Process>{new GroundwaterFlowProcess{

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -135,8 +135,10 @@ public:
         typename ShapeMatricesType::ShapeMatrices shape_matrices(
             ShapeFunction::DIM, GlobalDim, ShapeFunction::NPOINTS);
 
+        // Note: Axial symmetry is set to false here, because we only need dNdx
+        // here, which is not affected by axial symmetry.
         fe.computeShapeFunctions(p_local_coords.getCoords(), shape_matrices,
-                                 GlobalDim);
+                                 GlobalDim, false);
         std::vector<double> flux;
         flux.resize(3);
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -103,8 +103,8 @@ public:
             auto const& wp = _integration_method.getWeightedPoint(ip);
             auto const k = _process_data.hydraulic_conductivity(t, pos)[0];
 
-            local_K.noalias() +=
-                sm.dNdx.transpose() * k * sm.dNdx * sm.detJ * wp.getWeight();
+            local_K.noalias() += sm.dNdx.transpose() * k * sm.dNdx * sm.detJ *
+                                 sm.integralMeasure * wp.getWeight();
 
             // Darcy velocity only computed for output.
             GlobalDimVectorType const darcy_velocity =

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -66,6 +66,7 @@ public:
     /// element matrix.
     LocalAssemblerData(MeshLib::Element const& element,
                        std::size_t const /*local_matrix_size*/,
+                       bool is_axially_symmetric,
                        unsigned const integration_order,
                        GroundwaterFlowProcessData const& process_data)
         : _element(element),
@@ -73,7 +74,7 @@ public:
           _integration_method(integration_order),
           _shape_matrices(initShapeMatrices<ShapeFunction, ShapeMatricesType,
                                             IntegrationMethod, GlobalDim>(
-              element, _integration_method))
+              element, is_axially_symmetric, _integration_method))
     {
     }
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -44,8 +44,8 @@ void GroundwaterFlowProcess::initializeConcreteProcess(
     unsigned const integration_order)
 {
     ProcessLib::createLocalAssemblers<LocalAssemblerData>(
-        mesh.getDimension(), mesh.getElements(), dof_table, integration_order,
-        _local_assemblers, _process_data);
+        mesh.getDimension(), mesh.getElements(), dof_table, _local_assemblers,
+        mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(
         "darcy_velocity_x", 1,

--- a/ProcessLib/HeatConduction/HeatConductionFEM.h
+++ b/ProcessLib/HeatConduction/HeatConductionFEM.h
@@ -107,10 +107,11 @@ public:
             auto const heat_capacity = _process_data.heat_capacity(t, pos)[0];
             auto const density = _process_data.density(t, pos)[0];
 
-            local_K.noalias() +=
-                sm.dNdx.transpose() * k * sm.dNdx * sm.detJ * wp.getWeight();
+            local_K.noalias() += sm.dNdx.transpose() * k * sm.dNdx * sm.detJ *
+                                 wp.getWeight() * sm.integralMeasure;
             local_M.noalias() += sm.N.transpose() * density * heat_capacity *
-                                 sm.N * sm.detJ * wp.getWeight();
+                                 sm.N * sm.detJ * wp.getWeight() *
+                                 sm.integralMeasure;
             // heat flux only computed for output.
             GlobalDimVectorType const heat_flux =
                 -k * sm.dNdx * Eigen::Map<const NodalVectorType>(

--- a/ProcessLib/HeatConduction/HeatConductionFEM.h
+++ b/ProcessLib/HeatConduction/HeatConductionFEM.h
@@ -62,6 +62,7 @@ public:
     /// element matrix.
     LocalAssemblerData(MeshLib::Element const& element,
                        std::size_t const local_matrix_size,
+                       bool is_axially_symmetric,
                        unsigned const integration_order,
                        HeatConductionProcessData const& process_data)
         : _element(element),
@@ -69,11 +70,12 @@ public:
           _integration_method(integration_order),
           _shape_matrices(initShapeMatrices<ShapeFunction, ShapeMatricesType,
                                             IntegrationMethod, GlobalDim>(
-              element, _integration_method))
+              element, is_axially_symmetric, _integration_method))
     {
         // This assertion is valid only if all nodal d.o.f. use the same shape
         // matrices.
         assert(local_matrix_size == ShapeFunction::NPOINTS * NUM_NODAL_DOF);
+        (void) local_matrix_size;
     }
 
     void assemble(double const t, std::vector<double> const& local_x,

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -38,8 +38,8 @@ void HeatConductionProcess::initializeConcreteProcess(
     unsigned const integration_order)
 {
     ProcessLib::createLocalAssemblers<LocalAssemblerData>(
-        mesh.getDimension(), mesh.getElements(), dof_table, integration_order,
-        _local_assemblers, _process_data);
+        mesh.getDimension(), mesh.getElements(), dof_table, _local_assemblers,
+        mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(
         "heat_flux_x", 1,

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -57,8 +57,8 @@ public:
     /// Computes the flux in the point \c p_local_coords that is given in local
     /// coordinates using the values from \c local_x.
     virtual std::vector<double> getFlux(
-        MathLib::Point3d const& p_local_coords,
-        std::vector<double> const& local_x) const
+        MathLib::Point3d const& /*p_local_coords*/,
+        std::vector<double> const& /*local_x*/) const
     {
         return std::vector<double>();
     }

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -103,9 +103,9 @@ public:
     }
 
     // used as call back for CalculateSurfaceFlux process
-    virtual std::vector<double> getFlux(std::size_t element_id,
-                                        MathLib::Point3d const& p,
-                                        GlobalVector const&) const
+    virtual std::vector<double> getFlux(std::size_t /*element_id*/,
+                                        MathLib::Point3d const& /*p*/,
+                                        GlobalVector const& /*x*/) const
     {
         return std::vector<double>{};
     }

--- a/ProcessLib/SmallDeformation/CreateLocalAssemblers.h
+++ b/ProcessLib/SmallDeformation/CreateLocalAssemblers.h
@@ -30,7 +30,6 @@ template <unsigned GlobalDim, int DisplacementDim,
 void createLocalAssemblers(
     NumLib::LocalToGlobalIndexMap const& dof_table,
     std::vector<MeshLib::Element*> const& mesh_elements,
-    unsigned const integration_order,
     std::vector<std::unique_ptr<LocalAssemblerInterface>>& local_assemblers,
     ExtraCtorArgs&&... extra_ctor_args)
 {
@@ -51,7 +50,6 @@ void createLocalAssemblers(
         initializer,
         mesh_elements,
         local_assemblers,
-        integration_order,
         std::forward<ExtraCtorArgs>(extra_ctor_args)...);
 }
 
@@ -76,7 +74,6 @@ void createLocalAssemblers(
     const unsigned dimension,
     std::vector<MeshLib::Element*> const& mesh_elements,
     NumLib::LocalToGlobalIndexMap const& dof_table,
-    unsigned const integration_order,
     std::vector<std::unique_ptr<LocalAssemblerInterface>>& local_assemblers,
     ExtraCtorArgs&&... extra_ctor_args)
 {
@@ -87,13 +84,13 @@ void createLocalAssemblers(
         case 2:
             detail::createLocalAssemblers<2, DisplacementDim,
                                           LocalAssemblerImplementation>(
-                dof_table, mesh_elements, integration_order, local_assemblers,
+                dof_table, mesh_elements, local_assemblers,
                 std::forward<ExtraCtorArgs>(extra_ctor_args)...);
             break;
         case 3:
             detail::createLocalAssemblers<3, DisplacementDim,
                                           LocalAssemblerImplementation>(
-                dof_table, mesh_elements, integration_order, local_assemblers,
+                dof_table, mesh_elements, local_assemblers,
                 std::forward<ExtraCtorArgs>(extra_ctor_args)...);
             break;
         default:

--- a/ProcessLib/SmallDeformation/LocalDataInitializer.h
+++ b/ProcessLib/SmallDeformation/LocalDataInitializer.h
@@ -219,7 +219,6 @@ public:
             std::size_t const id,
             MeshLib::Element const& mesh_item,
             LADataIntfPtr& data_ptr,
-            unsigned const integration_order,
             ConstructorArgs&&... args) const
     {
         auto const type_idx = std::type_index(typeid(mesh_item));
@@ -228,7 +227,7 @@ public:
         if (it != _builder.end()) {
             auto const num_local_dof = _dof_table.getNumberOfElementDOF(id);
             data_ptr = it->second(
-                           mesh_item, num_local_dof, integration_order,
+                           mesh_item, num_local_dof,
                            std::forward<ConstructorArgs>(args)...);
         } else {
             OGS_FATAL("You are trying to build a local assembler for an unknown mesh element type (%s)."
@@ -241,7 +240,6 @@ private:
     using LADataBuilder = std::function<LADataIntfPtr(
             MeshLib::Element const& e,
             std::size_t const local_matrix_size,
-            unsigned const integration_order,
             ConstructorArgs&&...
         )>;
 
@@ -260,12 +258,11 @@ private:
     {
         return [](MeshLib::Element const& e,
                   std::size_t const local_matrix_size,
-                  unsigned const integration_order,
                   ConstructorArgs&&... args)
         {
             return LADataIntfPtr{
                 new LAData<ShapeFct>{
-                    e, local_matrix_size, integration_order,
+                    e, local_matrix_size,
                     std::forward<ConstructorArgs>(args)...
                 }};
         };

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -151,7 +151,7 @@ public:
         auto const shape_matrices =
             initShapeMatrices<ShapeFunction, ShapeMatricesType,
                               IntegrationMethod, DisplacementDim>(
-                e, _integration_method);
+                e, false /* TODO */, _integration_method);
 
         for (unsigned ip = 0; ip < n_integration_points; ip++)
         {

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -134,6 +134,7 @@ public:
     SmallDeformationLocalAssembler(
         MeshLib::Element const& e,
         std::size_t const /*local_matrix_size*/,
+        bool is_axially_symmetric,
         unsigned const integration_order,
         SmallDeformationProcessData<DisplacementDim>& process_data)
         : _process_data(process_data),
@@ -153,7 +154,7 @@ public:
         auto const shape_matrices =
             initShapeMatrices<ShapeFunction, ShapeMatricesType,
                               IntegrationMethod, DisplacementDim>(
-                e, false /* TODO */, _integration_method);
+                e, is_axially_symmetric, _integration_method);
 
         for (unsigned ip = 0; ip < n_integration_points; ip++)
         {
@@ -318,11 +319,13 @@ public:
     LocalAssemblerData(
         MeshLib::Element const& e,
         std::size_t const local_matrix_size,
+        bool is_axially_symmetric,
         unsigned const integration_order,
         SmallDeformationProcessData<DisplacementDim>& process_data)
         : SmallDeformationLocalAssembler<ShapeFunction, IntegrationMethod,
                                          DisplacementDim>(
-              e, local_matrix_size, integration_order, process_data)
+              e, local_matrix_size, is_axially_symmetric, integration_order,
+              process_data)
     {
     }
 };

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -160,15 +160,20 @@ public:
         {
             _ip_data.emplace_back(*_process_data._material);
             auto& ip_data = _ip_data[ip];
-            ip_data._detJ = shape_matrices[ip].detJ;
-            ip_data._integralMeasure = shape_matrices[ip].integralMeasure;
+            auto const& sm = shape_matrices[ip];
+            ip_data._detJ = sm.detJ;
+            ip_data._integralMeasure = sm.integralMeasure;
             ip_data._b_matrices.resize(
                 KelvinVectorDimensions<DisplacementDim>::value,
                 ShapeFunction::NPOINTS * DisplacementDim);
-            LinearBMatrix::computeBMatrix<
-                DisplacementDim, ShapeFunction::NPOINTS,
-                typename ShapeMatricesType::GlobalDimNodalMatrixType,
-                BMatrixType>(shape_matrices[ip].dNdx, ip_data._b_matrices);
+
+            auto const x_coord =
+                interpolateXCoordinate<ShapeFunction, ShapeMatricesType>(e,
+                                                                         sm.N);
+            LinearBMatrix::computeBMatrix<DisplacementDim,
+                                          ShapeFunction::NPOINTS>(
+                sm.dNdx, ip_data._b_matrices, is_axially_symmetric, sm.N,
+                x_coord);
 
             ip_data._sigma.resize(
                 KelvinVectorDimensions<DisplacementDim>::value);

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -90,10 +90,30 @@ private:
                 &SmallDeformationLocalAssemblerInterface::getIntPtSigmaYY));
 
         Base::_secondary_variables.addSecondaryVariable(
+            "sigma_zz", 1,
+            makeExtrapolator(
+                getExtrapolator(), _local_assemblers,
+                &SmallDeformationLocalAssemblerInterface::getIntPtSigmaZZ));
+
+        Base::_secondary_variables.addSecondaryVariable(
             "sigma_xy", 1,
             makeExtrapolator(
                 getExtrapolator(), _local_assemblers,
-                &SmallDeformationLocalAssemblerInterface::getIntPtSigmaXY));
+                &SmallDeformationLocalAssemblerInterface::getIntPtSigmaZZ));
+
+        if (DisplacementDim == 3) {
+            Base::_secondary_variables.addSecondaryVariable(
+                "sigma_xz", 1,
+                makeExtrapolator(
+                    getExtrapolator(), _local_assemblers,
+                    &SmallDeformationLocalAssemblerInterface::getIntPtSigmaXZ));
+
+            Base::_secondary_variables.addSecondaryVariable(
+                "sigma_yz", 1,
+                makeExtrapolator(
+                    getExtrapolator(), _local_assemblers,
+                    &SmallDeformationLocalAssemblerInterface::getIntPtSigmaYZ));
+        }
     }
 
     void assembleConcreteProcess(const double t, GlobalVector const& x,

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -62,7 +62,8 @@ private:
         ProcessLib::SmallDeformation::createLocalAssemblers<DisplacementDim,
                                                             LocalAssemblerData>(
             mesh.getDimension(), mesh.getElements(), dof_table,
-            integration_order, _local_assemblers, _process_data);
+            _local_assemblers, mesh.isAxiallySymmetric(), integration_order,
+            _process_data);
 
         // TODO move the two data members somewhere else.
         // for extrapolation of secondary variables

--- a/ProcessLib/TES/TESLocalAssembler-impl.h
+++ b/ProcessLib/TES/TESLocalAssembler-impl.h
@@ -110,12 +110,13 @@ template <typename ShapeFunction_, typename IntegrationMethod_,
 TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
     TESLocalAssembler(MeshLib::Element const& e,
                       std::size_t const /*local_matrix_size*/,
+                      bool is_axially_symmetric,
                       unsigned const integration_order,
                       AssemblyParams const& asm_params)
     : _integration_method(integration_order),
       _shape_matrices(initShapeMatrices<ShapeFunction, ShapeMatricesType,
                                         IntegrationMethod_, GlobalDim>(
-          e, _integration_method)),
+          e, is_axially_symmetric, _integration_method)),
       _d(asm_params,
          // TODO narrowing conversion
          static_cast<const unsigned>(

--- a/ProcessLib/TES/TESLocalAssembler-impl.h
+++ b/ProcessLib/TES/TESLocalAssembler-impl.h
@@ -155,8 +155,8 @@ void TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::assemble(
         auto const& wp = _integration_method.getWeightedPoint(ip);
         auto const weight = wp.getWeight();
 
-        _d.assembleIntegrationPoint(ip, local_x, sm.N, sm.dNdx, sm.J, sm.detJ,
-                                    weight, local_M, local_K, local_b);
+        _d.assembleIntegrationPoint(ip, local_x, sm, weight, local_M, local_K,
+                                    local_b);
     }
 
     if (_d.getAssemblyParameters().output_element_matrices)

--- a/ProcessLib/TES/TESLocalAssembler.h
+++ b/ProcessLib/TES/TESLocalAssembler.h
@@ -66,6 +66,7 @@ public:
 
     TESLocalAssembler(MeshLib::Element const& e,
                       std::size_t const local_matrix_size,
+                      bool is_axially_symmetric,
                       unsigned const integration_order,
                       AssemblyParams const& asm_params);
 

--- a/ProcessLib/TES/TESLocalAssemblerInner-impl.h
+++ b/ProcessLib/TES/TESLocalAssemblerInner-impl.h
@@ -191,10 +191,7 @@ template <typename Traits>
 void TESLocalAssemblerInner<Traits>::preEachAssembleIntegrationPoint(
     const unsigned int_pt,
     const std::vector<double>& localX,
-    typename Traits::ShapeMatrices::ShapeType const& smN,
-    typename Traits::ShapeMatrices::DxShapeType const& /*smDNdx*/,
-    typename Traits::ShapeMatrices::JacobianType const& /*smJ*/,
-    const double /*smDetJ*/)
+    typename Traits::ShapeMatrices const& sm)
 {
 #ifndef NDEBUG
     // fill local data with garbage to aid in debugging
@@ -202,7 +199,7 @@ void TESLocalAssemblerInner<Traits>::preEachAssembleIntegrationPoint(
         std::numeric_limits<double>::quiet_NaN();
 #endif
 
-    NumLib::shapeFunctionInterpolate(localX, smN, _d.p, _d.T,
+    NumLib::shapeFunctionInterpolate(localX, sm.N, _d.p, _d.T,
                                      _d.vapour_mass_fraction);
 
     // pre-compute certain properties
@@ -222,20 +219,16 @@ template <typename Traits>
 void TESLocalAssemblerInner<Traits>::assembleIntegrationPoint(
     unsigned integration_point,
     std::vector<double> const& localX,
-    const typename Traits::ShapeMatrices::ShapeType& smN,
-    const typename Traits::ShapeMatrices::DxShapeType& smDNdx,
-    const typename Traits::ShapeMatrices::JacobianType& smJ,
-    const double smDetJ,
+    typename Traits::ShapeMatrices const& sm,
     const double weight,
     Eigen::Map<typename Traits::LocalMatrix>& local_M,
     Eigen::Map<typename Traits::LocalMatrix>& local_K,
     Eigen::Map<typename Traits::LocalVector>& local_b)
 {
-    preEachAssembleIntegrationPoint(integration_point, localX, smN, smDNdx, smJ,
-                                    smDetJ);
+    preEachAssembleIntegrationPoint(integration_point, localX, sm);
 
-    auto const N = smDNdx.cols();  // number of integration points
-    auto const D = smDNdx.rows();  // global dimension: 1, 2 or 3
+    auto const N = sm.dNdx.cols();  // number of integration points
+    auto const D = sm.dNdx.rows();  // global dimension: 1, 2 or 3
 
     assert(N * NODAL_DOF == local_M.cols());
 
@@ -246,12 +239,12 @@ void TESLocalAssemblerInner<Traits>::assembleIntegrationPoint(
     auto const contentCoeffMat = getContentCoeffMatrix(integration_point);
 
     // calculate velocity
-    assert((unsigned)smDNdx.rows() == _d.velocity.size() &&
-           (unsigned)smDNdx.cols() == _d.velocity[0].size());
+    assert((unsigned)sm.dNdx.rows() == _d.velocity.size() &&
+           (unsigned)sm.dNdx.cols() == _d.velocity[0].size());
 
     auto const velocity =
         (Traits::blockDimDim(laplaceCoeffMat, 0, 0, D, D) *
-         (smDNdx * Eigen::Map<const typename Traits::Vector1Comp>(localX.data(),
+         (sm.dNdx * Eigen::Map<const typename Traits::Vector1Comp>(localX.data(),
                                                                   N)  // grad_p
           /
           -_d.rho_GR))
@@ -263,12 +256,12 @@ void TESLocalAssemblerInner<Traits>::assembleIntegrationPoint(
         _d.velocity[d][integration_point] = velocity[d];
     }
 
-    auto const detJ_w_NT = (smDetJ * weight * smN.transpose()).eval();
-    auto const detJ_w_NT_N = (detJ_w_NT * smN).eval();
+    auto const detJ_w_NT = (sm.detJ * weight * sm.N.transpose()).eval();
+    auto const detJ_w_NT_N = (detJ_w_NT * sm.N).eval();
     assert(detJ_w_NT_N.rows() == N && detJ_w_NT_N.cols() == N);
 
     auto const detJ_w_NT_vT_dNdx =
-        (detJ_w_NT * velocity.transpose() * smDNdx).eval();
+        (detJ_w_NT * velocity.transpose() * sm.dNdx).eval();
     assert(detJ_w_NT_vT_dNdx.rows() == N && detJ_w_NT_vT_dNdx.cols() == N);
 
     for (unsigned r = 0; r < NODAL_DOF; ++r)
@@ -276,9 +269,9 @@ void TESLocalAssemblerInner<Traits>::assembleIntegrationPoint(
         for (unsigned c = 0; c < NODAL_DOF; ++c)
         {
             Traits::blockShpShp(local_K, N * r, N * c, N, N).noalias() +=
-                smDetJ * weight * smDNdx.transpose() *
+                sm.detJ * weight * sm.dNdx.transpose() *
                     Traits::blockDimDim(laplaceCoeffMat, D * r, D * c, D, D) *
-                    smDNdx  // end Laplacian part
+                    sm.dNdx  // end Laplacian part
                 + detJ_w_NT_N * contentCoeffMat(r, c) +
                 detJ_w_NT_vT_dNdx * advCoeffMat(r, c);
             Traits::blockShpShp(local_M, N * r, N * c, N, N).noalias() +=
@@ -291,7 +284,7 @@ void TESLocalAssemblerInner<Traits>::assembleIntegrationPoint(
     for (unsigned r = 0; r < NODAL_DOF; ++r)
     {
         Traits::blockShp(local_b, N * r, N).noalias() +=
-            rhsCoeffVector(r) * smN.transpose() * smDetJ * weight;
+            rhsCoeffVector(r) * sm.N.transpose() * sm.detJ * weight;
     }
 }
 

--- a/ProcessLib/TES/TESLocalAssemblerInner.h
+++ b/ProcessLib/TES/TESLocalAssemblerInner.h
@@ -34,10 +34,7 @@ public:
     void assembleIntegrationPoint(
         unsigned integration_point,
         std::vector<double> const& localX,
-        typename Traits::ShapeMatrices::ShapeType const& smN,
-        typename Traits::ShapeMatrices::DxShapeType const& smDNdx,
-        typename Traits::ShapeMatrices::JacobianType const& smJ,
-        const double smDetJ,
+        typename Traits::ShapeMatrices const& sm,
         const double weight,
         Eigen::Map<typename Traits::LocalMatrix>& local_M,
         Eigen::Map<typename Traits::LocalMatrix>& local_K,
@@ -64,10 +61,7 @@ private:
     void preEachAssembleIntegrationPoint(
         const unsigned int_pt,
         std::vector<double> const& localX,
-        typename Traits::ShapeMatrices::ShapeType const& smN,
-        typename Traits::ShapeMatrices::DxShapeType const& smDNdx,
-        typename Traits::ShapeMatrices::JacobianType const& smJ,
-        const double smDetJ);
+        typename Traits::ShapeMatrices const& sm);
 
     void initReaction(const unsigned int_pt);
 

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -140,8 +140,8 @@ void TESProcess::initializeConcreteProcess(
     MeshLib::Mesh const& mesh, unsigned const integration_order)
 {
     ProcessLib::createLocalAssemblers<TESLocalAssembler>(
-        mesh.getDimension(), mesh.getElements(), dof_table, integration_order,
-        _local_assemblers, _assembly_params);
+        mesh.getDimension(), mesh.getElements(), dof_table, _local_assemblers,
+        mesh.isAxiallySymmetric(), integration_order, _assembly_params);
 
     initializeSecondaryVariables();
 }

--- a/ProcessLib/Utils/CreateLocalAssemblers.h
+++ b/ProcessLib/Utils/CreateLocalAssemblers.h
@@ -31,7 +31,6 @@ template<unsigned GlobalDim,
 void createLocalAssemblers(
         NumLib::LocalToGlobalIndexMap const& dof_table,
         std::vector<MeshLib::Element*> const& mesh_elements,
-        unsigned const integration_order,
         std::vector<std::unique_ptr<LocalAssemblerInterface>>& local_assemblers,
         ExtraCtorArgs&&... extra_ctor_args
         )
@@ -51,11 +50,8 @@ void createLocalAssemblers(
 
     DBUG("Calling local assembler builder for all mesh elements.");
     GlobalExecutor::transformDereferenced(
-            initializer,
-            mesh_elements,
-            local_assemblers,
-            integration_order,
-            std::forward<ExtraCtorArgs>(extra_ctor_args)...);
+        initializer, mesh_elements, local_assemblers,
+        std::forward<ExtraCtorArgs>(extra_ctor_args)...);
 }
 
 } // namespace detail
@@ -80,7 +76,6 @@ void createLocalAssemblers(
         const unsigned dimension,
         std::vector<MeshLib::Element*> const& mesh_elements,
         NumLib::LocalToGlobalIndexMap const& dof_table,
-        unsigned const integration_order,
         std::vector<std::unique_ptr<LocalAssemblerInterface>>& local_assemblers,
         ExtraCtorArgs&&... extra_ctor_args
         )
@@ -90,25 +85,19 @@ void createLocalAssemblers(
     switch (dimension)
     {
     case 1:
-        detail::createLocalAssemblers<
-            1, LocalAssemblerImplementation>(
-                dof_table, mesh_elements, integration_order,
-                local_assemblers,
-                std::forward<ExtraCtorArgs>(extra_ctor_args)...);
+        detail::createLocalAssemblers<1, LocalAssemblerImplementation>(
+            dof_table, mesh_elements, local_assemblers,
+            std::forward<ExtraCtorArgs>(extra_ctor_args)...);
         break;
     case 2:
-        detail::createLocalAssemblers<
-            2, LocalAssemblerImplementation>(
-                dof_table, mesh_elements, integration_order,
-                local_assemblers,
-                std::forward<ExtraCtorArgs>(extra_ctor_args)...);
+        detail::createLocalAssemblers<2, LocalAssemblerImplementation>(
+            dof_table, mesh_elements, local_assemblers,
+            std::forward<ExtraCtorArgs>(extra_ctor_args)...);
         break;
     case 3:
-        detail::createLocalAssemblers<
-            3, LocalAssemblerImplementation>(
-                dof_table, mesh_elements, integration_order,
-                local_assemblers,
-                std::forward<ExtraCtorArgs>(extra_ctor_args)...);
+        detail::createLocalAssemblers<3, LocalAssemblerImplementation>(
+            dof_table, mesh_elements, local_assemblers,
+            std::forward<ExtraCtorArgs>(extra_ctor_args)...);
         break;
     default:
         OGS_FATAL("Meshes with dimension greater than three are not supported.");

--- a/ProcessLib/Utils/InitShapeMatrices.h
+++ b/ProcessLib/Utils/InitShapeMatrices.h
@@ -44,6 +44,19 @@ std::vector<typename ShapeMatricesType::ShapeMatrices> initShapeMatrices(
     return shape_matrices;
 }
 
+template <typename ShapeFunction, typename ShapeMatricesType>
+double interpolateXCoordinate(
+    MeshLib::Element const& e,
+    typename ShapeMatricesType::ShapeMatrices::ShapeType const& N)
+{
+    using FemType = NumLib::TemplateIsoparametric<
+        ShapeFunction, ShapeMatricesType>;
+
+    FemType fe(*static_cast<const typename ShapeFunction::MeshElement*>(&e));
+
+    return fe.interpolateZerothCoordinate(N);
+}
+
 } // ProcessLib
 
 

--- a/ProcessLib/Utils/InitShapeMatrices.h
+++ b/ProcessLib/Utils/InitShapeMatrices.h
@@ -38,8 +38,7 @@ std::vector<typename ShapeMatricesType::ShapeMatrices> initShapeMatrices(
                                      ShapeFunction::NPOINTS);
         fe.computeShapeFunctions(
                 integration_method.getWeightedPoint(ip).getCoords(),
-                shape_matrices[ip], GlobalDim/*, is_axially_symmetric*/);
-        (void) is_axially_symmetric;
+                shape_matrices[ip], GlobalDim, is_axially_symmetric);
     }
 
     return shape_matrices;

--- a/ProcessLib/Utils/InitShapeMatrices.h
+++ b/ProcessLib/Utils/InitShapeMatrices.h
@@ -20,7 +20,8 @@ namespace ProcessLib
 template <typename ShapeFunction, typename ShapeMatricesType,
           typename IntegrationMethod, unsigned GlobalDim>
 std::vector<typename ShapeMatricesType::ShapeMatrices> initShapeMatrices(
-    MeshLib::Element const& e, IntegrationMethod const& integration_method)
+    MeshLib::Element const& e, bool is_axially_symmetric,
+    IntegrationMethod const& integration_method)
 {
     std::vector<typename ShapeMatricesType::ShapeMatrices> shape_matrices;
 
@@ -37,7 +38,8 @@ std::vector<typename ShapeMatricesType::ShapeMatrices> initShapeMatrices(
                                      ShapeFunction::NPOINTS);
         fe.computeShapeFunctions(
                 integration_method.getWeightedPoint(ip).getCoords(),
-                shape_matrices[ip], GlobalDim);
+                shape_matrices[ip], GlobalDim/*, is_axially_symmetric*/);
+        (void) is_axially_symmetric;
     }
 
     return shape_matrices;

--- a/ProcessLib/Utils/LocalDataInitializer.h
+++ b/ProcessLib/Utils/LocalDataInitializer.h
@@ -249,7 +249,6 @@ public:
             std::size_t const id,
             MeshLib::Element const& mesh_item,
             LADataIntfPtr& data_ptr,
-            unsigned const integration_order,
             ConstructorArgs&&... args) const
     {
         auto const type_idx = std::type_index(typeid(mesh_item));
@@ -257,9 +256,8 @@ public:
 
         if (it != _builder.end()) {
             auto const num_local_dof = _dof_table.getNumberOfElementDOF(id);
-            data_ptr = it->second(
-                           mesh_item, num_local_dof, integration_order,
-                           std::forward<ConstructorArgs>(args)...);
+            data_ptr = it->second(mesh_item, num_local_dof,
+                                  std::forward<ConstructorArgs>(args)...);
         } else {
             OGS_FATAL("You are trying to build a local assembler for an unknown mesh element type (%s)."
                 " Maybe you have disabled this mesh element type in your build configuration.",
@@ -271,7 +269,6 @@ private:
     using LADataBuilder = std::function<LADataIntfPtr(
             MeshLib::Element const& e,
             std::size_t const local_matrix_size,
-            unsigned const integration_order,
             ConstructorArgs&&...
         )>;
 
@@ -291,12 +288,11 @@ private:
     {
         return [](MeshLib::Element const& e,
                   std::size_t const local_matrix_size,
-                  unsigned const integration_order,
                   ConstructorArgs&&... args)
         {
             return LADataIntfPtr{
                 new LAData<ShapeFct>{
-                    e, local_matrix_size, integration_order,
+                    e, local_matrix_size,
                     std::forward<ConstructorArgs>(args)...
                 }};
         };

--- a/Tests/NumLib/TestFe.cpp
+++ b/Tests/NumLib/TestFe.cpp
@@ -195,7 +195,7 @@ TYPED_TEST(NumLibFemIsoTest, CheckMassMatrix)
         shape.setZero();
         auto wp = this->integration_method.getWeightedPoint(i);
         fe.template computeShapeFunctions<ShapeMatrixType::N_J>(
-            wp.getCoords(), shape, this->global_dim);
+            wp.getCoords(), shape, this->global_dim, false);
         M.noalias() += shape.N.transpose() * shape.N * shape.detJ * wp.getWeight();
     }
     //std::cout << "M=\n" << M;
@@ -220,7 +220,7 @@ TYPED_TEST(NumLibFemIsoTest, CheckLaplaceMatrix)
         shape.setZero();
         auto wp = this->integration_method.getWeightedPoint(i);
         fe.template computeShapeFunctions<ShapeMatrixType::DNDX>(
-            wp.getCoords(), shape, this->global_dim);
+            wp.getCoords(), shape, this->global_dim, false);
         K.noalias() += shape.dNdx.transpose() * this->globalD * shape.dNdx * shape.detJ * wp.getWeight();
     }
     //std::cout << "K=\n" << K << std::endl;
@@ -246,7 +246,7 @@ TYPED_TEST(NumLibFemIsoTest, CheckMassLaplaceMatrices)
     for (std::size_t i=0; i < this->integration_method.getNumberOfPoints(); i++) {
         shape.setZero();
         auto wp = this->integration_method.getWeightedPoint(i);
-        fe.computeShapeFunctions(wp.getCoords(), shape, this->global_dim);
+        fe.computeShapeFunctions(wp.getCoords(), shape, this->global_dim, false);
         M.noalias() += shape.N.transpose() * shape.N * shape.detJ * wp.getWeight();
         K.noalias() += shape.dNdx.transpose() * (this->globalD * shape.dNdx) * shape.detJ * wp.getWeight();
     }

--- a/Tests/NumLib/TestFunctionInterpolation.cpp
+++ b/Tests/NumLib/TestFunctionInterpolation.cpp
@@ -71,7 +71,7 @@ TEST(NumLibFunctionInterpolationTest, Linear1DElement)
 
     finite_element.computeShapeFunctions(
             integration_method.getWeightedPoint(0).getCoords(),
-            shape_matrix, ShapeFunction::DIM);
+            shape_matrix, ShapeFunction::DIM, false);
     ASSERT_EQ(2, shape_matrix.N.size());
 
     // actual test


### PR DESCRIPTION
Closes #1310.

The coordinates are mapped as follows:
Cartesian x to cylindrical r, Cartesian y to cylindrical z, i.e., axial symmetry is about the Cartesian y axis.

The solution in this PR is rather ad-hoc, so maybe some discussions are needed.

Major changes:
* Mesh now has flag `is_axially_symmetric`
* Constructors of all processes and local assemblers now have an argument telling if the problem is axially symmetric.
* The ShapeMatrices structure is extended by an `integralMeasure` member, which is 1 in the Cartesian case and 2 * pi * r in the axial case.

The added test results for GWFlow, T and TES are compared to numerical data from a wedge-shaped domain. I've added the corresponding wedge-files to the data repo and commented test cases Tests.cmake.