### PR TITLE
Relax tests tolerances

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -192,7 +192,7 @@ if(NOT OGS_USE_MPI)
             EXECUTABLE_ARGS line_${mesh_size}_time_dep_neumann.prj
             WRAPPER time
             TESTER vtkdiff
-            ABSTOL 1e-15 RELTOL 1e-15
+            ABSTOL 1e-14 RELTOL 1e-14
             DIFF_DATA
             line_1_time_dep_dirichlet.vtu line_${mesh_size}_time_dep_neumann_pcs_0_ts_1_t_1.000000.vtu t_1s pressure
             line_1_time_dep_dirichlet.vtu line_${mesh_size}_time_dep_neumann_pcs_0_ts_5_t_5.000000.vtu t_5s pressure

--- a/Tests/MaterialLib/KelvinVector.cpp
+++ b/Tests/MaterialLib/KelvinVector.cpp
@@ -154,7 +154,7 @@ TEST_F(MaterialLibSolidsKelvinVector4, Inverse)
             (inverse(v) - tensorToKelvin<4>(kelvinToTensor(v).inverse()))
                 .norm();
         // The error is only weekly depending on the input vector norm.
-        return error < 1e-7 && 1e-9 * std::pow(v.norm(), 1.2);
+        return error < 1e-7 && 1e-9 * std::pow(v.norm(), 1.3);
     };
 
     auto eps = std::numeric_limits<double>::epsilon();
@@ -175,7 +175,7 @@ TEST_F(MaterialLibSolidsKelvinVector6, Inverse)
             (inverse(v) - tensorToKelvin<6>(kelvinToTensor(v).inverse()))
                 .norm();
         // The error is only weekly depending on the input vector norm.
-        return error < 1e-7 && 1e-9 * std::pow(v.norm(), 1.2);
+        return error < 1e-7 && 1e-9 * std::pow(v.norm(), 1.3);
     };
 
     auto eps = std::numeric_limits<double>::epsilon();


### PR DESCRIPTION
 - The Kelvin inverse unit test fails sometimes for large (in norm) input vectors.
 - The GWF time dependent Neumann tests started failing on Jenkins [Tests_Linux_Large job](https://svn.ufz.de:8443/job/OGS-6/job/Tests_Linux_Large/) since the 21. Sep. but there was no related code change. Maybe something changed in the infrastructure (new LIS/Eigen/compilation options/...).

Fixes https://github.com/ufz/ogs/issues/1421
Fixes https://github.com/ufz/ogs/issues/1415