### PR TITLE
[Num/DOF] don't use conservative resize in DoF table 

### DIFF
--- a/NumLib/DOF/LocalToGlobalIndexMap.cpp
+++ b/NumLib/DOF/LocalToGlobalIndexMap.cpp
@@ -37,13 +37,6 @@ LocalToGlobalIndexMap::findGlobalIndicesWithElementID(
     std::vector<MeshLib::Node*> const& nodes, std::size_t const mesh_id,
     const unsigned comp_id, const unsigned comp_id_write)
 {
-    // _rows should be resized based on an element ID
-    std::size_t max_elem_id = 0;
-    for (ElementIterator e = first; e != last; ++e)
-        max_elem_id = std::max(max_elem_id, (*e)->getID());
-    if (max_elem_id+1 > static_cast<unsigned>(_rows.rows()))
-        _rows.conservativeResize(max_elem_id + 1, _mesh_subsets.size());
-
     std::unordered_set<MeshLib::Node*> const set_nodes(nodes.begin(), nodes.end());
 
     // For each element find the global indices for node/element
@@ -161,6 +154,14 @@ LocalToGlobalIndexMap::LocalToGlobalIndexMap(
     // For all MeshSubsets and each of their MeshSubset's and each element
     // of that MeshSubset save a line of global indices.
 
+    // _rows should be resized based on an element ID
+    std::size_t max_elem_id = 0;
+    for (std::vector<MeshLib::Element*>const* eles : vec_var_elements)
+    {
+        for (auto e : *eles)
+            max_elem_id = std::max(max_elem_id, e->getID());
+    }
+    _rows.resize(max_elem_id + 1, _mesh_subsets.size());
 
     std::size_t offset = 0;
     for (int variable_id = 0; variable_id < static_cast<int>(vec_var_n_components.size());


### PR DESCRIPTION
it seems `_rows.conservativeResize()` isn't working as expected on Windows or with MSVC. I observed entries in `_rows` are overwritten after the call.  `_rows` stores `std::vector<GlobalIndex>` in `Eigen::Matrix`, and maybe `conservativeResize()` cannot work well with this data type on MSVC.  

Instead of resizing each time, I changed it to compute the size beforehand and resize it only once.