### PR TITLE
Reduce number of instantiated local asms

### DIFF
--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/LocalDataInitializer.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/LocalDataInitializer.h
@@ -20,7 +20,6 @@
 #include "NumLib/DOF/LocalToGlobalIndexMap.h"
 #include "NumLib/Fem/Integration/GaussIntegrationPolicy.h"
 
-
 #ifndef OGS_MAX_ELEMENT_DIM
 static_assert(false, "The macro OGS_MAX_ELEMENT_DIM is undefined.");
 #endif
@@ -47,7 +46,7 @@ static_assert(false, "The macro OGS_MAX_ELEMENT_ORDER is undefined.");
 #ifdef OGS_ENABLE_ELEMENT_PRISM
 #define ENABLED_ELEMENT_TYPE_PRISM 1u << 2
 #else
-#define ENABLED_ELEMENT_TYPE_PRISM   0u
+#define ENABLED_ELEMENT_TYPE_PRISM 0u
 #endif
 
 #ifdef OGS_ENABLE_ELEMENT_PYRAMID
@@ -58,19 +57,18 @@ static_assert(false, "The macro OGS_MAX_ELEMENT_ORDER is undefined.");
 
 // Dependent element types.
 // Faces of tets, pyramids and prisms are triangles
-#define ENABLED_ELEMENT_TYPE_TRI  ((ENABLED_ELEMENT_TYPE_SIMPLEX) | (ENABLED_ELEMENT_TYPE_PYRAMID) \
-                                  |(ENABLED_ELEMENT_TYPE_PRISM))
+#define ENABLED_ELEMENT_TYPE_TRI                                       \
+    ((ENABLED_ELEMENT_TYPE_SIMPLEX) | (ENABLED_ELEMENT_TYPE_PYRAMID) | \
+     (ENABLED_ELEMENT_TYPE_PRISM))
 // Faces of hexes, pyramids and prisms are quads
-#define ENABLED_ELEMENT_TYPE_QUAD ((ENABLED_ELEMENT_TYPE_CUBOID) | (ENABLED_ELEMENT_TYPE_PYRAMID) \
-                                  |(ENABLED_ELEMENT_TYPE_PRISM))
+#define ENABLED_ELEMENT_TYPE_QUAD                                     \
+    ((ENABLED_ELEMENT_TYPE_CUBOID) | (ENABLED_ELEMENT_TYPE_PYRAMID) | \
+     (ENABLED_ELEMENT_TYPE_PRISM))
 
 // All enabled element types
-#define OGS_ENABLED_ELEMENTS \
-    ( (ENABLED_ELEMENT_TYPE_SIMPLEX) \
-    | (ENABLED_ELEMENT_TYPE_CUBOID ) \
-    | (ENABLED_ELEMENT_TYPE_PYRAMID) \
-    | (ENABLED_ELEMENT_TYPE_PRISM  ) )
-
+#define OGS_ENABLED_ELEMENTS                                          \
+    ((ENABLED_ELEMENT_TYPE_SIMPLEX) | (ENABLED_ELEMENT_TYPE_CUBOID) | \
+     (ENABLED_ELEMENT_TYPE_PYRAMID) | (ENABLED_ELEMENT_TYPE_PRISM))
 
 // Include only what is needed (Well, the conditions are not sharp).
 #if OGS_ENABLED_ELEMENTS != 0
@@ -115,18 +113,19 @@ namespace LIE
 {
 namespace SmallDeformation
 {
-
 /// The LocalDataInitializer is a functor creating a local assembler data with
 /// corresponding to the mesh element type shape functions and calling
 /// initialization of the new local assembler data.
 /// For example for MeshLib::Quad a local assembler data with template argument
 /// NumLib::ShapeQuad4 is created.
-template <
-    typename LocalAssemblerInterface,
-    template <typename, typename, unsigned, int> class LocalAssemblerDataMatrix,
-    template <typename, typename, unsigned, int> class LocalAssemblerDataMatrixNearFracture,
-    template <typename, typename, unsigned, int> class LocalAssemblerDataFracture,
-    unsigned GlobalDim, int DisplacementDim, typename... ConstructorArgs>
+template <typename LocalAssemblerInterface,
+          template <typename, typename, unsigned, int>
+          class LocalAssemblerDataMatrix,
+          template <typename, typename, unsigned, int>
+          class LocalAssemblerDataMatrixNearFracture,
+          template <typename, typename, unsigned, int>
+          class LocalAssemblerDataFracture,
+          unsigned GlobalDim, int DisplacementDim, typename... ConstructorArgs>
 class LocalDataInitializer final
 {
 public:
@@ -136,12 +135,12 @@ public:
         NumLib::LocalToGlobalIndexMap const& dof_table)
         : _dof_table(dof_table)
     {
-        //REMARKS: At the moment, only a 2D mesh with 1D elements are supported.
+// REMARKS: At the moment, only a 2D mesh with 1D elements are supported.
 
-        // /// Quads and Hexahedra ///////////////////////////////////
+// /// Quads and Hexahedra ///////////////////////////////////
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 1
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 1
         _builder[std::type_index(typeid(MeshLib::Quad))] =
             makeLocalAssemblerBuilder<NumLib::ShapeQuad4>();
 #endif
@@ -154,8 +153,8 @@ public:
 #endif
 */
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Quad8))] =
             makeLocalAssemblerBuilder<NumLib::ShapeQuad8>();
         _builder[std::type_index(typeid(MeshLib::Quad9))] =
@@ -170,11 +169,10 @@ public:
 #endif
 */
 
+// /// Simplices ////////////////////////////////////////////////
 
-        // /// Simplices ////////////////////////////////////////////////
-
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 1
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 1
         _builder[std::type_index(typeid(MeshLib::Tri))] =
             makeLocalAssemblerBuilder<NumLib::ShapeTri3>();
 #endif
@@ -187,8 +185,8 @@ public:
 #endif
 */
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Tri6))] =
             makeLocalAssemblerBuilder<NumLib::ShapeTri6>();
 #endif
@@ -201,8 +199,7 @@ public:
 #endif
 */
 
