### PR TITLE
Assert unique parameter and process variable names

### DIFF
--- a/ProcessLib/LIE/SmallDeformation/CreateSmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/CreateSmallDeformationProcess.cpp
@@ -54,7 +54,7 @@ createSmallDeformationProcess(
     for (std::string const& pv_name : range)
     {
         if (pv_name != "displacement"
-            && pv_name.find("displacement_jump")==std::string::npos)
+            && pv_name.find("displacement_jump") != 0)
             OGS_FATAL("Found a process variable name '%s'. It should be 'displacement' or 'displacement_jumpN'");
         auto variable = std::find_if(
             variables.cbegin(), variables.cend(),

--- a/ProcessLib/Parameter/ConstantParameter.cpp
+++ b/ProcessLib/Parameter/ConstantParameter.cpp
@@ -15,7 +15,7 @@
 namespace ProcessLib
 {
 std::unique_ptr<ParameterBase> createConstantParameter(
-    BaseLib::ConfigTree const& config)
+    std::string const& name, BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{parameter__type}
     config.checkConfigParameter("type", "Constant");
@@ -31,7 +31,7 @@ std::unique_ptr<ParameterBase> createConstantParameter(
         {
             DBUG("Using value %g for constant parameter.", *value);
             return std::unique_ptr<ParameterBase>(
-                new ConstantParameter<double>(*value));
+                new ConstantParameter<double>(name, *value));
         }
     }
 
@@ -51,7 +51,7 @@ std::unique_ptr<ParameterBase> createConstantParameter(
     }
 
     return std::unique_ptr<ParameterBase>(
-        new ConstantParameter<double>(values));
+        new ConstantParameter<double>(name, values));
 }
 
 }  // ProcessLib

--- a/ProcessLib/Parameter/ConstantParameter.h
+++ b/ProcessLib/Parameter/ConstantParameter.h
@@ -19,11 +19,16 @@ template <typename T>
 struct ConstantParameter final : public Parameter<T>
 {
     /// Construction with single value.
-    explicit ConstantParameter(T const& value) : _values({value}) {}
+    explicit ConstantParameter(std::string const& name_, T const& value)
+        : Parameter<T>(name_), _values({value})
+    {
+    }
 
     /// Construction with a tuple.
     /// The given tuple must be non-empty.
-    explicit ConstantParameter(std::vector<T> const& values) : _values(values)
+    explicit ConstantParameter(std::string const& name_,
+                               std::vector<T> const& values)
+        : Parameter<T>(name_), _values(values)
     {
         assert(!values.empty());
     }
@@ -46,7 +51,7 @@ private:
 };
 
 std::unique_ptr<ParameterBase> createConstantParameter(
-    BaseLib::ConfigTree const& config);
+    std::string const& name, BaseLib::ConfigTree const& config);
 
 }  // ProcessLib
 

