### PR TITLE
LIE/HM part 3: Local assembler implementations

### DIFF
--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
@@ -1,0 +1,314 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_FRACTURE_IMPL_H_
+#define PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_FRACTURE_IMPL_H_
+
+#include "HydroMechanicsLocalAssemblerFracture.h"
+
+#include "MaterialLib/FractureModels/FractureIdentity2.h"
+
+#include "ProcessLib/Utils/InitShapeMatrices.h"
+
+#include "ProcessLib/LIE/Common/LevelSetFunction.h"
+
+
+namespace ProcessLib
+{
+namespace LIE
+{
+namespace HydroMechanics
+{
+template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
+          typename IntegrationMethod, unsigned GlobalDim>
+HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
+                                     ShapeFunctionPressure, IntegrationMethod,
+                                     GlobalDim>::
+    HydroMechanicsLocalAssemblerFracture(
+        MeshLib::Element const& e,
+        std::size_t const /*local_matrix_size*/,
+        std::vector<unsigned> const& dofIndex_to_localIndex,
+        bool const is_axially_symmetric,
+        unsigned const integration_order,
+        HydroMechanicsProcessData<GlobalDim>& process_data)
+    : HydroMechanicsLocalAssemblerInterface(
+          e,
+          ShapeFunctionDisplacement::NPOINTS * GlobalDim + ShapeFunctionPressure::NPOINTS,
+          dofIndex_to_localIndex),
+      _process_data(process_data)
+{
+    assert(e.getDimension() == GlobalDim-1);
+
+    IntegrationMethod integration_method(integration_order);
+    unsigned const n_integration_points =
+        integration_method.getNumberOfPoints();
+
+    _ip_data.reserve(n_integration_points);
+
+    auto const shape_matrices_u =
+        initShapeMatrices<ShapeFunctionDisplacement, ShapeMatricesTypeDisplacement,
+                          IntegrationMethod, GlobalDim>(
+                e, is_axially_symmetric, integration_method);
+
+    auto const shape_matrices_p =
+        initShapeMatrices<ShapeFunctionPressure, ShapeMatricesTypePressure,
+                          IntegrationMethod, GlobalDim>(
+                e, is_axially_symmetric, integration_method);
+
+    auto const* frac_prop = _process_data.fracture_property.get();
+
+    SpatialPosition x_position;
+    x_position.setElementID(e.getID());
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        x_position.setIntegrationPoint(ip);
+
+        _ip_data.emplace_back(*_process_data.fracture_model);
+        auto const& sm_u = shape_matrices_u[ip];
+        auto const& sm_p = shape_matrices_p[ip];
+        auto& ip_data = _ip_data[ip];
+        ip_data.integration_weight =
+            sm_u.detJ * sm_u.integralMeasure *
+            integration_method.getWeightedPoint(ip).getWeight();
+
+        ip_data.H_u.resize(GlobalDim,
+                           ShapeFunctionDisplacement::NPOINTS * GlobalDim);
+        computeHMatrix<
+            GlobalDim, ShapeFunctionDisplacement::NPOINTS,
+            typename ShapeMatricesTypeDisplacement::NodalRowVectorType, HMatrixType>(
+            sm_u.N, ip_data.H_u);
+        ip_data.N_p = sm_p.N;
+        ip_data.dNdx_p = sm_p.dNdx;
+
+        ip_data.w.resize(GlobalDim);
+        ip_data.w_prev.resize(GlobalDim);
+        ip_data.sigma_eff.resize(GlobalDim);
+        ip_data.sigma_eff_prev.resize(GlobalDim);
+        ip_data.C.resize(GlobalDim, GlobalDim);
+        ip_data.aperture0 = (*frac_prop->aperture0)(0, x_position)[0];
+        ip_data.aperture = ip_data.aperture0;
+
+        auto const initial_effective_stress = _process_data.initial_fracture_effective_stress(0, x_position);
+        for (unsigned i=0; i<GlobalDim; i++)
+        {
+            ip_data.sigma_eff[i] = initial_effective_stress[i];
+            ip_data.sigma_eff_prev[i] = initial_effective_stress[i];
+        }
+    }
+}
+
+
+template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
+          typename IntegrationMethod, unsigned GlobalDim>
+void
+HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
+                                     ShapeFunctionPressure, IntegrationMethod,
+                                     GlobalDim>::
+assembleWithJacobianConcrete(
+    double const t,
+    Eigen::VectorXd const& local_x,
+    Eigen::VectorXd const& local_xdot,
+    Eigen::VectorXd& local_b,
+    Eigen::MatrixXd& local_J)
+{
+    auto const p = local_x.segment(pressure_index, pressure_size);
+    auto const p_dot = local_xdot.segment(pressure_index, pressure_size);
+    auto const g = local_x.segment(displacement_index, displacement_size);
+    auto const g_dot = local_xdot.segment(displacement_index, displacement_size);
+
+    auto rhs_p = local_b.segment(pressure_index, pressure_size);
+    auto rhs_g = local_b.segment(displacement_index, displacement_size);
+    auto J_pp = local_J.block(pressure_index, pressure_index, pressure_size,
+                              pressure_size);
+    auto J_pg = local_J.block(pressure_index, displacement_index, pressure_size,
+                              displacement_size);
+    auto J_gp = local_J.block(displacement_index, pressure_index,
+                              displacement_size, pressure_size);
+    auto J_gg = local_J.block(displacement_index, displacement_index,
+                              displacement_size, displacement_size);
+
+    assembleBlockMatricesWithJacobian(t, p, p_dot, g, g_dot, rhs_p, rhs_g, J_pp, J_pg, J_gg, J_gp);
+}
+
+
+template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
+          typename IntegrationMethod, unsigned GlobalDim>
+void HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
+                                          ShapeFunctionPressure,
+                                          IntegrationMethod, GlobalDim>::
+assembleBlockMatricesWithJacobian(
+    double const t,
+    Eigen::Ref<const Eigen::VectorXd> const& nodal_p,
+    Eigen::Ref<const Eigen::VectorXd> const& nodal_p_dot,
+    Eigen::Ref<const Eigen::VectorXd> const& nodal_g,
+    Eigen::Ref<const Eigen::VectorXd> const& nodal_g_dot,
+    Eigen::Ref<Eigen::VectorXd> rhs_p,
+    Eigen::Ref<Eigen::VectorXd> rhs_g,
+    Eigen::Ref<Eigen::MatrixXd> J_pp,
+    Eigen::Ref<Eigen::MatrixXd> J_pg,
+    Eigen::Ref<Eigen::MatrixXd> J_gg,
+    Eigen::Ref<Eigen::MatrixXd> J_gp)
+{
+    FractureProperty const& frac_prop = *_process_data.fracture_property;
+    auto const& R = frac_prop.R;
+    double const& dt = _process_data.dt;
+
+    // the index of a normal (normal to a fracture plane) component
+    // in a displacement vector
+    auto const index_normal = GlobalDim - 1;
+
+    typename ShapeMatricesTypePressure::NodalMatrixType laplace_p;
+    laplace_p.setZero(pressure_size, pressure_size);
+
+    typename ShapeMatricesTypePressure::NodalMatrixType storage_p;
+    storage_p.setZero(pressure_size, pressure_size);
+
+    typename ShapeMatricesTypeDisplacement::template MatrixType<
+        displacement_size, pressure_size>
+        Kgp;
+    Kgp.setZero(displacement_size, pressure_size);
+
+    using GlobalDimMatrix = Eigen::Matrix<double, GlobalDim, GlobalDim>;
+    using GlobalDimVector = Eigen::Matrix<double, GlobalDim, 1>;
+    GlobalDimMatrix local_k_tensor;
+    local_k_tensor.setZero();
+    GlobalDimMatrix local_dk_db_tensor;
+    local_dk_db_tensor.setZero();
+
+    SpatialPosition x_position;
+    x_position.setElementID(_element.getID());
+
+    unsigned const n_integration_points = _ip_data.size();
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        x_position.setIntegrationPoint(ip);
+
+        auto& ip_data = _ip_data[ip];
+        auto const& ip_w = ip_data.integration_weight;
+        auto const& N_p = ip_data.N_p;
+        auto const& dNdx_p = ip_data.dNdx_p;
+        auto const& H_g = ip_data.H_u;
+        auto const& identity2 =
+            MaterialLib::Fracture::FractureIdentity2<GlobalDim>::value;
+
+        auto& mat = ip_data.fracture_material;
+        auto& effective_stress = ip_data.sigma_eff;
+        auto const& effective_stress_prev = ip_data.sigma_eff_prev;
+        auto& w = ip_data.w;
+        auto const& w_prev = ip_data.w_prev;
+        auto& C = ip_data.C;
+        auto& b = ip_data.aperture;
+        auto q = ip_data.darcy_velocity.head(GlobalDim);
+
+        double const S = (*frac_prop.specific_storage)(t, x_position)[0];
+        double const mu = _process_data.fluid_viscosity(t, x_position)[0];
+        auto const alpha = (*frac_prop.biot_coefficient)(t, x_position)[0];
+        auto const rho_fr = _process_data.fluid_density(t, x_position)[0];
+        auto const& gravity_vec = _process_data.specific_body_force;
+
+        // displacement jumps in local coordinates
+        w.noalias() = R * H_g * nodal_g;
+
+        // aperture
+        b = ip_data.aperture0 + w[index_normal];
+        if (b < 0.0)
+            OGS_FATAL("Fracture aperture is %g, but it must be non-negative.", b);
+
+        // local C, local stress
+        mat.computeConstitutiveRelation(
+                    t, x_position,
+                    w_prev, w,
+                    effective_stress_prev, effective_stress, C);
+
+        // permeability
+        double const local_k = b * b / 12;
+        ip_data.permeability = local_k;
+        local_k_tensor.diagonal().head(GlobalDim-1).setConstant(local_k);
+        GlobalDimMatrix const k = R.transpose() * local_k_tensor * R;
+
+        // derivative of permeability respect to aperture
+        double const local_dk_db = b / 6.;
+        local_dk_db_tensor.diagonal().head(GlobalDim-1).setConstant(local_dk_db);
+        GlobalDimMatrix const dk_db = R.transpose() * local_dk_db_tensor * R;
+
+        // velocity
+        GlobalDimVector const grad_head = dNdx_p * nodal_p + rho_fr * gravity_vec;
+        q.noalias() = - k / mu * grad_head;
+
+        //
+        // displacement equation, displacement jump part
+        //
+        rhs_g.noalias() -= H_g.transpose() * R.transpose() * effective_stress * ip_w;
+        J_gg.noalias() += H_g.transpose() * R.transpose() * C * R * H_g * ip_w;
+
+        //
+        // displacement equation, pressure part
+        //
+        Kgp.noalias() += H_g.transpose() * R.transpose() * alpha * identity2 * N_p * ip_w;
+
+        //
+        // pressure equation, pressure part.
+        //
+        storage_p.noalias() += N_p.transpose() * b * S * N_p * ip_w;
+        laplace_p.noalias() += dNdx_p.transpose() * b * k / mu * dNdx_p * ip_w;
+        rhs_p.noalias() += dNdx_p.transpose() * b * k / mu * rho_fr * gravity_vec * ip_w;
+
+        //
+        // pressure equation, displacement jump part.
+        //
+        Eigen::Matrix<double, 1, displacement_size> const mT_R_Hg = identity2.transpose() * R * H_g;
+        J_pg.noalias() += N_p.transpose() * S * N_p * nodal_p_dot * mT_R_Hg * ip_w;
+        J_pg.noalias() += - dNdx_p.transpose() * q * mT_R_Hg * ip_w;
+        J_pg.noalias() += - dNdx_p.transpose() * b * (- dk_db / mu * grad_head) * mT_R_Hg * ip_w;
+    }
+
+    // displacement equation, pressure part
+    J_gp.noalias() -= Kgp;
+
+    // pressure equation, pressure part.
+    J_pp.noalias() += laplace_p + storage_p / dt;
+
+    // pressure equation, displacement jump part.
+    J_pg.noalias() += Kgp.transpose() / dt;
+
+    // pressure equation
+    rhs_p.noalias() -=
+        laplace_p * nodal_p + storage_p * nodal_p_dot + Kgp.transpose() * nodal_g_dot;
+
+    // displacement equation
+    rhs_g.noalias() -= - Kgp * nodal_p;
+}
+
+
+template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
+          typename IntegrationMethod, unsigned GlobalDim>
+void
+HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
+                                     ShapeFunctionPressure, IntegrationMethod,
+                                     GlobalDim>::
+postTimestepConcrete(std::vector<double> const& /*local_x*/)
+{
+    double ele_b = 0;
+    double ele_k = 0;
+    for (auto const& ip : _ip_data)
+    {
+        ele_b += ip.aperture;
+        ele_k += ip.permeability;
+    }
+    ele_b /= _ip_data.size();
+    ele_k /= _ip_data.size();
+    (*_process_data.mesh_prop_b)[this->_element.getID()] = ele_b;
+    (*_process_data.mesh_prop_k_f)[this->_element.getID()] = ele_k;
+}
+
+}  // namespace HydroMechanics
+}  // namespace LIE
+}  // namespace ProcessLib
+
+#endif  // PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_FRACTURE_IMPL_H_

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
@@ -61,7 +61,7 @@ HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
                           IntegrationMethod, GlobalDim>(
                 e, is_axially_symmetric, integration_method);
 