-
-        // /// Prisms ////////////////////////////////////////////////////
+// /// Prisms ////////////////////////////////////////////////////
 
 /*
 #if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PRISM) != 0 \
@@ -218,7 +215,7 @@ public:
 #endif
 */
 
-        // /// Pyramids //////////////////////////////////////////////////
+// /// Pyramids //////////////////////////////////////////////////
 
 /*
 #if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PYRAMID) != 0 \
@@ -233,7 +230,7 @@ public:
             makeLocalAssemblerBuilder<NumLib::ShapePyra13>();
 #endif
 */
-        // /// Lines ///////////////////////////////////
+// /// Lines ///////////////////////////////////
 
 #if OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 1
         _builder[std::type_index(typeid(MeshLib::Line))] =
@@ -251,87 +248,97 @@ public:
     /// \attention
     /// The index \c id is not necessarily the mesh item's id. Especially when
     /// having multiple meshes it will differ from the latter.
-    void operator()(
-            std::size_t const id,
-            MeshLib::Element const& mesh_item,
-            LADataIntfPtr& data_ptr,
-            ConstructorArgs&&... args) const
+    void operator()(std::size_t const id,
+                    MeshLib::Element const& mesh_item,
+                    LADataIntfPtr& data_ptr,
+                    ConstructorArgs&&... args) const
     {
         auto const type_idx = std::type_index(typeid(mesh_item));
         auto const it = _builder.find(type_idx);
 
-        if (it != _builder.end()) {
+        if (it != _builder.end())
+        {
             auto const n_local_dof = _dof_table.getNumberOfElementDOF(id);
-            auto const n_global_components = _dof_table.getNumberOfElementComponents(id);
-            const std::vector<std::size_t> varIDs(_dof_table.getElementVariableIDs(id));
+            auto const n_global_components =
+                _dof_table.getNumberOfElementComponents(id);
+            const std::vector<std::size_t> varIDs(
+                _dof_table.getElementVariableIDs(id));
 
             std::vector<unsigned> dofIndex_to_localIndex;
-            if (mesh_item.getDimension() < GlobalDim
-                || n_global_components > GlobalDim)
+            if (mesh_item.getDimension() < GlobalDim ||
+                n_global_components > GlobalDim)
             {
                 dofIndex_to_localIndex.resize(n_local_dof);
                 unsigned dof_id = 0;
                 unsigned local_id = 0;
                 for (auto i : varIDs)
                 {
-                    for (unsigned j=0; j<_dof_table.getNumberOfVariableComponents(i); j++)
+                    for (unsigned j = 0;
+                         j < _dof_table.getNumberOfVariableComponents(i); j++)
                     {
                         auto& mss = _dof_table.getMeshSubsets(i, j);
                         assert(mss.size() == 1);
                         auto mesh_id = mss.getMeshSubset(0).getMeshID();
-                        for (unsigned k=0; k<mesh_item.getNumberOfNodes(); k++)
+                        for (unsigned k = 0; k < mesh_item.getNumberOfNodes();
+                             k++)
                         {
                             MeshLib::Location l(mesh_id,
                                                 MeshLib::MeshItemType::Node,
                                                 mesh_item.getNodeIndex(k));
-                            auto global_index = _dof_table.getGlobalIndex(l, i, j);
+                            auto global_index =
+                                _dof_table.getGlobalIndex(l, i, j);
                             if (global_index != NumLib::MeshComponentMap::nop)
                                 dofIndex_to_localIndex[dof_id++] = local_id;
                             local_id++;
                         }
                     }
                 }
-
             }
 
-
-            data_ptr = it->second(
-                           mesh_item, varIDs.size(), n_local_dof, dofIndex_to_localIndex,
-                           std::forward<ConstructorArgs>(args)...);
-        } else {
-            OGS_FATAL("You are trying to build a local assembler for an unknown mesh element type (%s)."
-                " Maybe you have disabled this mesh element type in your build configuration.",
+            data_ptr = it->second(mesh_item, varIDs.size(), n_local_dof,
+                                  dofIndex_to_localIndex,
+                                  std::forward<ConstructorArgs>(args)...);
+        }
+        else
+        {
+            OGS_FATAL(
+                "You are trying to build a local assembler for an unknown mesh "
+                "element type (%s)."
+                " Maybe you have disabled this mesh element type in your build "
+                "configuration.",
                 type_idx.name());
         }
     }
 
 private:
     using LADataBuilder = std::function<LADataIntfPtr(
-            MeshLib::Element const& e,
-            std::size_t const n_variables,
-            std::size_t const local_matrix_size,
-            std::vector<unsigned> const& dofIndex_to_localIndex,
-            ConstructorArgs&&...
-        )>;
+        MeshLib::Element const& e,
+        std::size_t const n_variables,
+        std::size_t const local_matrix_size,
+        std::vector<unsigned> const& dofIndex_to_localIndex,
+        ConstructorArgs&&...)>;
 
     template <typename ShapeFunction>
     using IntegrationMethod = typename NumLib::GaussIntegrationPolicy<
-                typename ShapeFunction::MeshElement>::IntegrationMethod;
+        typename ShapeFunction::MeshElement>::IntegrationMethod;
 
     template <typename ShapeFunction>
     using LADataMatrix =
-        LocalAssemblerDataMatrix<ShapeFunction, IntegrationMethod<ShapeFunction>,
-                           GlobalDim, DisplacementDim>;
+        LocalAssemblerDataMatrix<ShapeFunction,
+                                 IntegrationMethod<ShapeFunction>, GlobalDim,
+                                 DisplacementDim>;
 
     template <typename ShapeFunction>
     using LADataMatrixNearFracture =
-        LocalAssemblerDataMatrixNearFracture<ShapeFunction, IntegrationMethod<ShapeFunction>,
-                           GlobalDim, DisplacementDim>;
+        LocalAssemblerDataMatrixNearFracture<ShapeFunction,
+                                             IntegrationMethod<ShapeFunction>,
+                                             GlobalDim, DisplacementDim>;
 
     template <typename ShapeFunction>
     using LAFractureData =
-        LocalAssemblerDataFracture<ShapeFunction, IntegrationMethod<ShapeFunction>,
-                           GlobalDim, DisplacementDim>;
+        LocalAssemblerDataFracture<ShapeFunction,
+                                   IntegrationMethod<ShapeFunction>, GlobalDim,
+                                   DisplacementDim>;
 
     /// Generates a function that creates a new LocalAssembler of type LAData<SHAPE_FCT>
     template<typename ShapeFct>
@@ -341,30 +348,26 @@ private:
                   std::size_t const n_variables,
                   std::size_t const local_matrix_size,
                   std::vector<unsigned> const& dofIndex_to_localIndex,
-                  ConstructorArgs&&... args)
-        {
+                  ConstructorArgs&&... args) {
             if (e.getDimension() == GlobalDim)
             {
                 if (dofIndex_to_localIndex.empty())
                 {
-                    return LADataIntfPtr{
-                        new LADataMatrix<ShapeFct>{
-                            e, local_matrix_size,
-                            std::forward<ConstructorArgs>(args)...
-                        }};
-                } else {
-                    return LADataIntfPtr{
-                        new LADataMatrixNearFracture<ShapeFct>{
-                            e, n_variables, local_matrix_size, dofIndex_to_localIndex,
-                            std::forward<ConstructorArgs>(args)...
-                        }};
+                    return LADataIntfPtr{new LADataMatrix<ShapeFct>{
+                        e, local_matrix_size,
+                        std::forward<ConstructorArgs>(args)...}};
+                }
+                else
+                {
+                    return LADataIntfPtr{new LADataMatrixNearFracture<ShapeFct>{
+                        e, n_variables, local_matrix_size,
+                        dofIndex_to_localIndex,
+                        std::forward<ConstructorArgs>(args)...}};
                 }
             }
-            return LADataIntfPtr{
-                new LAFractureData<ShapeFct>{
-                    e, local_matrix_size, dofIndex_to_localIndex,
-                    std::forward<ConstructorArgs>(args)...
-                }};
+            return LADataIntfPtr{new LAFractureData<ShapeFct>{
+                e, local_matrix_size, dofIndex_to_localIndex,
+                std::forward<ConstructorArgs>(args)...}};
         };
     }
 
