### PR TITLE
Move local NewtonRaphson from the Material\Solid to NumLib

### DIFF
--- a/MaterialLib/SolidModels/Lubby2-impl.h
+++ b/MaterialLib/SolidModels/Lubby2-impl.h
@@ -10,7 +10,7 @@
 #ifndef MATERIALLIB_SOLIDMODELS_LUBBY2_IMPL_H_
 #define MATERIALLIB_SOLIDMODELS_LUBBY2_IMPL_H_
 
-#include "NewtonRaphson.h"
+#include "NumLib/NewtonRaphson.h"
 
 namespace MaterialLib
 {
@@ -105,12 +105,12 @@ bool Lubby2<DisplacementDim>::computeConstitutiveRelation(
         const int maximum_iterations(20);
         const double tolerance(1.e-10);
 
-        auto newton_solver =
-            NewtonRaphson<decltype(linear_solver), LocalJacobianMatrix,
-                          decltype(update_jacobian), LocalResidualVector,
-                          decltype(update_residual), decltype(update_solution)>(
-                linear_solver, update_jacobian, update_residual,
-                update_solution, maximum_iterations, tolerance);
+        auto newton_solver = NumLib::NewtonRaphson<
+            decltype(linear_solver), LocalJacobianMatrix,
+            decltype(update_jacobian), LocalResidualVector,
+            decltype(update_residual), decltype(update_solution)>(
+            linear_solver, update_jacobian, update_residual, update_solution,
+            maximum_iterations, tolerance);
 
         auto const success_iterations = newton_solver.solve(K_loc);
 

--- a/NumLib/NewtonRaphson.h
+++ b/NumLib/NewtonRaphson.h
@@ -7,17 +7,15 @@
  *
  */
 
-#ifndef MATERIALLIB_SOLIDMODELS_NEWTONRAPHSON_H_
-#define MATERIALLIB_SOLIDMODELS_NEWTONRAPHSON_H_
+#ifndef NUMERICAL_NEWTONRAPHSON_H_
+#define NUMERICAL_NEWTONRAPHSON_H_
 
 #include <boost/optional.hpp>
 #include <logog/include/logog.hpp>
 
 #include <Eigen/Dense>
 
-namespace MaterialLib
-{
-namespace Solids
+namespace NumLib
 {
 /// Newton-Raphson solver for system of equations using an Eigen linear solvers
 /// library.
@@ -92,8 +90,6 @@ private:
     const int _maximum_iterations;
     const double _tolerance_squared;
 };
+}  // namespace NumLib
 
-}  // namespace Solids
-}  // namespace MaterialLib
-
-#endif  // MATERIALLIB_SOLIDMODELS_NEWTONRAPHSON_H_
+#endif  // NumLib_NEWTONRAPHSON_H_

--- a/NumLib/NewtonRaphson.h
+++ b/NumLib/NewtonRaphson.h
@@ -7,8 +7,8 @@
  *
  */
 
-#ifndef NUMERICAL_NEWTONRAPHSON_H_
-#define NUMERICAL_NEWTONRAPHSON_H_
+#ifndef NUMLIB_NEWTONRAPHSON_H_
+#define NUMLIB_NEWTONRAPHSON_H_
 
 #include <boost/optional.hpp>
 #include <logog/include/logog.hpp>
@@ -92,4 +92,4 @@ private:
 };
 }  // namespace NumLib
 
-#endif  // NumLib_NEWTONRAPHSON_H_
+#endif  // NUMLIB_NEWTONRAPHSON_H_

--- a/Tests/NumLib/NewtonRaphson.cpp
+++ b/Tests/NumLib/NewtonRaphson.cpp
@@ -9,9 +9,8 @@
 #include <gtest/gtest.h>
 #include <limits>
 
-#include "MaterialLib/SolidModels/NewtonRaphson.h"
-
-TEST(MaterialLibNewtonRaphson, Sqrt3)
+#include "NumLib/NewtonRaphson.h"
+TEST(NumLibNewtonRaphson, Sqrt3)
 {
     static const int N = 1;  // Problem's size.
 
@@ -40,7 +39,7 @@ TEST(MaterialLibNewtonRaphson, Sqrt3)
     auto const update_solution = [&state](
         LocalResidualVector const& increment) { state += increment[0]; };
 
-    auto const newton_solver = MaterialLib::Solids::NewtonRaphson<
+    auto const newton_solver = NumLib::NewtonRaphson<
         decltype(linear_solver), LocalJacobianMatrix, decltype(update_jacobian),
         LocalResidualVector, decltype(update_residual),
         decltype(update_solution)>(linear_solver, update_jacobian,


### PR DESCRIPTION
As titled, the local NewtonRaphson is moved from MaterialLib/SolidModels to NumLib in order for further reusing. 
This class provides a basic NewtonRaphson routine to handle the nonlinear constitutive relationships existing in the local problem. After being moved to NumLib , it can be reused by other processes, e.g the two-phase multicomponent process which I am working on now.
(p.s. Some of the changes are caused by running clang-format)