### PR TITLE
[Mat] FractureModel. Add explicit tpl declaration.

### DIFF
--- a/MaterialLib/FractureModels/FractureIdentity2.h
+++ b/MaterialLib/FractureModels/FractureIdentity2.h
@@ -27,6 +27,9 @@ struct FractureIdentity2
     static VectorType const value;
 };
 
+extern template struct FractureIdentity2<2>;
+extern template struct FractureIdentity2<3>;
+
 }  // namespace Fracture
 }  // namespace MaterialLib
 


### PR DESCRIPTION
Avoids a warning by clang-3.9, details in the commit message.
I'm not sure if this is the correct way to fix it.