### PR TITLE
Documentation of input keywords of relative permeability models

### DIFF
--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/Curve/c_Curve.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/Curve/c_Curve.md
@@ -1,0 +1,1 @@
+Relative permeability model: Curve

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/Curve/curve/i_curve.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/Curve/curve/i_curve.md
@@ -1,0 +1,1 @@
+Curve tag name

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/Curve/curve/t_coords.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/Curve/curve/t_coords.md
@@ -1,0 +1,1 @@
+Saturation data of the relative permeability vs saturation curve.

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/Curve/curve/t_values.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/Curve/curve/t_values.md
@@ -1,0 +1,1 @@
+Relative permeability data of the relative permeability vs saturation curve.

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseBrookCoreyOilGas/c_NonWettingPhaseBrookCoreyOilGas.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseBrookCoreyOilGas/c_NonWettingPhaseBrookCoreyOilGas.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::NonWettingPhaseBrookCoreyOilGas

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseBrookCoreyOilGas/t_krel_min.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseBrookCoreyOilGas/t_krel_min.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::NonWettingPhaseBrookCoreyOilGas::_krel_min

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseBrookCoreyOilGas/t_m.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseBrookCoreyOilGas/t_m.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::NonWettingPhaseBrookCoreyOilGas::_m

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseBrookCoreyOilGas/t_smax.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseBrookCoreyOilGas/t_smax.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::RelativePermeability::_saturation_max

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseBrookCoreyOilGas/t_sr.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseBrookCoreyOilGas/t_sr.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::RelativePermeability::_saturation_r

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseVanGenuchten/c_NonWettingPhaseVanGenuchten.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseVanGenuchten/c_NonWettingPhaseVanGenuchten.md
@@ -1,0 +1,2 @@
+\copydoc MaterialLib::PorousMedium::NonWettingPhaseVanGenuchten
+

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseVanGenuchten/t_krel_min.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseVanGenuchten/t_krel_min.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::NonWettingPhaseVanGenuchten::_krel_min

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseVanGenuchten/t_m.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseVanGenuchten/t_m.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::NonWettingPhaseVanGenuchten::_m

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseVanGenuchten/t_smax.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseVanGenuchten/t_smax.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::RelativePermeability::_saturation_max

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseVanGenuchten/t_sr.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/NonWettingPhaseVanGenuchten/t_sr.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::RelativePermeability::_saturation_r

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseBrookCoreyOilGas/c_WettingPhaseBrookCoreyOilGas.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseBrookCoreyOilGas/c_WettingPhaseBrookCoreyOilGas.md
@@ -1,0 +1,2 @@
+\copydoc MaterialLib::PorousMedium::WettingPhaseBrookCoreyOilGas
+

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseBrookCoreyOilGas/t_krel_min.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseBrookCoreyOilGas/t_krel_min.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::WettingPhaseBrookCoreyOilGas::_krel_min

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseBrookCoreyOilGas/t_m.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseBrookCoreyOilGas/t_m.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::WettingPhaseBrookCoreyOilGas::_m

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseBrookCoreyOilGas/t_smax.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseBrookCoreyOilGas/t_smax.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::RelativePermeability::_saturation_max

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseBrookCoreyOilGas/t_sr.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseBrookCoreyOilGas/t_sr.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::RelativePermeability::_saturation_r

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseVanGenuchten/c_WettingPhaseVanGenuchten.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseVanGenuchten/c_WettingPhaseVanGenuchten.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::WettingPhaseVanGenuchten

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseVanGenuchten/t_krel_min.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseVanGenuchten/t_krel_min.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::WettingPhaseVanGenuchten::_krel_min

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseVanGenuchten/t_m.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseVanGenuchten/t_m.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::WettingPhaseVanGenuchten::_m

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseVanGenuchten/t_smax.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseVanGenuchten/t_smax.md
@@ -1,0 +1,2 @@
+\copydoc MaterialLib::PorousMedium::RelativePermeability::_saturation_max
+

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseVanGenuchten/t_sr.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/WettingPhaseVanGenuchten/t_sr.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::PorousMedium::RelativePermeability::_saturation_r

--- a/Documentation/ProjectFile/material/porous_medium/relative_permeability/t_type.md
+++ b/Documentation/ProjectFile/material/porous_medium/relative_permeability/t_type.md
@@ -1,0 +1,6 @@
+Type of relative permeability model. The available models are:
+   WettingPhaseVanGenuchten
+   NonWettingPhaseVanGenuchten
+   WettingPhaseBrookCoreyOilGas
+   NonWettingPhaseBrookCoreyOilGas
+   Curve

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/CreateRelativePermeabilityModel.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/CreateRelativePermeabilityModel.cpp
@@ -20,6 +20,7 @@
 #include "BaseLib/ConfigTree.h"
 #include "BaseLib/Error.h"
 
+#include "MathLib/Curve/CreatePiecewiseLinearCurve.h"
 #include "MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h"
 
 #include "RelativePermeability.h"
@@ -191,33 +192,13 @@ std::unique_ptr<RelativePermeability> createRelativePermeabilityModel(
         //! \ogs_file_param{material__porous_medium__relative_permeability__Curve}
         config.checkConfigParameter("type", "Curve");
 
-        // TODO: parsing of curve will be replaced by the function for creating
-        // curve.
         //! \ogs_file_param{material__porous_medium__relative_permeability__Curve__curve}
         auto const& curve_config = config.getConfigSubtree("curve");
 
-        auto variables =
-            //! \ogs_file_param{material__porous_medium__relative_permeability__Curve__curve__coords}
-            curve_config.getConfigParameter<std::vector<double>>("coords");
-        auto values =
-            //! \ogs_file_param{material__porous_medium__relative_permeability__Curve__curve__values}
-            curve_config.getConfigParameter<std::vector<double>>("values");
-
-        if (variables.empty() || values.empty())
-        {
-            OGS_FATAL("The given coordinates or values vector is empty.");
-        }
-        if (values.size() != values.size())
-        {
-            OGS_FATAL(
-                "The given co-ordinates and values vector sizes are "
-                "different.");
-        }
-        auto curve = std::unique_ptr<MathLib::PiecewiseLinearInterpolation>(
-            new MathLib::PiecewiseLinearInterpolation(
-                std::move(variables), std::move(values), true));
+        auto curve = MathLib::createPiecewiseLinearCurve<MathLib
+                              ::PiecewiseLinearInterpolation>(curve_config);
         return std::unique_ptr<RelativePermeability>(
-            new RelativePermeabilityCurve(curve));
+            new RelativePermeabilityCurve(std::move(curve)));
     }
     else
     {

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/RelativePermeabilityCurve.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/RelativePermeabilityCurve.h
@@ -27,7 +27,7 @@ class RelativePermeabilityCurve final : public RelativePermeability
 {
 public:
     RelativePermeabilityCurve(
-        std::unique_ptr<MathLib::PiecewiseLinearInterpolation>& curve_data)
+        std::unique_ptr<MathLib::PiecewiseLinearInterpolation>&& curve_data)
         : RelativePermeability(curve_data->getSupportMin(),
                                curve_data->getSupportMax()),
           _curve_data(std::move(curve_data))


### PR DESCRIPTION
This PR
1.  replaces the local curve parsing of curve input of relative permeability with function of  createPiecewiseLinearCurve,
2. adds documentattions of input keywords of relative permeability models.