### PR TITLE
[Mesh] check IDs of nonlinear nodes

### DIFF
--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -162,6 +162,9 @@ protected:
     /// connected if they are shared by an element.
     void setNodesConnectedByElements();
 
+    /// Check if all the nonlinear nodes are stored at the end of the node vector
+    void checkNonlinearNodeIDs() const;
+
     std::size_t const _id;
     unsigned _mesh_dimension;
     /// The minimal and maximal edge length over all elements in the mesh


### PR DESCRIPTION
Current implementation of `Mesh` class assumes nodes are stored in the order: 1. base nodes, 2. nonlinear nodes. But the assumption has not been checked by ogs and it's possible a user provides a mesh with wrong node ordering. 