@@ -374,10 +377,9 @@ private:
     NumLib::LocalToGlobalIndexMap const& _dof_table;
 };
 
-}  // namespace SmallDeformation
-}   // namespace LIE
+}   // namespace SmallDeformationWithLIE
 }   // namespace ProcessLib
-
+}   // namespace ProcessLib
 
 #undef ENABLED_ELEMENT_TYPE_SIMPLEX
 #undef ENABLED_ELEMENT_TYPE_CUBOID

--- a/ProcessLib/SmallDeformation/LocalDataInitializer.h
+++ b/ProcessLib/SmallDeformation/LocalDataInitializer.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <typeindex>
 #include <typeinfo>
+#include <type_traits>
 #include <unordered_map>
 
 #include "MeshLib/Elements/Elements.h"
@@ -249,38 +250,48 @@ private:
         LocalAssemblerData<ShapeFunction, IntegrationMethod<ShapeFunction>,
                            GlobalDim, DisplacementDim>;
 
+    /// A helper forwarding to the correct version of makeLocalAssemblerBuilder
+    /// depending whether the global dimension is less than the shape function's
+    /// dimension or not.
+    template <typename ShapeFunction>
+    static LADataBuilder makeLocalAssemblerBuilder()
+    {
+        return makeLocalAssemblerBuilder<ShapeFunction>(
+            static_cast<std::integral_constant<
+                bool, (GlobalDim >= ShapeFunction::DIM)>*>(nullptr));
+    }
+
+
+    /// Mapping of element types to local assembler constructors.
+    std::unordered_map<std::type_index, LADataBuilder> _builder;
+
+    NumLib::LocalToGlobalIndexMap const& _dof_table;
+
+    // local assembler builder implementations.
+private:
     /// Generates a function that creates a new LocalAssembler of type
-    /// LAData<ShapeFct>. Only functions with shape function's dimension less or
-    /// equal to the global dimension are instantiated, e.g. following
+    /// LAData<ShapeFunction>. Only functions with shape function's dimension
+    /// less or equal to the global dimension are instantiated, e.g.  following
     /// combinations of shape functions and global dimensions: (Line2, 1),
     /// (Line2, 2), (Line2, 3), (Hex20, 3) but not (Hex20, 2) or (Hex20, 1).
-    template <typename ShapeFct>
-    static
-        typename std::enable_if<GlobalDim >= ShapeFct::DIM, LADataBuilder>::type
-        makeLocalAssemblerBuilder()
+    template <typename ShapeFunction>
+    static LADataBuilder makeLocalAssemblerBuilder(std::true_type*)
     {
         return [](MeshLib::Element const& e,
                   std::size_t const local_matrix_size,
                   ConstructorArgs&&... args) {
-            return LADataIntfPtr{new LAData<ShapeFct>{
+            return LADataIntfPtr{new LAData<ShapeFunction>{
                 e, local_matrix_size, std::forward<ConstructorArgs>(args)...}};
         };
     }
 
     /// Returns nullptr for shape functions whose dimensions are less than the
     /// global dimension.
-    template <typename ShapeFct>
-        static
-        typename std::enable_if < GlobalDim<ShapeFct::DIM, LADataBuilder>::type
-                                  makeLocalAssemblerBuilder()
+    template <typename ShapeFunction>
+    static LADataBuilder makeLocalAssemblerBuilder(std::false_type*)
     {
         return nullptr;
     }
-
-    /// Mapping of element types to local assembler constructors.
-    std::unordered_map<std::type_index, LADataBuilder> _builder;
-
-    NumLib::LocalToGlobalIndexMap const& _dof_table;
 };
 
 }  // namespace ProcessLib

--- a/ProcessLib/SmallDeformation/LocalDataInitializer.h
+++ b/ProcessLib/SmallDeformation/LocalDataInitializer.h
@@ -249,9 +249,15 @@ private:
         LocalAssemblerData<ShapeFunction, IntegrationMethod<ShapeFunction>,
                            GlobalDim, DisplacementDim>;
 
