### PR TITLE
Documentation

### DIFF
--- a/Documentation/ProjectFile/i_ProjectFile.md
+++ b/Documentation/ProjectFile/i_ProjectFile.md
@@ -43,8 +43,9 @@ prefix:
     prj and gml input file, respectively.
     All other top level cases, however, belong somewhere in the project file XML tree.
     You can see where they belong in the <em>Additional Info</em> section of the [tag] and
-    [attr] pages, e.g., \ref ogs_file_param__boundary_condition__geometry of the
-    boundary condition has the full XML tag path
+    [attr] pages, e.g., \ref
+    ogs_file_param__prj__process_variables__process_variable__boundary_conditions__boundary_condition__geometry
+    of the boundary condition has the full XML tag path
     <tt>process_variables.process_variable.boundary_conditions.boundary_condition.geometry</tt>.
  2. Cases that distinguish types do not translate to XML tags either.
     They enclose a set of configuration settings that can be used at that specific point.<br>

--- a/Documentation/ProjectFile/prj/time_loop/processes/process/convergence_criterion/PerComponentDeltaX/t_norm_type.md
+++ b/Documentation/ProjectFile/prj/time_loop/processes/process/convergence_criterion/PerComponentDeltaX/t_norm_type.md
@@ -1,3 +1,3 @@
 The type of norm of the solution vector being computed.
 
-See \ref ogs_file_param__process__convergence_criterion__DeltaX__norm_type.
+See \ref ogs_file_param__prj__time_loop__processes__process__convergence_criterion__DeltaX__norm_type.

--- a/Documentation/ProjectFile/prj/time_loop/processes/process/convergence_criterion/PerComponentDeltaX/t_reltols.md
+++ b/Documentation/ProjectFile/prj/time_loop/processes/process/convergence_criterion/PerComponentDeltaX/t_reltols.md
@@ -9,4 +9,4 @@ If for a certain component no relative tolerance shall be applied, zero can be
 given as the respective tolerance value.
 
 For the computation of the relative error for each component, see \ref
-ogs_file_param__process__convergence_criterion__DeltaX__reltol.
+ogs_file_param__prj__time_loop__processes__process__convergence_criterion__DeltaX__reltol.

--- a/Documentation/ProjectFile/prj/time_loop/processes/process/convergence_criterion/PerComponentResidual/t_norm_type.md
+++ b/Documentation/ProjectFile/prj/time_loop/processes/process/convergence_criterion/PerComponentResidual/t_norm_type.md
@@ -1,3 +1,3 @@
 The type of norm of the solution vector being computed.
 
-See also \ref ogs_file_param__process__convergence_criterion__DeltaX__norm_type.
+See also \ref ogs_file_param__prj__time_loop__processes__process__convergence_criterion__DeltaX__norm_type.

--- a/Documentation/ProjectFile/prj/time_loop/processes/process/convergence_criterion/PerComponentResidual/t_reltols.md
+++ b/Documentation/ProjectFile/prj/time_loop/processes/process/convergence_criterion/PerComponentResidual/t_reltols.md
@@ -9,4 +9,4 @@ If for a certain component no relative tolerance shall be applied, zero can be
 given as the respective tolerance value.
 
 For the computation of the relative error for each component, see \ref
-ogs_file_param__process__convergence_criterion__Residual__reltol.
+ogs_file_param__prj__time_loop__processes__process__convergence_criterion__Residual__reltol.

--- a/Documentation/ProjectFile/prj/time_loop/processes/process/convergence_criterion/Residual/t_norm_type.md
+++ b/Documentation/ProjectFile/prj/time_loop/processes/process/convergence_criterion/Residual/t_norm_type.md
@@ -1,3 +1,3 @@
 The type of norm of the solution vector being computed.
 
-See also \ref ogs_file_param__process__convergence_criterion__DeltaX__norm_type.
+See also \ref ogs_file_param__prj__time_loop__processes__process__convergence_criterion__DeltaX__norm_type.

--- a/scripts/doc/append-xml-tags.py
+++ b/scripts/doc/append-xml-tags.py
@@ -8,7 +8,7 @@
 
 # prevent broken pipe error
 from signal import signal, SIGPIPE, SIG_DFL
-signal(SIGPIPE,SIG_DFL)
+signal(SIGPIPE, SIG_DFL)
 
 import os
 import sys
@@ -16,7 +16,7 @@ import xml.etree.cElementTree as ET
 import json
 from print23 import print_
 
