### PR TITLE
[SD-LIE] post-processing tool

### DIFF
--- a/Applications/Utils/CMakeLists.txt
+++ b/Applications/Utils/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(GeoTools)
 add_subdirectory(MeshGeoTools)
 add_subdirectory(MeshEdit)
 add_subdirectory(ModelPreparation)
+add_subdirectory(PostProcessing)
 add_subdirectory(SimpleMeshCreation)
 
 if(OGS_BUILD_GUI)

--- a/Applications/Utils/PostProcessing/CMakeLists.txt
+++ b/Applications/Utils/PostProcessing/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+add_executable(postLIE postLIE.cpp)
+target_link_libraries(postLIE MeshLib ProcessLib)
+ADD_VTK_DEPENDENCY(postLIE)
+set_target_properties(postLIE PROPERTIES FOLDER Utilities)
+

--- a/Applications/Utils/PostProcessing/postLIE.cpp
+++ b/Applications/Utils/PostProcessing/postLIE.cpp
@@ -1,0 +1,94 @@
+/**
+ * @copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include <tclap/CmdLine.h>
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+
+#include "Applications/ApplicationsLib/LogogSetup.h"
+
+#include "BaseLib/FileTools.h"
+
+#include "MeshLib/IO/readMeshFromFile.h"
+#include "MeshLib/IO/writeMeshToFile.h"
+
+#include "MeshLib/Mesh.h"
+
+#include "ProcessLib/SmallDeformationWithLIE/Common/MeshUtils.h"
+#include "ProcessLib/SmallDeformationWithLIE/Common/PostUtils.h"
+
+
+int main (int argc, char* argv[])
+{
+    ApplicationsLib::LogogSetup logog_setup;
+
+    TCLAP::CmdLine cmd("Postp-process results of the LIE approach",
+                       ' ', "0.1");
+    TCLAP::ValueArg<std::string> arg_out_pvd("o", "output-file",
+                                          "the name of the new PVD file", true,
+                                          "", "path");
+    cmd.add(arg_out_pvd);
+    TCLAP::ValueArg<std::string> arg_in_pvd("i", "input-file",
+                                         "the original PVD file name", true,
+                                         "", "path");
+    cmd.add(arg_in_pvd);
+
+    cmd.parse(argc, argv);
+
+    auto const in_pvd_filename = arg_in_pvd.getValue();
+    auto const in_pvd_file_dir = BaseLib::extractPath(in_pvd_filename);
+    auto const out_pvd_filename = arg_out_pvd.getValue();
+    auto const out_pvd_file_dir = BaseLib::extractPath(out_pvd_filename);
+    INFO("start reading the PVD file %s", in_pvd_filename.c_str());
+    boost::property_tree::ptree pt;
+    read_xml(arg_in_pvd.getValue(), pt,  boost::property_tree::xml_parser::trim_whitespace);
+
+    for (auto& dataset : pt.get_child("VTKFile.Collection"))
+    {
+        if (dataset.first != "DataSet")
+            continue;
+
+        // read VTU with simulation results
+        auto const org_vtu_filename = dataset.second.get<std::string>("<xmlattr>.file");
+        INFO("processing %s...", (in_pvd_file_dir + org_vtu_filename).c_str());
+
+        std::unique_ptr<MeshLib::Mesh const> mesh(
+            MeshLib::IO::readMeshFromFile(in_pvd_file_dir + org_vtu_filename));
+
+        // post-process
+        std::vector<MeshLib::Element*> vec_matrix_elements;
+        std::vector<MeshLib::Element*> vec_fracture_elements;
+        std::vector<MeshLib::Element*> vec_fracture_matrix_elements;
+        std::vector<MeshLib::Node*> vec_fracture_nodes;
+        ProcessLib::SmallDeformationWithLIE::getFractureMatrixDataInMesh(
+            *mesh, vec_matrix_elements, vec_fracture_elements,
+            vec_fracture_matrix_elements, vec_fracture_nodes);
+
+        ProcessLib::SmallDeformationWithLIE::PostProcessTool post(
+            *mesh, vec_fracture_nodes, vec_fracture_matrix_elements);
+
+        // create a new VTU file and update XML
+        auto const dest_vtu_filename = "post_" + org_vtu_filename;
+        INFO("create %s", (out_pvd_file_dir + dest_vtu_filename).c_str());
+        MeshLib::IO::writeMeshToFile(post.getOutputMesh(), out_pvd_file_dir + dest_vtu_filename);
+
+        dataset.second.put("<xmlattr>.file", dest_vtu_filename);
+    }
+
+    // save into the new PVD file
+    INFO("save into the new PVD file %s", out_pvd_filename.c_str());
+    boost::property_tree::xml_writer_settings<std::string> settings('\t', 1);
+    write_xml(arg_out_pvd.getValue(), pt, std::locale(), settings);
+
+    return EXIT_SUCCESS;
+}

--- a/Applications/Utils/Tests.cmake
+++ b/Applications/Utils/Tests.cmake
@@ -25,3 +25,14 @@ AddTest(
     TESTER diff
     DIFF_DATA RiverNetwork-Mapped.gml
 )
+
+AddTest(
+    NAME postLIE
+    PATH LIE/PostProcessing
+    EXECUTABLE postLIE
+    EXECUTABLE_ARGS -i single_joint_pcs_0.pvd -o ${CMAKE_BINARY_DIR}/Tests/Data/LIE/PostProcessing/post_single_joint_pcs_0.pvd
+    ABSTOL 1e-14 RELTOL 1e-14
+    TESTER vtkdiff
+    DIFF_DATA
+    expected_post_single_joint_pcs_0_ts_1_t_1.000000.vtu post_single_joint_pcs_0_ts_1_t_1.000000.vtu u u
+)

--- a/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
@@ -77,14 +77,17 @@ PostProcessTool::PostProcessTool(
         MeshLib::Element* e = new_eles[eid];
         for (unsigned i=0; i<e->getNumberOfNodes(); i++)
         {
+            // only fracture nodes
             auto itr = _map_dup_newNodeIDs.find(e->getNodeIndex(i));
             if (itr == _map_dup_newNodeIDs.end())
                 continue;
 
+            // check if a node belongs to the particular fracture group
             auto itr2 = std::find_if(vec_fracture_nodes.begin(), vec_fracture_nodes.end(),
                                      [&](MeshLib::Node const*node) { return node->getID()==e->getNodeIndex(i);});
             if (itr2 == vec_fracture_nodes.end())
                 continue;
+
             e->setNode(i, new_nodes[itr->second]);
         }
     }

--- a/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
@@ -1,0 +1,205 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ */
+
+#include "PostUtils.h"
+
+#include <map>
+#include <vector>
+
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Node.h"
+#include "MeshLib/MeshEditing/DuplicateMeshComponents.h"
+
+namespace ProcessLib
+{
+namespace SmallDeformationWithLIE
+{
+
+namespace
+{
+
+template <typename T>
+inline void sort_unique(std::vector<T> &vec)
+{
+    std::sort(vec.begin(), vec.end());
+    vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
+}
+
+} // no named namespace
+
+PostProcessTool::PostProcessTool(
+    MeshLib::Mesh const& org_mesh,
+    std::vector<MeshLib::Node*> const& vec_fracture_nodes,
+    std::vector<MeshLib::Element*> const& vec_fracutre_matrix_elements)
+    :_org_mesh(org_mesh)
+{
+    if (!org_mesh.getProperties().hasPropertyVector("displacement")
+        || !org_mesh.getProperties().hasPropertyVector("displacement_jump1")
+        || !org_mesh.getProperties().hasPropertyVector("levelset1")
+        )
+    {
+        OGS_FATAL("The given mesh does not have relevant properties");
+    }
+
+    // clone nodes and elements
+    std::vector<MeshLib::Node*> new_nodes(MeshLib::copyNodeVector(org_mesh.getNodes()));
+    std::vector<MeshLib::Element*> new_eles(
+        MeshLib::copyElementVector(org_mesh.getElements(), new_nodes));
+
+    // duplicate fracture nodes
+    for (auto const* org_node : vec_fracture_nodes)
+    {
+        auto duplicated_node = new MeshLib::Node(org_node->getCoords(), new_nodes.size());
+        new_nodes.push_back(duplicated_node);
+        _map_dup_newNodeIDs[org_node->getID()] = duplicated_node->getID();
+    }
+
+    // split elements using the new duplicated nodes
+    auto prop_levelset = org_mesh.getProperties().getPropertyVector<double>("levelset1");
+    for (auto const* org_e : vec_fracutre_matrix_elements)
+    {
+        // only matrix elements
+        if (org_e->getDimension() != org_mesh.getDimension())
+            continue;
+
+        auto const eid = org_e->getID();
+
+        // keep original if the element has levelset=0
+        if ((*prop_levelset)[eid] == 0)
+            continue;
+
+        // replace fracture nodes with duplicated ones
+        MeshLib::Element* e = new_eles[eid];
+        for (unsigned i=0; i<e->getNumberOfNodes(); i++)
+        {
+            auto itr = _map_dup_newNodeIDs.find(e->getNodeIndex(i));
+            if (itr == _map_dup_newNodeIDs.end())
+                continue;
+
+            auto itr2 = std::find_if(vec_fracture_nodes.begin(), vec_fracture_nodes.end(),
+                                     [&](MeshLib::Node const*node) { return node->getID()==e->getNodeIndex(i);});
+            if (itr2 == vec_fracture_nodes.end())
+                continue;
+            e->setNode(i, new_nodes[itr->second]);
+        }
+    }
+
+    // new mesh
+    _output_mesh.reset(new MeshLib::Mesh(org_mesh.getName(), new_nodes, new_eles));
+    createProperties<int>();
+    createProperties<double>();
+    copyProperties<int>();
+    copyProperties<double>();
+    calculateTotalDisplacement();
+}
+
+template <typename T>
+void PostProcessTool::createProperties()
+{
+    MeshLib::Properties const& src_properteis = _org_mesh.getProperties();
+    for (auto name : src_properteis.getPropertyVectorNames())
+    {
+        auto const* src_prop = src_properteis.getPropertyVector<T>(name);
+        if (!src_prop)
+            continue;
+        auto const n_src_comp = src_prop->getNumberOfComponents();
+        // convert 2D vector to 3D. Otherwise Paraview Calculator filter does not recognize
+        // it as a vector
+        auto const n_dest_comp = (n_src_comp==2) ? 3 : n_src_comp;
+
+        if (src_prop->getMeshItemType() == MeshLib::MeshItemType::Node)
+        {
+            auto new_prop =
+                _output_mesh->getProperties().createNewPropertyVector<T>(
+                    name, MeshLib::MeshItemType::Node, n_dest_comp);
+            new_prop->resize(_output_mesh->getNumberOfNodes() * n_dest_comp);
+        }
+        else if (src_prop->getMeshItemType() == MeshLib::MeshItemType::Cell)
+        {
+            auto new_prop =
+                _output_mesh->getProperties().createNewPropertyVector<T>(
+                    name, MeshLib::MeshItemType::Cell, n_dest_comp);
+            new_prop->resize(src_prop->size());
+        }
+    }
+}
+
+template <typename T>
+void PostProcessTool::copyProperties()
+{
+    MeshLib::Properties const& src_properteis = _org_mesh.getProperties();
+    for (auto name : src_properteis.getPropertyVectorNames())
+    {
+        auto const* src_prop = src_properteis.getPropertyVector<T>(name);
+        if (!src_prop)
+            continue;
+        auto* dest_prop = _output_mesh->getProperties().getPropertyVector<T>(name);
+        assert(dest_prop);
+
+        if (src_prop->getMeshItemType() == MeshLib::MeshItemType::Node)
+        {
+            auto const n_src_comp = src_prop->getNumberOfComponents();
+            auto const n_dest_comp = dest_prop->getNumberOfComponents();
+            // copy existing
+            for (unsigned i=0; i<_org_mesh.getNumberOfNodes(); i++)
+            {
+                for (unsigned j=0; j<n_src_comp; j++)
+                    (*dest_prop)[i*n_dest_comp+j] = (*src_prop)[i*n_src_comp+j];
+                // set zero for components not existing in the original
+                for (unsigned j=n_src_comp; j<n_dest_comp; j++)
+                    (*dest_prop)[i*n_dest_comp+j] = 0;
+            }
+            // copy duplicated
+            for (auto itr : _map_dup_newNodeIDs)
+            {
+                for (unsigned j=0; j<n_dest_comp; j++)
+                    (*dest_prop)[itr.second*n_dest_comp + j] = (*dest_prop)[itr.first*n_dest_comp + j];
+            }
+        }
+        else if (src_prop->getMeshItemType() == MeshLib::MeshItemType::Cell)
+        {
+            std::copy(src_prop->begin(), src_prop->end(), dest_prop->begin());
+        }
+    }
+}
+
+void PostProcessTool::calculateTotalDisplacement()
+{
+    // nodal value of levelset
+    std::vector<double> nodal_levelset(_output_mesh->getNodes().size(), 0.0);
+    auto const& ele_levelset =  *_output_mesh->getProperties().getPropertyVector<double>("levelset1");
+    for (MeshLib::Element const* e : _output_mesh->getElements())
+    {
+        if (e->getDimension() != _output_mesh->getDimension())
+            continue;
+        const double e_levelset = ele_levelset[e->getID()];
+        if (e_levelset == 0)
+            continue;
+
+        for (unsigned i=0; i<e->getNumberOfNodes(); i++)
+            nodal_levelset[e->getNodeIndex(i)] = e_levelset;
+    }
+
+    // total displacements
+    auto const& u =  *_output_mesh->getProperties().getPropertyVector<double>("displacement");
+    auto const n_u_comp = u.getNumberOfComponents();
+    assert(u.size() == _output_mesh->getNodes().size() * 3);
+    auto const& g =  *_output_mesh->getProperties().getPropertyVector<double>("displacement_jump1");
+    auto& total_u =
+        *_output_mesh->getProperties().createNewPropertyVector<double>(
+            "u", MeshLib::MeshItemType::Node, n_u_comp);
+    total_u.resize(u.size());
+    for (unsigned i=0; i<_output_mesh->getNodes().size(); i++)
+    {
+        for (unsigned j=0; j<n_u_comp; j++)
+            total_u[i*n_u_comp+j] = u[i*n_u_comp+j] + nodal_levelset[i] * g[i*n_u_comp+j];
+    }
+}
+
+}  // namespace SmallDeformationWithLIE
+}  // namespace ProcessLib

