### PR TITLE
Extend postLIE

### DIFF
--- a/Applications/Utils/MeshEdit/CMakeLists.txt
+++ b/Applications/Utils/MeshEdit/CMakeLists.txt
@@ -96,6 +96,7 @@ install(TARGETS
     AddTopLayer
     appendLinesAlongPolyline
     checkMesh
+    convertToLinearMesh
     CreateBoundaryConditionsAlongPolylines
     createLayeredMeshFromRasters
     createQuadraticeMesh

--- a/Applications/Utils/PostProcessing/CMakeLists.txt
+++ b/Applications/Utils/PostProcessing/CMakeLists.txt
@@ -4,3 +4,11 @@ target_link_libraries(postLIE MeshLib ProcessLib)
 ADD_VTK_DEPENDENCY(postLIE)
 set_target_properties(postLIE PROPERTIES FOLDER Utilities)
 
+####################
+### Installation ###
+####################
+install(TARGETS
+    postLIE
+    RUNTIME DESTINATION bin
+    COMPONENT Utilities
+)

--- a/Applications/Utils/PostProcessing/postLIE.cpp
+++ b/Applications/Utils/PostProcessing/postLIE.cpp
@@ -102,7 +102,7 @@ int main (int argc, char* argv[])
 {
     ApplicationsLib::LogogSetup logog_setup;
 
-    TCLAP::CmdLine cmd("Postp-process results of the LIE approach",
+    TCLAP::CmdLine cmd("Post-process results of the LIE approach",
                        ' ', "0.1");
     TCLAP::ValueArg<std::string> arg_out_file("o", "output-file",
                                           "the name of the new PVD or VTU file", true,

--- a/Applications/Utils/PostProcessing/postLIE.cpp
+++ b/Applications/Utils/PostProcessing/postLIE.cpp
@@ -23,6 +23,7 @@
 #include "MeshLib/IO/writeMeshToFile.h"
 
 #include "MeshLib/Mesh.h"
+#include "MeshLib/MeshEditing/ConvertToLinearMesh.h"
 
 #include "ProcessLib/LIE/Common/MeshUtils.h"
 #include "ProcessLib/LIE/Common/PostUtils.h"
@@ -69,6 +70,8 @@ int main (int argc, char* argv[])
 
         std::unique_ptr<MeshLib::Mesh const> mesh(
             MeshLib::IO::readMeshFromFile(org_vtu_filepath));
+        if (mesh->isNonlinear())
+            mesh = MeshLib::convertToLinearMesh(*mesh, mesh->getName());
 
         // post-process
         std::vector<MeshLib::Element*> vec_matrix_elements;

--- a/Applications/Utils/PostProcessing/postLIE.cpp
+++ b/Applications/Utils/PostProcessing/postLIE.cpp
@@ -60,10 +60,15 @@ int main (int argc, char* argv[])
 
         // read VTU with simulation results
         auto const org_vtu_filename = dataset.second.get<std::string>("<xmlattr>.file");
-        INFO("processing %s...", (in_pvd_file_dir + org_vtu_filename).c_str());
+        auto const org_vtu_filebasename = BaseLib::extractBaseName(org_vtu_filename);
+        auto org_vtu_dir = BaseLib::extractPath(org_vtu_filename);
+        if (org_vtu_dir.empty())
+            org_vtu_dir = in_pvd_file_dir;
+        auto const org_vtu_filepath = BaseLib::joinPaths(org_vtu_dir, org_vtu_filebasename);
+        INFO("processing %s...", org_vtu_filepath.c_str());
 
         std::unique_ptr<MeshLib::Mesh const> mesh(
-            MeshLib::IO::readMeshFromFile(in_pvd_file_dir + org_vtu_filename));
+            MeshLib::IO::readMeshFromFile(org_vtu_filepath));
 
         // post-process
         std::vector<MeshLib::Element*> vec_matrix_elements;
@@ -79,9 +84,10 @@ int main (int argc, char* argv[])
             *mesh, vec_fracture_nodes, vec_fracture_matrix_elements);
 
         // create a new VTU file and update XML
-        auto const dest_vtu_filename = "post_" + org_vtu_filename;
-        INFO("create %s", (out_pvd_file_dir + dest_vtu_filename).c_str());
-        MeshLib::IO::writeMeshToFile(post.getOutputMesh(), out_pvd_file_dir + dest_vtu_filename);
+        auto const dest_vtu_filename = "post_" + org_vtu_filebasename;
+        auto const dest_vtu_filepath = BaseLib::joinPaths(out_pvd_file_dir, dest_vtu_filename);
+        INFO("create %s", dest_vtu_filepath.c_str());
+        MeshLib::IO::writeMeshToFile(post.getOutputMesh(), dest_vtu_filepath);
 
         dataset.second.put("<xmlattr>.file", dest_vtu_filename);
     }

--- a/ProcessLib/LIE/Common/PostUtils.cpp
+++ b/ProcessLib/LIE/Common/PostUtils.cpp
@@ -65,7 +65,7 @@ PostProcessTool::PostProcessTool(
     }
 
     // split elements using the new duplicated nodes
-    for (unsigned fracture_id=0; fracture_id<=vec_vec_fracture_matrix_elements.size(); fracture_id++)
+    for (unsigned fracture_id=0; fracture_id<vec_vec_fracture_matrix_elements.size(); fracture_id++)
     {
         auto const& vec_fracture_matrix_elements = vec_vec_fracture_matrix_elements[fracture_id];
         auto const& vec_fracture_nodes = vec_vec_fracture_nodes[fracture_id];


### PR DESCRIPTION
follow up of #1554 

Besides ~~a bugfix~~ two bugfixes, this PR extends the post-processing tool `postLIE` to
- converting the original quadratic mesh data to the linear mesh data
- supporting VTU files in command line arguments 