### PR TITLE
[Jenkins] Pipeline library is now pinned to a specific version.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,6 @@
 #!/usr/bin/env groovy
+@Library('jenkins-pipeline@1.0.0') _
+
 def builders = [:]
 def helper = new ogs.helper()
 


### PR DESCRIPTION
Corresponds to a tag at https://gitlab.opengeosys.org/bilke/jenkins-library/tags.

This allows to make and test breaking changes in the library without affecting other branches / forks / PRs.