-    auto const* frac_prop = _process_data.fracture_property.get();
+    auto const& frac_prop = *_process_data.fracture_property.get();
 
     SpatialPosition x_position;
     x_position.setElementID(e.getID());
@@ -91,7 +91,7 @@ HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
         ip_data.sigma_eff.resize(GlobalDim);
         ip_data.sigma_eff_prev.resize(GlobalDim);
         ip_data.C.resize(GlobalDim, GlobalDim);
-        ip_data.aperture0 = (*frac_prop->aperture0)(0, x_position)[0];
+        ip_data.aperture0 = (*frac_prop.aperture0)(0, x_position)[0];
         ip_data.aperture = ip_data.aperture0;
 
         auto const initial_effective_stress = _process_data.initial_fracture_effective_stress(0, x_position);

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture.h
@@ -1,0 +1,122 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_FRACTURE_H_
+#define PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_FRACTURE_H_
+
+#include <vector>
+
+#include "NumLib/Fem/ShapeMatrixPolicy.h"
+
+#include "ProcessLib/LIE/Common/HMatrixUtils.h"
+#include "ProcessLib/LIE/HydroMechanics/HydroMechanicsProcessData.h"
+
+#include "IntegrationPointDataFracture.h"
+#include "HydroMechanicsLocalAssemblerInterface.h"
+
+namespace ProcessLib
+{
+namespace LIE
+{
+namespace HydroMechanics
+{
+
+template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
+          typename IntegrationMethod, unsigned GlobalDim>
+class HydroMechanicsLocalAssemblerFracture
+    : public HydroMechanicsLocalAssemblerInterface
+{
+public:
+    HydroMechanicsLocalAssemblerFracture(HydroMechanicsLocalAssemblerFracture const&) =
+        delete;
+    HydroMechanicsLocalAssemblerFracture(HydroMechanicsLocalAssemblerFracture&&) = delete;
+
+    HydroMechanicsLocalAssemblerFracture(
+        MeshLib::Element const& e,
+        std::size_t const local_matrix_size,
+        std::vector<unsigned> const& dofIndex_to_localIndex,
+        bool const is_axially_symmetric,
+        unsigned const integration_order,
+        HydroMechanicsProcessData<GlobalDim>& process_data);
+
+    void preTimestepConcrete(std::vector<double> const& /*local_x*/,
+                             double const /*t*/,
+                             double const /*delta_t*/) override
+    {
+        for (auto &data : _ip_data)
+            data.pushBackState();
+    }
+
+    void postTimestepConcrete(std::vector<double> const& local_x) override;
+
+
+    Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
+        const unsigned integration_point) const override
+    {
+        auto const& N = _ip_data[integration_point].N_p;
+
+        // assumes N is stored contiguously in memory
+        return Eigen::Map<const Eigen::RowVectorXd>(N.data(), N.size());
+    }
+
+private:
+    void assembleWithJacobianConcrete(
+        double const t,
+        Eigen::VectorXd const& local_x,
+        Eigen::VectorXd const& local_xdot,
+        Eigen::VectorXd& local_b,
+        Eigen::MatrixXd& local_J) override;
+
+    void assembleBlockMatricesWithJacobian(
+        double const t,
+        Eigen::Ref<const Eigen::VectorXd> const& p,
+        Eigen::Ref<const Eigen::VectorXd> const& p_dot,
+        Eigen::Ref<const Eigen::VectorXd> const& g,
+        Eigen::Ref<const Eigen::VectorXd> const& g_dot,
+        Eigen::Ref<Eigen::VectorXd> rhs_p,
+        Eigen::Ref<Eigen::VectorXd> rhs_g,
+        Eigen::Ref<Eigen::MatrixXd> J_pp,
+        Eigen::Ref<Eigen::MatrixXd> J_pg,
+        Eigen::Ref<Eigen::MatrixXd> J_gg,
+        Eigen::Ref<Eigen::MatrixXd> J_gp);
+
+    // Types for displacement.
+    using ShapeMatricesTypeDisplacement =
+        ShapeMatrixPolicyType<ShapeFunctionDisplacement, GlobalDim>;
+    using HMatricesType = HMatrixPolicyType<ShapeFunctionDisplacement, GlobalDim>;
+    using HMatrixType = typename HMatricesType::HMatrixType;
+
+    // Types for pressure.
+    using ShapeMatricesTypePressure =
+        ShapeMatrixPolicyType<ShapeFunctionPressure, GlobalDim>;
+
+    // Types for the integration point data
+    using IntegrationPointDataType =
+        IntegrationPointDataFracture<HMatricesType,
+                                     ShapeMatricesTypeDisplacement,
+                                     ShapeMatricesTypePressure, GlobalDim>;
+
+    HydroMechanicsProcessData<GlobalDim>& _process_data;
+
+    std::vector<IntegrationPointDataType> _ip_data;
+
+    static const int pressure_index = 0;
+    static const int pressure_size = ShapeFunctionPressure::NPOINTS;
+    static const int displacement_index = ShapeFunctionPressure::NPOINTS;
+    static const int displacement_size =
+        ShapeFunctionDisplacement::NPOINTS * GlobalDim;
+};
+
+}  // namespace HydroMechanics
+}  // namespace LIE
+}  // namespace ProcessLib
+
+#include "HydroMechanicsLocalAssemblerFracture-impl.h"
+
+#endif  // PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_FRACTURE_H_

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerInterface.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerInterface.h
@@ -1,0 +1,114 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLERINTERFACE_H_
+#define PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLERINTERFACE_H_
+
+#include <vector>
+
+#include "BaseLib/Error.h"
+
+#include "MeshLib/Elements/Element.h"
+
+#include "NumLib/Extrapolation/ExtrapolatableElement.h"
+#include "ProcessLib/LocalAssemblerInterface.h"
+
+
+namespace ProcessLib
+{
+namespace LIE
+{
+namespace HydroMechanics
+{
+
+class HydroMechanicsLocalAssemblerInterface
+    : public ProcessLib::LocalAssemblerInterface,
+      public NumLib::ExtrapolatableElement
+{
+public:
+    HydroMechanicsLocalAssemblerInterface(
+            MeshLib::Element const& element,
+            std::size_t n_local_size,
+            std::vector<unsigned> const& dofIndex_to_localIndex)
+        : _element(element), _dofIndex_to_localIndex(dofIndex_to_localIndex)
+    {
+        _local_u.resize(n_local_size);
+        _local_udot.resize(n_local_size);
+        _local_b.resize(_local_u.size());
+        _local_J.resize(_local_u.size(), _local_u.size());
+    }
+
+    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+                  std::vector<double>& /*local_M_data*/,
+                  std::vector<double>& /*local_K_data*/,
+                  std::vector<double>& /*local_rhs_data*/) override
+    {
+        OGS_FATAL(
+            "HydroMechanicsLocalAssembler: assembly without jacobian is not "
+            "implemented.");
+    }
+
+    virtual void assembleWithJacobian(
+        double const t,
+        std::vector<double> const& local_x_,
+        std::vector<double> const& local_xdot_,
+        const double /*dxdot_dx*/, const double /*dx_dx*/,
+        std::vector<double>& /*local_M_data*/,
+        std::vector<double>& /*local_K_data*/,
+        std::vector<double>& local_b_data,
+        std::vector<double>& local_Jac_data) override
+    {
+        auto const local_dof_size = local_x_.size();
+
+        _local_u.setZero();
+        for (unsigned i=0; i<local_dof_size; i++)
+            _local_u[_dofIndex_to_localIndex[i]] = local_x_[i];
+        _local_udot.setZero();
+        for (unsigned i=0; i<local_dof_size; i++)
+            _local_udot[_dofIndex_to_localIndex[i]] = local_xdot_[i];
+        _local_b.setZero();
+        _local_J.setZero();
+
+        assembleWithJacobianConcrete(t, _local_u, _local_udot, _local_b, _local_J);
+
+        local_b_data.resize(local_dof_size);
+        for (unsigned i=0; i<local_dof_size; i++)
+             local_b_data[i] = _local_b[_dofIndex_to_localIndex[i]];
+
+        local_Jac_data.resize(local_dof_size*local_dof_size);
+         for (unsigned i=0; i<local_dof_size; i++)
+             for (unsigned j=0; j<local_dof_size; j++)
+                 local_Jac_data[i*local_dof_size + j] = _local_J(_dofIndex_to_localIndex[i],
+                                                                 _dofIndex_to_localIndex[j]);
+    }
+
+protected:
+    virtual void assembleWithJacobianConcrete(
+        double const t,
+        Eigen::VectorXd const& local_u,
+        Eigen::VectorXd const& local_udot,
+        Eigen::VectorXd& local_b,
+        Eigen::MatrixXd& local_J) = 0;
+
+
+    MeshLib::Element const& _element;
+
+private:
+    Eigen::VectorXd _local_u;
+    Eigen::VectorXd _local_udot;
+    Eigen::VectorXd _local_b;
+    Eigen::MatrixXd _local_J;
+    std::vector<unsigned> const _dofIndex_to_localIndex;
+};
+
+}  // namespace HydroMechanics
+}  // namespace LIE
+}  // namespace ProcessLib
+
+#endif  // PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLERINTERFACE_H_

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerInterface.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerInterface.h
@@ -104,6 +104,9 @@ private:
     Eigen::VectorXd _local_udot;
     Eigen::VectorXd _local_b;
     Eigen::MatrixXd _local_J;