-github_src_url  = "https://github.com/ufz/ogs/tree/master"
+github_src_url = "https://github.com/ufz/ogs/tree/master"
 github_data_url = "https://github.com/ufz/ogs-data/tree/master"
 
 if len(sys.argv) != 4:
@@ -24,14 +24,14 @@ if len(sys.argv) != 4:
     print_("{0} EXT DATADIR DOCAUXDIR".format(sys.argv[0]))
     sys.exit(1)
 
-ext       = sys.argv[1]
-datadir   = sys.argv[2]
+ext = sys.argv[1]
+datadir = sys.argv[2]
 docauxdir = sys.argv[3]
 
 extension = '.' + ext
-datadir   = os.path.abspath(datadir)
+datadir = os.path.abspath(datadir)
 docauxdir = os.path.abspath(docauxdir)
-docdir    = os.path.join(docauxdir, "dox", "ProjectFile")
+docdir = os.path.join(docauxdir, "dox", "ProjectFile")
 
 # used to expand documentation entry points to full xml tag paths
 # that are used in the prj file.
@@ -67,7 +67,7 @@ with open(os.path.join(docauxdir, "documented-parameters-cache.txt")) as fh:
 
 # traverse dox file hierarchy
 for (dirpath, _, filenames) in os.walk(docdir):
-    reldirpath = dirpath[len(docdir)+1:]
+    reldirpath = dirpath[len(docdir) + 1:]
     istag = True
 
     for f in filenames:
@@ -98,35 +98,44 @@ for (dirpath, _, filenames) in os.walk(docdir):
                 fh.write("\n\n# Additional info\n")
                 if tagpath in dict_tag_info:
                     for info in dict_tag_info[tagpath]:
-                        path = info[1]; line = info[2]
+                        path = info[1]
+                        line = info[2]
                         fh.write(("\n## From {0} line {1}\n\n")
-                                .format(path, line))
+                                 .format(path, line))
 
                         method = info[6]
                         if method.endswith("Optional"):
                             fh.write("- This is an optional parameter.\n")
                         elif method.endswith("List"):
-                            fh.write("- This parameter can be given arbitrarily many times.\n")
-                        elif method: # method not empty
+                            fh.write(
+                                "- This parameter can be given arbitrarily many times.\n"
+                            )
+                        elif method:  # method not empty
                             fh.write("- This is a required parameter.\n")
 
                         datatype = info[5]
-                        if datatype: fh.write("- Data type: <tt>{0}</tt>\n".format(datatype))
+                        if datatype:
+                            fh.write("- Data type: <tt>{0}</tt>\n".format(
+                                datatype))
 
-                        fh.write("- Expanded tag path: {0}\n".format(tagpath_expanded))
+                        fh.write("- Expanded tag path: {0}\n".format(
+                            tagpath_expanded))
 
-                        fh.write("- Go to source code: [&rarr; ufz/ogs/master]({2}/{0}#L{1})\n"
-                                .format(path, line, github_src_url))
+                        fh.write(
+                            "- Go to source code: [&rarr; ufz/ogs/master]({2}/{0}#L{1})\n"
+                            .format(path, line, github_src_url))
                 else:
                     fh.write("\nNo additional info.\n")
 
             if tagpath_expanded:
                 fh.write("\n\n# Used in the following test data files\n\n")
                 try:
-                    datafiles = tested_tags_attrs["tags" if istag else "attributes"][tagpath]
+                    datafiles = tested_tags_attrs["tags" if istag else
+                                                  "attributes"][tagpath]
 
                     for df in sorted(datafiles):
-                        pagename = "ogs_ctest_prj__" + df.replace("/", "__").replace(".", "__")
+                        pagename = "ogs_ctest_prj__" + df.replace(
+                            "/", "__").replace(".", "__")
                         fh.write(("- \\[[&rarr; ogs-data/master]({1}/{0}) | " \
                                 + "\\ref {2} \"&rarr; doc\"\\]&emsp;{0}\n") \
                                 .format(df, github_data_url, pagename))

--- a/scripts/doc/check-project-params.py
+++ b/scripts/doc/check-project-params.py
@@ -11,8 +11,10 @@ import json
 
 github_src_url = "https://github.com/ufz/ogs/tree/master"
 
+
 def debug(msg):
-    sys.stderr.write(msg+"\n")
+    sys.stderr.write(msg + "\n")
+
 
 if len(sys.argv) != 3:
     print_("USAGE: {0} DOCAUXDIR SRCDIR".format(sys.argv[0]))
