### PR TITLE
[Mesh] fix incorrect use of getNumberOfBaseNodes()

### DIFF
--- a/Applications/Utils/MeshEdit/createQuadraticeMesh.cpp
+++ b/Applications/Utils/MeshEdit/createQuadraticeMesh.cpp
@@ -15,128 +15,13 @@
 #include "Applications/ApplicationsLib/LogogSetup.h"
 
 #include "BaseLib/BuildInfo.h"
-#include "BaseLib/makeVectorUnique.h"
 
 #include "MeshLib/Mesh.h"
-#include "MeshLib/Node.h"
-#include "MeshLib/Elements/Element.h"
-#include "MeshLib/Elements/Line.h"
-#include "MeshLib/Elements/Quad.h"
-#include "MeshLib/MeshEditing/DuplicateMeshComponents.h"
-#include "MeshLib/Properties.h"
-#include "MeshLib/PropertyVector.h"
+#include "MeshLib/MeshGenerators/QuadraticeMeshGenerator.h"
 
 #include "MeshLib/IO/readMeshFromFile.h"
 #include "MeshLib/IO/writeMeshToFile.h"
 
-namespace
-{
-
-struct Edge
-{
-    Edge(std::size_t id1, std::size_t id2)
-        : _id1(std::min(id1, id2)), _id2(std::max(id1, id2))
-    {}
-
-    bool operator==(Edge const& r) const
-    {
-        return (_id1 == r._id1 && _id2 == r._id2);
-    }
-
-    std::size_t _id1;
-    std::size_t _id2;
-
-    std::size_t _edge_id = 0;
-};
-
-bool operator< (Edge const& l, Edge const& r)
-{
-    return (l._id1 != r._id1) ? (l._id1 < r._id1) : l._id2 < r._id2;
-}
-
-template <typename T_ELEMENT>
-T_ELEMENT* createQuadraticElement(MeshLib::Element const* e, std::vector<Edge> const& vec_edges,
-                  std::vector<MeshLib::Node*> const& vec_new_nodes, const std::size_t n_mesh_base_nodes)
-{
-    auto const n_all_nodes = T_ELEMENT::n_all_nodes;
-    auto const n_base_nodes = T_ELEMENT::n_base_nodes;
-    MeshLib::Node** nodes = new MeshLib::Node*[n_all_nodes];
-    for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++)
-        nodes[i] = const_cast<MeshLib::Node*>(e->getNode(i));
-    for (unsigned i=0; i<e->getNumberOfEdges(); i++)
-    {
-        auto itr = std::find(vec_edges.begin(), vec_edges.end(),
-                             Edge(e->getEdgeNode(i, 0)->getID(),
-                                  e->getEdgeNode(i, 1)->getID()));
-        assert(itr != vec_edges.end());
-        nodes[n_base_nodes + i] =
-            vec_new_nodes[n_mesh_base_nodes + itr->_edge_id];
-    }
-    return new T_ELEMENT(nodes);
-}
-
-
-static std::unique_ptr<MeshLib::Mesh> createQuadraticOrderMesh(MeshLib::Mesh const& org_mesh)
-{
-    std::vector<MeshLib::Node*> vec_new_nodes = MeshLib::copyNodeVector(org_mesh.getNodes());
-
-    // collect edges
-    std::vector<Edge> vec_edges;
-    for (MeshLib::Element const* e : org_mesh.getElements())
-    {
-        for (unsigned i=0; i<e->getNumberOfEdges(); i++)
-        {
-            auto node0 = e->getEdgeNode(i, 0);
-            auto node1 = e->getEdgeNode(i, 1);
-            vec_edges.emplace_back(node0->getID(), node1->getID());
-        }
-    }
-    BaseLib::makeVectorUnique(vec_edges);
-    for (std::size_t i=0; i<vec_edges.size(); i++)
-         vec_edges[i]._edge_id = i;
-    INFO("Found %d edges in the mesh", vec_edges.size());
-
-    // create mid-point nodes
-    double coords[3];
-    for (Edge const& edge : vec_edges)
-    {
-        auto const& node0 = *vec_new_nodes[edge._id1];
-        auto const& node1 = *vec_new_nodes[edge._id2];
-        for (unsigned i=0; i<3; i++)
-            coords[i] = (node0[i] + node1[i]) * 0.5;
-        vec_new_nodes.push_back(new MeshLib::Node(coords));
-    }
-
-    // create new elements with the quadratic nodes
-    std::vector<MeshLib::Element*> vec_new_eles;
-    for (MeshLib::Element const* e : org_mesh.getElements())
-    {
-        if (e->getCellType() == MeshLib::CellType::LINE2)
-        {
-            vec_new_eles.push_back(createQuadraticElement<MeshLib::Line3>(
-                e, vec_edges, vec_new_nodes, org_mesh.getNumberOfNodes()));
-        }
-        else if (e->getCellType() == MeshLib::CellType::QUAD4)
-        {
-            vec_new_eles.push_back(createQuadraticElement<MeshLib::Quad8>(
-                e, vec_edges, vec_new_nodes, org_mesh.getNumberOfNodes()));
-        }
-        else
-        {
-            OGS_FATAL("Mesh element type %s is not supported", MeshLib::CellType2String(e->getCellType()).c_str());
-        }
-    }
-
-    std::unique_ptr<MeshLib::Mesh> new_mesh(
-        new MeshLib::Mesh(org_mesh.getName(), vec_new_nodes, vec_new_eles,
-                          org_mesh.getProperties().excludeCopyProperties(
-                              std::vector<MeshLib::MeshItemType>(
-                                  1, MeshLib::MeshItemType::Node)),
-                          org_mesh.getNumberOfNodes()));
-    return new_mesh;
-}
-
-} // no named namespace
 
 int main(int argc, char *argv[])
 {
@@ -155,7 +40,7 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
 
     INFO("Create a quadratic order mesh");
-    auto new_mesh(createQuadraticOrderMesh(*mesh));
+    auto new_mesh(MeshLib::createQuadraticOrderMesh(*mesh));
 
     INFO("Save the new mesh into a file");
     MeshLib::IO::writeMeshToFile(*new_mesh, output_arg.getValue());

--- a/MeshLib/ElementStatus.cpp
+++ b/MeshLib/ElementStatus.cpp
@@ -113,7 +113,7 @@ void ElementStatus::setElementStatus(std::size_t i, bool status)
     {
         const int change = (status) ? 1 : -1;
         _element_status[i] = status;
-        const unsigned nElemNodes (_mesh->getElement(i)->getNumberOfBaseNodes());
+        const unsigned nElemNodes (_mesh->getElement(i)->getNumberOfNodes());
         MeshLib::Node const*const*const nodes = _mesh->getElement(i)->getNodes();
         for (unsigned j=0; j<nElemNodes; ++j)
         {

--- a/MeshLib/Elements/Element.cpp
+++ b/MeshLib/Elements/Element.cpp
@@ -134,7 +134,7 @@ const Element* Element::getNeighbor(unsigned i) const
 
 unsigned Element::getNodeIDinElement(const MeshLib::Node* node) const
 {
-    const unsigned nNodes (this->getNumberOfBaseNodes());
+    const unsigned nNodes (this->getNumberOfNodes());
     for (unsigned i(0); i<nNodes; i++)
         if (node == _nodes[i])
             return i;

--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -70,7 +70,7 @@ Mesh::Mesh(const Mesh &mesh)
     const std::size_t nElements (elements.size());
     for (unsigned i=0; i<nElements; ++i)
     {
-        const std::size_t nElemNodes = elements[i]->getNumberOfBaseNodes();
+        const std::size_t nElemNodes = elements[i]->getNumberOfNodes();
         _elements[i] = elements[i]->clone();
         for (unsigned j=0; j<nElemNodes; ++j)
             _elements[i]->_nodes[j] = _nodes[elements[i]->getNode(j)->getID()];
@@ -104,7 +104,7 @@ void Mesh::addElement(Element* elem)
     _elements.push_back(elem);
 
     // add element information to nodes
-    unsigned nNodes (elem->getNumberOfBaseNodes());
+    unsigned nNodes (elem->getNumberOfNodes());
     for (unsigned i=0; i<nNodes; ++i)
         elem->_nodes[i]->addElement(elem);
 }
@@ -135,7 +135,7 @@ void Mesh::setElementsConnectedToNodes()
 {
     for (auto e = _elements.begin(); e != _elements.end(); ++e)
     {
-        const unsigned nNodes ((*e)->getNumberOfBaseNodes());
+        const unsigned nNodes ((*e)->getNumberOfNodes());
         for (unsigned j=0; j<nNodes; ++j)
             (*e)->_nodes[j]->addElement(*e);
     }
@@ -206,18 +206,45 @@ void Mesh::setNodesConnectedByEdges()
         const std::size_t nConnElems (conn_elems.size());
         for (unsigned j=0; j<nConnElems; ++j)
         {
-            const unsigned idx (conn_elems[j]->getNodeIDinElement(node));
-            const unsigned nElemNodes (conn_elems[j]->getNumberOfBaseNodes());
+            MeshLib::Element* conn_ele = conn_elems[j];
+            const unsigned idx (conn_ele->getNodeIDinElement(node));
+            const unsigned nElemNodes (conn_ele->getNumberOfBaseNodes());
             for (unsigned k(0); k<nElemNodes; ++k)
             {
+                MeshLib::Node const* node_k = conn_ele->getNode(k);
                 bool is_in_vector (false);
                 const std::size_t nConnNodes (conn_set.size());
                 for (unsigned l(0); l<nConnNodes; ++l)
-                    if (conn_elems[j]->getNode(k) == conn_set[l])
+                    if (node_k == conn_set[l])
                         is_in_vector = true;
                 if (is_in_vector) continue;
-                if (conn_elems[j]->isEdge(idx, k)) //TODO doesn't work with higher order nodes
-                    conn_set.push_back(_nodes[conn_elems[j]->getNode(k)->getID()]);
+
+                if (conn_ele->getNumberOfBaseNodes() == conn_ele->getNumberOfNodes())
+                {
+                    if (conn_ele->isEdge(idx, k))
+                        conn_set.push_back(const_cast<MeshLib::Node*>(node_k));
+                }
+                else
+                {
+                    for (unsigned l=0; l<conn_ele->getNumberOfEdges(); l++)
+                    {
+                        std::unique_ptr<Element const> edge(conn_ele->getEdge(l));
+                        unsigned match = 0;
+                        for (unsigned m=0; m<edge->getNumberOfBaseNodes(); m++)
+                        {
+                            auto edge_node = edge->getNode(m);
+                            if (edge_node == node || edge_node == node_k)
+                                match++;
+                        }
+                        if (match != 2)
+                            continue;
+                        conn_set.push_back(const_cast<MeshLib::Node*>(node_k));
+                        for (unsigned m=edge->getNumberOfBaseNodes(); m<edge->getNumberOfNodes(); m++)
+                            conn_set.push_back(const_cast<MeshLib::Node*>(edge->getNode(m)));
+                        break;
+                    }
+                }
+
             }
         }
         node->setConnectedNodes(conn_set);
@@ -239,7 +266,7 @@ void Mesh::setNodesConnectedByElements()
         for (Element const* const element : conn_elems)
         {
             Node* const* const single_elem_nodes = element->getNodes();
-            std::size_t const nnodes = element->getNumberOfBaseNodes();
+            std::size_t const nnodes = element->getNumberOfNodes();
             for (std::size_t n = 0; n < nnodes; n++)
                 adjacent_nodes.push_back(single_elem_nodes[n]);
         }

--- a/MeshLib/MeshEditing/DuplicateMeshComponents.cpp
+++ b/MeshLib/MeshEditing/DuplicateMeshComponents.cpp
@@ -64,8 +64,8 @@ MeshLib::Element* copyElement(MeshLib::Element const*const element, const std::v
 template <typename E>
 MeshLib::Element* copyElement(MeshLib::Element const*const element, const std::vector<MeshLib::Node*> &nodes)
 {
-    MeshLib::Node** new_nodes = new MeshLib::Node*[element->getNumberOfBaseNodes()];
-    for (unsigned i=0; i<element->getNumberOfBaseNodes(); ++i)
+    MeshLib::Node** new_nodes = new MeshLib::Node*[element->getNumberOfNodes()];
+    for (unsigned i=0; i<element->getNumberOfNodes(); ++i)
         new_nodes[i] = nodes[element->getNode(i)->getID()];
     return new E(new_nodes);
 }

--- a/MeshLib/MeshGenerators/QuadraticeMeshGenerator.cpp
+++ b/MeshLib/MeshGenerators/QuadraticeMeshGenerator.cpp
@@ -1,0 +1,133 @@
+/**
+ * @copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ *
+ */
+
+#include "QuadraticeMeshGenerator.h"
+
+#include "BaseLib/makeVectorUnique.h"
+
+#include "MeshLib/Node.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Elements/Line.h"
+#include "MeshLib/Elements/Quad.h"
+#include "MeshLib/MeshEditing/DuplicateMeshComponents.h"
+#include "MeshLib/Properties.h"
+#include "MeshLib/PropertyVector.h"
+
+namespace MeshLib
+{
+namespace
+{
+
+struct Edge
+{
+    Edge(std::size_t id1, std::size_t id2)
+        : _id1(std::min(id1, id2)), _id2(std::max(id1, id2))
+    {}
+
+    bool operator==(Edge const& r) const
+    {
+        return (_id1 == r._id1 && _id2 == r._id2);
+    }
+
+    std::size_t _id1;
+    std::size_t _id2;
+
+    std::size_t _edge_id = 0;
+};
+
+bool operator< (Edge const& l, Edge const& r)
+{
+    return (l._id1 != r._id1) ? (l._id1 < r._id1) : l._id2 < r._id2;
+}
+
+template <typename T_ELEMENT>
+T_ELEMENT* createQuadraticElement(MeshLib::Element const* e, std::vector<Edge> const& vec_edges,
+                  std::vector<MeshLib::Node*> const& vec_new_nodes, const std::size_t n_mesh_base_nodes)
+{
+    auto const n_all_nodes = T_ELEMENT::n_all_nodes;
+    auto const n_base_nodes = T_ELEMENT::n_base_nodes;
+    MeshLib::Node** nodes = new MeshLib::Node*[n_all_nodes];
+    for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++)
+        nodes[i] = const_cast<MeshLib::Node*>(vec_new_nodes[e->getNode(i)->getID()]);
+    for (unsigned i=0; i<e->getNumberOfEdges(); i++)
+    {
+        auto itr = std::find(vec_edges.begin(), vec_edges.end(),
+                             Edge(e->getEdgeNode(i, 0)->getID(),
+                                  e->getEdgeNode(i, 1)->getID()));
+        assert(itr != vec_edges.end());
+        nodes[n_base_nodes + i] =
+            vec_new_nodes[n_mesh_base_nodes + itr->_edge_id];
+    }
+    return new T_ELEMENT(nodes);
+}
+
+} // no named namespace
+
+std::unique_ptr<Mesh> createQuadraticOrderMesh(Mesh const& org_mesh)
+{
+    std::vector<MeshLib::Node*> vec_new_nodes = MeshLib::copyNodeVector(org_mesh.getNodes());
+
+    // collect edges
+    std::vector<Edge> vec_edges;
+    for (MeshLib::Element const* e : org_mesh.getElements())
+    {
+        for (unsigned i=0; i<e->getNumberOfEdges(); i++)
+        {
+            auto node0 = e->getEdgeNode(i, 0);
+            auto node1 = e->getEdgeNode(i, 1);
+            vec_edges.emplace_back(node0->getID(), node1->getID());
+        }
+    }
+    BaseLib::makeVectorUnique(vec_edges);
+    for (std::size_t i=0; i<vec_edges.size(); i++)
+         vec_edges[i]._edge_id = i;
+    INFO("Found %d edges in the mesh", vec_edges.size());
+
+    // create mid-point nodes
+    double coords[3];
+    for (Edge const& edge : vec_edges)
+    {
+        auto const& node0 = *vec_new_nodes[edge._id1];
+        auto const& node1 = *vec_new_nodes[edge._id2];
+        for (unsigned i=0; i<3; i++)
+            coords[i] = (node0[i] + node1[i]) * 0.5;
+        vec_new_nodes.push_back(new MeshLib::Node(coords));
+    }
+
+    // create new elements with the quadratic nodes
+    std::vector<MeshLib::Element*> vec_new_eles;
+    for (MeshLib::Element const* e : org_mesh.getElements())
+    {
+        if (e->getCellType() == MeshLib::CellType::LINE2)
+        {
+            vec_new_eles.push_back(createQuadraticElement<MeshLib::Line3>(
+                e, vec_edges, vec_new_nodes, org_mesh.getNumberOfNodes()));
+        }
+        else if (e->getCellType() == MeshLib::CellType::QUAD4)
+        {
+            vec_new_eles.push_back(createQuadraticElement<MeshLib::Quad8>(
+                e, vec_edges, vec_new_nodes, org_mesh.getNumberOfNodes()));
+        }
+        else
+        {
+            OGS_FATAL("Mesh element type %s is not supported", MeshLib::CellType2String(e->getCellType()).c_str());
+        }
+    }
+
+    std::unique_ptr<MeshLib::Mesh> new_mesh(
+        new MeshLib::Mesh(org_mesh.getName(), vec_new_nodes, vec_new_eles,
+                          org_mesh.getProperties().excludeCopyProperties(
+                              std::vector<MeshLib::MeshItemType>(
+                                  1, MeshLib::MeshItemType::Node)),
+                          org_mesh.getNumberOfNodes()));
+    return new_mesh;
+}
+
+} // namespace MeshLib
+

--- a/MeshLib/MeshGenerators/QuadraticeMeshGenerator.h
+++ b/MeshLib/MeshGenerators/QuadraticeMeshGenerator.h
@@ -1,0 +1,20 @@
+/**
+ * @copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ *
+ */
+
+#include <memory>
+
+#include "MeshLib/Mesh.h"
+
+namespace MeshLib
+{
+
+/// create a quadratic order mesh from the linear order mesh
+std::unique_ptr<Mesh> createQuadraticOrderMesh(Mesh const& linear_order_mesh);
+
+} // namespace MeshLib

--- a/MeshLib/MeshSearch/NodeSearch.cpp
+++ b/MeshLib/MeshSearch/NodeSearch.cpp
@@ -36,7 +36,7 @@ std::size_t NodeSearch::searchNodesConnectedToOnlyGivenElements(
     for(std::size_t eid : elements)
     {
         auto* e = _mesh.getElement(eid);
-        for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++) {
+        for (unsigned i=0; i<e->getNumberOfNodes(); i++) {
             node_marked_counts[e->getNodeIndex(i)]++;
         }
     }

--- a/Tests/MeshLib/TestQuadraticMesh.cpp
+++ b/Tests/MeshLib/TestQuadraticMesh.cpp
@@ -1,0 +1,190 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include "GeoLib/Polyline.h"
+#include "GeoLib/PolylineVec.h"
+
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
+#include "MeshLib/MeshGenerators/QuadraticeMeshGenerator.h"
+#include "MeshLib/Node.h"
+#include "MeshGeoToolsLib/AppendLinesAlongPolyline.h"
+
+TEST(MeshLib, QuadraticOrderMesh_Line)
+{
+    using namespace MeshLib;
+
+    std::unique_ptr<Mesh> linear_mesh(MeshGenerator::generateLineMesh(
+        1, std::size_t(2)));
+    std::unique_ptr<Mesh> mesh(createQuadraticOrderMesh(*linear_mesh.get()));
+    ASSERT_EQ(5u, mesh->getNumberOfNodes());
+    ASSERT_EQ(3u, mesh->getNumberOfBaseNodes());
+    ASSERT_EQ(2u, mesh->getNumberOfElements());
+
+    for (MeshLib::Element const* e : mesh->getElements())
+    {
+        ASSERT_EQ(MeshLib::CellType::LINE3, e->getCellType());
+        ASSERT_EQ(2u, e->getNumberOfBaseNodes());
+        ASSERT_EQ(3u, e->getNumberOfNodes());
+
+        for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++)
+            ASSERT_TRUE(mesh->isBaseNode(e->getNodeIndex(i)));
+        for (unsigned i=e->getNumberOfBaseNodes(); i<e->getNumberOfNodes(); i++)
+            ASSERT_FALSE(mesh->isBaseNode(e->getNodeIndex(i)));
+    }
+
+    for (MeshLib::Node const* node : mesh->getNodes())
+    {
+        if (node->getID() == 1)
+        {
+            ASSERT_EQ(2u, node->getElements().size());
+            ASSERT_EQ(5u, node->getConnectedNodes().size());
+        }
+        else
+        {
+            ASSERT_EQ(1u, node->getElements().size());
+            ASSERT_EQ(3u, node->getConnectedNodes().size());
+        }
+    }
+}
+
+TEST(MeshLib, QuadraticOrderMesh_Quad)
+{
+    using namespace MeshLib;
+
+    std::unique_ptr<Mesh> linear_mesh(MeshGenerator::generateRegularQuadMesh(
+        1, 1, std::size_t(2), std::size_t(2)));
+    std::unique_ptr<Mesh> mesh(createQuadraticOrderMesh(*linear_mesh.get()));
+    ASSERT_EQ(21u, mesh->getNumberOfNodes());
+    ASSERT_EQ(9u, mesh->getNumberOfBaseNodes());
+    ASSERT_EQ(4u, mesh->getNumberOfElements());
+
+    for (MeshLib::Element const* e : mesh->getElements())
+    {
+        ASSERT_EQ(MeshLib::CellType::QUAD8, e->getCellType());
+        ASSERT_EQ(4u, e->getNumberOfBaseNodes());
+        ASSERT_EQ(8u, e->getNumberOfNodes());
+
+        for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++)
+            ASSERT_TRUE(mesh->isBaseNode(e->getNodeIndex(i)));
+        for (unsigned i=e->getNumberOfBaseNodes(); i<e->getNumberOfNodes(); i++)
+            ASSERT_FALSE(mesh->isBaseNode(e->getNodeIndex(i)));
+    }
+
+    auto isIn = [](MeshLib::Node const* node, std::initializer_list<std::size_t> list)
+    {
+        return list.end() != std::find(list.begin(), list.end(), node->getID());
+    };
+
+    for (MeshLib::Node const* node : mesh->getNodes())
+    {
+        if (isIn(node, {4}))
+        {
+            ASSERT_EQ(4u, node->getElements().size());
+            ASSERT_EQ(21u, node->getConnectedNodes().size());
+        }
+        else if (isIn(node, {0, 2, 6, 8, 9, 10, 11, 13, 15, 18, 19, 20}))
+        {
+            ASSERT_EQ(1u, node->getElements().size());
+            ASSERT_EQ(8u, node->getConnectedNodes().size());
+        }
+        else
+        {
+            ASSERT_EQ(2u, node->getElements().size());
+            ASSERT_EQ(13u, node->getConnectedNodes().size());
+        }
+    }
+}
+
+TEST(MeshLib, QuadraticOrderMesh_LineQuad)
+{
+    using namespace MeshLib;
+
+    std::unique_ptr<Mesh> linear_quad_mesh(MeshGenerator::generateRegularQuadMesh(
+        1, 1, std::size_t(2), std::size_t(2)));
+
+    std::unique_ptr<Mesh> linear_mesh;
+    {
+        std::vector<GeoLib::Point*> pnts;
+        pnts.push_back(new GeoLib::Point(0,0.5,0,0));
+        pnts.push_back(new GeoLib::Point(1,0.5,0,1));
+        GeoLib::Polyline* ply = new GeoLib::Polyline(pnts);
+        ply->addPoint(0);
+        ply->addPoint(1);
+        std::unique_ptr<std::vector<GeoLib::Polyline*>> plys(new std::vector<GeoLib::Polyline*>());
+        plys->push_back(ply);
+        GeoLib::PolylineVec ply_vec("", std::move(plys));
+
+        linear_mesh = MeshGeoToolsLib::appendLinesAlongPolylines(*linear_quad_mesh.get(), ply_vec);
+
+        for (auto p : pnts)
+            delete p;
+    }
+    ASSERT_EQ(6u, linear_mesh->getNumberOfElements());
+
+    std::unique_ptr<Mesh> mesh(createQuadraticOrderMesh(*linear_mesh.get()));
+    ASSERT_EQ(21u, mesh->getNumberOfNodes());
+    ASSERT_EQ(9u, mesh->getNumberOfBaseNodes());
+    ASSERT_EQ(6u, mesh->getNumberOfElements());
+
+    for (MeshLib::Element const* e : mesh->getElements())
+    {
+        if (e->getID() < 4)
+        {
+            ASSERT_EQ(MeshLib::CellType::QUAD8, e->getCellType());
+            ASSERT_EQ(4u, e->getNumberOfBaseNodes());
+            ASSERT_EQ(8u, e->getNumberOfNodes());
+        }
+        else
+        {
+            ASSERT_EQ(MeshLib::CellType::LINE3, e->getCellType());
+            ASSERT_EQ(2u, e->getNumberOfBaseNodes());
+            ASSERT_EQ(3u, e->getNumberOfNodes());
+        }
+
+        for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++)
+            ASSERT_TRUE(mesh->isBaseNode(e->getNodeIndex(i)));
+        for (unsigned i=e->getNumberOfBaseNodes(); i<e->getNumberOfNodes(); i++)
+            ASSERT_FALSE(mesh->isBaseNode(e->getNodeIndex(i)));
+    }
+
+    auto isIn = [](MeshLib::Node const* node, std::initializer_list<std::size_t> list)
+    {
+        return list.end() != std::find(list.begin(), list.end(), node->getID());
+    };
+
+    for (MeshLib::Node const* node : mesh->getNodes())
+    {
+        if (isIn(node, {4}))
+        {
+            ASSERT_EQ(6u, node->getElements().size());
+            ASSERT_EQ(21u, node->getConnectedNodes().size());
+        }
+        else if (isIn(node, {0, 2, 6, 8, 9, 10, 11, 13, 15, 18, 19, 20}))
+        {
+            ASSERT_EQ(1u, node->getElements().size());
+            ASSERT_EQ(8u, node->getConnectedNodes().size());
+        }
+        else if (isIn(node, {3, 5, 14, 16}))
+        {
+            ASSERT_EQ(3u, node->getElements().size());
+            ASSERT_EQ(13u, node->getConnectedNodes().size());
+        }
+        else
+        {
+            ASSERT_EQ(2u, node->getElements().size());
+            ASSERT_EQ(13u, node->getConnectedNodes().size());
+        }
+    }
+}


### PR DESCRIPTION
I've just realized some Mesh routines ignore nonlinear nodes, e.g. in constructing a list of connected elements to a node. This PR tries to fix them by using `getNumberOfNodes()` instead of `getNumberOfBaseNodes()`, except for `Mesh::setNodesConnectedByEdges()` where special care is required for nonlinear case. I haven't looked into classes used only in utility.