### PR TITLE
Change create/getPropertyVector to return a pointer.

### DIFF
--- a/Applications/DataExplorer/DataView/CreateStructuredGridDialog.cpp
+++ b/Applications/DataExplorer/DataView/CreateStructuredGridDialog.cpp
@@ -256,10 +256,10 @@ void CreateStructuredGridDialog::accept()
         return;
     }
 
-    boost::optional<MeshLib::PropertyVector<int>&> mat_ids (
-        mesh->getProperties().createNewPropertyVector<int>("MaterialIDs", MeshLib::MeshItemType::Cell));
-    mat_ids->reserve(mesh->getNumberOfElements());
-    std::fill_n(std::back_inserter(*mat_ids), mesh->getNumberOfElements(), 0);
+    auto* const mat_ids = mesh->getProperties().createNewPropertyVector<int>(
+        "MaterialIDs", MeshLib::MeshItemType::Cell);
+    assert(mat_ids != nullptr);
+    mat_ids->resize(mesh->getNumberOfElements());
     emit meshAdded(mesh);
     this->done(QDialog::Accepted);
 }

--- a/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
+++ b/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
@@ -97,9 +97,10 @@ const std::vector< std::pair<std::size_t,double> >& DirectConditionGenerator::di
     const std::size_t nNodes(surface_mesh->getNumberOfNodes());
     const double no_data(raster->getHeader().no_data);
 
