### PR TITLE
Fix failing Mechanics_SDL_square_1e2_quad8_traction_topBC

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -419,7 +419,7 @@ if(NOT OGS_USE_MPI)
         EXECUTABLE_ARGS square_1e2_quad8_traction_top.prj
         WRAPPER time
         TESTER vtkdiff
-        ABSTOL 5e-16 RELTOL 1e-15
+        ABSTOL 1e-15 RELTOL 1e-15
         DIFF_DATA
         expected_square_1e2_quad8_traction_topBC_pcs_0_ts_4_t_1.000000.vtu square_1e2_quad8_traction_topBC_pcs_0_ts_4_t_1.000000.vtu displacement displacement
     )


### PR DESCRIPTION
Just checking for now.

Replace expected vtu based on a new grid with reordered nodes. -- no difference.
Relaxed the absolute tolerance to 1e-15 for displacement field comparison.