@@ -49,7 +51,8 @@ with open(os.path.join(docauxdir, "documented-parameters-cache.txt")) as fh:
             or os.path.isfile(os.path.join(p, tag_name_comment, "i_" + tag_name_comment + ".dox")) \
             or os.path.isfile(os.path.join(p, tag_name_comment, "c_" + tag_name_comment + ".dox")) :
                 good_tagpaths.add((tag_path_comment, "param"))
-            elif os.path.isfile(os.path.join(p, "a_" + tag_name_comment + ".dox")):
+            elif os.path.isfile(
+                    os.path.join(p, "a_" + tag_name_comment + ".dox")):
                 good_tagpaths.add((tag_path_comment, "attr"))
             else:
                 no_doc_page.append((tag_path_comment, inline[1], inline[2]))
@@ -64,17 +67,17 @@ with open(os.path.join(docauxdir, "documented-parameters-cache.txt")) as fh:
         elif status == "UNNEEDED":
             unneeded_comments.append(inline[1:])
         elif status == "SPECIAL":
-            debug("SPECIAL: " + " ".join(inline[1:])) # TODO implement proper handling
+            debug("SPECIAL: " +
+                  " ".join(inline[1:]))  # TODO implement proper handling
             # unneeded.append(inline[1:])
         else:
             debug("ERROR: unrecognized status {0}".format(status))
             wrong_status = True
 
-
 # traverse dox file hierarchy
 srcdocdir = os.path.join(srcdir, "Documentation", "ProjectFile")
 for (dirpath, _, filenames) in os.walk(srcdocdir):
-    reldirpath = dirpath[len(srcdocdir)+1:]
+    reldirpath = dirpath[len(srcdocdir) + 1:]
 
     for f in filenames:
         if not f.endswith(".md"): continue
@@ -90,7 +93,7 @@ for (dirpath, _, filenames) in os.walk(srcdocdir):
             tag_or_attr = "attr"
         else:
             debug("ERROR: Found md file with unrecognized name: {0}"
-                    .format(filepath))
+                  .format(filepath))
             continue
 
         tagpath = tagpath.replace(os.sep, ".")
@@ -113,7 +116,6 @@ if unneeded_md_files:
                 if not unneeded_md_files: break
         if not unneeded_md_files: break
 
-
 if undocumented:
     qa_status_succeeded = False
     print_()
@@ -123,8 +125,8 @@ if undocumented:
     for u in sorted(undocumented):
         u2 = list(u)
         u2.append(github_src_url)
-        print_(("| {0} | {1} | {3} | <tt>{4}</tt> | <tt>{5}</tt> "
-            + "| [&rarr; ufz/ogs/master]({6}/{0}#L{1})").format(*u2))
+        print_(("| {0} | {1} | {3} | <tt>{4}</tt> | <tt>{5}</tt> " +
+                "| [&rarr; ufz/ogs/master]({6}/{0}#L{1})").format(*u2))
 
 if unneeded_comments:
     qa_status_succeeded = False
@@ -136,8 +138,8 @@ if unneeded_comments:
         u2 = list(u)
         u2.append(github_src_url)
         u2[2] = re.sub(r'([\\@&$#<>%".|])', r"\\\1", u2[2])
-        print_(("| {0} | {1} | {2} "
-            + "| [&rarr; ufz/ogs/master]({3}/{0}#L{1}) |").format(*u2))
+        print_(("| {0} | {1} | {2} " +
+                "| [&rarr; ufz/ogs/master]({3}/{0}#L{1}) |").format(*u2))
 
 if wrong_input:
     qa_status_succeeded = False
@@ -149,8 +151,8 @@ if wrong_input:
         w2 = list(w)
         w2.append(github_src_url)
         w2[2] = re.sub(r'([\\@&$#<>%".|])', r"\\\1", w2[2])
-        print_(("| {0} | {1} | {2} "
-            + "| [&rarr; ufz/ogs/master]({3}/{0}#L{1}) |").format(*w2))
+        print_(("| {0} | {1} | {2} " +
+                "| [&rarr; ufz/ogs/master]({3}/{0}#L{1}) |").format(*w2))
 
 if no_doc_page:
     qa_status_succeeded = False
@@ -161,8 +163,8 @@ if no_doc_page:
     for n in sorted(no_doc_page):
         n2 = list(n)
         n2.append(github_src_url)
-        print_(("| {0} | {1} | {2} "
-            + "| [&rarr; ufz/ogs/master]({3}/{1}#L{2}) |").format(*n2))
+        print_(("| {0} | {1} | {2} " +
+                "| [&rarr; ufz/ogs/master]({3}/{1}#L{2}) |").format(*n2))
 
 if unneeded_md_files:
     qa_status_succeeded = False
