### PR TITLE
Add the shape function order to ProcessVariable class

### DIFF
--- a/ProcessLib/BoundaryCondition/BoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/BoundaryCondition.cpp
@@ -22,6 +22,7 @@ std::unique_ptr<BoundaryCondition> BoundaryConditionBuilder::createBoundaryCondi
     const BoundaryConditionConfig& config,
     const NumLib::LocalToGlobalIndexMap& dof_table, const MeshLib::Mesh& mesh,
     const int variable_id, const unsigned integration_order,
+    const unsigned shapefunction_order,
     const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters)
 {
     MeshGeoToolsLib::MeshNodeSearcher& mesh_node_searcher =
@@ -37,21 +38,21 @@ std::unique_ptr<BoundaryCondition> BoundaryConditionBuilder::createBoundaryCondi
     {
         return createDirichletBoundaryCondition(
                     config, dof_table, mesh, variable_id,
-                    integration_order, parameters,
+                    integration_order, shapefunction_order, parameters,
                     mesh_node_searcher, boundary_element_searcher);
     }
     else if (type == "Neumann")
     {
         return createNeumannBoundaryCondition(
                     config, dof_table, mesh, variable_id,
-                    integration_order, parameters,
+                    integration_order, shapefunction_order, parameters,
                     mesh_node_searcher, boundary_element_searcher);
     }
     else if (type == "Robin")
     {
         return createRobinBoundaryCondition(
                     config, dof_table, mesh, variable_id,
-                    integration_order, parameters,
+                    integration_order, shapefunction_order, parameters,
                     mesh_node_searcher, boundary_element_searcher);
     }
     else
@@ -65,6 +66,7 @@ BoundaryConditionBuilder::createDirichletBoundaryCondition(
         const BoundaryConditionConfig& config,
         const NumLib::LocalToGlobalIndexMap& dof_table, const MeshLib::Mesh& mesh,
         const int variable_id, const unsigned /*integration_order*/,
+        const unsigned /*shapefunction_order*/,
         const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters,
         MeshGeoToolsLib::MeshNodeSearcher& mesh_node_searcher,
         MeshGeoToolsLib::BoundaryElementsSearcher& /*boundary_element_searcher*/)
@@ -110,6 +112,7 @@ BoundaryConditionBuilder::createNeumannBoundaryCondition(
         const BoundaryConditionConfig& config,
         const NumLib::LocalToGlobalIndexMap& dof_table, const MeshLib::Mesh& mesh,
         const int variable_id, const unsigned integration_order,
+        const unsigned shapefunction_order,
         const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters,
         MeshGeoToolsLib::MeshNodeSearcher& /*mesh_node_searcher*/,
         MeshGeoToolsLib::BoundaryElementsSearcher& boundary_element_searcher)
@@ -118,7 +121,7 @@ BoundaryConditionBuilder::createNeumannBoundaryCondition(
         config.config,
         getClonedElements(boundary_element_searcher, config.geometry),
         dof_table, variable_id, config.component_id,
-        mesh.isAxiallySymmetric(), integration_order, mesh.getDimension(),
+        mesh.isAxiallySymmetric(), integration_order, shapefunction_order, mesh.getDimension(),
         parameters);
 }
 
@@ -127,6 +130,7 @@ BoundaryConditionBuilder::createRobinBoundaryCondition(
         const BoundaryConditionConfig& config,
         const NumLib::LocalToGlobalIndexMap& dof_table, const MeshLib::Mesh& mesh,
         const int variable_id, const unsigned integration_order,
+        const unsigned shapefunction_order,
         const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters,
         MeshGeoToolsLib::MeshNodeSearcher& /*mesh_node_searcher*/,
         MeshGeoToolsLib::BoundaryElementsSearcher& boundary_element_searcher)
@@ -135,7 +139,7 @@ BoundaryConditionBuilder::createRobinBoundaryCondition(
         config.config,
         getClonedElements(boundary_element_searcher, config.geometry),
         dof_table, variable_id, config.component_id,
-        mesh.isAxiallySymmetric(), integration_order, mesh.getDimension(),
+        mesh.isAxiallySymmetric(), integration_order, shapefunction_order, mesh.getDimension(),
         parameters);
 }
 

