### PR TITLE
extend NodeReordering to correct ordering of nonlinear nodes

### DIFF
--- a/BaseLib/makeVectorUnique.h
+++ b/BaseLib/makeVectorUnique.h
@@ -27,5 +27,15 @@ void makeVectorUnique(std::vector<T>& v)
     v.erase(it, v.end());
 }
 
+/// Make the entries of the std::vector \c v unique using the given binary
+/// function. The remaining entries will be sorted.
+template <typename T, class Compare>
+void makeVectorUnique(std::vector<T>& v, Compare comp)
+{
+    std::sort(v.begin(), v.end(), comp);
+    auto it = std::unique(v.begin(), v.end());
+    v.erase(it, v.end());
+}
+
 } // end namespace BaseLib
 #endif


### PR DESCRIPTION
This PR adds the method 3 to NodeReordering tool to correct ordering of nonlinear nodes. In a nonlinear mesh, all the nonlinear nodes should be stored after the base nodes.