### PR TITLE
[CMake] Added dependency from ctest to its test executable.

### DIFF
--- a/scripts/cmake/test/AddTest.cmake
+++ b/scripts/cmake/test/AddTest.cmake
@@ -185,6 +185,11 @@ function (AddTest)
         -P ${PROJECT_SOURCE_DIR}/scripts/cmake/test/AddTestWrapper.cmake
     )
 
+    if(TARGET ${AddTest_EXECUTABLE})
+        add_dependencies(ctest ${AddTest_EXECUTABLE})
+        add_dependencies(ctest-large ${AddTest_EXECUTABLE})
+    endif()
+
     if(NOT AddTest_TESTER OR OGS_COVERAGE)
         return()
     endif()


### PR DESCRIPTION
This allows for:

```bash
cmake ../ogs -DOGS_BUILD_UTILS=ON
make ctest
```

This will build the required executables bedore running the tests.

Fixes missing executables on clang-sanitizer Jenkins job.