### PR TITLE
Reorder vector with a set of given indices

### DIFF
--- a/BaseLib/reorderVector.h
+++ b/BaseLib/reorderVector.h
@@ -17,23 +17,19 @@
 namespace BaseLib
 {
 /**
- * Reorder a vector by a given index vector.
- *  From
- *  <a href="reorderV">http://stackoverflow.com/questions/838384/reorder-vector-using-a-vector-of-indices</a>
+ *  Reorder a vector by a given index vector.
  *
- *  Note: The simple version on that page is taken, which is good enough in performance
- *        for medium size vectors.
+ *  Note: It is good enough in performance for medium size vectors.
  */
 template <typename ValueType, typename IndexType>
 void reorderVector(std::vector<ValueType>& v,
                    std::vector<IndexType> const& order)
 {
-    for (std::size_t s = 1, d; s < order.size(); ++s)
+    std::vector<ValueType> temp_v = v;
+
+    for (std::size_t i=0; i<order.size(); i++)
     {
-        for (d = order[s]; d < s; d = order[d]);
-        if (d == s)
-            while (d = order[d], d != s)
-                std::swap(v[s], v[d]);
+        v[i] =  temp_v[order[i]];
     }
 }
 

--- a/BaseLib/reorderVector.h
+++ b/BaseLib/reorderVector.h
@@ -25,11 +25,12 @@ template <typename ValueType, typename IndexType>
 void reorderVector(std::vector<ValueType>& v,
                    std::vector<IndexType> const& order)
 {
-    std::vector<ValueType> temp_v = v;
+    std::vector<ValueType> temp_v(v.size());
+    temp_v.swap(v);
 
     for (std::size_t i=0; i<order.size(); i++)
     {
-        v[i] =  temp_v[order[i]];
+        std::swap(v[i], temp_v[order[i]]);
     }
 }
 

--- a/BaseLib/reorderVector.h
+++ b/BaseLib/reorderVector.h
@@ -1,0 +1,42 @@
+/**
+ * \brief Reorder vector elements by given indices
+ *
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * \file   reorderVector.h
+ * Created on October 13, 2016, 5:37 PM
+ */
+
+#ifndef OGS_BASELIB_REORDERVECTOR_H
+#define OGS_BASELIB_REORDERVECTOR_H
+
+namespace BaseLib
+{
+/**
+ * Reorder a vector by a given index vector.
+ *  From
+ *  <a href="reorderV">http://stackoverflow.com/questions/838384/reorder-vector-using-a-vector-of-indices</a>
+ *
+ *  Note: The simple version on that page is taken, which is good enough in performance
+ *        for medium size vectors.
+ */
+template <typename ValueType, typename IndexType>
+void reorderVector(std::vector<ValueType>& v,
+                   std::vector<IndexType> const& order)
+{
+    for (std::size_t s = 1, d; s < order.size(); ++s)
+    {
+        for (d = order[s]; d < s; d = order[d]);
+        if (d == s)
+            while (d = order[d], d != s)
+                std::swap(v[s], v[d]);
+    }
+}
+
+} // end of namespace
+#endif /* OGS_BASELIB_REORDERVECTOR_H */
+

--- a/Tests/BaseLib/TestreorderVector.cpp
+++ b/Tests/BaseLib/TestreorderVector.cpp
@@ -12,6 +12,8 @@
  */
 
 #include <vector>
+#include <algorithm>
+#include <numeric>
 
 #include <gtest/gtest.h>
 
@@ -19,12 +21,19 @@
 
 TEST(BaseLib_reorderVector, testreorderVector)
 {
-    std::vector<double> vec {2016.0, 1996.0, 2006.0, 1986.0};
-    std::vector<int> order {3, 1, 2, 0};
+    const std::size_t size = 100;
+    std::vector<double> vec(size);
+    std::generate(vec.begin(), vec.end(), std::rand);
+    std::vector<double> vec0 = vec;
+
+    std::vector<int> order(size);
+    std::iota(order.begin(), order.end(), 0);
+    std::random_shuffle(order.begin(), order.end());
+
     BaseLib::reorderVector(vec, order);
 
-    EXPECT_EQ(1986.0, vec[0]);
-    EXPECT_EQ(1996.0, vec[1]);
-    EXPECT_EQ(2006.0, vec[2]);
-    EXPECT_EQ(2016.0, vec[3]);
+    for (std::size_t i= 0; i<size; i++)
+    {
+        EXPECT_EQ(vec0[order[i]], vec[i]);
+    }
 }

--- a/Tests/BaseLib/TestreorderVector.cpp
+++ b/Tests/BaseLib/TestreorderVector.cpp
@@ -1,0 +1,30 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ *   \file TestreorderVector.cpp
+ *
+ *   Created on August 14, 2016, 10:01 AM
+ *
+ */
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "BaseLib/reorderVector.h"
+
+TEST(BaseLib_reorderVector, testreorderVector)
+{
+    std::vector<double> vec {2016.0, 1996.0, 2006.0, 1986.0};
+    std::vector<int> order {3, 1, 2, 0};
+    BaseLib::reorderVector(vec, order);
+
+    EXPECT_EQ(1986.0, vec[0]);
+    EXPECT_EQ(1996.0, vec[1]);
+    EXPECT_EQ(2006.0, vec[2]);
+    EXPECT_EQ(2016.0, vec[3]);
+}


### PR DESCRIPTION
As tilted. Although BaseLib::quicksort can be used to reorder a vector, it changes the given index vector as well.

The application of this function is in PR #1468, the which the function re-orders several vectors with one index vector. 