### PR TITLE
Docu: Fix linked prj files containing dots.

### DIFF
--- a/scripts/doc/linked-xml-file.py
+++ b/scripts/doc/linked-xml-file.py
@@ -210,6 +210,7 @@ for (dirpath, dirnames, filenames) in os.walk(datadir, topdown=False):
             with open(outdoxfile, "w") as fh:
                 fh.write(r"""/*! \page %s %s
 
+\parblock
 <tt>
 """ % (pagename, fn))
 
@@ -222,6 +223,7 @@ for (dirpath, dirnames, filenames) in os.walk(datadir, topdown=False):
                 print_tags(xmlroot, 0, "prj", fh, None, 0, relfilepath)
 
                 fh.write(r"""</tt>
+\endparblock
 */
 """)
 


### PR DESCRIPTION
Problem reported by @endJunction .
It currently occurs e.g. in the `darcy_gravity.g` tag in https://doxygen.opengeosys.org/ogs_ctest_prj__Parabolic__LiquidFlow__AxiSymTheis__axisym_theis__prj.html
(the blank line) 

Reason for the error as far as I understand it:
The formatted XML file content is (implicitly) in the `\brief` section of `\page ogs_ctest_prj__Parabolic__LiquidFlow__AxiSymTheis__axisym_theis__prj axisym_theis.prj`.
Somehow the sequence `.<` (from the tag `<g>0.</g>`) is interpreted as "end of first sentence", i.e., also as "end of brief section". Therefore Doxygen generates an empty line at that point.
Note: In contrast strings like `1.e-6` or `mesh.vtu` don't confuse Doxygen.

Inserting `\parblock` fixed the issue on my system.