### PR TITLE
Add a model of Curve for capillary pressure saturation

### DIFF
--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/BrookCoreyCapillaryPressureSaturation.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/BrookCoreyCapillaryPressureSaturation.cpp
@@ -23,11 +23,12 @@ namespace PorousMedium
 double BrookCoreyCapillaryPressureSaturation::getCapillaryPressure(
     const double saturation) const
 {
-    const double S = MathLib::limitValueInInterval(
-        saturation, _Sr + _minor_offset, _Smax - _minor_offset);
-    const double Se = (S - _Sr) / (_Smax - _Sr);
-    const double pc = _pb * std::pow(Se, -1.0 / _mm);
-    return MathLib::limitValueInInterval(pc, _minor_offset, _Pc_max);
+    const double S =
+        MathLib::limitValueInInterval(saturation, _saturation_r + _minor_offset,
+                                      _saturation_max - _minor_offset);
+    const double Se = (S - _saturation_r) / (_saturation_max - _saturation_r);
+    const double pc = _pb * std::pow(Se, -1.0 / _m);
+    return MathLib::limitValueInInterval(pc, _minor_offset, _pc_max);
 }
 
 double BrookCoreyCapillaryPressureSaturation::getSaturation(
@@ -35,19 +36,21 @@ double BrookCoreyCapillaryPressureSaturation::getSaturation(
 {
     const double pc =
         (capillary_pressure < 0.0) ? _minor_offset : capillary_pressure;
-    const double Se = std::pow(pc / _pb, -_mm);
-    const double S = Se * (_Smax - _Sr) + _Sr;
-    return MathLib::limitValueInInterval(S, _Sr + _minor_offset,
-                                         _Smax - _minor_offset);
+    const double Se = std::pow(pc / _pb, -_m);
+    const double S = Se * (_saturation_max - _saturation_r) + _saturation_r;
+    return MathLib::limitValueInInterval(S, _saturation_r + _minor_offset,
+                                         _saturation_max - _minor_offset);
 }
 
 double BrookCoreyCapillaryPressureSaturation::getdPcdS(
     const double saturation) const
 {
-    const double S = MathLib::limitValueInInterval(
-        saturation, _Sr + _minor_offset, _Smax - _minor_offset);
-    const double val = std::pow(((S - _Sr) / (_Smax - _Sr)), -1.0 / _mm);
-    return (_pb * val) / (_mm * (_Sr - S));
+    const double S =
+        MathLib::limitValueInInterval(saturation, _saturation_r + _minor_offset,
+                                      _saturation_max - _minor_offset);
+    const double val = std::pow(
+        ((S - _saturation_r) / (_saturation_max - _saturation_r)), -1.0 / _m);
+    return (_pb * val) / (_m * (_saturation_r - S));
 }
 
 }  // end namespace

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/BrookCoreyCapillaryPressureSaturation.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/BrookCoreyCapillaryPressureSaturation.h
@@ -65,7 +65,7 @@ public:
     /// Get capillary pressure.
     double getCapillaryPressure(const double saturation) const override;
 
-    /// Get capillary pressure.
+    /// Get saturation.
     double getSaturation(const double capillary_pressure) const override;
 
     /// Get the derivative of the capillary pressure with respect to saturation
@@ -73,7 +73,7 @@ public:
 
 private:
     const double _pb;  ///< Entry pressure.
-    const double _m;  ///< Exponent (<=1.0), n=1/(1-mm).
+    const double _m;   ///< Exponent m, m>1.
 };
 
 }  // end namespace

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/BrookCoreyCapillaryPressureSaturation.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/BrookCoreyCapillaryPressureSaturation.h
@@ -52,7 +52,7 @@ public:
     BrookCoreyCapillaryPressureSaturation(const double pb, const double Sr,
                                           const double Smax, const double m,
                                           const double Pc_max)
-        : _pb(pb), _Sr(Sr), _Smax(Smax), _mm(m), _Pc_max(Pc_max)
+        : CapillaryPressureSaturation(Sr, Smax, Pc_max), _pb(pb), _m(m)
     {
     }
 
@@ -72,19 +72,8 @@ public:
     double getdPcdS(const double saturation) const override;
 
 private:
