### PR TITLE
CTests on Windows

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -10,7 +10,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/cube_1x1x1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS cube_${mesh_size}.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-15 RELTOL 1e-15
             DIFF_DATA
@@ -22,7 +21,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/cube_1x1x1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS cube_${mesh_size}_newton.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-15 RELTOL 1e-15
             DIFF_DATA
@@ -34,7 +32,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/cube_1x1x1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS cube_${mesh_size}_neumann.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-1 RELTOL 1e-1
             DIFF_DATA
@@ -48,7 +45,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/cube_1x1x1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS cube_${mesh_size}.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-13 RELTOL 1e-13
             DIFF_DATA
@@ -60,7 +56,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/cube_1x1x1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS cube_${mesh_size}_neumann.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-2 RELTOL 1e-2
             DIFF_DATA
@@ -75,7 +70,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/square_1x1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS square_${mesh_size}.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-13 RELTOL 1e-13
             DIFF_DATA
@@ -87,7 +81,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/square_1x1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS square_${mesh_size}_neumann.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-1 RELTOL 1e-1
             DIFF_DATA
@@ -101,7 +94,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/square_1x1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS square_${mesh_size}.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-12 RELTOL 1e-16
             DIFF_DATA
@@ -113,7 +105,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/square_1x1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS square_${mesh_size}_neumann.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-02 RELTOL 1e-02
             DIFF_DATA
@@ -128,7 +119,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/line_1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS line_${mesh_size}.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-15 RELTOL 1e-15
             DIFF_DATA
@@ -140,7 +130,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/line_1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS line_${mesh_size}_neumann.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-14 RELTOL 1e-14
             DIFF_DATA
@@ -152,7 +141,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/line_1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS line_${mesh_size}_robin_right_picard.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 4e-14 RELTOL 2e-14
             DIFF_DATA
@@ -164,7 +152,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/line_1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS line_${mesh_size}_robin_left_picard.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-14 RELTOL 1e-14
             DIFF_DATA
@@ -176,7 +163,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/line_1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS line_${mesh_size}_time_dep_dirichlet.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-14 RELTOL 1e-14
             DIFF_DATA
@@ -190,7 +176,6 @@ if(NOT OGS_USE_MPI)
             PATH Elliptic/line_1_GroundWaterFlow
             EXECUTABLE ogs
             EXECUTABLE_ARGS line_${mesh_size}_time_dep_neumann.prj
-            WRAPPER time
             TESTER vtkdiff
             ABSTOL 1e-14 RELTOL 1e-14
             DIFF_DATA
@@ -206,7 +191,6 @@ if(NOT OGS_USE_MPI)
         PATH Elliptic/cube_1x1x1_GroundWaterFlow
         EXECUTABLE ogs
         EXECUTABLE_ARGS cube_1e3_top_neumann.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-14 RELTOL 1e-14
         DIFF_DATA
@@ -217,7 +201,6 @@ if(NOT OGS_USE_MPI)
         PATH Elliptic/cube_1x1x1_GroundWaterFlow
         EXECUTABLE ogs
         EXECUTABLE_ARGS cube_1e3_bottom_neumann.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-14 RELTOL 1e-14
         DIFF_DATA
@@ -229,7 +212,6 @@ if(NOT OGS_USE_MPI)
         PATH Elliptic/cube_1x1x1_GroundWaterFlow
         EXECUTABLE ogs
         EXECUTABLE_ARGS cube_1e3_top_neumann_newton.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-14 RELTOL 1e-14
         DIFF_DATA
@@ -240,7 +222,6 @@ if(NOT OGS_USE_MPI)
         PATH Elliptic/cube_1x1x1_GroundWaterFlow
         EXECUTABLE ogs
         EXECUTABLE_ARGS cube_1e3_bottom_neumann_newton.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-14 RELTOL 1e-14
         DIFF_DATA
@@ -253,7 +234,6 @@ if(NOT OGS_USE_MPI)
         PATH Elliptic/cube_1x1x1_GroundWaterFlow
         EXECUTABLE ogs
         EXECUTABLE_ARGS cube_1e3_calculatesurfaceflux.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-15 RELTOL 1e-15
         DIFF_DATA
