### PR TITLE
Removed one unused variable type for the fluid property

### DIFF
--- a/MaterialLib/Fluid/Density/IdealGasLaw.h
+++ b/MaterialLib/Fluid/Density/IdealGasLaw.h
@@ -43,7 +43,7 @@ public:
     double getValue(const ArrayType& var_vals) const override
     {
         return _molar_mass *
-               var_vals[static_cast<int>(PropertyVariableType::pg)] /
+               var_vals[static_cast<int>(PropertyVariableType::p)] /
                (PhysicalConstant::IdealGasConstant *
                 var_vals[static_cast<int>(PropertyVariableType::T)]);
     }
@@ -57,12 +57,12 @@ public:
                      const PropertyVariableType var) const override
     {
         const double T = var_vals[static_cast<int>(PropertyVariableType::T)];
-        const double p = var_vals[static_cast<int>(PropertyVariableType::pg)];
+        const double p = var_vals[static_cast<int>(PropertyVariableType::p)];
         switch (var)
         {
             case PropertyVariableType::T:
                 return dIdealGasLaw_dT(T, p);
-            case PropertyVariableType::pg:
+            case PropertyVariableType::p:
                 return dIdealGasLaw_dp(T, p);
             default:
                 return 0.;

--- a/MaterialLib/Fluid/Density/LiquidDensity.h
+++ b/MaterialLib/Fluid/Density/LiquidDensity.h
@@ -71,7 +71,7 @@ public:
     double getValue(const ArrayType& var_vals) const override
     {
         const double T = var_vals[static_cast<int>(PropertyVariableType::T)];
-        const double p = var_vals[static_cast<int>(PropertyVariableType::pl)];
+        const double p = var_vals[static_cast<int>(PropertyVariableType::p)];
         return _rho0 / (1. + _beta * (T - _temperature0)) /
                (1. - (p - _p0) / _bulk_modulus);
     }
@@ -85,12 +85,12 @@ public:
                      const PropertyVariableType var) const override
     {
         const double T = var_vals[static_cast<int>(PropertyVariableType::T)];
-        const double p = var_vals[static_cast<int>(PropertyVariableType::pl)];
+        const double p = var_vals[static_cast<int>(PropertyVariableType::p)];
         switch (var)
         {
             case PropertyVariableType::T:
                 return dLiquidDensity_dT(T, p);
-            case PropertyVariableType::pl:
+            case PropertyVariableType::p:
                 return dLiquidDensity_dp(T, p);
             default:
                 return 0.;

--- a/MaterialLib/Fluid/FluidProperty.h
+++ b/MaterialLib/Fluid/FluidProperty.h
@@ -23,10 +23,9 @@ namespace Fluid
 /// Variable that determine the property.
 enum class PropertyVariableType
 {
-    T = 0,   ///< temperature.
-    pl = 1,  ///< pressure of the liquid phase (1st phase for some cases).
-    pg = 2,  ///< pressure of the gas phase (2nd phase for some cases).
-    number_of_variables = 3  ///< Number of property variables.
+    T = 0,                   ///< temperature.
+    p = 1,                   ///< pressure.
+    number_of_variables = 2  ///< Number of property variables.
 };
 
 const unsigned PropertyVariableNumber =

--- a/MaterialLib/Fluid/Viscosity/LinearPressureDependentViscosity.h
+++ b/MaterialLib/Fluid/Viscosity/LinearPressureDependentViscosity.h
@@ -60,7 +60,7 @@ public:
      */
     double getValue(const ArrayType& var_vals) const override
     {
-        const double p = var_vals[static_cast<int>(PropertyVariableType::pl)];
+        const double p = var_vals[static_cast<int>(PropertyVariableType::p)];
         return _mu0 * (1 + _gamma * (p - _p0));
     }
 

--- a/MaterialLib/TwoPhaseModels/TwoPhaseFlowWithPPMaterialProperties.cpp
+++ b/MaterialLib/TwoPhaseModels/TwoPhaseFlowWithPPMaterialProperties.cpp
@@ -71,7 +71,7 @@ double TwoPhaseFlowWithPPMaterialProperties::getLiquidDensity(
 {
     ArrayType vars;
     vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
-    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::pl)] = p;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
     return _liquid_density->getValue(vars);
 }
 
@@ -80,7 +80,7 @@ double TwoPhaseFlowWithPPMaterialProperties::getGasDensity(const double p,
 {
     ArrayType vars;
     vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
-    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::pg)] = p;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
     return _gas_density->getValue(vars);
 }
 
@@ -89,17 +89,17 @@ double TwoPhaseFlowWithPPMaterialProperties::getDerivGasDensity(
 {
     ArrayType vars;
     vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
-    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::pg)] = p;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
 
     return _gas_density->getdValue(
-        vars, MaterialLib::Fluid::PropertyVariableType::pg);
+        vars, MaterialLib::Fluid::PropertyVariableType::p);
 }
 double TwoPhaseFlowWithPPMaterialProperties::getLiquidViscosity(
     const double p, const double T) const
 {
     ArrayType vars;
     vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
-    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::pl)] = p;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
     return _viscosity->getValue(vars);
 }
 
