### PR TITLE
Fix computing sparsity pattern

### DIFF
--- a/MeshLib/Elements/Utils.h
+++ b/MeshLib/Elements/Utils.h
@@ -33,7 +33,9 @@ inline std::vector<Node*> getBaseNodes(std::vector<Element*> const& elements)
                   std::back_inserter(base_nodes));
     }
 
-    BaseLib::makeVectorUnique(base_nodes);
+    BaseLib::makeVectorUnique(base_nodes, [](Node const* a, Node* b) {
+        return a->getID() < b->getID();
+    });
 
     return base_nodes;
 }

--- a/NumLib/DOF/ComputeSparsityPattern.cpp
+++ b/NumLib/DOF/ComputeSparsityPattern.cpp
@@ -53,19 +53,11 @@ GlobalSparsityPattern computeSparsityPatternNonPETSc(
     // Map adjacent mesh nodes to "adjacent global indices".
     for (std::size_t n = 0; n < mesh.getNumberOfNodes(); ++n)
     {
-        auto const& node_ids = node_adjacency_table.getAdjacentNodes(n);
-        for (auto an : node_ids)
-        {
-            auto const& row_ids = global_idcs[an];
-            auto const num_components = row_ids.size();
-            for (auto r : row_ids)
-            {
-                // Each component leads to an entry in the row.
-                // For the sparsity pattern only the number of entries are
-                // needed.
-                sparsity_pattern[r] += num_components;
-            }
-        }
+        unsigned n_connected_dof = 0;
+        for (auto an : node_adjacency_table.getAdjacentNodes(n))
+            n_connected_dof += global_idcs[an].size();
+        for (auto global_index : global_idcs[n])
+            sparsity_pattern[global_index] = n_connected_dof;
     }
 
     return sparsity_pattern;

--- a/Tests/NumLib/TestSparsityPattern.cpp
+++ b/Tests/NumLib/TestSparsityPattern.cpp
@@ -1,0 +1,135 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include <gtest/gtest.h>
+
+#include "MeshLib/Elements/Utils.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
+#include "MeshLib/MeshGenerators/QuadraticeMeshGenerator.h"
+
+#include "NumLib/DOF/LocalToGlobalIndexMap.h"
+#include "NumLib/DOF/ComputeSparsityPattern.h"
+#include "NumLib/NumericsConfig.h"
+
+
+TEST(NumLib_SparsityPattern, SingleComponentLinearMesh)
+{
+    std::unique_ptr<MeshLib::Mesh> mesh(
+        MeshLib::MeshGenerator::generateLineMesh(3u, 1.));
+    std::unique_ptr<MeshLib::MeshSubset const> nodesSubset(
+        new MeshLib::MeshSubset(*mesh, &mesh->getNodes()));
+
+    std::vector<std::unique_ptr<MeshLib::MeshSubsets>> components;
+    components.emplace_back(new MeshLib::MeshSubsets{nodesSubset.get()});
+    NumLib::LocalToGlobalIndexMap dof_map(
+                      std::move(components),
+                      NumLib::ComponentOrder::BY_COMPONENT);
+
+    GlobalSparsityPattern sp = NumLib::computeSparsityPattern(dof_map, *mesh.get());
+
+    ASSERT_EQ(4u, sp.size());
+    ASSERT_EQ(2u, sp[0]);
+    ASSERT_EQ(3u, sp[1]);
+    ASSERT_EQ(3u, sp[2]);
+    ASSERT_EQ(2u, sp[3]);
+}
+
+
+TEST(NumLib_SparsityPattern, SingleComponentQuadraticMesh)
+{
+    std::unique_ptr<MeshLib::Mesh> linear_mesh(
+        MeshLib::MeshGenerator::generateLineMesh(3u, 1.));
+    std::unique_ptr<MeshLib::Mesh> mesh(
+        MeshLib::createQuadraticOrderMesh(*linear_mesh));
+    std::unique_ptr<MeshLib::MeshSubset const> nodesSubset(
+        new MeshLib::MeshSubset(*mesh, &mesh->getNodes()));
+
+    std::vector<std::unique_ptr<MeshLib::MeshSubsets>> components;
+    components.emplace_back(new MeshLib::MeshSubsets{nodesSubset.get()});
+    NumLib::LocalToGlobalIndexMap dof_map(
+                      std::move(components),
+                      NumLib::ComponentOrder::BY_COMPONENT);
+
+    GlobalSparsityPattern sp = NumLib::computeSparsityPattern(dof_map, *mesh.get());
+
+    ASSERT_EQ(7u, sp.size());
+    ASSERT_EQ(3u, sp[0]);
+    ASSERT_EQ(5u, sp[1]);
+    ASSERT_EQ(5u, sp[2]);
+    ASSERT_EQ(3u, sp[3]);
+    ASSERT_EQ(3u, sp[4]);
+    ASSERT_EQ(3u, sp[5]);
+    ASSERT_EQ(3u, sp[6]);
+}
+
+
+TEST(NumLib_SparsityPattern, MultipleComponentsLinearMesh)
+{
+    std::unique_ptr<MeshLib::Mesh> mesh(
+        MeshLib::MeshGenerator::generateLineMesh(3u, 1.));
+    std::unique_ptr<MeshLib::MeshSubset const> nodesSubset(
+        new MeshLib::MeshSubset(*mesh, &mesh->getNodes()));
+
+    std::vector<std::unique_ptr<MeshLib::MeshSubsets>> components;
+    components.emplace_back(new MeshLib::MeshSubsets{nodesSubset.get()});
+    components.emplace_back(new MeshLib::MeshSubsets{nodesSubset.get()});
+    NumLib::LocalToGlobalIndexMap dof_map(
+                      std::move(components),
+                      NumLib::ComponentOrder::BY_COMPONENT);
+
+    GlobalSparsityPattern sp = NumLib::computeSparsityPattern(dof_map, *mesh.get());
+
+    ASSERT_EQ(8u, sp.size());
+    for (int i=0; i<2; i++)
+    {
+        ASSERT_EQ(4u, sp[i*mesh->getNumberOfNodes() + 0]);
+        ASSERT_EQ(6u, sp[i*mesh->getNumberOfNodes() + 1]);
+        ASSERT_EQ(6u, sp[i*mesh->getNumberOfNodes() + 2]);
+        ASSERT_EQ(4u, sp[i*mesh->getNumberOfNodes() + 3]);
+    }
+}
+
+
+TEST(NumLib_SparsityPattern, MultipleComponentsLinearQuadraticMesh)
+{
+    std::unique_ptr<MeshLib::Mesh> linear_mesh(
+        MeshLib::MeshGenerator::generateLineMesh(3u, 1.));
+    std::unique_ptr<MeshLib::Mesh> mesh(
+        MeshLib::createQuadraticOrderMesh(*linear_mesh));
+    auto base_nodes = MeshLib::getBaseNodes(mesh->getElements());
+    std::unique_ptr<MeshLib::MeshSubset const> baseNodesSubset(
+        new MeshLib::MeshSubset(*mesh, &base_nodes));
+    std::unique_ptr<MeshLib::MeshSubset const> allNodesSubset(
+        new MeshLib::MeshSubset(*mesh, &mesh->getNodes()));
+
+    std::vector<std::unique_ptr<MeshLib::MeshSubsets>> components;
+    components.emplace_back(new MeshLib::MeshSubsets{baseNodesSubset.get()});
+    components.emplace_back(new MeshLib::MeshSubsets{allNodesSubset.get()});
+    NumLib::LocalToGlobalIndexMap dof_map(
+                      std::move(components),
+                      NumLib::ComponentOrder::BY_COMPONENT);
+
+    GlobalSparsityPattern sp = NumLib::computeSparsityPattern(dof_map, *mesh.get());
+
+    ASSERT_EQ(11u, sp.size());
+    // 1st component
+    ASSERT_EQ(5u, sp[0]);
+    ASSERT_EQ(8u, sp[1]);
+    ASSERT_EQ(8u, sp[2]);
+    ASSERT_EQ(5u, sp[3]);
+    // 2nd component
+    ASSERT_EQ(5u, sp[4]);
+    ASSERT_EQ(8u, sp[5]);
+    ASSERT_EQ(8u, sp[6]);
+    ASSERT_EQ(5u, sp[7]);
+    ASSERT_EQ(5u, sp[8]);
+    ASSERT_EQ(5u, sp[9]);
+    ASSERT_EQ(5u, sp[10]);
+}
+

--- a/Tests/NumLib/TestSparsityPattern.cpp
+++ b/Tests/NumLib/TestSparsityPattern.cpp
@@ -34,10 +34,10 @@ TEST(NumLib_SparsityPattern, SingleComponentLinearMesh)
     GlobalSparsityPattern sp = NumLib::computeSparsityPattern(dof_map, *mesh.get());
 
     ASSERT_EQ(4u, sp.size());
-    ASSERT_EQ(2u, sp[0]);
-    ASSERT_EQ(3u, sp[1]);
-    ASSERT_EQ(3u, sp[2]);
-    ASSERT_EQ(2u, sp[3]);
+    EXPECT_EQ(2u, sp[0]);
+    EXPECT_EQ(3u, sp[1]);
+    EXPECT_EQ(3u, sp[2]);
+    EXPECT_EQ(2u, sp[3]);
 }
 
 