-    const double _pb;      ///< Entry pressure.
-    const double _Sr;      ///< Residual saturation.
-    const double _Smax;    ///< Maximum saturation.
-    const double _mm;      ///< Exponent (<=1.0), n=1/(1-mm).
-    const double _Pc_max;  ///< Maximum capillaray pressure
-
-    /** A small number for an offset:
-     *  1. to set the bound of S, the saturation, such that
-     *     S in  [_Sr+_minor_offset, _Smax-_minor_offset]
-     *  2. to set the bound of Pc, the capillary pressure, such that
-     *     Pc in [_minor_offset, _Pc_max]
-     */
-    const double _minor_offset = std::numeric_limits<double>::epsilon();
+    const double _pb;  ///< Entry pressure.
+    const double _m;  ///< Exponent (<=1.0), n=1/(1-mm).
 };
 
 }  // end namespace

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturation.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturation.h
@@ -22,6 +22,16 @@ namespace PorousMedium
 class CapillaryPressureSaturation
 {
 public:
+    /**
+     * @param Sr     Residual saturation, \f$ S_r \f$
+     * @param Smax   Maximum saturation, \f$ S_{\mbox{max}} \f$
+     * @param Pc_max Maximum capillary pressure, \f$ P_c^{\mbox{max}}\f$
+     */
+    CapillaryPressureSaturation(const double Sr, const double Smax,
+                                const double Pc_max)
+        : _saturation_r(Sr), _saturation_max(Smax), _pc_max(Pc_max)
+    {
+    }
     virtual ~CapillaryPressureSaturation() = default;
 
     /// Get model name.
@@ -35,6 +45,19 @@ public:
 
     /// Get the derivative of the capillary pressure with respect to saturation
     virtual double getdPcdS(const double saturation) const = 0;
+
+protected:
+    const double _saturation_r;    ///< Residual saturation.
+    const double _saturation_max;  ///< Maximum saturation.
+    const double _pc_max;          ///< Maximum capillaray pressure
+
+    /** A small number for an offset:
+     *  1. to set the bound of S, the saturation, such that
+     *     S in  [_saturation_r+_minor_offset, _saturation_max-_minor_offset]
+     *  2. to set the bound of Pc, the capillary pressure, such that
+     *     Pc in [_minor_offset, _pc_max]
+     */
+    const double _minor_offset = std::numeric_limits<double>::epsilon();
 };
 
 }  // end namespace

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturation.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturation.h
@@ -40,7 +40,7 @@ public:
     /// Get capillary pressure.
     virtual double getCapillaryPressure(const double saturation) const = 0;
 
