### PR TITLE
[App/CLI] set command line arguments from the environment variable

### DIFF
--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -11,6 +11,9 @@
  */
 
 #include <chrono>
+#include <cstdlib>
+#include <string>
+#include <vector>
 #include <tclap/CmdLine.h>
 
 // BaseLib
@@ -19,6 +22,7 @@
 #include "BaseLib/DateTools.h"
 #include "BaseLib/FileTools.h"
 #include "BaseLib/RunTime.h"
+#include "BaseLib/StringTools.h"
 
 #include "Applications/ApplicationsLib/LinearSolverLibrarySetup.h"
 #include "Applications/ApplicationsLib/LogogSetup.h"
@@ -30,6 +34,17 @@
 
 int main(int argc, char *argv[])
 {
+    std::vector<std::string> args;
+    args.reserve(argc);
+    for (int i=0; i<argc; i++)
+        args.emplace_back(argv[i]);
+    if (char const* env_default_arguments = std::getenv("OGS6_CLI_DEFAULT_ARGS"))
+    {
+        auto vec_str(BaseLib::splitString(env_default_arguments));
+        for (auto const& str : vec_str)
+            args.emplace_back(str);
+    }
+
     // Parse CLI arguments.
     TCLAP::CmdLine cmd("OpenGeoSys-6 software.\n"
             "Copyright (c) 2012-2016, OpenGeoSys Community "
@@ -79,7 +94,7 @@ int main(int argc, char *argv[])
         "use unbuffered standard output");
     cmd.add(unbuffered_cout_arg);
 
-    cmd.parse(argc, argv);
+    cmd.parse(args);
 
     // deactivate buffer for standard output if specified
     if (unbuffered_cout_arg.isSet())


### PR DESCRIPTION
This PR suggests configuration of the command line arguments via the environmental variable `OGS6_CLI_DEFAULT_ARGS`.  I found it useful to specify some lengthy options which are not project dependent.

My use-case is 

```bash
export OGS6_CLI_DEFAULT_ARGS="-l debug --unbuffered-std-out"
ogs test1.prj &> test1.log
ogs test2.prj &> test2.log
```
