### PR TITLE
New tool: convertToLinearMesh

### DIFF
--- a/Applications/Utils/MeshEdit/CMakeLists.txt
+++ b/Applications/Utils/MeshEdit/CMakeLists.txt
@@ -85,6 +85,10 @@ add_executable(createQuadraticeMesh createQuadraticeMesh.cpp )
 target_link_libraries(createQuadraticeMesh MeshLib)
 set_target_properties(createQuadraticeMesh PROPERTIES FOLDER Utilities)
 
+add_executable(convertToLinearMesh convertToLinearMesh.cpp )
+target_link_libraries(convertToLinearMesh MeshLib)
+set_target_properties(convertToLinearMesh PROPERTIES FOLDER Utilities)
+
 ####################
 ### Installation ###
 ####################

--- a/Applications/Utils/MeshEdit/convertToLinearMesh.cpp
+++ b/Applications/Utils/MeshEdit/convertToLinearMesh.cpp
@@ -1,0 +1,55 @@
+/**
+ * @copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ *
+ */
+
+#include <memory>
+#include <string>
+
+#include <tclap/CmdLine.h>
+
+#include "Applications/ApplicationsLib/LogogSetup.h"
+
+#include "BaseLib/BuildInfo.h"
+
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshEditing/ConvertToLinearMesh.h"
+
+#include "MeshLib/IO/readMeshFromFile.h"
+#include "MeshLib/IO/writeMeshToFile.h"
+
+
+int main(int argc, char *argv[])
+{
+    ApplicationsLib::LogogSetup logog_setup;
+
+    TCLAP::CmdLine cmd("Convert a non-linear mesh to a linear mesh", ' ', BaseLib::BuildInfo::git_describe);
+    TCLAP::ValueArg<std::string> input_arg("i", "input-mesh-file","input mesh file",true,"","string");
+    cmd.add( input_arg );
+    TCLAP::ValueArg<std::string> output_arg("o", "output-mesh-file","output mesh file",true,"","string");
+    cmd.add( output_arg );
+
+    cmd.parse( argc, argv );
+
+    std::unique_ptr<MeshLib::Mesh> mesh(
+        MeshLib::IO::readMeshFromFile(input_arg.getValue()));
+    if (!mesh)
+        return EXIT_FAILURE;
+    if (!mesh->isNonlinear())
+    {
+        ERR("The input mesh is not non-linear. Exit.");
+        return EXIT_FAILURE;
+    }
+
+    INFO("Converting to a linear order mesh");
+    std::unique_ptr<MeshLib::Mesh> new_mesh(MeshLib::convertToLinearMesh(*mesh, mesh->getName()+"_linear"));
+
+    INFO("Save the new mesh into a file");
+    MeshLib::IO::writeMeshToFile(*new_mesh, output_arg.getValue());
+
+    return EXIT_SUCCESS;
+}