-    /// Get capillary pressure.
+    /// Get saturation.
     virtual double getSaturation(const double capillary_ressure) const = 0;
 
     /// Get the derivative of the capillary pressure with respect to saturation

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturationCurve.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturationCurve.h
@@ -1,0 +1,82 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * \file   CapillaryPressureSaturationCurve.h
+ *
+ * Created on November 3, 2016, 9:50 AM
+ */
+
+#ifndef OGS_CAPILLARY_PRESSURE_SATURATION_CURVE_H
+#define OGS_CAPILLARY_PRESSURE_SATURATION_CURVE_H
+
+#include <memory>
+
+#include "CapillaryPressureSaturation.h"
+
+#include "MathLib/Curve/PiecewiseLinearMonotonicCurve.h"
+#include "MathLib/MathTools.h"
+
+namespace MaterialLib
+{
+namespace PorousMedium
+{
+class CapillaryPressureSaturationCurve final
+    : public CapillaryPressureSaturation
+{
+public:
+    CapillaryPressureSaturationCurve(
+        std::unique_ptr<MathLib::PiecewiseLinearMonotonicCurve>& curve_data)
+        : CapillaryPressureSaturation(
+              curve_data->getSupportMin(),
+              curve_data->getSupportMax(),
+              curve_data->getValue(curve_data->getSupportMin())),
+          _curve_data(std::move(curve_data))
+    {
+    }
+
+    /// Get model name.
+    std::string getName() const override
+    {
+        return "Capillary pressure saturation curve.";
+    }
+
+    /// Get capillary pressure.
+    double getCapillaryPressure(const double saturation) const override
+    {
+        const double S = MathLib::limitValueInInterval(
+            saturation, _saturation_r + _minor_offset,
+            _saturation_max - _minor_offset);
+
+        return _curve_data->getValue(S);
+    }
+
+    /// Get saturation.
+    double getSaturation(const double capillary_pressure) const override
+    {
+        const double pc = MathLib::limitValueInInterval(capillary_pressure,
+                                                        _minor_offset, _pc_max);
+        return _curve_data->getInversVariable(pc);
+    }
+
+    /// Get the derivative of the capillary pressure with respect to saturation
+    double getdPcdS(const double saturation) const override
+    {
+        const double S = MathLib::limitValueInInterval(
+            saturation, _saturation_r + _minor_offset,
+            _saturation_max - _minor_offset);
+
+        return _curve_data->getDerivative(S);
+    }
+
+private:
+    std::unique_ptr<MathLib::PiecewiseLinearMonotonicCurve> _curve_data;
+};
+
+}  // end namespace
+}  // end namespace
+
+#endif /* OGS_CAPILLARY_PRESSURE_SATURATION_CURVE_H */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturationCurve.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturationCurve.h
@@ -29,7 +29,7 @@ class CapillaryPressureSaturationCurve final
 {
 public:
     CapillaryPressureSaturationCurve(
-        std::unique_ptr<MathLib::PiecewiseLinearMonotonicCurve>& curve_data)
+        std::unique_ptr<MathLib::PiecewiseLinearMonotonicCurve>&& curve_data)
         : CapillaryPressureSaturation(
               curve_data->getSupportMin(),
               curve_data->getSupportMax(),

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CreateCapillaryPressureModel.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CreateCapillaryPressureModel.cpp
@@ -123,7 +123,7 @@ std::unique_ptr<CapillaryPressureSaturation> createCapillaryPressureModel(
             MathLib::PiecewiseLinearMonotonicCurve>(curve_config);
 
         return std::unique_ptr<CapillaryPressureSaturation>(
-            new CapillaryPressureSaturationCurve(curve));
+            new CapillaryPressureSaturationCurve(std::move(curve)));
     }
     else
     {

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CreateCapillaryPressureModel.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CreateCapillaryPressureModel.cpp
@@ -15,8 +15,12 @@
 #include "BaseLib/ConfigTree.h"
 #include "BaseLib/Error.h"
 
-#include "CapillaryPressureSaturation.h"
+#include "MathLib/Curve/CreatePiecewiseLinearCurve.h"
+#include "MathLib/Curve/PiecewiseLinearMonotonicCurve.h"
+
 #include "BrookCoreyCapillaryPressureSaturation.h"
+#include "CapillaryPressureSaturation.h"
+#include "CapillaryPressureSaturationCurve.h"
 #include "VanGenuchtenCapillaryPressureSaturation.h"
 
 namespace MaterialLib
@@ -31,19 +35,19 @@ namespace PorousMedium
 static std::unique_ptr<CapillaryPressureSaturation> createBrookCorey(
     BaseLib::ConfigTree const& config)
 {
-    //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__type}
+    //! \ogs_file_param{material__porous_medium__capillary_pressure__BrookCorey}
     config.checkConfigParameter("type", "BrookCorey");
 
-    //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__BrookCorey__pd}
+    //! \ogs_file_param{material__porous_medium__capillary_pressure__BrookCorey__pd}
     const double pd = config.getConfigParameter<double>("pd");
 
-    //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__BrookCorey__sr}
+    //! \ogs_file_param{material__porous_medium__capillary_pressure__BrookCorey__sr}
     const double Sr = config.getConfigParameter<double>("sr");
 
-    //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__BrookCorey__smax}
+    //! \ogs_file_param{material__porous_medium__capillary_pressure__BrookCorey__smax}
     const double Smax = config.getConfigParameter<double>("smax");
 
-    //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__BrookCorey__m}
+    //! \ogs_file_param{material__porous_medium__capillary_pressure__BrookCorey__m}
     const double m = config.getConfigParameter<double>("m");
     if (m < 1.0)  // m >= 1
     {
@@ -51,7 +55,7 @@ static std::unique_ptr<CapillaryPressureSaturation> createBrookCorey(
             "The exponent parameter of BrookCorey capillary pressure "
             "saturation model, m, must not be smaller than 1");
     }
-    //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__BrookCorey__pc_max}
+    //! \ogs_file_param{material__porous_medium__capillary_pressure__BrookCorey__pc_max}
     const double Pc_max = config.getConfigParameter<double>("pc_max");
 
     return std::unique_ptr<CapillaryPressureSaturation>(
@@ -66,19 +70,19 @@ static std::unique_ptr<CapillaryPressureSaturation> createBrookCorey(
 static std::unique_ptr<CapillaryPressureSaturation> createVanGenuchten(
     BaseLib::ConfigTree const& config)
 {
-    //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__type}
+    //! \ogs_file_param{material__porous_medium__capillary_pressure__vanGenuchten}
     config.checkConfigParameter("type", "vanGenuchten");
 
-    //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__vanGenuchten__pd}
+    //! \ogs_file_param{material__porous_medium__capillary_pressure__vanGenuchten__pd}
     const double pd = config.getConfigParameter<double>("pd");
 
-    //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__vanGenuchten__sr}
+    //! \ogs_file_param{material__porous_medium__capillary_pressure__vanGenuchten__sr}
     const double Sr = config.getConfigParameter<double>("sr");
 
-    //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__vanGenuchten__smax}
+    //! \ogs_file_param{material__porous_medium__capillary_pressure__vanGenuchten__smax}
     const double Smax = config.getConfigParameter<double>("smax");
 
-    //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__vanGenuchten__m}
+    //! \ogs_file_param{material__porous_medium__capillary_pressure__vanGenuchten__m}
     const double m = config.getConfigParameter<double>("m");
     if (m < 0. || m > 1.0)
     {
@@ -86,7 +90,7 @@ static std::unique_ptr<CapillaryPressureSaturation> createVanGenuchten(
             "The exponent parameter of van Genuchten capillary pressure "
             "saturation model, m, must be in an interval of [0, 1]");
     }
-    //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__vanGenuchten__pc_max}
+    //! \ogs_file_param{material__porous_medium__capillary_pressure__vanGenuchten__pc_max}
     const double Pc_max = config.getConfigParameter<double>("pc_max");
 
     return std::unique_ptr<CapillaryPressureSaturation>(
@@ -96,7 +100,7 @@ static std::unique_ptr<CapillaryPressureSaturation> createVanGenuchten(
 std::unique_ptr<CapillaryPressureSaturation> createCapillaryPressureModel(
     BaseLib::ConfigTree const& config)
 {
-    //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__type}
+    //! \ogs_file_param{material__porous_medium__capillary_pressure__type}
     auto const type = config.peekConfigParameter<std::string>("type");
 
     if (type == "BrookCorey")
@@ -107,11 +111,26 @@ std::unique_ptr<CapillaryPressureSaturation> createCapillaryPressureModel(
     {
         return createVanGenuchten(config);
     }
+    else if (type == "Curve")
+    {
+        //! \ogs_file_param{material__porous_medium__capillary_pressure__Curve}
+        config.checkConfigParameter("type", "Curve");
+
+        //! \ogs_file_param{material__porous_medium__capillary_pressure__Curve__curve}
+        auto const& curve_config = config.getConfigSubtree("curve");
+
+        auto curve = MathLib::createPiecewiseLinearCurve<
+            MathLib::PiecewiseLinearMonotonicCurve>(curve_config);
+
+        return std::unique_ptr<CapillaryPressureSaturation>(
+            new CapillaryPressureSaturationCurve(curve));
+    }
     else
     {
         OGS_FATAL(
-            "The capillary pressure models %s are unavailable.\n"
-            "The available types are: \n\tBrookCorey, \n\tvanGenuchten.\n",
+            "The capillary pressure saturation models %s are unavailable.\n"
+            "The available types are: \n\tBrookCorey, \n\tvanGenuchten,",
+            "\n\tCurve.\n",
             type.data());
     }
 }

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CreateCapillaryPressureModel.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CreateCapillaryPressureModel.cpp
@@ -80,7 +80,7 @@ static std::unique_ptr<CapillaryPressureSaturation> createVanGenuchten(
 
     //! \ogs_file_param{material_property__porous_medium__porous_medium__capillary_pressure__vanGenuchten__m}
     const double m = config.getConfigParameter<double>("m");
-    if (m > 1.0)  // m <= 1
+    if (m < 0. || m > 1.0)
     {
         OGS_FATAL(
             "The exponent parameter of van Genuchten capillary pressure "

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/VanGenuchtenCapillaryPressureSaturation.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/VanGenuchtenCapillaryPressureSaturation.cpp
@@ -23,34 +23,37 @@ namespace PorousMedium
 double VanGenuchtenCapillaryPressureSaturation::getCapillaryPressure(
     const double saturation) const
 {
-    const double S = MathLib::limitValueInInterval(
-        saturation, _Sr + _minor_offset, _Smax - _minor_offset);
-    const double Se = (S - _Sr) / (_Smax - _Sr);
+    const double S =
+        MathLib::limitValueInInterval(saturation, _saturation_r + _minor_offset,
+                                      _saturation_max - _minor_offset);
+    const double Se = (S - _saturation_r) / (_saturation_max - _saturation_r);
     const double pc =
-        _pb * std::pow(std::pow(Se, (-1.0 / _mm)) - 1.0, 1.0 - _mm);
-    return MathLib::limitValueInInterval(pc, _minor_offset, _Pc_max);
+        _pb * std::pow(std::pow(Se, (-1.0 / _m)) - 1.0, 1.0 - _m);
+    return MathLib::limitValueInInterval(pc, _minor_offset, _pc_max);
 }
 
 double VanGenuchtenCapillaryPressureSaturation::getSaturation(
     const double capillary_pressure) const
 {
     const double pc =
-                (capillary_pressure < 0.0) ? _minor_offset : capillary_pressure;
-    double Se = std::pow(pc / _pb, 1.0 / (1.0 - _mm)) + 1.0;
-    Se = std::pow(Se, -_mm);
-    const double S = Se * (_Smax - _Sr) + _Sr;
-    return MathLib::limitValueInInterval(S, _Sr + _minor_offset,
-                                         _Smax - _minor_offset);
+        (capillary_pressure < 0.0) ? _minor_offset : capillary_pressure;
+    double Se = std::pow(pc / _pb, 1.0 / (1.0 - _m)) + 1.0;
+    Se = std::pow(Se, -_m);
+    const double S = Se * (_saturation_max - _saturation_r) + _saturation_r;
+    return MathLib::limitValueInInterval(S, _saturation_r + _minor_offset,
+                                         _saturation_max - _minor_offset);
 }
 
 double VanGenuchtenCapillaryPressureSaturation::getdPcdS(
     const double saturation) const
 {
-    const double S = MathLib::limitValueInInterval(
-        saturation, _Sr + _minor_offset, _Smax - _minor_offset);
-    const double val1 = std::pow(((S - _Sr) / (_Smax - _Sr)), -1.0 / _mm);
-    const double val2 = std::pow(val1 - 1.0, -_mm);
-    return _pb * (_mm - 1.0) * val1 * val2 / (_mm * (S - _Sr));
+    const double S =
+        MathLib::limitValueInInterval(saturation, _saturation_r + _minor_offset,
+                                      _saturation_max - _minor_offset);
+    const double val1 = std::pow(
+        ((S - _saturation_r) / (_saturation_max - _saturation_r)), -1.0 / _m);
+    const double val2 = std::pow(val1 - 1.0, -_m);
+    return _pb * (_m - 1.0) * val1 * val2 / (_m * (S - _saturation_r));
 }
 
 }  // end namespace

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/VanGenuchtenCapillaryPressureSaturation.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/VanGenuchtenCapillaryPressureSaturation.cpp
@@ -27,8 +27,7 @@ double VanGenuchtenCapillaryPressureSaturation::getCapillaryPressure(
         MathLib::limitValueInInterval(saturation, _saturation_r + _minor_offset,
                                       _saturation_max - _minor_offset);
     const double Se = (S - _saturation_r) / (_saturation_max - _saturation_r);
-    const double pc =
-        _pb * std::pow(std::pow(Se, (-1.0 / _m)) - 1.0, 1.0 - _m);
+    const double pc = _pb * std::pow(std::pow(Se, (-1.0 / _m)) - 1.0, 1.0 - _m);
     return MathLib::limitValueInInterval(pc, _minor_offset, _pc_max);
 }
 

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/VanGenuchtenCapillaryPressureSaturation.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/VanGenuchtenCapillaryPressureSaturation.h
@@ -57,7 +57,7 @@ public:
     VanGenuchtenCapillaryPressureSaturation(const double pb, const double Sr,
                                             const double Smax, const double m,
                                             const double Pc_max)
-        : _pb(pb), _Sr(Sr), _Smax(Smax), _mm(m), _Pc_max(Pc_max)
+        : CapillaryPressureSaturation(Sr, Smax, Pc_max), _pb(pb), _m(m)
     {
     }
 
@@ -77,19 +77,8 @@ public:
     double getdPcdS(const double saturation) const override;
 
 private:
-    const double _pb;      ///< Entry pressure.
-    const double _Sr;      ///< Residual saturation.
-    const double _Smax;    ///< Maximum saturation.
-    const double _mm;      ///< Exponent (<=1.0), n=1/(1-mm).
-    const double _Pc_max;  ///< Maximum capillaray pressure
-
-    /** A small number for an offset:
-     *  1. to set the bound of S, the saturation, such that
-     *     S in  [_Sr+_minor_offset, _Smax-_minor_offset]
-     *  2. to set the bound of Pc, the capillary pressure, such that
-     *     Pc in [_minor_offset, _Pc_max]
-     */
-    const double _minor_offset = std::numeric_limits<double>::epsilon();
+    const double _pb;  ///< Entry pressure.
+    const double _m;  ///< Exponent (<=1.0), n=1/(1-mm).
 };
 
 }  // end namespace

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/VanGenuchtenCapillaryPressureSaturation.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/VanGenuchtenCapillaryPressureSaturation.h
@@ -70,7 +70,7 @@ public:
     /// Get capillary pressure.
     double getCapillaryPressure(const double saturation) const override;
 
-    /// Get capillary pressure.
+    /// Get saturation.
     double getSaturation(const double capillary_pressure) const override;
 
     /// Get the derivative of the capillary pressure with respect to saturation
@@ -78,7 +78,7 @@ public:
 
 private:
     const double _pb;  ///< Entry pressure.
-    const double _m;  ///< Exponent (<=1.0), n=1/(1-mm).
+    const double _m;   ///< Exponent m, m in [0,1]. n=1/(1-m).
 };
 
 }  // end namespace

--- a/Tests/MaterialLib/TestCapillaryPressureSaturationModel.cpp
+++ b/Tests/MaterialLib/TestCapillaryPressureSaturationModel.cpp
@@ -32,7 +32,6 @@ std::unique_ptr<CapillaryPressureSaturation> createCapillaryPressureModel(
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
                              BaseLib::ConfigTree::onwarning);
     auto const& sub_config = conf.getConfigSubtree("capillary_pressure");
-    sub_config.ignoreConfigAttribute("id");
     return MaterialLib::PorousMedium::createCapillaryPressureModel(sub_config);
 }
 
@@ -106,7 +105,7 @@ TEST(MaterialPorousMedium, checkVanGenuchtenCapillaryPressure)
 TEST(MaterialPorousMedium, checkCapillaryPressureCurve)
 {
     const char xml[] =
-        "<capillary_pressure id=\"0\">"
+        "<capillary_pressure>"
         "   <type>Curve</type>"
         "       <curve>"
         "           <coords> 0.     0.5   0.9  </coords>"


### PR DESCRIPTION
This PR:
1 adds  a model of Curve for capillary pressure saturation,
2. changes some member names starting with an underscore and followed by a capital letter,
3. moves common members of capillary pressure saturation classes to their base class,
4. corrects some documentations.