@@ -264,7 +244,6 @@ if(NOT OGS_USE_MPI)
         PATH Elliptic/cube_1x1x1_GroundWaterFlow
         EXECUTABLE ogs
         EXECUTABLE_ARGS cube_1e3_neumann_calculatesurfaceflux.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-15 RELTOL 1e-15
         DIFF_DATA
@@ -276,7 +255,6 @@ if(NOT OGS_USE_MPI)
         PATH Parabolic/TES/1D
         EXECUTABLE ogs
         EXECUTABLE_ARGS tes-1D-zeolite-discharge-small.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-7 RELTOL 5e-9
         DIFF_DATA
@@ -292,7 +270,6 @@ if(NOT OGS_USE_MPI)
         PATH Parabolic/TES/1D
         EXECUTABLE ogs
         EXECUTABLE_ARGS tes-1D-zeolite-discharge-large.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-3 RELTOL 1e-4
         DIFF_DATA
@@ -308,7 +285,6 @@ if(NOT OGS_USE_MPI)
         PATH Parabolic/TES/1D
         EXECUTABLE ogs
         EXECUTABLE_ARGS tes-1D-zeolite-discharge-small-newton.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1.5e-3 RELTOL 1.5e-3
         DIFF_DATA
@@ -323,7 +299,6 @@ if(NOT OGS_USE_MPI)
          PATH Parabolic/T/1D_dirichlet
          EXECUTABLE ogs
          EXECUTABLE_ARGS line_60_heat.prj
-         WRAPPER time
          TESTER vtkdiff
          ABSTOL 1e-5 RELTOL 1e-5
          DIFF_DATA
@@ -336,7 +311,6 @@ if(NOT OGS_USE_MPI)
          PATH Parabolic/T/1D_neumann
          EXECUTABLE ogs
          EXECUTABLE_ARGS line_60_heat.prj
-         WRAPPER time
          TESTER vtkdiff
          ABSTOL 1e-4 RELTOL 1e-4
          DIFF_DATA
@@ -350,7 +324,6 @@ if(NOT OGS_USE_MPI)
         PATH Mechanics/Linear
         EXECUTABLE ogs
         EXECUTABLE_ARGS square_1e0.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
@@ -361,7 +334,6 @@ if(NOT OGS_USE_MPI)
         PATH Mechanics/Linear
         EXECUTABLE ogs
         EXECUTABLE_ARGS square_1e2.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
@@ -372,7 +344,6 @@ if(NOT OGS_USE_MPI)
         PATH Mechanics/Linear
         EXECUTABLE ogs
         EXECUTABLE_ARGS disc_with_hole.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
@@ -383,7 +354,6 @@ if(NOT OGS_USE_MPI)
         PATH Mechanics/Linear
         EXECUTABLE ogs
         EXECUTABLE_ARGS square_1e5.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
@@ -407,7 +377,6 @@ if(NOT OGS_USE_MPI)
         PATH Mechanics/Burgers
         EXECUTABLE ogs
         EXECUTABLE_ARGS cube_1e0.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
@@ -419,7 +388,6 @@ if(NOT OGS_USE_MPI)
         PATH Mechanics/Burgers
         EXECUTABLE ogs
         EXECUTABLE_ARGS cube_1e3.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-16 RELTOL 1e-16
         DIFF_DATA
@@ -434,7 +402,6 @@ if(NOT OGS_USE_MPI)
         PATH Elliptic/square_1x1_GroundWaterFlow
         EXECUTABLE ogs
         EXECUTABLE_ARGS square_1e2_axi.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1.6e-5 RELTOL 1e-5
         DIFF_DATA
@@ -455,7 +422,6 @@ if(NOT OGS_USE_MPI)
         PATH Elliptic/square_1x1_GroundWaterFlow
         EXECUTABLE ogs
         EXECUTABLE_ARGS square_1e4_axi.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 1.6e-5 RELTOL 1e-5
         DIFF_DATA
@@ -475,7 +441,6 @@ if(NOT OGS_USE_MPI)
         PATH Mechanics/Linear
         EXECUTABLE ogs
         EXECUTABLE_ARGS ring_plane_strain.prj
-        WRAPPER time
         TESTER vtkdiff
         ABSTOL 6e-4 RELTOL 1e-4
         DIFF_DATA
@@ -491,7 +456,6 @@ if(NOT OGS_USE_MPI)
          PATH Parabolic/T/2D_axially_symmetric
          EXECUTABLE ogs
          EXECUTABLE_ARGS square_1e2_axi.prj
