### PR TITLE
Added computeSecondaryVariable to class Process

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -598,7 +598,8 @@ if(NOT OGS_USE_MPI)
         TESTER vtkdiff
         ABSTOL 1e-8 RELTOL 1e-8
         DIFF_DATA
-        sat1D.vtu sat_1D_pcs_0_ts_1_t_1.000000.vtu AnalyticSolution pressure
+        sat1D.vtu sat_1D_pcs_0_ts_1_t_1.000000.vtu AnalyticPressure pressure
+        sat1D.vtu sat_1D_pcs_0_ts_1_t_1.000000.vtu AnalyticVec v_x
     )
     AddTest(
         NAME LiquidFlow_PressureBCatCornerOfAnisotropicSquare
@@ -620,7 +621,9 @@ if(NOT OGS_USE_MPI)
         TESTER vtkdiff
         ABSTOL 1e-8 RELTOL 1e-8
         DIFF_DATA
-        mesh2D.vtu gravity_driven_pcs_0_ts_1_t_1.000000.vtu AnalyticSolution pressure
+        mesh2D.vtu gravity_driven_pcs_0_ts_1_t_1.000000.vtu AnalyticPressure pressure
+        mesh2D.vtu gravity_driven_pcs_0_ts_1_t_1.000000.vtu AnalyticVx v_x
+        mesh2D.vtu gravity_driven_pcs_0_ts_1_t_1.000000.vtu AnalyticVy v_y
     )
     AddTest(
         NAME LiquidFlow_AxisymTheis
@@ -877,7 +880,8 @@ else()
         TESTER vtkdiff
         ABSTOL 1e-8 RELTOL 1e-8
         DIFF_DATA
-        sat1D.vtu sat_1D_pcs_0_ts_1_t_1.000000.vtu AnalyticSolution pressure
+        sat1D.vtu sat_1D_pcs_0_ts_1_t_1.000000.vtu AnalyticPressure pressure
+        sat1D.vtu sat_1D_pcs_0_ts_1_t_1.000000.vtu AnalyticVec v_x
     )
     AddTest(
         NAME LiquidFlow_GravityDriven
@@ -888,7 +892,9 @@ else()
         TESTER vtkdiff
         ABSTOL 1e-8 RELTOL 1e-8
         DIFF_DATA
-        mesh2D.vtu gravity_driven_pcs_0_ts_1_t_1.000000.vtu AnalyticSolution pressure
+        mesh2D.vtu gravity_driven_pcs_0_ts_1_t_1.000000.vtu AnalyticPressure pressure
+        mesh2D.vtu gravity_driven_pcs_0_ts_1_t_1.000000.vtu AnalyticVx v_x
+        mesh2D.vtu gravity_driven_pcs_0_ts_1_t_1.000000.vtu AnalyticVy v_y
     )
     AddTest(
         NAME LiquidFlow_PressureBCatCornerOfAnisotropicSquare

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -100,5 +100,15 @@ void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(
         dx_dx, M, K, b, Jac);
 }
 
+
+void GroundwaterFlowProcess::computeSecondaryVariableConcrete(const double t,
+                                                         GlobalVector const& x)
+{
+    DBUG("Compute the velocity for GroundwaterFlowProcess.");
+    GlobalExecutor::executeMemberOnDereferenced(
+            &GroundwaterFlowLocalAssemblerInterface::computeSecondaryVariable,
+            _local_assemblers, *_local_to_global_index_map, t, x);
+}
+
 }   // namespace GroundwaterFlow
 }   // namespace ProcessLib

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -88,6 +88,9 @@ public:
         }
     }
 
+    void computeSecondaryVariableConcrete(double const t,
+                                          GlobalVector const& x) override;
+
 private:
     void initializeConcreteProcess(
         NumLib::LocalToGlobalIndexMap const& dof_table,

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -96,5 +96,14 @@ void HeatConductionProcess::assembleWithJacobianConcreteProcess(
         dx_dx, M, K, b, Jac);
 }
 
