### PR TITLE
[Nonlinear] skip linear solve if residual is satisfied

### DIFF
--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.cpp
@@ -42,9 +42,7 @@ void ConvergenceCriterionPerComponentResidual::checkResidual(
         OGS_FATAL("D.o.f. table or mesh have not been set.");
 
     bool satisfied_abs = true;
-    // Make sure that in the first iteration the relative residual tolerance is
-    // not satisfied.
-    bool satisfied_rel = _is_first_iteration ? false : true;
+    bool satisfied_rel = true;
 
     for (unsigned global_component = 0; global_component < _abstols.size();
          ++global_component)

--- a/NumLib/ODESolver/ConvergenceCriterionResidual.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionResidual.cpp
@@ -47,7 +47,7 @@ void ConvergenceCriterionResidual::checkResidual(const GlobalVector& residual)
     if (_abstol) {
         satisfied_abs = norm_res < *_abstol;
     }
-    if (_reltol && !_is_first_iteration) {
+    if (_reltol) {
         satisfied_rel =
             checkRelativeTolerance(*_reltol, norm_res, _residual_norm_0);
     }

--- a/NumLib/ODESolver/NonlinearSolver.cpp
+++ b/NumLib/ODESolver/NonlinearSolver.cpp
@@ -215,10 +215,14 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
         sys.applyKnownSolutionsNewton(J, res, minus_delta_x);
         INFO("[time] Applying Dirichlet BCs took %g s.", time_dirichlet.elapsed());
 
-        if (!sys.isLinear() && _convergence_criterion->hasResidualCheck())
+        if (_convergence_criterion->hasResidualCheck())
             _convergence_criterion->checkResidual(res);
 
-        if (!_convergence_criterion->isSatisfied())
+        if (_convergence_criterion->hasResidualCheck() && _convergence_criterion->isSatisfied())
+        {
+            minus_delta_x.setZero();
+        }
+        else
         {
             BaseLib::RunTime time_linear_solver;
             time_linear_solver.start();
@@ -232,8 +236,6 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
                 error_norms_met = false;
                 break;
             }
-        } else {
-            minus_delta_x.setZero();
         }
 
         // TODO could be solved in a better way

--- a/NumLib/ODESolver/NonlinearSolver.h
+++ b/NumLib/ODESolver/NonlinearSolver.h
@@ -122,8 +122,8 @@ private:
     std::size_t _res_id = 0u;            //!< ID of the residual vector.
     std::size_t _J_id = 0u;              //!< ID of the Jacobian matrix.
     std::size_t _minus_delta_x_id = 0u;  //!< ID of the \f$ -\Delta x\f$ vector.
-    std::size_t _x_new_id =
-        0u;  //!< ID of the vector storing \f$ x - (-\Delta x) \f$.
+    std::size_t _x_old_id =
+        0u;  //!< ID of the vector storing previous solution.
 };
 
 /*! Find a solution to a nonlinear equation using the Picard fixpoint iteration


### PR DESCRIPTION
This PR tries to introduce the following changes:
- allows convergence in the first iteration when the residual is checked (e.g. solution is same as previous time step, if BC is inactive, or if the system reaches steady-state)
- skip solving a linear system if the residual error is below the given tolerance
- store previous solution instead of new solution for better efficiency 

Let me know if I miss something here