### PR TITLE
Test Line3 coordinates mapping

### DIFF
--- a/Tests/NumLib/CoordinatesMappingTestData/TestLine3.h
+++ b/Tests/NumLib/CoordinatesMappingTestData/TestLine3.h
@@ -1,0 +1,106 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#ifndef COORDINATESMAPPINGTESTDATA_TESTLINE3_H_
+#define COORDINATESMAPPINGTESTDATA_TESTLINE3_H_
+
+#include "MeshLib/Elements/Line.h"
+#include "NumLib/Fem/ShapeFunction/ShapeLine3.h"
+
+namespace CoordinatesMappingTestData
+{
+class TestLine3
+{
+public:
+    // Element information
+    typedef MeshLib::Line3 ElementType;
+    typedef NumLib::ShapeLine3 ShapeFunctionType;
+    static const unsigned global_dim = ElementType::dimension;
+    static const unsigned dim = ElementType::dimension;
+    static const unsigned e_nnodes = ElementType::n_all_nodes;
+    // Coordinates where shape functions are evaluated
+    static const double r[dim];
+    // Expected results for natural shape
+    static const double nat_exp_N[e_nnodes];
+    static const double nat_exp_dNdr[e_nnodes * dim];
+    // Expected results for irregular shape
+    static const double ir_exp_J[dim * dim];
+    static const double ir_exp_invJ[dim * dim];
+    static const double ir_exp_detJ;
+    static const double ir_exp_dNdx[e_nnodes * dim];
+    // Expected results for clock-wise node ordering
+    static const double cl_exp_J[dim * dim];
+    // Expected results for zero volume
+    static const double cl_exp_detJ;
+    static const double ze_exp_J[dim * dim];
+
+    // element shape identical to that in natural coordinates (see ShapeLine3.h)
+    static MeshLib::Line3* createNaturalShape()
+    {
+        MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
+        nodes[0] = new MeshLib::Node(-1.0, 0.0, 0.0);
+        nodes[1] = new MeshLib::Node(1.0, 0.0, 0.0);
+        nodes[2] = new MeshLib::Node(0.0, 0.0, 0.0);
+        return new MeshLib::Line3(nodes);
+    }
+
+    // element having irregular or skew shape
+    MeshLib::Line3* createIrregularShape()
+    {
+        // two times longer than the natural
+        MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
+        nodes[0] = new MeshLib::Node(-2.0, 0.0, 0.0);
+        nodes[1] = new MeshLib::Node(2.0, 0.0, 0.0);
+        nodes[2] = new MeshLib::Node(0.0, 0.0, 0.0);
+        return new MeshLib::Line3(nodes);
+    }
+
+    // invalid case: clock wise node ordering
+    MeshLib::Line3* createClockWise()
+    {
+        MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
+        nodes[0] = new MeshLib::Node(1.0, 0.0, 0.0);
+        nodes[1] = new MeshLib::Node(-1.0, 0.0, 0.0);
+        nodes[2] = new MeshLib::Node(0.0, 0.0, 0.0);
+        return new MeshLib::Line3(nodes);
+    }
+
+    // invalid case: zero volume
+    MeshLib::Line3* createZeroVolume()
+    {
+        MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
+        nodes[0] = new MeshLib::Node(0.0, 0.0, 0.0);
+        nodes[1] = new MeshLib::Node(0.0, 0.0, 0.0);
+        nodes[2] = new MeshLib::Node(0.0, 0.0, 0.0);
+        return new MeshLib::Line3(nodes);
+    }
+
+    // 1.5d line
+    static MeshLib::Line3* createY()
+    {
+        MeshLib::Node** nodes = new MeshLib::Node*[e_nnodes];
+        nodes[0] = new MeshLib::Node(0.0, -1.0, 0.0);
+        nodes[1] = new MeshLib::Node(0.0, 1.0, 0.0);
+        nodes[2] = new MeshLib::Node(0.0, 0.0, 0.0);
+        return new MeshLib::Line3(nodes);
+    }
+};
+
+const double TestLine3::r[dim] = {0.5};
+const double TestLine3::nat_exp_N[e_nnodes] = {-0.125, 0.375, 0.75};
+const double TestLine3::nat_exp_dNdr[e_nnodes * dim] = {0, 1, -1};
+const double TestLine3::ir_exp_J[dim * dim] = {2.0};
+const double TestLine3::ir_exp_invJ[dim * dim] = {0.5};
+const double TestLine3::ir_exp_detJ = 2.;
+const double TestLine3::ir_exp_dNdx[dim * e_nnodes] = {0, 0.5, -0.5};
+const double TestLine3::cl_exp_J[dim * dim] = {-1.};
+const double TestLine3::cl_exp_detJ = -1;
+const double TestLine3::ze_exp_J[dim * dim] = {0.0};
+}
+
+#endif