-    boost::optional<MeshLib::PropertyVector<int>&> const opt_node_id_pv(
-        surface_mesh->getProperties().getPropertyVector<int>(prop_name));
-    if (!opt_node_id_pv) {
+    auto const* const node_id_pv =
+        surface_mesh->getProperties().getPropertyVector<int>(prop_name);
+    if (!node_id_pv)
+    {
         ERR(
             "Need subsurface node ids, but the property \"%s\" is not "
             "available.",
@@ -107,13 +108,13 @@ const std::vector< std::pair<std::size_t,double> >& DirectConditionGenerator::di
         return _direct_values;
     }
 
-    MeshLib::PropertyVector<int> const& node_id_pv(*opt_node_id_pv);
     _direct_values.reserve(nNodes);
     for (std::size_t i=0; i<nNodes; ++i)
     {
         double val(raster->getValueAtPoint(*surface_nodes[i]));
         val = (val == no_data) ? 0 : ((val*node_area_vec[i])/scaling);
-        _direct_values.push_back(std::pair<std::size_t, double>(node_id_pv[i], val));
+        _direct_values.push_back(
+            std::pair<std::size_t, double>((*node_id_pv)[i], val));
     }
 
     return _direct_values;

--- a/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
@@ -171,20 +171,25 @@ void MeshElementRemovalDialog::on_materialIDCheckBox_toggled(bool is_checked)
         materialListWidget->clear();
         _matIDIndex = _currentIndex;
         auto mesh = _project.getMesh(meshNameComboBox->currentText().toStdString());
-        auto const opt_mat_ids = mesh->getProperties().getPropertyVector<int>("MaterialIDs");
-        if (!opt_mat_ids) {
+        auto const* const mat_ids =
+            mesh->getProperties().getPropertyVector<int>("MaterialIDs");
+        if (!mat_ids)
+        {
             INFO("Properties \"MaterialIDs\" not found in the mesh \"%s\".",
                 mesh->getName().c_str());
             return;
         }
-        auto const& mat_ids = opt_mat_ids.get();
-        if (mat_ids.size() != mesh->getNumberOfElements()) {
-            INFO("Size mismatch: Properties \"MaterialIDs\" contains %u values,"
-                " the mesh \"%s\" contains %u elements.", mat_ids.size(),
-                mesh->getName().c_str(), mesh->getNumberOfElements());
+        if (mat_ids->size() != mesh->getNumberOfElements())
+        {
+            INFO(
+                "Size mismatch: Properties \"MaterialIDs\" contains %u values,"
+                " the mesh \"%s\" contains %u elements.",
+                mat_ids->size(), mesh->getName().c_str(),
+                mesh->getNumberOfElements());
             return;
         }
-        auto max_material = std::max_element(mat_ids.cbegin(), mat_ids.cend());
+        auto max_material =
+            std::max_element(mat_ids->cbegin(), mat_ids->cend());
 
         for (unsigned i=0; i <= static_cast<unsigned>(*max_material); ++i)
             materialListWidget->addItem(QString::number(i));
@@ -200,7 +205,8 @@ void MeshElementRemovalDialog::on_meshNameComboBox_currentIndexChanged(int idx)
     this->materialListWidget->clearSelection();
     if (this->boundingBoxCheckBox->isChecked()) this->on_boundingBoxCheckBox_toggled(true);
     auto mesh = _project.getMesh(meshNameComboBox->currentText().toStdString());
-    auto materialIds = mesh->getProperties().getPropertyVector<int>("MaterialIDs");
+    auto const* const materialIds =
+        mesh->getProperties().getPropertyVector<int>("MaterialIDs");
     if (materialIds)
     {
         if (materialIds->size() != mesh->getNumberOfElements())

--- a/Applications/FileIO/GMSInterface.cpp
+++ b/Applications/FileIO/GMSInterface.cpp
@@ -325,8 +325,7 @@ MeshLib::Mesh* GMSInterface::readGMS3DMMesh(const std::string &filename)
     MeshLib::Properties properties;
     if (mat_ids.size() == elements.size())
     {
-        boost::optional<MeshLib::PropertyVector<int> &> opt_pv
-            = properties.createNewPropertyVector<int>(
+        auto* const opt_pv = properties.createNewPropertyVector<int>(
             "MaterialIDs", MeshLib::MeshItemType::Cell);
         if (!opt_pv)
         {

--- a/Applications/FileIO/Gmsh/GmshReader.cpp
+++ b/Applications/FileIO/Gmsh/GmshReader.cpp
@@ -244,16 +244,17 @@ MeshLib::Mesh* readGMSHMesh(std::string const& fname)
     MeshLib::Mesh * mesh(new MeshLib::Mesh(
         BaseLib::extractBaseNameWithoutExtension(fname), nodes, elements));
 
-    boost::optional<MeshLib::PropertyVector<int> &> opt_material_ids(
+    auto* const material_ids =
         mesh->getProperties().createNewPropertyVector<int>(
-            "MaterialIDs", MeshLib::MeshItemType::Cell, 1)
-    );
-    if (!opt_material_ids) {
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1);
+    if (!material_ids)
+    {
         WARN("Could not create PropertyVector for MaterialIDs in Mesh.");
-    } else {
-        MeshLib::PropertyVector<int> & material_ids(opt_material_ids.get());
-        material_ids.insert(material_ids.end(), materials.cbegin(),
-            materials.cend());
+    }
+    else
+    {
+        material_ids->insert(material_ids->end(), materials.cbegin(),
+                             materials.cend());
     }
 
     MeshLib::ElementValueModification::condense(*mesh);

--- a/Applications/FileIO/SWMM/SWMMInterface.cpp
+++ b/Applications/FileIO/SWMM/SWMMInterface.cpp
@@ -781,8 +781,8 @@ bool SwmmInterface::readSwmmInputToLineMesh()
     }
 
     MeshLib::Properties props;
-    boost::optional< MeshLib::PropertyVector<int>& > mat_ids =
-        props.createNewPropertyVector<int>("MaterialIDs", MeshLib::MeshItemType::Cell, 1);
+    auto* const mat_ids = props.createNewPropertyVector<int>(
+        "MaterialIDs", MeshLib::MeshItemType::Cell, 1);
     mat_ids->resize(elements.size(), 0);
     for (std::size_t i=1; i<n_types; ++i)
     {
@@ -792,8 +792,8 @@ bool SwmmInterface::readSwmmInputToLineMesh()
 
     if (nodes.size() == max_depth.size())
     {
-        boost::optional< MeshLib::PropertyVector<double>& > depth =
-            props.createNewPropertyVector<double>("Max Depth", MeshLib::MeshItemType::Node, 1);
+        auto* const depth = props.createNewPropertyVector<double>(
+            "Max Depth", MeshLib::MeshItemType::Node, 1);
         depth->reserve(max_depth.size());
         std::copy(max_depth.cbegin(), max_depth.cend(), std::back_inserter(*depth));
     }
@@ -971,7 +971,7 @@ bool SwmmInterface::addResultsToMesh(MeshLib::Mesh &mesh, SwmmObject const swmm_
     MeshLib::Properties& p = mesh.getProperties();
     MeshLib::MeshItemType item_type = (swmm_type == SwmmObject::NODE) ?
         MeshLib::MeshItemType::Node : MeshLib::MeshItemType::Cell;
-    boost::optional<MeshLib::PropertyVector<double>&> prop =
+    auto* const prop =
         p.createNewPropertyVector<double>(vec_name, item_type, 1);
     if (!prop)
     {

--- a/Applications/FileIO/TetGenInterface.cpp
+++ b/Applications/FileIO/TetGenInterface.cpp
@@ -231,9 +231,8 @@ MeshLib::Mesh* TetGenInterface::readTetGenMesh (std::string const& nodes_fname,
     // Transmit material values if there is any material value != 0
     if (std::any_of(materials.cbegin(), materials.cend(), [](int m){ return m != 0; }))
     {
-        boost::optional<MeshLib::PropertyVector<int>&> mat_props =
-            properties.createNewPropertyVector<int>(
-                "MaterialIDs", MeshLib::MeshItemType::Cell);
+        auto* const mat_props = properties.createNewPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell);
         mat_props->reserve(elements.size());
         std::copy(materials.cbegin(),
                   materials.cend(),
@@ -615,12 +614,14 @@ void TetGenInterface::write2dElements(std::ofstream &out,
     out << nTotalTriangles << " 1\n";
 
     const std::vector<MeshLib::Element*> &elements = mesh.getElements();
-    boost::optional< MeshLib::PropertyVector<int> const&> materialIds (mesh.getProperties().getPropertyVector<int>("MaterialIDs"));
+    auto const* const materialIds =
+        mesh.getProperties().getPropertyVector<int>("MaterialIDs");
     const std::size_t nElements (elements.size());
     unsigned element_count(0);
     for (std::size_t i=0; i<nElements; ++i)
     {
-        std::string matId = (materialIds) ? std::to_string((*materialIds)[i]) : "";
+        std::string matId =
+            materialIds ? std::to_string((*materialIds)[i]) : "";
         this->writeElementToFacets(out, *elements[i], element_count, matId);
     }
 }
@@ -638,7 +639,8 @@ void TetGenInterface::write3dElements(std::ofstream &out,
     const std::streamoff before_elems_pos (out.tellp());
     const unsigned n_spaces (static_cast<unsigned>(std::floor(log(nElements*8))) + 1);
     out << std::string(n_spaces, ' ') << " 1\n";
-    boost::optional< MeshLib::PropertyVector<int> const&> materialIds = mesh.getProperties().getPropertyVector<int>("MaterialIDs");
+    auto const* const materialIds =
+        mesh.getProperties().getPropertyVector<int>("MaterialIDs");
     unsigned element_count(0);
     for (std::size_t i=0; i<nElements; ++i)
     {
@@ -646,7 +648,8 @@ void TetGenInterface::write3dElements(std::ofstream &out,
             continue;
 
         const unsigned nFaces (elements[i]->getNumberOfNeighbors());
-        std::string const mat_id_str = (materialIds) ? std::to_string((*materialIds)[i]) : "";
+        std::string const mat_id_str =
+            materialIds ? std::to_string((*materialIds)[i]) : "";
         for (std::size_t j=0; j<nFaces; ++j)
         {
             MeshLib::Element const*const neighbor ( elements[i]->getNeighbor(j) );

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -79,17 +79,15 @@ template <typename PT>
 void resetMeshElementProperty(MeshLib::Mesh &mesh, GeoLib::Polygon const& polygon,
     std::string const& property_name, PT new_property_value)
 {
-    boost::optional<MeshLib::PropertyVector<PT> &> opt_pv(
-        mesh.getProperties().getPropertyVector<PT>(property_name)
-    );
-    if (!opt_pv) {
+    auto* const pv = mesh.getProperties().getPropertyVector<PT>(property_name);
+    if (!pv) {
         WARN("Did not find a PropertyVector with name \"%s\".",
             property_name.c_str());
         return;
     }
 
-    MeshLib::PropertyVector<PT> & pv(opt_pv.get());
-    if (pv.getMeshItemType() != MeshLib::MeshItemType::Cell) {
+    if (pv->getMeshItemType() != MeshLib::MeshItemType::Cell)
+    {
         ERR("Values of the PropertyVector are not assigned to cells.");
         return;
     }
@@ -108,7 +106,7 @@ void resetMeshElementProperty(MeshLib::Mesh &mesh, GeoLib::Polygon const& polygo
             }
         }
         if (!elem_out) {
-            pv[j] = new_property_value;
+            (*pv)[j] = new_property_value;
         }
     }
 }
@@ -206,14 +204,14 @@ int main (int argc, char* argv[])
         char new_property_val(char_property_arg.getValue());
 
         // check if PropertyVector exists
-        boost::optional<MeshLib::PropertyVector<char> &> opt_pv(
-            mesh->getProperties().getPropertyVector<char>(property_name)
-        );
-        if (!opt_pv) {
-            opt_pv = mesh->getProperties().createNewPropertyVector<char>(
+        auto* pv = mesh->getProperties().getPropertyVector<char>(property_name);
+        if (!pv)
+        {
+            pv = mesh->getProperties().createNewPropertyVector<char>(
                 property_name, MeshLib::MeshItemType::Cell, 1);
-            opt_pv.get().resize(mesh->getElements().size());
-            INFO("Created PropertyVector with name \"%s\".", property_name.c_str());
+            pv->resize(mesh->getElements().size());
+            INFO("Created PropertyVector with name \"%s\".",
+                 property_name.c_str());
         }
         resetMeshElementProperty(*mesh, polygon, property_name, new_property_val);
     }
@@ -222,13 +220,12 @@ int main (int argc, char* argv[])
         int int_property_val(int_property_arg.getValue());
 
         // check if PropertyVector exists
-        boost::optional<MeshLib::PropertyVector<int> &> opt_pv(
-            mesh->getProperties().getPropertyVector<int>(property_name)
-        );
-        if (!opt_pv) {
-            opt_pv = mesh->getProperties().createNewPropertyVector<int>(
+        auto* pv = mesh->getProperties().getPropertyVector<int>(property_name);
+        if (!pv)
+        {
+            pv = mesh->getProperties().createNewPropertyVector<int>(
                 property_name, MeshLib::MeshItemType::Cell, 1);
-            opt_pv.get().resize(mesh->getElements().size());
+            pv->resize(mesh->getElements().size());
             INFO("Created PropertyVector with name \"%s\".", property_name.c_str());
         }
 

--- a/Applications/Utils/ModelPreparation/ComputeNodeAreasFromSurfaceMesh.cpp
+++ b/Applications/Utils/ModelPreparation/ComputeNodeAreasFromSurfaceMesh.cpp
@@ -83,21 +83,22 @@ int main (int argc, char* argv[])
     // ToDo check if mesh is read correct and if the mesh is a surface mesh
 
     // check if a node property containing the subsurface ids is available
-    boost::optional<MeshLib::PropertyVector<std::size_t>&> orig_node_ids(
+    auto* orig_node_ids =
         surface_mesh->getProperties().getPropertyVector<std::size_t>(
-            id_prop_name.getValue()));
+            id_prop_name.getValue());
     // if the node property is not available generate it
-    if (!orig_node_ids) {
-        boost::optional<MeshLib::PropertyVector<std::size_t>&> node_ids(
+    if (!orig_node_ids)
+    {
+        orig_node_ids =
             surface_mesh->getProperties().createNewPropertyVector<std::size_t>(
-                id_prop_name.getValue(), MeshLib::MeshItemType::Node, 1));
-        if (!node_ids) {
+                id_prop_name.getValue(), MeshLib::MeshItemType::Node, 1);
+        if (!orig_node_ids)
+        {
             ERR("Fatal error: could not create property.");
             return EXIT_FAILURE;
         }
-        node_ids->resize(surface_mesh->getNumberOfNodes());
-        std::iota(node_ids->begin(), node_ids->end(), 0);
-        orig_node_ids = node_ids;
+        orig_node_ids->resize(surface_mesh->getNumberOfNodes());
+        std::iota(orig_node_ids->begin(), orig_node_ids->end(), 0);
     }
 
     std::vector<double> areas(

--- a/Applications/Utils/ModelPreparation/createNeumannBc.cpp
+++ b/Applications/Utils/ModelPreparation/createNeumannBc.cpp
@@ -38,8 +38,8 @@ std::vector<double> getSurfaceIntegratedValuesForNodes(
         return std::vector<double>();
     }
 
-    boost::optional<MeshLib::PropertyVector<double> const&> elem_pv(
-        mesh.getProperties().getPropertyVector<double>(prop_name));
+    auto const* const elem_pv =
+        mesh.getProperties().getPropertyVector<double>(prop_name);
     if (!elem_pv)
     {
         ERR("Need element property, but the property \"%s\" is not "
@@ -131,9 +131,8 @@ int main(int argc, char* argv[])
         MeshLib::IO::readMeshFromFile(in_mesh.getValue()));
 
     std::string const prop_name("OriginalSubsurfaceNodeIDs");
-    boost::optional<MeshLib::PropertyVector<std::size_t>&> const node_id_pv(
-        surface_mesh->getProperties().getPropertyVector<std::size_t>(
-            prop_name));
+    auto const* const node_id_pv =
+        surface_mesh->getProperties().getPropertyVector<std::size_t>(prop_name);
     if (!node_id_pv)
     {
         ERR(
@@ -156,10 +155,10 @@ int main(int argc, char* argv[])
         direct_values.push_back(std::make_pair(subsurface_node_id, val));
     }
 
-    boost::optional<MeshLib::PropertyVector<double>&> pv(
+    auto* const pv =
         surface_mesh->getProperties().createNewPropertyVector<double>(
-            property_out_arg.getValue(), MeshLib::MeshItemType::Node, 1));
-    (*pv).resize(surface_mesh->getNodes().size());
+            property_out_arg.getValue(), MeshLib::MeshItemType::Node, 1);
+    pv->resize(surface_mesh->getNodes().size());
     for (std::size_t k(0); k<surface_mesh->getNodes().size(); ++k) {
         (*pv)[k] = direct_values[k].second;
     }

--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -8,7 +8,11 @@
  *              http://www.opengeosys.org/LICENSE.txt
  */
 
-#include "MeshGeoToolsLib/MeshNodeSearcher.h"
+#include "MeshNodeSearcher.h"
+#include "HeuristicSearchLength.h"
+#include "MeshNodesAlongPolyline.h"
+#include "MeshNodesAlongSurface.h"
+#include "MeshNodesOnPoint.h"
 
 #include <logog/include/logog.hpp>
 
@@ -20,12 +24,6 @@
 #include "MeshLib/Elements/Element.h"
 #include "MeshLib/Mesh.h"
 #include "MeshLib/Node.h"
-
-// MeshGeoToolsLib
-#include "MeshGeoToolsLib/HeuristicSearchLength.h"
-#include "MeshGeoToolsLib/MeshNodesOnPoint.h"
-#include "MeshGeoToolsLib/MeshNodesAlongPolyline.h"
-#include "MeshGeoToolsLib/MeshNodesAlongSurface.h"
 
 namespace MeshGeoToolsLib
 {

--- a/MeshGeoToolsLib/MeshNodeSearcher.h
+++ b/MeshGeoToolsLib/MeshNodeSearcher.h
@@ -13,8 +13,6 @@
 #include <memory>
 #include <vector>
 
-#include <boost/optional.hpp>
-
 // GeoLib
 #include "GeoLib/Grid.h"
 

--- a/MeshLib/IO/Legacy/MeshIO.h
+++ b/MeshLib/IO/Legacy/MeshIO.h
@@ -18,17 +18,17 @@
 
 #include <string>
 #include <vector>
-#include <boost/optional.hpp>
 
 #include "BaseLib/IO/Writer.h"
 #include "MeshLib/MeshEnums.h"
-#include "MeshLib/PropertyVector.h"
 
 namespace MeshLib
 {
 class Mesh;
 class Node;
 class Element;
+template <typename T>
+class PropertyVector;
 enum class MeshElemType;
 namespace IO
 {
@@ -55,8 +55,8 @@ protected:
 
 private:
     void writeElements(std::vector<MeshLib::Element*> const& ele_vec,
-        boost::optional<MeshLib::PropertyVector<int> const&> material_ids,
-        std::ostream &out) const;
+                       MeshLib::PropertyVector<int> const* const material_ids,
+                       std::ostream& out) const;
     std::size_t readMaterialID(std::istream & in) const;
     MeshLib::Element* readElement(std::istream& line, const std::vector<MeshLib::Node*> &nodes) const;
     std::string ElemType2StringOutput(const MeshLib::MeshElemType t) const;

--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -257,10 +257,8 @@ void scaleMeshPropertyVector(MeshLib::Mesh & mesh,
                              std::string const& property_name,
                              double factor)
 {
-    boost::optional<MeshLib::PropertyVector<double> &> pv(
-        mesh.getProperties().getPropertyVector<double>(property_name));
-
-    for (auto & v : *pv)
+    for (auto& v :
+         *mesh.getProperties().getPropertyVector<double>(property_name))
         v *= factor;
 }
 

--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -215,9 +215,8 @@ void addPropertyToMesh(MeshLib::Mesh& mesh, std::string const& name,
                 mesh.getNumberOfElements(),
                 values.size() / number_of_components);
 
-    boost::optional<MeshLib::PropertyVector<T>&> property(
-        mesh.getProperties().createNewPropertyVector<T>(name, item_type,
-                                                        number_of_components));
+    auto* const property = mesh.getProperties().createNewPropertyVector<T>(
+        name, item_type, number_of_components);
     if (!property)
     {
         OGS_FATAL("Error while creating PropertyVector \"%s\".", name.c_str());

--- a/MeshLib/MeshEditing/ElementValueModification.h
+++ b/MeshLib/MeshEditing/ElementValueModification.h
@@ -17,15 +17,14 @@
 
 #include <vector>
 
-#include <boost/optional.hpp>
-
 #include "MeshLib/MeshEnums.h"
 #include "MeshLib/Mesh.h"
-#include "MeshLib/PropertyVector.h"
 
 namespace MeshLib {
 // forward declarations
 class Mesh;
+template <typename T>
+class PropertyVector;
 
 /**
  * \brief A set of methods for manipulating mesh element values

--- a/MeshLib/MeshEditing/MeshRevision.cpp
+++ b/MeshLib/MeshEditing/MeshRevision.cpp
@@ -63,14 +63,14 @@ MeshLib::Mesh* MeshRevision::simplifyMesh(const std::string &new_mesh_name,
     // original data
     std::vector<MeshLib::Element*> const& elements(this->_mesh.getElements());
     MeshLib::Properties const& properties(_mesh.getProperties());
-    boost::optional<MeshLib::PropertyVector<int> const&> material_vec(
-        properties.getPropertyVector<int>("MaterialIDs"));
+    auto const* const material_vec =
+        properties.getPropertyVector<int>("MaterialIDs");
 
     // data structures for the new mesh
     std::vector<MeshLib::Node*> new_nodes = this->constructNewNodesArray(this->collapseNodeIndices(eps));
     std::vector<MeshLib::Element*> new_elements;
     MeshLib::Properties new_properties;
-    boost::optional<PropertyVector<int> &> new_material_vec;
+    PropertyVector<int>* new_material_vec = nullptr;
     if (material_vec) {
         new_material_vec = new_properties.createNewPropertyVector<int>(
             "MaterialIDs", MeshItemType::Cell, 1);
@@ -134,14 +134,13 @@ MeshLib::Mesh* MeshRevision::subdivideMesh(const std::string &new_mesh_name) con
     // original data
     std::vector<MeshLib::Element*> const& elements(this->_mesh.getElements());
     MeshLib::Properties const& properties(_mesh.getProperties());
-    boost::optional<MeshLib::PropertyVector<int> const&> material_vec(
-        properties.getPropertyVector<int>("MaterialIDs"));
+    auto const* material_vec = properties.getPropertyVector<int>("MaterialIDs");
 
     // data structures for the new mesh
     std::vector<MeshLib::Node*> new_nodes = MeshLib::copyNodeVector(_mesh.getNodes());
     std::vector<MeshLib::Element*> new_elements;
     MeshLib::Properties new_properties;
-    boost::optional<PropertyVector<int> &> new_material_vec;
+    PropertyVector<int>* new_material_vec = nullptr;
     if (material_vec) {
         new_material_vec = new_properties.createNewPropertyVector<int>(
             "MaterialIDs", MeshItemType::Cell, 1

--- a/MeshLib/MeshGenerators/LayeredMeshGenerator.cpp
+++ b/MeshLib/MeshGenerators/LayeredMeshGenerator.cpp
@@ -57,10 +57,9 @@ LayeredMeshGenerator::getMesh(std::string const& mesh_name) const
     MeshLib::Properties properties;
     if (_materials.size() == _elements.size())
     {
-        boost::optional<MeshLib::PropertyVector<int>&> materials =
-            properties.createNewPropertyVector<int>(
-                "MaterialIDs", MeshLib::MeshItemType::Cell);
-        assert(materials != boost::none);
+        auto* const materials = properties.createNewPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell);
+        assert(materials != nullptr);
         materials->reserve(_materials.size());
         std::copy(_materials.cbegin(),
                   _materials.cend(),

--- a/MeshLib/MeshGenerators/MeshLayerMapper.cpp
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.cpp
@@ -60,9 +60,8 @@ MeshLib::Mesh* MeshLayerMapper::createStaticLayers(MeshLib::Mesh const& mesh, st
     std::vector<MeshLib::Element*> new_elems;
     new_elems.reserve(nElems * nLayers);
     MeshLib::Properties properties;
-    boost::optional<PropertyVector<int>&> materials =
-        properties.createNewPropertyVector<int>("MaterialIDs",
-                                                MeshLib::MeshItemType::Cell);
+    auto* const materials = properties.createNewPropertyVector<int>(
+        "MaterialIDs", MeshLib::MeshItemType::Cell);
     if (!materials)
     {
         ERR("Could not create PropertyVector object \"MaterialIDs\".");

--- a/MeshLib/MeshGenerators/RasterToMesh.cpp
+++ b/MeshLib/MeshGenerators/RasterToMesh.cpp
@@ -147,14 +147,14 @@ MeshLib::Mesh* RasterToMesh::constructMesh(
     MeshLib::Properties properties;
     if (intensity_type == MeshLib::UseIntensityAs::MATERIALS)
     {
-        boost::optional< MeshLib::PropertyVector<int>& > prop_vec =
-            properties.createNewPropertyVector<int>("MaterialIDs", MeshLib::MeshItemType::Cell, 1);
+        auto* const prop_vec = properties.createNewPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1);
         fillPropertyVector<int>(*prop_vec, pix_val, pix_vis, header.n_rows, header.n_cols, elem_type);
     }
     else if (intensity_type == MeshLib::UseIntensityAs::DATAVECTOR)
     {
-        boost::optional< MeshLib::PropertyVector<double>& > prop_vec =
-            properties.createNewPropertyVector<double>(array_name, MeshLib::MeshItemType::Cell, 1);
+        auto* const prop_vec = properties.createNewPropertyVector<double>(
+            array_name, MeshLib::MeshItemType::Cell, 1);
         fillPropertyVector<double>(*prop_vec, pix_val, pix_vis, header.n_rows, header.n_cols, elem_type);
     }
 

--- a/MeshLib/MeshGenerators/RasterToMesh.h
+++ b/MeshLib/MeshGenerators/RasterToMesh.h
@@ -11,14 +11,12 @@
 #ifndef RASTERTOMESH_H
 #define RASTERTOMESH_H
 
-#include <boost/optional.hpp>
 #include <logog/include/logog.hpp>
 
 #include "GeoLib/Raster.h"
 #include "MeshLib/Location.h"
 #include "MeshLib/MeshEnums.h"
 #include "MeshLib/Properties.h"
-#include "MeshLib/PropertyVector.h"
 
 class vtkImageData; // For conversion from Image to QuadMesh
 
@@ -27,6 +25,8 @@ namespace MeshLib {
 class Mesh;
 class Node;
 class Element;
+template <typename T>
+class PropertyVector;
 
 /**
  * \brief Converts raster data into an OGS mesh.

--- a/MeshLib/MeshGenerators/VtkMeshConverter.h
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.h
@@ -16,7 +16,6 @@
 #ifndef VTKMESHCONVERTER_H
 #define VTKMESHCONVERTER_H
 
-#include <boost/optional.hpp>
 #include <vtkDataArray.h>
 #include <vtkType.h>
 
@@ -105,8 +104,8 @@ private:
         int const nComponents (array.GetNumberOfComponents());
         char const*const array_name (array.GetName());
 
-        boost::optional<MeshLib::PropertyVector<T> &> vec
-            (properties.createNewPropertyVector<T>(array_name, type, nComponents));
+        auto* const vec = properties.createNewPropertyVector<T>(
+            array_name, type, nComponents);
         if (!vec)
         {
             WARN("Array %s could not be converted to PropertyVector.", array_name);

--- a/MeshLib/MeshInformation.h
+++ b/MeshLib/MeshInformation.h
@@ -38,8 +38,8 @@ public:
     static std::pair<T, T> const
         getValueBounds(MeshLib::Mesh const& mesh, std::string const& name)
     {
-        boost::optional<MeshLib::PropertyVector<T> const&> 
-            data_vec (mesh.getProperties().getPropertyVector<T>(name));
+        auto const* const data_vec =
+            mesh.getProperties().getPropertyVector<T>(name);
         if (!data_vec)
             return {std::numeric_limits<T>::max(), std::numeric_limits<T>::max()};
         if (data_vec->empty()) {

--- a/MeshLib/MeshSearch/ElementSearch.h
+++ b/MeshLib/MeshSearch/ElementSearch.h
@@ -48,24 +48,25 @@ public:
         PROPERTY_TYPE const property_value,
         std::string const& property_name = "MaterialIDs")
     {
-        boost::optional<MeshLib::PropertyVector<PROPERTY_TYPE> const&> opt_pv(
+        auto const* const pv =
             _mesh.getProperties().getPropertyVector<PROPERTY_TYPE>(
-                property_name));
-        if (!opt_pv) {
+                property_name);
+        if (!pv)
+        {
             WARN("Property \"%s\" not found in mesh.", property_name.c_str());
             return 0;
         }
 
-        MeshLib::PropertyVector<PROPERTY_TYPE> const& pv(opt_pv.get());
-        if (pv.getMeshItemType() != MeshLib::MeshItemType::Cell) {
+        if (pv->getMeshItemType() != MeshLib::MeshItemType::Cell)
+        {
             WARN("The property \"%s\" is not assigned to mesh elements.",
                  property_name.c_str());
             return 0;
         }
 
         std::vector<std::size_t> matchedIDs;
-        for (std::size_t i(0); i < pv.getNumberOfTuples(); ++i) {
-            if (pv[i] == property_value)
+        for (std::size_t i(0); i < pv->getNumberOfTuples(); ++i) {
+            if ((*pv)[i] == property_value)
                 matchedIDs.push_back(i);
         }
 

--- a/MeshLib/Properties-impl.h
+++ b/MeshLib/Properties-impl.h
@@ -10,10 +10,9 @@
  *
  */
 
-
 template <typename T>
-boost::optional<PropertyVector<T> &>
-Properties::createNewPropertyVector(std::string const& name,
+PropertyVector<T>* Properties::createNewPropertyVector(
+    std::string const& name,
     MeshItemType mesh_item_type,
     std::size_t n_components)
 {
@@ -23,7 +22,7 @@ Properties::createNewPropertyVector(std::string const& name,
     if (it != _properties.end()) {
         ERR("A property of the name \"%s\" is already assigned to the mesh.",
             name.c_str());
-        return boost::optional<PropertyVector<T> &>();
+        return nullptr;
     }
     auto entry_info(
         _properties.insert(
@@ -32,15 +31,12 @@ Properties::createNewPropertyVector(std::string const& name,
             )
         )
     );
-    return boost::optional<PropertyVector<T> &>(*(
-            static_cast<PropertyVector<T>*>((entry_info.first)->second)
-        )
-    );
+    return static_cast<PropertyVector<T>*>((entry_info.first)->second);
 }
 
 template <typename T>
-boost::optional<PropertyVector<T> &>
-Properties::createNewPropertyVector(std::string const& name,
+PropertyVector<T>* Properties::createNewPropertyVector(
+    std::string const& name,
     std::size_t n_prop_groups,
     std::vector<std::size_t> const& item2group_mapping,
     MeshItemType mesh_item_type,
@@ -54,7 +50,7 @@ Properties::createNewPropertyVector(std::string const& name,
     if (it != _properties.end()) {
         ERR("A property of the name \"%s\" already assigned to the mesh.",
             name.c_str());
-        return boost::optional<PropertyVector<T> &>();
+        return nullptr;
     }
 
     // check entries of item2group_mapping for consistence
@@ -62,7 +58,7 @@ Properties::createNewPropertyVector(std::string const& name,
         std::size_t const group_id (item2group_mapping[k]);
         if (group_id >= n_prop_groups) {
             ERR("The mapping to property %d for item %d is not in the correct range [0,%d).", group_id, k, n_prop_groups);
-            return boost::optional<PropertyVector<T> &>();
+            return nullptr;
         }
     }
 
@@ -75,47 +71,37 @@ Properties::createNewPropertyVector(std::string const& name,
             )
         )
     );
-    return boost::optional<PropertyVector<T> &>
-        (*(static_cast<PropertyVector<T>*>((entry_info.first)->second)));
+    return static_cast<PropertyVector<T>*>((entry_info.first)->second);
 }
 
 template <typename T>
-boost::optional<PropertyVector<T> const&>
-Properties::getPropertyVector(std::string const& name) const
+PropertyVector<T> const* Properties::getPropertyVector(
+    std::string const& name) const
 {
     std::map<std::string, PropertyVectorBase*>::const_iterator it(
-        _properties.find(name)
-    );
-    if (it == _properties.end()) {
+        _properties.find(name));
+    if (it == _properties.end())
+    {
         ERR("A property with the specified name \"%s\" is not available.",
             name.c_str());
-        return boost::optional<PropertyVector<T> const&>();
+        return nullptr;
     }
 
-    PropertyVector<T> const* t=dynamic_cast<PropertyVector<T>const*>(it->second);
-    if (!t) {
-        return boost::optional<PropertyVector<T> const&>();
-    }
-    return *t;
+    return dynamic_cast<PropertyVector<T> const*>(it->second);
 }
 
 template <typename T>
-boost::optional<PropertyVector<T>&>
-Properties::getPropertyVector(std::string const& name)
+PropertyVector<T>* Properties::getPropertyVector(std::string const& name)
 {
     std::map<std::string, PropertyVectorBase*>::iterator it(
-        _properties.find(name)
-    );
-    if (it == _properties.end()) {
+        _properties.find(name));
+    if (it == _properties.end())
+    {
         ERR("A property with the specified name \"%s\" is not available.",
             name.c_str());
-        return boost::optional<PropertyVector<T>&>();
+        return nullptr;
     }
 
-    PropertyVector<T> *t=dynamic_cast<PropertyVector<T>*>(it->second);
-    if (!t) {
-        return boost::optional<PropertyVector<T> &>();
-    }
-    return *t;
+    return dynamic_cast<PropertyVector<T>*>(it->second);
 }
 

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -18,8 +18,6 @@
 #include <string>
 #include <map>
 
-#include <boost/optional.hpp>
-
 #include <logog/include/logog.hpp>
 
 #include "Location.h"
@@ -42,28 +40,25 @@ class Properties
 public:
     /// Method creates a PropertyVector if a PropertyVector with the same name
     /// and the same type T was not already created before. In case there exists
-    /// already such a PropertyVector the returned boost::optional holds an
-    /// invalid/unusable PropertyVector.
-    /// There are two versions of this method. This method is used
-    /// when every mesh item at hand has its own property value, i.e. \f$n\f$
-    /// mesh item and \f$n\f$ different property values.
+    /// already such a PropertyVector a nullptr is returned.
+    /// There are two versions of this method. This method is used when every
+    /// mesh item at hand has its own property value, i.e. \f$n\f$ mesh item and
+    /// \f$n\f$ different property values.
     /// The user has to ensure the correct usage of the vector later on.
     /// @tparam T type of the property value
     /// @param name the name of the property
     /// @param mesh_item_type for instance node or element assigned properties
     /// @param n_components number of components for each tuple
-    /// @return On success a reference to a PropertyVector packed into a
-    ///   boost::optional else an empty boost::optional.
+    /// @return A pointer to a PropertyVector on success and a nullptr
+    /// otherwise.
     template <typename T>
-    boost::optional<PropertyVector<T> &>
-    createNewPropertyVector(std::string const& name,
-        MeshItemType mesh_item_type,
-        std::size_t n_components = 1);
+    PropertyVector<T>* createNewPropertyVector(std::string const& name,
+                                               MeshItemType mesh_item_type,
+                                               std::size_t n_components = 1);
 
     /// Method creates a PropertyVector if a PropertyVector with the same name
     /// and the same type T was not already created before. In case there exists
-    /// already such a PropertyVector the returned boost::optional holds an
-    /// invalid/unusable PropertyVector.
+    /// already such a PropertyVector a nullptr is returned.
     /// This method is used if only a small number of distinct property values
     /// in a property exist (e.g. mapping property groups to elements).
     /// In this case a mapping between mesh items and properties (stored
@@ -75,25 +70,25 @@ public:
     /// group
     /// @param mesh_item_type for instance node or element assigned properties
     /// @param n_components number of components for each tuple
-    /// @return On success a reference to a PropertyVector packed into a
-    ///   boost::optional else an empty boost::optional.
+    /// @return A pointer to a PropertyVector on success and a nullptr
+    /// otherwise.
     template <typename T>
-    boost::optional<PropertyVector<T> &>
-    createNewPropertyVector(std::string const& name,
+    PropertyVector<T>* createNewPropertyVector(
+        std::string const& name,
         std::size_t n_prop_groups,
         std::vector<std::size_t> const& item2group_mapping,
         MeshItemType mesh_item_type,
         std::size_t n_components = 1);
 
-    /// Method to get a vector of property values.
+    /// Returns a property vector with given \c name or nullptr if no such
+    /// property vector exists.
     template <typename T>
-    boost::optional<PropertyVector<T> const&>
-    getPropertyVector(std::string const& name) const;
+    PropertyVector<T> const* getPropertyVector(std::string const& name) const;
 
-    /// Method to get a vector of property values.
+    /// Returns a property vector with given \c name or nullptr if no such
+    /// property vector exists.
     template <typename T>
-    boost::optional<PropertyVector<T>&>
-    getPropertyVector(std::string const& name);
+    PropertyVector<T>* getPropertyVector(std::string const& name);
 
     void removePropertyVector(std::string const& name);
 

--- a/MeshLib/Vtk/VtkMappedMeshSource.h
+++ b/MeshLib/Vtk/VtkMappedMeshSource.h
@@ -26,8 +26,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/optional.hpp>
-
 #include <vtkCellData.h>
 #include <vtkPointData.h>
 #include <vtkNew.h>
@@ -88,8 +86,7 @@ private:
     bool addProperty(MeshLib::Properties const& properties,
                      std::string const& prop_name) const
     {
-        boost::optional<MeshLib::PropertyVector<T> const &> propertyVector(
-            properties.getPropertyVector<T>(prop_name));
+        auto* const propertyVector = properties.getPropertyVector<T>(prop_name);
         if(!propertyVector)
             return false;
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -76,9 +76,9 @@ public:
                 getProcessVariables()[0].get().getNumberOfComponents(),
                 _integration_order);
 
-            boost::optional<MeshLib::PropertyVector<double>&> balance_pv(
+            auto* const balance_pv =
                 _balance_mesh->getProperties()
-                    .template getPropertyVector<double>(_balance_pv_name));
+                    .template getPropertyVector<double>(_balance_pv_name);
 
             balance.integrate(x, *balance_pv, *this);
             // post: surface_mesh has vectorial element property

--- a/ProcessLib/ProcessOutput.cpp
+++ b/ProcessLib/ProcessOutput.cpp
@@ -135,7 +135,7 @@ void doProcessOutput(
         std::string const& property_name, MeshLib::MeshItemType type)
     {
         // Get or create a property vector for results.
-        boost::optional<MeshLib::PropertyVector<double>&> result;
+        MeshLib::PropertyVector<double>* result = nullptr;
 
         auto const N = count_mesh_items(mesh, type);
 

--- a/Tests/FileIO_SWMM/TestSwmmInterface.cpp
+++ b/Tests/FileIO_SWMM/TestSwmmInterface.cpp
@@ -58,7 +58,7 @@ TEST(FileIO, TestSwmmInterface)
     ASSERT_EQ(n_nodes, mesh.getNumberOfNodes());
     ASSERT_EQ(n_elems, mesh.getNumberOfElements());
 
-    boost::optional<MeshLib::PropertyVector<double> const&> depth =
+    auto const* const depth =
         mesh.getProperties().getPropertyVector<double>("Max Depth");
     ASSERT_TRUE(n_nodes == depth->size());
     ASSERT_NEAR((*depth)[1], 2*(*depth)[0], std::numeric_limits<double>::epsilon());

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -40,15 +40,13 @@ TEST_F(MeshLibProperties, PropertyVectorTestMetaData)
     ASSERT_TRUE(mesh != nullptr);
 
     std::string const prop_name("TestProperty");
-    boost::optional<MeshLib::PropertyVector<double> &> p(
-        mesh->getProperties().createNewPropertyVector<double>(prop_name,
-            MeshLib::MeshItemType::Cell)
-    );
+    auto const* const p = mesh->getProperties().createNewPropertyVector<double>(
+        prop_name, MeshLib::MeshItemType::Cell);
 
-    ASSERT_EQ(0u, (*p).getPropertyName().compare(prop_name));
-    ASSERT_EQ(MeshLib::MeshItemType::Cell, (*p).getMeshItemType());
-    ASSERT_EQ(1u, (*p).getNumberOfComponents());
-    ASSERT_EQ(0u, (*p).size());
+    ASSERT_EQ(0u, p->getPropertyName().compare(prop_name));
+    ASSERT_EQ(MeshLib::MeshItemType::Cell, p->getMeshItemType());
+    ASSERT_EQ(1u, p->getNumberOfComponents());
+    ASSERT_EQ(0u, p->size());
 }
 
 TEST_F(MeshLibProperties, AddDoubleProperties)
@@ -57,23 +55,21 @@ TEST_F(MeshLibProperties, AddDoubleProperties)
     const std::size_t size(mesh_size*mesh_size*mesh_size);
 
     std::string const prop_name("TestProperty");
-    boost::optional<MeshLib::PropertyVector<double> &> double_properties(
-        mesh->getProperties().createNewPropertyVector<double>(prop_name,
-            MeshLib::MeshItemType::Cell)
-    );
-    ASSERT_EQ(0u, (*double_properties).size());
+    auto* const double_properties =
+        mesh->getProperties().createNewPropertyVector<double>(
+            prop_name, MeshLib::MeshItemType::Cell);
+    ASSERT_EQ(0u, double_properties->size());
 
-    (*double_properties).resize(size);
-    ASSERT_EQ(size, (*double_properties).size());
+    double_properties->resize(size);
+    ASSERT_EQ(size, double_properties->size());
 
-    std::iota((*double_properties).begin(), (*double_properties).end(), 1);
+    std::iota(double_properties->begin(), double_properties->end(), 1);
     for (std::size_t k(0); k<size; k++) {
         ASSERT_EQ(static_cast<double>(k+1), (*double_properties)[k]);
     }
 
-    boost::optional<MeshLib::PropertyVector<double>&> const
-    double_properties_cpy(
-        mesh->getProperties().getPropertyVector<double>(prop_name));
+    auto* const double_properties_cpy =
+        mesh->getProperties().getPropertyVector<double>(prop_name);
     ASSERT_FALSE(!double_properties_cpy);
 
     for (std::size_t k(0); k<size; k++) {
@@ -81,9 +77,8 @@ TEST_F(MeshLibProperties, AddDoubleProperties)
     }
 
     mesh->getProperties().removePropertyVector(prop_name);
-    boost::optional<MeshLib::PropertyVector<double>&> const
-    removed_double_properties(
-        mesh->getProperties().getPropertyVector<double>(prop_name));
+    auto* const removed_double_properties =
+        mesh->getProperties().getPropertyVector<double>(prop_name);
 
     ASSERT_TRUE(!removed_double_properties);
 }
@@ -115,17 +110,15 @@ TEST_F(MeshLibProperties, AddDoublePointerProperties)
         }
     }
     // obtain PropertyVector data structure
-    boost::optional<MeshLib::PropertyVector<double*> &> group_properties(
+    auto* const group_properties =
         mesh->getProperties().createNewPropertyVector<double*>(
             prop_name, n_prop_val_groups, prop_item2group_mapping,
-            MeshLib::MeshItemType::Cell
-        )
-    );
-    ASSERT_EQ(prop_item2group_mapping.size(), (*group_properties).size());
+            MeshLib::MeshItemType::Cell);
+    ASSERT_EQ(prop_item2group_mapping.size(), group_properties->size());
 
     // initialize the property values
     for (std::size_t i(0); i<n_prop_val_groups; i++) {
-        (*group_properties).initPropertyValue(i, static_cast<double>(i+1));
+        group_properties->initPropertyValue(i, static_cast<double>(i+1));
     }
     // check mapping to values
     for (std::size_t i(0); i<n_prop_val_groups; i++) {
@@ -148,9 +141,8 @@ TEST_F(MeshLibProperties, AddDoublePointerProperties)
     // the mesh should have the property assigned to cells
     ASSERT_TRUE(mesh->getProperties().hasPropertyVector(prop_name));
     // fetch the properties from the container
-    boost::optional<MeshLib::PropertyVector<double*>&> const
-    group_properties_cpy(
-        mesh->getProperties().getPropertyVector<double*>(prop_name));
+    auto const* const group_properties_cpy =
+        mesh->getProperties().getPropertyVector<double*>(prop_name);
     ASSERT_FALSE(!group_properties_cpy);
 
     for (std::size_t k(0); k<n_items; k++) {
@@ -158,9 +150,8 @@ TEST_F(MeshLibProperties, AddDoublePointerProperties)
     }
 
     mesh->getProperties().removePropertyVector(prop_name);
-    boost::optional<MeshLib::PropertyVector<double*>&> const
-    removed_group_properties(
-        mesh->getProperties().getPropertyVector<double*>(prop_name));
+    auto const* const removed_group_properties =
+        mesh->getProperties().getPropertyVector<double*>(prop_name);
 
     ASSERT_TRUE(!removed_group_properties);
 }
@@ -188,18 +179,15 @@ TEST_F(MeshLibProperties, AddArrayPointerProperties)
             prop_item2group_mapping[k] = j;
         }
     }
-    boost::optional<MeshLib::PropertyVector<std::array<double,3>*> &>
-        group_prop_vec(
-            mesh->getProperties().createNewPropertyVector<std::array<double,3>*>(
-                prop_name, n_prop_val_groups, prop_item2group_mapping,
-                MeshLib::MeshItemType::Cell
-            )
-        );
+    auto* const group_prop_vec =
+        mesh->getProperties().createNewPropertyVector<std::array<double, 3>*>(
+            prop_name, n_prop_val_groups, prop_item2group_mapping,
+            MeshLib::MeshItemType::Cell);
     ASSERT_EQ(prop_item2group_mapping.size(), group_prop_vec->size());
 
     // initialize the property values
     for (std::size_t i(0); i<n_prop_val_groups; i++) {
-        (*group_prop_vec).initPropertyValue(i,
+        group_prop_vec->initPropertyValue(i,
             std::array<double,3>({{static_cast<double>(i),
                 static_cast<double>(i+1),
                 static_cast<double>(i+2)}}
@@ -228,10 +216,9 @@ TEST_F(MeshLibProperties, AddArrayPointerProperties)
         }
     }
 
-    boost::optional<MeshLib::PropertyVector<std::array<double, 3>*>&> const
-    group_properties_cpy(
+    auto* const group_properties_cpy =
         mesh->getProperties().getPropertyVector<std::array<double, 3>*>(
-            prop_name));
+            prop_name);
     ASSERT_FALSE(!group_properties_cpy);
 
     for (std::size_t k(0); k<n_items; k++) {
@@ -244,10 +231,9 @@ TEST_F(MeshLibProperties, AddArrayPointerProperties)
     }
 
     mesh->getProperties().removePropertyVector(prop_name);
-    boost::optional<MeshLib::PropertyVector<std::array<double, 3>*>&> const
-    removed_group_properties(
+    auto const* const removed_group_properties =
         mesh->getProperties().getPropertyVector<std::array<double, 3>*>(
-            prop_name));
+            prop_name);
 
     ASSERT_TRUE(!removed_group_properties);
 }
@@ -279,16 +265,13 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
         }
     }
     // create data structure for the property
-    boost::optional<MeshLib::PropertyVector<std::array<double,3>*> &>
-        group_properties(
-            mesh->getProperties().createNewPropertyVector<std::array<double,3>*>(
-                prop_name, n_prop_val_groups, prop_item2group_mapping,
-                MeshLib::MeshItemType::Cell
-            )
-        );
+    auto* const group_properties =
+        mesh->getProperties().createNewPropertyVector<std::array<double, 3>*>(
+            prop_name, n_prop_val_groups, prop_item2group_mapping,
+            MeshLib::MeshItemType::Cell);
     // initialize the property values
     for (std::size_t i(0); i<n_prop_val_groups; i++) {
-        (*group_properties).initPropertyValue(i,
+        group_properties->initPropertyValue(i,
             std::array<double,3>({{static_cast<double>(i),
                 static_cast<double>(i+1),
                 static_cast<double>(i+2)}}
@@ -300,10 +283,9 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
     ASSERT_TRUE(mesh->getProperties().hasPropertyVector(prop_name));
 
     // fetch the vector filled with property values from mesh
-    boost::optional<MeshLib::PropertyVector<std::array<double, 3>*>&> const
-    group_properties_cpy(
+    auto const* const group_properties_cpy =
         mesh->getProperties().getPropertyVector<std::array<double, 3>*>(
-            prop_name));
+            prop_name);
     ASSERT_FALSE(!group_properties_cpy);
     // compare the content
     const std::size_t n_elements(mesh_size*mesh_size*mesh_size);
@@ -321,13 +303,11 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
     // check if the property is already assigned to the mesh
     ASSERT_FALSE(mesh->getProperties().hasPropertyVector(prop_name_2));
     const std::size_t n_items_2(mesh_size*mesh_size*mesh_size);
-    boost::optional<MeshLib::PropertyVector<std::array<float,9>> &>
-        array_properties(mesh->getProperties().createNewPropertyVector<
-            std::array<float,9>
-        > (prop_name_2, MeshLib::MeshItemType::Cell)
-    );
+    auto* const array_properties =
+        mesh->getProperties().createNewPropertyVector<std::array<float, 9>>(
+            prop_name_2, MeshLib::MeshItemType::Cell);
 
-    (*array_properties).resize(n_items_2);
+    array_properties->resize(n_items_2);
 
     // initialize the property values
     for (std::size_t i(0); i<n_items_2; i++) {
@@ -343,10 +323,9 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
     ASSERT_TRUE(mesh->getProperties().hasPropertyVector(prop_name_2));
 
     // fetch the vector in order to compare the content
-    boost::optional<MeshLib::PropertyVector<std::array<float,9>> &>const
-        array_properties_cpy(mesh->getProperties().getPropertyVector<std::array<float,9>>(
-            prop_name_2)
-    );
+    auto const* const array_properties_cpy =
+        mesh->getProperties().getPropertyVector<std::array<float, 9>>(
+            prop_name_2);
     ASSERT_FALSE(!array_properties_cpy);
 
     // compare the values/matrices
@@ -360,14 +339,14 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
     std::string const& prop_name_3("ItemwiseEigenMatrixProperties");
     // check if the property is already assigned to the mesh
     ASSERT_FALSE(mesh->getProperties().hasPropertyVector(prop_name_3));
-    boost::optional<
-        MeshLib::PropertyVector<Eigen::Matrix<double,3,3,Eigen::RowMajor>> &>
-    matrix_properties(mesh->getProperties().createNewPropertyVector
-        <Eigen::Matrix<double,3,3,Eigen::RowMajor>> (
-            prop_name_3, MeshLib::MeshItemType::Cell)
-    );
+    auto* const matrix_properties =
+        mesh->getProperties()
+            .createNewPropertyVector<
+                Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>(
+                prop_name_3, MeshLib::MeshItemType::Cell);
     // init property values
-    for (auto it=matrix_properties->begin(); it != matrix_properties->end(); it++)
+    for (auto it = matrix_properties->begin(); it != matrix_properties->end();
+         it++)
     {
         for (int r(0); r<it->rows(); r++) {
             for (int c(0); c<it->cols(); c++) {
@@ -381,18 +360,17 @@ TEST_F(MeshLibProperties, AddVariousDifferentProperties)
     ASSERT_TRUE(mesh->getProperties().hasPropertyVector(prop_name_3));
 
     // fetch the vector in order to compare the content
-    boost::optional<MeshLib::PropertyVector<
-        Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>&> const
-    matrix_properties_cpy(
+    auto const* const matrix_properties_cpy =
         mesh->getProperties()
             .getPropertyVector<Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>(
-                prop_name_3));
+                prop_name_3);
     ASSERT_FALSE(!matrix_properties_cpy);
 
     // compare the values/matrices
-    auto it_cpy=matrix_properties_cpy->begin();
-    for (auto it=matrix_properties->begin(); it != matrix_properties->end();
-        it++, it_cpy++) {
+    auto it_cpy = matrix_properties_cpy->begin();
+    for (auto it = matrix_properties->begin(); it != matrix_properties->end();
+         it++, it_cpy++)
+    {
         for (int r(0); r<it->rows(); r++) {
             for (int c(0); c<it->cols(); c++) {
                 ASSERT_EQ((*it)(r,c), (*it_cpy)(r,c));
@@ -426,7 +404,7 @@ TEST_F(MeshLibProperties, CopyConstructor)
         }
     }
     // obtain PropertyVector data structure
-    boost::optional<MeshLib::PropertyVector<double*> &> group_properties(
+    auto* const group_properties(
         mesh->getProperties().createNewPropertyVector<double*>(
             prop_name, n_prop_val_groups, prop_item2group_mapping,
             MeshLib::MeshItemType::Cell
@@ -434,7 +412,7 @@ TEST_F(MeshLibProperties, CopyConstructor)
     );
     // initialize the property values
     for (std::size_t i(0); i<n_prop_val_groups; i++) {
-        (*group_properties).initPropertyValue(i, static_cast<double>(i+1));
+        group_properties->initPropertyValue(i, static_cast<double>(i + 1));
     }
 
     // create a copy from the original Properties object
@@ -442,8 +420,8 @@ TEST_F(MeshLibProperties, CopyConstructor)
     // check if the Properties have a PropertyVector with the correct name
     ASSERT_TRUE(properties_copy.hasPropertyVector(prop_name));
     // fetch the PropertyVector from the copy of the Properties object
-    boost::optional<MeshLib::PropertyVector<double*>&> const
-    group_properties_cpy(properties_copy.getPropertyVector<double*>(prop_name));
+    auto const* const group_properties_cpy(
+        properties_copy.getPropertyVector<double*>(prop_name));
     ASSERT_FALSE(!group_properties_cpy);
 
     // check if the values in the PropertyVector of the copy of the Properties
@@ -459,33 +437,29 @@ TEST_F(MeshLibProperties, AddDoublePropertiesTupleSize2)
     const std::size_t number_of_tuples(mesh_size*mesh_size*mesh_size);
 
     std::string const prop_name("TestProperty");
-    boost::optional<MeshLib::PropertyVector<double> &> opt_pv(
-        mesh->getProperties().createNewPropertyVector<double>(prop_name,
-            MeshLib::MeshItemType::Cell, 2)
-    );
+    auto* const pv = mesh->getProperties().createNewPropertyVector<double>(
+        prop_name, MeshLib::MeshItemType::Cell, 2);
     // PropertyVector should be created in a correct way
-    ASSERT_TRUE(!(!opt_pv));
+    ASSERT_NE(nullptr, pv);
 
-    MeshLib::PropertyVector<double> & pv(opt_pv.get());
-
-    ASSERT_EQ(0u, pv.getPropertyName().compare(prop_name));
-    ASSERT_EQ(MeshLib::MeshItemType::Cell, pv.getMeshItemType());
-    ASSERT_EQ(2u, pv.getNumberOfComponents());
-    ASSERT_EQ(0u, pv.getNumberOfTuples());
-    ASSERT_EQ(0u, pv.size());
+    ASSERT_EQ(0u, pv->getPropertyName().compare(prop_name));
+    ASSERT_EQ(MeshLib::MeshItemType::Cell, pv->getMeshItemType());
+    ASSERT_EQ(2u, pv->getNumberOfComponents());
+    ASSERT_EQ(0u, pv->getNumberOfTuples());
+    ASSERT_EQ(0u, pv->size());
 
     // push some values (2 tuples) into the vector
     for (std::size_t k(0); k<number_of_tuples; k++) {
-        pv.push_back(static_cast<double>(k));
-        pv.push_back(static_cast<double>(k));
+        pv->push_back(static_cast<double>(k));
+        pv->push_back(static_cast<double>(k));
     }
     // check the number of tuples
-    ASSERT_EQ(number_of_tuples, pv.getNumberOfTuples());
-    ASSERT_EQ(pv.getNumberOfTuples()*pv.getNumberOfComponents(), pv.size());
+    ASSERT_EQ(number_of_tuples, pv->getNumberOfTuples());
+    ASSERT_EQ(pv->getNumberOfTuples()*pv->getNumberOfComponents(), pv->size());
     // check the values
     for (std::size_t k(0); k<number_of_tuples; k++) {
-        ASSERT_EQ(static_cast<double>(k), pv[2*k]);
-        ASSERT_EQ(static_cast<double>(k), pv[2*k+1]);
+        ASSERT_EQ(static_cast<double>(k), (*pv)[2*k]);
+        ASSERT_EQ(static_cast<double>(k), (*pv)[2*k+1]);
     }
 }
 

--- a/Tests/MeshLib/TestAddLayerToMesh.cpp
+++ b/Tests/MeshLib/TestAddLayerToMesh.cpp
@@ -92,19 +92,17 @@ TEST(MeshLib, AddTopLayerToTriMesh)
 {
     std::unique_ptr<MeshLib::Mesh> const mesh (MeshLib::MeshGenerator::generateRegularTriMesh(5, 5));
     std::string const& mat_name ("MaterialIDs");
-    boost::optional<MeshLib::PropertyVector<int>&> mats =
-        mesh->getProperties().createNewPropertyVector<int>(mat_name, MeshLib::MeshItemType::Cell);
+    auto* const mats = mesh->getProperties().createNewPropertyVector<int>(
+        mat_name, MeshLib::MeshItemType::Cell);
     if (mats)
     {
-        mats->resize(mesh->getNumberOfElements());
-        std::fill_n(mats->begin(), mesh->getNumberOfElements(), 0);
+        mats->resize(mesh->getNumberOfElements(), 0);
     }
-    boost::optional<MeshLib::PropertyVector<double>&> test =
-        mesh->getProperties().createNewPropertyVector<double>("test", MeshLib::MeshItemType::Cell);
+    auto* const test = mesh->getProperties().createNewPropertyVector<double>(
+        "test", MeshLib::MeshItemType::Cell);
     if (test)
     {
-        test->resize(mesh->getNumberOfElements());
-        std::fill_n(test->begin(), mesh->getNumberOfElements(), 0.1);
+        test->resize(mesh->getNumberOfElements(), 0.1);
     }
     ASSERT_EQ(2, mesh->getProperties().getPropertyVectorNames().size());
     double const height (1);
@@ -118,7 +116,7 @@ TEST(MeshLib, AddTopLayerToTriMesh)
     ASSERT_EQ(mesh->getNumberOfElements(), n_elems[6]); // tests if 50 prisms are present
 
     ASSERT_EQ(1, result->getProperties().getPropertyVectorNames().size());
-    boost::optional<MeshLib::PropertyVector<int>&> new_mats =
+    auto const* const new_mats =
         result->getProperties().getPropertyVector<int>(mat_name);
     ASSERT_EQ(result->getNumberOfElements(), new_mats->size());
     ASSERT_EQ(mesh->getNumberOfElements(), std::count(new_mats->cbegin(), new_mats->cend(), 0));
@@ -249,12 +247,11 @@ TEST(MeshLib, AddBottomLayerToPrismMesh)
     std::unique_ptr<MeshLib::Mesh> const mesh2 (MeshLib::addLayerToMesh(*mesh, 5, "mesh", true));
     double const height (1);
     std::string const& mat_name ("MaterialIDs");
-    boost::optional<MeshLib::PropertyVector<int>&> mats =
-        mesh2->getProperties().createNewPropertyVector<int>(mat_name, MeshLib::MeshItemType::Cell);
+    auto* const mats = mesh2->getProperties().createNewPropertyVector<int>(
+        mat_name, MeshLib::MeshItemType::Cell);
     if (mats)
     {
-        mats->resize(mesh2->getNumberOfElements());
-        std::fill_n(mats->begin(), mesh2->getNumberOfElements(), 0);
+        mats->resize(mesh2->getNumberOfElements(), 0);
     }
 
     std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh2, height, "mesh", false));
@@ -265,7 +262,7 @@ TEST(MeshLib, AddBottomLayerToPrismMesh)
     ASSERT_EQ(mesh->getNumberOfElements(), n_elems[1]); // tests if 50 tris are present
     ASSERT_EQ(2 * mesh->getNumberOfElements(), n_elems[6]); // tests if 50 prisms are present
     ASSERT_EQ(1, result->getProperties().getPropertyVectorNames().size());
-    boost::optional<MeshLib::PropertyVector<int>&> new_mats =
+    auto const* const new_mats =
         result->getProperties().getPropertyVector<int>(mat_name);
     ASSERT_EQ(result->getNumberOfElements(), new_mats->size());
     ASSERT_EQ(mesh2->getNumberOfElements(), std::count(new_mats->cbegin(), new_mats->cend(), 0));

--- a/Tests/MeshLib/TestElementStatus.cpp
+++ b/Tests/MeshLib/TestElementStatus.cpp
@@ -29,12 +29,11 @@ TEST(MeshLib, ElementStatus)
     auto const mesh = std::unique_ptr<MeshLib::Mesh>{
         MeshLib::MeshGenerator::generateRegularQuadMesh(width, elements_per_side)};
 
-    boost::optional<MeshLib::PropertyVector<int> &> material_id_properties(
-        mesh->getProperties().createNewPropertyVector<int>("MaterialIDs",
-                                                           MeshLib::MeshItemType::Cell)
-    );
-    ASSERT_TRUE(bool(material_id_properties));
-    (*material_id_properties).resize(mesh->getNumberOfElements());
+    auto* const material_id_properties =
+        mesh->getProperties().createNewPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell);
+    ASSERT_NE(nullptr, material_id_properties);
+    material_id_properties->resize(mesh->getNumberOfElements());
 
     const std::vector<MeshLib::Element*> elements (mesh->getElements());
 

--- a/Tests/MeshLib/TestVtkMappedMeshSource.cpp
+++ b/Tests/MeshLib/TestVtkMappedMeshSource.cpp
@@ -42,66 +42,67 @@ class InSituMesh : public ::testing::Test
     InSituMesh()
      : mesh(nullptr)
     {
-        mesh = MeshLib::MeshGenerator::generateRegularHexMesh(this->length, this->subdivisions);
+        mesh = MeshLib::MeshGenerator::generateRegularHexMesh(
+            this->length, this->subdivisions);
 
         std::string const point_prop_name("PointDoubleProperty");
-        boost::optional<MeshLib::PropertyVector<double> &> point_double_properties(
-            mesh->getProperties().createNewPropertyVector<double>(point_prop_name,
-                MeshLib::MeshItemType::Node)
-        );
-        (*point_double_properties).resize(mesh->getNumberOfNodes());
-        std::iota((*point_double_properties).begin(), (*point_double_properties).end(), 1);
+        auto* const point_double_properties =
+            mesh->getProperties().createNewPropertyVector<double>(
+                point_prop_name, MeshLib::MeshItemType::Node);
+        point_double_properties->resize(mesh->getNumberOfNodes());
+        std::iota(point_double_properties->begin(),
+                  point_double_properties->end(),
+                  1);
 
         std::string const cell_prop_name("CellDoubleProperty");
-        boost::optional<MeshLib::PropertyVector<double> &> cell_double_properties(
-            mesh->getProperties().createNewPropertyVector<double>(cell_prop_name,
-                MeshLib::MeshItemType::Cell)
-        );
-        (*cell_double_properties).resize(mesh->getNumberOfElements());
-        std::iota((*cell_double_properties).begin(), (*cell_double_properties).end(), 1);
+        auto* const cell_double_properties =
+            mesh->getProperties().createNewPropertyVector<double>(
+                cell_prop_name, MeshLib::MeshItemType::Cell);
+        cell_double_properties->resize(mesh->getNumberOfElements());
+        std::iota(
+            cell_double_properties->begin(), cell_double_properties->end(), 1);
 
         std::string const point_int_prop_name("PointIntProperty");
-        boost::optional<MeshLib::PropertyVector<int> &> point_int_properties(
-            mesh->getProperties().createNewPropertyVector<int>(point_int_prop_name,
-                MeshLib::MeshItemType::Node)
-        );
-        (*point_int_properties).resize(mesh->getNumberOfNodes());
-        std::iota((*point_int_properties).begin(), (*point_int_properties).end(), 1);
+        auto* const point_int_properties =
+            mesh->getProperties().createNewPropertyVector<int>(
+                point_int_prop_name, MeshLib::MeshItemType::Node);
+        point_int_properties->resize(mesh->getNumberOfNodes());
+        std::iota(
+            point_int_properties->begin(), point_int_properties->end(), 1);
 
         std::string const cell_int_prop_name("CellIntProperty");
-        boost::optional<MeshLib::PropertyVector<int> &> cell_int_properties(
-            mesh->getProperties().createNewPropertyVector<int>(cell_int_prop_name,
-                MeshLib::MeshItemType::Cell)
-        );
-        (*cell_int_properties).resize(mesh->getNumberOfElements());
-        std::iota((*cell_int_properties).begin(), (*cell_int_properties).end(), 1);
+        auto* const cell_int_properties =
+            mesh->getProperties().createNewPropertyVector<int>(
+                cell_int_prop_name, MeshLib::MeshItemType::Cell);
+        cell_int_properties->resize(mesh->getNumberOfElements());
+        std::iota(cell_int_properties->begin(), cell_int_properties->end(), 1);
 
         std::string const point_unsigned_prop_name("PointUnsignedProperty");
-        boost::optional<MeshLib::PropertyVector<unsigned> &> point_unsigned_properties(
-            mesh->getProperties().createNewPropertyVector<unsigned>(point_unsigned_prop_name,
-                MeshLib::MeshItemType::Node)
-        );
-        (*point_unsigned_properties).resize(mesh->getNumberOfNodes());
-        std::iota((*point_unsigned_properties).begin(), (*point_unsigned_properties).end(), 1);
+        auto point_unsigned_properties =
+            mesh->getProperties().createNewPropertyVector<unsigned>(
+                point_unsigned_prop_name, MeshLib::MeshItemType::Node);
+        point_unsigned_properties->resize(mesh->getNumberOfNodes());
+        std::iota(point_unsigned_properties->begin(),
+                  point_unsigned_properties->end(),
+                  1);
 
         std::string const cell_unsigned_prop_name("CellUnsignedProperty");
-        boost::optional<MeshLib::PropertyVector<unsigned> &> cell_unsigned_properties(
-            mesh->getProperties().createNewPropertyVector<unsigned>(cell_unsigned_prop_name,
-                MeshLib::MeshItemType::Cell)
-        );
-        (*cell_unsigned_properties).resize(mesh->getNumberOfElements());
-        std::iota((*cell_unsigned_properties).begin(), (*cell_unsigned_properties).end(), 1);
+        auto cell_unsigned_properties =
+            mesh->getProperties().createNewPropertyVector<unsigned>(
+                cell_unsigned_prop_name, MeshLib::MeshItemType::Cell);
+        cell_unsigned_properties->resize(mesh->getNumberOfElements());
+        std::iota(cell_unsigned_properties->begin(),
+                  cell_unsigned_properties->end(),
+                  1);
 
         std::string const material_ids_name("MaterialIDs");
-        boost::optional<MeshLib::PropertyVector<int> &> material_id_properties(
-            mesh->getProperties().createNewPropertyVector<int>(material_ids_name,
-                MeshLib::MeshItemType::Cell)
-        );
-        (*material_id_properties).resize(mesh->getNumberOfElements());
-        std::iota((*material_id_properties).begin(), (*material_id_properties).end(), 1);
+        auto material_id_properties =
+            mesh->getProperties().createNewPropertyVector<int>(
+                material_ids_name, MeshLib::MeshItemType::Cell);
+        material_id_properties->resize(mesh->getNumberOfElements());
+        std::iota(
+            material_id_properties->begin(), material_id_properties->end(), 1);
     }
-
-
 
     ~InSituMesh()
     {
@@ -232,7 +233,7 @@ TEST_F(InSituMesh, DISABLED_MappedMeshSourceRoundtrip)
             ASSERT_EQ(vtkMesh->GetPointData()->GetScalars("PointIntProperty")->GetNumberOfTuples(),
                 pointIntArray->GetNumberOfTuples());
             ASSERT_EQ(vtkMesh->GetPointData()->GetScalars("PointUnsignedProperty")->GetNumberOfTuples(),
-                      pointUnsignedArray->GetNumberOfTuples());
+                pointUnsignedArray->GetNumberOfTuples());
             ASSERT_EQ(vtkMesh->GetCellData()->GetScalars("CellDoubleProperty")->GetNumberOfTuples(),
                 cellDoubleArray->GetNumberOfTuples());
             ASSERT_EQ(vtkMesh->GetCellData()->GetScalars("CellIntProperty")->GetNumberOfTuples(),
@@ -251,42 +252,55 @@ TEST_F(InSituMesh, DISABLED_MappedMeshSourceRoundtrip)
             ASSERT_EQ(newMeshProperties.hasPropertyVector("PointDoubleProperty"),
                 meshProperties.hasPropertyVector("PointDoubleProperty"));
             ASSERT_EQ(newMeshProperties.hasPropertyVector("PointIntProperty"),
-                meshProperties.hasPropertyVector("PointIntProperty"));
+                      meshProperties.hasPropertyVector("PointIntProperty"));
             ASSERT_EQ(newMeshProperties.hasPropertyVector("PointUnsignedProperty"),
-                      meshProperties.hasPropertyVector("PointUnsignedProperty"));
+                meshProperties.hasPropertyVector("PointUnsignedProperty"));
             ASSERT_EQ(newMeshProperties.hasPropertyVector("CellDoubleProperty"),
                 meshProperties.hasPropertyVector("CellDoubleProperty"));
             ASSERT_EQ(newMeshProperties.hasPropertyVector("CellIntProperty"),
                 meshProperties.hasPropertyVector("CellIntProperty"));
             ASSERT_EQ(newMeshProperties.hasPropertyVector("CellUnsignedProperty"),
-                      meshProperties.hasPropertyVector("CellUnsignedProperty"));
+                meshProperties.hasPropertyVector("CellUnsignedProperty"));
             ASSERT_EQ(newMeshProperties.hasPropertyVector("MaterialIDs"),
                 meshProperties.hasPropertyVector("MaterialIDs"));
 
             // Check some properties on equality
-            auto doubleProps = meshProperties.getPropertyVector<double>("PointDoubleProperty");
-            auto newDoubleProps = newMeshProperties.getPropertyVector<double>("PointDoubleProperty");
-            ASSERT_EQ((*newDoubleProps).getNumberOfComponents(), (*doubleProps).getNumberOfComponents());
-            ASSERT_EQ((*newDoubleProps).getNumberOfTuples(), (*doubleProps).getNumberOfTuples());
-            ASSERT_EQ((*newDoubleProps).size(), (*doubleProps).size());
-            for(std::size_t i = 0; i < (*doubleProps).size(); i++)
+            auto const* const doubleProps =
+                meshProperties.getPropertyVector<double>("PointDoubleProperty");
+            auto const* const newDoubleProps =
+                newMeshProperties.getPropertyVector<double>(
+                    "PointDoubleProperty");
+            ASSERT_EQ(newDoubleProps->getNumberOfComponents(),
+                      doubleProps->getNumberOfComponents());
+            ASSERT_EQ(newDoubleProps->getNumberOfTuples(),
+                      doubleProps->getNumberOfTuples());
+            ASSERT_EQ(newDoubleProps->size(), doubleProps->size());
+            for (std::size_t i = 0; i < doubleProps->size(); i++)
                 ASSERT_EQ((*newDoubleProps)[i], (*doubleProps)[i]);
 
-            auto unsignedProps = meshProperties.getPropertyVector<unsigned>("CellUnsignedProperty");
-            auto newUnsignedIds = newMeshProperties.getPropertyVector<unsigned>("CellUnsignedProperty");
+            auto unsignedProps = meshProperties.getPropertyVector<unsigned>(
+                "CellUnsignedProperty");
+            auto newUnsignedIds = newMeshProperties.getPropertyVector<unsigned>(
+                "CellUnsignedProperty");
 
-            ASSERT_EQ((*newUnsignedIds).getNumberOfComponents(), (*unsignedProps).getNumberOfComponents());
-            ASSERT_EQ((*newUnsignedIds).getNumberOfTuples(), (*unsignedProps).getNumberOfTuples());
-            ASSERT_EQ((*newUnsignedIds).size(), (*unsignedProps).size());
-            for(std::size_t i = 0; i < (*unsignedProps).size(); i++)
+            ASSERT_EQ(newUnsignedIds->getNumberOfComponents(),
+                      unsignedProps->getNumberOfComponents());
+            ASSERT_EQ(newUnsignedIds->getNumberOfTuples(),
+                      unsignedProps->getNumberOfTuples());
+            ASSERT_EQ(newUnsignedIds->size(), unsignedProps->size());
+            for (std::size_t i = 0; i < unsignedProps->size(); i++)
                 ASSERT_EQ((*newUnsignedIds)[i], (*unsignedProps)[i]);
 
-            auto materialIds = meshProperties.getPropertyVector<int>("MaterialIDs");
-            auto newMaterialIds = newMeshProperties.getPropertyVector<int>("MaterialIDs");
-            ASSERT_EQ((*newMaterialIds).getNumberOfComponents(), (*materialIds).getNumberOfComponents());
-            ASSERT_EQ((*newMaterialIds).getNumberOfTuples(), (*materialIds).getNumberOfTuples());
-            ASSERT_EQ((*newMaterialIds).size(), (*materialIds).size());
-            for(std::size_t i = 0; i < (*materialIds).size(); i++)
+            auto const* const materialIds =
+                meshProperties.getPropertyVector<int>("MaterialIDs");
+            auto const* const newMaterialIds =
+                newMeshProperties.getPropertyVector<int>("MaterialIDs");
+            ASSERT_EQ(newMaterialIds->getNumberOfComponents(),
+                      materialIds->getNumberOfComponents());
+            ASSERT_EQ(newMaterialIds->getNumberOfTuples(),
+                      materialIds->getNumberOfTuples());
+            ASSERT_EQ(newMaterialIds->size(), materialIds->size());
+            for (std::size_t i = 0; i < materialIds->size(); i++)
                 ASSERT_EQ((*newMaterialIds)[i], (*materialIds)[i]);
         }
     }

--- a/Tests/MeshLib/TestVtkMappedPropertyVector.cpp
+++ b/Tests/MeshLib/TestVtkMappedPropertyVector.cpp
@@ -34,11 +34,11 @@ TEST(MeshLibMappedPropertyVector, Double)
     const std::size_t number_of_tuples(mesh_size*mesh_size*mesh_size);
 
     std::string const prop_name("TestProperty");
-    boost::optional<MeshLib::PropertyVector<double> &> double_properties(
-        mesh->getProperties().createNewPropertyVector<double>(prop_name,
-            MeshLib::MeshItemType::Cell));
-    (*double_properties).resize(number_of_tuples);
-    std::iota((*double_properties).begin(), (*double_properties).end(), 1);
+    auto* const double_properties =
+        mesh->getProperties().createNewPropertyVector<double>(
+            prop_name, MeshLib::MeshItemType::Cell);
+    double_properties->resize(number_of_tuples);
+    std::iota(double_properties->begin(), double_properties->end(), 1);
 
     vtkNew<MeshLib::VtkMappedPropertyVectorTemplate<double> > dataArray;
     dataArray->SetPropertyVector(*double_properties);
@@ -66,11 +66,10 @@ TEST(MeshLibMappedPropertyVector, Int)
     const std::size_t number_of_tuples(mesh_size*mesh_size*mesh_size);
 
     std::string const prop_name("TestProperty");
-    boost::optional<MeshLib::PropertyVector<int> &> properties(
-        mesh->getProperties().createNewPropertyVector<int>(prop_name,
-            MeshLib::MeshItemType::Cell));
-    (*properties).resize(number_of_tuples);
-    std::iota((*properties).begin(), (*properties).end(), -5);
+    auto* const properties = mesh->getProperties().createNewPropertyVector<int>(
+        prop_name, MeshLib::MeshItemType::Cell);
+    properties->resize(number_of_tuples);
+    std::iota(properties->begin(), properties->end(), -5);
 
     vtkNew<MeshLib::VtkMappedPropertyVectorTemplate<int> > dataArray;
     dataArray->SetPropertyVector(*properties);
@@ -98,11 +97,11 @@ TEST(MeshLibMappedPropertyVector, Unsigned)
     const std::size_t number_of_tuples(mesh_size*mesh_size*mesh_size);
 
     std::string const prop_name("TestProperty");
-    boost::optional<MeshLib::PropertyVector<unsigned> &> properties(
-        mesh->getProperties().createNewPropertyVector<unsigned>(prop_name,
-                                                           MeshLib::MeshItemType::Cell));
-    (*properties).resize(number_of_tuples);
-    std::iota((*properties).begin(), (*properties).end(), 0);
+    auto* const properties =
+        mesh->getProperties().createNewPropertyVector<unsigned>(
+            prop_name, MeshLib::MeshItemType::Cell);
+    properties->resize(number_of_tuples);
+    std::iota(properties->begin(), properties->end(), 0);
 
     vtkNew<MeshLib::VtkMappedPropertyVectorTemplate<unsigned> > dataArray;
     dataArray->SetPropertyVector(*properties);


### PR DESCRIPTION
Current implementation returns an optional reference to a PropertyVector. This is semantically equivalent to a pointer. (Thanks to Christoph pointing this out). See the first commit's message for some details.

The main change is contained in the first commit, other are just updates to the new type.
Along the changed lines you will find changes:
 - `(*something).memberfunction()` to `something->memberfunction()`
 - removal of `T& obj_T = an_optional_to_T.get()` and direct usage of `*` and `->` operators.
 - removal of unecessary fill_n preceded by resize; std::vector::resize takes a second argument for the value. (Especially if the value is the type's default value.)
 - one untangling of nested if else with returns into a flat if error return ...
 - remove boost/optional.hpp include, fwd declare PropertyVector.
 - clang-format of all changed lines (automatically!).

It was a mistake from my side to suggest the usage of `boost::optional` for references. I hope this PR clarifies the semantic/usage of get and create property vectors.