### PR TITLE
[SD-LIE] Multiple fractures

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -574,6 +574,20 @@ if(NOT OGS_USE_MPI)
         single_joint_inside_expected_pcs_0_ts_1_t_1.000000.vtu single_joint_inside_pcs_0_ts_1_t_1.000000.vtu displacement_jump1 displacement_jump1
     )
 
+    AddTest(
+        NAME LIE_M_two_joints
+        PATH LIE/Mechanics
+        EXECUTABLE ogs
+        EXECUTABLE_ARGS two_joints.prj
+        WRAPPER time
+        TESTER vtkdiff
+        ABSTOL 1e-16 RELTOL 1e-16
+        DIFF_DATA
+        two_joints_expected_pcs_0_ts_1_t_1.000000.vtu two_joints_pcs_0_ts_1_t_1.000000.vtu displacement displacement
+        two_joints_expected_pcs_0_ts_1_t_1.000000.vtu two_joints_pcs_0_ts_1_t_1.000000.vtu displacement_jump1 displacement_jump1
+        two_joints_expected_pcs_0_ts_1_t_1.000000.vtu two_joints_pcs_0_ts_1_t_1.000000.vtu displacement_jump2 displacement_jump2
+    )
+
     # Liquid flow
     AddTest(
         NAME LiquidFlow_LineDirichletNeumannBC

--- a/Applications/Utils/PostProcessing/postLIE.cpp
+++ b/Applications/Utils/PostProcessing/postLIE.cpp
@@ -67,11 +67,12 @@ int main (int argc, char* argv[])
 
         // post-process
         std::vector<MeshLib::Element*> vec_matrix_elements;
-        std::vector<MeshLib::Element*> vec_fracture_elements;
-        std::vector<MeshLib::Element*> vec_fracture_matrix_elements;
-        std::vector<MeshLib::Node*> vec_fracture_nodes;
+        std::vector<int> vec_fracture_mat_IDs;
+        std::vector<std::vector<MeshLib::Element*>> vec_fracture_elements;
+        std::vector<std::vector<MeshLib::Element*>> vec_fracture_matrix_elements;
+        std::vector<std::vector<MeshLib::Node*>> vec_fracture_nodes;
         ProcessLib::SmallDeformationWithLIE::getFractureMatrixDataInMesh(
-            *mesh, vec_matrix_elements, vec_fracture_elements,
+            *mesh, vec_matrix_elements, vec_fracture_mat_IDs, vec_fracture_elements,
             vec_fracture_matrix_elements, vec_fracture_nodes);
 
         ProcessLib::SmallDeformationWithLIE::PostProcessTool post(

--- a/BaseLib/makeVectorUnique.h
+++ b/BaseLib/makeVectorUnique.h
@@ -27,5 +27,15 @@ void makeVectorUnique(std::vector<T>& v)
     v.erase(it, v.end());
 }
 
+/// Make the entries of the std::vector \c v unique using the given binary
+/// function. The remaining entries will be sorted.
+template <typename T, class Compare>
+void makeVectorUnique(std::vector<T>& v, Compare comp)
+{
+    std::sort(v.begin(), v.end(), comp);
+    auto it = std::unique(v.begin(), v.end());
+    v.erase(it, v.end());
+}
+
 } // end namespace BaseLib
 #endif

