### PR TITLE
support Pardiso in Eigen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,9 @@ option(OGS_USE_EIGEN "Use Eigen linear solver" ON)
 option(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES "Use dynamically allocated shape matrices" ON)
 option(EIGEN_NO_DEBUG "Disables Eigen's assertions" OFF)
 
+# MKL
+option(OGS_USE_MKL "Use Intel MKL" OFF)
+
 # Logging
 option(OGS_DISABLE_LOGGING "Disables all logog messages." OFF)
 
@@ -133,6 +136,11 @@ if(OGS_USE_LIS)
     add_definitions(-DUSE_LIS)
     include_directories(SYSTEM ${LIS_INCLUDE_DIR})
     set(OGS_USE_EIGEN ON)
+endif()
+
+if(OGS_USE_MKL)
+    add_definitions(-DUSE_MKL)
+    include_directories(SYSTEM ${MKL_INCLUDE_DIR})
 endif()
 
 if(OGS_USE_PETSC)

--- a/MathLib/CMakeLists.txt
+++ b/MathLib/CMakeLists.txt
@@ -43,6 +43,10 @@ if (OGS_USE_LIS)
     target_link_libraries(MathLib ${LIS_LIBRARIES})
 endif()
 
+if (OGS_USE_MKL)
+    target_link_libraries(MathLib ${MKL_LIBRARIES})
+endif()
+
 if (OGS_USE_PETSC)
     target_link_libraries(MathLib ${PETSC_LIBRARIES})
 endif()

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -178,13 +178,17 @@ EigenLinearSolver::EigenLinearSolver(
             _solver = details::createIterativeSolver(_option.solver_type,
                                                      _option.precon_type);
             return;
-#ifdef USE_MKL
         case EigenOption::SolverType::PardisoLU: {
+#ifdef USE_MKL
             using SolverType = Eigen::PardisoLU<EigenMatrix::RawMatrixType>;
             _solver.reset(new details::EigenDirectLinearSolver<SolverType>);
             return;
-        }
+#else
+            OGS_FATAL(
+                "The code is not compiled with Intel MKL. Linear solver type "
+                "PardisoLU is not available.");
 #endif
+        }
     }
 
     OGS_FATAL("Invalid Eigen linear solver type. Aborting.");

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -11,6 +11,10 @@
 
 #include <logog/include/logog.hpp>
 
+#ifdef USE_MKL
+#include <Eigen/PardisoSupport>
+#endif
+
 #include "BaseLib/ConfigTree.h"
 #include "EigenVector.h"
 #include "EigenMatrix.h"
@@ -174,6 +178,13 @@ EigenLinearSolver::EigenLinearSolver(
             _solver = details::createIterativeSolver(_option.solver_type,
                                                      _option.precon_type);
             return;
+#ifdef USE_MKL
+        case EigenOption::SolverType::PardisoLU: {
+            using SolverType = Eigen::PardisoLU<EigenMatrix::RawMatrixType>;
+            _solver.reset(new details::EigenDirectLinearSolver<SolverType>);
+            return;
+        }
+#endif
     }
 
     OGS_FATAL("Invalid Eigen linear solver type. Aborting.");

--- a/MathLib/LinAlg/Eigen/EigenOption.cpp
+++ b/MathLib/LinAlg/Eigen/EigenOption.cpp
@@ -29,6 +29,10 @@ EigenOption::SolverType EigenOption::getSolverType(const std::string &solver_nam
         return SolverType::BiCGSTAB;
     if (solver_name == "SparseLU")
         return SolverType::SparseLU;
+#ifdef USE_MKL
+    if (solver_name == "PardisoLU")
+        return SolverType::PardisoLU;
+#endif
 
     OGS_FATAL("Unknown Eigen solver type `%s'", solver_name.c_str());
 }

--- a/MathLib/LinAlg/Eigen/EigenOption.cpp
+++ b/MathLib/LinAlg/Eigen/EigenOption.cpp
@@ -29,10 +29,8 @@ EigenOption::SolverType EigenOption::getSolverType(const std::string &solver_nam
         return SolverType::BiCGSTAB;
     if (solver_name == "SparseLU")
         return SolverType::SparseLU;
-#ifdef USE_MKL
     if (solver_name == "PardisoLU")
         return SolverType::PardisoLU;
-#endif
 
     OGS_FATAL("Unknown Eigen solver type `%s'", solver_name.c_str());
 }

--- a/MathLib/LinAlg/Eigen/EigenOption.h
+++ b/MathLib/LinAlg/Eigen/EigenOption.h
@@ -24,6 +24,9 @@ struct EigenOption final
         CG,
         BiCGSTAB,
         SparseLU
+#ifdef USE_MKL
+        , PardisoLU
+#endif
     };
 
     /// Preconditioner type

--- a/MathLib/LinAlg/Eigen/EigenOption.h
+++ b/MathLib/LinAlg/Eigen/EigenOption.h
@@ -23,10 +23,8 @@ struct EigenOption final
     {
         CG,
         BiCGSTAB,
-        SparseLU
-#ifdef USE_MKL
-        , PardisoLU
-#endif
+        SparseLU,
+        PardisoLU
     };
 
     /// Preconditioner type

--- a/scripts/cmake/Find.cmake
+++ b/scripts/cmake/Find.cmake
@@ -115,6 +115,10 @@ if(OGS_USE_LIS)
     find_package( LIS REQUIRED )
 endif()
 
