### PR TITLE
support scaling and GMRES in Eigen linear solvers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ option(OGS_USE_MPI "Use MPI" OFF)
 
 # Eigen
 option(OGS_USE_EIGEN "Use Eigen linear solver" ON)
+option(OGS_USE_EIGEN_UNSUPPORTED "Use Eigen unsupported modules" ON)
 option(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES "Use dynamically allocated shape matrices" ON)
 option(EIGEN_NO_DEBUG "Disables Eigen's assertions" OFF)
 
@@ -171,6 +172,9 @@ endif()
 
 if(OGS_USE_EIGEN)
     add_definitions(-DOGS_USE_EIGEN)
+    if(OGS_USE_EIGEN_UNSUPPORTED)
+        add_definitions(-DUSE_EIGEN_UNSUPPORTED)
+    endif()
 endif()
 
 if (OGS_FATAL_ABORT)

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -154,11 +154,15 @@ std::unique_ptr<EigenLinearSolverBase> createIterativeSolver(
         case EigenOption::SolverType::CG: {
             return createIterativeSolver<EigenCGSolver>(precon_type);
         }
-#ifdef USE_EIGEN_UNSUPPORTED
         case EigenOption::SolverType::GMRES: {
+#ifdef USE_EIGEN_UNSUPPORTED
             return createIterativeSolver<Eigen::GMRES>(precon_type);
-        }
+#else
+            OGS_FATAL(
+                "The code is not compiled with the Eigen unsupported modules. "
+                "Linear solver type GMRES is not available.");
 #endif
+        }
         default:
             OGS_FATAL("Invalid Eigen iterative linear solver type. Aborting.");
     }
@@ -186,9 +190,7 @@ EigenLinearSolver::EigenLinearSolver(
         }
         case EigenOption::SolverType::BiCGSTAB:
         case EigenOption::SolverType::CG:
-#ifdef USE_EIGEN_UNSUPPORTED
         case EigenOption::SolverType::GMRES:
-#endif
             _solver = details::createIterativeSolver(_option.solver_type,
                                                      _option.precon_type);
             return;
@@ -238,13 +240,17 @@ void EigenLinearSolver::setOption(BaseLib::ConfigTree const& option)
             ptSolver->getConfigParameterOptional<int>("max_iteration_step")) {
         _option.max_iterations = *max_iteration_step;
     }
-#ifdef USE_EIGEN_UNSUPPORTED
     if (auto scaling =
             //! \ogs_file_param{linear_solver__eigen__scaling}
             ptSolver->getConfigParameterOptional<bool>("scaling")) {
+#ifdef USE_EIGEN_UNSUPPORTED
         _option.scaling = *scaling;
-    }
+#else
+        OGS_FATAL(
+            "The code is not compiled with the Eigen unsupported modules. "
+            "scaling is not available.");
 #endif
+    }
 }
 
 bool EigenLinearSolver::solve(EigenMatrix &A, EigenVector& b, EigenVector &x)

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -16,6 +16,8 @@
 #endif
 
 #ifdef USE_EIGEN_UNSUPPORTED
+#include <iostream> // to fix compiling errors in Eigen
+#include <unsupported/Eigen/IterativeSolvers>
 #include <unsupported/Eigen/src/IterativeSolvers/Scaling.h>
 #endif
 
@@ -152,6 +154,11 @@ std::unique_ptr<EigenLinearSolverBase> createIterativeSolver(
         case EigenOption::SolverType::CG: {
             return createIterativeSolver<EigenCGSolver>(precon_type);
         }
+#ifdef USE_EIGEN_UNSUPPORTED
+        case EigenOption::SolverType::GMRES: {
+            return createIterativeSolver<Eigen::GMRES>(precon_type);
+        }
+#endif
         default:
             OGS_FATAL("Invalid Eigen iterative linear solver type. Aborting.");
     }
@@ -179,6 +186,9 @@ EigenLinearSolver::EigenLinearSolver(
         }
         case EigenOption::SolverType::BiCGSTAB:
         case EigenOption::SolverType::CG:
+#ifdef USE_EIGEN_UNSUPPORTED
+        case EigenOption::SolverType::GMRES:
+#endif
             _solver = details::createIterativeSolver(_option.solver_type,
                                                      _option.precon_type);
             return;

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -241,8 +241,8 @@ void EigenLinearSolver::setOption(BaseLib::ConfigTree const& option)
 #ifdef USE_EIGEN_UNSUPPORTED
     if (auto scaling =
             //! \ogs_file_param{linear_solver__eigen__scaling}
-            ptSolver->getConfigParameterOptional<int>("scaling")) {
-        _option.scaling = static_cast<bool>(*scaling);
+            ptSolver->getConfigParameterOptional<bool>("scaling")) {
+        _option.scaling = *scaling;
     }
 #endif
 }

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -16,8 +16,8 @@
 #endif
 
 #ifdef USE_EIGEN_UNSUPPORTED
-#include <iostream> // to fix compiling errors in Eigen
-#include <unsupported/Eigen/IterativeSolvers>
+#include <Eigen/Sparse>
+#include <unsupported/Eigen/src/IterativeSolvers/GMRES.h>
 #include <unsupported/Eigen/src/IterativeSolvers/Scaling.h>
 #endif
 

--- a/MathLib/LinAlg/Eigen/EigenOption.cpp
+++ b/MathLib/LinAlg/Eigen/EigenOption.cpp
@@ -19,6 +19,9 @@ EigenOption::EigenOption()
     precon_type = PreconType::NONE;
     max_iterations = static_cast<int>(1e6);
     error_tolerance = 1.e-16;
+#ifdef USE_EIGEN_UNSUPPORTED
+    scaling = false;
+#endif
 }
 
 EigenOption::SolverType EigenOption::getSolverType(const std::string &solver_name)

--- a/MathLib/LinAlg/Eigen/EigenOption.cpp
+++ b/MathLib/LinAlg/Eigen/EigenOption.cpp
@@ -34,6 +34,8 @@ EigenOption::SolverType EigenOption::getSolverType(const std::string &solver_nam
         return SolverType::SparseLU;
     if (solver_name == "PardisoLU")
         return SolverType::PardisoLU;
+    if (solver_name == "GMRES")
+        return SolverType::GMRES;
 
     OGS_FATAL("Unknown Eigen solver type `%s'", solver_name.c_str());
 }

--- a/MathLib/LinAlg/Eigen/EigenOption.h
+++ b/MathLib/LinAlg/Eigen/EigenOption.h
@@ -43,6 +43,10 @@ struct EigenOption final
     int max_iterations;
     /// Error tolerance
     double error_tolerance;
+#ifdef USE_EIGEN_UNSUPPORTED
+    /// Scaling the coefficient matrix and the RHS bector
+    bool scaling;
+#endif
 
     /// Constructor
     ///

--- a/MathLib/LinAlg/Eigen/EigenOption.h
+++ b/MathLib/LinAlg/Eigen/EigenOption.h
@@ -24,7 +24,8 @@ struct EigenOption final
         CG,
         BiCGSTAB,
         SparseLU,
-        PardisoLU
+        PardisoLU,
+        GMRES
     };
 
     /// Preconditioner type


### PR DESCRIPTION
This PR introduces
- add `OGS_USE_EIGEN_UNSUPPORTED` CMake option (default is ON) to support unsupported modules in Eigen. If this option is ON, the followings become available:
- support scaling of a linear system before solve. `<scaling>1</scaling>` should be specified under `<eigen>` tag in a config file.
- support GMRES solver type