--- a/ProcessLib/Parameter/CurveScaledParameter.cpp
+++ b/ProcessLib/Parameter/CurveScaledParameter.cpp
@@ -13,6 +13,7 @@
 namespace ProcessLib
 {
 std::unique_ptr<ParameterBase> createCurveScaledParameter(
+    std::string const& name,
     BaseLib::ConfigTree const& config,
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
@@ -30,12 +31,13 @@ std::unique_ptr<ParameterBase> createCurveScaledParameter(
         OGS_FATAL("Curve `%s' does not exists.", curve_name.c_str());
 
     //! \ogs_file_param{parameter__CurveScaled__parameter}
-    auto parameter_name = config.getConfigParameter<std::string>("parameter");
-    DBUG("Using parameter %s", parameter_name.c_str());
+    auto referenced_parameter_name =
+            config.getConfigParameter<std::string>("parameter");
+    DBUG("Using parameter %s", referenced_parameter_name.c_str());
 
     // TODO other data types than only double
-    return std::unique_ptr<ParameterBase>(
-        new CurveScaledParameter<double>(*curve_it->second, parameter_name));
+    return std::unique_ptr<ParameterBase>(new CurveScaledParameter<double>(
+        name, *curve_it->second, referenced_parameter_name));
 }
 
 }  // ProcessLib

--- a/ProcessLib/Parameter/CurveScaledParameter.h
+++ b/ProcessLib/Parameter/CurveScaledParameter.h
@@ -19,10 +19,10 @@ namespace ProcessLib
 {
 template <typename T>
 struct CurveScaledParameter final : public Parameter<T> {
-    CurveScaledParameter(MathLib::PiecewiseLinearInterpolation const& curve,
+    CurveScaledParameter(std::string const& name_,
+                         MathLib::PiecewiseLinearInterpolation const& curve,
                          std::string const& parameter_name)
-        : _curve(curve),
-          _parameter_name(parameter_name)
+        : Parameter<T>(name_), _curve(curve), _parameter_name(parameter_name)
     {
     }
 
@@ -63,6 +63,7 @@ private:
 };
 
 std::unique_ptr<ParameterBase> createCurveScaledParameter(
+    std::string const& name,
     BaseLib::ConfigTree const& config,
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&

--- a/ProcessLib/Parameter/CurveScaledParameter.h
+++ b/ProcessLib/Parameter/CurveScaledParameter.h
@@ -12,8 +12,8 @@
 
 #include <map>
 #include "MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h"
-#include "ProcessLib/Utils/ProcessUtils.h"
 #include "Parameter.h"
+#include "ProcessLib/Utils/ProcessUtils.h"
 
 namespace ProcessLib
 {
@@ -21,19 +21,20 @@ template <typename T>
 struct CurveScaledParameter final : public Parameter<T> {
     CurveScaledParameter(std::string const& name_,
                          MathLib::PiecewiseLinearInterpolation const& curve,
-                         std::string const& parameter_name)
-        : Parameter<T>(name_), _curve(curve), _parameter_name(parameter_name)
+                         std::string const& referenced_parameter_name)
+        : Parameter<T>(name_),
+          _curve(curve),
+          _referenced_parameter_name(referenced_parameter_name)
     {
     }
 
     bool isTimeDependent() const override { return true; }
-
     void initialize(
-        std::vector<
-            std::unique_ptr<ProcessLib::ParameterBase>> const& parameters)
-        override
+        std::vector<std::unique_ptr<ProcessLib::ParameterBase>> const&
+            parameters) override
     {
-        _parameter = &findParameter<T>(_parameter_name, parameters, 0);
+        _parameter =
+            &findParameter<T>(_referenced_parameter_name, parameters, 0);
         _cache.resize(_parameter->getNumberOfComponents());
     }
 
@@ -49,7 +50,7 @@ struct CurveScaledParameter final : public Parameter<T> {
         auto const scaling = _curve.getValue(t);
 
         auto const num_comp = _parameter->getNumberOfComponents();
-        for (std::size_t c=0; c<num_comp; ++c) {
+        for (std::size_t c = 0; c < num_comp; ++c) {
             _cache[c] = scaling * tup[c];
         }
         return _cache;
@@ -59,7 +60,7 @@ private:
     MathLib::PiecewiseLinearInterpolation const& _curve;
     Parameter<double> const* _parameter;
     mutable std::vector<double> _cache;
-    std::string const _parameter_name;
+    std::string const _referenced_parameter_name;
 };
 
 std::unique_ptr<ParameterBase> createCurveScaledParameter(

--- a/ProcessLib/Parameter/GroupBasedParameter.cpp
+++ b/ProcessLib/Parameter/GroupBasedParameter.cpp
@@ -16,7 +16,8 @@
 namespace ProcessLib
 {
 std::unique_ptr<ParameterBase> createGroupBasedParameter(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh)
+    std::string const& name, BaseLib::ConfigTree const& config,
+    MeshLib::Mesh const& mesh)
 {
     //! \ogs_file_param{parameter__type}
     config.checkConfigParameter("type", "Group");
@@ -79,17 +80,21 @@ std::unique_ptr<ParameterBase> createGroupBasedParameter(
     }
 
     // create a mapping table
-    const int max_index = *std::max_element(group_id_property->begin(), group_id_property->end());
+    const int max_index =
+        *std::max_element(group_id_property->begin(), group_id_property->end());
     std::vector<Values> vec_values(max_index + 1);
     for (auto p : vec_index_values)
         vec_values[p.first] = p.second;
 
     if (group_id_property->getMeshItemType() == MeshLib::MeshItemType::Node)
         return std::unique_ptr<ParameterBase>(
-            new GroupBasedParameter<double, MeshLib::MeshItemType::Node>(*group_id_property, vec_values));
-    else if (group_id_property->getMeshItemType() == MeshLib::MeshItemType::Cell)
+            new GroupBasedParameter<double, MeshLib::MeshItemType::Node>(
+                name, *group_id_property, vec_values));
+    else if (group_id_property->getMeshItemType() ==
+             MeshLib::MeshItemType::Cell)
         return std::unique_ptr<ParameterBase>(
-            new GroupBasedParameter<double, MeshLib::MeshItemType::Cell>(*group_id_property, vec_values));
+            new GroupBasedParameter<double, MeshLib::MeshItemType::Cell>(
+                name, *group_id_property, vec_values));
 
     OGS_FATAL("Mesh item type of the specified property is not supported.");
 }

--- a/ProcessLib/Parameter/GroupBasedParameter.h
+++ b/ProcessLib/Parameter/GroupBasedParameter.h
@@ -37,10 +37,12 @@ struct GroupBasedParameter final
      * @param property    a property vector of index for mesh items
      * @param vec_values  a vector of values for each index
      */
-    GroupBasedParameter(
-        MeshLib::PropertyVector<int> const& property,
-        std::vector<std::vector<double>> const& vec_values)
-        : _property_index(property), _vec_values(vec_values)
+    GroupBasedParameter(std::string const& name_,
+                        MeshLib::PropertyVector<int> const& property,
+                        std::vector<std::vector<double>> const& vec_values)
+        : Parameter<T>(name_),
+          _property_index(property),
+          _vec_values(vec_values)
     {
     }
 
@@ -82,9 +84,10 @@ private:
     std::vector<std::vector<T>> const _vec_values;
 };
 
-
 std::unique_ptr<ParameterBase> createGroupBasedParameter(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh);
+    std::string const& name,
+    BaseLib::ConfigTree const& config,
+    MeshLib::Mesh const& mesh);
 
 }  // ProcessLib
 

--- a/ProcessLib/Parameter/MeshElementParameter.cpp
+++ b/ProcessLib/Parameter/MeshElementParameter.cpp
@@ -15,7 +15,8 @@
 namespace ProcessLib
 {
 std::unique_ptr<ParameterBase> createMeshElementParameter(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh)
+    std::string const& name, BaseLib::ConfigTree const& config,
+    MeshLib::Mesh const& mesh)
 {
     //! \ogs_file_param{parameter__type}
     config.checkConfigParameter("type", "MeshElement");
@@ -42,7 +43,7 @@ std::unique_ptr<ParameterBase> createMeshElementParameter(
     }
 
     return std::unique_ptr<ParameterBase>(
-        new MeshElementParameter<double>(*property));
+        new MeshElementParameter<double>(name, *property));
 }
 
 }  // ProcessLib