-    /// Generates a function that creates a new LocalAssembler of type LAData<SHAPE_FCT>
-    template<typename ShapeFct>
-    static LADataBuilder makeLocalAssemblerBuilder()
+    /// Generates a function that creates a new LocalAssembler of type
+    /// LAData<ShapeFct>. Only functions with shape function's dimension less or
+    /// equal to the global dimension are instantiated, e.g. following
+    /// combinations of shape functions and global dimensions: (Line2, 1),
+    /// (Line2, 2), (Line2, 3), (Hex20, 3) but not (Hex20, 2) or (Hex20, 1).
+    template <typename ShapeFct>
+    static
+        typename std::enable_if<GlobalDim >= ShapeFct::DIM, LADataBuilder>::type
+        makeLocalAssemblerBuilder()
     {
         return [](MeshLib::Element const& e,
                   std::size_t const local_matrix_size,
@@ -259,6 +265,16 @@ private:
             return LADataIntfPtr{new LAData<ShapeFct>{
                 e, local_matrix_size, std::forward<ConstructorArgs>(args)...}};
         };
+    }
+
+    /// Returns nullptr for shape functions whose dimensions are less than the
+    /// global dimension.
+    template <typename ShapeFct>
+        static
+        typename std::enable_if < GlobalDim<ShapeFct::DIM, LADataBuilder>::type
+                                  makeLocalAssemblerBuilder()
+    {
+        return nullptr;
     }
 
     /// Mapping of element types to local assembler constructors.

--- a/ProcessLib/SmallDeformation/LocalDataInitializer.h
+++ b/ProcessLib/SmallDeformation/LocalDataInitializer.h
@@ -20,7 +20,6 @@
 #include "NumLib/DOF/LocalToGlobalIndexMap.h"
 #include "NumLib/Fem/Integration/GaussIntegrationPolicy.h"
 
-
 #ifndef OGS_MAX_ELEMENT_DIM
 static_assert(false, "The macro OGS_MAX_ELEMENT_DIM is undefined.");
 #endif
@@ -47,7 +46,7 @@ static_assert(false, "The macro OGS_MAX_ELEMENT_ORDER is undefined.");
 #ifdef OGS_ENABLE_ELEMENT_PRISM
 #define ENABLED_ELEMENT_TYPE_PRISM 1u << 2
 #else
-#define ENABLED_ELEMENT_TYPE_PRISM   0u
+#define ENABLED_ELEMENT_TYPE_PRISM 0u
 #endif
 
 #ifdef OGS_ENABLE_ELEMENT_PYRAMID
@@ -58,19 +57,18 @@ static_assert(false, "The macro OGS_MAX_ELEMENT_ORDER is undefined.");
 
 // Dependent element types.
 // Faces of tets, pyramids and prisms are triangles
-#define ENABLED_ELEMENT_TYPE_TRI  ((ENABLED_ELEMENT_TYPE_SIMPLEX) | (ENABLED_ELEMENT_TYPE_PYRAMID) \
-                                  |(ENABLED_ELEMENT_TYPE_PRISM))
+#define ENABLED_ELEMENT_TYPE_TRI                                       \
+    ((ENABLED_ELEMENT_TYPE_SIMPLEX) | (ENABLED_ELEMENT_TYPE_PYRAMID) | \
+     (ENABLED_ELEMENT_TYPE_PRISM))
 // Faces of hexes, pyramids and prisms are quads
-#define ENABLED_ELEMENT_TYPE_QUAD ((ENABLED_ELEMENT_TYPE_CUBOID) | (ENABLED_ELEMENT_TYPE_PYRAMID) \
-                                  |(ENABLED_ELEMENT_TYPE_PRISM))
+#define ENABLED_ELEMENT_TYPE_QUAD                                     \
+    ((ENABLED_ELEMENT_TYPE_CUBOID) | (ENABLED_ELEMENT_TYPE_PYRAMID) | \
+     (ENABLED_ELEMENT_TYPE_PRISM))
 
 // All enabled element types
-#define OGS_ENABLED_ELEMENTS \
-    ( (ENABLED_ELEMENT_TYPE_SIMPLEX) \
-    | (ENABLED_ELEMENT_TYPE_CUBOID ) \
-    | (ENABLED_ELEMENT_TYPE_PYRAMID) \
-    | (ENABLED_ELEMENT_TYPE_PRISM  ) )
-
+#define OGS_ENABLED_ELEMENTS                                          \
+    ((ENABLED_ELEMENT_TYPE_SIMPLEX) | (ENABLED_ELEMENT_TYPE_CUBOID) | \
+     (ENABLED_ELEMENT_TYPE_PYRAMID) | (ENABLED_ELEMENT_TYPE_PRISM))
 
 // Include only what is needed (Well, the conditions are not sharp).
 #if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_SIMPLEX) != 0
@@ -106,16 +104,14 @@ static_assert(false, "The macro OGS_MAX_ELEMENT_ORDER is undefined.");
 
 namespace ProcessLib
 {
-
 /// The LocalDataInitializer is a functor creating a local assembler data with
 /// corresponding to the mesh element type shape functions and calling
 /// initialization of the new local assembler data.
 /// For example for MeshLib::Quad a local assembler data with template argument
 /// NumLib::ShapeQuad4 is created.
-template <
-    typename LocalAssemblerInterface,
-    template <typename, typename, unsigned, int> class LocalAssemblerData,
-    unsigned GlobalDim, int DisplacementDim, typename... ConstructorArgs>
+template <typename LocalAssemblerInterface,
+          template <typename, typename, unsigned, int> class LocalAssemblerData,
+          unsigned GlobalDim, int DisplacementDim, typename... ConstructorArgs>
 class LocalDataInitializer final
 {
 public:
@@ -125,86 +121,84 @@ public:
         NumLib::LocalToGlobalIndexMap const& dof_table)
         : _dof_table(dof_table)
     {
-        // /// Quads and Hexahedra ///////////////////////////////////
+// /// Quads and Hexahedra ///////////////////////////////////
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 1
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 1
         _builder[std::type_index(typeid(MeshLib::Quad))] =
             makeLocalAssemblerBuilder<NumLib::ShapeQuad4>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_CUBOID) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_CUBOID) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
         _builder[std::type_index(typeid(MeshLib::Hex))] =
             makeLocalAssemblerBuilder<NumLib::ShapeHex8>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Quad8))] =
             makeLocalAssemblerBuilder<NumLib::ShapeQuad8>();
         _builder[std::type_index(typeid(MeshLib::Quad9))] =
             makeLocalAssemblerBuilder<NumLib::ShapeQuad9>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_CUBOID) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_CUBOID) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Hex20))] =
             makeLocalAssemblerBuilder<NumLib::ShapeHex20>();
 #endif
 
