### PR TITLE
fix a bug in obtaining the value for the given component stored in the given tuple

### DIFF
--- a/MeshLib/PropertyVector.h
+++ b/MeshLib/PropertyVector.h
@@ -72,8 +72,7 @@ public:
     {
         assert(component < _n_components);
         assert(tuple_index < getNumberOfTuples());
-        return this->operator[](tuple_index* getNumberOfComponents() +
-                                component);
+		return this->operator[](tuple_index* _n_components + component);
     }
 
     PropertyVectorBase* clone(std::vector<std::size_t> const& exclude_positions) const


### PR DESCRIPTION
as titiled.
in MeshLib/PropertyVector.h 