-         WRAPPER time
          TESTER vtkdiff
          ABSTOL 1.7e-5 RELTOL 1e-5
          DIFF_DATA
@@ -513,7 +477,6 @@ if(NOT OGS_USE_MPI)
         PATH Parabolic/TES/2D
         EXECUTABLE ogs
         EXECUTABLE_ARGS tes-inert-axi.prj
-        WRAPPER time
         TESTER vtkdiff
         # Note: Since the temperature and pressure only vary by a factor of ~ 1.e-6 in x-direction
         # the relative tolerance has to be much smaller than 1.e-6

--- a/Applications/Utils/Tests.cmake
+++ b/Applications/Utils/Tests.cmake
@@ -4,7 +4,6 @@ AddTest(
     PATH MeshGeoToolsLib/Ammer/
     EXECUTABLE MapGeometryToMeshSurface
     EXECUTABLE_ARGS -m Ammer-Homogen100m-Final-TopSurface.vtu -i Ammer-Rivers.gml -o ${CMAKE_BINARY_DIR}/Tests/Data/MeshGeoToolsLib/Ammer/Ammer-Rivers-Mapped.gml
-    WRAPPER time
     TESTER diff
     DIFF_DATA Ammer-Rivers-Mapped.gml
 )
@@ -14,7 +13,6 @@ AddTest(
     PATH MeshGeoToolsLib/Bode/
     EXECUTABLE MapGeometryToMeshSurface
     EXECUTABLE_ARGS -m BodeComplex.msh -i BodeEZG_Fliessgewaesser.gml -o ${CMAKE_BINARY_DIR}/Tests/Data/MeshGeoToolsLib/Bode/BodeEZG_Fliessgewaesser-Mapped.gml
-    WRAPPER time
     TESTER diff
     DIFF_DATA BodeEZG_Fliessgewaesser-Mapped.gml
 )
@@ -24,7 +22,6 @@ AddTest(
     PATH MeshGeoToolsLib/Naegelstedt
     EXECUTABLE MapGeometryToMeshSurface
     EXECUTABLE_ARGS -m SmallTest.vtu -i RiverNetwork.gml -o ${CMAKE_BINARY_DIR}/Tests/Data/MeshGeoToolsLib/Naegelstedt/RiverNetwork-Mapped.gml
-    WRAPPER time
     TESTER diff
     DIFF_DATA RiverNetwork-Mapped.gml
 )