+// /// Simplices ////////////////////////////////////////////////
 
-        // /// Simplices ////////////////////////////////////////////////
-
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 1
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 1
         _builder[std::type_index(typeid(MeshLib::Tri))] =
             makeLocalAssemblerBuilder<NumLib::ShapeTri3>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_SIMPLEX) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_SIMPLEX) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
         _builder[std::type_index(typeid(MeshLib::Tet))] =
             makeLocalAssemblerBuilder<NumLib::ShapeTet4>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Tri6))] =
             makeLocalAssemblerBuilder<NumLib::ShapeTri6>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_SIMPLEX) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_SIMPLEX) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Tet10))] =
             makeLocalAssemblerBuilder<NumLib::ShapeTet10>();
 #endif
 
+// /// Prisms ////////////////////////////////////////////////////
 
-        // /// Prisms ////////////////////////////////////////////////////
-
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PRISM) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PRISM) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
         _builder[std::type_index(typeid(MeshLib::Prism))] =
             makeLocalAssemblerBuilder<NumLib::ShapePrism6>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PRISM) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PRISM) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Prism15))] =
             makeLocalAssemblerBuilder<NumLib::ShapePrism15>();
 #endif
 
-        // /// Pyramids //////////////////////////////////////////////////
+// /// Pyramids //////////////////////////////////////////////////
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PYRAMID) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PYRAMID) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
         _builder[std::type_index(typeid(MeshLib::Pyramid))] =
             makeLocalAssemblerBuilder<NumLib::ShapePyra5>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PYRAMID) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PYRAMID) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
         _builder[std::type_index(typeid(MeshLib::Pyramid13))] =
             makeLocalAssemblerBuilder<NumLib::ShapePyra13>();
 #endif
@@ -215,37 +209,40 @@ public:
     /// \attention
     /// The index \c id is not necessarily the mesh item's id. Especially when
     /// having multiple meshes it will differ from the latter.
-    void operator()(
-            std::size_t const id,
-            MeshLib::Element const& mesh_item,
-            LADataIntfPtr& data_ptr,
-            ConstructorArgs&&... args) const
+    void operator()(std::size_t const id,
+                    MeshLib::Element const& mesh_item,
+                    LADataIntfPtr& data_ptr,
+                    ConstructorArgs&&... args) const
     {
         auto const type_idx = std::type_index(typeid(mesh_item));
         auto const it = _builder.find(type_idx);
 
-        if (it != _builder.end()) {
+        if (it != _builder.end())
+        {
             auto const num_local_dof = _dof_table.getNumberOfElementDOF(id);
-            data_ptr = it->second(
-                           mesh_item, num_local_dof,
-                           std::forward<ConstructorArgs>(args)...);
-        } else {
-            OGS_FATAL("You are trying to build a local assembler for an unknown mesh element type (%s)."
-                " Maybe you have disabled this mesh element type in your build configuration.",
+            data_ptr = it->second(mesh_item, num_local_dof,
+                                  std::forward<ConstructorArgs>(args)...);
+        }
+        else
+        {
+            OGS_FATAL(
+                "You are trying to build a local assembler for an unknown mesh "
+                "element type (%s)."
+                " Maybe you have disabled this mesh element type in your build "
+                "configuration.",
                 type_idx.name());
         }
     }
 
 private:
-    using LADataBuilder = std::function<LADataIntfPtr(
-            MeshLib::Element const& e,
-            std::size_t const local_matrix_size,
-            ConstructorArgs&&...
-        )>;
+    using LADataBuilder =
+        std::function<LADataIntfPtr(MeshLib::Element const& e,
+                                    std::size_t const local_matrix_size,
+                                    ConstructorArgs&&...)>;
 
     template <typename ShapeFunction>
     using IntegrationMethod = typename NumLib::GaussIntegrationPolicy<
-                typename ShapeFunction::MeshElement>::IntegrationMethod;
+        typename ShapeFunction::MeshElement>::IntegrationMethod;
 
     template <typename ShapeFunction>
     using LAData =
@@ -258,13 +255,9 @@ private:
     {
         return [](MeshLib::Element const& e,
                   std::size_t const local_matrix_size,
-                  ConstructorArgs&&... args)
-        {
-            return LADataIntfPtr{
-                new LAData<ShapeFct>{
-                    e, local_matrix_size,
-                    std::forward<ConstructorArgs>(args)...
-                }};
+                  ConstructorArgs&&... args) {
+            return LADataIntfPtr{new LAData<ShapeFct>{
+                e, local_matrix_size, std::forward<ConstructorArgs>(args)...}};
         };
     }
 
@@ -274,8 +267,7 @@ private:
     NumLib::LocalToGlobalIndexMap const& _dof_table;
 };
 
-}   // namespace ProcessLib
-
+}  // namespace ProcessLib
 
 #undef ENABLED_ELEMENT_TYPE_SIMPLEX
 #undef ENABLED_ELEMENT_TYPE_CUBOID

--- a/ProcessLib/Utils/LocalDataInitializer.h
+++ b/ProcessLib/Utils/LocalDataInitializer.h
@@ -342,9 +342,14 @@ private:
                            GlobalDim>;
 
     /// Generates a function that creates a new LocalAssembler of type
-    /// LAData<SHAPE_FCT>
+    /// LAData<ShapeFct>. Only functions with shape function's dimension less or
+    /// equal to the global dimension are instantiated, e.g. following
+    /// combinations of shape functions and global dimensions: (Line2, 1),
+    /// (Line2, 2), (Line2, 3), (Hex20, 3) but not (Hex20, 2) or (Hex20, 1).
     template <typename ShapeFct>
