### PR TITLE
Add material properties in two-phase flow with PP model

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -437,7 +437,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
         else if (type == "TWOPHASE_FLOW_PP")
         {
             process =
-                ProcessLib::TwoPhaseFlowWithPP::CreateTwoPhaseFlowWithPPProcess(
+                ProcessLib::TwoPhaseFlowWithPP::createTwoPhaseFlowWithPPProcess(
                     *_mesh_vec[0], std::move(jacobian_assembler),
                     _process_variables, _parameters, integration_order,
                     process_config, _curves);

--- a/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/porous_medium/porous_medium/relative_permeability/i_relative_permeability.md
+++ b/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/porous_medium/porous_medium/relative_permeability/i_relative_permeability.md
@@ -1,0 +1,1 @@
+A tag for the relative permeability model, which holds two ids: one is for the Nonwetting phase and the other is for the Wetting phase.

--- a/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/porous_medium/porous_medium/relative_permeability/relative_permeability/a_id.md
+++ b/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/porous_medium/porous_medium/relative_permeability/relative_permeability/a_id.md
@@ -1,0 +1,1 @@
+A tag for the relative permeability model id: 0 is Nonwetting phase and 1 is Wetting phase.

--- a/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/porous_medium/porous_medium/relative_permeability/relative_permeability/i_relative_permeability.md
+++ b/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/porous_medium/porous_medium/relative_permeability/relative_permeability/i_relative_permeability.md
@@ -1,0 +1,1 @@
+Defines the relative permeability model.

--- a/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/porous_medium/porous_medium/t_capillary_pressure.md
+++ b/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/porous_medium/porous_medium/t_capillary_pressure.md
@@ -1,0 +1,1 @@
+Capillary pressure model.

--- a/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/t_gas_density.md
+++ b/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/t_gas_density.md
@@ -1,0 +1,1 @@
+Density model of the gas phase.

--- a/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/t_gas_viscosity.md
+++ b/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/t_gas_viscosity.md
@@ -1,0 +1,1 @@
+Viscosity model of the gas phase.

--- a/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/t_liquid_density.md
+++ b/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/t_liquid_density.md
@@ -1,0 +1,1 @@
+Density model of the liquid phase.

--- a/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/t_liquid_viscosity.md
+++ b/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/t_liquid_viscosity.md
@@ -1,0 +1,1 @@
+Viscosity model of the liquid phase.

--- a/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/t_mass_lumping.md
+++ b/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/t_mass_lumping.md
@@ -1,1 +1,1 @@
-\copydoc ProcessLib::TwoPhaseFlowWithPP::TwoPhaseFlowWithPPProcessData::_has_mass_lumping
+\copydoc ProcessLib::TwoPhaseFlowWithPP::TwoPhaseFlowWithPPProcessData::has_mass_lumping

--- a/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/t_specific_body_force.md
+++ b/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/t_specific_body_force.md
@@ -1,1 +1,1 @@
-\copydoc ProcessLib::TwoPhaseFlowWithPP::TwoPhaseFlowWithPPProcessData::_specific_body_force
+\copydoc ProcessLib::TwoPhaseFlowWithPP::TwoPhaseFlowWithPPProcessData::specific_body_force

--- a/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/t_temperature.md
+++ b/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/t_temperature.md
@@ -1,0 +1,2 @@
+An input of a reference temperature (K) for two-phase flow process.
+It is fixed to be constant for the simulation due to an isothermal assumption.

--- a/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.cpp
+++ b/MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.cpp
@@ -95,7 +95,7 @@ double PiecewiseLinearInterpolation::getDerivative(
         interval_idx = 1;
     }
 
-    if (interval_idx > 2 && interval_idx < _supp_pnts.size() - 1)
+    if (interval_idx > 1 && interval_idx < _supp_pnts.size() - 2)
     {
         // left and right support points.
         double const x_ll = _supp_pnts[interval_idx - 2];

--- a/ProcessLib/TwoPhaseFlowWithPP/CMakeLists.txt
+++ b/ProcessLib/TwoPhaseFlowWithPP/CMakeLists.txt
@@ -1,26 +1,69 @@
 AddTest(
-    NAME 2D_TwoPhase_PP_Lia_quad
+    NAME 2D_TwoPhase_PP_Lia_quad_1
     PATH Parabolic/TwoPhaseFlowPP/Liakopoulos
     EXECUTABLE ogs
-    EXECUTABLE_ARGS Twophase_Lia_quad2_short.prj
+    EXECUTABLE_ARGS TwoPhase_Lia_quad_short.prj
     TESTER vtkdiff
     REQUIREMENTS NOT OGS_USE_MPI
-    ABSTOL 1e-8 RELTOL 1e-12
+    ABSTOL 1e-2 RELTOL 1e-4
     DIFF_DATA
-    Lia_20.vtu twophaseflow_pcs_0_ts_119_t_20.000000.vtu capillary_pressure capillary_pressure
-    Lia_20.vtu twophaseflow_pcs_0_ts_119_t_20.000000.vtu gas_pressure gas_pressure
-    Lia_20.vtu twophaseflow_pcs_0_ts_119_t_20.000000.vtu saturation saturation
+    h2_Liako_20.vtu twophaseflow_pcs_0_ts_218_t_20.000000.vtu saturation saturation
 )
 AddTest(
-    NAME LARGE_2D_TwoPhase_PP_Lia_quad
+    NAME 2D_TwoPhase_PP_Lia_quad_2
     PATH Parabolic/TwoPhaseFlowPP/Liakopoulos
     EXECUTABLE ogs
-    EXECUTABLE_ARGS Twophase_Lia_quad2_large.prj
+    EXECUTABLE_ARGS TwoPhase_Lia_quad_short.prj
     TESTER vtkdiff
     REQUIREMENTS NOT OGS_USE_MPI
-    ABSTOL 1e-8 RELTOL 1e-12
+    ABSTOL 20 RELTOL 1e-3
     DIFF_DATA
-    Lia_1000.vtu twophaseflow_pcs_0_ts_1180_t_1000.000000.vtu capillary_pressure capillary_pressure
-    Lia_1000.vtu twophaseflow_pcs_0_ts_1180_t_1000.000000.vtu gas_pressure gas_pressure
-    Lia_1000.vtu twophaseflow_pcs_0_ts_1180_t_1000.000000.vtu saturation saturation
+    h2_Liako_20.vtu twophaseflow_pcs_0_ts_218_t_20.000000.vtu capillary_pressure capillary_pressure
+    h2_Liako_20.vtu twophaseflow_pcs_0_ts_218_t_20.000000.vtu gas_pressure gas_pressure
+)
+AddTest(
+    NAME LARGE_2D_TwoPhase_PP_Lia_quad_1
+    PATH Parabolic/TwoPhaseFlowPP/Liakopoulos
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS TwoPhase_Lia_quad_large.prj
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    ABSTOL 1e-2 RELTOL 1e-3
+    DIFF_DATA
+    h2_Liako_1198.vtu twophaseflow_pcs_0_ts_1198_t_1000.000000.vtu SATURATION1 saturation
+)
+AddTest(
+    NAME LARGE_2D_TwoPhase_PP_Lia_quad_2
+    PATH Parabolic/TwoPhaseFlowPP/Liakopoulos
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS TwoPhase_Lia_quad_large.prj
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    ABSTOL 20 RELTOL 1e-2
+    DIFF_DATA
+    h2_Liako_1198.vtu twophaseflow_pcs_0_ts_1198_t_1000.000000.vtu PRESSURE1 capillary_pressure
+    h2_Liako_1198.vtu twophaseflow_pcs_0_ts_1198_t_1000.000000.vtu PRESSURE2 gas_pressure
+)
+AddTest(
+    NAME 1D_TwoPhase_PP_mcwt_1
+    PATH Parabolic/TwoPhaseFlowPP/McWorts
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS TwoPhase_mcwt_line.prj
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    ABSTOL 1e-2 RELTOL 1e-4
+    DIFF_DATA
+    mcwt_1000.vtu twophaseflow_pcs_0_ts_519_t_1000.000000.vtu SATURATION1 saturation
+)
+AddTest(
+    NAME 1D_TwoPhase_PP_mcwt_2
+    PATH Parabolic/TwoPhaseFlowPP/McWorts
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS TwoPhase_mcwt_line.prj
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    ABSTOL 10 RELTOL 1e-3
+    DIFF_DATA
+    mcwt_1000.vtu twophaseflow_pcs_0_ts_519_t_1000.000000.vtu PRESSURE1 capillary_pressure
+    mcwt_1000.vtu twophaseflow_pcs_0_ts_519_t_1000.000000.vtu PRESSURE2 gas_pressure
 )

--- a/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPMaterialProperties.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPMaterialProperties.cpp
@@ -1,0 +1,139 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "CreateTwoPhaseFlowWithPPMaterialProperties.h"
+#include <logog/include/logog.hpp>
+#include "BaseLib/reorderVector.h"
+#include "MaterialLib/Fluid/FluidProperty.h"
+#include "MaterialLib/PorousMedium/Porosity/Porosity.h"
+#include "MaterialLib/PorousMedium/Storage/Storage.h"
+#include "MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturation.h"
+#include "MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CreateCapillaryPressureModel.h"
+#include "MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/CreateRelativePermeabilityModel.h"
+#include "MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/RelativePermeability.h"
+#include "MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/PropertyVector.h"
+#include "ProcessLib/Parameter/Parameter.h"
+#include "ProcessLib/Parameter/SpatialPosition.h"
+#include "TwoPhaseFlowWithPPMaterialProperties.h"
+
+namespace ProcessLib
+{
+namespace TwoPhaseFlowWithPP
+{
+std::unique_ptr<TwoPhaseFlowWithPPMaterialProperties>
+createTwoPhaseFlowWithPPMaterialProperties(
+    BaseLib::ConfigTree const& config,
+    boost::optional<MeshLib::PropertyVector<int> const&>
+        material_ids)
+{
+    DBUG("Reading material properties of two-phase flow process.");
+
+    //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property__fluid}
+    auto const& fluid_config = config.getConfigSubtree("fluid");
+
+    // Get fluid properties
+    //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property__liquid_density}
+    auto const& rho_conf = fluid_config.getConfigSubtree("liquid_density");
+    auto liquid_density = MaterialLib::Fluid::createFluidDensityModel(rho_conf);
+    //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property__gas_density}
+    auto const& rho_gas_conf = fluid_config.getConfigSubtree("gas_density");
+    auto gas_density =
+        MaterialLib::Fluid::createFluidDensityModel(rho_gas_conf);
+    //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property__liquid_viscosity}
+    auto const& mu_conf = fluid_config.getConfigSubtree("liquid_viscosity");
+    auto liquid_viscosity = MaterialLib::Fluid::createViscosityModel(mu_conf);
+    //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property__gas_viscosity}
+    auto const& mu_gas_conf = fluid_config.getConfigSubtree("gas_viscosity");
+    auto gas_viscosity = MaterialLib::Fluid::createViscosityModel(mu_gas_conf);
+
+    // Get porous properties
+    std::vector<int> mat_ids;
+    std::vector<int> mat_krel_ids;
+    std::vector<Eigen::MatrixXd> intrinsic_permeability_models;
+    std::vector<std::unique_ptr<MaterialLib::PorousMedium::Porosity>>
+        porosity_models;
+    std::vector<std::unique_ptr<MaterialLib::PorousMedium::Storage>>
+        storage_models;
+    std::vector<
+        std::unique_ptr<MaterialLib::PorousMedium::CapillaryPressureSaturation>>
+        capillary_pressure_models;
+    std::vector<
+        std::unique_ptr<MaterialLib::PorousMedium::RelativePermeability>>
+        relative_permeability_models;
+
+    //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property__porous_medium}
+    auto const& poro_config = config.getConfigSubtree("porous_medium");
+    //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property__porous_medium__porous_medium}
+    for (auto const& conf : poro_config.getConfigSubtreeList("porous_medium"))
+    {
+        //! \ogs_file_attr{prj__processes__process__TWOPHASE_FLOW_PP__material_property__porous_medium__porous_medium__id}
+        auto const id = conf.getConfigAttributeOptional<int>("id");
+        mat_ids.push_back(*id);
+
+        //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property__porous_medium__porous_medium__permeability}
+        auto const& permeability_conf = conf.getConfigSubtree("permeability");
+        intrinsic_permeability_models.emplace_back(
+            MaterialLib::PorousMedium::createPermeabilityModel(
+                permeability_conf));
+
+        //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property__porous_medium__porous_medium__porosity}
+        auto const& porosity_conf = conf.getConfigSubtree("porosity");
+        auto n = MaterialLib::PorousMedium::createPorosityModel(porosity_conf);
+        porosity_models.emplace_back(std::move(n));
+
+        //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property__porous_medium__porous_medium__storage}
+        auto const& storage_conf = conf.getConfigSubtree("storage");
+        auto beta = MaterialLib::PorousMedium::createStorageModel(storage_conf);
+        storage_models.emplace_back(std::move(beta));
+
+        auto const& capillary_pressure_conf =
+            //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property__porous_medium__porous_medium__capillary_pressure}
+            conf.getConfigSubtree("capillary_pressure");
+        auto pc = MaterialLib::PorousMedium::createCapillaryPressureModel(
+            capillary_pressure_conf);
+        capillary_pressure_models.emplace_back(std::move(pc));
+
+        auto const& krel_config =
+            //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property__porous_medium__porous_medium__relative_permeability}
+            conf.getConfigSubtree("relative_permeability");
+        for (
+            auto const& krel_conf :
+            //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property__porous_medium__porous_medium__relative_permeability__relative_permeability}
+            krel_config.getConfigSubtreeList("relative_permeability"))
+        {
+            auto const krel_id =
+                //! \ogs_file_attr{prj__processes__process__TWOPHASE_FLOW_PP__material_property__porous_medium__porous_medium__relative_permeability__relative_permeability__id}
+                krel_conf.getConfigAttributeOptional<int>("id");
+            mat_krel_ids.push_back(*krel_id);
+            auto krel_n =
+                MaterialLib::PorousMedium::createRelativePermeabilityModel(
+                    krel_conf);
+            relative_permeability_models.emplace_back(std::move(krel_n));
+        }
+        BaseLib::reorderVector(relative_permeability_models, mat_krel_ids);
+    }
+
+    BaseLib::reorderVector(intrinsic_permeability_models, mat_ids);
+    BaseLib::reorderVector(porosity_models, mat_ids);
+    BaseLib::reorderVector(storage_models, mat_ids);
+
+    return std::unique_ptr<TwoPhaseFlowWithPPMaterialProperties>{
+        new TwoPhaseFlowWithPPMaterialProperties{
+            material_ids, std::move(liquid_density),
+            std::move(liquid_viscosity), std::move(gas_density),
+            std::move(gas_viscosity), intrinsic_permeability_models,
+            std::move(porosity_models), std::move(storage_models),
+            std::move(capillary_pressure_models),
+            std::move(relative_permeability_models)}};
+}
+
+}  // end namespace
+}  // end namespace

--- a/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPMaterialProperties.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPMaterialProperties.h
@@ -1,0 +1,30 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+
+#include "TwoPhaseFlowWithPPMaterialProperties.h"
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace ProcessLib
+{
+namespace TwoPhaseFlowWithPP
+{
+std::unique_ptr<TwoPhaseFlowWithPPMaterialProperties>
+createTwoPhaseFlowWithPPMaterialProperties(
+    BaseLib::ConfigTree const& config,
+    boost::optional<MeshLib::PropertyVector<int> const&>
+        material_ids);
+
+}  // end namespace
+}  // end namespace

--- a/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.h
@@ -16,7 +16,7 @@ namespace ProcessLib
 {
 namespace TwoPhaseFlowWithPP
 {
-std::unique_ptr<Process> CreateTwoPhaseFlowWithPPProcess(
+std::unique_ptr<Process> createTwoPhaseFlowWithPPProcess(
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler.h
@@ -20,13 +20,35 @@
 #include "ProcessLib/Parameter/Parameter.h"
 #include "ProcessLib/Utils/InitShapeMatrices.h"
 
-#include "MaterialLib/TwoPhaseModels/TwoPhaseFlowWithPPMaterialProperties.h"
+#include "TwoPhaseFlowWithPPMaterialProperties.h"
 #include "TwoPhaseFlowWithPPProcessData.h"
 
 namespace ProcessLib
 {
 namespace TwoPhaseFlowWithPP
 {
+template <typename NodalRowVectorType, typename GlobalDimNodalMatrixType,
+          typename NodalMatrixType>
+struct IntegrationPointData final
+{
+    explicit IntegrationPointData(
+        NodalRowVectorType const& N_, GlobalDimNodalMatrixType const& dNdx_,
+        TwoPhaseFlowWithPPMaterialProperties& material_property_,
+        double const& integration_weight_, NodalMatrixType const massOperator_)
+        : N(N_),
+          dNdx(dNdx_),
+          mat_property(material_property_),
+          integration_weight(integration_weight_),
+          massOperator(massOperator_)
+
+    {
+    }
+    NodalRowVectorType const N;
+    GlobalDimNodalMatrixType const dNdx;
+    TwoPhaseFlowWithPPMaterialProperties const& mat_property;
+    const double integration_weight;
+    NodalMatrixType const massOperator;
+};
 const unsigned NUM_NODAL_DOF = 2;
 
 class TwoPhaseFlowWithPPLocalAssemblerInterface
@@ -37,7 +59,7 @@ public:
     virtual std::vector<double> const& getIntPtSaturation(
         std::vector<double>& /*cache*/) const = 0;
 
-    virtual std::vector<double> const& getIntPtWettingPressure(
+    virtual std::vector<double> const& getIntPtWetPressure(
         std::vector<double>& /*cache*/) const = 0;
 };
 
@@ -51,7 +73,10 @@ class TwoPhaseFlowWithPPLocalAssembler
 
     using LocalAssemblerTraits = ProcessLib::LocalAssemblerTraits<
         ShapeMatricesType, ShapeFunction::NPOINTS, NUM_NODAL_DOF, GlobalDim>;
+    using NodalRowVectorType = typename ShapeMatricesType::NodalRowVectorType;
 
+    using GlobalDimNodalMatrixType =
+        typename ShapeMatricesType::GlobalDimNodalMatrixType;
     using NodalMatrixType = typename ShapeMatricesType::NodalMatrixType;
     using NodalVectorType = typename ShapeMatricesType::NodalVectorType;
     using GlobalDimMatrixType = typename ShapeMatricesType::GlobalDimMatrixType;
@@ -68,15 +93,29 @@ public:
         TwoPhaseFlowWithPPProcessData const& process_data)
         : _element(element),
           _integration_method(integration_order),
-          _shape_matrices(initShapeMatrices<ShapeFunction, ShapeMatricesType,
-                                            IntegrationMethod, GlobalDim>(
-              element, is_axially_symmetric, _integration_method)),
           _process_data(process_data),
           _saturation(
               std::vector<double>(_integration_method.getNumberOfPoints())),
-          _pressure_wetting(
+          _pressure_wet(
               std::vector<double>(_integration_method.getNumberOfPoints()))
     {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+        _ip_data.reserve(n_integration_points);
+        auto const shape_matrices =
+            initShapeMatrices<ShapeFunction, ShapeMatricesType,
+                              IntegrationMethod, GlobalDim>(
+                element, is_axially_symmetric, _integration_method);
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            auto const& sm = shape_matrices[ip];
+            _ip_data.emplace_back(
+                sm.N, sm.dNdx, *_process_data.material,
+                sm.integralMeasure * sm.detJ *
+                    _integration_method.getWeightedPoint(ip).getWeight(),
+                sm.N.transpose() * sm.N * sm.integralMeasure * sm.detJ *
+                    _integration_method.getWeightedPoint(ip).getWeight());
+        }
     }
 
     void assemble(double const t, std::vector<double> const& local_x,
@@ -87,7 +126,7 @@ public:
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         const unsigned integration_point) const override
     {
-        auto const& N = _shape_matrices[integration_point].N;
+        auto const& N = _ip_data[integration_point].N;
 
         // assumes N is stored contiguously in memory
         return Eigen::Map<const Eigen::RowVectorXd>(N.data(), N.size());
@@ -100,28 +139,32 @@ public:
         return _saturation;
     }
 
-    std::vector<double> const& getIntPtWettingPressure(
+    std::vector<double> const& getIntPtWetPressure(
         std::vector<double>& /*cache*/) const override
     {
-        assert(_pressure_wetting.size() > 0);
-        return _pressure_wetting;
+        assert(_pressure_wet.size() > 0);
+        return _pressure_wet;
     }
 
 private:
     MeshLib::Element const& _element;
 
     IntegrationMethod const _integration_method;
-    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
-        _shape_matrices;
 
     TwoPhaseFlowWithPPProcessData const& _process_data;
+    std::vector<
+        IntegrationPointData<NodalRowVectorType, GlobalDimNodalMatrixType,
+                             NodalMatrixType>,
+        Eigen::aligned_allocator<IntegrationPointData<
+            NodalRowVectorType, GlobalDimNodalMatrixType, NodalMatrixType>>>
+        _ip_data;
 
-    // Note: currently only isothermal case is considered, so the temperature is
-    // assumed to be const
-    // the variation of temperature will be taken into account in future
-    double _temperature = 293.15;
+    // output vector for wetting phase saturation with
+    // respect to each integration point
     std::vector<double> _saturation;
-    std::vector<double> _pressure_wetting;
+    // output vector for wetting phase pressure with respect
+    // to each integration point
+    std::vector<double> _pressure_wet;
     static const int nonwet_pressure_coeff_index = 0;
     static const int cap_pressure_coeff_index = 1;
 

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPMaterialProperties.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPMaterialProperties.cpp
@@ -1,0 +1,169 @@
+/**
+* \copyright
+* Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+*            Distributed under a Modified BSD License.
+*              See accompanying file LICENSE.txt or
+*              http://www.opengeosys.org/project/license
+*
+*/
+
+#include "TwoPhaseFlowWithPPMaterialProperties.h"
+#include <logog/include/logog.hpp>
+#include "BaseLib/reorderVector.h"
+#include "MaterialLib/Fluid/FluidProperty.h"
+#include "MaterialLib/PorousMedium/Porosity/Porosity.h"
+#include "MaterialLib/PorousMedium/Storage/Storage.h"
+#include "MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturation.h"
+#include "MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CreateCapillaryPressureModel.h"
+#include "MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/CreateRelativePermeabilityModel.h"
+#include "MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/RelativePermeability.h"
+#include "MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/PropertyVector.h"
+#include "ProcessLib/Parameter/Parameter.h"
+#include "ProcessLib/Parameter/SpatialPosition.h"
+namespace ProcessLib
+{
+namespace TwoPhaseFlowWithPP
+{
+TwoPhaseFlowWithPPMaterialProperties::TwoPhaseFlowWithPPMaterialProperties(
+    boost::optional<MeshLib::PropertyVector<int> const&> const material_ids,
+    std::unique_ptr<MaterialLib::Fluid::FluidProperty>
+        liquid_density,
+    std::unique_ptr<MaterialLib::Fluid::FluidProperty>
+        liquid_viscosity,
+    std::unique_ptr<MaterialLib::Fluid::FluidProperty>
+        gas_density,
+    std::unique_ptr<MaterialLib::Fluid::FluidProperty>
+        gas_viscosity,
+    std::vector<Eigen::MatrixXd>
+        intrinsic_permeability_models,
+    std::vector<std::unique_ptr<MaterialLib::PorousMedium::Porosity>>&&
+        porosity_models,
+    std::vector<std::unique_ptr<MaterialLib::PorousMedium::Storage>>&&
+        storage_models,
+    std::vector<std::unique_ptr<
+        MaterialLib::PorousMedium::CapillaryPressureSaturation>>&&
+        capillary_pressure_models,
+    std::vector<
+        std::unique_ptr<MaterialLib::PorousMedium::RelativePermeability>>&&
+        relative_permeability_models)
+    : _liquid_density(std::move(liquid_density)),
+      _liquid_viscosity(std::move(liquid_viscosity)),
+      _gas_density(std::move(gas_density)),
+      _gas_viscosity(std::move(gas_viscosity)),
+      _material_ids(material_ids),
+      _intrinsic_permeability_models(intrinsic_permeability_models),
+      _porosity_models(std::move(porosity_models)),
+      _storage_models(std::move(storage_models)),
+      _capillary_pressure_models(std::move(capillary_pressure_models)),
+      _relative_permeability_models(std::move(relative_permeability_models))
+{
+    DBUG("Create material properties for Two-Phase flow with PP model.");
+}
+
+int TwoPhaseFlowWithPPMaterialProperties::getMaterialID(
+    const std::size_t element_id)
+{
+    if (!_material_ids)
+    {
+        return 0;
+    }
+
+    assert(element_id < _material_ids->size());
+    return (*_material_ids)[element_id];
+}
+
+double TwoPhaseFlowWithPPMaterialProperties::getLiquidDensity(
+    const double p, const double T) const
+{
+    ArrayType vars;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
+    return _liquid_density->getValue(vars);
+}
+
+double TwoPhaseFlowWithPPMaterialProperties::getGasDensity(const double p,
+                                                           const double T) const
+{
+    ArrayType vars;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
+    return _gas_density->getValue(vars);
+}
+
+double TwoPhaseFlowWithPPMaterialProperties::getGasDensityDerivative(
+    const double p, const double T) const
+{
+    ArrayType vars;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
+
+    return _gas_density->getdValue(vars,
+                                   MaterialLib::Fluid::PropertyVariableType::p);
+}
+double TwoPhaseFlowWithPPMaterialProperties::getLiquidViscosity(
+    const double p, const double T) const
+{
+    ArrayType vars;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
+    return _liquid_viscosity->getValue(vars);
+}
+
+double TwoPhaseFlowWithPPMaterialProperties::getGasViscosity(
+    const double p, const double T) const
+{
+    ArrayType vars;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
+    return _gas_viscosity->getValue(vars);
+}
+
+Eigen::MatrixXd const& TwoPhaseFlowWithPPMaterialProperties::getPermeability(
+    const int material_id, const double /*t*/,
+    const ProcessLib::SpatialPosition& /*pos*/, const int /*dim*/) const
+{
+    return _intrinsic_permeability_models[material_id];
+}
+
+double TwoPhaseFlowWithPPMaterialProperties::getPorosity(
+    const int material_id, const double /*t*/,
+    const ProcessLib::SpatialPosition& /*pos*/, const double /*p*/,
+    const double T, const double porosity_variable) const
+{
+    return _porosity_models[material_id]->getValue(porosity_variable, T);
+}
+
+double TwoPhaseFlowWithPPMaterialProperties::getNonwetRelativePermeability(
+    const double /*t*/, const ProcessLib::SpatialPosition& /*pos*/,
+    const double /*p*/, const double /*T*/, const double saturation) const
+{
+    return _relative_permeability_models[0]->getValue(saturation);
+}
+
+double TwoPhaseFlowWithPPMaterialProperties::getWetRelativePermeability(
+    const double /*t*/, const ProcessLib::SpatialPosition& /*pos*/,
+    const double /*p*/, const double /*T*/, const double saturation) const
+{
+    return _relative_permeability_models[1]->getValue(saturation);
+}
+
+double TwoPhaseFlowWithPPMaterialProperties::getSaturation(
+    const int material_id, const double /*t*/,
+    const ProcessLib::SpatialPosition& /*pos*/, const double /*p*/,
+    const double /*T*/, const double pc) const
+{
+    return _capillary_pressure_models[material_id]->getSaturation(pc);
+}
+double TwoPhaseFlowWithPPMaterialProperties::getSaturationDerivative(
+    const int material_id, const double /*t*/,
+    const ProcessLib::SpatialPosition& /*pos*/, const double /*p*/,
+    const double /*T*/, const double saturation) const
+{
+    const double dpcdsw =
+        _capillary_pressure_models[material_id]->getdPcdS(saturation);
+    return 1 / dpcdsw;
+}
+}  // end of namespace
+}  // end of namespace

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPMaterialProperties.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPMaterialProperties.h
@@ -1,0 +1,129 @@
+/**
+* \copyright
+* Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+*            Distributed under a Modified BSD License.
+*              See accompanying file LICENSE.txt or
+*              http://www.opengeosys.org/project/license
+*
+*/
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include "MaterialLib/Fluid/FluidPropertyHeaders.h"
+#include "MaterialLib/PhysicalConstant.h"
+#include "MaterialLib/PorousMedium/Porosity/Porosity.h"
+#include "MaterialLib/PorousMedium/PorousPropertyHeaders.h"
+#include "MaterialLib/PorousMedium/Storage/Storage.h"
+#include "MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturation.h"
+#include "MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CreateCapillaryPressureModel.h"
+#include "MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/CreateRelativePermeabilityModel.h"
+#include "MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/RelativePermeability.h"
+
+namespace MeshLib
+{
+template <typename PROP_VAL_TYPE>
+class PropertyVector;
+}
+
+namespace ProcessLib
+{
+class SpatialPosition;
+namespace TwoPhaseFlowWithPP
+{
+    /** This class has a collection of material properties for two-phase flow with PP model
+    *  and it makes description of the material properties for two-phase condition,
+    *  i.e. the gas/liquid density and viscosity models, respectively,
+    *  the relative permeability models with respect to two phases,
+    *  the capillary pressure-saturation relationships.
+    *  It generally provides the computation of the PDE coefficients for two-phase flow.
+    */
+
+class TwoPhaseFlowWithPPMaterialProperties
+{
+public:
+    using ArrayType = MaterialLib::Fluid::FluidProperty::ArrayType;
+
+    TwoPhaseFlowWithPPMaterialProperties(
+        boost::optional<MeshLib::PropertyVector<int> const&> const material_ids,
+        std::unique_ptr<MaterialLib::Fluid::FluidProperty>
+            liquid_density,
+        std::unique_ptr<MaterialLib::Fluid::FluidProperty>
+            liquid_viscosity,
+        std::unique_ptr<MaterialLib::Fluid::FluidProperty>
+            gas_density,
+        std::unique_ptr<MaterialLib::Fluid::FluidProperty>
+            gas_viscosity,
+        std::vector<Eigen::MatrixXd>
+            intrinsic_permeability_models,
+        std::vector<std::unique_ptr<MaterialLib::PorousMedium::Porosity>>&&
+            porosity_models,
+        std::vector<std::unique_ptr<MaterialLib::PorousMedium::Storage>>&&
+            storage_models,
+        std::vector<std::unique_ptr<
+            MaterialLib::PorousMedium::CapillaryPressureSaturation>>&&
+            capillary_pressure_models,
+        std::vector<
+            std::unique_ptr<MaterialLib::PorousMedium::RelativePermeability>>&&
+            relative_permeability_models);
+
+    int getMaterialID(const std::size_t element_id);
+
+    Eigen::MatrixXd const& getPermeability(
+        const int material_id,
+        const double t,
+        const ProcessLib::SpatialPosition& pos,
+        const int dim) const;
+
+    double getPorosity(const int material_id, const double t,
+                       const ProcessLib::SpatialPosition& pos, const double p,
+                       const double T, const double porosity_variable) const;
+
+    double getNonwetRelativePermeability(const double t,
+                                         const ProcessLib::SpatialPosition& pos,
+                                         const double p, const double T,
+                                         const double saturation) const;
+    double getWetRelativePermeability(const double t,
+                                      const ProcessLib::SpatialPosition& pos,
+                                      const double p, const double T,
+                                      const double saturation) const;
+    double getSaturation(const int material_id, const double t,
+                         const ProcessLib::SpatialPosition& pos, const double p,
+                         const double T, const double pc) const;
+    double getSaturationDerivative(const int material_id, const double t,
+                                   const ProcessLib::SpatialPosition& pos,
+                                   const double p, const double T,
+                                   const double saturation) const;
+    double getLiquidDensity(const double p, const double T) const;
+    double getGasDensity(const double p, const double T) const;
+    double getGasViscosity(const double p, const double T) const;
+    double getLiquidViscosity(const double p, const double T) const;
+    double getGasDensityDerivative(double const p, double const T) const;
+
+protected:
+    std::unique_ptr<MaterialLib::Fluid::FluidProperty> _liquid_density;
+    std::unique_ptr<MaterialLib::Fluid::FluidProperty> _liquid_viscosity;
+    std::unique_ptr<MaterialLib::Fluid::FluidProperty> _gas_density;
+    std::unique_ptr<MaterialLib::Fluid::FluidProperty> _gas_viscosity;
+
+    /** Use two phase models for different material zones.
+    *  Material IDs must be given as mesh element properties.
+    */
+    boost::optional<MeshLib::PropertyVector<int> const&> const _material_ids;
+
+    std::vector<Eigen::MatrixXd> _intrinsic_permeability_models;
+    std::vector<std::unique_ptr<MaterialLib::PorousMedium::Porosity>>
+        _porosity_models;
+    std::vector<std::unique_ptr<MaterialLib::PorousMedium::Storage>>
+        _storage_models;
+    std::vector<
+        std::unique_ptr<MaterialLib::PorousMedium::CapillaryPressureSaturation>>
+        _capillary_pressure_models;
+    std::vector<
+        std::unique_ptr<MaterialLib::PorousMedium::RelativePermeability>>
+        _relative_permeability_models;
+};
+
+}  // end of namespace
+}  // end of namespace

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
@@ -35,7 +35,7 @@ TwoPhaseFlowWithPPProcess::TwoPhaseFlowWithPPProcess(
     BaseLib::ConfigTree const& /*config*/,
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
-        /*curves*/)
+    /*curves*/)
     : Process(mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller)),
@@ -62,10 +62,10 @@ void TwoPhaseFlowWithPPProcess::initializeConcreteProcess(
             &TwoPhaseFlowWithPPLocalAssemblerInterface::getIntPtSaturation));
 
     _secondary_variables.addSecondaryVariable(
-        "pressure_wetting", 1,
+        "pressure_wet", 1,
         makeExtrapolator(getExtrapolator(), _local_assemblers,
                          &TwoPhaseFlowWithPPLocalAssemblerInterface::
-                             getIntPtWettingPressure));
+                             getIntPtWetPressure));
 }
 
 void TwoPhaseFlowWithPPProcess::assembleConcreteProcess(const double t,

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include "MaterialLib/TwoPhaseModels/TwoPhaseFlowWithPPMaterialProperties.h"
 #include "MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h"
 #include "NumLib/DOF/LocalToGlobalIndexMap.h"
 #include "ProcessLib/Process.h"

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcessData.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcessData.h
@@ -8,7 +8,7 @@
  */
 
 #pragma once
-
+#include "TwoPhaseFlowWithPPMaterialProperties.h"
 namespace MeshLib
 {
 class Element;
@@ -27,29 +27,23 @@ struct TwoPhaseFlowWithPPProcessData
         Eigen::VectorXd const specific_body_force_,
         bool const has_gravity_,
         bool const has_mass_lumping_,
-        std::unique_ptr<MaterialLib::TwoPhaseFlowWithPP::
-                            TwoPhaseFlowWithPPMaterialProperties>&& material_,
-        MathLib::PiecewiseLinearInterpolation const& interpolated_Pc_,
-        MathLib::PiecewiseLinearInterpolation const& interpolated_Kr_wet_,
-        MathLib::PiecewiseLinearInterpolation const& interpolated_Kr_nonwet_)
-        : _specific_body_force(specific_body_force_),
-          _has_gravity(has_gravity_),
-          _has_mass_lumping(has_mass_lumping_),
-          _material(std::move(material_)),
-          _interpolated_Pc(interpolated_Pc_),
-          _interpolated_Kr_wet(interpolated_Kr_wet_),
-          _interpolated_Kr_nonwet(interpolated_Kr_nonwet_)
+        Parameter<double> const& temperature_,
+        std::unique_ptr<TwoPhaseFlowWithPPMaterialProperties>&& material_)
+        : specific_body_force(specific_body_force_),
+          has_gravity(has_gravity_),
+          has_mass_lumping(has_mass_lumping_),
+          temperature(temperature_),
+          material(std::move(material_))
+
     {
     }
 
     TwoPhaseFlowWithPPProcessData(TwoPhaseFlowWithPPProcessData&& other)
-        : _specific_body_force(other._specific_body_force),
-          _has_gravity(other._has_gravity),
-          _has_mass_lumping(other._has_mass_lumping),
-          _material(std::move(other._material)),
-          _interpolated_Pc(other._interpolated_Pc),
-          _interpolated_Kr_wet(other._interpolated_Kr_wet),
-          _interpolated_Kr_nonwet(other._interpolated_Kr_nonwet)
+        : specific_body_force(other.specific_body_force),
+          has_gravity(other.has_gravity),
+          has_mass_lumping(other.has_mass_lumping),
+          temperature(other.temperature),
+          material(std::move(other.material))
     {
     }
 
@@ -66,18 +60,14 @@ struct TwoPhaseFlowWithPPProcessData
     //! Specific body forces applied to solid and fluid.
     //! It is usually used to apply gravitational forces.
     //! A vector of displacement dimension's length.
-    Eigen::VectorXd const _specific_body_force;
+    Eigen::VectorXd const specific_body_force;
 
-    bool const _has_gravity;
+    bool const has_gravity;
 
     //! Enables lumping of the mass matrix.
-    bool const _has_mass_lumping;
-    std::unique_ptr<
-        MaterialLib::TwoPhaseFlowWithPP::TwoPhaseFlowWithPPMaterialProperties>
-        _material;
-    MathLib::PiecewiseLinearInterpolation const& _interpolated_Pc;
-    MathLib::PiecewiseLinearInterpolation const& _interpolated_Kr_wet;
-    MathLib::PiecewiseLinearInterpolation const& _interpolated_Kr_nonwet;
+    bool const has_mass_lumping;
+    Parameter<double> const& temperature;
+    std::unique_ptr<TwoPhaseFlowWithPPMaterialProperties> material;
 };
 
 }  // namespace TwoPhaseFlowWithPP

--- a/Tests/MathLib/TestPiecewiseLinearInterpolation.cpp
+++ b/Tests/MathLib/TestPiecewiseLinearInterpolation.cpp
@@ -143,6 +143,13 @@ TEST(MathLibInterpolationAlgorithms, PiecewiseLinearInterpolationDerivative)
                     interpolation.getDerivative(k + 0.5),
                     std::numeric_limits<double>::epsilon());
     }
+    //check, if a point is located between the first and second points
+    //(or last and second to last point), the derivative is calculated
+    //using linear interpolation.
+    ASSERT_NEAR(2.6, interpolation.getDerivative(1.3),
+        std::numeric_limits<double>::epsilon());
+    ASSERT_NEAR(1995, interpolation.getDerivative(997.3),
+        std::numeric_limits<double>::epsilon());
     // max and min value test
     ASSERT_NEAR(1, interpolation.getDerivative(0),
                 std::numeric_limits<double>::epsilon());


### PR DESCRIPTION
As titled, update the two-phase flow with PP-model based on fluid and porous media properties, and update the Test/data accordingly.
Here, the results of ctest are updated due to the BrookCorey type relative permeability model is applied instead of the previous curve type by following the original benchmark setting.  
The results are compared with ogs5 results. 