--- a/BaseLib/DateTools.cpp
+++ b/BaseLib/DateTools.cpp
@@ -121,7 +121,7 @@ std::string formatDate(
 {
     auto const time_t = std::chrono::system_clock::to_time_t(time);
     char time_str[100];
-    if (std::strftime(time_str, sizeof(time_str), "%F %T%z",
+    if (std::strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S%z",
                       std::localtime(&time_t))) {
         return time_str;
     } else {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Features:
 ### Utilities
 ### Infrastructure:
+
+- ctest now works on Windows too by removing time-wrappers
+
 ### Fixes:
 
 # 6.0.7

--- a/scripts/cmake/ExternalProjectEigen.cmake
+++ b/scripts/cmake/ExternalProjectEigen.cmake
@@ -5,12 +5,12 @@ if(USE_CONAN)
 endif()
 
 if(OGS_LIB_EIGEN STREQUAL "System")
-    find_package(Eigen3 3.2.5 REQUIRED)
+    find_package(Eigen3 3.2.8 REQUIRED)
     if(NOT EIGEN3_FOUND)
         message(FATAL_ERROR "Aborting CMake because system Eigen was not found!")
     endif()
 elseif(OGS_LIB_EIGEN STREQUAL "Default")
-    find_package(Eigen3 3.2.5)
+    find_package(Eigen3 3.2.8)
 endif()
 
 # First check for system Eigen

--- a/scripts/cmake/ThirdPartyLibVersions.cmake
+++ b/scripts/cmake/ThirdPartyLibVersions.cmake
@@ -3,8 +3,8 @@ string(REPLACE "." "_" OGS_BOOST_VERSION_UNDERLINE ${OGS_BOOST_VERSION})
 set(OGS_BOOST_URL "http://opengeosys.s3.amazonaws.com/ogs6-lib-sources/boost_${OGS_BOOST_VERSION_UNDERLINE}.tar.bz2")
 set(OGS_BOOST_MD5 "a744cf167b05d72335f27c88115f211d")
 
-set(OGS_EIGEN_URL "http://opengeosys.s3.amazonaws.com/ogs6-lib-sources/eigen-3.2.5.tar.gz")
-set(OGS_EIGEN_MD5 "8cc513ac6ec687117acadddfcacf551b")
+set(OGS_EIGEN_URL "http://opengeosys.s3.amazonaws.com/ogs6-lib-sources/eigen-3.2.8.tar.gz")
+set(OGS_EIGEN_MD5 "135d8d43aaee5fb54cf5f3e981b1a6db")
 
 set(OGS_VTK_VERSION 6.3.0)
 set(OGS_VTK_URL "http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz")

--- a/scripts/cmake/test/AddTestTester.cmake
+++ b/scripts/cmake/test/AddTestTester.cmake
@@ -1,8 +1,18 @@
-execute_process(
-    COMMAND bash -c ${TESTER_COMMAND}
-    WORKING_DIRECTORY ${case_path}
-    RESULT_VARIABLE EXIT_CODE
-)
+if(WIN32)
+    execute_process(
+        COMMAND cmd /C ${TESTER_COMMAND}
+        WORKING_DIRECTORY ${case_path}
+        RESULT_VARIABLE EXIT_CODE
+        OUTPUT_VARIABLE OUTPUT
+  )
+else()
+    execute_process(
+        COMMAND bash -c ${TESTER_COMMAND}
+        WORKING_DIRECTORY ${case_path}
+        RESULT_VARIABLE EXIT_CODE
+        OUTPUT_VARIABLE OUTPUT
+    )
+endif()
 
 if(NOT EXIT_CODE STREQUAL "0")
     message(FATAL_ERROR "Error exit code: ${EXIT_CODE}")

--- a/scripts/cmake/test/Test.cmake
+++ b/scripts/cmake/test/Test.cmake
@@ -62,11 +62,20 @@ add_custom_target(
     ${CONFIG_PARAMETER} --parallel ${NUM_PROCESSORS} --test-action test
     DEPENDS ogs vtkdiff ctest-large-cleanup
 )
+add_custom_target(
+    ctest-large-serial
+    COMMAND ${CMAKE_CTEST_COMMAND} -T Test
+    --force-new-ctest-process
+    --output-on-failure --output-log Tests/ctest-large.log
+    ${CONFIG_PARAMETER} --test-action test
+    DEPENDS ogs vtkdiff ctest-large-cleanup
+)
 set_directory_properties(PROPERTIES
     ADDITIONAL_MAKE_CLEAN_FILES ${PROJECT_BINARY_DIR}/Tests/Data
 )
 
 set_target_properties(ctest PROPERTIES FOLDER Testing)
 set_target_properties(ctest-large PROPERTIES FOLDER Testing)
+set_target_properties(ctest-large-serial PROPERTIES FOLDER Testing)
 set_target_properties(ctest-cleanup PROPERTIES FOLDER Testing)
 set_target_properties(ctest-large-cleanup PROPERTIES FOLDER Testing)

--- a/scripts/cmake/test/Test.cmake
+++ b/scripts/cmake/test/Test.cmake
@@ -65,3 +65,8 @@ add_custom_target(
 set_directory_properties(PROPERTIES
     ADDITIONAL_MAKE_CLEAN_FILES ${PROJECT_BINARY_DIR}/Tests/Data
 )
+
+set_target_properties(ctest PROPERTIES FOLDER Testing)
+set_target_properties(ctest-large PROPERTIES FOLDER Testing)
+set_target_properties(ctest-cleanup PROPERTIES FOLDER Testing)
+set_target_properties(ctest-large-cleanup PROPERTIES FOLDER Testing)

--- a/scripts/jenkins/msvc.groovy
+++ b/scripts/jenkins/msvc.groovy
@@ -26,6 +26,7 @@ node('win && conan') {
 
         stage 'Test (Win)'
         build.win 'build', 'tests'
+        build.win 'build', 'ctest'
 
         stage 'Data Explorer (Win)'
         configure.win 'build', "${defaultCMakeOptions} ${guiCMakeOptions}",


### PR DESCRIPTION
- `time`-wrapper is now optional and was removed from all tests
- All tests using the `vtkdiff`-tester run on Windows