### PR TITLE
Integration order in project files.

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -265,6 +265,10 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
         //! \ogs_file_param{process__name}
         auto const name = process_config.getConfigParameter<std::string>("name");
 
+        auto const integration_order =
+            //! \ogs_file_param{process__integration_order}
+            process_config.getConfigParameter<int>("integration_order");
+
         std::unique_ptr<ProcessLib::Process> process;
 
         auto jacobian_assembler = ProcessLib::createJacobianAssembler(
@@ -280,20 +284,22 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
             // here.
             process = ProcessLib::GroundwaterFlow::createGroundwaterFlowProcess(
                 *_mesh_vec[0], std::move(jacobian_assembler),
-                _process_variables, _parameters, process_config,
-                project_directory, output_directory);
+                _process_variables, _parameters, integration_order,
+                process_config, project_directory, output_directory);
         }
         else if (type == "TES")
         {
             process = ProcessLib::TES::createTESProcess(
                 *_mesh_vec[0], std::move(jacobian_assembler),
-                _process_variables, _parameters, process_config);
+                _process_variables, _parameters, integration_order,
+                process_config);
         }
         else if (type == "HEAT_CONDUCTION")
         {
             process = ProcessLib::HeatConduction::createHeatConductionProcess(
                 *_mesh_vec[0], std::move(jacobian_assembler),
-                _process_variables, _parameters, process_config);
+                _process_variables, _parameters, integration_order,
+                process_config);
         }
         else if (type == "SMALL_DEFORMATION")
         {
@@ -304,13 +310,15 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                     process = ProcessLib::SmallDeformation::
                         createSmallDeformationProcess<2>(
                             *_mesh_vec[0], std::move(jacobian_assembler),
-                            _process_variables, _parameters, process_config);
+                            _process_variables, _parameters, integration_order,
+                            process_config);
                     break;
                 case 3:
                     process = ProcessLib::SmallDeformation::
                         createSmallDeformationProcess<3>(
                             *_mesh_vec[0], std::move(jacobian_assembler),
-                            _process_variables, _parameters, process_config);
+                            _process_variables, _parameters, integration_order,
+                            process_config);
                     break;
                 default:
                     OGS_FATAL(

--- a/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.cpp
+++ b/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.cpp
@@ -15,8 +15,10 @@
 
 namespace ProcessLib
 {
-CalculateSurfaceFlux::CalculateSurfaceFlux(MeshLib::Mesh& boundary_mesh,
-                               std::size_t bulk_property_number_of_components)
+CalculateSurfaceFlux::CalculateSurfaceFlux(
+    MeshLib::Mesh& boundary_mesh,
+    std::size_t bulk_property_number_of_components,
+    unsigned const integration_order)
 {
     DBUG("Create local balance assemblers.");
     // Populate the vector of local assemblers.
@@ -53,7 +55,6 @@ CalculateSurfaceFlux::CalculateSurfaceFlux(MeshLib::Mesh& boundary_mesh,
     if (!bulk_face_ids)
         OGS_FATAL("OriginalFaceIDs boundary mesh property not found.");
 
-    const unsigned integration_order = 2;
     ProcessLib::createLocalAssemblers<CalculateSurfaceFluxLocalAssembler>(
         boundary_mesh.getDimension() + 1,  // or bulk_mesh.getDimension()?
         boundary_mesh.getElements(), *dof_table, _local_assemblers,

--- a/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.h
+++ b/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.h
@@ -22,8 +22,10 @@ public:
     /// @param mesh This mesh represents the boundary that is integrated over.
     /// @param bulk_property_number_of_components The number of components the
     /// variable has.
+    /// @param integration_order Integration order used in local assembly.
     CalculateSurfaceFlux(MeshLib::Mesh& boundary_mesh,
-                   std::size_t bulk_property_number_of_components);
+                         std::size_t bulk_property_number_of_components,
+                         unsigned const integration_order);
 
     /// Executes for each element of the mesh the local intergration procedure.
     /// @param x The global solution the intergration values will be fetched of.

--- a/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
@@ -26,6 +26,7 @@ std::unique_ptr<Process> createGroundwaterFlowProcess(
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    unsigned const integration_order,
     BaseLib::ConfigTree const& config,
     std::string const& project_directory,
     std::string const& output_directory)
@@ -88,7 +89,7 @@ std::unique_ptr<Process> createGroundwaterFlowProcess(
     }
 
     return std::unique_ptr<Process>{new GroundwaterFlowProcess{
-        mesh, std::move(jacobian_assembler), parameters,
+        mesh, std::move(jacobian_assembler), parameters, integration_order,
         std::move(process_variables), std::move(process_data),
         std::move(secondary_variables), std::move(named_function_caller),
         surface_mesh.release(), std::move(balance_pv_name),

--- a/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.h
@@ -23,6 +23,7 @@ std::unique_ptr<Process> createGroundwaterFlowProcess(
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    unsigned const integration_order,
     BaseLib::ConfigTree const& config,
     std::string const& project_directory,
     std::string const& output_directory);

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -21,6 +21,7 @@ GroundwaterFlowProcess::GroundwaterFlowProcess(
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    unsigned const integration_order,
     std::vector<std::reference_wrapper<ProcessVariable>>&& process_variables,
     GroundwaterFlowProcessData&& process_data,
     SecondaryVariableCollection&& secondary_variables,
@@ -29,8 +30,8 @@ GroundwaterFlowProcess::GroundwaterFlowProcess(
     std::string&& balance_pv_name,
     std::string&& balance_out_fname)
     : Process(mesh, std::move(jacobian_assembler), parameters,
-              std::move(process_variables), std::move(secondary_variables),
-              std::move(named_function_caller)),
+              integration_order, std::move(process_variables),
+              std::move(secondary_variables), std::move(named_function_caller)),
       _process_data(std::move(process_data)),
       _balance_mesh(balance_mesh),
       _balance_pv_name(std::move(balance_pv_name)),

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -73,7 +73,8 @@ public:
                                        init_values);
             auto balance = ProcessLib::CalculateSurfaceFlux(
                 *_balance_mesh,
-                getProcessVariables()[0].get().getNumberOfComponents());
+                getProcessVariables()[0].get().getNumberOfComponents(),
+                _integration_order);
 
             boost::optional<MeshLib::PropertyVector<double>&> balance_pv(
                 _balance_mesh->getProperties()

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -34,6 +34,7 @@ public:
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,
         std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+        unsigned const integration_order,
         std::vector<std::reference_wrapper<ProcessVariable>>&&
             process_variables,
         GroundwaterFlowProcessData&& process_data,

--- a/ProcessLib/HeatConduction/CreateHeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/CreateHeatConductionProcess.cpp
@@ -23,6 +23,7 @@ std::unique_ptr<Process> createHeatConductionProcess(
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    unsigned const integration_order,
     BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{process__type}
@@ -73,7 +74,7 @@ std::unique_ptr<Process> createHeatConductionProcess(
                                         named_function_caller);
 
     return std::unique_ptr<Process>{new HeatConductionProcess{
-        mesh, std::move(jacobian_assembler), parameters,
+        mesh, std::move(jacobian_assembler), parameters, integration_order,
         std::move(process_variables), std::move(process_data),
         std::move(secondary_variables), std::move(named_function_caller)}};
 }

--- a/ProcessLib/HeatConduction/CreateHeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/CreateHeatConductionProcess.h
@@ -22,6 +22,7 @@ std::unique_ptr<Process> createHeatConductionProcess(
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    unsigned const integration_order,
     BaseLib::ConfigTree const& config);
 
 }  // namespace HeatConduction

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -21,13 +21,14 @@ HeatConductionProcess::HeatConductionProcess(
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    unsigned const integration_order,
     std::vector<std::reference_wrapper<ProcessVariable>>&& process_variables,
     HeatConductionProcessData&& process_data,
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller)
     : Process(mesh, std::move(jacobian_assembler), parameters,
-              std::move(process_variables), std::move(secondary_variables),
-              std::move(named_function_caller)),
+              integration_order, std::move(process_variables),
+              std::move(secondary_variables), std::move(named_function_caller)),
       _process_data(std::move(process_data))
 {
 }

--- a/ProcessLib/HeatConduction/HeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.h
@@ -28,6 +28,7 @@ public:
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,
         std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+        unsigned const integration_order,
         std::vector<std::reference_wrapper<ProcessVariable>>&&
             process_variables,
         HeatConductionProcessData&& process_data,

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -30,8 +30,8 @@ Process::Process(
       _secondary_variables(std::move(secondary_variables)),
       _named_function_caller(std::move(named_function_caller)),
       _global_assembler(std::move(jacobian_assembler)),
-      _process_variables(std::move(process_variables)),
       _integration_order(integration_order),
+      _process_variables(std::move(process_variables)),
       _boundary_conditions(parameters)
 {
 }

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -22,6 +22,7 @@ Process::Process(
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    unsigned const integration_order,
     std::vector<std::reference_wrapper<ProcessVariable>>&& process_variables,
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller)
@@ -30,6 +31,7 @@ Process::Process(
       _named_function_caller(std::move(named_function_caller)),
       _global_assembler(std::move(jacobian_assembler)),
       _process_variables(std::move(process_variables)),
+      _integration_order(integration_order),
       _boundary_conditions(parameters)
 {
 }

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -181,8 +181,9 @@ protected:
 
     VectorMatrixAssembler _global_assembler;
 
-private:
     unsigned const _integration_order;
+
+private:
     GlobalSparsityPattern _sparsity_pattern;
 
     /// Variables used by this process.

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -40,15 +40,14 @@ public:
     using NonlinearSolver = NumLib::NonlinearSolverBase;
     using TimeDiscretization = NumLib::TimeDiscretization;
 
-    Process(
-        MeshLib::Mesh& mesh,
-        std::unique_ptr<AbstractJacobianAssembler>&&
-            jacobian_assembler,
-        std::vector<std::unique_ptr<ParameterBase>> const& parameters,
-        std::vector<std::reference_wrapper<ProcessVariable>>&&
-            process_variables,
-        SecondaryVariableCollection&& secondary_variables,
-        NumLib::NamedFunctionCaller&& named_function_caller);
+    Process(MeshLib::Mesh& mesh,
+            std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
+            std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+            unsigned const integration_order,
+            std::vector<std::reference_wrapper<ProcessVariable>>&&
+                process_variables,
+            SecondaryVariableCollection&& secondary_variables,
+            NumLib::NamedFunctionCaller&& named_function_caller);
 
     /// Preprocessing before starting assembly for new timestep.
     void preTimestep(GlobalVector const& x, const double t,
@@ -183,7 +182,7 @@ protected:
     VectorMatrixAssembler _global_assembler;
 
 private:
-    unsigned const _integration_order = 2;
+    unsigned const _integration_order;
     GlobalSparsityPattern _sparsity_pattern;
 
     /// Variables used by this process.

--- a/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.cpp
@@ -35,6 +35,7 @@ createSmallDeformationProcess(
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    unsigned const integration_order,
     BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{process__type}
@@ -104,7 +105,7 @@ createSmallDeformationProcess(
 
     return std::unique_ptr<SmallDeformationProcess<DisplacementDim>>{
         new SmallDeformationProcess<DisplacementDim>{
-            mesh, std::move(jacobian_assembler), parameters,
+            mesh, std::move(jacobian_assembler), parameters, integration_order,
             std::move(process_variables), std::move(process_data),
             std::move(secondary_variables), std::move(named_function_caller)}};
 }
@@ -114,6 +115,7 @@ template std::unique_ptr<Process> createSmallDeformationProcess<2>(
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    unsigned const integration_order,
     BaseLib::ConfigTree const& config);
 
 template std::unique_ptr<Process> createSmallDeformationProcess<3>(
@@ -121,6 +123,7 @@ template std::unique_ptr<Process> createSmallDeformationProcess<3>(
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    unsigned const integration_order,
     BaseLib::ConfigTree const& config);
 
 }  // namespace SmallDeformation

--- a/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.h
@@ -23,6 +23,7 @@ std::unique_ptr<Process> createSmallDeformationProcess(
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    unsigned const integration_order,
     BaseLib::ConfigTree const& config);
 
 }  // namespace SmallDeformation

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -33,13 +33,15 @@ public:
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,
         std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+        unsigned const integration_order,
         std::vector<std::reference_wrapper<ProcessVariable>>&&
             process_variables,
         SmallDeformationProcessData<DisplacementDim>&& process_data,
         SecondaryVariableCollection&& secondary_variables,
         NumLib::NamedFunctionCaller&& named_function_caller)
         : Process(mesh, std::move(jacobian_assembler), parameters,
-                  std::move(process_variables), std::move(secondary_variables),
+                  integration_order, std::move(process_variables),
+                  std::move(secondary_variables),
                   std::move(named_function_caller)),
           _process_data(std::move(process_data))
     {

--- a/ProcessLib/TES/CreateTESProcess.cpp
+++ b/ProcessLib/TES/CreateTESProcess.cpp
@@ -21,6 +21,7 @@ std::unique_ptr<Process> createTESProcess(
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    unsigned const integration_order,
     BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{process__type}
@@ -41,7 +42,7 @@ std::unique_ptr<Process> createTESProcess(
                                         named_function_caller);
 
     return std::unique_ptr<Process>{new TESProcess{
-        mesh, std::move(jacobian_assembler), parameters,
+        mesh, std::move(jacobian_assembler), parameters, integration_order,
         std::move(process_variables), std::move(secondary_variables),
         std::move(named_function_caller), config}};
 }

--- a/ProcessLib/TES/CreateTESProcess.h
+++ b/ProcessLib/TES/CreateTESProcess.h
@@ -22,6 +22,7 @@ std::unique_ptr<Process> createTESProcess(
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterBase>> const& /*parameters*/,
+    unsigned const integration_order,
     BaseLib::ConfigTree const& config);
 
 }  // namespace TES

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -20,13 +20,14 @@ TESProcess::TESProcess(
     MeshLib::Mesh& mesh,
     std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    unsigned const integration_order,
     std::vector<std::reference_wrapper<ProcessVariable>>&& process_variables,
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller,
     const BaseLib::ConfigTree& config)
     : Process(mesh, std::move(jacobian_assembler), parameters,
-              std::move(process_variables), std::move(secondary_variables),
-              std::move(named_function_caller))
+              integration_order, std::move(process_variables),
+              std::move(secondary_variables), std::move(named_function_caller))
 {
     DBUG("Create TESProcess.");
 

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -31,15 +31,15 @@ namespace TES
 class TESProcess final : public Process
 {
 public:
-    TESProcess(
-        MeshLib::Mesh& mesh,
-        std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
-        std::vector<std::unique_ptr<ParameterBase>> const& parameters,
-        std::vector<std::reference_wrapper<ProcessVariable>>&&
-            process_variables,
-        SecondaryVariableCollection&& secondary_variables,
-        NumLib::NamedFunctionCaller&& named_function_caller,
-        BaseLib::ConfigTree const& config);
+    TESProcess(MeshLib::Mesh& mesh,
+               std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
+               std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+               unsigned const integration_order,
+               std::vector<std::reference_wrapper<ProcessVariable>>&&
+                   process_variables,
+               SecondaryVariableCollection&& secondary_variables,
+               NumLib::NamedFunctionCaller&& named_function_caller,
+               BaseLib::ConfigTree const& config);
 
     void preTimestepConcreteProcess(GlobalVector const& x, const double t,
                                     const double delta_t) override;


### PR DESCRIPTION
Until now the integration order was hardcoded into default value of 2 in Process class.
I introduced a new tag `<integration_order>` for each `<process>` which is parsed and propagated to the `Process` ctor.