### PR TITLE
Fix a bug in the initialization of the secondary variable

### DIFF
--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -74,7 +74,9 @@ public:
           _integration_method(integration_order),
           _shape_matrices(initShapeMatrices<ShapeFunction, ShapeMatricesType,
                                             IntegrationMethod, GlobalDim>(
-              element, is_axially_symmetric, _integration_method))
+              element, is_axially_symmetric, _integration_method)),
+          _darcy_velocities(GlobalDim,
+			  std::vector<double>(_integration_method.getNumberOfPoints()))
     {
     }
 
@@ -102,6 +104,7 @@ public:
             auto const& sm = _shape_matrices[ip];
             auto const& wp = _integration_method.getWeightedPoint(ip);
             auto const k = _process_data.hydraulic_conductivity(t, pos)[0];
+
 
             local_K.noalias() += sm.dNdx.transpose() * k * sm.dNdx * sm.detJ *
                                  sm.integralMeasure * wp.getWeight();
@@ -193,9 +196,7 @@ private:
     IntegrationMethod const _integration_method;
     std::vector<ShapeMatrices> _shape_matrices;
 
-    std::vector<std::vector<double>> _darcy_velocities
-        = std::vector<std::vector<double>>(
-            GlobalDim, std::vector<double>(_integration_method.getNumberOfPoints()));
+    std::vector<std::vector<double>> _darcy_velocities;
 };
 
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -193,9 +193,9 @@ private:
     IntegrationMethod const _integration_method;
     std::vector<ShapeMatrices> _shape_matrices;
 
-    std::vector<std::vector<double>> _darcy_velocities =
-        std::vector<std::vector<double>>(
-            GlobalDim, std::vector<double>(ShapeFunction::NPOINTS));
+    std::vector<std::vector<double>> _darcy_velocities
+        = std::vector<std::vector<double>>(
+            GlobalDim, std::vector<double>(_integration_method.getNumberOfPoints()));
 };
 
 

--- a/ProcessLib/HeatConduction/HeatConductionFEM.h
+++ b/ProcessLib/HeatConduction/HeatConductionFEM.h
@@ -70,7 +70,9 @@ public:
           _integration_method(integration_order),
           _shape_matrices(initShapeMatrices<ShapeFunction, ShapeMatricesType,
                                             IntegrationMethod, GlobalDim>(
-              element, is_axially_symmetric, _integration_method))
+              element, is_axially_symmetric, _integration_method)),
+          _heat_fluxes(GlobalDim,
+              std::vector<double>(_integration_method.getNumberOfPoints()))
     {
         // This assertion is valid only if all nodal d.o.f. use the same shape
         // matrices.
@@ -161,9 +163,7 @@ private:
     IntegrationMethod const _integration_method;
     std::vector<ShapeMatrices> _shape_matrices;
 
-    std::vector<std::vector<double>> _heat_fluxes =
-        std::vector<std::vector<double>>(
-            GlobalDim, std::vector<double>(ShapeFunction::NPOINTS));
+    std::vector<std::vector<double>> _heat_fluxes;
 };
 
 }  // namespace HeatConduction

--- a/ProcessLib/TES/TESLocalAssembler-impl.h
+++ b/ProcessLib/TES/TESLocalAssembler-impl.h
@@ -117,12 +117,7 @@ TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
       _shape_matrices(initShapeMatrices<ShapeFunction, ShapeMatricesType,
                                         IntegrationMethod_, GlobalDim>(
           e, is_axially_symmetric, _integration_method)),
-      _d(asm_params,
-         // TODO narrowing conversion
-         static_cast<const unsigned>(
-             _shape_matrices.front()
-                 .N.cols()) /* number of integration points */,
-         GlobalDim)
+      _d(asm_params, _integration_method.getNumberOfPoints(), GlobalDim)
 {
 }
 


### PR DESCRIPTION
as titled.
 in ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h 
Replaced the size of the secondary variable vector as the number of integration points