@@ -59,13 +59,13 @@ TEST(NumLib_SparsityPattern, SingleComponentQuadraticMesh)
     GlobalSparsityPattern sp = NumLib::computeSparsityPattern(dof_map, *mesh.get());
 
     ASSERT_EQ(7u, sp.size());
-    ASSERT_EQ(3u, sp[0]);
-    ASSERT_EQ(5u, sp[1]);
-    ASSERT_EQ(5u, sp[2]);
-    ASSERT_EQ(3u, sp[3]);
-    ASSERT_EQ(3u, sp[4]);
-    ASSERT_EQ(3u, sp[5]);
-    ASSERT_EQ(3u, sp[6]);
+    EXPECT_EQ(3u, sp[0]);
+    EXPECT_EQ(5u, sp[1]);
+    EXPECT_EQ(5u, sp[2]);
+    EXPECT_EQ(3u, sp[3]);
+    EXPECT_EQ(3u, sp[4]);
+    EXPECT_EQ(3u, sp[5]);
+    EXPECT_EQ(3u, sp[6]);
 }
 
 
@@ -88,10 +88,10 @@ TEST(NumLib_SparsityPattern, MultipleComponentsLinearMesh)
     ASSERT_EQ(8u, sp.size());
     for (int i=0; i<2; i++)
     {
-        ASSERT_EQ(4u, sp[i*mesh->getNumberOfNodes() + 0]);
-        ASSERT_EQ(6u, sp[i*mesh->getNumberOfNodes() + 1]);
-        ASSERT_EQ(6u, sp[i*mesh->getNumberOfNodes() + 2]);
-        ASSERT_EQ(4u, sp[i*mesh->getNumberOfNodes() + 3]);
+        EXPECT_EQ(4u, sp[i*mesh->getNumberOfNodes() + 0]);
+        EXPECT_EQ(6u, sp[i*mesh->getNumberOfNodes() + 1]);
+        EXPECT_EQ(6u, sp[i*mesh->getNumberOfNodes() + 2]);
+        EXPECT_EQ(4u, sp[i*mesh->getNumberOfNodes() + 3]);
     }
 }
 