-    static LADataBuilder makeLocalAssemblerBuilder()
+    static
+        typename std::enable_if<GlobalDim >= ShapeFct::DIM, LADataBuilder>::type
+        makeLocalAssemblerBuilder()
     {
         return [](MeshLib::Element const& e,
                   std::size_t const local_matrix_size,
@@ -352,6 +357,16 @@ private:
             return LADataIntfPtr{new LAData<ShapeFct>{
                 e, local_matrix_size, std::forward<ConstructorArgs>(args)...}};
         };
+    }
+
+    /// Returns nullptr for shape functions whose dimensions are less than the
+    /// global dimension.
+    template <typename ShapeFct>
+        static
+        typename std::enable_if < GlobalDim<ShapeFct::DIM, LADataBuilder>::type
+                                  makeLocalAssemblerBuilder()
+    {
+        return nullptr;
     }
 
     /// Mapping of element types to local assembler constructors.

--- a/ProcessLib/Utils/LocalDataInitializer.h
+++ b/ProcessLib/Utils/LocalDataInitializer.h
@@ -20,7 +20,6 @@
 #include "NumLib/DOF/LocalToGlobalIndexMap.h"
 #include "NumLib/Fem/Integration/GaussIntegrationPolicy.h"
 
-
 #ifndef OGS_MAX_ELEMENT_DIM
 static_assert(false, "The macro OGS_MAX_ELEMENT_DIM is undefined.");
 #endif
@@ -47,7 +46,7 @@ static_assert(false, "The macro OGS_MAX_ELEMENT_ORDER is undefined.");
 #ifdef OGS_ENABLE_ELEMENT_PRISM
 #define ENABLED_ELEMENT_TYPE_PRISM 1u << 2
 #else
-#define ENABLED_ELEMENT_TYPE_PRISM   0u
+#define ENABLED_ELEMENT_TYPE_PRISM 0u
 #endif
 
 #ifdef OGS_ENABLE_ELEMENT_PYRAMID
@@ -58,21 +57,21 @@ static_assert(false, "The macro OGS_MAX_ELEMENT_ORDER is undefined.");
 
 // Dependent element types.
 // Faces of tets, pyramids and prisms are triangles
-#define ENABLED_ELEMENT_TYPE_TRI  ((ENABLED_ELEMENT_TYPE_SIMPLEX) | (ENABLED_ELEMENT_TYPE_PYRAMID) \
-                                  |(ENABLED_ELEMENT_TYPE_PRISM))
+#define ENABLED_ELEMENT_TYPE_TRI                                       \
+    ((ENABLED_ELEMENT_TYPE_SIMPLEX) | (ENABLED_ELEMENT_TYPE_PYRAMID) | \
+     (ENABLED_ELEMENT_TYPE_PRISM))
 // Faces of hexes, pyramids and prisms are quads
-#define ENABLED_ELEMENT_TYPE_QUAD ((ENABLED_ELEMENT_TYPE_CUBOID) | (ENABLED_ELEMENT_TYPE_PYRAMID) \
-                                  |(ENABLED_ELEMENT_TYPE_PRISM))
+#define ENABLED_ELEMENT_TYPE_QUAD                                     \
+    ((ENABLED_ELEMENT_TYPE_CUBOID) | (ENABLED_ELEMENT_TYPE_PYRAMID) | \
+     (ENABLED_ELEMENT_TYPE_PRISM))
 // Faces of triangles and quads are lines
-#define ENABLED_ELEMENT_TYPE_LINE ((ENABLED_ELEMENT_TYPE_TRI) | (ENABLED_ELEMENT_TYPE_QUAD))
+#define ENABLED_ELEMENT_TYPE_LINE \
+    ((ENABLED_ELEMENT_TYPE_TRI) | (ENABLED_ELEMENT_TYPE_QUAD))
 
 // All enabled element types
-#define OGS_ENABLED_ELEMENTS \
-    ( (ENABLED_ELEMENT_TYPE_SIMPLEX) \
-    | (ENABLED_ELEMENT_TYPE_CUBOID ) \
-    | (ENABLED_ELEMENT_TYPE_PYRAMID) \
-    | (ENABLED_ELEMENT_TYPE_PRISM  ) )
-
+#define OGS_ENABLED_ELEMENTS                                          \
+    ((ENABLED_ELEMENT_TYPE_SIMPLEX) | (ENABLED_ELEMENT_TYPE_CUBOID) | \
+     (ENABLED_ELEMENT_TYPE_PYRAMID) | (ENABLED_ELEMENT_TYPE_PRISM))
 
 // Include only what is needed (Well, the conditions are not sharp).
 #if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_LINE) != 0
@@ -114,7 +113,6 @@ static_assert(false, "The macro OGS_MAX_ELEMENT_ORDER is undefined.");
 
 namespace ProcessLib
 {
-
 /// The LocalDataInitializer is a functor creating a local assembler data with
 /// corresponding to the mesh element type shape functions and calling
 /// initialization of the new local assembler data.
@@ -128,176 +126,172 @@ class LocalDataInitializer final
 public:
     using LADataIntfPtr = std::unique_ptr<LocalAssemblerInterface>;
 
-    LocalDataInitializer(
-        NumLib::LocalToGlobalIndexMap const& dof_table,
-        const unsigned shapefunction_order)
+    LocalDataInitializer(NumLib::LocalToGlobalIndexMap const& dof_table,
+                         const unsigned shapefunction_order)
         : _dof_table(dof_table)
     {
         if (shapefunction_order < 1 || 2 < shapefunction_order)
-            OGS_FATAL("The given shape function order %d is not supported", shapefunction_order);
+            OGS_FATAL("The given shape function order %d is not supported",
+                      shapefunction_order);
 
         if (shapefunction_order == 1)
         {
-        // /// Lines and points ///////////////////////////////////
+// /// Lines and points ///////////////////////////////////
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_LINE) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 0 && OGS_MAX_ELEMENT_ORDER >= 1
-        _builder[std::type_index(typeid(MeshLib::Point))] =
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_LINE) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 0 && OGS_MAX_ELEMENT_ORDER >= 1
+            _builder[std::type_index(typeid(MeshLib::Point))] =
                 makeLocalAssemblerBuilder<NumLib::ShapePoint1>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_LINE) != 0 \
