### PR TITLE
[CMake] OGS_EIGEN_DYNAMIC_SHAPE_MATRICES defaults to OFF on Release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 ## Release notes
+
+# 6.0.9 (In preparation)
+
+### Features
+
+### Utilities
+
+### Infrastructure
+
+### Fixes
+
 # 6.0.8
 
 The highlight of the release is the implementation of the Lower-Interface
@@ -20,7 +31,7 @@ fluids pressure, density, permeability, and viscosity were added.
  - Liquid process. #1468
  - Classes for relative permeability models. #1531
  - Classes for capillary models. #1517, #1578
- - Ehlers single-surface yield function constitutive relation model. #1556 
+ - Ehlers single-surface yield function constitutive relation model. #1556
  - Support scaling, GMRES, and Pardiso in Eigen linear solvers. #1509 #1510
  - Piecewise linear Monotonic curve and a generic curve parser. #1529
  - Support searching boundary nodes in MeshLib::NodeSearch. #1459
@@ -51,7 +62,7 @@ New features:
 
 ### Fixes:
  - Fix LocalToGlobalIndexMap with mutliple variables and with multiple componets. #1433 #1440
- - Fix PropertyVector<T*> for multi-component case. #1441 
+ - Fix PropertyVector<T*> for multi-component case. #1441
  - Fix checking IDs of nonlinear nodes. #1495
  - Fix incorrect use of getNumberOfBaseNodes(). #1515
  - Fix computing sparsity pattern for mixed shape function order cases. #1548

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Infrastructure
 
+- CMake option OGS_EIGEN_DYNAMIC_SHAPE_MATRICES defaults to OFF on Release
+  config, ON otherwise. Can be overridden by explicitly setting the option. #1673
+
 ### Fixes
 
 # 6.0.8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,22 @@ option(OGS_USE_MPI "Use MPI" OFF)
 # Eigen
 option(OGS_USE_EIGEN "Use Eigen linear solver" ON)
 option(OGS_USE_EIGEN_UNSUPPORTED "Use Eigen unsupported modules" ON)
-option(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES "Use dynamically allocated shape matrices" ON)
 option(EIGEN_NO_DEBUG "Disables Eigen's assertions" OFF)
+
+set(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES "Default" CACHE STRING "Use dynamically allocated shape matrices")
+set_property(CACHE OGS_EIGEN_DYNAMIC_SHAPE_MATRICES
+             PROPERTY STRINGS "Default" "ON" "OFF")
+
+if(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES STREQUAL "Default")
+    if(CMAKE_BUILD_TYPE STREQUAL "Release" OR
+        CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+        set(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES_INTERNAL OFF)
+    else()
+        set(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES_INTERNAL ON)
+    endif()
+else()
+    set(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES_INTERNAL ${OGS_EIGEN_DYNAMIC_SHAPE_MATRICES})
+endif()
 
 # MKL
 option(OGS_USE_MKL "Use Intel MKL" OFF)
@@ -166,7 +180,7 @@ add_definitions(-DEIGEN_INITIALIZE_MATRICES_BY_ZERO) # TODO check if needed
 if (EIGEN_NO_DEBUG)
     add_definitions(-DEIGEN_NO_DEBUG)
 endif()
-if(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES)
+if(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES_INTERNAL)
     add_definitions(-DOGS_EIGEN_DYNAMIC_SHAPE_MATRICES)
 endif()
 


### PR DESCRIPTION
The performance differences between static and dynamic matrices are not obvious and some accidently use dynamic matrices when doing performance measurements (using release compilation modes).