### PR TITLE
Tiny change

### DIFF
--- a/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
@@ -81,8 +81,8 @@ struct HydroMechanicsProcessData
     Parameter<double> const& porosity;
     Parameter<double> const& solid_density;
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
-    double dt;
-    double t;
+    double dt = 0.0;
+    double t = 0.0;
 };
 
 }  // namespace HydroMechanics

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -160,7 +160,7 @@ public:
 
         for (unsigned ip = 0; ip < n_integration_points; ip++)
         {
-            _ip_data.emplace_back(*_process_data._material);
+            _ip_data.emplace_back(*_process_data.material);
             auto& ip_data = _ip_data[ip];
             auto const& sm = shape_matrices[ip];
             ip_data._detJ = sm.detJ;

--- a/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
@@ -45,8 +45,8 @@ struct SmallDeformationProcessData
 
     std::unique_ptr<MaterialLib::Solids::MechanicsBase<DisplacementDim>>
         _material;
-    double dt;
-    double t;
+    double dt = 0;
+    double t = 0;
 };
 
 }  // namespace SmallDeformation

--- a/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
@@ -25,12 +25,12 @@ struct SmallDeformationProcessData
     SmallDeformationProcessData(
         std::unique_ptr<MaterialLib::Solids::MechanicsBase<DisplacementDim>>&&
             material)
-        : _material{std::move(material)}
+        : material{std::move(material)}
     {
     }
 
     SmallDeformationProcessData(SmallDeformationProcessData&& other)
-        : _material{std::move(other._material)}
+        : material{std::move(other.material)}
     {
     }
 
@@ -44,7 +44,7 @@ struct SmallDeformationProcessData
     void operator=(SmallDeformationProcessData&&) = delete;
 
     std::unique_ptr<MaterialLib::Solids::MechanicsBase<DisplacementDim>>
-        _material;
+        material;
     double dt = 0;
     double t = 0;
 };

--- a/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
@@ -30,7 +30,7 @@ struct SmallDeformationProcessData
     }
 
     SmallDeformationProcessData(SmallDeformationProcessData&& other)
-        : material{std::move(other.material)}
+        : material{std::move(other.material)}, dt{other.dt}, t{other.t}
     {
     }
 


### PR DESCRIPTION
fixes an uninitialized warning

A similar change would be sensible for SmallDeformationProcessData. Furthermore there the naming of members is inconsistent: _material, t, dt.