### PR TITLE
[SD-LIE] supporting fracture tips

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -561,6 +561,19 @@ if(NOT OGS_USE_MPI)
         single_joint_expected_pcs_0_ts_1_t_1.000000.vtu single_joint_pcs_0_ts_1_t_1.000000.vtu displacement_jump1 displacement_jump1
     )
 
+    AddTest(
+        NAME LIE_M_single_joint_inside
+        PATH LIE/Mechanics
+        EXECUTABLE ogs
+        EXECUTABLE_ARGS single_joint_inside.prj
+        WRAPPER time
+        TESTER vtkdiff
+        ABSTOL 1e-16 RELTOL 1e-16
+        DIFF_DATA
+        single_joint_inside_expected_pcs_0_ts_1_t_1.000000.vtu single_joint_inside_pcs_0_ts_1_t_1.000000.vtu displacement displacement
+        single_joint_inside_expected_pcs_0_ts_1_t_1.000000.vtu single_joint_inside_pcs_0_ts_1_t_1.000000.vtu displacement_jump1 displacement_jump1
+    )
+
 else()
     # MPI groundwater flow tests
     AddTest(

--- a/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.cpp
@@ -18,6 +18,10 @@ namespace SmallDeformationWithLIE
 namespace
 {
 
+// A class to check whether a node is located on a crack tip with
+// the following conditions:
+// - the number of connected fracture elements is one
+// - the node is not located on a domain boundary
 class IsCrackTip
 {
 public:

--- a/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.cpp
@@ -8,11 +8,52 @@
 
 #include "MeshUtils.h"
 
+#include "MeshLib/MeshSearch/NodeSearch.h"
 
 namespace ProcessLib
 {
 namespace SmallDeformationWithLIE
 {
+
+namespace
+{
+
+class IsCrackTip
+{
+public:
+    explicit IsCrackTip(MeshLib::Mesh const& mesh)
+        : _fracture_element_dim(mesh.getDimension()-1)
+    {
+        _is_internal_node.resize(mesh.getNumberOfNodes(), true);
+
+        MeshLib::NodeSearch nodeSearch(mesh);
+        nodeSearch.searchBoundaryNodes();
+        for (auto i : nodeSearch.getSearchedNodeIDs())
+            _is_internal_node[i] = false;
+    }
+
+    bool operator()(MeshLib::Node const& node) const
+    {
+        if (!_is_internal_node[node.getID()])
+            return false;
+
+        unsigned n_connected_fracture_elements = 0;
+        for (MeshLib::Element const* e : node.getElements())
+            if (e->getDimension() == _fracture_element_dim)
+                n_connected_fracture_elements++;
+        assert(n_connected_fracture_elements>0);
+
+        return (n_connected_fracture_elements == 1);
+    }
+
+private:
+    unsigned const _fracture_element_dim;
+    std::vector<bool> _is_internal_node;
+};
+
+
+} // no named namespace
+
 
 void getFractureMatrixDataInMesh(
         MeshLib::Mesh const& mesh,
@@ -22,6 +63,8 @@ void getFractureMatrixDataInMesh(
         std::vector<MeshLib::Node*>& vec_fracture_nodes
         )
 {
+    IsCrackTip isCrackTip(mesh);
+
     // get vectors of matrix elements and fracture elements
     vec_matrix_elements.reserve(mesh.getNumberOfElements());
     for (MeshLib::Element* e : mesh.getElements())
@@ -39,6 +82,8 @@ void getFractureMatrixDataInMesh(
     {
         for (unsigned i=0; i<e->getNumberOfNodes(); i++)
         {
+            if (isCrackTip(*e->getNode(i)))
+                continue;
             vec_fracture_nodes.push_back(const_cast<MeshLib::Node*>(e->getNode(i)));
         }
     }
@@ -58,6 +103,8 @@ void getFractureMatrixDataInMesh(
         for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++)
         {
             MeshLib::Node const* node = e->getNode(i);
+            if (isCrackTip(*node))
+                continue;
             for (unsigned j=0; j<node->getNumberOfElements(); j++)
             {
                 // only matrix elements


### PR DESCRIPTION
follow up of #1452

Current implementation supports a fracture cutting through an entire domain. This PR will extend it to enabling to have fracture tips inside of a domain. What the implementation does is simply, not to create DoFs for those tip nodes, meaning displacement jumps are zero at those nodes.