--- a/ProcessLib/SmallDeformationWithLIE/Common/FractureProperty.h
+++ b/ProcessLib/SmallDeformationWithLIE/Common/FractureProperty.h
@@ -27,6 +27,7 @@ namespace SmallDeformationWithLIE
 
 struct FractureProperty
 {
+    int fracture_id = 0;
     int mat_id = 0;
     Eigen::Vector3d point_on_fracture;
     Eigen::Vector3d normal_vector;

--- a/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.cpp
@@ -62,73 +62,106 @@ private:
 void getFractureMatrixDataInMesh(
         MeshLib::Mesh const& mesh,
         std::vector<MeshLib::Element*>& vec_matrix_elements,
-        std::vector<MeshLib::Element*>& vec_fracture_elements,
-        std::vector<MeshLib::Element*>& vec_fracture_matrix_elements,
-        std::vector<MeshLib::Node*>& vec_fracture_nodes
+        std::vector<int>& vec_fracture_mat_IDs,
+        std::vector<std::vector<MeshLib::Element*>>& vec_fracture_elements,
+        std::vector<std::vector<MeshLib::Element*>>& vec_fracture_matrix_elements,
+        std::vector<std::vector<MeshLib::Node*>>& vec_fracture_nodes
         )
 {
     IsCrackTip isCrackTip(mesh);
 
     // get vectors of matrix elements and fracture elements
     vec_matrix_elements.reserve(mesh.getNumberOfElements());
+    std::vector<MeshLib::Element*> all_fracture_elements;
     for (MeshLib::Element* e : mesh.getElements())
     {
         if (e->getDimension() == mesh.getDimension())
             vec_matrix_elements.push_back(e);
         else
-            vec_fracture_elements.push_back(e);
+            all_fracture_elements.push_back(e);
     }
     DBUG("-> found total %d matrix elements and %d fracture elements",
-         vec_matrix_elements.size(), vec_fracture_elements.size());
+         vec_matrix_elements.size(), all_fracture_elements.size());
+
+    // get fracture material IDs
+    auto opt_material_ids(mesh.getProperties().getPropertyVector<int>("MaterialIDs"));
+    if (!opt_material_ids)
+        OGS_FATAL("MaterialIDs propery vector not found in a mesh");
+    for (MeshLib::Element* e : all_fracture_elements)
+        vec_fracture_mat_IDs.push_back((*opt_material_ids)[e->getID()]);
+    std::sort(vec_fracture_mat_IDs.begin(), vec_fracture_mat_IDs.end());
+    vec_fracture_mat_IDs.erase(
+        std::unique(vec_fracture_mat_IDs.begin(), vec_fracture_mat_IDs.end()),
+        vec_fracture_mat_IDs.end());
+    DBUG("-> found %d fracture material groups", vec_fracture_mat_IDs.size());
+
+    // create a vector of fracture elements for each group
+    vec_fracture_elements.resize(vec_fracture_mat_IDs.size());
+    for (unsigned frac_id=0; frac_id<vec_fracture_mat_IDs.size(); frac_id++)
+    {
+        const auto frac_mat_id = vec_fracture_mat_IDs[frac_id];
+        std::vector<MeshLib::Element*> &vec_elements = vec_fracture_elements[frac_id];
+        for (MeshLib::Element* e : all_fracture_elements)
+        {
+            if ((*opt_material_ids)[e->getID()] == frac_mat_id)
+                vec_elements.push_back(e);
+        }
+        DBUG("-> found %d elements on the fracture %d", vec_elements.size(), frac_id);
+    }
 
     // get a vector of fracture nodes
-    for (MeshLib::Element* e : vec_fracture_elements)
+    vec_fracture_nodes.resize(vec_fracture_mat_IDs.size());
+    for (unsigned frac_id=0; frac_id<vec_fracture_mat_IDs.size(); frac_id++)
     {
-        for (unsigned i=0; i<e->getNumberOfNodes(); i++)
+        std::vector<MeshLib::Node*> &vec_nodes = vec_fracture_nodes[frac_id];
+        for (MeshLib::Element* e : vec_fracture_elements[frac_id])
         {
-            if (isCrackTip(*e->getNode(i)))
-                continue;
-            vec_fracture_nodes.push_back(const_cast<MeshLib::Node*>(e->getNode(i)));
+            for (unsigned i=0; i<e->getNumberOfNodes(); i++)
+            {
+                if (isCrackTip(*e->getNode(i)))
+                    continue;
+                vec_nodes.push_back(const_cast<MeshLib::Node*>(e->getNode(i)));
+            }
         }
+        std::sort(vec_nodes.begin(), vec_nodes.end(),
+            [](MeshLib::Node* node1, MeshLib::Node* node2) { return (node1->getID() < node2->getID()); }
+            );
+        vec_nodes.erase(std::unique(vec_nodes.begin(), vec_nodes.end()), vec_nodes.end());
+        DBUG("-> found %d nodes on the fracture %d", vec_nodes.size(), frac_id);
     }
-    std::sort(vec_fracture_nodes.begin(), vec_fracture_nodes.end(),
-        [](MeshLib::Node* node1, MeshLib::Node* node2) { return (node1->getID() < node2->getID()); }
-        );
-    vec_fracture_nodes.erase(
-                std::unique(vec_fracture_nodes.begin(), vec_fracture_nodes.end()),
-                vec_fracture_nodes.end());
-    DBUG("-> found %d nodes on the fracture", vec_fracture_nodes.size());
 
     // create a vector fracture elements and connected matrix elements,
     // which are passed to a DoF table
-    // first, collect matrix elements
-    for (MeshLib::Element *e : vec_fracture_elements)
+    for (auto fracture_elements : vec_fracture_elements)
     {
-        for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++)
+        std::vector<MeshLib::Element*> vec_ele;
+        // first, collect matrix elements
+        for (MeshLib::Element*e : fracture_elements)
         {
-            MeshLib::Node const* node = e->getNode(i);
-            if (isCrackTip(*node))
-                continue;
-            for (unsigned j=0; j<node->getNumberOfElements(); j++)
+            for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++)
             {
-                // only matrix elements
-                if (node->getElement(j)->getDimension() == mesh.getDimension()-1)
+                MeshLib::Node const* node = e->getNode(i);
+                if (isCrackTip(*node))
                     continue;
-                vec_fracture_matrix_elements.push_back(const_cast<MeshLib::Element*>(node->getElement(j)));
+                for (unsigned j=0; j<node->getNumberOfElements(); j++)
+                {
+                    // only matrix elements
+                    if (node->getElement(j)->getDimension() < mesh.getDimension())
+                        continue;
+                    vec_ele.push_back(const_cast<MeshLib::Element*>(node->getElement(j)));
+                }
             }
         }
-    }
-    std::sort(vec_fracture_matrix_elements.begin(), vec_fracture_matrix_elements.end(),
-        [](MeshLib::Element* p1, MeshLib::Element* p2) { return (p1->getID() < p2->getID()); }
-        );
-    vec_fracture_matrix_elements.erase(
-                std::unique(vec_fracture_matrix_elements.begin(), vec_fracture_matrix_elements.end()),
-                vec_fracture_matrix_elements.end());
+        std::sort(vec_ele.begin(), vec_ele.end(),
+            [](MeshLib::Element* p1, MeshLib::Element* p2) { return (p1->getID() < p2->getID()); }
+            );
+        vec_ele.erase(std::unique(vec_ele.begin(), vec_ele.end()), vec_ele.end());
 
-    // second, append fracture elements
-    vec_fracture_matrix_elements.insert(
-                vec_fracture_matrix_elements.end(),
-                vec_fracture_elements.begin(), vec_fracture_elements.end());
+        // second, append fracture elements
+        vec_ele.insert(vec_ele.end(), fracture_elements.begin(), fracture_elements.end());
+
+        vec_fracture_matrix_elements.push_back(vec_ele);
+    }
 }
 
 }  // namespace SmallDeformationWithLIE

--- a/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.cpp
@@ -8,6 +8,7 @@
 
 #include "MeshUtils.h"
 
+#include "BaseLib/makeVectorUnique.h"
 #include "MeshLib/MeshSearch/NodeSearch.h"
 
 namespace ProcessLib
@@ -89,10 +90,7 @@ void getFractureMatrixDataInMesh(
         OGS_FATAL("MaterialIDs propery vector not found in a mesh");
     for (MeshLib::Element* e : all_fracture_elements)
         vec_fracture_mat_IDs.push_back((*opt_material_ids)[e->getID()]);
-    std::sort(vec_fracture_mat_IDs.begin(), vec_fracture_mat_IDs.end());
-    vec_fracture_mat_IDs.erase(
-        std::unique(vec_fracture_mat_IDs.begin(), vec_fracture_mat_IDs.end()),
-        vec_fracture_mat_IDs.end());
+    BaseLib::makeVectorUnique(vec_fracture_mat_IDs);
     DBUG("-> found %d fracture material groups", vec_fracture_mat_IDs.size());
 
     // create a vector of fracture elements for each group
@@ -123,10 +121,11 @@ void getFractureMatrixDataInMesh(
                 vec_nodes.push_back(const_cast<MeshLib::Node*>(e->getNode(i)));
             }
         }