--- a/ProcessLib/Parameter/MeshElementParameter.h
+++ b/ProcessLib/Parameter/MeshElementParameter.h
@@ -23,9 +23,11 @@ namespace ProcessLib
 /// A parameter represented by a mesh property vector.
 template <typename T>
 struct MeshElementParameter final : public Parameter<T> {
-    MeshElementParameter(MeshLib::PropertyVector<T> const& property)
-        : _property(property)
-        , _cache(_property.getNumberOfComponents())
+    MeshElementParameter(std::string const& name_,
+                         MeshLib::PropertyVector<T> const& property)
+        : Parameter<T>(name_),
+          _property(property),
+          _cache(_property.getNumberOfComponents())
     {
     }
 
@@ -54,7 +56,8 @@ private:
 };
 
 std::unique_ptr<ParameterBase> createMeshElementParameter(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh);
+    std::string const& name, BaseLib::ConfigTree const& config,
+    MeshLib::Mesh const& mesh);
 
 }  // ProcessLib
 

--- a/ProcessLib/Parameter/MeshNodeParameter.cpp
+++ b/ProcessLib/Parameter/MeshNodeParameter.cpp
@@ -15,7 +15,8 @@
 namespace ProcessLib
 {
 std::unique_ptr<ParameterBase> createMeshNodeParameter(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh)
+    std::string const& name, BaseLib::ConfigTree const& config,
+    MeshLib::Mesh const& mesh)
 {
     //! \ogs_file_param{parameter__type}
     config.checkConfigParameter("type", "MeshNode");
@@ -42,7 +43,7 @@ std::unique_ptr<ParameterBase> createMeshNodeParameter(
     }
 
     return std::unique_ptr<ParameterBase>(
-        new MeshNodeParameter<double>(*property));
+        new MeshNodeParameter<double>(name, *property));
 }
 
 }  // ProcessLib