-        && OGS_MAX_ELEMENT_DIM >= 1 && OGS_MAX_ELEMENT_ORDER >= 1
-        _builder[std::type_index(typeid(MeshLib::Line))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeLine2>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_LINE) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 1 && OGS_MAX_ELEMENT_ORDER >= 1
+            _builder[std::type_index(typeid(MeshLib::Line))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeLine2>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_LINE) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 1 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Line3))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeLine2>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_LINE) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 1 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Line3))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeLine2>();
 #endif
 
-        // /// Quads and Hexahedra ///////////////////////////////////
+// /// Quads and Hexahedra ///////////////////////////////////
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 1
-        _builder[std::type_index(typeid(MeshLib::Quad))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeQuad4>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 1
+            _builder[std::type_index(typeid(MeshLib::Quad))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeQuad4>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_CUBOID) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
-        _builder[std::type_index(typeid(MeshLib::Hex))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeHex8>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_CUBOID) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
+            _builder[std::type_index(typeid(MeshLib::Hex))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeHex8>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Quad8))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeQuad4>();
-        _builder[std::type_index(typeid(MeshLib::Quad9))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeQuad4>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Quad8))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeQuad4>();
+            _builder[std::type_index(typeid(MeshLib::Quad9))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeQuad4>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_CUBOID) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Hex20))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeHex8>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_CUBOID) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Hex20))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeHex8>();
 #endif
 
-        // /// Simplices ////////////////////////////////////////////////
+// /// Simplices ////////////////////////////////////////////////
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 1
-        _builder[std::type_index(typeid(MeshLib::Tri))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeTri3>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 1
+            _builder[std::type_index(typeid(MeshLib::Tri))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeTri3>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_SIMPLEX) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
-        _builder[std::type_index(typeid(MeshLib::Tet))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeTet4>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_SIMPLEX) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
+            _builder[std::type_index(typeid(MeshLib::Tet))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeTet4>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Tri6))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeTri3>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Tri6))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeTri3>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_SIMPLEX) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Tet10))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeTet4>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_SIMPLEX) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Tet10))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeTet4>();
 #endif
 
-        // /// Prisms ////////////////////////////////////////////////////
+// /// Prisms ////////////////////////////////////////////////////
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PRISM) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
-        _builder[std::type_index(typeid(MeshLib::Prism))] =
-            makeLocalAssemblerBuilder<NumLib::ShapePrism6>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PRISM) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
+            _builder[std::type_index(typeid(MeshLib::Prism))] =
+                makeLocalAssemblerBuilder<NumLib::ShapePrism6>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PRISM) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Prism15))] =
-            makeLocalAssemblerBuilder<NumLib::ShapePrism6>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PRISM) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Prism15))] =
+                makeLocalAssemblerBuilder<NumLib::ShapePrism6>();
 #endif
 
-        // /// Pyramids //////////////////////////////////////////////////
+// /// Pyramids //////////////////////////////////////////////////
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PYRAMID) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
-        _builder[std::type_index(typeid(MeshLib::Pyramid))] =
-            makeLocalAssemblerBuilder<NumLib::ShapePyra5>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PYRAMID) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 1
+            _builder[std::type_index(typeid(MeshLib::Pyramid))] =
+                makeLocalAssemblerBuilder<NumLib::ShapePyra5>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PYRAMID) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Pyramid13))] =
-            makeLocalAssemblerBuilder<NumLib::ShapePyra5>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PYRAMID) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Pyramid13))] =
+                makeLocalAssemblerBuilder<NumLib::ShapePyra5>();
 #endif
-
         }
         else if (shapefunction_order == 2)
         {
-            // /// Lines and points ///////////////////////////////////
+// /// Lines and points ///////////////////////////////////
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_LINE) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 1 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Line3))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeLine3>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_LINE) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 1 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Line3))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeLine3>();
 #endif
 
+// /// Quads and Hexahedra ///////////////////////////////////
 
-            // /// Quads and Hexahedra ///////////////////////////////////
-
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Quad8))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeQuad8>();
-        _builder[std::type_index(typeid(MeshLib::Quad9))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeQuad9>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_QUAD) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Quad8))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeQuad8>();
+            _builder[std::type_index(typeid(MeshLib::Quad9))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeQuad9>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_CUBOID) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Hex20))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeHex20>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_CUBOID) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Hex20))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeHex20>();
 #endif
 
+// /// Simplices ////////////////////////////////////////////////
 
-            // /// Simplices ////////////////////////////////////////////////
-
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Tri6))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeTri6>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_TRI) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 2 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Tri6))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeTri6>();
 #endif
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_SIMPLEX) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Tet10))] =
-            makeLocalAssemblerBuilder<NumLib::ShapeTet10>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_SIMPLEX) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Tet10))] =
+                makeLocalAssemblerBuilder<NumLib::ShapeTet10>();
 #endif
 
+// /// Prisms ////////////////////////////////////////////////////
 
-            // /// Prisms ////////////////////////////////////////////////////
-
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PRISM) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Prism15))] =
-            makeLocalAssemblerBuilder<NumLib::ShapePrism15>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PRISM) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Prism15))] =
+                makeLocalAssemblerBuilder<NumLib::ShapePrism15>();
 #endif
 
-            // /// Pyramids //////////////////////////////////////////////////
+// /// Pyramids //////////////////////////////////////////////////
 
-#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PYRAMID) != 0 \
-    && OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
-        _builder[std::type_index(typeid(MeshLib::Pyramid13))] =
-            makeLocalAssemblerBuilder<NumLib::ShapePyra13>();
+#if (OGS_ENABLED_ELEMENTS & ENABLED_ELEMENT_TYPE_PYRAMID) != 0 && \
+    OGS_MAX_ELEMENT_DIM >= 3 && OGS_MAX_ELEMENT_ORDER >= 2
+            _builder[std::type_index(typeid(MeshLib::Pyramid13))] =
+                makeLocalAssemblerBuilder<NumLib::ShapePyra13>();
 #endif
         }
     }
@@ -307,36 +301,40 @@ public:
     /// \attention
     /// The index \c id is not necessarily the mesh item's id. Especially when
     /// having multiple meshes it will differ from the latter.