-        std::sort(vec_nodes.begin(), vec_nodes.end(),
-            [](MeshLib::Node* node1, MeshLib::Node* node2) { return (node1->getID() < node2->getID()); }
-            );
-        vec_nodes.erase(std::unique(vec_nodes.begin(), vec_nodes.end()), vec_nodes.end());
+        BaseLib::makeVectorUnique(
+            vec_nodes,
+            [](MeshLib::Node* node1, MeshLib::Node* node2) {
+                return node1->getID() < node2->getID();
+            });
         DBUG("-> found %d nodes on the fracture %d", vec_nodes.size(), frac_id);
     }
 
@@ -152,10 +151,11 @@ void getFractureMatrixDataInMesh(
                 }
             }
         }
-        std::sort(vec_ele.begin(), vec_ele.end(),
-            [](MeshLib::Element* p1, MeshLib::Element* p2) { return (p1->getID() < p2->getID()); }
-            );
-        vec_ele.erase(std::unique(vec_ele.begin(), vec_ele.end()), vec_ele.end());
+        BaseLib::makeVectorUnique(
+            vec_ele,
+            [](MeshLib::Element* e1, MeshLib::Element* e2) {
+                return e1->getID() < e2->getID();
+            });
 
         // second, append fracture elements
         vec_ele.insert(vec_ele.end(), fracture_elements.begin(), fracture_elements.end());

--- a/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.cpp
@@ -137,7 +137,9 @@ void getFractureMatrixDataInMesh(
         // first, collect matrix elements
         for (MeshLib::Element*e : fracture_elements)
         {
-            for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++)
+            // it is sufficient to iterate over base nodes, because they are
+            // already connected to all neighbours
+            for (unsigned i = 0; i < e->getNumberOfBaseNodes(); i++)
             {
                 MeshLib::Node const* node = e->getNode(i);
                 if (isCrackTip(*node))

--- a/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.cpp
@@ -99,11 +99,11 @@ void getFractureMatrixDataInMesh(
     {
         const auto frac_mat_id = vec_fracture_mat_IDs[frac_id];
         std::vector<MeshLib::Element*> &vec_elements = vec_fracture_elements[frac_id];
-        for (MeshLib::Element* e : all_fracture_elements)
-        {
-            if ((*opt_material_ids)[e->getID()] == frac_mat_id)
-                vec_elements.push_back(e);
-        }
+        std::copy_if(all_fracture_elements.begin(), all_fracture_elements.end(),
+                     std::back_inserter(vec_elements),
+                     [&](MeshLib::Element* e) {
+                         return (*opt_material_ids)[e->getID()] == frac_mat_id;
+                     });
         DBUG("-> found %d elements on the fracture %d", vec_elements.size(), frac_id);
     }
 
@@ -158,7 +158,8 @@ void getFractureMatrixDataInMesh(
             });
 
         // second, append fracture elements
-        vec_ele.insert(vec_ele.end(), fracture_elements.begin(), fracture_elements.end());
+        std::copy(fracture_elements.begin(), fracture_elements.end(),
+                  std::back_inserter(vec_ele));
 
         vec_fracture_matrix_elements.push_back(vec_ele);
     }

--- a/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.h
+++ b/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.h
@@ -26,16 +26,19 @@ namespace SmallDeformationWithLIE
  * @param mesh  A mesh which includes fracture elements, i.e. lower-dimensional elements.
  * It is assumed that elements forming a fracture have a distinct material ID.
  * @param vec_matrix_elements  a vector of matrix elements
- * @param vec_fracture_elements  a vector of fracture elements
- * @param vec_fracture_matrix_elements  a vector of fracture elements and matrix elements connecting to the fracture
- * @param vec_fracture_nodes  a vector of fracture element nodes
+ * @param vec_fracture_mat_IDs  fracture material IDs found in the mesh
+ * @param vec_fracture_elements  a vector of fracture elements (grouped by fracture IDs)
+ * @param vec_fracture_matrix_elements  a vector of fracture elements and matrix elements
+ * connecting to the fracture (grouped by fracture IDs)
+ * @param vec_fracture_nodes  a vector of fracture element nodes (grouped by fracture IDs)
  */
 void getFractureMatrixDataInMesh(
         MeshLib::Mesh const& mesh,
         std::vector<MeshLib::Element*>& vec_matrix_elements,
-        std::vector<MeshLib::Element*>& vec_fracture_elements,
-        std::vector<MeshLib::Element*>& vec_fracture_matrix_elements,
-        std::vector<MeshLib::Node*>& vec_fracture_nodes
+        std::vector<int>& vec_fracture_mat_IDs,
+        std::vector<std::vector<MeshLib::Element*>>& vec_fracture_elements,
+        std::vector<std::vector<MeshLib::Element*>>& vec_fracture_matrix_elements,
+        std::vector<std::vector<MeshLib::Node*>>& vec_fracture_nodes
         );
 
 }  // namespace SmallDeformationWithLIE

--- a/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
@@ -58,7 +58,8 @@ PostProcessTool::PostProcessTool(
         {
             auto duplicated_node = new MeshLib::Node(org_node->getCoords(), new_nodes.size());
             new_nodes.push_back(duplicated_node);
-            assert(_map_dup_newNodeIDs.count(org_node->getID())==0);
+            if (_map_dup_newNodeIDs.count(org_node->getID())>0)
+                OGS_FATAL("Intersection of fractures is not supported");
             _map_dup_newNodeIDs[org_node->getID()] = duplicated_node->getID();
         }
     }