--- a/ProcessLib/BoundaryCondition/BoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/BoundaryCondition.h
@@ -76,6 +76,7 @@ public:
         const BoundaryConditionConfig& config,
         const NumLib::LocalToGlobalIndexMap& dof_table, const MeshLib::Mesh& mesh,
         const int variable_id, const unsigned integration_order,
+        const unsigned shapefunction_order,
         const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters);
 
 protected:
@@ -84,6 +85,7 @@ protected:
         const NumLib::LocalToGlobalIndexMap& dof_table,
         const MeshLib::Mesh& mesh, const int variable_id,
         const unsigned integration_order,
+        const unsigned shapefunction_order,
         const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>&
             parameters,
         MeshGeoToolsLib::MeshNodeSearcher& mesh_node_searcher,
@@ -94,6 +96,7 @@ protected:
         const NumLib::LocalToGlobalIndexMap& dof_table,
         const MeshLib::Mesh& mesh, const int variable_id,
         const unsigned integration_order,
+        const unsigned shapefunction_order,
         const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>&
             parameters,
         MeshGeoToolsLib::MeshNodeSearcher& mesh_node_searcher,
@@ -104,6 +107,7 @@ protected:
         const NumLib::LocalToGlobalIndexMap& dof_table,
         const MeshLib::Mesh& mesh, const int variable_id,
         const unsigned integration_order,
+        const unsigned shapefunction_order,
         const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>&
             parameters,
         MeshGeoToolsLib::MeshNodeSearcher& mesh_node_searcher,

--- a/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.cpp
@@ -45,6 +45,8 @@ void DirichletBoundaryCondition::getEssentialBCValues(
         // TODO: that might be slow, but only done once
         const auto g_idx =
             _dof_table.getGlobalIndex(l, _variable_id, _component_id);
+        if (g_idx == NumLib::MeshComponentMap::nop)
+            continue;
         // For the DDC approach (e.g. with PETSc option), the negative
         // index of g_idx means that the entry by that index is a ghost one,
         // which should be dropped. Especially for PETSc routines MatZeroRows

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
@@ -26,6 +26,7 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
                          typename std::decay<Data>::type>::value,
             bool>::type is_axially_symmetric,
         unsigned const integration_order,
+        unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
         unsigned const global_dim, std::vector<MeshLib::Element*>&& elements,
@@ -55,7 +56,7 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
         variable_id, component_id, std::move(all_mesh_subsets), _elements));
 
     createLocalAssemblers<LocalAssemblerImplementation>(
-        global_dim, _elements, *_dof_table_boundary, _local_assemblers,
+        global_dim, _elements, *_dof_table_boundary, shapefunction_order, _local_assemblers,
         is_axially_symmetric, _integration_order, _data);
 }
 

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition.h
@@ -33,6 +33,7 @@ public:
                          typename std::decay<Data>::type>::value,
             bool>::type is_axially_symmetric,
         unsigned const integration_order,