--- a/Tests/NumLib/TestCoordinatesMapping.cpp
+++ b/Tests/NumLib/TestCoordinatesMapping.cpp
@@ -20,6 +20,7 @@
 
 #include "CoordinatesMappingTestData/TestHex8.h"
 #include "CoordinatesMappingTestData/TestLine2.h"
+#include "CoordinatesMappingTestData/TestLine3.h"
 #include "CoordinatesMappingTestData/TestQuad4.h"
 #include "CoordinatesMappingTestData/TestTri3.h"
 
@@ -31,7 +32,8 @@ using namespace CoordinatesMappingTestData;
 namespace
 {
 // Element types to be tested
-typedef ::testing::Types<TestLine2, TestTri3, TestQuad4, TestHex8> TestTypes;
+typedef ::testing::Types<TestLine2, TestLine3, TestTri3, TestQuad4, TestHex8>
+    TestTypes;
 }
 
 template <class T_TEST>

--- a/Tests/NumLib/TestCoordinatesMapping.cpp
+++ b/Tests/NumLib/TestCoordinatesMapping.cpp
@@ -8,41 +8,35 @@
 
 #include <gtest/gtest.h>
 
-#include <limits>
 #include <algorithm>
+#include <limits>
 #include <vector>
 
 #include <Eigen/Eigen>
 
-#include "NumLib/Fem/CoordinatesMapping/ShapeMatrices.h"
 #include "NumLib/Fem/CoordinatesMapping/NaturalCoordinatesMapping.h"
+#include "NumLib/Fem/CoordinatesMapping/ShapeMatrices.h"
 #include "NumLib/Fem/ShapeMatrixPolicy.h"
 
-#include "CoordinatesMappingTestData/TestLine2.h"
-#include "CoordinatesMappingTestData/TestTri3.h"
-#include "CoordinatesMappingTestData/TestQuad4.h"
 #include "CoordinatesMappingTestData/TestHex8.h"
+#include "CoordinatesMappingTestData/TestLine2.h"
+#include "CoordinatesMappingTestData/TestQuad4.h"
+#include "CoordinatesMappingTestData/TestTri3.h"
 
 #include "../TestTools.h"
 
 using namespace NumLib;
 using namespace CoordinatesMappingTestData;
 
-
 namespace
 {
-
 // Element types to be tested
-typedef ::testing::Types<
-        TestLine2,
-        TestTri3,
-        TestQuad4,
-        TestHex8
-        > TestTypes;
+typedef ::testing::Types<TestLine2, TestTri3, TestQuad4, TestHex8> TestTypes;
 }
 
 template <class T_TEST>
