### PR TITLE
BoundaryConditionBuilder

### DIFF
--- a/ProcessLib/BoundaryCondition/BoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/BoundaryCondition.cpp
@@ -33,13 +33,12 @@ static std::vector<MeshLib::Element*> getClonedElements(
 
 namespace ProcessLib
 {
-std::unique_ptr<BoundaryCondition> createBoundaryCondition(
+
+std::unique_ptr<BoundaryCondition> BoundaryConditionBuilder::createBoundaryCondition(
     const BoundaryConditionConfig& config,
-    const NumLib::LocalToGlobalIndexMap& dof_table,
-    const MeshLib::Mesh& mesh,
-    const int variable_id,
-    const unsigned integration_order,
-    std::vector<std::unique_ptr<ParameterBase>> const& parameters)
+    const NumLib::LocalToGlobalIndexMap& dof_table, const MeshLib::Mesh& mesh,
+    const int variable_id, const unsigned integration_order,
+    const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters)
 {
     MeshGeoToolsLib::MeshNodeSearcher& mesh_node_searcher =
         MeshGeoToolsLib::MeshNodeSearcher::getMeshNodeSearcher(mesh);
@@ -101,5 +100,6 @@ std::unique_ptr<BoundaryCondition> createBoundaryCondition(
         OGS_FATAL("Unknown boundary condition type: `%s'.", type.c_str());
     }
 }
+
 
 }  // ProcessLib

--- a/ProcessLib/BoundaryCondition/BoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/BoundaryCondition.h
@@ -55,11 +55,17 @@ public:
     virtual ~BoundaryCondition() = default;
 };
 
-std::unique_ptr<BoundaryCondition> createBoundaryCondition(
-    const BoundaryConditionConfig& config,
-    const NumLib::LocalToGlobalIndexMap& dof_table, const MeshLib::Mesh& mesh,
-    const int variable_id, const unsigned integration_order,
-    const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters);
+class BoundaryConditionBuilder
+{
+public:
+    virtual ~BoundaryConditionBuilder() {}
+
+    virtual std::unique_ptr<BoundaryCondition> createBoundaryCondition(
+        const BoundaryConditionConfig& config,
+        const NumLib::LocalToGlobalIndexMap& dof_table, const MeshLib::Mesh& mesh,
+        const int variable_id, const unsigned integration_order,
+        const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters);
+};
 
 }  // ProcessLib
 

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -30,7 +30,8 @@ ProcessVariable::ProcessVariable(
       _initial_condition(findParameter<double>(
           //! \ogs_file_param{prj__process_variables__process_variable__initial_condition}
           config.getConfigParameter<std::string>("initial_condition"),
-          parameters, _n_components))
+          parameters, _n_components)),
+      _bc_builder(new BoundaryConditionBuilder())
 {
     DBUG("Constructing process variable %s", _name.c_str());
 
@@ -95,7 +96,8 @@ ProcessVariable::ProcessVariable(ProcessVariable&& other)
       _mesh(other._mesh),
       _n_components(other._n_components),
       _initial_condition(std::move(other._initial_condition)),
-      _bc_configs(std::move(other._bc_configs))
+      _bc_configs(std::move(other._bc_configs)),
+      _bc_builder(std::move(other._bc_builder))
 {
 }
 
@@ -139,7 +141,7 @@ ProcessVariable::createBoundaryConditions(
     std::vector<std::unique_ptr<BoundaryCondition>> bcs;
 
     for (auto& config : _bc_configs)
-        bcs.emplace_back(createBoundaryCondition(
+        bcs.emplace_back(_bc_builder->createBoundaryCondition(
             config, dof_table, _mesh, variable_id, integration_order, parameters));
 
     return bcs;

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -22,6 +22,8 @@ template <typename T> class PropertyVector;
 
 namespace ProcessLib
 {
+class BoundaryConditionBuilder;
+
 /// A named process variable. Its properties includes the mesh, and the initial
 /// and boundary conditions.
 class ProcessVariable
@@ -41,6 +43,11 @@ public:
 
     /// Returns the number of components of the process variable.
     int getNumberOfComponents() const { return _n_components; }
+
+    void setBoundaryConditionBuilder(std::unique_ptr<BoundaryConditionBuilder> bc_builder)
+    {
+        _bc_builder = std::move(bc_builder);
+    }
 
     std::vector<std::unique_ptr<BoundaryCondition>> createBoundaryConditions(
         const NumLib::LocalToGlobalIndexMap& dof_table, const int variable_id,
@@ -64,6 +71,7 @@ private:
     Parameter<double> const& _initial_condition;
 
     std::vector<BoundaryConditionConfig> _bc_configs;
+    std::unique_ptr<BoundaryConditionBuilder> _bc_builder;
 };
 
 }  // namespace ProcessLib


### PR DESCRIPTION
In #1452, I need [a custom local assembler for Neumann boundary conditions](https://github.com/norihiro-w/ogs/blob/1b30d78beddf459bed84be64f74062c6f159b9d4/ProcessLib/SmallDeformationWithLIE/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h) .  In order to enable it, I came to a solution introducing `BoundaryConditionBuilder` class. The class can be derived and Primary variable class owns a pointer to the base class. Thus I can set a custom builder for some variables. Let me know if you have a better solution for it.

