### PR TITLE
[Jenkins] Run doxygen job in Ubuntu 16.04 container.

### DIFF
--- a/scripts/jenkins/docs.groovy
+++ b/scripts/jenkins/docs.groovy
@@ -6,7 +6,7 @@ node('docker') {
     stage 'Checkout (Docs)'
     dir('ogs') { checkout scm }
 
-    docker.image('ogs6/gcc-gui:latest').inside() {
+    docker.image('ogs6/gcc-base:16.04').inside() {
         stage 'Configure (Docs)'
         configure.linux 'build', "${defaultCMakeOptions}"
 


### PR DESCRIPTION
16.04 has a more up-to-date doxygen package and so this
fixes some non-html-ized characters in the navigation.