--- a/MeshLib/MeshEditing/ConvertToLinearMesh.cpp
+++ b/MeshLib/MeshEditing/ConvertToLinearMesh.cpp
@@ -1,0 +1,107 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "ConvertToLinearMesh.h"
+
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/Elements/Line.h"
+#include "MeshLib/Elements/Quad.h"
+#include "MeshLib/Elements/Utils.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshEditing/DuplicateMeshComponents.h"
+#include "MeshLib/Node.h"
+#include "MeshLib/Properties.h"
+#include "MeshLib/PropertyVector.h"
+
+
+namespace MeshLib
+{
+
+namespace
+{
+
+template <typename T_ELEMENT>
+T_ELEMENT* createLinearElement(MeshLib::Element const* e,
+                  std::vector<MeshLib::Node*> const& vec_new_nodes)
+{
+    auto const n_base_nodes = T_ELEMENT::n_base_nodes;
+    MeshLib::Node** nodes = new MeshLib::Node*[n_base_nodes];
+    for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++)
+        nodes[i] = const_cast<MeshLib::Node*>(vec_new_nodes[e->getNode(i)->getID()]);
+    return new T_ELEMENT(nodes);
+}
+
+} // unnamed namespace
+
+
+std::unique_ptr<MeshLib::Mesh> convertToLinearMesh(MeshLib::Mesh const& org_mesh, std::string const& new_mesh_name)
+{
+    std::vector<MeshLib::Node*> vec_new_nodes = MeshLib::copyNodeVector(MeshLib::getBaseNodes(org_mesh.getElements()));
+
+    // create new elements with the quadratic nodes
+    std::vector<MeshLib::Element*> vec_new_eles;
+    for (MeshLib::Element const* e : org_mesh.getElements())
+    {
+        if (e->getCellType() == MeshLib::CellType::LINE3)
+        {
+            vec_new_eles.push_back(createLinearElement<MeshLib::Line>(
+                e, vec_new_nodes));
+        }
+        else if (e->getCellType() == MeshLib::CellType::QUAD8)
+        {
+            vec_new_eles.push_back(createLinearElement<MeshLib::Quad>(
+                e, vec_new_nodes));
+        }
+        else
+        {
+            OGS_FATAL("Mesh element type %s is not supported", MeshLib::CellType2String(e->getCellType()).c_str());
+        }
+    }
+
+    std::unique_ptr<MeshLib::Mesh> new_mesh(
+        new MeshLib::Mesh(new_mesh_name, vec_new_nodes, vec_new_eles,
+                          org_mesh.getProperties().excludeCopyProperties(
+                              std::vector<MeshLib::MeshItemType>(
+                                  1, MeshLib::MeshItemType::Node))));
+
+    MeshLib::Properties const& src_properties = org_mesh.getProperties();
+    for (auto name : src_properties.getPropertyVectorNames())
+    {
+        auto const* src_prop = src_properties.getPropertyVector<double>(name);
+        if (!src_prop)
+            continue;
+        if (src_prop->getMeshItemType() != MeshLib::MeshItemType::Node)
+            continue;
+
+        auto const n_src_comp = src_prop->getNumberOfComponents();
+        // convert 2D vector to 3D. Otherwise Paraview Calculator filter does not recognize
+        // it as a vector
+        auto const n_dest_comp = (n_src_comp==2) ? 3 : n_src_comp;
+
+        auto new_prop =
+            new_mesh->getProperties().createNewPropertyVector<double>(
+                name, MeshLib::MeshItemType::Node, n_dest_comp);
+        new_prop->resize(new_mesh->getNumberOfNodes() * n_dest_comp);
+
+        // copy existing
+        for (unsigned i=0; i<org_mesh.getNumberOfBaseNodes(); i++)
+        {
+            for (unsigned j=0; j<n_src_comp; j++)
+                (*new_prop)[i*n_dest_comp+j] = (*src_prop)[i*n_src_comp+j];
+            // set zero for components not existing in the original
+            for (unsigned j=n_src_comp; j<n_dest_comp; j++)
+                (*new_prop)[i*n_dest_comp+j] = 0;
+        }
+    }
+
+    return new_mesh;
+}
+
+} // end namespace MeshLib
+

--- a/MeshLib/MeshEditing/ConvertToLinearMesh.h
+++ b/MeshLib/MeshEditing/ConvertToLinearMesh.h
@@ -13,10 +13,13 @@
 #include <memory>
 #include <string>
 
+#include "MeshLib/Mesh.h"
+
 namespace MeshLib
 {
-class Mesh;
 
+/// Converts a non-linear mesh to a linear meash. All the mesh properties will
+/// be copied except for entries for non-linear nodes.
 std::unique_ptr<MeshLib::Mesh> convertToLinearMesh(
     const MeshLib::Mesh& mesh, const std::string& new_mesh_name);
 

--- a/MeshLib/MeshEditing/ConvertToLinearMesh.h
+++ b/MeshLib/MeshEditing/ConvertToLinearMesh.h
@@ -18,7 +18,7 @@
 namespace MeshLib
 {
 
-/// Converts a non-linear mesh to a linear meash. All the mesh properties will
+/// Converts a non-linear mesh to a linear mesh. All the mesh properties will
 /// be copied except for entries for non-linear nodes.
 std::unique_ptr<MeshLib::Mesh> convertToLinearMesh(
     const MeshLib::Mesh& mesh, const std::string& new_mesh_name);

--- a/MeshLib/MeshEditing/ConvertToLinearMesh.h
+++ b/MeshLib/MeshEditing/ConvertToLinearMesh.h
@@ -1,0 +1,25 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#ifndef MESHLIB_CONVERRTTOLINEARMESH_H_
+#define MESHLIB_CONVERRTTOLINEARMESH_H_
+
+#include <memory>
+#include <string>
+
+namespace MeshLib
+{
+class Mesh;
+
+std::unique_ptr<MeshLib::Mesh> convertToLinearMesh(
+    const MeshLib::Mesh& mesh, const std::string& new_mesh_name);
+
+} // end namespace MeshLib
+
+#endif //MESHLIB_CONVERRTTOLINEARMESH_H_


### PR DESCRIPTION
This PR adds the new tool `convertToLinearMesh` which will convert a nonlinear mesh to a linear mesh while keeping property values for base nodes. 