### PR TITLE
Eigen aligned storage

### DIFF
--- a/MaterialLib/SolidModels/LinearElasticIsotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.h
@@ -55,6 +55,13 @@ public:
     struct MaterialStateVariables
         : public MechanicsBase<DisplacementDim>::MaterialStateVariables
     {
+        std::unique_ptr<typename MechanicsBase<DisplacementDim>::MaterialStateVariables> clone() override
+        {
+            return std::unique_ptr<
+                typename MechanicsBase<DisplacementDim>::MaterialStateVariables>
+                {new MaterialStateVariables{*this}};
+        }
+
         void pushBackState() {}
     };
 

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.h
@@ -62,7 +62,7 @@ public:
                 {new MaterialStateVariables{*this}};
         }
 
-        void pushBackState() {}
+        void pushBackState() override {}
     };
 
     std::unique_ptr<

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -64,6 +64,13 @@ public:
     struct MaterialStateVariables
         : public MechanicsBase<DisplacementDim>::MaterialStateVariables
     {
+        std::unique_ptr<typename MechanicsBase<DisplacementDim>::MaterialStateVariables> clone() override
+        {
+            return std::unique_ptr<
+                typename MechanicsBase<DisplacementDim>::MaterialStateVariables>
+                {new MaterialStateVariables{*this}};
+        }
+
         MaterialStateVariables()
         {
             eps_K_t.resize(KelvinVectorSize);

--- a/MaterialLib/SolidModels/MechanicsBase.h
+++ b/MaterialLib/SolidModels/MechanicsBase.h
@@ -39,6 +39,7 @@ struct MechanicsBase
     /// createMaterialStateVariables().
     struct MaterialStateVariables
     {
+        virtual std::unique_ptr<MaterialStateVariables> clone() = 0;
         virtual ~MaterialStateVariables() = default;
         virtual void pushBackState() = 0;
     };

--- a/NumLib/Fem/CoordinatesMapping/ShapeMatrices.h
+++ b/NumLib/Fem/CoordinatesMapping/ShapeMatrices.h
@@ -14,6 +14,7 @@
 #define SHAPEMATRICES_H_
 
 #include <ostream>
+#include <Eigen/Core>
 
 namespace NumLib
 {
@@ -43,6 +44,8 @@ enum class ShapeMatrixType
 template <class T_N, class T_DNDR, class T_J, class T_DNDX>
 struct ShapeMatrices
 {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     typedef T_N ShapeType;
     typedef T_DNDR DrShapeType;
     typedef T_J JacobianType;

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryConditionLocalAssembler.h
@@ -49,7 +49,10 @@ public:
 
 protected:
     IntegrationMethod const _integration_method;
-    std::vector<typename ShapeMatricesType::ShapeMatrices> const _shape_matrices;
+    std::vector<typename ShapeMatricesType::ShapeMatrices,
+                Eigen::aligned_allocator<
+                    typename ShapeMatricesType::ShapeMatrices>> const
+        _shape_matrices;
 };
 
 }  // ProcessLib

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
@@ -22,6 +22,8 @@ class NeumannBoundaryConditionLocalAssembler final
     : public GenericNaturalBoundaryConditionLocalAssembler<
           ShapeFunction, IntegrationMethod, GlobalDim>
 {
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     using Base = GenericNaturalBoundaryConditionLocalAssembler<
         ShapeFunction, IntegrationMethod, GlobalDim>;
 

--- a/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
@@ -27,6 +27,9 @@ class RobinBoundaryConditionLocalAssembler final
     : public GenericNaturalBoundaryConditionLocalAssembler<
           ShapeFunction, IntegrationMethod, GlobalDim>
 {
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     using Base = GenericNaturalBoundaryConditionLocalAssembler<
         ShapeFunction, IntegrationMethod, GlobalDim>;
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -191,7 +191,8 @@ private:
     GroundwaterFlowProcessData const& _process_data;
 
     IntegrationMethod const _integration_method;
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
 
     std::vector<std::vector<double>> _darcy_velocities;
 };

--- a/ProcessLib/HeatConduction/HeatConductionFEM.h
+++ b/ProcessLib/HeatConduction/HeatConductionFEM.h
@@ -163,7 +163,8 @@ private:
     HeatConductionProcessData const& _process_data;
 
     IntegrationMethod const _integration_method;
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
 
     std::vector<std::vector<double>> _heat_fluxes;
 };

--- a/ProcessLib/RichardsFlow/RichardsFlowFEM.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowFEM.h
@@ -181,7 +181,8 @@ private:
     RichardsFlowProcessData const& _process_data;
 
     IntegrationMethod const _integration_method;
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
 
     std::vector<double> _saturation;
 };

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -41,9 +41,22 @@ struct IntegrationPointData final
     {
     }
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-    // The default generated move-ctor is correctly generated for other
-    // compilers.
+    explicit IntegrationPointData(IntegrationPointData const& other)
+        : _b_matrices(other._b_matrices),
+          _sigma(other._sigma),
+          _sigma_prev(other._sigma_prev),
+          _eps(other._eps),
+          _eps_prev(other._eps_prev),
+          _solid_material(other._solid_material),
+          _material_state_variables(other._material_state_variables->clone()),
+          _C(other._C),
+          _detJ(other._detJ),
+          _integralMeasure(other._integralMeasure)
+    {
+    }
+
+    ~IntegrationPointData() = default;
+
     explicit IntegrationPointData(IntegrationPointData&& other)
         : _b_matrices(std::move(other._b_matrices)),
           _sigma(std::move(other._sigma)),
@@ -57,7 +70,6 @@ struct IntegrationPointData final
           _integralMeasure(other._integralMeasure)
     {
     }
-#endif  // _MSC_VER
 
     typename BMatricesType::BMatrixType _b_matrices;
     typename BMatricesType::KelvinVectorType _sigma, _sigma_prev;

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -88,7 +88,7 @@ namespace SmallDeformation
 template <typename ShapeMatrixType>
 struct SecondaryData
 {
-    std::vector<ShapeMatrixType> N;
+    std::vector<ShapeMatrixType, Eigen::aligned_allocator<ShapeMatrixType>> N;
 };
 
 struct SmallDeformationLocalAssemblerInterface
@@ -337,7 +337,10 @@ private:
 
     SmallDeformationProcessData<DisplacementDim>& _process_data;
 
-    std::vector<IntegrationPointData<BMatricesType, DisplacementDim>> _ip_data;
+    std::vector<IntegrationPointData<BMatricesType, DisplacementDim>,
+                Eigen::aligned_allocator<
+                    IntegrationPointData<BMatricesType, DisplacementDim>>>
+        _ip_data;
 
     IntegrationMethod _integration_method;
     MeshLib::Element const& _element;

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -31,6 +31,8 @@
 template <typename BMatricesType, int DisplacementDim>
 struct IntegrationPointData final
 {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     explicit IntegrationPointData(
         MaterialLib::Solids::MechanicsBase<DisplacementDim>& solid_material)
         : _solid_material(solid_material),

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
@@ -153,7 +153,8 @@ private:
     std::vector<IntegrationPointDataFracture<HMatricesType, DisplacementDim>> _ip_data;
 
     IntegrationMethod _integration_method;
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
     MeshLib::Element const& _element;
     SecondaryData<typename ShapeMatrices::ShapeType> _secondary_data;
 };

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
@@ -162,7 +162,8 @@ private:
     std::vector<IntegrationPointDataMatrix<BMatricesType, DisplacementDim>> _ip_data;
 
     IntegrationMethod _integration_method;
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
 
     MeshLib::Element const& _element;
     SecondaryData<typename ShapeMatrices::ShapeType> _secondary_data;

--- a/ProcessLib/TES/TESLocalAssembler.h
+++ b/ProcessLib/TES/TESLocalAssembler.h
@@ -110,7 +110,8 @@ public:
 private:
     IntegrationMethod_ const _integration_method;
 
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
 
     using LAT = LocalAssemblerTraits<ShapeMatricesType, ShapeFunction::NPOINTS,
                                      NODAL_DOF, GlobalDim>;

--- a/ProcessLib/Utils/InitShapeMatrices.h
+++ b/ProcessLib/Utils/InitShapeMatrices.h
@@ -10,6 +10,7 @@
 #define PROCESSLIB_UTILS_INIT_SHAPE_MATRICES_H_
 
 #include <vector>
+#include <Eigen/StdVector>
 
 #include "MeshLib/Elements/Element.h"
 #include "NumLib/Fem/FiniteElement/TemplateIsoparametric.h"
@@ -19,11 +20,15 @@ namespace ProcessLib
 {
 template <typename ShapeFunction, typename ShapeMatricesType,
           typename IntegrationMethod, unsigned GlobalDim>
-std::vector<typename ShapeMatricesType::ShapeMatrices> initShapeMatrices(
-    MeshLib::Element const& e, bool is_axially_symmetric,
-    IntegrationMethod const& integration_method)
+std::vector<typename ShapeMatricesType::ShapeMatrices,
+            Eigen::aligned_allocator<typename ShapeMatricesType::ShapeMatrices>>
+initShapeMatrices(MeshLib::Element const& e, bool is_axially_symmetric,
+                  IntegrationMethod const& integration_method)
 {
-    std::vector<typename ShapeMatricesType::ShapeMatrices> shape_matrices;
+    std::vector<
+        typename ShapeMatricesType::ShapeMatrices,
+        Eigen::aligned_allocator<typename ShapeMatricesType::ShapeMatrices>>
+        shape_matrices;
 
     using FemType = NumLib::TemplateIsoparametric<
         ShapeFunction, ShapeMatricesType>;

--- a/Tests/NumLib/TestExtrapolation.cpp
+++ b/Tests/NumLib/TestExtrapolation.cpp
@@ -32,11 +32,12 @@
 
 namespace
 {
-template<typename ShapeMatrices>
+template <typename ShapeMatrices>
 void interpolateNodalValuesToIntegrationPoints(
-        std::vector<double> const& local_nodal_values,
-        std::vector<ShapeMatrices> const& shape_matrices,
-        std::vector<double>& interpolated_values)
+    std::vector<double> const& local_nodal_values,
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>> const&
+        shape_matrices,
+    std::vector<double>& interpolated_values)
 {
     for (unsigned ip=0; ip<shape_matrices.size(); ++ip)
     {
@@ -116,7 +117,10 @@ public:
     }
 
 private:
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<
+        typename ShapeMatricesType::ShapeMatrices,
+        Eigen::aligned_allocator<typename ShapeMatricesType::ShapeMatrices>>
+        _shape_matrices;
     std::vector<double> _int_pt_values;
 };
 


### PR DESCRIPTION
Some part of my OS changed in the course of last month and the default heap allocation is no longer sufficiently aligned for the Eigen matrices. This is well known to the Eigen people and is discussed in their [documention](http://eigen.tuxfamily.org/dox/group__DenseMatrixManipulation__Alignement.html).

Until now we have tried not to see this special requirement but now a point where the code is no longer running correctly on modern linux' program set is reached.

There might be more places where this changes are needed and so far I only changed the minimum to get all the tests running.

At one place (MechanicsBase) I had to add a copy-ctor required by the operator new (though I don't understand all details why).