### PR TITLE
Calculate surface flux; small fixes

### DIFF
--- a/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.cpp
+++ b/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.cpp
@@ -44,9 +44,15 @@ CalculateSurfaceFlux::CalculateSurfaceFlux(MeshLib::Mesh& boundary_mesh,
     auto const bulk_element_ids =
         boundary_mesh.getProperties().template getPropertyVector<std::size_t>(
             "OriginalSubsurfaceElementIDs");
+    if (!bulk_element_ids)
+        OGS_FATAL(
+            "OriginalSubsurfaceElementIDs boundary mesh property not found.");
     auto const bulk_face_ids =
         boundary_mesh.getProperties().template getPropertyVector<std::size_t>(
             "OriginalFaceIDs");
+    if (!bulk_face_ids)
+        OGS_FATAL("OriginalFaceIDs boundary mesh property not found.");
+
     const unsigned integration_order = 2;
     ProcessLib::createLocalAssemblers<CalculateSurfaceFluxLocalAssembler>(
         boundary_mesh.getDimension() + 1,  // or bulk_mesh.getDimension()?

--- a/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.cpp
+++ b/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.cpp
@@ -41,13 +41,12 @@ CalculateSurfaceFlux::CalculateSurfaceFlux(MeshLib::Mesh& boundary_mesh,
         new NumLib::LocalToGlobalIndexMap(std::move(all_mesh_subsets),
                                           NumLib::ComponentOrder::BY_LOCATION));
 
-    boost::optional<MeshLib::PropertyVector<std::size_t> const&>
-        bulk_element_ids(boundary_mesh.getProperties()
-                             .template getPropertyVector<std::size_t>(
-                                 "OriginalSubsurfaceElementIDs"));
-    boost::optional<MeshLib::PropertyVector<std::size_t> const&> bulk_face_ids(
+    auto const bulk_element_ids =
         boundary_mesh.getProperties().template getPropertyVector<std::size_t>(
-            "OriginalFaceIDs"));
+            "OriginalSubsurfaceElementIDs");
+    auto const bulk_face_ids =
+        boundary_mesh.getProperties().template getPropertyVector<std::size_t>(
+            "OriginalFaceIDs");
     const unsigned integration_order = 2;
     ProcessLib::createLocalAssemblers<CalculateSurfaceFluxLocalAssembler>(
         boundary_mesh.getDimension() + 1,  // or bulk_mesh.getDimension()?

--- a/ProcessLib/CalculateSurfaceFlux/MapBulkElementPoint.cpp
+++ b/ProcessLib/CalculateSurfaceFlux/MapBulkElementPoint.cpp
@@ -13,7 +13,7 @@
 
 namespace ProcessLib
 {
-MathLib::Point3d getBulkElementPoint(MeshLib::Quad const& quad,
+MathLib::Point3d getBulkElementPoint(MeshLib::Quad const& /*quad*/,
                                      std::size_t const face_id,
                                      MathLib::WeightedPoint1D const& wp)
 {
@@ -31,7 +31,7 @@ MathLib::Point3d getBulkElementPoint(MeshLib::Quad const& quad,
     }
 }
 
-MathLib::Point3d getBulkElementPoint(MeshLib::Hex const& hex,
+MathLib::Point3d getBulkElementPoint(MeshLib::Hex const& /*hex*/,
                                      std::size_t const face_id,
                                      MathLib::WeightedPoint2D const& wp)
 {
@@ -89,10 +89,10 @@ MathLib::Point3d getBulkElementPoint(MeshLib::Mesh const& mesh,
 }
 
 // TODO disable the 3d elements in the local assembler creator
-MathLib::Point3d getBulkElementPoint(MeshLib::Mesh const& mesh,
-                                     std::size_t bulk_element_id,
-                                     std::size_t bulk_face_id,
-                                     MathLib::WeightedPoint3D const& wp)
+MathLib::Point3d getBulkElementPoint(MeshLib::Mesh const& /*mesh*/,
+                                     std::size_t /*bulk_element_id*/,
+                                     std::size_t /*bulk_face_id*/,
+                                     MathLib::WeightedPoint3D const& /*wp*/)
 {
     return MathLib::ORIGIN;
 }

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -102,7 +102,7 @@ public:
         return _secondary_variables;
     }
 
-    // used as call back for CalculateSurfaceFlux process
+    // Used as a call back for CalculateSurfaceFlux process.
     virtual std::vector<double> getFlux(std::size_t /*element_id*/,
                                         MathLib::Point3d const& /*p*/,
                                         GlobalVector const& /*x*/) const


### PR DESCRIPTION
Fixing the boost::optional<T const&> usage, which causes compilation error when using boost-1.61.
Second one is small safety net feature.