### PR TITLE
[SD-LIE] Local assemblers - part 2

### DIFF
--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerFracture-impl.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerFracture-impl.h
@@ -105,6 +105,8 @@ assembleWithJacobian(
     FractureProperty const& frac_prop = *_process_data._fracture_property;
     auto const& R = frac_prop.R;
 
+    // the index of a normal (normal to a fracture plane) component
+    // in a displacement vector
     int const index_normal = DisplacementDim - 1;
 
     unsigned const n_integration_points =

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerFracture-impl.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerFracture-impl.h
@@ -1,0 +1,174 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLER_FRACTURE_IMPL_H_
+#define PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLER_FRACTURE_IMPL_H_
+
+#include "SmallDeformationLocalAssemblerFracture.h"
+
+#include <Eigen/Eigen>
+
+#include "MathLib/LinAlg/Eigen/EigenMapTools.h"
+
+#include "ProcessLib/Utils/InitShapeMatrices.h"
+
+#include "ProcessLib/SmallDeformationWithLIE/Common/LevelSetFunction.h"
+
+
+namespace ProcessLib
+{
+namespace SmallDeformationWithLIE
+{
+template <typename ShapeFunction, typename IntegrationMethod,
+          int DisplacementDim>
+SmallDeformationLocalAssemblerFracture<ShapeFunction, IntegrationMethod,
+                               DisplacementDim>::
+    SmallDeformationLocalAssemblerFracture(
+        MeshLib::Element const& e,
+        std::size_t const /*local_matrix_size*/,
+        std::vector<unsigned> const& dofIndex_to_localIndex,
+        bool is_axially_symmetric,
+        unsigned const integration_order,
+        SmallDeformationProcessData<DisplacementDim>& process_data)
+    : SmallDeformationLocalAssemblerInterface(
+          ShapeFunction::NPOINTS * DisplacementDim, // no intersection
+          dofIndex_to_localIndex),
+      _process_data(process_data),
+      _integration_method(integration_order),
+      _shape_matrices(
+          initShapeMatrices<ShapeFunction, ShapeMatricesType,
+                            IntegrationMethod, DisplacementDim>(
+              e, is_axially_symmetric, _integration_method)),
+      _element(e)
+{
+    assert(_element.getDimension() == DisplacementDim-1);
+
+    unsigned const n_integration_points =
+        _integration_method.getNumberOfPoints();
+
+    _ip_data.reserve(n_integration_points);
+    _secondary_data.N.resize(n_integration_points);
+
+    auto const* frac_prop = _process_data._fracture_property.get();
+
+    SpatialPosition x_position;
+    x_position.setElementID(_element.getID());
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        x_position.setIntegrationPoint(ip);
+
+        _ip_data.emplace_back(*_process_data._fracture_model);
+        auto const& sm = _shape_matrices[ip];
+        auto& ip_data = _ip_data[ip];
+        ip_data._detJ = sm.detJ;
+        ip_data._integralMeasure = sm.integralMeasure;
+        ip_data._h_matrices.resize(
+            DisplacementDim,
+            ShapeFunction::NPOINTS * DisplacementDim);
+
+        computeHMatrix<
+            DisplacementDim, ShapeFunction::NPOINTS,
+            typename ShapeMatricesType::NodalRowVectorType, HMatrixType>(
+            sm.N, ip_data._h_matrices);
+
+        ip_data._w.resize(DisplacementDim);
+        ip_data._w_prev.resize(DisplacementDim);
+        ip_data._sigma.resize(DisplacementDim);
+        ip_data._sigma_prev.resize(DisplacementDim);
+        ip_data._C.resize(DisplacementDim, DisplacementDim);
+        ip_data._aperture0 = (*frac_prop->aperture0)(0, x_position)[0];
+        ip_data._aperture_prev = ip_data._aperture0;
+
+        _secondary_data.N[ip] = sm.N;
+    }
+}
+
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          int DisplacementDim>
+void SmallDeformationLocalAssemblerFracture<ShapeFunction, IntegrationMethod,
+                                    DisplacementDim>::
+assembleWithJacobian(
+    double const t,
+    Eigen::VectorXd const& local_u,
+    Eigen::VectorXd& local_b,
+    Eigen::MatrixXd& local_J)
+{
+    auto const& nodal_jump = local_u;
+
+    FractureProperty const& frac_prop = *_process_data._fracture_property;
+    auto const& R = frac_prop.R;
+
+    int const index_normal = DisplacementDim - 1;
+
+    unsigned const n_integration_points =
+        _integration_method.getNumberOfPoints();
+
+    SpatialPosition x_position;
+    x_position.setElementID(_element.getID());
+
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        x_position.setIntegrationPoint(ip);
+        auto const& wp = _integration_method.getWeightedPoint(ip);
+
+        auto& ip_data = _ip_data[ip];
+        auto const& detJ = ip_data._detJ;
+        auto const& integralMeasure = ip_data._integralMeasure;
+        auto const& H = ip_data._h_matrices;
+        auto& mat = ip_data._fracture_material;
+        auto& sigma = ip_data._sigma;
+        auto const& sigma_prev = ip_data._sigma_prev;
+        auto& w = ip_data._w;
+        auto const& w_prev = ip_data._w_prev;
+        auto& C = ip_data._C;
+
+        // displacement jumps
+        w.noalias() = R * H * nodal_jump;
+
+        // total aperture
+        ip_data._aperture = ip_data._aperture0 + w[index_normal];
+
+        // local C, local stress
+        mat.computeConstitutiveRelation(
+                    t, x_position,
+                    w_prev, w,
+                    sigma_prev, sigma, C);
+
+        // r_[u] += H^T*Stress
+        local_b.noalias() -= H.transpose() * R.transpose() * sigma * detJ * wp.getWeight() * integralMeasure;
+
+        // J_[u][u] += H^T*C*H
+        local_J.noalias() += H.transpose() * R.transpose() * C * R * H * detJ * wp.getWeight() * integralMeasure;
+    }
+
+}
+
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          int DisplacementDim>
+void SmallDeformationLocalAssemblerFracture<ShapeFunction, IntegrationMethod,
+                                    DisplacementDim>::
+postTimestepConcrete(std::vector<double> const& /*local_x*/)
+{
+    double ele_b = 0;
+    unsigned const n_integration_points =
+        _integration_method.getNumberOfPoints();
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        ele_b += _ip_data[ip]._aperture;
+    }
+    ele_b /= n_integration_points;
+    (*_process_data._mesh_prop_b)[_element.getID()] = ele_b;
+}
+
+}  // namespace SmallDeformationWithLIE
+}  // namespace ProcessLib
+
+#endif  // PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLER_FRACTURE_IMPL_H_

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
@@ -1,0 +1,166 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLER_FRACTURE_H_
+#define PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLER_FRACTURE_H_
+
+#include <vector>
+
+#include "NumLib/Fem/ShapeMatrixPolicy.h"
+
+#include "ProcessLib/SmallDeformationWithLIE/Common/HMatrixUtils.h"
+#include "ProcessLib/SmallDeformationWithLIE/SmallDeformationProcessData.h"
+
+#include "IntegrationPointDataFracture.h"
+#include "SecondaryData.h"
+#include "SmallDeformationLocalAssemblerInterface.h"
+
+namespace ProcessLib
+{
+namespace SmallDeformationWithLIE
+{
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          int DisplacementDim>
+class SmallDeformationLocalAssemblerFracture
+    : public SmallDeformationLocalAssemblerInterface
+{
+public:
+    using ShapeMatricesType =
+        ShapeMatrixPolicyType<ShapeFunction, DisplacementDim>;
+    using NodalMatrixType = typename ShapeMatricesType::NodalMatrixType;
+    using NodalVectorType = typename ShapeMatricesType::NodalVectorType;
+    using ShapeMatrices = typename ShapeMatricesType::ShapeMatrices;
+    using HMatricesType = HMatrixPolicyType<ShapeFunction, DisplacementDim>;
+
+    using HMatrixType = typename HMatricesType::HMatrixType;
+    using StiffnessMatrixType = typename HMatricesType::StiffnessMatrixType;
+    using NodalForceVectorType = typename HMatricesType::NodalForceVectorType;
+    using NodalDisplacementVectorType =
+        typename HMatricesType::NodalForceVectorType;
+
+    using ForceVectorType =
+        typename HMatricesType::ForceVectorType;
+
+    SmallDeformationLocalAssemblerFracture(SmallDeformationLocalAssemblerFracture const&) =
+        delete;
+    SmallDeformationLocalAssemblerFracture(SmallDeformationLocalAssemblerFracture&&) = delete;
+
+    SmallDeformationLocalAssemblerFracture(
+        MeshLib::Element const& e,
+        std::size_t const local_matrix_size,
+        std::vector<unsigned> const& dofIndex_to_localIndex,
+        bool is_axially_symmetric,
+        unsigned const integration_order,
+        SmallDeformationProcessData<DisplacementDim>& process_data);
+
+    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+                  std::vector<double>& /*local_M_data*/,
+                  std::vector<double>& /*local_K_data*/,
+                  std::vector<double>& /*local_b_data*/) override
+    {
+        OGS_FATAL(
+            "SmallDeformationLocalAssembler: assembly without jacobian is not "
+            "implemented.");
+    }
+
+    void assembleWithJacobian(
+        double const t,
+        Eigen::VectorXd const& local_u,
+        Eigen::VectorXd& local_b,
+        Eigen::MatrixXd& local_J) override;
+
+    void preTimestepConcrete(std::vector<double> const& /*local_x*/,
+                             double const /*t*/,
+                             double const /*delta_t*/) override
+    {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            _ip_data[ip].pushBackState();
+        }
+    }
+
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/) override;
+
+
+    Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
+        const unsigned integration_point) const override
+    {
+        auto const& N = _secondary_data.N[integration_point];
+
+        // assumes N is stored contiguously in memory
+        return Eigen::Map<const Eigen::RowVectorXd>(N.data(), N.size());
+    }
+
+    std::vector<double> const& getIntPtSigmaXX(
+        std::vector<double>& cache) const override
+    {
+        return getIntPtSigma(cache, 0);
+    }
+
+    std::vector<double> const& getIntPtSigmaYY(
+        std::vector<double>& cache) const override
+    {
+        return getIntPtSigma(cache, 1);
+    }
+
+    std::vector<double> const& getIntPtSigmaZZ(
+        std::vector<double>& cache) const override
+    {
+        return getIntPtSigma(cache, 2);
+    }
+
+    std::vector<double> const& getIntPtSigmaXY(
+        std::vector<double>& cache) const override
+    {
+        return getIntPtSigma(cache, 3);
+    }
+
+    std::vector<double> const& getIntPtSigmaXZ(
+        std::vector<double>& cache) const override
+    {
+        assert(DisplacementDim == 3);
+        return getIntPtSigma(cache, 4);
+    }
+
+    std::vector<double> const& getIntPtSigmaYZ(
+        std::vector<double>& cache) const override
+    {
+        assert(DisplacementDim == 3);
+        return getIntPtSigma(cache, 5);
+    }
+
+private:
+    std::vector<double> const& getIntPtSigma(std::vector<double>& cache,
+                                             std::size_t const /*component*/) const
+    {
+        cache.resize(_ip_data.size());
+
+        return cache;
+    }
+
+    SmallDeformationProcessData<DisplacementDim>& _process_data;
+
+    std::vector<IntegrationPointDataFracture<HMatricesType, DisplacementDim>> _ip_data;
+
+    IntegrationMethod _integration_method;
+    std::vector<ShapeMatrices> _shape_matrices;
+    MeshLib::Element const& _element;
+    SecondaryData<typename ShapeMatrices::ShapeType> _secondary_data;
+};
+
+}  // namespace SmallDeformationWithLIE
+}  // namespace ProcessLib
+
+#include "SmallDeformationLocalAssemblerFracture-impl.h"
+
+#endif  // PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLER_FRACTURE_H_

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerInterface.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerInterface.h
@@ -1,0 +1,115 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLERINTERFACE_H_
+#define PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLERINTERFACE_H_
+
+#include <vector>
+
+#include "BaseLib/Error.h"
+
+#include "NumLib/Extrapolation/ExtrapolatableElement.h"
+#include "ProcessLib/LocalAssemblerInterface.h"
+
+
+namespace ProcessLib
+{
+namespace SmallDeformationWithLIE
+{
+
+class SmallDeformationLocalAssemblerInterface
+    : public ProcessLib::LocalAssemblerInterface,
+      public NumLib::ExtrapolatableElement
+{
+public:
+    SmallDeformationLocalAssemblerInterface() {}
+
+    SmallDeformationLocalAssemblerInterface(
+            std::size_t n_local_size,
+            std::vector<unsigned> const& dofIndex_to_localIndex)
+        : _dofIndex_to_localIndex(dofIndex_to_localIndex)
+    {
+        _local_u.resize(n_local_size);
+        _local_b.resize(_local_u.size());
+        _local_J.resize(_local_u.size(), _local_u.size());
+    }
+
+
+    virtual void assembleWithJacobian(
+        double const t,
+        std::vector<double> const& local_x_,
+        std::vector<double> const& /*local_xdot*/,
+        const double /*dxdot_dx*/, const double /*dx_dx*/,
+        std::vector<double>& /*local_M_data*/,
+        std::vector<double>& /*local_K_data*/,
+        std::vector<double>& local_b_data,
+        std::vector<double>& local_Jac_data) override
+    {
+        auto const local_dof_size = local_x_.size();
+
+        _local_u.setZero();
+        for (unsigned i=0; i<local_dof_size; i++)
+            _local_u[_dofIndex_to_localIndex[i]] = local_x_[i];
+        _local_b.setZero();
+        _local_J.setZero();
+
+        assembleWithJacobian(t, _local_u, _local_b, _local_J);
+
+        local_b_data.resize(local_dof_size);
+        for (unsigned i=0; i<local_dof_size; i++)
+             local_b_data[i] = _local_b[_dofIndex_to_localIndex[i]];
+
+        local_Jac_data.resize(local_dof_size*local_dof_size);
+         for (unsigned i=0; i<local_dof_size; i++)
+             for (unsigned j=0; j<local_dof_size; j++)
+                 local_Jac_data[i*local_dof_size + j] = _local_J(_dofIndex_to_localIndex[i],
+                                                                 _dofIndex_to_localIndex[j]);
+    }
+
+    virtual void assembleWithJacobian(
+        double const t,
+        Eigen::VectorXd const& local_u,
+        Eigen::VectorXd& local_b,
+        Eigen::MatrixXd& local_J) {
+        (void)t;
+        (void)local_u;
+        (void)local_b;
+        (void)local_J;
+        OGS_FATAL("SmallDeformationLocalAssemblerInterface::assembleWithJacobian() is not implemented");
+    }
+
+    virtual std::vector<double> const& getIntPtSigmaXX(
+        std::vector<double>& cache) const = 0;
+
+    virtual std::vector<double> const& getIntPtSigmaYY(
+        std::vector<double>& cache) const = 0;
+
+    virtual std::vector<double> const& getIntPtSigmaZZ(
+        std::vector<double>& cache) const = 0;
+
+    virtual std::vector<double> const& getIntPtSigmaXY(
+        std::vector<double>& cache) const = 0;
+
+    virtual std::vector<double> const& getIntPtSigmaXZ(
+        std::vector<double>& cache) const = 0;
+
+    virtual std::vector<double> const& getIntPtSigmaYZ(
+        std::vector<double>& cache) const = 0;
+
+private:
+    Eigen::VectorXd _local_u;
+    Eigen::VectorXd _local_b;
+    Eigen::MatrixXd _local_J;
+    std::vector<unsigned> const _dofIndex_to_localIndex;
+};
+
+}  // namespace SmallDeformationWithLIE
+}  // namespace ProcessLib
+
+#endif  // PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLERINTERFACE_H_

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrix-impl.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrix-impl.h
@@ -1,0 +1,196 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLER_MATRIX_IMPL_H_
+#define PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLER_MATRIX_IMPL_H_
+
+#include "SmallDeformationLocalAssemblerMatrix.h"
+
+#include <valarray>
+#include <vector>
+
+#include <Eigen/Eigen>
+
+#include "MathLib/LinAlg/Eigen/EigenMapTools.h"
+
+#include "NumLib/Fem/ShapeMatrixPolicy.h"
+#include "ProcessLib/Deformation/BMatrixPolicy.h"
+#include "ProcessLib/Deformation/LinearBMatrix.h"
+#include "ProcessLib/Utils/InitShapeMatrices.h"
+
+#include "ProcessLib/SmallDeformationWithLIE/SmallDeformationProcessData.h"
+
+#include "IntegrationPointDataMatrix.h"
+#include "SecondaryData.h"
+#include "SmallDeformationLocalAssemblerInterface.h"
+
+namespace ProcessLib
+{
+namespace SmallDeformationWithLIE
+{
+template <typename ShapeFunction, typename IntegrationMethod,
+          int DisplacementDim>
+SmallDeformationLocalAssemblerMatrix<ShapeFunction, IntegrationMethod,
+                               DisplacementDim>::
+    SmallDeformationLocalAssemblerMatrix(
+        MeshLib::Element const& e,
+        std::size_t const /*local_matrix_size*/,
+        bool is_axially_symmetric,
+        unsigned const integration_order,
+        SmallDeformationProcessData<DisplacementDim>& process_data)
+    : _process_data(process_data),
+      _integration_method(integration_order),
+      _element(e)
+{
+    unsigned const n_integration_points =
+        _integration_method.getNumberOfPoints();
+
+    _ip_data.reserve(n_integration_points);
+    _secondary_data.N.resize(n_integration_points);
+
+    auto const shape_matrices =
+        initShapeMatrices<ShapeFunction, ShapeMatricesType,
+                          IntegrationMethod, DisplacementDim>(
+                e, is_axially_symmetric, _integration_method);
+
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        _ip_data.emplace_back(*_process_data._material);
+        auto& ip_data = _ip_data[ip];
+        auto const& sm = shape_matrices[ip];
+        ip_data._detJ = sm.detJ;
+        ip_data._integralMeasure = sm.integralMeasure;
+        ip_data._b_matrices.resize(
+            KelvinVectorDimensions<DisplacementDim>::value,
+            ShapeFunction::NPOINTS * DisplacementDim);
+
+        auto const x_coord =
+            interpolateXCoordinate<ShapeFunction, ShapeMatricesType>(e,
+                                                                     sm.N);
+        LinearBMatrix::computeBMatrix<DisplacementDim,
+                                      ShapeFunction::NPOINTS>(
+            sm.dNdx, ip_data._b_matrices, is_axially_symmetric, sm.N,
+            x_coord);
+
+        ip_data._sigma.resize(KelvinVectorDimensions<DisplacementDim>::value);
+        ip_data._sigma_prev.resize(
+            KelvinVectorDimensions<DisplacementDim>::value);
+        ip_data._eps.resize(KelvinVectorDimensions<DisplacementDim>::value);
+        ip_data._eps_prev.resize(
+            KelvinVectorDimensions<DisplacementDim>::value);
+        ip_data._C.resize(KelvinVectorDimensions<DisplacementDim>::value,
+                          KelvinVectorDimensions<DisplacementDim>::value);
+
+        _secondary_data.N[ip] = sm.N;
+    }
+}
+
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          int DisplacementDim>
+void SmallDeformationLocalAssemblerMatrix<ShapeFunction, IntegrationMethod,
+                                    DisplacementDim>::
+assembleWithJacobian(
+    double const t,
+    std::vector<double> const& local_x,
+    std::vector<double> const& /*local_xdot*/,
+    const double /*dxdot_dx*/, const double /*dx_dx*/,
+    std::vector<double>& /*local_M_data*/,
+    std::vector<double>& /*local_K_data*/,
+    std::vector<double>& local_b_data,
+    std::vector<double>& local_Jac_data)
+{
+    assert (_element.getDimension() == DisplacementDim);
+
+    auto const local_matrix_size = local_x.size();
+
+    auto local_Jac = MathLib::createZeroedMatrix<StiffnessMatrixType>(
+        local_Jac_data, local_matrix_size, local_matrix_size);
+
+    auto local_b = MathLib::createZeroedVector<NodalDisplacementVectorType>(
+        local_b_data, local_matrix_size);
+
+    unsigned const n_integration_points =
+        _integration_method.getNumberOfPoints();
+
+    SpatialPosition x_position;
+    x_position.setElementID(_element.getID());
+
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        x_position.setIntegrationPoint(ip);
+        auto const& wp = _integration_method.getWeightedPoint(ip);
+        auto const& detJ = _ip_data[ip]._detJ;
+        auto const& integralMeasure = _ip_data[ip]._integralMeasure;
+
+        auto const& B = _ip_data[ip]._b_matrices;
+        auto const& eps_prev = _ip_data[ip]._eps_prev;
+        auto const& sigma_prev = _ip_data[ip]._sigma_prev;
+
+        auto& eps = _ip_data[ip]._eps;
+        auto& sigma = _ip_data[ip]._sigma;
+        auto& C = _ip_data[ip]._C;
+        auto& material_state_variables =
+            *_ip_data[ip]._material_state_variables;
+
+        eps.noalias() =
+            B *
+            Eigen::Map<typename BMatricesType::NodalForceVectorType const>(
+                local_x.data(), ShapeFunction::NPOINTS * DisplacementDim);
+
+        if (!_ip_data[ip]._solid_material.computeConstitutiveRelation(
+                t, x_position, _process_data.dt, eps_prev, eps, sigma_prev,
+                sigma, C, material_state_variables))
+            OGS_FATAL("Computation of local constitutive relation failed.");
+
+        local_b.noalias() -=
+            B.transpose() * sigma * detJ * wp.getWeight() * integralMeasure;
+        local_Jac.noalias() +=
+            B.transpose() * C * B * detJ * wp.getWeight() * integralMeasure;
+    }
+}
+
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          int DisplacementDim>
+void SmallDeformationLocalAssemblerMatrix<ShapeFunction, IntegrationMethod,
+                                    DisplacementDim>::
+postTimestepConcrete(std::vector<double> const& /*local_x*/)
+{
+    const int n = 3;
+    std::valarray<double> ele_stress(0.0, n);
+    std::valarray<double> ele_strain(0.0, n);
+    unsigned const n_integration_points =
+        _integration_method.getNumberOfPoints();
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        auto& ip_data = _ip_data[ip];
+
+        ele_stress[0] += ip_data._sigma[0];
+        ele_stress[1] += ip_data._sigma[1];
+        ele_stress[2] += ip_data._sigma[3];
+
+        ele_strain[0] += ip_data._eps[0];
+        ele_strain[1] += ip_data._eps[1];
+        ele_strain[2] += ip_data._eps[3];
+    }
+    ele_stress /= n_integration_points;
+    ele_strain /= n_integration_points;
+    (*_process_data._mesh_prop_stress_xx)[_element.getID()] = ele_stress[0];
+    (*_process_data._mesh_prop_stress_yy)[_element.getID()] = ele_stress[1];
+    (*_process_data._mesh_prop_stress_xy)[_element.getID()] = ele_stress[2];
+    (*_process_data._mesh_prop_strain_xx)[_element.getID()] = ele_strain[0];
+    (*_process_data._mesh_prop_strain_yy)[_element.getID()] = ele_strain[1];
+    (*_process_data._mesh_prop_strain_xy)[_element.getID()] = ele_strain[2];
+}
+
+}  // namespace SmallDeformationWithLIE
+}  // namespace ProcessLib
+
+#endif  // PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLER_MATRIX_IMPL_H_

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
@@ -1,0 +1,170 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLER_MATRIX_H_
+#define PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLER_MATRIX_H_
+
+#include <vector>
+
+#include "NumLib/Fem/ShapeMatrixPolicy.h"
+#include "ProcessLib/Deformation/BMatrixPolicy.h"
+#include "ProcessLib/Deformation/LinearBMatrix.h"
+#include "ProcessLib/Utils/InitShapeMatrices.h"
+
+#include "ProcessLib/SmallDeformationWithLIE/SmallDeformationProcessData.h"
+
+#include "IntegrationPointDataMatrix.h"
+#include "SecondaryData.h"
+#include "SmallDeformationLocalAssemblerInterface.h"
+
+namespace ProcessLib
+{
+namespace SmallDeformationWithLIE
+{
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          int DisplacementDim>
+class SmallDeformationLocalAssemblerMatrix
+    : public SmallDeformationLocalAssemblerInterface
+{
+public:
+    using ShapeMatricesType =
+        ShapeMatrixPolicyType<ShapeFunction, DisplacementDim>;
+    using NodalMatrixType = typename ShapeMatricesType::NodalMatrixType;
+    using NodalVectorType = typename ShapeMatricesType::NodalVectorType;
+    using ShapeMatrices = typename ShapeMatricesType::ShapeMatrices;
+    using BMatricesType = BMatrixPolicyType<ShapeFunction, DisplacementDim>;
+
+    using BMatrixType = typename BMatricesType::BMatrixType;
+    using StiffnessMatrixType = typename BMatricesType::StiffnessMatrixType;
+    using NodalForceVectorType = typename BMatricesType::NodalForceVectorType;
+    using NodalDisplacementVectorType =
+        typename BMatricesType::NodalForceVectorType;
+
+    SmallDeformationLocalAssemblerMatrix(SmallDeformationLocalAssemblerMatrix const&) =
+        delete;
+    SmallDeformationLocalAssemblerMatrix(SmallDeformationLocalAssemblerMatrix&&) = delete;
+
+    SmallDeformationLocalAssemblerMatrix(
+        MeshLib::Element const& e,
+        std::size_t const local_matrix_size,
+        bool is_axially_symmetric,
+        unsigned const integration_order,
+        SmallDeformationProcessData<DisplacementDim>& process_data);
+
+    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+                  std::vector<double>& /*local_M_data*/,
+                  std::vector<double>& /*local_K_data*/,
+                  std::vector<double>& /*local_b_data*/) override
+    {
+        OGS_FATAL(
+            "SmallDeformationLocalAssembler: assembly without jacobian is not "
+            "implemented.");
+    }
+
+    void assembleWithJacobian(double const t,
+                              std::vector<double> const& local_x,
+                              std::vector<double> const& /*local_xdot*/,
+                              const double /*dxdot_dx*/, const double /*dx_dx*/,
+                              std::vector<double>& /*local_M_data*/,
+                              std::vector<double>& /*local_K_data*/,
+                              std::vector<double>& local_b_data,
+                              std::vector<double>& local_Jac_data) override;
+
+    void preTimestepConcrete(std::vector<double> const& /*local_x*/,
+                             double const /*t*/,
+                             double const /*delta_t*/) override
+    {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            _ip_data[ip].pushBackState();
+        }
+    }
+
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/) override;
+
+    Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
+        const unsigned integration_point) const override
+    {
+        auto const& N = _secondary_data.N[integration_point];
+
+        // assumes N is stored contiguously in memory
+        return Eigen::Map<const Eigen::RowVectorXd>(N.data(), N.size());
+    }
+
+    std::vector<double> const& getIntPtSigmaXX(
+        std::vector<double>& cache) const override
+    {
+        return getIntPtSigma(cache, 0);
+    }
+
+    std::vector<double> const& getIntPtSigmaYY(
+        std::vector<double>& cache) const override
+    {
+        return getIntPtSigma(cache, 1);
+    }
+
+    std::vector<double> const& getIntPtSigmaZZ(
+        std::vector<double>& cache) const override
+    {
+        return getIntPtSigma(cache, 2);
+    }
+
+    std::vector<double> const& getIntPtSigmaXY(
+        std::vector<double>& cache) const override
+    {
+        return getIntPtSigma(cache, 3);
+    }
+
+    std::vector<double> const& getIntPtSigmaXZ(
+        std::vector<double>& cache) const override
+    {
+        assert(DisplacementDim == 3);
+        return getIntPtSigma(cache, 4);
+    }
+
+    std::vector<double> const& getIntPtSigmaYZ(
+        std::vector<double>& cache) const override
+    {
+        assert(DisplacementDim == 3);
+        return getIntPtSigma(cache, 5);
+    }
+
+private:
+    std::vector<double> const& getIntPtSigma(std::vector<double>& cache,
+                                             std::size_t const component) const
+    {
+        cache.clear();
+        cache.reserve(_ip_data.size());
+
+        for (auto const& ip_data : _ip_data) {
+            cache.push_back(ip_data._sigma[component]);
+        }
+
+        return cache;
+    }
+
+    SmallDeformationProcessData<DisplacementDim>& _process_data;
+
+    std::vector<IntegrationPointDataMatrix<BMatricesType, DisplacementDim>> _ip_data;
+
+    IntegrationMethod _integration_method;
+    MeshLib::Element const& _element;
+    SecondaryData<typename ShapeMatrices::ShapeType> _secondary_data;
+};
+
+}  // namespace SmallDeformationWithLIE
+}  // namespace ProcessLib
+
+#include "SmallDeformationLocalAssemblerMatrix-impl.h"
+
+#endif  // PROCESSLIB_SMALLDEFORMATION_WITH_LIE_SMALLDEFORMATIONLOCALASSEMBLER_MATRIX_H_

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
@@ -1,0 +1,228 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include "SmallDeformationLocalAssemblerMatrixNearFracture.h"
+
+#include <valarray>
+#include <vector>
+
+#include <Eigen/Eigen>
+
+#include "MathLib/LinAlg/Eigen/EigenMapTools.h"
+#include "MathLib/Point3d.h"
+
+#include "MeshLib/Node.h"
+
+#include "NumLib/DOF/LocalToGlobalIndexMap.h"
+#include "NumLib/Fem/ShapeMatrixPolicy.h"
+
+
+#include "ProcessLib/Deformation/BMatrixPolicy.h"
+#include "ProcessLib/Deformation/LinearBMatrix.h"
+#include "ProcessLib/Utils/InitShapeMatrices.h"
+
+#include "ProcessLib/SmallDeformationWithLIE/Common/LevelSetFunction.h"
+#include "ProcessLib/SmallDeformationWithLIE/Common/Utils.h"
+
+#include "IntegrationPointDataMatrix.h"
+#include "SecondaryData.h"
+#include "SmallDeformationLocalAssemblerInterface.h"
+
+namespace ProcessLib
+{
+namespace SmallDeformationWithLIE
+{
+template <typename ShapeFunction, typename IntegrationMethod,
+          int DisplacementDim>
+SmallDeformationLocalAssemblerMatrixNearFracture<ShapeFunction, IntegrationMethod,
+                               DisplacementDim>::
+    SmallDeformationLocalAssemblerMatrixNearFracture(
+        MeshLib::Element const& e,
+        std::size_t const n_variables,
+        std::size_t const /*local_matrix_size*/,
+        std::vector<unsigned> const& dofIndex_to_localIndex,
+        bool is_axially_symmetric,
+        unsigned const integration_order,
+        SmallDeformationProcessData<DisplacementDim>& process_data)
+    : SmallDeformationLocalAssemblerInterface(
+          n_variables * ShapeFunction::NPOINTS * DisplacementDim,
+          dofIndex_to_localIndex),
+      _process_data(process_data),
+      _integration_method(integration_order),
+      _shape_matrices(
+          initShapeMatrices<ShapeFunction, ShapeMatricesType,
+                            IntegrationMethod, DisplacementDim>(
+              e, is_axially_symmetric, _integration_method)),
+      _element(e)
+{
+    unsigned const n_integration_points =
+        _integration_method.getNumberOfPoints();
+
+    _ip_data.reserve(n_integration_points);
+    _secondary_data.N.resize(n_integration_points);
+
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        _ip_data.emplace_back(*_process_data._material);
+        auto& ip_data = _ip_data[ip];
+        auto const& sm = _shape_matrices[ip];
+        ip_data._detJ = sm.detJ;
+        ip_data._integralMeasure = sm.integralMeasure;
+        ip_data._b_matrices.resize(
+            KelvinVectorDimensions<DisplacementDim>::value,
+            ShapeFunction::NPOINTS * DisplacementDim);
+
+        auto const x_coord =
+            interpolateXCoordinate<ShapeFunction, ShapeMatricesType>(e,
+                                                                     sm.N);
+        LinearBMatrix::computeBMatrix<DisplacementDim,
+                                      ShapeFunction::NPOINTS>(
+            sm.dNdx, ip_data._b_matrices, is_axially_symmetric, sm.N,
+            x_coord);
+
+        ip_data._sigma.resize(KelvinVectorDimensions<DisplacementDim>::value);
+        ip_data._sigma_prev.resize(
+            KelvinVectorDimensions<DisplacementDim>::value);
+        ip_data._eps.resize(KelvinVectorDimensions<DisplacementDim>::value);
+        ip_data._eps_prev.resize(
+            KelvinVectorDimensions<DisplacementDim>::value);
+        ip_data._C.resize(KelvinVectorDimensions<DisplacementDim>::value,
+                          KelvinVectorDimensions<DisplacementDim>::value);
+
+        _secondary_data.N[ip] = sm.N;
+    }
+}
+
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          int DisplacementDim>
+void SmallDeformationLocalAssemblerMatrixNearFracture<ShapeFunction, IntegrationMethod,
+                                    DisplacementDim>::
+assembleWithJacobian(
+    double const t,
+    Eigen::VectorXd const& local_u,
+    Eigen::VectorXd& local_b,
+    Eigen::MatrixXd& local_J)
+{
+    assert (_element.getDimension() == DisplacementDim);
+
+    auto const n_dof_per_var = ShapeFunction::NPOINTS * DisplacementDim;
+
+    auto localRhs_ru = local_b.segment(0, n_dof_per_var);
+    auto localRhs_du = local_b.segment(n_dof_per_var, n_dof_per_var);
+
+    auto localA_uu = local_J.block(0, 0, n_dof_per_var, n_dof_per_var);
+    auto localA_ug = local_J.block(0, n_dof_per_var, n_dof_per_var, n_dof_per_var);
+    auto localA_gu = local_J.block(n_dof_per_var, 0, n_dof_per_var, n_dof_per_var);
+    auto localA_gg = local_J.block(n_dof_per_var, n_dof_per_var, n_dof_per_var, n_dof_per_var);
+
+    auto const nodal_ru = local_u.segment(0, n_dof_per_var);
+    auto nodal_du = local_u.segment(n_dof_per_var, n_dof_per_var);
+
+    auto const &fracture_props = *_process_data._fracture_property;
+
+    unsigned const n_integration_points =
+        _integration_method.getNumberOfPoints();
+
+    SpatialPosition x_position;
+    x_position.setElementID(_element.getID());
+
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        x_position.setIntegrationPoint(ip);
+
+        auto const& sm = _shape_matrices[ip];
+        auto &ip_data = _ip_data[ip];
+        auto const& wp = _integration_method.getWeightedPoint(ip);
+        auto const& detJ = ip_data._detJ;
+        auto const& integralMeasure = ip_data._integralMeasure;
+
+        // levelset functions
+        auto const ip_physical_coords = computePhysicalCoordinates(_element, sm.N);
+        double levelsets = calculateLevelSetFunction(fracture_props, ip_physical_coords.getCoords());
+
+        // nodal displacement = u^hat + levelset* [u]
+        NodalDisplacementVectorType nodal_u = nodal_ru + levelsets * nodal_du;
+
+        // strain, stress
+        auto const& B = ip_data._b_matrices;
+        auto const& eps_prev = ip_data._eps_prev;
+        auto const& sigma_prev = ip_data._sigma_prev;
+
+        auto& eps = ip_data._eps;
+        auto& sigma = ip_data._sigma;
+        auto& C = ip_data._C;
+        auto& material_state_variables = *ip_data._material_state_variables;
+
+        eps.noalias() = B * nodal_u;
+
+        if (!ip_data._solid_material.computeConstitutiveRelation(
+                t, x_position, _process_data.dt, eps_prev, eps, sigma_prev,
+                sigma, C, material_state_variables))
+            OGS_FATAL("Computation of local constitutive relation failed.");
+
+        // r_ru = B^T Stress = B^T C B (u + phi*[u])
+        localRhs_ru.noalias() -= B.transpose() * sigma * detJ * wp.getWeight() * integralMeasure;
+
+        // r_[u] = (phi*B)^T Stress = (phi*B)^T C B (u + phi*[u])
+        localRhs_du.noalias() -= levelsets * B.transpose() * sigma * detJ * wp.getWeight() * integralMeasure;
+
+        // J_uu += B^T * C * B
+        localA_uu.noalias() += B.transpose() * C * B * detJ * wp.getWeight() * integralMeasure;
+
+        // J_u[u] += B^T * C * B * levelset
+        localA_ug.noalias() += B.transpose() * C * levelsets * B * detJ * wp.getWeight() * integralMeasure;
+
+        // J_[u]u += (levelset B)^T * C * B
+        localA_gu.noalias() += levelsets * B.transpose() * C * B * detJ * wp.getWeight() * integralMeasure;
+
+        // J_[u][u] += (levelset B)^T * C * (levelset B)
+        localA_gg.noalias() += levelsets * B.transpose() * C * levelsets * B * detJ * wp.getWeight() * integralMeasure;
+    }
+}
+
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          int DisplacementDim>
+void SmallDeformationLocalAssemblerMatrixNearFracture<ShapeFunction, IntegrationMethod,
+                                    DisplacementDim>::
+postTimestepConcrete(std::vector<double> const& /*local_x*/)
+{
+    const int n = 3;
+    std::valarray<double> ele_stress(0.0, n);
+    std::valarray<double> ele_strain(0.0, n);
+    unsigned const n_integration_points =
+        _integration_method.getNumberOfPoints();
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        auto& ip_data = _ip_data[ip];
+
+        ele_stress[0] += ip_data._sigma[0];
+        ele_stress[1] += ip_data._sigma[1];
+        ele_stress[2] += ip_data._sigma[3];
+
+        ele_strain[0] += ip_data._eps[0];
+        ele_strain[1] += ip_data._eps[1];
+        ele_strain[2] += ip_data._eps[3];
+    }
+    ele_stress /= n_integration_points;
+    ele_strain /= n_integration_points;
+    (*_process_data._mesh_prop_stress_xx)[_element.getID()] = ele_stress[0];
+    (*_process_data._mesh_prop_stress_yy)[_element.getID()] = ele_stress[1];
+    (*_process_data._mesh_prop_stress_xy)[_element.getID()] = ele_stress[2];
+    (*_process_data._mesh_prop_strain_xx)[_element.getID()] = ele_strain[0];
+    (*_process_data._mesh_prop_strain_yy)[_element.getID()] = ele_strain[1];
+    (*_process_data._mesh_prop_strain_xy)[_element.getID()] = ele_strain[2];
+}
+
+}  // namespace SmallDeformationWithLIE
+}  // namespace ProcessLib
+

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
@@ -1,0 +1,171 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "NumLib/Fem/ShapeMatrixPolicy.h"
+
+#include "ProcessLib/Deformation/BMatrixPolicy.h"
+#include "ProcessLib/Deformation/LinearBMatrix.h"
+#include "ProcessLib/Utils/InitShapeMatrices.h"
+
+#include "ProcessLib/SmallDeformationWithLIE/Common/FractureProperty.h"
+#include "ProcessLib/SmallDeformationWithLIE/SmallDeformationProcessData.h"
+
+#include "IntegrationPointDataMatrix.h"
+#include "SecondaryData.h"
+#include "SmallDeformationLocalAssemblerInterface.h"
+
+namespace ProcessLib
+{
+namespace SmallDeformationWithLIE
+{
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          int DisplacementDim>
+class SmallDeformationLocalAssemblerMatrixNearFracture
+    : public SmallDeformationLocalAssemblerInterface
+{
+public:
+    using ShapeMatricesType =
+        ShapeMatrixPolicyType<ShapeFunction, DisplacementDim>;
+    using NodalMatrixType = typename ShapeMatricesType::NodalMatrixType;
+    using NodalVectorType = typename ShapeMatricesType::NodalVectorType;
+    using ShapeMatrices = typename ShapeMatricesType::ShapeMatrices;
+    using BMatricesType = BMatrixPolicyType<ShapeFunction, DisplacementDim>;
+
+    using BMatrixType = typename BMatricesType::BMatrixType;
+    using StiffnessMatrixType = typename BMatricesType::StiffnessMatrixType;
+    using NodalForceVectorType = typename BMatricesType::NodalForceVectorType;
+    using NodalDisplacementVectorType =
+        typename BMatricesType::NodalForceVectorType;
+
+    SmallDeformationLocalAssemblerMatrixNearFracture(SmallDeformationLocalAssemblerMatrixNearFracture const&) =
+        delete;
+    SmallDeformationLocalAssemblerMatrixNearFracture(SmallDeformationLocalAssemblerMatrixNearFracture&&) = delete;
+
+    SmallDeformationLocalAssemblerMatrixNearFracture(
+        MeshLib::Element const& e,
+        std::size_t const n_variables,
+        std::size_t const local_matrix_size,
+        std::vector<unsigned> const& dofIndex_to_localIndex,
+        bool is_axially_symmetric,
+        unsigned const integration_order,
+        SmallDeformationProcessData<DisplacementDim>& process_data);
+
+    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+                  std::vector<double>& /*local_M_data*/,
+                  std::vector<double>& /*local_K_data*/,
+                  std::vector<double>& /*local_b_data*/) override
+    {
+        OGS_FATAL(
+            "SmallDeformationLocalAssembler: assembly without jacobian is not "
+            "implemented.");
+    }
+
+    void assembleWithJacobian(
+        double const t,
+        Eigen::VectorXd const& local_u,
+        Eigen::VectorXd& local_b,
+        Eigen::MatrixXd& local_J) override;
+
+    void preTimestepConcrete(std::vector<double> const& /*local_x*/,
+                             double const /*t*/,
+                             double const /*delta_t*/) override
+    {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            _ip_data[ip].pushBackState();
+        }
+    }
+
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/) override;
+
+    Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
+        const unsigned integration_point) const override
+    {
+        auto const& N = _secondary_data.N[integration_point];
+
+        // assumes N is stored contiguously in memory
+        return Eigen::Map<const Eigen::RowVectorXd>(N.data(), N.size());
+    }
+
+    std::vector<double> const& getIntPtSigmaXX(
+        std::vector<double>& cache) const override
+    {
+        return getIntPtSigma(cache, 0);
+    }
+
+    std::vector<double> const& getIntPtSigmaYY(
+        std::vector<double>& cache) const override
+    {
+        return getIntPtSigma(cache, 1);
+    }
+
+    std::vector<double> const& getIntPtSigmaZZ(
+        std::vector<double>& cache) const override
+    {
+        return getIntPtSigma(cache, 2);
+    }
+
+    std::vector<double> const& getIntPtSigmaXY(
+        std::vector<double>& cache) const override
+    {
+        return getIntPtSigma(cache, 3);
+    }
+
+    std::vector<double> const& getIntPtSigmaXZ(
+        std::vector<double>& cache) const override
+    {
+        assert(DisplacementDim == 3);
+        return getIntPtSigma(cache, 4);
+    }
+
+    std::vector<double> const& getIntPtSigmaYZ(
+        std::vector<double>& cache) const override
+    {
+        assert(DisplacementDim == 3);
+        return getIntPtSigma(cache, 5);
+    }
+
+private:
+    std::vector<double> const& getIntPtSigma(std::vector<double>& cache,
+                                             std::size_t const component) const
+    {
+        cache.clear();
+        cache.reserve(_ip_data.size());
+
+        for (auto const& ip_data : _ip_data) {
+            cache.push_back(ip_data._sigma[component]);
+        }
+
+        return cache;
+    }
+
+    SmallDeformationProcessData<DisplacementDim>& _process_data;
+
+    std::vector<IntegrationPointDataMatrix<BMatricesType, DisplacementDim>> _ip_data;
+
+    IntegrationMethod _integration_method;
+    std::vector<ShapeMatrices> _shape_matrices;
+
+    MeshLib::Element const& _element;
+    SecondaryData<typename ShapeMatrices::ShapeType> _secondary_data;
+};
+
+}  // namespace SmallDeformationWithLIE
+}  // namespace ProcessLib
+
+#include "SmallDeformationLocalAssemblerMatrixNearFracture-impl.h"
+


### PR DESCRIPTION
part of #1452, follow up of #1475, followed by #1476. ~~Relevant commits are d472a6a and 	3cdb30d~~

This PR includes 
- SmallDeformationLocalAssemblerInterface
- SmallDeformationLocalAssembler for matrix elements, matrix elements having fracture nodes, fracture elements

There are mainly two points to be remarked
- There are three local assemblers for 1) matrix elements (quad or triangle elements) including no fracture nodes,  2) matrix elements including fracture  nodes, and 3) fracture elements (line elements). Case 1) should be identical to the assembler of the standard SD process. Case 2 involves enrichment variables (i.e. displacement jumps) in addition to displacement variables. Case 3 deals only with the enrichment variables.
- In case 2 and 3, the size of local matrix is not equal to the number of element nodes multiplied by N, because additional DoFs are assigned to only fracture nodes. Therefore, I introduced a wrapper function to `assembleWithJacobian()` in `SmallDeformationLocalAssemblerInterface` such that actual local assembly routines do not need to know which nodes have the additional DoF or not.

TODO
- [ ] replace pragma once