+if(OGS_USE_MKL)
+    find_package( MKL REQUIRED )
+endif()
+
 if(OGS_USE_PETSC)
     message(STATUS "Configuring for PETSc")
 

--- a/scripts/cmake/cmake/FindMKL.cmake
+++ b/scripts/cmake/cmake/FindMKL.cmake
@@ -1,0 +1,69 @@
+# Find Intel Math Karnel Library (MKL)
+#
+# Options
+# - MKL_DIR      MKL root directory
+# - MKL_OPENMP   use OpenMP threading
+#
+# Results
+# - MKL_INCLUDE_DIR
+# - MKL_LIBRARIES
+
+# Lookg for MKL root dir
+#SET(MKL_DIR $ENV{MKL_DIR} CACHE PATH "MKL root directory")
+if (NOT MKL_DIR)
+    find_path(MKL_DIR
+        include/mkl.h
+        PATHS
+        $ENV{MKL_DIR}
+        /opt/intel/mkl/
+        )
+endif()
+MESSAGE("MKL_DIR : ${MKL_DIR}")
+
+# Find MKL include dir
+FIND_PATH(MKL_INCLUDE_DIR NAMES mkl.h
+    PATHS
+    ${MKL_DIR}/include
+)
+
+# Set the directory path storing MKL libraries
+if (NOT MKL_LIB_DIR)
+    if(APPLE)
+        set(MKL_LIB_DIR ${MKL_DIR}/lib)
+    else()
+        if (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+            set(MKL_LIB_DIR ${MKL_DIR}/lib/intel64)
+        else()
+            set(MKL_LIB_DIR ${MKL_DIR}/lib/ia32)
+        endif()
+    endif()
+endif()
+
+# Find MKL libs
+find_library(MKL_LIB_CORE mkl_core PATHS ${MKL_LIB_DIR})
+
+if (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+    set(MKL_INTEL_LIB_NAME mkl_intel_lp64)
+else()
+    set(MKL_INTEL_LIB_NAME mkl_intel)
+endif()
+
+find_library(MKL_LIB_INTEL ${MKL_INTEL_LIB_NAME} PATHS ${MKL_LIB_DIR})
+
+if(OPENMP_FOUND)
+    set(MKL_THREAD_LIB_NAME "mkl_gnu_thread")
+else()
+    set(MKL_THREAD_LIB_NAME "mkl_sequential")
+endif()
+find_library(MKL_LIB_THREAD ${MKL_THREAD_LIB_NAME} PATHS ${MKL_LIB_DIR})
+
+
+SET (MKL_LIBRARIES 
+    "${MKL_LIB_INTEL}" 
+    "${MKL_LIB_THREAD}"
+    "${MKL_LIB_CORE}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MKL DEFAULT_MSG MKL_INCLUDE_DIR MKL_LIBRARIES)
+mark_as_advanced(MKL_INCLUDE_DIR MKL_LIBRARIES)
+

--- a/scripts/cmake/cmake/FindMKL.cmake
+++ b/scripts/cmake/cmake/FindMKL.cmake
@@ -7,6 +7,11 @@
 # Results
 # - MKL_INCLUDE_DIR
 # - MKL_LIBRARIES
+#
+# Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+# Distributed under a Modified BSD License.
+# See accompanying file LICENSE.txt or
+# http://www.opengeosys.org/project/license
 
 # Lookg for MKL root dir
 if (NOT MKL_DIR)

--- a/scripts/cmake/cmake/FindMKL.cmake
+++ b/scripts/cmake/cmake/FindMKL.cmake
@@ -9,7 +9,6 @@
 # - MKL_LIBRARIES
 
 # Lookg for MKL root dir
-#SET(MKL_DIR $ENV{MKL_DIR} CACHE PATH "MKL root directory")
 if (NOT MKL_DIR)
     find_path(MKL_DIR
         include/mkl.h
@@ -18,10 +17,10 @@ if (NOT MKL_DIR)
         /opt/intel/mkl/
         )
 endif()
-MESSAGE("MKL_DIR : ${MKL_DIR}")
+message("MKL_DIR : ${MKL_DIR}")
 
 # Find MKL include dir
-FIND_PATH(MKL_INCLUDE_DIR NAMES mkl.h
+find_path(MKL_INCLUDE_DIR NAMES mkl.h
     PATHS
     ${MKL_DIR}/include
 )
@@ -58,12 +57,8 @@ endif()
 find_library(MKL_LIB_THREAD ${MKL_THREAD_LIB_NAME} PATHS ${MKL_LIB_DIR})
 
 
-SET (MKL_LIBRARIES 
-    "${MKL_LIB_INTEL}" 
-    "${MKL_LIB_THREAD}"
-    "${MKL_LIB_CORE}")
+set(MKL_LIBRARIES "${MKL_LIB_INTEL}" "${MKL_LIB_THREAD}" "${MKL_LIB_CORE}")
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(MKL DEFAULT_MSG MKL_INCLUDE_DIR MKL_LIBRARIES)
 mark_as_advanced(MKL_INCLUDE_DIR MKL_LIBRARIES)
-


### PR DESCRIPTION
Credit goes to @chleh, because it's based on his branch (see #1175) and enables to use Pardiso solver with Eigen interface. To use it, one needs to set CMake as `-DOGS_USE_EIGEN=ON -DOGS_USE_MKL=ON -DMKL_DIR=(a path to MKL root directory)`. In a config file, you can set `PardisoLU` as a solver type.
 
@chleh Let me know if I miss something from your branch.