### PR TITLE
[CMake] set the default OGS_LOG_LEVEL to debug also in release build

### DIFF
--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -61,7 +61,11 @@ int main(int argc, char *argv[])
         "l", "log-level",
         "the verbosity of logging messages: none, error, warn, info, debug, all",
         false,
+#ifdef NDEBUG
+        "info",
+#else
         "all",
+#endif
         "log level");
     cmd.add(log_level_arg);
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,15 @@ option(EIGEN_NO_DEBUG "Disables Eigen's assertions" OFF)
 
 # Logging
 option(OGS_DISABLE_LOGGING "Disables all logog messages." OFF)
+set(OGS_LOG_LEVEL "LOGOG_LEVEL_DEBUG" CACHE STRING "Set logging level included in compilation.")
+set_property(CACHE OGS_LOG_LEVEL PROPERTY STRINGS
+    LOGOG_LEVEL_NONE
+    LOGOG_LEVEL_ERROR
+    LOGOG_LEVEL_WARN
+    LOGOG_LEVEL_INFO
+    LOGOG_LEVEL_DEBUG
+    LOGOG_LEVEL_ALL
+)
 
 # Debug
 option(OGS_FATAL_ABORT "Abort in OGS_FATAL" OFF)
@@ -165,6 +174,13 @@ if(OGS_BUILD_TESTS)
     set(Data_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Tests/Data CACHE INTERNAL "")
     set(Data_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/Tests/Data CACHE INTERNAL "")
 endif()
+
+# Logging level
+if(OGS_DISABLE_LOGGING)
+    set(OGS_LOG_LEVEL LOGOG_LEVEL_NONE)
+endif()
+add_definitions(-DLOGOG_LEVEL=${OGS_LOG_LEVEL})
+
 
 ######################
 ### Subdirectories ###

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,6 @@ option(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES "Use dynamically allocated shape matrice
 option(EIGEN_NO_DEBUG "Disables Eigen's assertions" OFF)
 
 # Logging
-option(OGS_DISABLE_LOGGING "Disables all logog messages." OFF)
 set(OGS_LOG_LEVEL "LOGOG_LEVEL_DEBUG" CACHE STRING "Set logging level included in compilation.")
 set_property(CACHE OGS_LOG_LEVEL PROPERTY STRINGS
     LOGOG_LEVEL_NONE
@@ -176,9 +175,6 @@ if(OGS_BUILD_TESTS)
 endif()
 
 # Logging level
-if(OGS_DISABLE_LOGGING)
-    set(OGS_LOG_LEVEL LOGOG_LEVEL_NONE)
-endif()
 add_definitions(-DLOGOG_LEVEL=${OGS_LOG_LEVEL})
 
 

--- a/scripts/cmake/ProjectSetup.cmake
+++ b/scripts/cmake/ProjectSetup.cmake
@@ -9,21 +9,6 @@ endif()
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 
-# Logging level
-if(OGS_DISABLE_LOGGING)
-    set(OGS_LOG_LEVEL LOGOG_LEVEL_NONE)
-endif()
-
-if(NOT DEFINED OGS_LOG_LEVEL)
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        add_definitions(-DLOGOG_LEVEL=LOGOG_LEVEL_DEBUG)
-    else()
-        add_definitions(-DLOGOG_LEVEL=LOGOG_LEVEL_INFO)
-    endif() # CMAKE_BUILD_TYPE = Debug
-else()
-    add_definitions(-DLOGOG_LEVEL=${OGS_LOG_LEVEL})
-endif() # NOT DEFINED OGS_LOG_LEVEL
-
 # Enable Visual Studio project folder grouping
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 


### PR DESCRIPTION
This PR suggests  
- to change the default compilation logog level in release builds from info to debug
- to change the default runtime logog level in release builds from all to info 

IMO the default setting should be configured for normal users who download the OGS executable from the website. With current setting, users cannot see debug messages even if they set the runtime logog level with `-l debug`. This also helps us/developers to support users because we can ask them to run ogs with debug level to get detailed logs and we don't need to run it by ourselves (of course, sometimes it's not enough).

