### PR TITLE
[PL] DirichletBC: Comment out the already computed

### DIFF
--- a/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.cpp
@@ -25,8 +25,9 @@ void DirichletBoundaryCondition::preTimestep(const double /*t*/)
 void DirichletBoundaryCondition::getEssentialBCValues(
     const double t, NumLib::IndexValueVector<GlobalIndexType>& bc_values) const
 {
-    if (_already_computed)
-        return;
+    // TODO: Reenable when fixed ;)
+    //if (_already_computed)
+        //return;
 
     _already_computed = true;
 


### PR DESCRIPTION
This optimization is not working correctly with time-dependent boundary
conditions and result in a "step" of the values for the second time step.

![image](https://cloud.githubusercontent.com/assets/329493/19899104/17ecf730-a05f-11e6-8e18-5f4a8ea89af9.png)


This is required for upcoming HM Process PR. The shown plots are from the HM test case with and without the optimization. The boundary condition is a constant parameter scaled with curve.