### PR TITLE
Boundary element search along polylines for Line3 elements.

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -389,6 +389,17 @@ if(NOT OGS_USE_MPI)
         DIFF_DATA
         square_1e5_expected_pcs_0_ts_4_t_1.000000.vtu square_1e5_pcs_0_ts_4_t_1.000000.vtu displacement displacement
     )
+    AddTest(
+        NAME Mechanics_SDL_square_1e2_quad8_traction_topBC
+        PATH Mechanics/Linear
+        EXECUTABLE ogs
+        EXECUTABLE_ARGS square_1e2_quad8_traction_top.prj
+        WRAPPER time
+        TESTER vtkdiff
+        ABSTOL 5e-16 RELTOL 1e-15
+        DIFF_DATA
+        expected_square_1e2_quad8_traction_topBC_pcs_0_ts_4_t_1.000000.vtu square_1e2_quad8_traction_topBC_pcs_0_ts_4_t_1.000000.vtu displacement displacement
+    )
 
     # Mechanics; Small deformations, Burgers (SDB)
     AddTest(

--- a/MeshLib/Elements/Element.h
+++ b/MeshLib/Elements/Element.h
@@ -173,6 +173,14 @@ public:
     virtual Element* clone() const = 0;
 
     /**
+     * Constructs a new object polymorphically. This is similar to clone, but
+     * accepts new nodes and id.
+     * \pre The length of the \c nodes vector is equal to the derived element's
+     * total number of nodes.
+     */
+    virtual Element* clone(Node** nodes, std::size_t id) const = 0;
+
+    /**
      * Computes the length / area / volumen of this element. This is automatically
      * done at initalisation time but can be repeated by calling this function at any time.
      */

--- a/MeshLib/Elements/TemplateElement.h
+++ b/MeshLib/Elements/TemplateElement.h
@@ -69,6 +69,12 @@ public:
         return new TemplateElement(*this);
     }
 
+    /// \copydoc MeshLib::Element::clone(Node*[], std::size_t)
+    virtual Element* clone(Node** nodes, std::size_t id) const
+    {
+        return new TemplateElement(nodes, id);
+    }
+
     /// Get dimension of the mesh element.
     unsigned getDimension() const { return dimension; }
 

--- a/Tests/NumLib/LocalToGlobalIndexMapMultiComponent.cpp
+++ b/Tests/NumLib/LocalToGlobalIndexMapMultiComponent.cpp
@@ -63,7 +63,7 @@ public:
         // deep copy because the searcher destroys the elements.
         std::transform(elems.cbegin(), elems.cend(),
                        std::back_inserter(boundary_elements),
-                       std::mem_fn(&MeL::Element::clone));
+                       [](MeL::Element const* e) { return e->clone(); });
 
         std::vector<MeL::Node*> nodes = MeL::getUniqueNodes(boundary_elements);
 


### PR DESCRIPTION
In the current implementation the Neumann boundary conditions applied on second order meshes (e.g. quad8) is not working correctly.

To fix it the BoundaryElementsAlongPolylines searcher is extended for Line3 element type.
Also a MeshLib::Element::construct function is required to construct new elements polymorphically. 