### PR TITLE
[Jenkins] Keep build when commit is tag 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,8 @@
 def builders = [:]
 def helper = new ogs.helper()
 
+timestamps {
+
 builders['gcc'] = {
     node('docker') {
         dir('ogs') { checkout scm }
@@ -57,3 +59,5 @@ if (currentBuild.result == "SUCCESS" || currentBuild.result == "UNSTABLE") {
         }
     }
 }
+
+} // end timestamps

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,13 @@ node { step([$class: 'GitHubCommitStatusSetter']) }
 if (currentBuild.result == "SUCCESS" || currentBuild.result == "UNSTABLE") {
     if (helper.isOriginMaster(this)) {
         build job: 'OGS-6/clang-sanitizer', wait: false
-        build job: 'OGS-6/Deploy', wait: false
+        node('master') {
+            checkout scm
+            def tag = helper.getTag()
+            if (tag != "") {
+                keepBuild()
+                currentBuild.displayName = tag
+            }
+        }
     }
 }

--- a/scripts/jenkins/deploy.groovy
+++ b/scripts/jenkins/deploy.groovy
@@ -6,16 +6,25 @@ node {
             fingerprintArtifacts: true, flatten: true,
             projectName: 'OGS-6/ufz/master',
             selector: [$class: 'LastCompletedBuildSelector']])
-            s3upload('*')
+            if (gitTag == "")
+                s3upload('*')
+            else
+                s3upload('*', "opengeosys/ogs6-releases/${gitTag}")
         build job: 'OGS-6/Deploy-Post', wait: false
     }
 }
 
-def s3upload(files) {
+def s3upload(files, bucket = null) {
+    def managed = false
+    if (bucket == null) {
+        managed = true
+        bucket = 'opengeosys'
+    }
+
     step([$class: 'S3BucketPublisher',
         dontWaitForConcurrentBuildCompletion: true, entries:
-        [[bucket: 'opengeosys', excludedFile: '', flatten: true, gzipFiles: false,
-            managedArtifacts: true, noUploadOnFailure: true, selectedRegion: 'eu-central-1',
+        [[bucket: "${bucket}", excludedFile: '', flatten: true, gzipFiles: false,
+            managedArtifacts: managed, noUploadOnFailure: true, selectedRegion: 'eu-central-1',
             sourceFile: "${files}", storageClass: 'STANDARD', uploadFromSlave: true,
             useServerSideEncryption: false]], profileName: 'S3 UFZ', userMetadata: []])
 }


### PR DESCRIPTION
As we now have a publicly accessible Jenkins we can now host OGS binaries directly on Jenkins (before they were hosted on Amazon S3). This will also make the Deploy-jobs obsolete.

I also added useful output of timestamps in the Jenkins build log.

TODO after merge:

- [ ] Dynamically construct download links of binaries on docs.opengeosys.org by using Jenkins REST API
- [ ] Delete / remove Deploy-jobs