### PR TITLE
Accelerate extrapolation

### DIFF
--- a/MathLib/LinAlg/Eigen/EigenMapTools.h
+++ b/MathLib/LinAlg/Eigen/EigenMapTools.h
@@ -188,6 +188,28 @@ Eigen::Map<Vector> toVector(std::vector<double>& data,
     return {data.data(), size};
 }
 
+/*! Creates an Eigen mapped vector from the given data vector.
+ *
+ * This is a convienence method which makes the specification of dynamically
+ * allocated Eigen vectors as return type easier.
+ */
+inline Eigen::Map<const Eigen::VectorXd> toVector(
+    std::vector<double> const& data)
+{
+    return {data.data(), static_cast<Eigen::VectorXd::Index>(data.size())};
+}
+
+/*! Creates an Eigen mapped vector from the given data vector.
+ *
+ * This is a convienence method which makes the specification of dynamically
+ * allocated Eigen vectors as return type easier.
+ */
+inline Eigen::Map<Eigen::VectorXd> toVector(
+    std::vector<double>& data)
+{
+    return {data.data(), static_cast<Eigen::VectorXd::Index>(data.size())};
+}
+
 }  // MathLib
 
 #endif  // MATHLIB_EIGENMAPTOOLS_H

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
@@ -106,11 +106,12 @@ private:
         {
         }
 
-        //! Zeroth shape matrix. Used for assertion only
+        //! Zeroth shape matrix. Used for assertion only.
         Eigen::RowVectorXd const N_0;
 
-        Eigen::MatrixXd Q_T; //!< Transpose of Q from the QR decomposition.
-        Eigen::MatrixXd R;   //!< R from the QR decomposition.
+        //! Moore-Penrose pseudo-inverse of the nodal value to integration point
+        //! value interpolation matrix.
+        Eigen::MatrixXd p_inv;
     };
 
     /*! Maps (#nodes, #int_pts) to (N_0, QR decomposition),

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
@@ -99,19 +99,14 @@ private:
     //! Avoids frequent reallocations.
     std::vector<double> _integration_point_values_cache;
 
-    //! Stores a QR decomposition of some matrix.
-    struct CachedData {
-        explicit CachedData(Eigen::Ref<const Eigen::RowVectorXd> N_0_)
-            : N_0(N_0_)
-        {
-        }
+    //! Stores a matrix and its Moore-Penrose pseudo-inverse.
+    struct CachedData
+    {
+        //! The matrix A.
+        Eigen::MatrixXd A;
 
-        //! Zeroth shape matrix. Used for assertion only.
-        Eigen::RowVectorXd const N_0;
-
-        //! Moore-Penrose pseudo-inverse of the nodal value to integration point
-        //! value interpolation matrix.
-        Eigen::MatrixXd p_inv;
+        //! Moore-Penrose pseudo-inverse of A.
+        Eigen::MatrixXd A_pinv;
     };
 
     /*! Maps (#nodes, #int_pts) to (N_0, QR decomposition),

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -11,7 +11,6 @@
 #define PROCESS_LIB_GROUNDWATERFLOWPROCESS_H_
 
 #include "NumLib/DOF/LocalToGlobalIndexMap.h"
-#include "NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h"
 #include "ProcessLib/Process.h"
 #include "GroundwaterFlowFEM.h"
 #include "GroundwaterFlowProcessData.h"

--- a/ProcessLib/HeatConduction/HeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.h
@@ -10,7 +10,6 @@
 #ifndef PROCESS_LIB_HEATCONDUCTIONPROCESS_H_
 #define PROCESS_LIB_HEATCONDUCTIONPROCESS_H_
 
-#include "NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h"
 #include "ProcessLib/Process.h"
 #include "HeatConductionFEM.h"
 #include "HeatConductionProcessData.h"

--- a/Tests/NumLib/TestExtrapolation.cpp
+++ b/Tests/NumLib/TestExtrapolation.cpp
@@ -196,8 +196,8 @@ void extrapolate(TestProcess const& pcs, IntegrationPointValuesMethod method,
 {
     namespace LinAlg = MathLib::LinAlg;
 
-    auto const tolerance_dx  = 20.0 * std::numeric_limits<double>::epsilon();
-    auto const tolerance_res =  5.0 * std::numeric_limits<double>::epsilon();
+    auto const tolerance_dx  = 30.0 * std::numeric_limits<double>::epsilon();
+    auto const tolerance_res = 15.0 * std::numeric_limits<double>::epsilon();
 
     auto const result = pcs.extrapolate(method);
     auto const& x_extra = *result.first;

--- a/Tests/NumLib/TestExtrapolation.cpp
+++ b/Tests/NumLib/TestExtrapolation.cpp
@@ -12,6 +12,7 @@
 #include "MathLib/LinAlg/LinAlg.h"
 
 #include "MeshLib/MeshGenerators/MeshGenerator.h"
+#include "MeshLib/IO/writeMeshToFile.h"
 
 #include "NumLib/DOF/DOFTableUtil.h"
 #include "NumLib/DOF/MatrixProviderUser.h"
@@ -31,7 +32,6 @@
 
 namespace
 {
-
 template<typename ShapeMatrices>
 void interpolateNodalValuesToIntegrationPoints(
         std::vector<double> const& local_nodal_values,
@@ -45,7 +45,7 @@ void interpolateNodalValuesToIntegrationPoints(
     }
 }
 
-}
+} // anonymous namespace
 
 class LocalAssemblerDataInterface : public NumLib::ExtrapolatableElement
 {
@@ -171,6 +171,7 @@ public:
     {
         auto const extrapolatables =
             NumLib::makeExtrapolatable(_local_assemblers, method);
+
         _extrapolator->extrapolate(extrapolatables);
         _extrapolator->calculateResiduals(extrapolatables);
 
@@ -234,18 +235,17 @@ TEST(NumLib, DISABLED_Extrapolation)
      * x.
      */
 
+    const double mesh_length = 1.0;
+    const std::size_t mesh_elements_in_each_direction = 5;
+
+    // generate mesh
+    std::unique_ptr<MeshLib::Mesh> mesh(
+                MeshLib::MeshGenerator::generateRegularHexMesh(
+                    mesh_length, mesh_elements_in_each_direction));
+
     for (unsigned integration_order : {2, 3, 4})
     {
-
         namespace LinAlg = MathLib::LinAlg;
-
-        const double mesh_length = 1.0;
-        const double mesh_elements_in_each_direction = 5.0;
-
-        // generate mesh
-        std::unique_ptr<MeshLib::Mesh> mesh(
-                    MeshLib::MeshGenerator::generateRegularHexMesh(
-                        mesh_length, mesh_elements_in_each_direction));
 
         auto const nnodes    = mesh->getNumberOfNodes();
         auto const nelements = mesh->getNumberOfElements();


### PR DESCRIPTION
I recognized that the shape matrices N are the same for a given element with a given set of integration points.

Therefore the extrapolation matrices only need to be computed once for each (element/integration point) combination, which speeds extrapolation up by roughly a factor of 10 (the TestExtrapolation unit test with 4th integration order, release build, fixed-size shape matrices, 20^3 hex elements; time needed for extrapolation before this PR: 0.075s, afterwards: 0.0072s).

The central assumption of this PR is that the set of shape matrices is uniquely defined by the number of nodes and the number of integration points in an element.
That should work with our current element types. I'd leave any better identification method for later refactoring.

Actually, the precomputation could even happen offline, s.t. linear solvers are not needed for extrapolation anymore.