+    // a vector for mapping the index in the local DoF vector to the index in the
+    // complete local solution vector which also include nodes where DoF are not
+    // assigned.
     std::vector<unsigned> const _dofIndex_to_localIndex;
 };
 

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
@@ -244,10 +244,6 @@ assembleBlockMatricesWithJacobian(
         storage_p.noalias() += N_p.transpose() * S * N_p * ip_w;
 
         rhs_p.noalias() += dNdx_p.transpose() * rho_fr * k_over_mu * gravity_vec * ip_w;
-
-        //
-        // pressure equation, displacement part.
-        //
     }
 
     // displacement equation, pressure part

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
@@ -287,10 +287,12 @@ postTimestepConcrete(std::vector<double> const& /*local_x*/)
     {
         ele_stress[0] += ip_data.sigma_eff[0];
         ele_stress[1] += ip_data.sigma_eff[1];
-        ele_stress[2] += ip_data.sigma_eff[3];
+        // sigma_xy
+        ele_stress[2] += ip_data.sigma_eff[3]; // sigma_eff[2] stores sigma_z
 
         ele_strain[0] += ip_data.eps[0];
         ele_strain[1] += ip_data.eps[1];
+        // strain_xy
         ele_strain[2] += ip_data.eps[3];
 
         ele_velocity += ip_data.darcy_velocity;

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
@@ -1,0 +1,317 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_MATRIX_IMPL_H_
+#define PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_MATRIX_IMPL_H_
+
+#include "HydroMechanicsLocalAssemblerMatrix.h"
+
+#include "MaterialLib/SolidModels/KelvinVector.h"
+
+#include "ProcessLib/Deformation/LinearBMatrix.h"
+#include "ProcessLib/Utils/InitShapeMatrices.h"
+
+namespace ProcessLib
+{
+namespace LIE
+{
+namespace HydroMechanics
+{
+template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
+          typename IntegrationMethod, unsigned GlobalDim>
+HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
+                                   ShapeFunctionPressure, IntegrationMethod,
+                                   GlobalDim>::
+    HydroMechanicsLocalAssemblerMatrix(
+        MeshLib::Element const& e,
+        std::size_t const n_variables,
+        std::size_t const /*local_matrix_size*/,
+        std::vector<unsigned> const& dofIndex_to_localIndex,
+        bool const is_axially_symmetric,
+        unsigned const integration_order,
+        HydroMechanicsProcessData<GlobalDim>& process_data)
+    : HydroMechanicsLocalAssemblerInterface(
+          e,
+          (n_variables - 1) * ShapeFunctionDisplacement::NPOINTS * GlobalDim +
+              ShapeFunctionPressure::NPOINTS,
+          dofIndex_to_localIndex),
+      _process_data(process_data)
+{
+    IntegrationMethod integration_method(integration_order);
+    unsigned const n_integration_points =
+        integration_method.getNumberOfPoints();
+
+    _ip_data.reserve(n_integration_points);
+
+    auto const shape_matrices_u =
+        initShapeMatrices<ShapeFunctionDisplacement, ShapeMatricesTypeDisplacement,
+                          IntegrationMethod, GlobalDim>(
+                e, is_axially_symmetric, integration_method);
+
+    auto const shape_matrices_p =
+        initShapeMatrices<ShapeFunctionPressure, ShapeMatricesTypePressure,
+                          IntegrationMethod, GlobalDim>(
+                e, is_axially_symmetric, integration_method);
+
+    SpatialPosition x_position;
+    x_position.setElementID(e.getID());
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        x_position.setIntegrationPoint(ip);
+
+        _ip_data.emplace_back(*_process_data.material);
+        auto& ip_data = _ip_data[ip];
+        auto const& sm_u = shape_matrices_u[ip];
+        auto const& sm_p = shape_matrices_p[ip];
+        ip_data.integration_weight =
+            sm_u.detJ * sm_u.integralMeasure *
+            integration_method.getWeightedPoint(ip).getWeight();
+        ip_data.b_matrices.resize(kelvin_vector_size, displacement_size);
+
+        ip_data.N_u = sm_u.N;
+        ip_data.H_u.setZero(GlobalDim, displacement_size);
+        for (unsigned i = 0; i < GlobalDim; ++i)
+            ip_data.H_u.template block<1, displacement_size / GlobalDim>(
+                   i, i * displacement_size / GlobalDim)
+                .noalias() = ip_data.N_u;
+        auto const x_coord =
+            interpolateXCoordinate<ShapeFunctionDisplacement,
+                                   ShapeMatricesTypeDisplacement>(e, sm_u.N);
+        LinearBMatrix::computeBMatrix<GlobalDim,
+                                      ShapeFunctionDisplacement::NPOINTS>(
+            sm_u.dNdx, ip_data.b_matrices, is_axially_symmetric, sm_u.N,
+            x_coord);
+
+        ip_data.N_p = sm_p.N;
+        ip_data.dNdx_p = sm_p.dNdx;
+
+        ip_data.sigma_eff.resize(kelvin_vector_size);
+        ip_data.sigma_eff_prev.resize(kelvin_vector_size);
+        ip_data.eps.resize(kelvin_vector_size);
+        ip_data.eps_prev.resize(kelvin_vector_size);
+        ip_data.C.resize(kelvin_vector_size, kelvin_vector_size);
+
+        auto const initial_effective_stress = _process_data.initial_effective_stress(0, x_position);
+        for (unsigned i=0; i<kelvin_vector_size; i++)
+        {
+            ip_data.sigma_eff[i] = initial_effective_stress[i];
+            ip_data.sigma_eff_prev[i] = initial_effective_stress[i];
+        }
+    }
+}
+
+
+template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
+          typename IntegrationMethod, unsigned GlobalDim>
+void
+HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
+                                   ShapeFunctionPressure, IntegrationMethod,
+                                   GlobalDim>::
+assembleWithJacobianConcrete(
+    double const t,
+    Eigen::VectorXd const& local_x,
+    Eigen::VectorXd const& local_x_dot,
+    Eigen::VectorXd& local_rhs,
+    Eigen::MatrixXd& local_Jac)
+{
+    auto p = local_x.segment(pressure_index, pressure_size);
+    auto p_dot = local_x_dot.segment(pressure_index, pressure_size);
+
+    auto u = local_x.segment(displacement_index, displacement_size);
+    auto u_dot = local_x_dot.segment(displacement_index, displacement_size);
+
+    auto rhs_p = local_rhs.template segment<pressure_size>(pressure_index);
+    auto rhs_u =
+        local_rhs.template segment<displacement_size>(displacement_index);
+
+    auto J_pp = local_Jac.template block<pressure_size, pressure_size>(
+        pressure_index, pressure_index);
+    auto J_pu = local_Jac.template block<pressure_size, displacement_size>(
+        pressure_index, displacement_index);
+    auto J_uu = local_Jac.template block<displacement_size, displacement_size>(
+        displacement_index, displacement_index);
+    auto J_up = local_Jac.template block<displacement_size, pressure_size>(
+        displacement_index, pressure_index);
+
+    assembleBlockMatricesWithJacobian(t, p, p_dot, u, u_dot, rhs_p, rhs_u, J_pp,
+                                      J_pu, J_uu, J_up);
+}
+
+template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
+          typename IntegrationMethod, unsigned GlobalDim>
+void
+HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
+                                   ShapeFunctionPressure, IntegrationMethod,
+                                   GlobalDim>::
+assembleBlockMatricesWithJacobian(
+    double const t,
+    Eigen::Ref<const Eigen::VectorXd> const& p,
+    Eigen::Ref<const Eigen::VectorXd> const& p_dot,
+    Eigen::Ref<const Eigen::VectorXd> const& u,
+    Eigen::Ref<const Eigen::VectorXd> const& u_dot,
+    Eigen::Ref<Eigen::VectorXd> rhs_p,
+    Eigen::Ref<Eigen::VectorXd> rhs_u,
+    Eigen::Ref<Eigen::MatrixXd> J_pp,
+    Eigen::Ref<Eigen::MatrixXd> J_pu,
+    Eigen::Ref<Eigen::MatrixXd> J_uu,
+    Eigen::Ref<Eigen::MatrixXd> J_up)
+{
+    assert (this->_element.getDimension() == GlobalDim);
+
+    typename ShapeMatricesTypePressure::NodalMatrixType laplace_p;
+    laplace_p.setZero(pressure_size, pressure_size);
+
+    typename ShapeMatricesTypePressure::NodalMatrixType storage_p;
+    storage_p.setZero(pressure_size, pressure_size);
+
+    typename ShapeMatricesTypeDisplacement::template MatrixType<
+        displacement_size, pressure_size>
+        Kup;
+    Kup.setZero(displacement_size, pressure_size);
+
+    double const& dt = _process_data.dt;
+
+    SpatialPosition x_position;
+    x_position.setElementID(_element.getID());
+
+    unsigned const n_integration_points = _ip_data.size();
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        x_position.setIntegrationPoint(ip);
+
+        auto& ip_data = _ip_data[ip];
+        auto const& ip_w = ip_data.integration_weight;
+        auto const& N_p = ip_data.N_p;
+        auto const& dNdx_p = ip_data.dNdx_p;
+        auto const& H_u = ip_data.H_u;
+
+        auto const& B = ip_data.b_matrices;
+        auto const& eps_prev = ip_data.eps_prev;
+        auto const& sigma_eff_prev = ip_data.sigma_eff_prev;
+
+        auto& eps = ip_data.eps;
+        auto& sigma_eff = ip_data.sigma_eff;
+        auto& C = ip_data.C;
+        auto& material_state_variables = *ip_data.material_state_variables;
+
+        auto q = ip_data.darcy_velocity.head(GlobalDim);
+
+        double const S =
+            _process_data.specific_storage(t, x_position)[0];
+        double const k_over_mu =
+            _process_data.intrinsic_permeability(t, x_position)[0] /
+            _process_data.fluid_viscosity(t, x_position)[0];
+        auto const alpha = _process_data.biot_coefficient(t, x_position)[0];
+        auto const rho_sr = _process_data.solid_density(t, x_position)[0];
+        auto const rho_fr = _process_data.fluid_density(t, x_position)[0];
+        auto const porosity = _process_data.porosity(t, x_position)[0];
+        auto const& gravity_vec = _process_data.specific_body_force;
+
+        double const rho = rho_sr * (1 - porosity) + porosity * rho_fr;
+        auto const& identity2 =
+            MaterialLib::SolidModels::Invariants<kelvin_vector_size>::identity2;
+
+        eps.noalias() = B * u;
+
+        if (!_ip_data[ip].solid_material.computeConstitutiveRelation(
+                t, x_position, _process_data.dt, eps_prev, eps, sigma_eff_prev,
+                sigma_eff, C, material_state_variables))
+            OGS_FATAL("Computation of local constitutive relation failed.");
+
+        q.noalias() = - k_over_mu * (dNdx_p * p + rho_fr * gravity_vec);
+
+        J_uu.noalias() += B.transpose() * C * B * ip_w;
+
+        rhs_u.noalias() -= B.transpose() * sigma_eff * ip_w;
+        rhs_u.noalias() -= - H_u.transpose() * rho * gravity_vec * ip_w;
+
+        //
+        // displacement equation, pressure part
+        //
+        Kup.noalias() += B.transpose() * alpha * identity2 * N_p * ip_w;
+
+        //
+        // pressure equation, pressure part.
+        //
+        laplace_p.noalias() += dNdx_p.transpose() * k_over_mu * dNdx_p * ip_w;
+
+        storage_p.noalias() += N_p.transpose() * S * N_p * ip_w;
+
+        rhs_p.noalias() += dNdx_p.transpose() * rho_fr * k_over_mu * gravity_vec * ip_w;
+
+        //
+        // pressure equation, displacement part.
+        //
+    }
+
+    // displacement equation, pressure part
+    J_up.noalias() -= Kup;
+
+    // pressure equation, pressure part.
+    J_pp.noalias() += laplace_p + storage_p / dt;
+
+    // pressure equation, displacement part.
+    J_pu.noalias() += Kup.transpose() / dt;
+
+    // pressure equation
+    rhs_p.noalias() -=
+        laplace_p * p + storage_p * p_dot + Kup.transpose() * u_dot;
+
+    // displacement equation
+    rhs_u.noalias() -= - Kup * p;
+}
+
+
+template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
+          typename IntegrationMethod, unsigned GlobalDim>
+void
+HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
+                                   ShapeFunctionPressure, IntegrationMethod,
+                                   GlobalDim>::
+postTimestepConcrete(std::vector<double> const& /*local_x*/)
+{
+    Eigen::Vector3d ele_stress;
+    ele_stress.setZero();
+    Eigen::Vector3d ele_strain;
+    ele_strain.setZero();
+    Eigen::Vector3d ele_velocity;
+    ele_velocity.setZero();
+
+    for (auto const& ip_data : _ip_data)
+    {
+        ele_stress[0] += ip_data.sigma_eff[0];
+        ele_stress[1] += ip_data.sigma_eff[1];
+        ele_stress[2] += ip_data.sigma_eff[3];
+
+        ele_strain[0] += ip_data.eps[0];
+        ele_strain[1] += ip_data.eps[1];
+        ele_strain[2] += ip_data.eps[3];
+
+        ele_velocity += ip_data.darcy_velocity;
+    }
+
+    ele_stress /= _ip_data.size();
+    ele_strain /= _ip_data.size();
+    ele_velocity /= _ip_data.size();
+
+    (*_process_data.mesh_prop_stress_xx)[_element.getID()] = ele_stress[0];
+    (*_process_data.mesh_prop_stress_yy)[_element.getID()] = ele_stress[1];
+    (*_process_data.mesh_prop_stress_xy)[_element.getID()] = ele_stress[2];
+    (*_process_data.mesh_prop_strain_xx)[_element.getID()] = ele_strain[0];
+    (*_process_data.mesh_prop_strain_yy)[_element.getID()] = ele_strain[1];
+    (*_process_data.mesh_prop_strain_xy)[_element.getID()] = ele_strain[2];
+    for (unsigned i=0; i<3; i++)
+        (*_process_data.mesh_prop_velocity)[_element.getID()*3 + i] = ele_velocity[i];
+}
+
+}  // namespace HydroMechanics
+}  // namespace LIE
+}  // namespace ProcessLib
+
+#endif  // PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_MATRIX_IMPL_H_

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix.h
@@ -1,0 +1,125 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_MATRIX_H_
+#define PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_MATRIX_H_
+
+#include <vector>
+
+#include "NumLib/Fem/ShapeMatrixPolicy.h"
+#include "ProcessLib/Deformation/BMatrixPolicy.h"
+
+#include "ProcessLib/LIE/HydroMechanics/HydroMechanicsProcessData.h"
+
+#include "HydroMechanicsLocalAssemblerInterface.h"
+#include "IntegrationPointDataMatrix.h"
+
+namespace ProcessLib
+{
+namespace LIE
+{
+namespace HydroMechanics
+{
+
+template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
+          typename IntegrationMethod, unsigned GlobalDim>
+class HydroMechanicsLocalAssemblerMatrix
+    : public HydroMechanicsLocalAssemblerInterface
+{
+public:
+    HydroMechanicsLocalAssemblerMatrix(HydroMechanicsLocalAssemblerMatrix const&) =
+        delete;
+    HydroMechanicsLocalAssemblerMatrix(HydroMechanicsLocalAssemblerMatrix&&) = delete;
+
+    HydroMechanicsLocalAssemblerMatrix(
+            MeshLib::Element const& e,
+            std::size_t const n_variables,
+            std::size_t const local_matrix_size,
+            std::vector<unsigned> const& dofIndex_to_localIndex,
+            bool const is_axially_symmetric,
+            unsigned const integration_order,
+            HydroMechanicsProcessData<GlobalDim>& process_data);
+
+    void preTimestepConcrete(std::vector<double> const& /*local_x*/,
+                             double const /*t*/,
+                             double const /*delta_t*/) override
+    {
+        for (auto &data : _ip_data)
+            data.pushBackState();
+    }
+
+    void postTimestepConcrete(std::vector<double> const& local_x) override;
+
+    Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
+        const unsigned integration_point) const override
+    {
+        auto const& N = _ip_data[integration_point].N_u;
+
+        // assumes N is stored contiguously in memory
+        return Eigen::Map<const Eigen::RowVectorXd>(N.data(), N.size());
+    }
+
+protected:
+    virtual void assembleWithJacobianConcrete(
+        double const t,
+        Eigen::VectorXd const& local_x,
+        Eigen::VectorXd const& local_x_dot,
+        Eigen::VectorXd& local_rhs,
+        Eigen::MatrixXd& local_Jac) override;
+
+    void assembleBlockMatricesWithJacobian(
+        double const t,
+        Eigen::Ref<const Eigen::VectorXd> const& p,
+        Eigen::Ref<const Eigen::VectorXd> const& p_dot,
+        Eigen::Ref<const Eigen::VectorXd> const& u,
+        Eigen::Ref<const Eigen::VectorXd> const& u_dot,
+        Eigen::Ref<Eigen::VectorXd> rhs_p,
+        Eigen::Ref<Eigen::VectorXd> rhs_u,
+        Eigen::Ref<Eigen::MatrixXd> J_pp,
+        Eigen::Ref<Eigen::MatrixXd> J_pu,
+        Eigen::Ref<Eigen::MatrixXd> J_uu,
+        Eigen::Ref<Eigen::MatrixXd> J_up);
+
+    // Types for displacement.
+    using ShapeMatricesTypeDisplacement =
+        ShapeMatrixPolicyType<ShapeFunctionDisplacement, GlobalDim>;
+    using BMatricesType =
+        BMatrixPolicyType<ShapeFunctionDisplacement, GlobalDim>;
+
+    // Types for pressure.
+    using ShapeMatricesTypePressure =
+        ShapeMatrixPolicyType<ShapeFunctionPressure, GlobalDim>;
+
+    using IntegrationPointDataType =
+        IntegrationPointDataMatrix<BMatricesType,
+                                   ShapeMatricesTypeDisplacement,
+                                   ShapeMatricesTypePressure,
+                                   GlobalDim,
+                                   ShapeFunctionDisplacement::NPOINTS>;
+
+    HydroMechanicsProcessData<GlobalDim>& _process_data;
+
+    std::vector<IntegrationPointDataType> _ip_data;
+
+    static const int pressure_index = 0;
+    static const int pressure_size = ShapeFunctionPressure::NPOINTS;
+    static const int displacement_index = ShapeFunctionPressure::NPOINTS;
+    static const int displacement_size =
+        ShapeFunctionDisplacement::NPOINTS * GlobalDim;
+    static const int kelvin_vector_size =
+        KelvinVectorDimensions<GlobalDim>::value;
+};
+
+}  // namespace HydroMechanics
+}  // namespace LIE
+}  // namespace ProcessLib
+
+#include "HydroMechanicsLocalAssemblerMatrix-impl.h"
+
+#endif  // PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_MATRIX_H_

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture-impl.h
@@ -1,0 +1,124 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_MATRIX_NEAR_FRACTUER_IMPL_H_
+#define PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_MATRIX_NEAR_FRACTUER_IMPL_H_
+
+#include "HydroMechanicsLocalAssemblerMatrixNearFracture.h"
+
+namespace ProcessLib
+{
+namespace LIE
+{
+namespace HydroMechanics
+{
+template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
+          typename IntegrationMethod, unsigned GlobalDim>
+HydroMechanicsLocalAssemblerMatrixNearFracture<
+    ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
+    GlobalDim>::
+    HydroMechanicsLocalAssemblerMatrixNearFracture(
+        MeshLib::Element const& e,
+        std::size_t const n_variables,
+        std::size_t const local_matrix_size,
+        std::vector<unsigned> const& dofIndex_to_localIndex,
+        bool const is_axially_symmetric,
+        unsigned const integration_order,
+        HydroMechanicsProcessData<GlobalDim>& process_data)
+    : HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
+                                         ShapeFunctionPressure,
+                                         IntegrationMethod, GlobalDim>(
+          e, n_variables, local_matrix_size, dofIndex_to_localIndex,
+          is_axially_symmetric, integration_order, process_data)
+{
+}
+
+
+template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
+          typename IntegrationMethod, unsigned GlobalDim>
+void
+HydroMechanicsLocalAssemblerMatrixNearFracture<
+    ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
+    GlobalDim>::
+assembleWithJacobianConcrete(
+    double const t,
+    Eigen::VectorXd const& local_x,
+    Eigen::VectorXd const& local_x_dot,
+    Eigen::VectorXd& local_b,
+    Eigen::MatrixXd& local_J)
+{
+    auto const p = local_x.segment(pressure_index, pressure_size);
+    auto const p_dot = local_x_dot.segment(pressure_index, pressure_size);
+    auto const u = local_x.segment(displacement_index, displacement_size);
+    auto const u_dot =
+        local_x_dot.segment(displacement_index, displacement_size);
+
+    auto rhs_p = local_b.segment(pressure_index, pressure_size);
+    auto rhs_u = local_b.segment(displacement_index, displacement_size);
+
+    auto J_pp = local_J.block(pressure_index, pressure_index, pressure_size,
+                              pressure_size);
+    auto J_pu = local_J.block(pressure_index, displacement_index, pressure_size,
+                              displacement_size);
+    auto J_up = local_J.block(displacement_index, pressure_index,
+                              displacement_size, pressure_size);
+    auto J_uu = local_J.block(displacement_index, displacement_index,
+                              displacement_size, displacement_size);
+
+    // levelset value of the element
+    // remark: this assumes the levelset function is uniform within an element
+    auto const& fracture_props = *_process_data.fracture_property;
+    double const ele_levelset = calculateLevelSetFunction(
+        fracture_props, _element.getCenterOfGravity().getCoords());
+
+    if (ele_levelset == 0)
+    {
+        // no DoF exists for displacement jumps. do the normal assebmly
+        Base::assembleBlockMatricesWithJacobian(t, p, p_dot, u, u_dot, rhs_p, rhs_u, J_pp, J_pu, J_uu, J_up);
+        return;
+    }
+
+    // Displacement jumps should be taken into account
+
+    // compute true displacements
+    auto const g = local_x.segment(displacement_jump_index, displacement_size);
+    auto const g_dot = local_x_dot.segment(displacement_jump_index, displacement_size);
+    Eigen::VectorXd const total_u = u + ele_levelset * g;
+    Eigen::VectorXd const total_u_dot = u_dot + ele_levelset * g_dot;
+
+    // evaluate residuals and Jacobians for pressure and displacements
+    Base::assembleBlockMatricesWithJacobian(t, p, p_dot, total_u, total_u_dot, rhs_p, rhs_u, J_pp, J_pu, J_uu, J_up);
+
+    // compute residuals and Jacobians for displacement jumps
+    auto rhs_g = local_b.segment(displacement_jump_index, displacement_size);
+    auto J_pg = local_J.block(pressure_index, displacement_jump_index,
+                              pressure_size, displacement_size);
+    auto J_ug = local_J.block(displacement_index, displacement_jump_index,
+                              displacement_size, displacement_size);
+    auto J_gp = local_J.block(displacement_jump_index, pressure_index,
+                              displacement_size, pressure_size);
+    auto J_gu = local_J.block(displacement_jump_index, displacement_index,
+                              displacement_size, displacement_size);
+    auto J_gg = local_J.block(displacement_jump_index, displacement_jump_index,
+                              displacement_size, displacement_size);
+
+    rhs_g = ele_levelset * rhs_u;
+    J_pg = ele_levelset * J_pu;
+    J_ug = ele_levelset * J_uu;
+    J_gp = ele_levelset * J_up;
+    J_gu = ele_levelset * J_uu;
+    J_gg = ele_levelset * ele_levelset * J_uu;
+}
+
+
+}  // namespace HydroMechanics
+}  // namespace LIE
+}  // namespace ProcessLib
+
+#endif // PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_MATRIX_NEAR_FRACTUER_IMPL_H_

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture.h
@@ -1,0 +1,81 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_MATRIX_NEAR_FRACTUER_H_
+#define PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_MATRIX_NEAR_FRACTUER_H_
+
+#include <vector>
+
+#include "HydroMechanicsLocalAssemblerMatrix.h"
+
+namespace ProcessLib
+{
+namespace LIE
+{
+namespace HydroMechanics
+{
+template <typename ShapeFunctionDisplacement,
+          typename ShapeFunctionPressure,
+          typename IntegrationMethod,
+          unsigned GlobalDim>
+class HydroMechanicsLocalAssemblerMatrixNearFracture
+    : public HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
+                                                ShapeFunctionPressure,
+                                                IntegrationMethod,
+                                                GlobalDim>
+{
+    using Base = HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
+                                                    ShapeFunctionPressure,
+                                                    IntegrationMethod,
+                                                    GlobalDim>;
+
+public:
+    HydroMechanicsLocalAssemblerMatrixNearFracture(HydroMechanicsLocalAssemblerMatrixNearFracture const&) =
+        delete;
+    HydroMechanicsLocalAssemblerMatrixNearFracture(HydroMechanicsLocalAssemblerMatrixNearFracture&&) = delete;
+
+    HydroMechanicsLocalAssemblerMatrixNearFracture(
+        MeshLib::Element const& e,
+        std::size_t const n_variables,
+        std::size_t const local_matrix_size,
+        std::vector<unsigned> const& dofIndex_to_localIndex,
+        bool const is_axially_symmetric,
+        unsigned const integration_order,
+        HydroMechanicsProcessData<GlobalDim>& process_data);
+
+private:
+    void assembleWithJacobianConcrete(
+        double const t,
+        Eigen::VectorXd const& local_u,
+        Eigen::VectorXd const& local_udot,
+        Eigen::VectorXd& local_b,
+        Eigen::MatrixXd& local_J) override;
+
+    using typename Base::ShapeMatricesTypeDisplacement;
+    using typename Base::BMatricesType;
+    using Base::_process_data;
+    using Base::_ip_data;
+    using Base::_element;
+    using Base::pressure_index;
+    using Base::pressure_size;
+    using Base::displacement_index;
+    using Base::displacement_size;
+    using Base::kelvin_vector_size;
+
+    static const int displacement_jump_index =
+        displacement_index + displacement_size;
+};
+
+}  // namespace HydroMechanics
+}  // namespace LIE
+}  // namespace ProcessLib
+
+#include "HydroMechanicsLocalAssemblerMatrixNearFracture-impl.h"
+
+#endif // PROCESSLIB_LIE_HYDROMECHANICS_HYDROMECHANICSLOCALASSEMBLER_MATRIX_H_


### PR DESCRIPTION
a part of #1535, depends on #1538

This PR focuses on local assemblers of LIE/HM for matrix elements, matrix near fracture elements, and fracture elements. 

Remarks
- `HydroMechanicsLocalAssemblerInterface` is the base class for all the three assemblers. The base class calls `assembleWithJacobianConcrete()` and the derived classes implement the virtual function.
- Major difference in the governing equations from the HydroMechanics process is the additional flow equation for fractures, which is `b S p^dot + alpha b^dot + div(-b k/mu grad(head))` where `b` is fracture aperture and `k=b^2/12`.