+void HeatConductionProcess::computeSecondaryVariableConcrete(const double t,
+                                                         GlobalVector const& x)
+{
+    DBUG("Compute the velocity for LiquidFlowProcess.");
+    GlobalExecutor::executeMemberOnDereferenced(
+            &HeatConductionLocalAssemblerInterface::computeSecondaryVariable,
+            _local_assemblers, *_local_to_global_index_map, t, x);
+}
+
 }  // namespace HeatConduction
 }  // namespace ProcessLib

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -99,7 +99,7 @@ void HeatConductionProcess::assembleWithJacobianConcreteProcess(
 void HeatConductionProcess::computeSecondaryVariableConcrete(const double t,
                                                          GlobalVector const& x)
 {
-    DBUG("Compute the velocity for LiquidFlowProcess.");
+    DBUG("Compute heat flux for HeatConductionProcess.");
     GlobalExecutor::executeMemberOnDereferenced(
             &HeatConductionLocalAssemblerInterface::computeSecondaryVariable,
             _local_assemblers, *_local_to_global_index_map, t, x);

--- a/ProcessLib/HeatConduction/HeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.h
@@ -38,7 +38,9 @@ public:
     //! @{
 
     bool isLinear() const override { return true; }
-    //! @}
+
+    void computeSecondaryVariableConcrete(double const t,
+                                          GlobalVector const& x) override;
 
 private:
     void initializeConcreteProcess(

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
@@ -154,7 +154,8 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
 template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
 void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
-    computeSecondaryVariableConcrete(std::vector<double> const& local_x)
+    computeSecondaryVariableConcrete(double const t,
+                                     std::vector<double> const& local_x)
 {
     auto const local_matrix_size = local_x.size();
     assert(local_matrix_size == ShapeFunction::NPOINTS);
@@ -194,7 +195,7 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
             GlobalDimVectorType darcy_velocity = -K * sm.dNdx * local_p_vec;
             // gravity term
             if (_gravitational_axis_id >= 0)
-                darcy_velocity[GlobalDim - 1] -= K * rho_g;
+                darcy_velocity[_gravitational_axis_id] -= K * rho_g;
             for (unsigned d = 0; d < GlobalDim; ++d)
             {
                 _darcy_velocities[d][ip] = darcy_velocity[d];
@@ -203,10 +204,12 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
         else
         {
             // Compute the velocity
-            GlobalDimVectorType darcy_velocity = -perm * sm.dNdx * local_p_vec / mu;
+            GlobalDimVectorType darcy_velocity
+                    = -perm * sm.dNdx * local_p_vec / mu;
             if (_gravitational_axis_id >= 0)
             {
-                darcy_velocity.noalias() -=  rho_g * perm.col(GlobalDim - 1) / mu;
+                darcy_velocity.noalias() -=
+                        rho_g * perm.col(_gravitational_axis_id) / mu;
             }
             for (unsigned d = 0; d < GlobalDim; ++d)
             {

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
@@ -150,6 +150,15 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
             fac * rho_g * sm.dNdx.transpose() * perm.col(gravitational_axis_id);
     }
 }
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          unsigned GlobalDim>
+void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
+    computeSecondaryVariable(std::vector<double> const& local_x)
+{
+  (void) local_x;
+}
+
 }  // end of namespace
 }  // end of namespace
 

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
@@ -49,7 +49,7 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
 
 template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
-template <typename Calculator>
+template <typename LaplacianGravityVelocityCalculator>
 void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
     local_assemble(double const t, std::vector<double> const& local_x,
                    std::vector<double>& local_M_data,
@@ -100,7 +100,7 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
         const double mu = _material_properties.getViscosity(p, _temperature);
 
         // Assemble Laplacian, K, and RHS by the gravitational term
-        Calculator::calculateLaplacianAndGravityTerm(
+        LaplacianGravityVelocityCalculator::calculateLaplacianAndGravityTerm(
             local_K, local_b, sm, perm, integration_factor, mu, rho_g,
             _gravitational_axis_id);
     }
@@ -132,7 +132,7 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
 
 template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
-template <typename Calculator>
+template <typename LaplacianGravityVelocityCalculator>
 void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
     computeSecondaryVariableLocal(double const /*t*/,
                                   std::vector<double> const& local_x,
@@ -161,7 +161,8 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
         // Compute viscosity:
         const double mu = _material_properties.getViscosity(p, _temperature);
 
-        Calculator::calculateVelocity(_darcy_velocities, local_p_vec, sm, perm,
+        LaplacianGravityVelocityCalculator
+                  ::calculateVelocity(_darcy_velocities, local_p_vec, sm, perm,
                                       ip, mu, rho_g, _gravitational_axis_id);
     }
 }

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -85,7 +85,8 @@ public:
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;
 
-    void computeSecondaryVariableConcrete(std::vector<double> const& local_x) override;
+    void computeSecondaryVariableConcrete(double const /*t*/,
+                                std::vector<double> const& local_x) override;
 
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         const unsigned integration_point) const override

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -85,6 +85,8 @@ public:
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;
 
+    void computeSecondaryVariable(std::vector<double> const& local_x) override;
+
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         const unsigned integration_point) const override
     {

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -171,7 +171,7 @@ private:
             int const gravitational_axis_id);
     };
 
-    template <typename Calculator>
+    template <typename LaplacianGravityVelocityCalculator>
     void local_assemble(double const t, std::vector<double> const& local_x,
                         std::vector<double>& local_M_data,
                         std::vector<double>& local_K_data,
@@ -179,7 +179,7 @@ private:
                         SpatialPosition const& pos,
                         Eigen::MatrixXd const& perm);
 
-    template <typename Calculator>
+    template <typename LaplacianGravityVelocityCalculator>
     void computeSecondaryVariableLocal(double const /*t*/,
                                        std::vector<double> const& local_x,
                                        SpatialPosition const& pos,

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -85,7 +85,7 @@ public:
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;
 
-    void computeSecondaryVariable(std::vector<double> const& local_x) override;
+    void computeSecondaryVariableConcrete(std::vector<double> const& local_x) override;
 
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         const unsigned integration_point) const override

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -85,8 +85,8 @@ public:
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;
 
-    void computeSecondaryVariableConcrete(double const /*t*/,
-                                std::vector<double> const& local_x) override;
+    void computeSecondaryVariableConcrete(
+        double const /*t*/, std::vector<double> const& local_x) override;
 
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         const unsigned integration_point) const override
@@ -133,39 +133,57 @@ private:
      *  Calculator of the Laplacian and the gravity term for anisotropic
      *  permeability tensor
      */