@@ -171,10 +173,11 @@ if unneeded_md_files:
     print_("| Page | *.md file | Link |")
     print_("| ---- | --------- | ---- |")
     for (tagpath, tag_or_attr), filepath in sorted(unneeded_md_files.items()):
-        print_((r'| \ref ogs_file_{0}__{1} | Documentation/ProjectFile/{2} '
-            + "| [&rarr; ufz/ogs/master]({3}/Documentation/ProjectFile/{2}#) |")
-            .format(tag_or_attr, tagpath.replace(".", "__"),
-                filepath, github_src_url))
+        print_(
+            (r'| \ref ogs_file_{0}__{1} | Documentation/ProjectFile/{2} ' +
+             "| [&rarr; ufz/ogs/master]({3}/Documentation/ProjectFile/{2}#) |")
+            .format(tag_or_attr,
+                    tagpath.replace(".", "__"), filepath, github_src_url))
 
 with open(os.path.join(docauxdir, "untested-parameters-cache.json")) as fh:
     untested_tags_attrs = json.load(fh)

--- a/scripts/doc/linked-xml-file.py
+++ b/scripts/doc/linked-xml-file.py
@@ -37,7 +37,11 @@ outdir = os.path.join(docauxdir, "dox", "CTestProjectFiles")
 # following format:
 # "prj__processes__process": "process",
 # See the expansion table in the append-xml-tags.py too.
-tag_path_expansion_table = {}
+tag_path_expansion_table = {
+        "prj__processes__process__constitutive_relation" : "material__solid__constitutive_relation",
+        "prj__processes__process__material_property" : "material",
+        "material__porous_medium__porous_medium" : "material__porous_medium",
+        }
 
 indent = "&nbsp;" * 2
 
