### PR TITLE
[Mesh] fix the nonlinear node ID check

### DIFF
--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -42,7 +42,7 @@ Mesh::Mesh(const std::string &name,
     assert(n_base_nodes <= nodes.size());
     this->resetNodeIDs();
     this->resetElementIDs();
-    if (isNonlinear())
+    if ((n_base_nodes==0 && hasNonlinearElement()) || isNonlinear())
         this->checkNonlinearNodeIDs();
     this->setDimension();
     this->setElementsConnectedToNodes();
@@ -276,6 +276,17 @@ void Mesh::checkNonlinearNodeIDs() const
                     e->getNodeIndex(i), getNumberOfBaseNodes());
         }
     }
+}
+
+bool Mesh::hasNonlinearElement() const
+{
+    for (auto* const e : _elements)
+    {
+        if (e->getNumberOfNodes() == e->getNumberOfBaseNodes())
+            continue;
+        return true;
+    }
+    return false;
 }
 
 void scaleMeshPropertyVector(MeshLib::Mesh & mesh,

--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -259,21 +259,18 @@ void Mesh::checkNonlinearNodeIDs() const
 {
     for (MeshLib::Element const* e : _elements)
     {
-        for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++)
-        {
-            if (!(e->getNodeIndex(i) < getNumberOfBaseNodes()))
-                OGS_FATAL(
-                    "Node %d is a base/linear node, but the ID is not smaller "
-                    "than the number of base nodes %d. Please renumber node IDs in the mesh.",
-                    e->getNodeIndex(i), getNumberOfBaseNodes());
-        }
         for (unsigned i=e->getNumberOfBaseNodes(); i<e->getNumberOfNodes(); i++)
         {
-            if (!(e->getNodeIndex(i) >= getNumberOfBaseNodes()))
-                OGS_FATAL(
-                    "Node %d is a non-linear node, but the ID is smaller "
-                    "than the number of base nodes %d. Please renumber node IDs in the mesh.",
-                    e->getNodeIndex(i), getNumberOfBaseNodes());
+            if (e->getNodeIndex(i) >= getNumberOfBaseNodes())
+                continue;
+
+            DBUG(
+                "Node %d is a non-linear node, but the ID is smaller "
+                "than the number of base nodes %d.",
+                e->getNodeIndex(i), getNumberOfBaseNodes());
+            ERR("Found a nonlinear node whose ID is smaller than base node IDs."
+                "Some functions may not work properly.");
+            return;
         }
     }
 }

--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -273,12 +273,10 @@ void Mesh::checkNonlinearNodeIDs() const
             if (e->getNodeIndex(i) >= getNumberOfBaseNodes())
                 continue;
 
-            DBUG(
-                "Node %d is a non-linear node, but the ID is smaller "
-                "than the number of base nodes %d.",
+            ERR("Found a nonlinear node whose ID (%d) is smaller than the "
+                "number of base node IDs (%d)."
+                "Some functions may not work properly.",
                 e->getNodeIndex(i), getNumberOfBaseNodes());
-            ERR("Found a nonlinear node whose ID is smaller than base node IDs."
-                "Some functions may not work properly.");
             return;
         }
     }

--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -36,7 +36,7 @@ Mesh::Mesh(const std::string &name,
       _edge_length(std::numeric_limits<double>::max(), 0),
       _node_distance(std::numeric_limits<double>::max(), 0),
       _name(name), _nodes(nodes), _elements(elements),
-      _n_base_nodes(n_base_nodes==0 ? nodes.size() : n_base_nodes),
+      _n_base_nodes(n_base_nodes),
       _properties(properties)
 {
     assert(n_base_nodes <= nodes.size());
@@ -114,6 +114,15 @@ void Mesh::resetNodeIDs()
     const std::size_t nNodes (this->_nodes.size());
     for (unsigned i=0; i<nNodes; ++i)
         _nodes[i]->setID(i);
+
+    if (_n_base_nodes==0)
+    {
+        unsigned max_basenode_ID = 0;
+        for (Element const* e : _elements)
+            for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++)
+                max_basenode_ID = std::max(max_basenode_ID, e->getNodeIndex(i));
+        _n_base_nodes = max_basenode_ID + 1;
+    }
 }
 
 void Mesh::resetElementIDs()

--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -280,13 +280,10 @@ void Mesh::checkNonlinearNodeIDs() const
 
 bool Mesh::hasNonlinearElement() const
 {
-    for (auto* const e : _elements)
-    {
-        if (e->getNumberOfNodes() == e->getNumberOfBaseNodes())
-            continue;
-        return true;
-    }
-    return false;
+    return std::any_of(std::begin(_elements), std::end(_elements),
+        [](Element const* const e) {
+            return e->getNumberOfNodes() != e->getNumberOfBaseNodes();
+        });
 }
 
 void scaleMeshPropertyVector(MeshLib::Mesh & mesh,

--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -165,6 +165,9 @@ protected:
     /// Check if all the nonlinear nodes are stored at the end of the node vector
     void checkNonlinearNodeIDs() const;
 
+    /// Check if the mesh contains any nonlinear element
+    bool hasNonlinearElement() const;
+
     std::size_t const _id;
     unsigned _mesh_dimension;
     /// The minimal and maximal edge length over all elements in the mesh


### PR DESCRIPTION
fix #1495. The check doesn't work if the number of base nodes is provided to a constructor, which is the case in VtuInterface.