@@ -108,7 +108,7 @@ double TwoPhaseFlowWithPPMaterialProperties::getGasViscosity(
 {
     ArrayType vars;
     vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
-    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::pg)] = p;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
     return _gas_viscosity->getValue(vars);
 }
 

--- a/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.cpp
@@ -97,7 +97,7 @@ double LiquidFlowMaterialProperties::getLiquidDensity(const double p,
 {
     ArrayType vars;
     vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
-    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::pl)] = p;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
     return _liquid_density->getValue(vars);
 }
 
@@ -106,7 +106,7 @@ double LiquidFlowMaterialProperties::getViscosity(const double p,
 {
     ArrayType vars;
     vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
-    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::pl)] = p;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
     return _viscosity->getValue(vars);
 }
 
@@ -117,9 +117,9 @@ double LiquidFlowMaterialProperties::getMassCoefficient(
 {
     ArrayType vars;
     vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
-    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::pl)] = p;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
     const double drho_dp = _liquid_density->getdValue(
-        vars, MaterialLib::Fluid::PropertyVariableType::pl);
+        vars, MaterialLib::Fluid::PropertyVariableType::p);
     const double rho = _liquid_density->getValue(vars);
     assert(rho > 0.);
 

--- a/Tests/MaterialLib/TestFluidDensity.cpp
+++ b/Tests/MaterialLib/TestFluidDensity.cpp
@@ -65,7 +65,7 @@ TEST(Material, checkIdealGasLaw)
     const double p = 1.e+5;
     const double R = PhysicalConstant::IdealGasConstant;
     const double expected_air_dens = molar_air * p / (R * T);
-    ArrayType vars = {{290, 0, 1.e+5}};
+    ArrayType vars = {{290, 1.e+5}};
     ASSERT_NEAR(expected_air_dens, rho->getValue(vars), 1.e-10);
 
     const double expected_d_air_dens_dT = -molar_air * p / (R * T * T);
@@ -74,7 +74,7 @@ TEST(Material, checkIdealGasLaw)
 
     const double expected_d_air_dens_dp = molar_air / (R * T);
     ASSERT_NEAR(expected_d_air_dens_dp,
-                rho->getdValue(vars, Fluid::PropertyVariableType::pg), 1.e-10);
+                rho->getdValue(vars, Fluid::PropertyVariableType::p), 1.e-10);
 }
 
 TEST(Material, checkLinearTemperatureDependentDensity)
@@ -110,7 +110,7 @@ TEST(Material, checkLiquidDensity)
         "</density>";
     const auto rho = createTestFluidDensityModel(xml);
 
-    const ArrayType vars = {{273.15 + 60.0, 1.e+6, 0.}};
+    const ArrayType vars = {{273.15 + 60.0, 1.e+6}};
     const double T0 = 273.15;
     const double p0 = 1.e+5;
     const double rho0 = 999.8;
@@ -130,5 +130,5 @@ TEST(Material, checkLiquidDensity)
     // Test the derivative with respect to pressure.
     const double fac_p = 1. - (p - p0) / K;
     ASSERT_NEAR(rho0 / (1. + beta * (T - T0)) / (fac_p * fac_p * K),
-                rho->getdValue(vars, Fluid::PropertyVariableType::pl), 1.e-10);
+                rho->getdValue(vars, Fluid::PropertyVariableType::p), 1.e-10);
 }

--- a/Tests/MaterialLib/TestFluidViscosity.cpp
+++ b/Tests/MaterialLib/TestFluidViscosity.cpp
@@ -86,7 +86,7 @@ TEST(Material, checkLinearPressureDependentViscosity)
     ASSERT_NEAR(1.e-3 * (1. + 1.e-6 * (vars[1] - 1.e+5)), mu->getValue(vars),
                 1.e-10);
     ASSERT_NEAR(1.e-9,
-                mu->getdValue(vars, MaterialLib::Fluid::PropertyVariableType::pl),
+                mu->getdValue(vars, MaterialLib::Fluid::PropertyVariableType::p),
                 1.e-10);
 }
 


### PR DESCRIPTION
Removed MaterialLib::Fluid::FluidProperty::pg because it is unnecessary to distinguish the type of pressure, which is one of variables of  fluid property models.

This change is driven by the implementation of the IAPWS fluid properties, which will be in another PR.