-    struct AnisotropicLaplacianAndGravityTermCalculator
+    struct AnisotropicCalculator
     {
-        static void calculate(Eigen::Map<NodalMatrixType>& local_K,
-                              Eigen::Map<NodalVectorType>& local_b,
-                              ShapeMatrices const& sm,
-                              Eigen::MatrixXd const& perm,
-                              double const integration_factor, double const mu,
-                              double const rho_g,
-                              int const gravitational_axis_id);
+        static void calculateLaplacianAndGravityTerm(
+            Eigen::Map<NodalMatrixType>& local_K,
+            Eigen::Map<NodalVectorType>& local_b, ShapeMatrices const& sm,
+            Eigen::MatrixXd const& perm, double const integration_factor,
+            double const mu, double const rho_g,
+            int const gravitational_axis_id);
+
+        static void calculateVelocity(
+            std::vector<std::vector<double>>& darcy_velocities,
+            Eigen::Map<const NodalVectorType> const& local_p,
+            ShapeMatrices const& sm, Eigen::MatrixXd const& perm,
+            unsigned const ip, double const mu, double const rho_g,
+            int const gravitational_axis_id);
     };
 
     /**
      *  Calculator of the Laplacian and the gravity term for isotropic
      *  permeability tensor
      */
-    struct IsotropicLaplacianAndGravityTermCalculator
+    struct IsotropicCalculator
     {
-        static void calculate(Eigen::Map<NodalMatrixType>& local_K,
-                              Eigen::Map<NodalVectorType>& local_b,
-                              ShapeMatrices const& sm,
-                              Eigen::MatrixXd const& perm,
-                              double const integration_factor, double const mu,
-                              double const rho_g,
-                              int const gravitational_axis_id);
+        static void calculateLaplacianAndGravityTerm(
+            Eigen::Map<NodalMatrixType>& local_K,
+            Eigen::Map<NodalVectorType>& local_b, ShapeMatrices const& sm,
+            Eigen::MatrixXd const& perm, double const integration_factor,
+            double const mu, double const rho_g,
+            int const gravitational_axis_id);
+
+        static void calculateVelocity(
+            std::vector<std::vector<double>>& darcy_velocities,
+            Eigen::Map<const NodalVectorType> const& local_p,
+            ShapeMatrices const& sm, Eigen::MatrixXd const& perm,
+            unsigned const ip, double const mu, double const rho_g,
+            int const gravitational_axis_id);
     };
 
