### PR TITLE
[Nonlinear] print norms of delta x in ConvergenceCriterionPerComponentResidual

### DIFF
--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.cpp
@@ -35,6 +35,30 @@ ConvergenceCriterionPerComponentResidual::
         OGS_FATAL("The given tolerances vector is empty.");
 }
 
+
+void ConvergenceCriterionPerComponentResidual::checkDeltaX(
+    const GlobalVector& minus_delta_x, GlobalVector const& x)
+{
+    if ((!_dof_table) || (!_mesh))
+        OGS_FATAL("D.o.f. table or mesh have not been set.");
+
+    for (unsigned global_component = 0; global_component < _abstols.size();
+         ++global_component)
+    {
+        // TODO short cut if tol <= 0.0
+        auto error_dx = norm(minus_delta_x, global_component, _norm_type,
+                             *_dof_table, *_mesh);
+        auto norm_x =
+            norm(x, global_component, _norm_type, *_dof_table, *_mesh);
+
+        INFO(
+            "Convergence criterion, component %u: |dx|=%.4e, |x|=%.4e, "
+            "|dx|/|x|=%.4e",
+            error_dx, global_component, norm_x, error_dx / norm_x);
+    }
+}
+
+
 void ConvergenceCriterionPerComponentResidual::checkResidual(
     const GlobalVector& residual)
 {

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.h
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.h
@@ -36,6 +36,8 @@ public:
     bool hasDeltaXCheck() const override { return true; }
     bool hasResidualCheck() const override { return true; }
 
+    /// The function will only do diagnostic output and no actual check of the
+    /// solution increment is made
     void checkDeltaX(const GlobalVector& minus_delta_x,
                      GlobalVector const& x) override;
     void checkResidual(const GlobalVector& residual) override;

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.h
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.h
@@ -33,11 +33,11 @@ public:
         std::vector<double>&& relative_tolerances,
         MathLib::VecNormType norm_type);
 
-    bool hasDeltaXCheck() const override { return false; }
+    bool hasDeltaXCheck() const override { return true; }
     bool hasResidualCheck() const override { return true; }
 
-    void checkDeltaX(const GlobalVector& /*minus_delta_x*/,
-                     GlobalVector const& /*x*/) override {}
+    void checkDeltaX(const GlobalVector& minus_delta_x,
+                     GlobalVector const& x) override;
     void checkResidual(const GlobalVector& residual) override;
 
     void preFirstIteration() override { _is_first_iteration = true; }

--- a/NumLib/ODESolver/ConvergenceCriterionResidual.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionResidual.cpp
@@ -29,6 +29,16 @@ ConvergenceCriterionResidual::ConvergenceCriterionResidual(
             "specified.");
 }
 
+void ConvergenceCriterionResidual::checkDeltaX(const GlobalVector& minus_delta_x,
+                                             GlobalVector const& x)
+{
+    auto error_dx = MathLib::LinAlg::norm(minus_delta_x, _norm_type);
+    auto norm_x = MathLib::LinAlg::norm(x, _norm_type);
+
+    INFO("Convergence criterion: |dx|=%.4e, |x|=%.4e, |dx|/|x|=%.4e", error_dx,
+         norm_x, error_dx / norm_x);
+}
+
 void ConvergenceCriterionResidual::checkResidual(const GlobalVector& residual)
 {
     auto norm_res = MathLib::LinAlg::norm(residual, _norm_type);

--- a/NumLib/ODESolver/ConvergenceCriterionResidual.h
+++ b/NumLib/ODESolver/ConvergenceCriterionResidual.h
@@ -30,11 +30,13 @@ public:
         boost::optional<double>&& relative_tolerance,
         MathLib::VecNormType norm_type);
 
-    bool hasDeltaXCheck() const override { return false; }
+    bool hasDeltaXCheck() const override { return true; }
     bool hasResidualCheck() const override { return true; }
 
-    void checkDeltaX(const GlobalVector& /*minus_delta_x*/,
-                     GlobalVector const& /*x*/) override {}
+    /// The function will only do diagnostic output and no actual check of the
+    /// solution increment is made
+    void checkDeltaX(const GlobalVector& minus_delta_x,
+                     GlobalVector const& x) override;
     void checkResidual(const GlobalVector& residual) override;
 
     void preFirstIteration() override { _is_first_iteration = true; }


### PR DESCRIPTION
With this PR, I want to print norms of delta x in Newton-Raphson iterations although only residual is used for convergence checks. This helps to understand why the iteration is not converging, e.g. the criteria for residual is too strict.