+        unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
         unsigned const global_dim, std::vector<MeshLib::Element*>&& elements,

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.cpp
@@ -17,7 +17,9 @@ std::unique_ptr<NeumannBoundaryCondition> createNeumannBoundaryCondition(
     std::vector<MeshLib::Element*>&& elements,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
-    unsigned const integration_order, unsigned const global_dim,
+    unsigned const integration_order,
+    unsigned const shapefunction_order,
+    unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters)
 {
     DBUG("Constructing Neumann BC from config.");
@@ -31,7 +33,7 @@ std::unique_ptr<NeumannBoundaryCondition> createNeumannBoundaryCondition(
     auto const& param = findParameter<double>(param_name, parameters, 1);
 
     return std::unique_ptr<NeumannBoundaryCondition>(
-        new NeumannBoundaryCondition(is_axially_symmetric, integration_order,
+        new NeumannBoundaryCondition(is_axially_symmetric, integration_order, shapefunction_order,
                                      dof_table, variable_id, component_id,
                                      global_dim, std::move(elements), param));
 }

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.h
@@ -24,7 +24,9 @@ std::unique_ptr<NeumannBoundaryCondition> createNeumannBoundaryCondition(
     std::vector<MeshLib::Element*>&& elements,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
-    unsigned const integration_order, unsigned const global_dim,
+    unsigned const integration_order,
+    unsigned const shapefunction_order,
+    unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters);
 
 }  // ProcessLib

--- a/ProcessLib/BoundaryCondition/RobinBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryCondition.cpp
@@ -17,7 +17,9 @@ std::unique_ptr<RobinBoundaryCondition> createRobinBoundaryCondition(
     std::vector<MeshLib::Element*>&& elements,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
-    unsigned const integration_order, unsigned const global_dim,
+    unsigned const integration_order,
+    unsigned const shapefunction_order,
+    unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters)
 {
     DBUG("Constructing RobinBcConfig from config.");
@@ -33,7 +35,7 @@ std::unique_ptr<RobinBoundaryCondition> createRobinBoundaryCondition(
     auto const& u_0 = findParameter<double>(u_0_name, parameters, 1);
 
     return std::unique_ptr<RobinBoundaryCondition>(new RobinBoundaryCondition(
-        is_axially_symmetric, integration_order, dof_table, variable_id,
+        is_axially_symmetric, integration_order, shapefunction_order, dof_table, variable_id,
         component_id, global_dim, std::move(elements),
         RobinBoundaryConditionData{alpha, u_0}));
 }

--- a/ProcessLib/BoundaryCondition/RobinBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryCondition.h
@@ -40,7 +40,9 @@ std::unique_ptr<RobinBoundaryCondition> createRobinBoundaryCondition(
     std::vector<MeshLib::Element*>&& elements,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
-    unsigned const integration_order, unsigned const global_dim,
+    unsigned const integration_order,
+    unsigned const shapefunction_order,
+    unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters);
 
 }  // ProcessLib

--- a/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.cpp
+++ b/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.cpp
@@ -57,7 +57,7 @@ CalculateSurfaceFlux::CalculateSurfaceFlux(
 
     ProcessLib::createLocalAssemblers<CalculateSurfaceFluxLocalAssembler>(
         boundary_mesh.getDimension() + 1,  // or bulk_mesh.getDimension()?
-        boundary_mesh.getElements(), *dof_table, _local_assemblers,
+        boundary_mesh.getElements(), *dof_table, 1, _local_assemblers,
         boundary_mesh.isAxiallySymmetric(), integration_order,
         *bulk_element_ids, *bulk_face_ids);
 }

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -44,8 +44,10 @@ void GroundwaterFlowProcess::initializeConcreteProcess(
     MeshLib::Mesh const& mesh,
     unsigned const integration_order)
 {
+    ProcessLib::ProcessVariable const& pv = getProcessVariables()[0];
     ProcessLib::createLocalAssemblers<LocalAssemblerData>(
-        mesh.getDimension(), mesh.getElements(), dof_table, _local_assemblers,
+        mesh.getDimension(), mesh.getElements(), dof_table,
+        pv.getShapeFunctionOrder(), _local_assemblers,
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -38,8 +38,10 @@ void HeatConductionProcess::initializeConcreteProcess(
     MeshLib::Mesh const& mesh,
     unsigned const integration_order)
 {
+    ProcessLib::ProcessVariable const& pv = getProcessVariables()[0];
     ProcessLib::createLocalAssemblers<LocalAssemblerData>(
-        mesh.getDimension(), mesh.getElements(), dof_table, _local_assemblers,
+        mesh.getDimension(), mesh.getElements(), dof_table,
+        pv.getShapeFunctionOrder(), _local_assemblers,
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -55,8 +55,10 @@ void LiquidFlowProcess::initializeConcreteProcess(
     MeshLib::Mesh const& mesh,
     unsigned const integration_order)
 {
+    ProcessLib::ProcessVariable const& pv = getProcessVariables()[0];
     ProcessLib::createLocalAssemblers<LiquidFlowLocalAssembler>(
-        mesh.getDimension(), mesh.getElements(), dof_table, _local_assemblers,
+        mesh.getDimension(), mesh.getElements(), dof_table,
+        pv.getShapeFunctionOrder(), _local_assemblers,
         mesh.isAxiallySymmetric(), integration_order, _gravitational_axis_id,
         _gravitational_acceleration, _material_properties);
 

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -37,6 +37,9 @@ ProcessVariable::ProcessVariable(
 {
     DBUG("Constructing process variable %s", _name.c_str());
 
+    if (_shapefunction_order < 1 || 2 < _shapefunction_order)
+        OGS_FATAL("The given shape function order %d is not supported", _shapefunction_order);
+
     // Boundary conditions
     //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions}
     if (auto bcs_config = config.getConfigSubtreeOptional("boundary_conditions"))

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -27,6 +27,8 @@ ProcessVariable::ProcessVariable(
       _mesh(mesh),
       //! \ogs_file_param{prj__process_variables__process_variable__components}
       _n_components(config.getConfigParameter<int>("components")),
+      //! \ogs_file_param{prj__process_variables__process_variable__order}
+      _shapefunction_order(config.getConfigParameter<int>("order")),
       _initial_condition(findParameter<double>(
           //! \ogs_file_param{prj__process_variables__process_variable__initial_condition}
           config.getConfigParameter<std::string>("initial_condition"),
@@ -95,6 +97,7 @@ ProcessVariable::ProcessVariable(ProcessVariable&& other)
     : _name(std::move(other._name)),
       _mesh(other._mesh),
       _n_components(other._n_components),
+      _shapefunction_order(other._shapefunction_order),
       _initial_condition(std::move(other._initial_condition)),
       _bc_configs(std::move(other._bc_configs)),
       _bc_builder(std::move(other._bc_builder))

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -27,8 +27,6 @@ ProcessVariable::ProcessVariable(
       _mesh(mesh),
       //! \ogs_file_param{prj__process_variables__process_variable__components}
       _n_components(config.getConfigParameter<int>("components")),
-      //! \ogs_file_param{prj__process_variables__process_variable__order}
-      _shapefunction_order(config.getConfigParameter<int>("order")),
       _initial_condition(findParameter<double>(
           //! \ogs_file_param{prj__process_variables__process_variable__initial_condition}
           config.getConfigParameter<std::string>("initial_condition"),
@@ -36,6 +34,9 @@ ProcessVariable::ProcessVariable(
       _bc_builder(new BoundaryConditionBuilder())
 {
     DBUG("Constructing process variable %s", _name.c_str());
+    //! \ogs_file_param{prj__process_variables__process_variable__order}
+    auto opt_shapefunction_order = config.getConfigParameterOptional<int>("order");
+    _shapefunction_order = (opt_shapefunction_order ? opt_shapefunction_order.get() : 1);
 
     // Boundary conditions
     //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions}

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -27,6 +27,8 @@ ProcessVariable::ProcessVariable(
       _mesh(mesh),
       //! \ogs_file_param{prj__process_variables__process_variable__components}
       _n_components(config.getConfigParameter<int>("components")),
+      //! \ogs_file_param{prj__process_variables__process_variable__order}
+      _shapefunction_order(config.getConfigParameter<unsigned>("order")),
       _initial_condition(findParameter<double>(
           //! \ogs_file_param{prj__process_variables__process_variable__initial_condition}
           config.getConfigParameter<std::string>("initial_condition"),
@@ -34,9 +36,6 @@ ProcessVariable::ProcessVariable(
       _bc_builder(new BoundaryConditionBuilder())
 {
     DBUG("Constructing process variable %s", _name.c_str());
-    //! \ogs_file_param{prj__process_variables__process_variable__order}
-    auto opt_shapefunction_order = config.getConfigParameterOptional<int>("order");
-    _shapefunction_order = (opt_shapefunction_order ? opt_shapefunction_order.get() : 1);
 
     // Boundary conditions
     //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions}

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -145,7 +145,7 @@ ProcessVariable::createBoundaryConditions(
 
     for (auto& config : _bc_configs)
         bcs.emplace_back(_bc_builder->createBoundaryCondition(
-            config, dof_table, _mesh, variable_id, integration_order, parameters));
+            config, dof_table, _mesh, variable_id, integration_order, _shapefunction_order, parameters));
 
     return bcs;
 }

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -64,10 +64,14 @@ public:
     // components.
     MeshLib::PropertyVector<double>& getOrCreateMeshProperty();
 
+    unsigned getShapeFunctionOrder() const { return _shapefunction_order; }
+
 private:
     std::string const _name;
     MeshLib::Mesh& _mesh;
     const int _n_components;
+    unsigned _shapefunction_order;  ///< Order of the shapefunctions. Requires
+                               /// appropriate mesh.
     Parameter<double> const& _initial_condition;
 
     std::vector<BoundaryConditionConfig> _bc_configs;

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -71,7 +71,7 @@ private:
     MeshLib::Mesh& _mesh;
     const int _n_components;
     unsigned _shapefunction_order;  ///< Order of the shapefunctions. Requires
-                               /// appropriate mesh.
+                                    /// appropriate mesh.
     Parameter<double> const& _initial_condition;
 
     std::vector<BoundaryConditionConfig> _bc_configs;

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
@@ -38,8 +38,10 @@ void RichardsFlowProcess::initializeConcreteProcess(
     MeshLib::Mesh const& mesh,
     unsigned const integration_order)
 {
+    ProcessLib::ProcessVariable const& pv = getProcessVariables()[0];
     ProcessLib::createLocalAssemblers<LocalAssemblerData>(
-        mesh.getDimension(), mesh.getElements(), dof_table, _local_assemblers,
+        mesh.getDimension(), mesh.getElements(), dof_table,
+        pv.getShapeFunctionOrder(), _local_assemblers,
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(

--- a/ProcessLib/SmallDeformationWithLIE/BoundaryCondition/BoundaryConditionBuilder.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/BoundaryCondition/BoundaryConditionBuilder.cpp
@@ -23,6 +23,7 @@ BoundaryConditionBuilder::createNeumannBoundaryCondition(
         const BoundaryConditionConfig& config,
         const NumLib::LocalToGlobalIndexMap& dof_table, const MeshLib::Mesh& mesh,
         const int variable_id, const unsigned integration_order,
+        const unsigned shapefunction_order,
         const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters,
         MeshGeoToolsLib::MeshNodeSearcher& /*mesh_node_searcher*/,
         MeshGeoToolsLib::BoundaryElementsSearcher& boundary_element_searcher)
@@ -31,7 +32,7 @@ BoundaryConditionBuilder::createNeumannBoundaryCondition(
         config.config,
         getClonedElements(boundary_element_searcher, config.geometry),
         dof_table, variable_id, config.component_id,
-        mesh.isAxiallySymmetric(), integration_order, mesh.getDimension(),
+        mesh.isAxiallySymmetric(), integration_order, shapefunction_order, mesh.getDimension(),
         parameters, _fracture_prop);
 }
 

--- a/ProcessLib/SmallDeformationWithLIE/BoundaryCondition/BoundaryConditionBuilder.h
+++ b/ProcessLib/SmallDeformationWithLIE/BoundaryCondition/BoundaryConditionBuilder.h
@@ -45,6 +45,7 @@ private:
         const NumLib::LocalToGlobalIndexMap& dof_table,
         const MeshLib::Mesh& mesh, const int variable_id,
         const unsigned integration_order,
+        const unsigned shapefunction_order,
         const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>&
             parameters,
         MeshGeoToolsLib::MeshNodeSearcher& mesh_node_searcher,

--- a/ProcessLib/SmallDeformationWithLIE/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/SmallDeformationWithLIE/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
@@ -33,6 +33,7 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
                          typename std::decay<Data>::type>::value,
             bool>::type is_axially_symmetric,
         unsigned const integration_order,
+        unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
         unsigned const global_dim,
@@ -63,7 +64,7 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
         variable_id, component_id, std::move(all_mesh_subsets), _elements));
 
     createLocalAssemblers<LocalAssemblerImplementation>(
-        global_dim, _elements, *_dof_table_boundary, _local_assemblers,
+        global_dim, _elements, *_dof_table_boundary, shapefunction_order, _local_assemblers,
         is_axially_symmetric, _integration_order, _data, fracture_prop, variable_id);
 }
 

--- a/ProcessLib/SmallDeformationWithLIE/BoundaryCondition/GenericNaturalBoundaryCondition.h
+++ b/ProcessLib/SmallDeformationWithLIE/BoundaryCondition/GenericNaturalBoundaryCondition.h
@@ -37,6 +37,7 @@ public:
                          typename std::decay<Data>::type>::value,
             bool>::type is_axially_symmetric,
         unsigned const integration_order,
+        unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
         unsigned const global_dim,

--- a/ProcessLib/SmallDeformationWithLIE/BoundaryCondition/NeumannBoundaryCondition.cpp
+++ b/ProcessLib/SmallDeformationWithLIE/BoundaryCondition/NeumannBoundaryCondition.cpp
@@ -22,13 +22,13 @@ namespace SmallDeformationWithLIE
 using NeumannBoundaryCondition = GenericNaturalBoundaryCondition<
     Parameter<double> const&, NeumannBoundaryConditionLocalAssembler>;
 
-std::unique_ptr<BoundaryCondition>
-createNeumannBoundaryCondition(
+std::unique_ptr<BoundaryCondition> createNeumannBoundaryCondition(
     BaseLib::ConfigTree const& config,
     std::vector<MeshLib::Element*>&& elements,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
-        int const component_id, bool is_axially_symmetric,
-        unsigned const integration_order, unsigned const global_dim,
+    int const component_id, bool is_axially_symmetric,
+    unsigned const integration_order, unsigned const shapefunction_order,
+    unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
     FractureProperty const& fracture_prop)
 {
@@ -44,7 +44,7 @@ createNeumannBoundaryCondition(
 
     return std::unique_ptr<BoundaryCondition>(
         new NeumannBoundaryCondition(
-            is_axially_symmetric, integration_order,
+            is_axially_symmetric, integration_order, shapefunction_order,
             dof_table, variable_id, component_id,
             global_dim, std::move(elements), param, fracture_prop));
 }

--- a/ProcessLib/SmallDeformationWithLIE/BoundaryCondition/NeumannBoundaryCondition.h
+++ b/ProcessLib/SmallDeformationWithLIE/BoundaryCondition/NeumannBoundaryCondition.h
@@ -32,7 +32,9 @@ createNeumannBoundaryCondition(
     std::vector<MeshLib::Element*>&& elements,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
-    unsigned const integration_order, unsigned const global_dim,
+    unsigned const integration_order,
+    unsigned const shapefunction_order,
+    unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
     FractureProperty const& fracture_prop);
 

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -140,8 +140,10 @@ void TESProcess::initializeConcreteProcess(
     NumLib::LocalToGlobalIndexMap const& dof_table,
     MeshLib::Mesh const& mesh, unsigned const integration_order)
 {
+    ProcessLib::ProcessVariable const& pv = getProcessVariables()[0];
     ProcessLib::createLocalAssemblers<TESLocalAssembler>(
-        mesh.getDimension(), mesh.getElements(), dof_table, _local_assemblers,
+        mesh.getDimension(), mesh.getElements(), dof_table,
+        pv.getShapeFunctionOrder(), _local_assemblers,
         mesh.isAxiallySymmetric(), integration_order, _assembly_params);
 
     initializeSecondaryVariables();

--- a/ProcessLib/Utils/CreateLocalAssemblers.h
+++ b/ProcessLib/Utils/CreateLocalAssemblers.h
@@ -28,6 +28,7 @@ template <unsigned GlobalDim, template <typename, typename, unsigned>
           typename LocalAssemblerInterface, typename... ExtraCtorArgs>
 void createLocalAssemblers(
     NumLib::LocalToGlobalIndexMap const& dof_table,
+    const unsigned shapefunction_order,
     std::vector<MeshLib::Element*> const& mesh_elements,
     std::vector<std::unique_ptr<LocalAssemblerInterface>>& local_assemblers,
     ExtraCtorArgs&&... extra_ctor_args)
@@ -42,7 +43,7 @@ void createLocalAssemblers(
     // Populate the vector of local assemblers.
     local_assemblers.resize(mesh_elements.size());
 
-    LocalDataInitializer initializer(dof_table);
+    LocalDataInitializer initializer(dof_table, shapefunction_order);
 
     DBUG("Calling local assembler builder for all mesh elements.");
     GlobalExecutor::transformDereferenced(
@@ -70,6 +71,7 @@ void createLocalAssemblers(
     const unsigned dimension,
     std::vector<MeshLib::Element*> const& mesh_elements,
     NumLib::LocalToGlobalIndexMap const& dof_table,
+    const unsigned shapefunction_order,
     std::vector<std::unique_ptr<LocalAssemblerInterface>>& local_assemblers,
     ExtraCtorArgs&&... extra_ctor_args)
 {
@@ -79,17 +81,17 @@ void createLocalAssemblers(
     {
         case 1:
             detail::createLocalAssemblers<1, LocalAssemblerImplementation>(
-                dof_table, mesh_elements, local_assemblers,
+                dof_table, shapefunction_order, mesh_elements, local_assemblers,
                 std::forward<ExtraCtorArgs>(extra_ctor_args)...);
             break;
         case 2:
             detail::createLocalAssemblers<2, LocalAssemblerImplementation>(
-                dof_table, mesh_elements, local_assemblers,
+                dof_table, shapefunction_order, mesh_elements, local_assemblers,
                 std::forward<ExtraCtorArgs>(extra_ctor_args)...);
             break;
         case 3:
             detail::createLocalAssemblers<3, LocalAssemblerImplementation>(
-                dof_table, mesh_elements, local_assemblers,
+                dof_table, shapefunction_order, mesh_elements, local_assemblers,
                 std::forward<ExtraCtorArgs>(extra_ctor_args)...);
             break;
         default:

--- a/ProcessLib/Utils/LocalDataInitializer.h
+++ b/ProcessLib/Utils/LocalDataInitializer.h
@@ -133,6 +133,9 @@ public:
         const unsigned shapefunction_order)
         : _dof_table(dof_table)
     {
+        if (shapefunction_order < 1 || 2 < shapefunction_order)
+            OGS_FATAL("The given shape function order %d is not supported", shapefunction_order);
+
         if (shapefunction_order == 1)
         {
         // /// Lines and points ///////////////////////////////////

--- a/ProcessLib/Utils/LocalDataInitializer.h
+++ b/ProcessLib/Utils/LocalDataInitializer.h
@@ -128,10 +128,13 @@ class LocalDataInitializer final
 public:
     using LADataIntfPtr = std::unique_ptr<LocalAssemblerInterface>;
 
-    explicit LocalDataInitializer(
-        NumLib::LocalToGlobalIndexMap const& dof_table)
+    LocalDataInitializer(
+        NumLib::LocalToGlobalIndexMap const& dof_table,
+        const unsigned shapefunction_order)
         : _dof_table(dof_table)
     {
+        if (shapefunction_order == 1)
+        {
         // /// Lines and points ///////////////////////////////////
 
 #if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_LINE) != 0 \
@@ -149,9 +152,8 @@ public:
 #if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_LINE) != 0 \
     && OGS_MAX_ELEMENT_DIM >= 1 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Line3))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeLine3>();
+            makeLocalAssemblerBuilder<NumLib::ShapeLine2>();
 #endif
-
 
         // /// Quads and Hexahedra ///////////////////////////////////
 
@@ -170,17 +172,16 @@ public:
 #if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 \
     && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Quad8))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeQuad8>();
+            makeLocalAssemblerBuilder<NumLib::ShapeQuad4>();
         _builder[std::type_index(typeid(MeshLib::Quad9))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeQuad9>();
+            makeLocalAssemblerBuilder<NumLib::ShapeQuad4>();
 #endif
 
 #if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_CUBOID) != 0 \
     && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Hex20))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeHex20>();
+            makeLocalAssemblerBuilder<NumLib::ShapeHex8>();
 #endif
-
 
         // /// Simplices ////////////////////////////////////////////////
 
@@ -199,15 +200,14 @@ public:
 #if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 \
     && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Tri6))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeTri6>();
+            makeLocalAssemblerBuilder<NumLib::ShapeTri3>();
 #endif
 
 #if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_SIMPLEX) != 0 \
     && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Tet10))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeTet10>();
+            makeLocalAssemblerBuilder<NumLib::ShapeTet4>();
 #endif
-
 
         // /// Prisms ////////////////////////////////////////////////////
 
@@ -220,7 +220,7 @@ public:
 #if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PRISM) != 0 \
     && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Prism15))] =
-            makeLocalAssemblerBuilder<NumLib::ShapePrism15>();
+            makeLocalAssemblerBuilder<NumLib::ShapePrism6>();
 #endif
 
         // /// Pyramids //////////////////////////////////////////////////
@@ -234,8 +234,69 @@ public:
 #if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PYRAMID) != 0 \
     && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Pyramid13))] =
+            makeLocalAssemblerBuilder<NumLib::ShapePyra5>();
+#endif
+
+        }
+        else if (shapefunction_order == 2)
+        {
+            // /// Lines and points ///////////////////////////////////
+
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_LINE) != 0 \
+    && OGS_MAX_ELEMENT_DIM >= 1 && OGS_MAX_ELEMENT_ORDER >= 2
+        _builder[std::type_index(typeid(MeshLib::Line3))] =
+            makeLocalAssemblerBuilder<NumLib::ShapeLine3>();
+#endif
+
+
+            // /// Quads and Hexahedra ///////////////////////////////////
+
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 \
+    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
+        _builder[std::type_index(typeid(MeshLib::Quad8))] =
+            makeLocalAssemblerBuilder<NumLib::ShapeQuad8>();
+        _builder[std::type_index(typeid(MeshLib::Quad9))] =
+            makeLocalAssemblerBuilder<NumLib::ShapeQuad9>();
+#endif
+
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_CUBOID) != 0 \
+    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+        _builder[std::type_index(typeid(MeshLib::Hex20))] =
+            makeLocalAssemblerBuilder<NumLib::ShapeHex20>();
+#endif
+
+
+            // /// Simplices ////////////////////////////////////////////////
+
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 \
+    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
+        _builder[std::type_index(typeid(MeshLib::Tri6))] =
+            makeLocalAssemblerBuilder<NumLib::ShapeTri6>();
+#endif
+
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_SIMPLEX) != 0 \
+    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+        _builder[std::type_index(typeid(MeshLib::Tet10))] =
+            makeLocalAssemblerBuilder<NumLib::ShapeTet10>();
+#endif
+
+
+            // /// Prisms ////////////////////////////////////////////////////
+
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PRISM) != 0 \
+    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+        _builder[std::type_index(typeid(MeshLib::Prism15))] =
+            makeLocalAssemblerBuilder<NumLib::ShapePrism15>();
+#endif
+
+            // /// Pyramids //////////////////////////////////////////////////
+
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PYRAMID) != 0 \
+    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+        _builder[std::type_index(typeid(MeshLib::Pyramid13))] =
             makeLocalAssemblerBuilder<NumLib::ShapePyra13>();
 #endif
+        }
     }
 
     /// Sets the provided \c data_ptr to the newly created local assembler data.

--- a/Tests/NumLib/TestExtrapolation.cpp
+++ b/Tests/NumLib/TestExtrapolation.cpp
@@ -146,7 +146,7 @@ public:
 
         // createAssemblers(mesh);
         ProcessLib::createLocalAssemblers<LocalAssemblerData>(
-            mesh.getDimension(), mesh.getElements(), *_dof_table,
+            mesh.getDimension(), mesh.getElements(), *_dof_table, 1,
             _local_assemblers, mesh.isAxiallySymmetric(), _integration_order);
     }
 


### PR DESCRIPTION
Until now, the shape function order is decided by the order of the given mesh. This PR enables users to specify the shape function order in a config file, which can be different from the order of the given mesh, though appropriate mesh (e.g. 2nd order mesh for use of linear or quadratic order shape functions) should be provided. 

This PR is extracted & modified after Dima's HM branch and is needed for implementing HM and "HM with LIE" processes, which use linear order for pressure and quadratic order for displacements. Major changes are
- add the shape function order to ProcessVariable class
- create local assemblers with the order provided in ProcessVariable
- support the order in BC handling
- pass the shape function order to local assembler creations in every process classes

Remarks
- Currently linear and quadratic orders are supported
- Config file needs <order> tag for each process variable, e.g. `<order>1</order>`
- I assume existing processes use the same order for all its variables. 
- The order in CalculateSurfaceFlux is fixed to 1. Correct me if it's wrong.
