### PR TITLE
add the unconfined compression test compared with analytical solution

### DIFF
--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -658,29 +658,29 @@ if(NOT OGS_USE_MPI)
         expected_square_1e2_pcs_0_ts_120_t_1000.000000.vtu square_1e2_pcs_0_ts_120_t_1000.000000.vtu pressure pressure
         expected_square_1e2_pcs_0_ts_420_t_4000.000000.vtu square_1e2_pcs_0_ts_420_t_4000.000000.vtu pressure pressure
     )
-    # HydroMechanics; Small deformation, linear poroelastic (unconfined compression short time)
+    # HydroMechanics; Small deformation, linear poroelastic (unconfined compression early) The drainage process is ongoing and the displacement behaviour is related to water pressure and solid properties.
     AddTest(
-        NAME HydroMechanics_HML_square_1e2_unconfined_compression_short
+        NAME HydroMechanics_HML_square_1e2_unconfined_compression_early
         PATH HydroMechanics/Linear/Unconfined_Compression_early
         EXECUTABLE ogs
-        EXECUTABLE_ARGS square_1e2.prj
+        EXECUTABLE_ARGS square_1e2_UC_early.prj
         WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-3 RELTOL 1e-3
         DIFF_DATA
-        UnconfinedCompressionAnalytical_1s.vtu square_1e2_pcs_0_ts_10_t_1.000000.vtu displacement_ana displacement
+        UnconfinedCompressionAnalytical_1s.vtu square_1e2_UC_early_pcs_0_ts_10_t_1.000000.vtu displacement_ana displacement
     )
-    # HydroMechanics; Small deformation, linear poroelastic (unconfined compression long time)
+    # HydroMechanics; Small deformation, linear poroelastic (unconfined compression late) the drainage process is finished and the displacement of the porous media is only a result of solid properties.
     AddTest(
-        NAME HydroMechanics_HML_square_1e2_unconfined_compression_long
+        NAME HydroMechanics_HML_square_1e2_unconfined_compression_late
         PATH HydroMechanics/Linear/Unconfined_Compression_late
         EXECUTABLE ogs
-        EXECUTABLE_ARGS square_1e2.prj
+        EXECUTABLE_ARGS square_1e2_UC_late.prj
         WRAPPER time
         TESTER vtkdiff
         ABSTOL 1e-3 RELTOL 1e-3
         DIFF_DATA
-        UnconfinedCompressionAnalytical_1000s.vtu square_1e2_pcs_0_ts_100_t_1000.000000.vtu displacement_ana displacement
+        UnconfinedCompressionAnalytical_1000s.vtu square_1e2_UC_late_pcs_0_ts_10_t_1000.000000.vtu displacement_ana displacement
     )
 
 

--- a/Applications/CLI/Tests.cmake
+++ b/Applications/CLI/Tests.cmake
@@ -658,6 +658,31 @@ if(NOT OGS_USE_MPI)
         expected_square_1e2_pcs_0_ts_120_t_1000.000000.vtu square_1e2_pcs_0_ts_120_t_1000.000000.vtu pressure pressure
         expected_square_1e2_pcs_0_ts_420_t_4000.000000.vtu square_1e2_pcs_0_ts_420_t_4000.000000.vtu pressure pressure
     )
+    # HydroMechanics; Small deformation, linear poroelastic (unconfined compression short time)
+    AddTest(
+        NAME HydroMechanics_HML_square_1e2_unconfined_compression_short
+        PATH HydroMechanics/Linear/Unconfined_Compression_early
+        EXECUTABLE ogs
+        EXECUTABLE_ARGS square_1e2.prj
+        WRAPPER time
+        TESTER vtkdiff
+        ABSTOL 1e-3 RELTOL 1e-3
+        DIFF_DATA
+        UnconfinedCompressionAnalytical_1s.vtu square_1e2_pcs_0_ts_10_t_1.000000.vtu displacement_ana displacement
+    )
+    # HydroMechanics; Small deformation, linear poroelastic (unconfined compression long time)
+    AddTest(
+        NAME HydroMechanics_HML_square_1e2_unconfined_compression_long
+        PATH HydroMechanics/Linear/Unconfined_Compression_late
+        EXECUTABLE ogs
+        EXECUTABLE_ARGS square_1e2.prj
+        WRAPPER time
+        TESTER vtkdiff
+        ABSTOL 1e-3 RELTOL 1e-3
+        DIFF_DATA
+        UnconfinedCompressionAnalytical_1000s.vtu square_1e2_pcs_0_ts_100_t_1000.000000.vtu displacement_ana displacement
+    )
+
 
     # LIE; Small deformation
     AddTest(


### PR DESCRIPTION
As titled.  The unconfined compression is divided into two steps. In early time, the drainage process is ongoing and the displacement behaviour is related to water pressure and solid properties. In late time, the drainage process is finished and the displacement of the porous media is only a result of solid properties. 

Todo:
- [ ] Update the docs.ogs.org with analytical solution and possibly a script.
- [x] Update ufz/ogs-data repository.