--- a/ProcessLib/Parameter/MeshNodeParameter.h
+++ b/ProcessLib/Parameter/MeshNodeParameter.h
@@ -23,9 +23,11 @@ namespace ProcessLib
 /// A parameter represented by a mesh property vector.
 template <typename T>
 struct MeshNodeParameter final : public Parameter<T> {
-    MeshNodeParameter(MeshLib::PropertyVector<T> const& property)
-        : _property(property)
-        , _cache(_property.getNumberOfComponents())
+    MeshNodeParameter(std::string const& name_,
+                      MeshLib::PropertyVector<T> const& property)
+        : Parameter<T>(name_),
+          _property(property),
+          _cache(_property.getNumberOfComponents())
     {
     }
 
@@ -54,7 +56,8 @@ private:
 };
 
 std::unique_ptr<ParameterBase> createMeshNodeParameter(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh);
+    std::string const& name, BaseLib::ConfigTree const& config,
+    MeshLib::Mesh const& mesh);
 
 }  // ProcessLib
 

--- a/ProcessLib/Parameter/Parameter.cpp
+++ b/ProcessLib/Parameter/Parameter.cpp
@@ -36,36 +36,31 @@ std::unique_ptr<ParameterBase> createParameter(
     if (type == "Constant")
     {
         INFO("ConstantParameter: %s", name.c_str());
-        auto param = createConstantParameter(config);
-        param->name = name;
+        auto param = createConstantParameter(name, config);
         return param;
     }
     else if (type == "CurveScaled")
     {
         INFO("CurveScaledParameter: %s", name.c_str());
-        auto param = createCurveScaledParameter(config, curves);
-        param->name = name;
+        auto param = createCurveScaledParameter(name, config, curves);
         return param;
     }
     else if (type == "Group")
     {
         INFO("GroupBasedParameter: %s", name.c_str());
-        auto param = createGroupBasedParameter(config, *meshes.front());
-        param->name = name;
+        auto param = createGroupBasedParameter(name, config, *meshes.front());
         return param;
     }
     else if (type == "MeshElement")
     {
         INFO("MeshElementParameter: %s", name.c_str());
-        auto param = createMeshElementParameter(config, *meshes.front());
-        param->name = name;
+        auto param = createMeshElementParameter(name, config, *meshes.front());
         return param;
     }
     else if (type == "MeshNode")
     {
         INFO("MeshElementParameter: %s", name.c_str());
-        auto param = createMeshNodeParameter(config, *meshes.front());
-        param->name = name;
+        auto param = createMeshNodeParameter(name, config, *meshes.front());
         return param;
     }
     else

--- a/ProcessLib/Parameter/Parameter.h
+++ b/ProcessLib/Parameter/Parameter.h
@@ -37,6 +37,8 @@ namespace ProcessLib
 /// Its property name helps addressing the right parameter.
 struct ParameterBase
 {
+    ParameterBase(std::string const& name_) : name(name_) {}
+
     virtual ~ParameterBase() = default;
 
     virtual bool isTimeDependent() const = 0;
@@ -49,7 +51,7 @@ struct ParameterBase
     {
     }
 
-    std::string name;
+    std::string const name;
 };
 
 /*! A Parameter is a function \f$ (t, x) \mapsto f(t, x) \in T^n \f$.
@@ -61,6 +63,8 @@ struct ParameterBase
 template <typename T>
 struct Parameter : public ParameterBase
 {
+    Parameter(std::string const& name_) : ParameterBase(name_) {}
+
     virtual ~Parameter() = default;
 
     //! Returns the number of components this Parameter has at every position and

--- a/Tests/MaterialLib/TestFractureModels.cpp
+++ b/Tests/MaterialLib/TestFractureModels.cpp
@@ -27,8 +27,8 @@ static const double eps_C = 1e10*1e-5;
 
 TEST(MaterialLib_Fracture, LinearElasticIsotropic)
 {
-    ProcessLib::ConstantParameter<double> const kn(1e11);
-    ProcessLib::ConstantParameter<double> const ks(1e9);
+    ProcessLib::ConstantParameter<double> const kn("", 1e11);
+    ProcessLib::ConstantParameter<double> const ks("", 1e9);
     LinearElasticIsotropic<2>::MaterialProperties const mp{kn, ks};
 
     LinearElasticIsotropic<2> fractureModel{mp};
@@ -61,11 +61,11 @@ TEST(MaterialLib_Fracture, LinearElasticIsotropic)
 
 TEST(MaterialLib_Fracture, MohrCoulomb)
 {
-    ProcessLib::ConstantParameter<double> const kn(50e9);
-    ProcessLib::ConstantParameter<double> const ks(20e9);
-    ProcessLib::ConstantParameter<double> const phi(15);
-    ProcessLib::ConstantParameter<double> const psi(5);
-    ProcessLib::ConstantParameter<double> const c(3e6);
+    ProcessLib::ConstantParameter<double> const kn("", 50e9);
+    ProcessLib::ConstantParameter<double> const ks("", 20e9);
+    ProcessLib::ConstantParameter<double> const phi("", 15);
+    ProcessLib::ConstantParameter<double> const psi("", 5);
+    ProcessLib::ConstantParameter<double> const c("", 3e6);
     MohrCoulomb<2>::MaterialProperties const mp{kn, ks, phi, psi, c};
 
     MohrCoulomb<2> fractureModel{mp};

--- a/Tests/ProcessLib/TestParameter.cpp
+++ b/Tests/ProcessLib/TestParameter.cpp
@@ -36,15 +36,20 @@ TEST(ProcessLib_Parameter, GroupBasedParameterElement)
             "</parameter>";
     auto const ptree = readXml(xml);
 
-    std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::MeshGenerator::generateLineMesh(4u, 1.0));
-    std::vector<int> mat_ids({0,1,2,3});
-    MeshLib::addPropertyToMesh(*mesh, "MaterialIDs", MeshLib::MeshItemType::Cell, 1, mat_ids);
+    std::unique_ptr<MeshLib::Mesh> mesh(
+        MeshLib::MeshGenerator::generateLineMesh(4u, 1.0));
+    std::vector<int> mat_ids({0, 1, 2, 3});
+    MeshLib::addPropertyToMesh(*mesh, "MaterialIDs",
+                               MeshLib::MeshItemType::Cell, 1, mat_ids);
 
-    BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror, BaseLib::ConfigTree::onwarning);
-    std::unique_ptr<ProcessLib::ParameterBase> parameter_base
-            = ProcessLib::createGroupBasedParameter(conf.getConfigSubtree("parameter"), *mesh);
+    BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
+                             BaseLib::ConfigTree::onwarning);
+    std::unique_ptr<ProcessLib::ParameterBase> parameter_base =
+        ProcessLib::createGroupBasedParameter(
+            "", conf.getConfigSubtree("parameter"), *mesh);
 
-    auto parameter = dynamic_cast<ProcessLib::Parameter<double>*>(parameter_base.get());
+    auto parameter =
+        dynamic_cast<ProcessLib::Parameter<double>*>(parameter_base.get());
     double t = 0;
     ProcessLib::SpatialPosition x;
     x.setElementID(0);
@@ -70,15 +75,20 @@ TEST(ProcessLib_Parameter, GroupBasedParameterNode)
             "</parameter>";
     auto const ptree = readXml(xml);
 
-    std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::MeshGenerator::generateLineMesh(4u, 1.0));
-    std::vector<int> group_ids({0,1,2,3,4});
-    MeshLib::addPropertyToMesh(*mesh, "PointGroupIDs", MeshLib::MeshItemType::Node, 1, group_ids);
+    std::unique_ptr<MeshLib::Mesh> mesh(
+        MeshLib::MeshGenerator::generateLineMesh(4u, 1.0));
+    std::vector<int> group_ids({0, 1, 2, 3, 4});
+    MeshLib::addPropertyToMesh(*mesh, "PointGroupIDs",
+                               MeshLib::MeshItemType::Node, 1, group_ids);
 
-    BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror, BaseLib::ConfigTree::onwarning);
-    std::unique_ptr<ProcessLib::ParameterBase> parameter_base
-            = ProcessLib::createGroupBasedParameter(conf.getConfigSubtree("parameter"), *mesh);
+    BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
+                             BaseLib::ConfigTree::onwarning);
+    std::unique_ptr<ProcessLib::ParameterBase> parameter_base =
+        ProcessLib::createGroupBasedParameter(
+            "", conf.getConfigSubtree("parameter"), *mesh);
 
-    auto parameter = dynamic_cast<ProcessLib::Parameter<double>*>(parameter_base.get());
+    auto parameter =
+        dynamic_cast<ProcessLib::Parameter<double>*>(parameter_base.get());
     double t = 0;
     ProcessLib::SpatialPosition x;
     x.setNodeID(0);


### PR DESCRIPTION
... since it is rather likely that users mess up their input files.
- ProjectData now stores parameters and process variables in a std::map
- ParameterBase::name is const now

I think it's best to review commit-wise since there are some commits with search & replace changes.
Note, however, that the "dependent changes for SD with LIE" are a tiny bit more than search & replace.