--- a/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
@@ -126,6 +126,13 @@ void PostProcessTool::createProperties()
                     name, MeshLib::MeshItemType::Cell, n_dest_comp);
             new_prop->resize(src_prop->size());
         }
+        else
+        {
+            WARN(
+                "Property '%s' cannot be created because its mesh item type is "
+                "not supported.",
+                name.c_str());
+        }
     }
 }
 
@@ -164,6 +171,13 @@ void PostProcessTool::copyProperties()
         else if (src_prop->getMeshItemType() == MeshLib::MeshItemType::Cell)
         {
             std::copy(src_prop->begin(), src_prop->end(), dest_prop->begin());
+        }
+        else
+        {
+            WARN(
+                "Property '%s' cannot be created because its mesh item type is "
+                "not supported.",
+                name.c_str());
         }
     }
 }

--- a/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.cpp
@@ -101,10 +101,10 @@ PostProcessTool::PostProcessTool(
 template <typename T>
 void PostProcessTool::createProperties()
 {
-    MeshLib::Properties const& src_properteis = _org_mesh.getProperties();
-    for (auto name : src_properteis.getPropertyVectorNames())
+    MeshLib::Properties const& src_properties = _org_mesh.getProperties();
+    for (auto name : src_properties.getPropertyVectorNames())
     {
-        auto const* src_prop = src_properteis.getPropertyVector<T>(name);
+        auto const* src_prop = src_properties.getPropertyVector<T>(name);
         if (!src_prop)
             continue;
         auto const n_src_comp = src_prop->getNumberOfComponents();
@@ -132,10 +132,10 @@ void PostProcessTool::createProperties()
 template <typename T>
 void PostProcessTool::copyProperties()
 {
-    MeshLib::Properties const& src_properteis = _org_mesh.getProperties();
-    for (auto name : src_properteis.getPropertyVectorNames())
+    MeshLib::Properties const& src_properties = _org_mesh.getProperties();
+    for (auto name : src_properties.getPropertyVectorNames())
     {
-        auto const* src_prop = src_properteis.getPropertyVector<T>(name);
+        auto const* src_prop = src_properties.getPropertyVector<T>(name);
         if (!src_prop)
             continue;
         auto* dest_prop = _output_mesh->getProperties().getPropertyVector<T>(name);

--- a/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.h
+++ b/ProcessLib/SmallDeformationWithLIE/Common/PostUtils.h
@@ -1,0 +1,52 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ */
+
+#ifndef PROCESSLIB_SMALLDEFORMATION_WITH_LIE_COMMON_POSTUTILS_H_
+#define PROCESSLIB_SMALLDEFORMATION_WITH_LIE_COMMON_POSTUTILS_H_
+
+#include <map>
+#include <memory>
+
+#include "MeshLib/Mesh.h"
+#include "MeshLib/Node.h"
+
+namespace ProcessLib
+{
+namespace SmallDeformationWithLIE
+{
+
+/// A tool for post-processing results from the LIE approach
+///
+/// The tool creates a new mesh containing duplicated fracture nodes
+/// to represent geometric discontinuities in visualization.
+class PostProcessTool
+{
+public:
+    PostProcessTool(
+        MeshLib::Mesh const& org_mesh,
+        std::vector<MeshLib::Node*> const& vec_fracture_nodes,
+        std::vector<MeshLib::Element*> const& vec_fracutre_matrix_elements);
+
+    MeshLib::Mesh const& getOutputMesh() const { return *_output_mesh; }
+
+private:
+    template <typename T>
+    void createProperties();
+    template <typename T>
+    void copyProperties();
+    void calculateTotalDisplacement();
+
+    MeshLib::Mesh const& _org_mesh;
+    std::unique_ptr<MeshLib::Mesh> _output_mesh;
+    std::map<std::size_t, std::size_t> _map_dup_newNodeIDs;
+};
+
+}  // namespace SmallDeformationWithLIE
+}  // namespace ProcessLib
+
+#endif // PROCESSLIB_SMALLDEFORMATION_WITH_LIE_COMMON_POSTUTILS_H_


### PR DESCRIPTION
This PR adds a post-processing tool for results obtained with the LIE approach. The tool reads a PVD file and process each VTU file with the following jobs:
- create a new mesh which includes duplicated fracture nodes. This is needed to compute discontinuities in displacement field and visualize it on ParaView
- compute total displacements based on regular displacements, displacement jumps, and levelset functions