-    template <typename LaplacianAndGravityTermCalculator>
+    template <typename Calculator>
     void local_assemble(double const t, std::vector<double> const& local_x,
                         std::vector<double>& local_M_data,
                         std::vector<double>& local_K_data,
                         std::vector<double>& local_b_data,
                         SpatialPosition const& pos,
                         Eigen::MatrixXd const& perm);
+
+    template <typename Calculator>
+    void computeSecondaryVariableLocal(double const /*t*/,
+                                       std::vector<double> const& local_x,
+                                       SpatialPosition const& pos,
+                                       Eigen::MatrixXd const& perm);
 
     const int _gravitational_axis_id;
     const double _gravitational_acceleration;

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -118,9 +118,9 @@ void LiquidFlowProcess::computeSecondaryVariableConcrete(const double t,
 {
     DBUG("Compute the velocity for LiquidFlowProcess.");
     GlobalExecutor::executeMemberOnDereferenced(
-            &LiquidFlowLocalAssemblerInterface::computeSecondaryVariable,
-            _local_assemblers, *_local_to_global_index_map, t, x);
+        &LiquidFlowLocalAssemblerInterface::computeSecondaryVariable,
+        _local_assemblers, *_local_to_global_index_map, t, x);
 }
-        
+
 }  // end of namespace
 }  // end of namespace

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -113,12 +113,13 @@ void LiquidFlowProcess::assembleWithJacobianConcreteProcess(
         dx_dx, M, K, b, Jac);
 }
 
-void LiquidFlowProcess::computeSecondaryVariableConcrete(GlobalVector const& x)
+void LiquidFlowProcess::computeSecondaryVariableConcrete(const double t,
+                                                         GlobalVector const& x)
 {
     DBUG("Compute the velocity for LiquidFlowProcess.");
     GlobalExecutor::executeMemberOnDereferenced(
             &LiquidFlowLocalAssemblerInterface::computeSecondaryVariable,
-            _local_assemblers, *_local_to_global_index_map, x);
+            _local_assemblers, *_local_to_global_index_map, t, x);
 }
         
 }  // end of namespace

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -113,5 +113,13 @@ void LiquidFlowProcess::assembleWithJacobianConcreteProcess(
         dx_dx, M, K, b, Jac);
 }
 
+void LiquidFlowProcess::computeSecondaryVariableConcrete(GlobalVector const& x)
+{
+    DBUG("Compute the velocity for LiquidFlowProcess.");
+    GlobalExecutor::executeMemberOnDereferenced(
+            &LiquidFlowLocalAssemblerInterface::computeSecondaryVariable,
+            _local_assemblers, *_local_to_global_index_map, x);
+}
+        
 }  // end of namespace
 }  // end of namespace

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -69,7 +69,8 @@ public:
         double const gravitational_acceleration,
         BaseLib::ConfigTree const& config);
 
-    void computeSecondaryVariableConcrete(GlobalVector const& x) override;
+    void computeSecondaryVariableConcrete(double const t,
+                                          GlobalVector const& x) override;
 
     bool isLinear() const override { return true; }
 private:

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -69,6 +69,8 @@ public:
         double const gravitational_acceleration,
         BaseLib::ConfigTree const& config);
 
+    void computeSecondaryVariableConcrete(GlobalVector const& x) override;
+
     bool isLinear() const override { return true; }
 private:
     void initializeConcreteProcess(

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -26,6 +26,13 @@ void LocalAssemblerInterface::assembleWithJacobian(
         "assembler.");
 }
 