-    void operator()(
-            std::size_t const id,
-            MeshLib::Element const& mesh_item,
-            LADataIntfPtr& data_ptr,
-            ConstructorArgs&&... args) const
+    void operator()(std::size_t const id,
+                    MeshLib::Element const& mesh_item,
+                    LADataIntfPtr& data_ptr,
+                    ConstructorArgs&&... args) const
     {
         auto const type_idx = std::type_index(typeid(mesh_item));
         auto const it = _builder.find(type_idx);
 
-        if (it != _builder.end()) {
+        if (it != _builder.end())
+        {
             auto const num_local_dof = _dof_table.getNumberOfElementDOF(id);
             data_ptr = it->second(mesh_item, num_local_dof,
                                   std::forward<ConstructorArgs>(args)...);
-        } else {
-            OGS_FATAL("You are trying to build a local assembler for an unknown mesh element type (%s)."
-                " Maybe you have disabled this mesh element type in your build configuration.",
+        }
+        else
+        {
+            OGS_FATAL(
+                "You are trying to build a local assembler for an unknown mesh "
+                "element type (%s)."
+                " Maybe you have disabled this mesh element type in your build "
+                "configuration.",
                 type_idx.name());
         }
     }
 
 private:
-    using LADataBuilder = std::function<LADataIntfPtr(
-            MeshLib::Element const& e,
-            std::size_t const local_matrix_size,
-            ConstructorArgs&&...
-        )>;
+    using LADataBuilder =
+        std::function<LADataIntfPtr(MeshLib::Element const& e,
+                                    std::size_t const local_matrix_size,
+                                    ConstructorArgs&&...)>;
 
     template <typename ShapeFunction>
     using IntegrationMethod = typename NumLib::GaussIntegrationPolicy<
-                typename ShapeFunction::MeshElement>::IntegrationMethod;
+        typename ShapeFunction::MeshElement>::IntegrationMethod;
 
     template <typename ShapeFunction>
     using LAData =
@@ -362,8 +360,7 @@ private:
     NumLib::LocalToGlobalIndexMap const& _dof_table;
 };
 
-}   // namespace ProcessLib
-
+}  // namespace ProcessLib
 
 #undef ENABLED_ELEMENT_TYPE_SIMPLEX
 #undef ENABLED_ELEMENT_TYPE_CUBOID

--- a/ProcessLib/Utils/LocalDataInitializer.h
+++ b/ProcessLib/Utils/LocalDataInitializer.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <typeindex>
 #include <typeinfo>
+#include <type_traits>
 #include <unordered_map>
 
 #include "MeshLib/Elements/Elements.h"
@@ -341,38 +342,48 @@ private:
         LocalAssemblerData<ShapeFunction, IntegrationMethod<ShapeFunction>,
                            GlobalDim>;
 
+    /// A helper forwarding to the correct version of makeLocalAssemblerBuilder
+    /// depending whether the global dimension is less than the shape function's
+    /// dimension or not.
+    template <typename ShapeFunction>
+    static LADataBuilder makeLocalAssemblerBuilder()
+    {
+        return makeLocalAssemblerBuilder<ShapeFunction>(
+            static_cast<std::integral_constant<
+                bool, (GlobalDim >= ShapeFunction::DIM)>*>(nullptr));
+    }
+
+
+    /// Mapping of element types to local assembler constructors.
+    std::unordered_map<std::type_index, LADataBuilder> _builder;
+
+    NumLib::LocalToGlobalIndexMap const& _dof_table;
+
+    // local assembler builder implementations.
+private:
     /// Generates a function that creates a new LocalAssembler of type
-    /// LAData<ShapeFct>. Only functions with shape function's dimension less or
-    /// equal to the global dimension are instantiated, e.g. following
+    /// LAData<ShapeFunction>. Only functions with shape function's dimension
+    /// less or equal to the global dimension are instantiated, e.g.  following
     /// combinations of shape functions and global dimensions: (Line2, 1),
     /// (Line2, 2), (Line2, 3), (Hex20, 3) but not (Hex20, 2) or (Hex20, 1).
-    template <typename ShapeFct>
-    static
-        typename std::enable_if<GlobalDim >= ShapeFct::DIM, LADataBuilder>::type
-        makeLocalAssemblerBuilder()
+    template <typename ShapeFunction>
+    static LADataBuilder makeLocalAssemblerBuilder(std::true_type*)
     {
         return [](MeshLib::Element const& e,
                   std::size_t const local_matrix_size,
                   ConstructorArgs&&... args) {
-            return LADataIntfPtr{new LAData<ShapeFct>{
+            return LADataIntfPtr{new LAData<ShapeFunction>{
                 e, local_matrix_size, std::forward<ConstructorArgs>(args)...}};
         };
     }
 
     /// Returns nullptr for shape functions whose dimensions are less than the
     /// global dimension.
-    template <typename ShapeFct>
-        static
-        typename std::enable_if < GlobalDim<ShapeFct::DIM, LADataBuilder>::type
-                                  makeLocalAssemblerBuilder()
+    template <typename ShapeFunction>
+    static LADataBuilder makeLocalAssemblerBuilder(std::false_type*)
     {
         return nullptr;
     }
-
-    /// Mapping of element types to local assembler constructors.
-    std::unordered_map<std::type_index, LADataBuilder> _builder;
-
-    NumLib::LocalToGlobalIndexMap const& _dof_table;
 };
 
 }  // namespace ProcessLib


### PR DESCRIPTION
As of now the local assemblers were instantiated for example for Hex8 and GlobalDim=1, 2, 3, but the dimensions 1 and 2 do not make any sense. These are excluded from the instantiation.
For Line3 still all GlobalDims are used.

See for example output of `nm -C bin/ogs | grep Hex8 | grep GroundwaterFlow::LocalAssemblerData | grep assemble`

There exist a computer s.t. the compilation took before and after (in Release, with fixed size matrices, clang-4.0 and LTO):
CCACHE_DISABLE=1 make -j5  1135.72s user 31.24s system 400% cpu 4:51.06 total
CCACHE_DISABLE=1 make -j5  1047.01s user 28.57s system 413% cpu 4:20.00 total
so around 8% less cpu time.