@@ -110,7 +114,9 @@ def print_tags(node, level, pagename, fh, typetag, typetag_levels_up,
             dict_of_set_add(map_attr_to_prj_files, attrpath, relfilepath)
 
     if len(node) > 0:
-        # node having child tags
+        # node having child tag
+
+        # print opening tag
         fh.write(format_if_documented(is_doc, \
                 indent*level + '\\<{0}{2}\\><br>\n', fullpagename, tag, attrs))
 
@@ -126,10 +132,12 @@ def print_tags(node, level, pagename, fh, typetag, typetag_levels_up,
             typetag_children = typetag
             typetag_children_levels_up = typetag_levels_up + 1
 
+        # Recursively process children tags.
         for child in node:
             print_tags(child, level + 1, pagename, fh, typetag_children,
                        typetag_children_levels_up, relfilepath)
 
+        # print closing tag
         fh.write((indent * level) + r"\</" + tag + "\\><br>\n")
     else:
         # node having no children
@@ -138,11 +146,7 @@ def print_tags(node, level, pagename, fh, typetag, typetag_levels_up,
                 fh.write(format_if_documented(is_doc, \
                         indent*level + '\\<{0}{2}\\>{3}\\</{1}\\><br>\n', fullpagename, tag, attrs, node.text.strip()))
             else:
-                if rootpagename:
-                    typepagename = rootpagename + "__" + node.text.strip()
-                else:
-                    typepagename = node.text.strip()
-
+                typepagename = rootpagename + "__" + node.text.strip()
                 typetagpath, typepagename, type_is_doc = get_tagpath(
                     typepagename, None, 0)
                 if type_is_doc:

--- a/scripts/doc/linked-xml-file.py
+++ b/scripts/doc/linked-xml-file.py
@@ -13,7 +13,7 @@
 
 # prevent broken pipe error
 from signal import signal, SIGPIPE, SIG_DFL
-signal(SIGPIPE,SIG_DFL)
+signal(SIGPIPE, SIG_DFL)
 
 from print23 import print_
 import os
@@ -26,29 +26,31 @@ if len(sys.argv) != 3:
     sys.stderr.write("{0} DATADIR DOCAUXDIR\n".format(sys.argv[0]))
     sys.exit(1)
 
-datadir   = sys.argv[1]
+datadir = sys.argv[1]
 docauxdir = sys.argv[2]
 
-datadir   = os.path.abspath(datadir)
+datadir = os.path.abspath(datadir)
 docauxdir = os.path.abspath(docauxdir)
-outdir    = os.path.join(docauxdir, "dox", "CTestProjectFiles")
+outdir = os.path.join(docauxdir, "dox", "CTestProjectFiles")
 
 # Expansions or shortcuts for the documenation can be added here in the
 # following format:
 # "prj__processes__process": "process",
 # See the expansion table in the append-xml-tags.py too.
-tag_path_expansion_table = {
-}
+tag_path_expansion_table = {}
 
-indent = "&nbsp;"*2
+indent = "&nbsp;" * 2
+
 
 def format_if_documented(is_doc, fmt, fullpagename, tag_attr, *args):
     if is_doc:
         tag_attr_formatted = r'\ref {0} "{1}"'.format(fullpagename, tag_attr)
     else:
-        tag_attr_formatted = r'<span style="color: red;" title="undocumented: {0}">{1}</span>'.format(fullpagename, tag_attr)
+        tag_attr_formatted = r'<span style="color: red;" title="undocumented: {0}">{1}</span>'.format(
+            fullpagename, tag_attr)
 
     return fmt.format(tag_attr_formatted, tag_attr, *args)
+
 
 def format_if_documented_nowarn(is_doc, fmt, fullpagename, tag_attr, *args):
     if is_doc:
@@ -57,6 +59,7 @@ def format_if_documented_nowarn(is_doc, fmt, fullpagename, tag_attr, *args):
         tag_attr_formatted = tag_attr
 
     return fmt.format(tag_attr_formatted, tag_attr, *args)
+
 
 def get_tagpath(pagename, typetag, typetag_levels_up):
     tagpath = pagename.replace("__", ".")
@@ -72,7 +75,9 @@ def get_tagpath(pagename, typetag, typetag_levels_up):
 
     return tagpath, pagename, is_doc
 
-def print_tags(node, level, pagename, fh, typetag, typetag_levels_up, relfilepath):
+
+def print_tags(node, level, pagename, fh, typetag, typetag_levels_up,
+               relfilepath):
     global map_tag_to_prj_files
     tag = node.tag
     rootpagename = pagename
@@ -85,7 +90,8 @@ def print_tags(node, level, pagename, fh, typetag, typetag_levels_up, relfilepat
         dict_of_set_add(map_tag_to_prj_files, tagpath_unexpanded, relfilepath)
         pagename = tag_path_expansion_table[pagename]
 
-    tagpath, pagename, is_doc = get_tagpath(pagename, typetag, typetag_levels_up)
+    tagpath, pagename, is_doc = get_tagpath(pagename, typetag,
+                                            typetag_levels_up)
     if is_doc:
         dict_of_set_add(map_tag_to_prj_files, tagpath, relfilepath)
 
@@ -98,7 +104,8 @@ def print_tags(node, level, pagename, fh, typetag, typetag_levels_up, relfilepat
         attrpath = tagpath + "." + attr
         attrpagename = "ogs_file_attr__" + attrpath.replace(".", "__")
         a_is_doc = (attrpath, False) in documented_tags_attrs
-        attrs += format_if_documented(a_is_doc, ' {0}="{2}"', attrpagename, attr, value)
+        attrs += format_if_documented(a_is_doc, ' {0}="{2}"', attrpagename,
+                                      attr, value)
         if a_is_doc:
             dict_of_set_add(map_attr_to_prj_files, attrpath, relfilepath)
 
@@ -108,7 +115,7 @@ def print_tags(node, level, pagename, fh, typetag, typetag_levels_up, relfilepat
                 indent*level + '\\<{0}{2}\\><br>\n', fullpagename, tag, attrs))
 
         if node.text and node.text.strip():
-            fh.write(indent*(level+1) + node.text.strip() + "<br>\n")
+            fh.write(indent * (level + 1) + node.text.strip() + "<br>\n")
 
         for child in node:
             if child.tag == "type" and child.text and child.text.strip():
@@ -120,9 +127,10 @@ def print_tags(node, level, pagename, fh, typetag, typetag_levels_up, relfilepat
             typetag_children_levels_up = typetag_levels_up + 1
 
         for child in node:
-            print_tags(child, level + 1, pagename, fh, typetag_children, typetag_children_levels_up, relfilepath)
+            print_tags(child, level + 1, pagename, fh, typetag_children,
+                       typetag_children_levels_up, relfilepath)
 
-        fh.write((indent*level) + r"\</" + tag + "\\><br>\n")
+        fh.write((indent * level) + r"\</" + tag + "\\><br>\n")
     else:
         # node having no children
         if node.text and node.text.strip():
@@ -135,9 +143,11 @@ def print_tags(node, level, pagename, fh, typetag, typetag_levels_up, relfilepat
                 else:
                     typepagename = node.text.strip()
 
-                typetagpath, typepagename, type_is_doc = get_tagpath(typepagename, None, 0)
+                typetagpath, typepagename, type_is_doc = get_tagpath(
+                    typepagename, None, 0)
                 if type_is_doc:
-                    dict_of_set_add(map_tag_to_prj_files, typetagpath, relfilepath)
+                    dict_of_set_add(map_tag_to_prj_files, typetagpath,
+                                    relfilepath)
                 typepagename = "ogs_file_param__" + typepagename
 
                 # If the content of a type tag is undocumented no red
@@ -150,6 +160,7 @@ def print_tags(node, level, pagename, fh, typetag, typetag_levels_up, relfilepat
         else:
             fh.write(format_if_documented(is_doc, \
                     indent*level + '\\<{0}{2} /\\><br>\n', fullpagename, tag, attrs))
+
 
 # set of (str tagpath, bool is_tag)
 documented_tags_attrs = set()
@@ -179,15 +190,18 @@ def has_prj_file_in_subdirs(reldirpath):
             return True
     return False
 
+
 dirs_with_prj_files = set()
 
 # maps tags/attributes to the set of prj files they appear in
 map_tag_to_prj_files = dict()
 map_attr_to_prj_files = dict()
 
+
 def dict_of_set_add(dos, key, value):
     if key not in dos: dos[key] = set()
     dos[key].add(value)
+
 
 for (dirpath, dirnames, filenames) in os.walk(datadir, topdown=False):
     reldirpath = os.path.relpath(dirpath, datadir)
@@ -199,7 +213,8 @@ for (dirpath, dirnames, filenames) in os.walk(datadir, topdown=False):
     for fn in filenames:
         filepath = os.path.join(dirpath, fn)
         relfilepath = os.path.relpath(filepath, datadir)
-        pagename = "ogs_ctest_prj__" + relfilepath.replace("/", "__").replace(".", "__")
+        pagename = "ogs_ctest_prj__" + relfilepath.replace("/", "__").replace(
+            ".", "__")
 
         if fn.endswith(".prj"):
             outdoxfile = os.path.join(outdirpath, fn + ".dox")
@@ -234,15 +249,17 @@ for (dirpath, dirnames, filenames) in os.walk(datadir, topdown=False):
         filepath = os.path.join(dirpath, fn)
         relfilepath = os.path.relpath(filepath, datadir)
         if has_prj_file_in_subdirs(relfilepath):
-            pagename = "ogs_ctest_prj__" + relfilepath.replace("/", "__").replace(".", "__")
+            pagename = "ogs_ctest_prj__" + relfilepath.replace(
+                "/", "__").replace(".", "__")
             subpages.append(pagename)
 
     if subpages:
         if not os.path.exists(outdirpath):
             os.makedirs(outdirpath)
 
-        pagename = "ogs_ctest_prj__" + reldirpath.replace("/", "__").replace(".", "__")
-        pagetitle =os.path.split(reldirpath)[1]
+        pagename = "ogs_ctest_prj__" + reldirpath.replace("/", "__").replace(
+            ".", "__")
+        pagetitle = os.path.split(reldirpath)[1]
 
         if pagetitle == ".":
             pagetitle = "OGS CTests&mdash;Project Files"
@@ -263,7 +280,6 @@ for k, v in map_tag_to_prj_files.items():
     map_tag_to_prj_files[k] = list(v)
     documented_tags_attrs.discard((k, True))
 
-
 for k, v in map_attr_to_prj_files.items():
     map_attr_to_prj_files[k] = list(v)
     documented_tags_attrs.discard((k, False))
@@ -272,9 +288,10 @@ with open(os.path.join(docauxdir, "tested-parameters-cache.json"), "w") as fh:
     json.dump({ "tags": map_tag_to_prj_files, "attributes": map_attr_to_prj_files }, \
             fh, indent=2)
 
-untested_tags  = [ tag  for tag,  is_tag in documented_tags_attrs if is_tag ]
-untested_attrs = [ attr for attr, is_tag in documented_tags_attrs if not is_tag ]
+untested_tags = [tag for tag, is_tag in documented_tags_attrs if is_tag]
+untested_attrs = [attr for attr, is_tag in documented_tags_attrs if not is_tag]
 
-with open(os.path.join(docauxdir, "untested-parameters-cache.json"), "w") as fh:
+with open(os.path.join(docauxdir, "untested-parameters-cache.json"),
+          "w") as fh:
     json.dump({ "tags": untested_tags, "attributes": untested_attrs }, \
             fh, indent=2)

--- a/scripts/doc/normalize-param-cache.py
+++ b/scripts/doc/normalize-param-cache.py
@@ -9,23 +9,29 @@ import sys
 import re
 import os.path
 
+
 def debug(msg):
-    sys.stderr.write(msg+"\n")
+    sys.stderr.write(msg + "\n")
+
 
 def write_out(*args):
     print_("@@@".join(str(a) for a in args))
 
+
 # capture #2 is the parameter path
-comment = re.compile(r"//! \\ogs_file_(param|attr)\{([A-Za-z_0-9]+)\}( \\todo .*)?$")
-comment_special = re.compile(r"//! \\ogs_file(_param|_attr)?_special(\{[A-Za-z_0-9]+\})?( \\todo .*)?$")
+comment = re.compile(
+    r"//! \\ogs_file_(param|attr)\{([A-Za-z_0-9]+)\}( \\todo .*)?$")
+comment_special = re.compile(
+    r"//! \\ogs_file(_param|_attr)?_special(\{[A-Za-z_0-9]+\})?( \\todo .*)?$")
 
 # capture #5 is the parameter name
-getter = re.compile(r'(get|check|ignore|peek)Config(Parameter|Attribute|Subtree)(List|Optional|All)?'
-                   +r'\s*(<.*>)?'
-                   +r'\s*\(\s*"([a-zA-Z_0-9:]+)"\s*[,)]')
+getter = re.compile(
+    r'(get|check|ignore|peek)Config(Parameter|Attribute|Subtree)(List|Optional|All)?'
+    + r'\s*(<.*>)?' + r'\s*\(\s*"([a-zA-Z_0-9:]+)"\s*[,)]')
 
-getter_special = re.compile(r'(get|check|ignore|peek)Config(Parameter|Attribute|Subtree)(List|Optional|All)?'
-                           +r'\s*(<.*>)?\(')
+getter_special = re.compile(
+    r'(get|check|ignore|peek)Config(Parameter|Attribute|Subtree)(List|Optional|All)?'
+    + r'\s*(<.*>)?\(')
 
 
 # merge lines belonging together from grep -A 2 output.
@@ -50,7 +56,7 @@ def merge_lines(it):
             fn = m.group(1)
             lno = int(m.group(3))
             line = m.group(5)
-            msg =  fn + m.group(2) + str(lno) + m.group(4) + line
+            msg = fn + m.group(2) + str(lno) + m.group(4) + line
 
             # remove non-doxygen comments
             line = re.sub('/\*[^!*].*\*/|/\*\*/', '', line)
@@ -75,7 +81,8 @@ def merge_lines(it):
                 # continuation line and empty buffer
                 pass
 
-            if buf_fn and (comment.search(line) or comment_special.search(line)):
+            if buf_fn and (comment.search(line) or
+                           comment_special.search(line)):
                 # make sure nothing can be appended to doxygen comment lines
                 yield buf_fn, buf_lno, buf
                 buf = ""
@@ -97,7 +104,9 @@ tag_path_comment = ""
 param_or_attr_comment = ""
 
 for inline in merge_lines(sys.stdin):
-    oldpath = path; oldlineno = lineno; oldline = line
+    oldpath = path
+    oldlineno = lineno
+    oldline = line
     path, lineno, line = inline
 
     if path != oldpath: debug(path)
@@ -122,14 +131,15 @@ for inline in merge_lines(sys.stdin):
         state = "comment"
         param_or_attr_comment = "special"
 
-        if m.group(1): # param|attr matched
+        if m.group(1):  # param|attr matched
             # second group must not be empty!
             tag_path_comment = m.group(2).strip("{}").replace("__", ".")
             param = tag_path_comment.split(".")[-1]
             paramtype = ""
             method = ""
-            write_out("OK", path, lineno, tag_path_comment, param, paramtype, method)
-            state = "getter" # reset state s.t. next time a comment is accepted
+            write_out("OK", path, lineno, tag_path_comment, param, paramtype,
+                      method)
+            state = "getter"  # reset state s.t. next time a comment is accepted
 
         continue
 
@@ -145,24 +155,33 @@ for inline in merge_lines(sys.stdin):
             debug(" {0:>5}  {1} {2} ".format(lineno, param, paramtype))
 
             if param != tag_name_comment:
-                debug("error: parameter name from comment and code do not match: "
-                        + tag_name_comment + " vs. " + param)
-                write_out("NODOC", path, lineno, tag_path_comment, param, paramtype, method)
-            elif lineno != oldlineno+1:
-                debug("error: the associated comment is not on the line preceding this one."
-                        + " line numbers {0} vs. {1}".format(oldlineno, lineno))
-                write_out("NODOC", path, lineno, tag_path_comment, param, paramtype, method)
-            elif param_or_attr_comment == "param" and m.group(2) != "Parameter" and m.group(2) != "Subtree":
+                debug(
+                    "error: parameter name from comment and code do not match: "
+                    + tag_name_comment + " vs. " + param)
+                write_out("NODOC", path, lineno, tag_path_comment, param,
+                          paramtype, method)
+            elif lineno != oldlineno + 1:
+                debug(
+                    "error: the associated comment is not on the line preceding this one."
+                    + " line numbers {0} vs. {1}".format(oldlineno, lineno))
+                write_out("NODOC", path, lineno, tag_path_comment, param,
+                          paramtype, method)
+            elif param_or_attr_comment == "param" and m.group(
+                    2) != "Parameter" and m.group(2) != "Subtree":
                 debug("error: comment says param but code says different.")
-                write_out("NODOC", path, lineno, tag_path_comment, param, paramtype, method)
+                write_out("NODOC", path, lineno, tag_path_comment, param,
+                          paramtype, method)
             elif param_or_attr_comment == "attr" and m.group(2) != "Attribute":
                 debug("error: comment says attr but code says different.")
-                write_out("NODOC", path, lineno, tag_path_comment, param, paramtype, method)
+                write_out("NODOC", path, lineno, tag_path_comment, param,
+                          paramtype, method)
             elif param_or_attr_comment == "special":
                 debug("error: comment comments a special line.")
-                write_out("NODOC", path, lineno, "UNKNOWN", "UNKNOWN", paramtype, method)
+                write_out("NODOC", path, lineno, "UNKNOWN", "UNKNOWN",
+                          paramtype, method)
             else:
-                write_out("OK", path, lineno, tag_path_comment, param, paramtype, method)
+                write_out("OK", path, lineno, tag_path_comment, param,
+                          paramtype, method)
 
         state = "getter"
         continue
@@ -173,15 +192,19 @@ for inline in merge_lines(sys.stdin):
         method = m.group(1) + "Config" + m.group(2) + (m.group(3) or "")
 
         if state != "comment" or oldpath != path:
-            write_out("NODOC", path, lineno, "NONE", "UNKNOWN", paramtype, method)
+            write_out("NODOC", path, lineno, "NONE", "UNKNOWN", paramtype,
+                      method)
         else:
-            if lineno != oldlineno+1:
-                debug("error: the associated comment is not on the line preceding this one."
-                        + " line numbers {0} vs. {1}".format(oldlineno, lineno))
-                write_out("NODOC", path, lineno, "UNKNOWN", "UNKNOWN", paramtype, method)
+            if lineno != oldlineno + 1:
+                debug(
+                    "error: the associated comment is not on the line preceding this one."
+                    + " line numbers {0} vs. {1}".format(oldlineno, lineno))
+                write_out("NODOC", path, lineno, "UNKNOWN", "UNKNOWN",
+                          paramtype, method)
             elif param_or_attr_comment != "special":
                 debug("error: comment does not comment a special line.")
-                write_out("NODOC", path, lineno, "UNKNOWN", "UNKNOWN", paramtype, method)
+                write_out("NODOC", path, lineno, "UNKNOWN", "UNKNOWN",
+                          paramtype, method)
             else:
                 write_out("SPECIAL", path, lineno, paramtype, method)
 
@@ -189,4 +212,4 @@ for inline in merge_lines(sys.stdin):
         continue
 
     write_out("WRONGIN", path, lineno, line.strip())
-    state = "getter" # reset state in order to avoid warnings
+    state = "getter"  # reset state in order to avoid warnings

--- a/scripts/jenkins/docs.groovy
+++ b/scripts/jenkins/docs.groovy
@@ -26,7 +26,6 @@ stage('Reports (Docs)') {
         reportName: 'Doxygen'])
     step([$class: 'WarningsPublisher', canResolveRelativePaths: false,
         messagesPattern:
-            '.*ogs_file_.*,' +
             '.*potential recursive class relation.*',
         parserConfigurations: [[parserName: 'Doxygen', pattern:
         'build/DoxygenWarnings.log']], unstableNewAll: '0'])


### PR DESCRIPTION
This are few final fixes for the documentation of the input files.

The ignore pattern for ogs_file_param is now removed from the doxygen warning/error parser, so proper documentation of the input parameters is obligatory now.