+void LocalAssemblerInterface::computeSecondaryVariable(std::vector<double> const& /*local_x*/)
+{
+    OGS_FATAL(
+        "computeSecondaryVariable(...) function is not implemented in the local "
+        "assembler.");
+}
+
 void LocalAssemblerInterface::preTimestep(
     std::size_t const mesh_item_id,
     NumLib::LocalToGlobalIndexMap const& dof_table, GlobalVector const& x,

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -26,11 +26,13 @@ void LocalAssemblerInterface::assembleWithJacobian(
         "assembler.");
 }
 
-void LocalAssemblerInterface::computeSecondaryVariable(std::vector<double> const& /*local_x*/)
+void LocalAssemblerInterface::computeSecondaryVariable(std::size_t const mesh_item_id,
+                              NumLib::LocalToGlobalIndexMap const& dof_table,
+                              GlobalVector const& x)
 {
-    OGS_FATAL(
-        "computeSecondaryVariable(...) function is not implemented in the local "
-        "assembler.");
+    auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
+    auto const local_x = x.get(indices);
+    computeSecondaryVariableConcrete(local_x);
 }
 
 void LocalAssemblerInterface::preTimestep(

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -26,13 +26,14 @@ void LocalAssemblerInterface::assembleWithJacobian(
         "assembler.");
 }
 
-void LocalAssemblerInterface::computeSecondaryVariable(std::size_t const mesh_item_id,
+void LocalAssemblerInterface::computeSecondaryVariable(
+                              std::size_t const mesh_item_id,
                               NumLib::LocalToGlobalIndexMap const& dof_table,
-                              GlobalVector const& x)
+                              double const t, GlobalVector const& x)
 {
     auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
     auto const local_x = x.get(indices);
-    computeSecondaryVariableConcrete(local_x);
+    computeSecondaryVariableConcrete(t, local_x);
 }
 
 void LocalAssemblerInterface::preTimestep(

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -45,6 +45,8 @@ public:
                                       std::vector<double>& local_b_data,
                                       std::vector<double>& local_Jac_data);
 
+    virtual void computeSecondaryVariable(std::vector<double> const& local_x);
+
     virtual void preTimestep(std::size_t const mesh_item_id,
                              NumLib::LocalToGlobalIndexMap const& dof_table,
                              GlobalVector const& x, double const t,

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -47,7 +47,7 @@ public:
 
     virtual void computeSecondaryVariable(std::size_t const mesh_item_id,
                               NumLib::LocalToGlobalIndexMap const& dof_table,
-                              GlobalVector const& x);
+                              const double t, GlobalVector const& x);
 
     virtual void preTimestep(std::size_t const mesh_item_id,
                              NumLib::LocalToGlobalIndexMap const& dof_table,
@@ -76,7 +76,7 @@ private:
     virtual void postTimestepConcrete(std::vector<double> const& /*local_x*/) {}
 
     virtual void computeSecondaryVariableConcrete
-                         (std::vector<double> const& /*local_x*/) {}
+                (double const /*t*/, std::vector<double> const& /*local_x*/) {}
 };
 
 } // namespace ProcessLib

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -45,7 +45,9 @@ public:
                                       std::vector<double>& local_b_data,
                                       std::vector<double>& local_Jac_data);
 
-    virtual void computeSecondaryVariable(std::vector<double> const& local_x);
+    virtual void computeSecondaryVariable(std::size_t const mesh_item_id,
+                              NumLib::LocalToGlobalIndexMap const& dof_table,
+                              GlobalVector const& x);
 
     virtual void preTimestep(std::size_t const mesh_item_id,
                              NumLib::LocalToGlobalIndexMap const& dof_table,
@@ -72,6 +74,9 @@ private:
     }
 
     virtual void postTimestepConcrete(std::vector<double> const& /*local_x*/) {}
+
+    virtual void computeSecondaryVariableConcrete
+                         (std::vector<double> const& /*local_x*/) {}
 };
 
 } // namespace ProcessLib

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -242,9 +242,9 @@ void Process::postTimestep(GlobalVector const& x)
     postTimestepConcreteProcess(x);
 }
 
-void Process::computeSecondaryVariable(GlobalVector const& x)
+void Process::computeSecondaryVariable( const double t, GlobalVector const& x)
 {
-    computeSecondaryVariableConcrete(x);
+    computeSecondaryVariableConcrete(t, x);
 }
 
 void Process::preIteration(const unsigned iter, const GlobalVector &x)

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -242,6 +242,11 @@ void Process::postTimestep(GlobalVector const& x)
     postTimestepConcreteProcess(x);
 }
 