--- a/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
@@ -68,7 +68,8 @@ PostProcessTool::PostProcessTool(
     {
         auto const& vec_fracutre_matrix_elements = vec_vec_fracutre_matrix_elements[fracture_id];
         auto const& vec_fracture_nodes = vec_vec_fracture_nodes[fracture_id];
-        auto prop_levelset = org_mesh.getProperties().getPropertyVector<double>("levelset" + std::to_string(fracture_id+1));
+        auto prop_levelset = org_mesh.getProperties().getPropertyVector<double>(
+            "levelset" + std::to_string(fracture_id + 1));
         for (auto const* org_e : vec_fracutre_matrix_elements)
         {
             // only matrix elements
@@ -91,8 +92,11 @@ PostProcessTool::PostProcessTool(
                     continue;
 
                 // check if a node belongs to the particular fracture group
-                auto itr2 = std::find_if(vec_fracture_nodes.begin(), vec_fracture_nodes.end(),
-                                         [&](MeshLib::Node const*node) { return node->getID()==e->getNodeIndex(i);});
+                auto itr2 = std::find_if(
+                    vec_fracture_nodes.begin(), vec_fracture_nodes.end(),
+                    [&](MeshLib::Node const* node) {
+                        return node->getID() == e->getNodeIndex(i);
+                    });
                 if (itr2 == vec_fracture_nodes.end())
                     continue;
 
@@ -177,7 +181,8 @@ void PostProcessTool::copyProperties()
             for (auto itr : _map_dup_newNodeIDs)
             {
                 for (unsigned j=0; j<n_dest_comp; j++)
-                    (*dest_prop)[itr.second*n_dest_comp + j] = (*dest_prop)[itr.first*n_dest_comp + j];
+                    (*dest_prop)[itr.second * n_dest_comp + j] =
+                        (*dest_prop)[itr.first * n_dest_comp + j];
             }
         }
         else if (src_prop->getMeshItemType() == MeshLib::MeshItemType::Cell)
@@ -213,7 +218,9 @@ void PostProcessTool::calculateTotalDisplacement(unsigned const n_fractures)
     {
         // nodal value of levelset
         std::vector<double> nodal_levelset(_output_mesh->getNodes().size(), 0.0);
-        auto const& ele_levelset =  *_output_mesh->getProperties().getPropertyVector<double>("levelset" + std::to_string(fracture_id+1));
+        auto const& ele_levelset =
+            *_output_mesh->getProperties().getPropertyVector<double>(
+                "levelset" + std::to_string(fracture_id + 1));
         for (MeshLib::Element const* e : _output_mesh->getElements())
         {
             if (e->getDimension() != _output_mesh->getDimension())
@@ -227,8 +234,10 @@ void PostProcessTool::calculateTotalDisplacement(unsigned const n_fractures)
         }
 
         // update total displacements
-        auto const& g =  *_output_mesh->getProperties().getPropertyVector<double>("displacement_jump" + std::to_string(fracture_id+1));
-        for (unsigned i=0; i<_output_mesh->getNodes().size(); i++)
+        auto const& g =
+            *_output_mesh->getProperties().getPropertyVector<double>(
+                "displacement_jump" + std::to_string(fracture_id + 1));
+        for (unsigned i = 0; i < _output_mesh->getNodes().size(); i++)
         {
             for (unsigned j=0; j<n_u_comp; j++)
                 total_u[i*n_u_comp+j] += nodal_levelset[i] * g[i*n_u_comp+j];

--- a/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
@@ -35,7 +35,7 @@ inline void sort_unique(std::vector<T> &vec)
 PostProcessTool::PostProcessTool(
     MeshLib::Mesh const& org_mesh,
     std::vector<std::vector<MeshLib::Node*>> const& vec_vec_fracture_nodes,
-    std::vector<std::vector<MeshLib::Element*>> const& vec_vec_fracutre_matrix_elements)
+    std::vector<std::vector<MeshLib::Element*>> const& vec_vec_fracture_matrix_elements)
     :_org_mesh(org_mesh)
 {
     if (!org_mesh.getProperties().hasPropertyVector("displacement")
@@ -65,13 +65,13 @@ PostProcessTool::PostProcessTool(
     }
 
     // split elements using the new duplicated nodes
-    for (unsigned fracture_id=0; fracture_id<=vec_vec_fracutre_matrix_elements.size(); fracture_id++)
+    for (unsigned fracture_id=0; fracture_id<=vec_vec_fracture_matrix_elements.size(); fracture_id++)
     {
-        auto const& vec_fracutre_matrix_elements = vec_vec_fracutre_matrix_elements[fracture_id];
+        auto const& vec_fracture_matrix_elements = vec_vec_fracture_matrix_elements[fracture_id];
         auto const& vec_fracture_nodes = vec_vec_fracture_nodes[fracture_id];
         auto prop_levelset = org_mesh.getProperties().getPropertyVector<double>(
             "levelset" + std::to_string(fracture_id + 1));
-        for (auto const* org_e : vec_fracutre_matrix_elements)
+        for (auto const* org_e : vec_fracture_matrix_elements)
         {
             // only matrix elements
             if (org_e->getDimension() != org_mesh.getDimension())

--- a/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.h
+++ b/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.h
@@ -29,8 +29,8 @@ class PostProcessTool
 public:
     PostProcessTool(
         MeshLib::Mesh const& org_mesh,
-        std::vector<MeshLib::Node*> const& vec_fracture_nodes,
-        std::vector<MeshLib::Element*> const& vec_fracutre_matrix_elements);
+        std::vector<std::vector<MeshLib::Node*>> const& vec_vec_fracture_nodes,
+        std::vector<std::vector<MeshLib::Element*>> const& vec_vec_fracutre_matrix_elements);
 
     MeshLib::Mesh const& getOutputMesh() const { return *_output_mesh; }
 
@@ -39,7 +39,7 @@ private:
     void createProperties();
     template <typename T>
     void copyProperties();
-    void calculateTotalDisplacement();
+    void calculateTotalDisplacement(unsigned const n_fractures);
 
     MeshLib::Mesh const& _org_mesh;
     std::unique_ptr<MeshLib::Mesh> _output_mesh;

--- a/ProcessLib/SmallDeformationWithLIE/CreateSmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/CreateSmallDeformationProcess.cpp
@@ -69,8 +69,9 @@ createSmallDeformationProcess(
 
         process_variables.emplace_back(const_cast<ProcessVariable&>(*variable));
     }
-    if (process_variables.size() > 2)
-        OGS_FATAL("Currently only one displacement jump is supported");
+    auto const n_fractures = process_variables.size()-1;
+    if (n_fractures < 1)
+        OGS_FATAL("No displacement jump variables are specified");
 
     DBUG("Associate displacement with process variable \'%s\'.",
          process_variables.back().get().getName().c_str());

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerFracture-impl.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerFracture-impl.h
@@ -55,7 +55,9 @@ SmallDeformationLocalAssemblerFracture<ShapeFunction, IntegrationMethod,
     _ip_data.reserve(n_integration_points);
     _secondary_data.N.resize(n_integration_points);
 
-    auto const* frac_prop = _process_data._fracture_property.get();
+    auto mat_id = (*_process_data._mesh_prop_materialIDs)[e.getID()];
+    auto frac_id = _process_data._map_materialID_to_fractureID[mat_id];
+    _fracture_property = _process_data._vec_fracture_property[frac_id].get();
 
     SpatialPosition x_position;
     x_position.setElementID(_element.getID());
@@ -82,7 +84,7 @@ SmallDeformationLocalAssemblerFracture<ShapeFunction, IntegrationMethod,
         ip_data._sigma.resize(DisplacementDim);
         ip_data._sigma_prev.resize(DisplacementDim);
         ip_data._C.resize(DisplacementDim, DisplacementDim);
-        ip_data._aperture0 = (*frac_prop->aperture0)(0, x_position)[0];
+        ip_data._aperture0 = (*_fracture_property->aperture0)(0, x_position)[0];
         ip_data._aperture_prev = ip_data._aperture0;
 
         _secondary_data.N[ip] = sm.N;
@@ -102,8 +104,7 @@ assembleWithJacobian(
 {
     auto const& nodal_jump = local_u;
 
-    FractureProperty const& frac_prop = *_process_data._fracture_property;
-    auto const& R = frac_prop.R;
+    auto const& R = _fracture_property->R;
 
     // the index of a normal (normal to a fracture plane) component
     // in a displacement vector

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
@@ -149,6 +149,7 @@ private:
     }
 
     SmallDeformationProcessData<DisplacementDim>& _process_data;
+    FractureProperty const* _fracture_property = nullptr;
 
     std::vector<IntegrationPointDataFracture<HMatricesType, DisplacementDim>> _ip_data;
 

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
@@ -118,7 +118,7 @@ assembleWithJacobian(
 {
     assert (_element.getDimension() == DisplacementDim);
 
-    auto constexpr N_DOF_PER_VAR = ShapeFunction::NPOINTS * DisplacementDim;
+    auto const N_DOF_PER_VAR = ShapeFunction::NPOINTS * DisplacementDim;
     auto const n_fractures = _fracture_props.size();
 
     using BlockVectorType = typename Eigen::VectorXd::FixedSegmentReturnType<N_DOF_PER_VAR>::Type;

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
@@ -122,7 +122,7 @@ assembleWithJacobian(
     auto const n_fractures = _fracture_props.size();
 
     using BlockVectorType = typename Eigen::VectorXd::FixedSegmentReturnType<N_DOF_PER_VAR>::Type;
-    using BlockMatrixType = typename Eigen::MatrixXd::FixedBlockXpr<N_DOF_PER_VAR,N_DOF_PER_VAR>::Type;
+    using BlockMatrixType = Eigen::Block<Eigen::MatrixXd,N_DOF_PER_VAR,N_DOF_PER_VAR>;
 
     //--------------------------------------------------------------------------------------
     // prepare sub vectors, matrices for regular displacement (u) and displacement jumps (g)

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
@@ -133,7 +133,7 @@ assembleWithJacobian(
     //     |b(g2)|
     //
     //     |J(u,u)  J(u,g1)  J(u,g2) |
-    // J = |J(g1,u) J(g1,g1) J(g2,g2)|
+    // J = |J(g1,u) J(g1,g1) J(g1,g2)|
     //     |J(g2,u) J(g2,g1) J(g2,g2)|
     //--------------------------------------------------------------------------------------
     auto local_b_u = local_b.segment<N_DOF_PER_VAR>(0);

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
@@ -100,6 +100,9 @@ SmallDeformationLocalAssemblerMatrixNearFracture<ShapeFunction, IntegrationMetho
 
         _secondary_data.N[ip] = sm.N;
     }
+
+    for (auto fid : process_data._vec_ele_connected_fractureIDs[e.getID()])
+        _fracture_props.push_back(_process_data._vec_fracture_property[fid].get());
 }
 
 
@@ -115,21 +118,60 @@ assembleWithJacobian(
 {
     assert (_element.getDimension() == DisplacementDim);
 
-    auto const n_dof_per_var = ShapeFunction::NPOINTS * DisplacementDim;
+    auto constexpr N_DOF_PER_VAR = ShapeFunction::NPOINTS * DisplacementDim;
+    auto const n_fractures = _fracture_props.size();
 
-    auto localRhs_ru = local_b.segment(0, n_dof_per_var);
-    auto localRhs_du = local_b.segment(n_dof_per_var, n_dof_per_var);
+    using BlockVectorType = typename Eigen::VectorXd::FixedSegmentReturnType<N_DOF_PER_VAR>::Type;
+    using BlockMatrixType = typename Eigen::MatrixXd::FixedBlockXpr<N_DOF_PER_VAR,N_DOF_PER_VAR>::Type;
 
-    auto localA_uu = local_J.block(0, 0, n_dof_per_var, n_dof_per_var);
-    auto localA_ug = local_J.block(0, n_dof_per_var, n_dof_per_var, n_dof_per_var);
-    auto localA_gu = local_J.block(n_dof_per_var, 0, n_dof_per_var, n_dof_per_var);
-    auto localA_gg = local_J.block(n_dof_per_var, n_dof_per_var, n_dof_per_var, n_dof_per_var);
+    //--------------------------------------------------------------------------------------
+    // prepare sub vectors, matrices for regular displacement (u) and displacement jumps (g)
+    //
+    // example with two fractures:
+    //     |b(u)|
+    // b = |b(g1)|
+    //     |b(g2)|
+    //
+    //     |J(u,u)  J(u,g1)  J(u,g2) |
+    // J = |J(g1,u) J(g1,g1) J(g2,g2)|
+    //     |J(g2,u) J(g2,g1) J(g2,g2)|
+    //--------------------------------------------------------------------------------------
+    auto local_b_u = local_b.segment<N_DOF_PER_VAR>(0);
+    std::vector<BlockVectorType> vec_local_b_g;
+    for (unsigned i=0; i<n_fractures; i++)
+        vec_local_b_g.push_back(local_b.segment<N_DOF_PER_VAR>(N_DOF_PER_VAR*(i+1)));
 
-    auto const nodal_ru = local_u.segment(0, n_dof_per_var);
-    auto nodal_du = local_u.segment(n_dof_per_var, n_dof_per_var);
+    auto local_J_uu = local_J.block<N_DOF_PER_VAR, N_DOF_PER_VAR>(0, 0);
+    std::vector<BlockMatrixType> vec_local_J_ug;
+    std::vector<BlockMatrixType> vec_local_J_gu;
+    std::vector<std::vector<BlockMatrixType>> vec_local_J_gg(n_fractures);
+    for (unsigned i=0; i<n_fractures; i++)
+    {
+        auto sub_ug = local_J.block<N_DOF_PER_VAR, N_DOF_PER_VAR>(0, N_DOF_PER_VAR*(i+1));
+        vec_local_J_ug.push_back(sub_ug);
 
-    auto const &fracture_props = *_process_data._fracture_property;
+        auto sub_gu = local_J.block<N_DOF_PER_VAR, N_DOF_PER_VAR>(N_DOF_PER_VAR*(i+1), 0);
+        vec_local_J_gu.push_back(sub_gu);
 
+        for (unsigned j=0; j<n_fractures; j++)
+        {
+            auto sub_gg =
+                local_J.block<N_DOF_PER_VAR, N_DOF_PER_VAR>(N_DOF_PER_VAR * (i + 1), N_DOF_PER_VAR * (j + 1));
+            vec_local_J_gg[i].push_back(sub_gg);
+        }
+    }
+
+    auto const nodal_u = local_u.segment<N_DOF_PER_VAR>(0);
+    std::vector<BlockVectorType> vec_nodal_g;
+    for (unsigned i=0; i<n_fractures; i++)
+    {
+        auto sub = const_cast<Eigen::VectorXd&>(local_u).segment<N_DOF_PER_VAR>(N_DOF_PER_VAR*(i+1));
+        vec_nodal_g.push_back(sub);
+    }
+
+    //------------------------------------------------
+    // integration
+    //------------------------------------------------
     unsigned const n_integration_points =
         _integration_method.getNumberOfPoints();
 
@@ -143,15 +185,19 @@ assembleWithJacobian(
         auto const& sm = _shape_matrices[ip];
         auto &ip_data = _ip_data[ip];
         auto const& wp = _integration_method.getWeightedPoint(ip);
-        auto const& detJ = ip_data._detJ;
-        auto const& integralMeasure = ip_data._integralMeasure;
+        auto const ip_factor = ip_data._detJ * wp.getWeight() * ip_data._integralMeasure;
 
         // levelset functions
         auto const ip_physical_coords = computePhysicalCoordinates(_element, sm.N);
-        double levelsets = calculateLevelSetFunction(fracture_props, ip_physical_coords.getCoords());
+        std::vector<double> levelsets(n_fractures);
+        for (unsigned i = 0; i < n_fractures; i++)
+            levelsets[i] = calculateLevelSetFunction(*_fracture_props[i],
+                                                     ip_physical_coords.getCoords());
 
-        // nodal displacement = u^hat + levelset* [u]
-        NodalDisplacementVectorType nodal_u = nodal_ru + levelsets * nodal_du;
+        // nodal displacement = u^hat + sum_i(levelset_i(x) * [u]_i)
+        NodalDisplacementVectorType nodal_total_u = nodal_u;
+        for (unsigned i=0; i<n_fractures; i++)
+            nodal_total_u += levelsets[i] * vec_nodal_g[i];
 
         // strain, stress
         auto const& B = ip_data._b_matrices;
@@ -163,30 +209,36 @@ assembleWithJacobian(
         auto& C = ip_data._C;
         auto& material_state_variables = *ip_data._material_state_variables;
 
-        eps.noalias() = B * nodal_u;
+        eps.noalias() = B * nodal_total_u;
 
         if (!ip_data._solid_material.computeConstitutiveRelation(
                 t, x_position, _process_data.dt, eps_prev, eps, sigma_prev,
                 sigma, C, material_state_variables))
             OGS_FATAL("Computation of local constitutive relation failed.");
 
-        // r_ru = B^T Stress = B^T C B (u + phi*[u])
-        localRhs_ru.noalias() -= B.transpose() * sigma * detJ * wp.getWeight() * integralMeasure;
-
-        // r_[u] = (phi*B)^T Stress = (phi*B)^T C B (u + phi*[u])
-        localRhs_du.noalias() -= levelsets * B.transpose() * sigma * detJ * wp.getWeight() * integralMeasure;
+        // r_u = B^T * Sigma = B^T * C * B * (u+phi*[u])
+        // r_[u] = (phi*B)^T * Sigma = (phi*B)^T * C * B * (u+phi*[u])
+        local_b_u.noalias() -= B.transpose() * sigma * ip_factor;
+        for (unsigned i=0; i<n_fractures; i++)
+            vec_local_b_g[i].noalias() -= levelsets[i] * B.transpose() * sigma * ip_factor;
 
         // J_uu += B^T * C * B
-        localA_uu.noalias() += B.transpose() * C * B * detJ * wp.getWeight() * integralMeasure;
+        local_J_uu.noalias() += B.transpose() * C * B * ip_factor;
 
-        // J_u[u] += B^T * C * B * levelset
-        localA_ug.noalias() += B.transpose() * C * levelsets * B * detJ * wp.getWeight() * integralMeasure;
+        for (unsigned i=0; i<n_fractures; i++)
+        {
+            // J_u[u] += B^T * C * (levelset * B)
+            vec_local_J_ug[i].noalias() += B.transpose() * C *(levelsets[i] * B) * ip_factor;
 
-        // J_[u]u += (levelset B)^T * C * B
-        localA_gu.noalias() += levelsets * B.transpose() * C * B * detJ * wp.getWeight() * integralMeasure;
+            // J_[u]u += (levelset * B)^T * C * B
+            vec_local_J_gu[i].noalias() += (levelsets[i] * B.transpose()) * C * B * ip_factor;
 
-        // J_[u][u] += (levelset B)^T * C * (levelset B)
-        localA_gg.noalias() += levelsets * B.transpose() * C * levelsets * B * detJ * wp.getWeight() * integralMeasure;
+            for (unsigned j=0; j<n_fractures; j++)
+            {
+                // J_[u][u] += (levelset * B)^T * C * (levelset * B)
+                vec_local_J_gg[i][j].noalias() += (levelsets[i] * B.transpose()) * C * (levelsets[j] * B) * ip_factor;
+            }
+        }
     }
 }
 

--- a/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
+++ b/ProcessLib/SmallDeformationWithLIE/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
@@ -158,6 +158,7 @@ private:
     }
 
     SmallDeformationProcessData<DisplacementDim>& _process_data;
+    std::vector<FractureProperty*> _fracture_props;
 
     std::vector<IntegrationPointDataMatrix<BMatricesType, DisplacementDim>> _ip_data;
 

--- a/ProcessLib/SmallDeformationWithLIE/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/SmallDeformationProcess.cpp
@@ -57,25 +57,57 @@ SmallDeformationProcess<DisplacementDim>::SmallDeformationProcess(
 {
     getFractureMatrixDataInMesh(mesh,
                                 _vec_matrix_elements,
+                                _vec_fracture_mat_IDs,
                                 _vec_fracture_elements,
                                 _vec_fracture_matrix_elements,
                                 _vec_fracture_nodes);
 
-    // set fracture property assuming a fracture forms a straight line
-    setFractureProperty(DisplacementDim,
-                        *_vec_fracture_elements[0],
-                        *_process_data._fracture_property.get());
+    if (_vec_fracture_mat_IDs.size() != _process_data._vec_fracture_property.size())
+        OGS_FATAL("The number of the given fracture properties (%d) are not consistent"
+                  " with the number of fracture groups in a mesh (%d).",
+                  _process_data._vec_fracture_property.size(),
+                  _vec_fracture_mat_IDs.size());
+
+    // create a map from a material ID to a fracture ID
+    auto max_frac_mat_id = std::max_element(_vec_fracture_mat_IDs.begin(),
+                                            _vec_fracture_mat_IDs.end());
+    _process_data._map_materialID_to_fractureID.resize(*max_frac_mat_id + 1);
+    for (unsigned i=0; i<_vec_fracture_mat_IDs.size(); i++)
+        _process_data._map_materialID_to_fractureID[_vec_fracture_mat_IDs[i]] = i;
+
+    // create a table of connected fracture IDs for each element
+    _process_data._vec_ele_connected_fractureIDs.resize(mesh.getNumberOfElements());
+    for (unsigned i=0; i<_vec_fracture_matrix_elements.size(); i++)
+        for (auto e : _vec_fracture_matrix_elements[i])
+            _process_data._vec_ele_connected_fractureIDs[e->getID()].push_back(i);
+
+    // set fracture property
+    for (auto& fracture_prop : _process_data._vec_fracture_property)
+    {
+        // based on the 1st element assuming a fracture forms a straight line
+        setFractureProperty(DisplacementDim,
+                            *_vec_fracture_elements[fracture_prop->fracture_id][0],
+                            *fracture_prop.get());
+    }
 
     // need to use a custom Neumann BC assembler for displacement jumps
+    int pv_disp_jump_id = 0;
     for (ProcessVariable& pv : getProcessVariables())
     {
         if (pv.getName().find("displacement_jump") == std::string::npos)
             continue;
         pv.setBoundaryConditionBuilder(
-                    std::unique_ptr<ProcessLib::BoundaryConditionBuilder>(
-                        new BoundaryConditionBuilder(*_process_data._fracture_property.get())));
+            std::unique_ptr<ProcessLib::BoundaryConditionBuilder>(
+                new BoundaryConditionBuilder(
+                    *_process_data._vec_fracture_property[pv_disp_jump_id].get())));
+        pv_disp_jump_id++;
     }
 
+    MeshLib::PropertyVector<int> const* material_ids(
+        mesh.getProperties().getPropertyVector<int>("MaterialIDs"));
+    if (!material_ids)
+        OGS_FATAL("MaterialIDs property not found in a mesh");
+    _process_data._mesh_prop_materialIDs = material_ids;
 }
 
 
@@ -90,7 +122,13 @@ void SmallDeformationProcess<DisplacementDim>::constructDofTable()
     // regular u
     _mesh_subset_matrix_nodes.reset(new MeshLib::MeshSubset(_mesh, &_mesh.getNodes()));
     // u jump
-    _mesh_subset_fracture_nodes.reset(new MeshLib::MeshSubset(_mesh, &_vec_fracture_nodes));
+    for (unsigned i=0; i<_vec_fracture_nodes.size(); i++)
+    {
+        _mesh_subset_fracture_nodes.push_back(
+            std::unique_ptr<MeshLib::MeshSubset const>(
+                        new MeshLib::MeshSubset(_mesh, &_vec_fracture_nodes[i])
+                        ));
+    }
 
     // Collect the mesh subsets in a vector.
     std::vector<std::unique_ptr<MeshLib::MeshSubsets>> all_mesh_subsets;
@@ -101,19 +139,24 @@ void SmallDeformationProcess<DisplacementDim>::constructDofTable()
             return std::unique_ptr<MeshLib::MeshSubsets>{
                 new MeshLib::MeshSubsets{_mesh_subset_matrix_nodes.get()}};
         });
-    std::generate_n(
-        std::back_inserter(all_mesh_subsets),
-        DisplacementDim,
-        [&]() {
-            return std::unique_ptr<MeshLib::MeshSubsets>{
-                new MeshLib::MeshSubsets{_mesh_subset_fracture_nodes.get()}};
-        });
+    for (auto& ms : _mesh_subset_fracture_nodes)
+    {
+        std::generate_n(
+            std::back_inserter(all_mesh_subsets),
+            DisplacementDim,
+            [&]() {
+                return std::unique_ptr<MeshLib::MeshSubsets>{
+                    new MeshLib::MeshSubsets{ms.get()}};
+            });
+    }
 
-    std::vector<unsigned> const vec_n_components(2, DisplacementDim);
+    std::vector<unsigned> const vec_n_components(
+        1 + _vec_fracture_mat_IDs.size(), DisplacementDim);
 
     std::vector<std::vector<MeshLib::Element*>const*> vec_var_elements;
     vec_var_elements.push_back(&_vec_matrix_elements);
-    vec_var_elements.push_back(&_vec_fracture_matrix_elements);
+    for (unsigned i=0; i<_vec_fracture_matrix_elements.size(); i++)
+        vec_var_elements.push_back(&_vec_fracture_matrix_elements[i]);
 
     _local_to_global_index_map.reset(
         new NumLib::LocalToGlobalIndexMap(
@@ -220,20 +263,24 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
     mesh_prop_epsilon_xy->resize(mesh.getNumberOfElements());
     _process_data._mesh_prop_strain_xy = mesh_prop_epsilon_xy;
 
-    auto mesh_prop_levelset = const_cast<MeshLib::Mesh&>(mesh)
-                                  .getProperties()
-                                  .template createNewPropertyVector<double>(
-                                      "levelset1", MeshLib::MeshItemType::Cell);
-    mesh_prop_levelset->resize(mesh.getNumberOfElements());
-    for (MeshLib::Element const* e : _mesh.getElements())
+    for (auto const& fracture_prop : _process_data._vec_fracture_property)
     {
-        if (e->getDimension() < DisplacementDim)
-            continue;
+        auto mesh_prop_levelset = const_cast<MeshLib::Mesh&>(mesh)
+                                      .getProperties()
+                                      .template createNewPropertyVector<double>(
+                                          "levelset" + std::to_string(fracture_prop->fracture_id + 1),
+                                          MeshLib::MeshItemType::Cell);
+        mesh_prop_levelset->resize(mesh.getNumberOfElements());
+        for (MeshLib::Element const* e : _mesh.getElements())
+        {
+            if (e->getDimension() < DisplacementDim)
+                continue;
 
-        double const levelsets =
-            calculateLevelSetFunction(*_process_data._fracture_property,
-                                      e->getCenterOfGravity().getCoords());
-        (*mesh_prop_levelset)[e->getID()] = levelsets;
+            double const levelsets = calculateLevelSetFunction(
+                *fracture_prop,
+                e->getCenterOfGravity().getCoords());
+            (*mesh_prop_levelset)[e->getID()] = levelsets;
+        }
     }
 
     auto mesh_prop_b = const_cast<MeshLib::Mesh&>(mesh)
@@ -241,17 +288,19 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
                            .template createNewPropertyVector<double>(
                                "aperture", MeshLib::MeshItemType::Cell);
     mesh_prop_b->resize(mesh.getNumberOfElements());
-    auto mesh_prop_matid = mesh.getProperties().getPropertyVector<int>("MaterialIDs");
-    auto frac = _process_data._fracture_property.get();
-    for (MeshLib::Element const* e : _mesh.getElements())
+    auto const& mesh_prop_matid = *_process_data._mesh_prop_materialIDs;
+    for (auto const& fracture_prop : _process_data._vec_fracture_property)
     {
-        if (e->getDimension() == DisplacementDim)
-            continue;
-        if ((*mesh_prop_matid)[e->getID()] != frac->mat_id)
-            continue;
-        ProcessLib::SpatialPosition x;
-        x.setElementID(e->getID());
-        (*mesh_prop_b)[e->getID()] = (*frac->aperture0)(0, x)[0];
+        for (MeshLib::Element const* e : _mesh.getElements())
+        {
+            if (e->getDimension() == DisplacementDim)
+                continue;
+            if (mesh_prop_matid[e->getID()] != fracture_prop->mat_id)
+                continue;
+            ProcessLib::SpatialPosition x;
+            x.setElementID(e->getID());
+            (*mesh_prop_b)[e->getID()] = (*fracture_prop->aperture0)(0, x)[0];
+        }
     }
     _process_data._mesh_prop_b = mesh_prop_b;
 }

--- a/ProcessLib/SmallDeformationWithLIE/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformationWithLIE/SmallDeformationProcess.h
@@ -111,11 +111,12 @@ private:
         _local_to_global_index_map_single_component;
 
     std::vector<MeshLib::Element*> _vec_matrix_elements;
-    std::vector<MeshLib::Element*> _vec_fracture_elements;
-    std::vector<MeshLib::Element*> _vec_fracture_matrix_elements;
-    std::vector<MeshLib::Node*> _vec_fracture_nodes;
+    std::vector<int> _vec_fracture_mat_IDs;
+    std::vector<std::vector<MeshLib::Element*>> _vec_fracture_elements;
+    std::vector<std::vector<MeshLib::Element*>> _vec_fracture_matrix_elements;
+    std::vector<std::vector<MeshLib::Node*>> _vec_fracture_nodes;
 
-    std::unique_ptr<MeshLib::MeshSubset const> _mesh_subset_fracture_nodes;
+    std::vector<std::unique_ptr<MeshLib::MeshSubset const>> _mesh_subset_fracture_nodes;
     std::unique_ptr<MeshLib::MeshSubset const> _mesh_subset_matrix_nodes;
 };
 

--- a/ProcessLib/SmallDeformationWithLIE/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformationWithLIE/SmallDeformationProcessData.h
@@ -34,17 +34,17 @@ struct SmallDeformationProcessData
     SmallDeformationProcessData(
         std::unique_ptr<MaterialLib::Solids::MechanicsBase<DisplacementDim>>&& material,
         std::unique_ptr<MaterialLib::Fracture::FractureModelBase<DisplacementDim>>&& fracture_model,
-        std::unique_ptr<FractureProperty>&& fracture_prop
+        std::vector<std::unique_ptr<FractureProperty>>&& vec_fracture_prop
         )
         : _material{std::move(material)}, _fracture_model{std::move(fracture_model)},
-          _fracture_property{std::move(fracture_prop)}
+          _vec_fracture_property(std::move(vec_fracture_prop))
     {
     }
 
     SmallDeformationProcessData(SmallDeformationProcessData&& other)
         : _material{std::move(other._material)},
           _fracture_model{std::move(other._fracture_model)},
-          _fracture_property{std::move(other._fracture_property)}
+          _vec_fracture_property(std::move(other._vec_fracture_property))
     {
     }
 
@@ -59,7 +59,13 @@ struct SmallDeformationProcessData
 
     std::unique_ptr<MaterialLib::Solids::MechanicsBase<DisplacementDim>> _material;
     std::unique_ptr<MaterialLib::Fracture::FractureModelBase<DisplacementDim>> _fracture_model;
-    std::unique_ptr<FractureProperty> _fracture_property;
+    std::vector<std::unique_ptr<FractureProperty>> _vec_fracture_property;
+
+    MeshLib::PropertyVector<int> const* _mesh_prop_materialIDs = nullptr;
+    std::vector<int> _map_materialID_to_fractureID;
+
+    // a table of connected fracture IDs for each element
+    std::vector<std::vector<int>> _vec_ele_connected_fractureIDs;
 
     double dt = 0.0;
     double t = 0.0;


### PR DESCRIPTION
This PR introduces a support of multiple non-intersecting fractures in SD-LIE process. Major changes are
- extend `getFractureMatrixDataInMesh()` to looking for multiple fracture groups having distinct material IDs
- extend the local assembler for matrix near fractures. Now the displacement function is given as `u(x) =  N(x) {u} + sum_i [phi_i(x) N(x) {g_i}]` where `phi_i(x)` is the levelest function, `g_i` is  the nodal enrichment values for `i` th fracture.
- extend the post processing tool