-class NumLibFemNaturalCoordinatesMappingTest : public ::testing::Test, public T_TEST
+class NumLibFemNaturalCoordinatesMappingTest : public ::testing::Test,
+                                               public T_TEST
 {
 public:
     typedef typename T_TEST::ElementType ElementType;
@@ -52,23 +46,29 @@ public:
     static const unsigned global_dim = T_TEST::global_dim;
     // Matrix types
     typedef typename ::detail::EigenMatrixType<1, e_nnodes>::type NodalVector;
-    typedef typename ::detail::EigenMatrixType<dim, e_nnodes>::type DimNodalMatrix;
+    typedef
+        typename ::detail::EigenMatrixType<dim, e_nnodes>::type DimNodalMatrix;
     typedef typename ::detail::EigenMatrixType<dim, dim>::type DimMatrix;
-    typedef typename ::detail::EigenMatrixType<global_dim, e_nnodes>::type GlobalDimNodalMatrix;
+    typedef typename ::detail::EigenMatrixType<global_dim, e_nnodes>::type
+        GlobalDimNodalMatrix;
     // Shape data type
-    typedef ShapeMatrices<NodalVector,DimNodalMatrix,DimMatrix,GlobalDimNodalMatrix> ShapeMatricesType;
+    typedef ShapeMatrices<NodalVector, DimNodalMatrix, DimMatrix,
+                          GlobalDimNodalMatrix>
+        ShapeMatricesType;
     // Natural coordinates mapping type
-    typedef NaturalCoordinatesMapping<ElementType, ShapeFunctionType, ShapeMatricesType> NaturalCoordsMappingType;
+    typedef NaturalCoordinatesMapping<ElementType, ShapeFunctionType,
+                                      ShapeMatricesType>
+        NaturalCoordsMappingType;
 
 public:
     NumLibFemNaturalCoordinatesMappingTest()
-    : eps(2*std::numeric_limits<double>::epsilon())
+        : eps(2 * std::numeric_limits<double>::epsilon())
     {
         // create four elements used for testing
-        naturalEle   = this->createNaturalShape();
+        naturalEle = this->createNaturalShape();
         irregularEle = this->createIrregularShape();
-        clockwiseEle  = this->createClockWise();
-        zeroVolumeEle  = this->createZeroVolume();
+        clockwiseEle = this->createClockWise();
+        zeroVolumeEle = this->createZeroVolume();
 
         // for destructor
         vec_eles.push_back(naturalEle);
@@ -76,15 +76,15 @@ public:
         vec_eles.push_back(clockwiseEle);
         vec_eles.push_back(zeroVolumeEle);
         for (auto e : vec_eles)
-            for (unsigned i=0; i<e->getNumberOfNodes(); i++)
+            for (unsigned i = 0; i < e->getNumberOfNodes(); i++)
                 vec_nodes.push_back(e->getNode(i));
     }
 
     virtual ~NumLibFemNaturalCoordinatesMappingTest()
     {
-        for (auto itr = vec_nodes.begin(); itr!=vec_nodes.end(); ++itr )
+        for (auto itr = vec_nodes.begin(); itr != vec_nodes.end(); ++itr)
             delete *itr;
-        for (auto itr = vec_eles.begin(); itr!=vec_eles.end(); ++itr )
+        for (auto itr = vec_eles.begin(); itr != vec_eles.end(); ++itr)
             delete *itr;
     }
 
@@ -102,11 +102,13 @@ TYPED_TEST_CASE(NumLibFemNaturalCoordinatesMappingTest, TestTypes);
 TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_N)
 {
     typedef typename TestFixture::ShapeMatricesType ShapeMatricesType;
-    typedef typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
+    typedef
+        typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
 
-    //only N
-    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::N>(*this->naturalEle, this->r, shape, this->global_dim);
+    // only N
+    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::N>(
+        *this->naturalEle, this->r, shape, this->global_dim);
     ASSERT_FALSE(shape.N.isZero());
     ASSERT_TRUE(shape.dNdr.isZero());
     ASSERT_TRUE(shape.J.isZero());
@@ -118,11 +120,14 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_N)
 TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_DNDR)
 {
     typedef typename TestFixture::ShapeMatricesType ShapeMatricesType;
-    typedef typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
+    typedef
+        typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
 
     // dNdr
-    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::DNDR>(*this->naturalEle, this->r, shape, this->global_dim);
+    NaturalCoordsMappingType::template computeShapeMatrices<
+        ShapeMatrixType::DNDR>(*this->naturalEle, this->r, shape,
+                               this->global_dim);
     ASSERT_TRUE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_TRUE(shape.J.isZero());
@@ -134,12 +139,15 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_DNDR)
 TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_N_J)
 {
     typedef typename TestFixture::ShapeMatricesType ShapeMatricesType;
-    typedef typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
+    typedef
+        typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
 
     // N_J
     shape.setZero();
-    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::N_J>(*this->naturalEle, this->r, shape, this->global_dim);
+    NaturalCoordsMappingType::template computeShapeMatrices<
+        ShapeMatrixType::N_J>(*this->naturalEle, this->r, shape,
+                              this->global_dim);
     ASSERT_FALSE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_FALSE(shape.J.isZero());
@@ -148,14 +156,18 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_N_J)
     ASSERT_TRUE(shape.dNdx.isZero());
 }
 
-TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_DNDR_J)
+TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest,
+           CheckFieldSpecification_DNDR_J)
 {
     typedef typename TestFixture::ShapeMatricesType ShapeMatricesType;
-    typedef typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
+    typedef
+        typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
 
     // dNdr, J
-    NaturalCoordsMappingType::template computeShapeMatrices<ShapeMatrixType::DNDR_J>(*this->naturalEle, this->r, shape, this->global_dim);
+    NaturalCoordsMappingType::template computeShapeMatrices<
+        ShapeMatrixType::DNDR_J>(*this->naturalEle, this->r, shape,
+                                 this->global_dim);
     ASSERT_TRUE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_FALSE(shape.J.isZero());
@@ -167,14 +179,14 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_DNDR_
 TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_DNDX)
 {
     typedef typename TestFixture::ShapeMatricesType ShapeMatricesType;
-    typedef typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
+    typedef
+        typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
 
     // DNDX
     shape.setZero();
     NaturalCoordsMappingType::template computeShapeMatrices<
-        ShapeMatrixType::DNDX>(*this->naturalEle, this->r, shape,
-                               this->dim);
+        ShapeMatrixType::DNDX>(*this->naturalEle, this->r, shape, this->dim);
     ASSERT_TRUE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_FALSE(shape.J.isZero());
@@ -186,12 +198,14 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_DNDX)
 TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_ALL)
 {
     typedef typename TestFixture::ShapeMatricesType ShapeMatricesType;
-    typedef typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
+    typedef
+        typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
 
     // ALL
     shape.setZero();
-    NaturalCoordsMappingType::computeShapeMatrices(*this->naturalEle, this->r, shape, this->global_dim);
+    NaturalCoordsMappingType::computeShapeMatrices(*this->naturalEle, this->r,
+                                                   shape, this->global_dim);
     ASSERT_FALSE(shape.N.isZero());
     ASSERT_FALSE(shape.dNdr.isZero());
     ASSERT_FALSE(shape.J.isZero());
@@ -203,45 +217,58 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckFieldSpecification_ALL)
 TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckNaturalShape)
 {
     typedef typename TestFixture::ShapeMatricesType ShapeMatricesType;
-    typedef typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
+    typedef
+        typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
 
     // identical to natural coordinates
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    NaturalCoordsMappingType::computeShapeMatrices(*this->naturalEle, this->r, shape, this->global_dim);
-    double exp_J[TestFixture::dim*TestFixture::dim]= {0.0};
-    for (unsigned i=0; i<this->dim; i++)
-        exp_J[i+this->dim*i] = 1.0;
+    NaturalCoordsMappingType::computeShapeMatrices(*this->naturalEle, this->r,
+                                                   shape, this->global_dim);
+    double exp_J[TestFixture::dim * TestFixture::dim] = {0.0};
+    for (unsigned i = 0; i < this->dim; i++)
+        exp_J[i + this->dim * i] = 1.0;
 
-    ASSERT_ARRAY_NEAR(this->nat_exp_N, shape.N.data(), shape.N.size(), this->eps);
-    ASSERT_ARRAY_NEAR(this->nat_exp_dNdr, shape.dNdr.data(), shape.dNdr.size(), this->eps);
+    ASSERT_ARRAY_NEAR(this->nat_exp_N, shape.N.data(), shape.N.size(),
+                      this->eps);
+    ASSERT_ARRAY_NEAR(this->nat_exp_dNdr, shape.dNdr.data(), shape.dNdr.size(),
+                      this->eps);
     ASSERT_ARRAY_NEAR(exp_J, shape.J.data(), shape.J.size(), this->eps);
     ASSERT_ARRAY_NEAR(exp_J, shape.invJ.data(), shape.invJ.size(), this->eps);
     ASSERT_NEAR(1.0, shape.detJ, this->eps);
-    ASSERT_ARRAY_NEAR(this->nat_exp_dNdr, shape.dNdx.data(), shape.dNdx.size(), this->eps);
+    ASSERT_ARRAY_NEAR(this->nat_exp_dNdr, shape.dNdx.data(), shape.dNdx.size(),
+                      this->eps);
 }
 
 TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckIrregularShape)
 {
     typedef typename TestFixture::ShapeMatricesType ShapeMatricesType;
-    typedef typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
+    typedef
+        typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
 
     // irregular shape
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
-    NaturalCoordsMappingType::computeShapeMatrices(*this->irregularEle, this->r, shape, this->global_dim);
-    //std::cout <<  std::setprecision(16) << shape;
+    NaturalCoordsMappingType::computeShapeMatrices(*this->irregularEle, this->r,
+                                                   shape, this->global_dim);
+    // std::cout <<  std::setprecision(16) << shape;
 
-    ASSERT_ARRAY_NEAR(this->nat_exp_N, shape.N.data(), shape.N.size(), this->eps);
-    ASSERT_ARRAY_NEAR(this->nat_exp_dNdr, shape.dNdr.data(), shape.dNdr.size(), this->eps);
-    ASSERT_ARRAY_NEAR(this->ir_exp_J, shape.J.data(), shape.J.size(), this->eps);
+    ASSERT_ARRAY_NEAR(this->nat_exp_N, shape.N.data(), shape.N.size(),
+                      this->eps);
+    ASSERT_ARRAY_NEAR(this->nat_exp_dNdr, shape.dNdr.data(), shape.dNdr.size(),
+                      this->eps);
+    ASSERT_ARRAY_NEAR(this->ir_exp_J, shape.J.data(), shape.J.size(),
+                      this->eps);
     ASSERT_NEAR(this->ir_exp_detJ, shape.detJ, this->eps);
-    ASSERT_ARRAY_NEAR(this->ir_exp_invJ, shape.invJ.data(), shape.invJ.size(), this->eps);
-    ASSERT_ARRAY_NEAR(this->ir_exp_dNdx, shape.dNdx.data(), shape.dNdx.size(), this->eps);
+    ASSERT_ARRAY_NEAR(this->ir_exp_invJ, shape.invJ.data(), shape.invJ.size(),
+                      this->eps);
+    ASSERT_ARRAY_NEAR(this->ir_exp_dNdx, shape.dNdx.data(), shape.dNdx.size(),
+                      this->eps);
 }
 
 TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckClockwise)
 {
     typedef typename TestFixture::ShapeMatricesType ShapeMatricesType;
-    typedef typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
+    typedef
+        typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
 
     // clockwise node ordering, which is invalid)
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
@@ -253,7 +280,8 @@ TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckClockwise)
 TYPED_TEST(NumLibFemNaturalCoordinatesMappingTest, CheckZeroVolume)
 {
     typedef typename TestFixture::ShapeMatricesType ShapeMatricesType;
-    typedef typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
+    typedef
+        typename TestFixture::NaturalCoordsMappingType NaturalCoordsMappingType;
 
     ShapeMatricesType shape(this->dim, this->global_dim, this->e_nnodes);
 
@@ -268,8 +296,12 @@ TEST(NumLib, FemNaturalCoordinatesMappingLineY)
     typedef ::detail::EigenMatrixType<1, 1>::type DimMatrix;
     typedef ::detail::EigenMatrixType<2, 2>::type GlobalDimNodalMatrix;
     // Shape data type
-    typedef ShapeMatrices<NodalVector,DimNodalMatrix,DimMatrix,GlobalDimNodalMatrix> ShapeMatricesType;
-    typedef NaturalCoordinatesMapping<MeshLib::Line, ShapeLine2, ShapeMatricesType> MappingType;
+    typedef ShapeMatrices<NodalVector, DimNodalMatrix, DimMatrix,
+                          GlobalDimNodalMatrix>
+        ShapeMatricesType;
+    typedef NaturalCoordinatesMapping<MeshLib::Line, ShapeLine2,
+                                      ShapeMatricesType>
+        MappingType;
     double r[] = {0.5};
     auto line = TestLine2::createY();
     static const unsigned dim = 1;
@@ -277,17 +309,19 @@ TEST(NumLib, FemNaturalCoordinatesMappingLineY)
     ShapeMatricesType shape(dim, 2, e_nnodes);
     MappingType::computeShapeMatrices(*line, r, shape, 2);
 
-    double exp_J[dim*dim]= {0.0};
-    for (unsigned i=0; i<dim; i++)
-        exp_J[i+dim*i] = 1.0;
+    double exp_J[dim * dim] = {0.0};
+    for (unsigned i = 0; i < dim; i++)
+        exp_J[i + dim * i] = 1.0;
 
     const double eps(std::numeric_limits<double>::epsilon());
-    ASSERT_ARRAY_NEAR(TestLine2::nat_exp_N, shape.N.data(), shape.N.size(), eps);
-    ASSERT_ARRAY_NEAR(TestLine2::nat_exp_dNdr, shape.dNdr.data(), shape.dNdr.size(), eps);
+    ASSERT_ARRAY_NEAR(TestLine2::nat_exp_N, shape.N.data(), shape.N.size(),
+                      eps);
+    ASSERT_ARRAY_NEAR(TestLine2::nat_exp_dNdr, shape.dNdr.data(),
+                      shape.dNdr.size(), eps);
     ASSERT_ARRAY_NEAR(exp_J, shape.J.data(), shape.J.size(), eps);
     ASSERT_ARRAY_NEAR(exp_J, shape.invJ.data(), shape.invJ.size(), eps);
     ASSERT_NEAR(1.0, shape.detJ, eps);
-    double exp_dNdx[2*e_nnodes] = {0, 0, -0.5, 0.5};
+    double exp_dNdx[2 * e_nnodes] = {0, 0, -0.5, 0.5};
     ASSERT_ARRAY_NEAR(exp_dNdx, shape.dNdx.data(), shape.dNdx.size(), eps);
 
     for (auto n = 0u; n < line->getNumberOfNodes(); ++n)


### PR DESCRIPTION
The tests of coordinates mapping for quadratic order elements/shape functions are not all implemented.

This one is mainly a copy of the TestLine2 with an additional node (the origin 0,0,0) for the middle node of the line3 element.
In principle only the expected values `nat_exp_N`, `nat_exp_dNdr`, and `ir_exp_dNdx` have to be checked.