+void Process::computeSecondaryVariable(GlobalVector const& x)
+{
+    computeSecondaryVariableConcrete(x);
+}
+
 void Process::preIteration(const unsigned iter, const GlobalVector &x)
 {
     // In every new iteration cached values of secondary variables are expired.

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -152,7 +152,7 @@ private:
                                              GlobalVector const& /*x*/){}
 
     virtual void computeSecondaryVariableConcrete(const double /*t*/,
-                                                  GlobalVector const& /*x*/) {};
+                                                  GlobalVector const& /*x*/) {}
 
     virtual NumLib::IterationResult postIterationConcreteProcess(
         GlobalVector const& /*x*/)

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -59,8 +59,8 @@ public:
     void preIteration(const unsigned iter,
                       GlobalVector const& x) override final;
 
-    /// computeSecondaryVariable for the coupled equations or for output.
-    void computeSecondaryVariable(GlobalVector const& x);
+    /// compute secondary variables for the coupled equations or for output.
+    void computeSecondaryVariable(const double t, GlobalVector const& x);
 
     NumLib::IterationResult postIteration(GlobalVector const& x) override final;
 
@@ -151,7 +151,8 @@ private:
     virtual void preIterationConcreteProcess(const unsigned /*iter*/,
                                              GlobalVector const& /*x*/){}
 
-    virtual void computeSecondaryVariableConcrete(GlobalVector const& /*x*/) {};
+    virtual void computeSecondaryVariableConcrete(const double /*t*/,
+                                                  GlobalVector const& /*x*/) {};
 
     virtual NumLib::IterationResult postIterationConcreteProcess(
         GlobalVector const& /*x*/)

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -59,6 +59,9 @@ public:
     void preIteration(const unsigned iter,
                       GlobalVector const& x) override final;
 
+    /// computeSecondaryVariable for the coupled equations or for output.
+    void computeSecondaryVariable(GlobalVector const& x);
+
     NumLib::IterationResult postIteration(GlobalVector const& x) override final;
 
     void initialize();
@@ -147,6 +150,8 @@ private:
 
     virtual void preIterationConcreteProcess(const unsigned /*iter*/,
                                              GlobalVector const& /*x*/){}
+
+    virtual void computeSecondaryVariableConcrete(GlobalVector const& /*x*/) {};
 
     virtual NumLib::IterationResult postIterationConcreteProcess(
         GlobalVector const& /*x*/)

--- a/ProcessLib/UncoupledProcessesTimeLoop.cpp
+++ b/ProcessLib/UncoupledProcessesTimeLoop.cpp
@@ -505,7 +505,7 @@ bool UncoupledProcessesTimeLoop::loop()
             nonlinear_solver_succeeded = solveOneTimeStepOneProcess(
                 x, timestep, t, delta_t, *spd, *_output);
 
-            pcs.computeSecondaryVariable(x);
+            pcs.computeSecondaryVariable(t, x);
 
             INFO("[time] Solving process #%u took %g s in timestep #%u.",
                  timestep, time_timestep.elapsed(), pcs_idx);

--- a/ProcessLib/UncoupledProcessesTimeLoop.cpp
+++ b/ProcessLib/UncoupledProcessesTimeLoop.cpp
@@ -505,6 +505,8 @@ bool UncoupledProcessesTimeLoop::loop()
             nonlinear_solver_succeeded = solveOneTimeStepOneProcess(
                 x, timestep, t, delta_t, *spd, *_output);
 
+            pcs.computeSecondaryVariable(x);
+
             INFO("[time] Solving process #%u took %g s in timestep #%u.",
                  timestep, time_timestep.elapsed(), pcs_idx);
 


### PR DESCRIPTION
Follow up PR ufz/ogs#1468, this PR corrected the calculations of  heat flux and flow velocity
by
1 introducing a member of computeSecondaryVariable to class Process.
2. calling the new member after UncoupledProcessesTimeLoop

This is the 1st PR for the staggered scheme.
