### PR TITLE
[CLI] add --unbuffered-std-out option to deactivate buffer for cout

### DIFF
--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -70,7 +70,16 @@ int main(int argc, char *argv[])
         "warnings from parsing the configuration file will not trigger program abortion");
     cmd.add(nonfatal_arg);
 
+    TCLAP::SwitchArg unbuffered_cout_arg("",
+        "unbuffered-std-out",
+        "use unbuffered standard output");
+    cmd.add(unbuffered_cout_arg);
+
     cmd.parse(argc, argv);
+
+    // deactivate buffer for standard output if specified
+    if (unbuffered_cout_arg.isSet())
+        std::cout.setf(std::ios::unitbuf);
 
     ApplicationsLib::LogogSetup logog_setup;
     logog_setup.setLevel(log_level_arg.getValue());


### PR DESCRIPTION
as titled. This is helpful for those who saves/forwards stadard output to a file and wants to trace real-time output from ogs.