@@ -119,17 +119,17 @@ TEST(NumLib_SparsityPattern, MultipleComponentsLinearQuadraticMesh)
 
     ASSERT_EQ(11u, sp.size());
     // 1st component
-    ASSERT_EQ(5u, sp[0]);
-    ASSERT_EQ(8u, sp[1]);
-    ASSERT_EQ(8u, sp[2]);
-    ASSERT_EQ(5u, sp[3]);
+    EXPECT_EQ(5u, sp[0]);
+    EXPECT_EQ(8u, sp[1]);
+    EXPECT_EQ(8u, sp[2]);
+    EXPECT_EQ(5u, sp[3]);
     // 2nd component
-    ASSERT_EQ(5u, sp[4]);
-    ASSERT_EQ(8u, sp[5]);
-    ASSERT_EQ(8u, sp[6]);
-    ASSERT_EQ(5u, sp[7]);
-    ASSERT_EQ(5u, sp[8]);
-    ASSERT_EQ(5u, sp[9]);
-    ASSERT_EQ(5u, sp[10]);
+    EXPECT_EQ(5u, sp[4]);
+    EXPECT_EQ(8u, sp[5]);
+    EXPECT_EQ(8u, sp[6]);
+    EXPECT_EQ(5u, sp[7]);
+    EXPECT_EQ(5u, sp[8]);
+    EXPECT_EQ(5u, sp[9]);
+    EXPECT_EQ(5u, sp[10]);
 }
 


### PR DESCRIPTION
`computeSparsityPatternNonPETSc()` is computing a wrong sparsity pattern if a process uses multiple variables with linear and quadratic order nodes, e.g. Hydromechanics. 

