### PR TITLE
Fixing Lubby2 initialization of local variables.

### DIFF
--- a/MaterialLib/SolidModels/CreateLubby2.h
+++ b/MaterialLib/SolidModels/CreateLubby2.h
@@ -92,8 +92,7 @@ std::unique_ptr<MechanicsBase<DisplacementDim>> createLubby2(
     DBUG("Use '%s' as dependency parameter mvM.",
          dependency_parameter_mvM.name.c_str());
 
-
-    typename Lubby2<DisplacementDim>::MaterialProperties mp{
+    Lubby2MaterialProperties mp{
         kelvin_shear_modulus,     maxwell_shear_modulus,
         maxwell_bulk_modulus,     kelvin_viscosity,
         maxwell_viscosity,        dependency_parameter_mK,

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -533,7 +533,7 @@ bool SolidEhlers<DisplacementDim>::computeConstitutiveRelation(
            nullptr);
     MaterialStateVariables& _state =
         static_cast<MaterialStateVariables&>(material_state_variables);
-    _state.loadState();
+    _state.setInitialConditions();
 
     using Invariants = MaterialLib::SolidModels::Invariants<KelvinVectorSize>;
     C.setZero();

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -128,7 +128,7 @@ public:
         {
         }
 
-        void loadState()
+        void setInitialConditions()
         {
             eps_p_D = eps_p_D_prev;
             eps_p_V = eps_p_V_prev;

--- a/MaterialLib/SolidModels/Lubby2-impl.h
+++ b/MaterialLib/SolidModels/Lubby2-impl.h
@@ -142,8 +142,9 @@ bool Lubby2<DisplacementDim>::computeConstitutiveRelation(
     // Consistent tangent from local Newton iteration of material
     // functionals.
     // Only the upper left block is relevant for the global tangent.
-    auto dzdE = linear_solver.solve(-dGdE)
-                    .template block<KelvinVectorSize, KelvinVectorSize>(0, 0);
+    KelvinMatrix const dzdE =
+        linear_solver.solve(-dGdE)
+            .template block<KelvinVectorSize, KelvinVectorSize>(0, 0);
 
     auto const& P_sph = Invariants::spherical_projection;
     C.noalias() = local_lubby2_properties.GM0 * dzdE * P_dev +

--- a/MaterialLib/SolidModels/Lubby2-impl.h
+++ b/MaterialLib/SolidModels/Lubby2-impl.h
@@ -34,7 +34,7 @@ bool Lubby2<DisplacementDim>::computeConstitutiveRelation(
            nullptr);
     MaterialStateVariables& state =
         static_cast<MaterialStateVariables&>(material_state_variables);
-    state.loadState();
+    state.setInitialConditions();
 
     auto local_lubby2_properties =
         detail::LocalLubby2Properties<DisplacementDim>{t, x, _mp};

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -114,7 +114,7 @@ public:
             eps_M_j.resize(KelvinVectorSize);
         }
 
-        void loadState()
+        void setInitialConditions()
         {
             eps_K_j = eps_K_t;
             eps_M_j = eps_M_t;

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -56,46 +56,52 @@ struct Lubby2MaterialProperties
     P const& mvM;
 };
 
+namespace detail
+{
+template <int DisplacementDim>
+struct LocalLubby2Properties
+{
+    LocalLubby2Properties(double const t,
+                          ProcessLib::SpatialPosition const& x,
+                          Lubby2MaterialProperties const& mp)
+        : GM0(mp.GM0(t, x)[0]),
+          KM0(mp.KM0(t, x)[0]),
+          GK0(mp.GK0(t, x)[0]),
+          etaK0(mp.etaK0(t, x)[0]),
+          etaM0(mp.etaM0(t, x)[0]),
+          mK(mp.mK(t, x)[0]),
+          mvK(mp.mvK(t, x)[0]),
+          mvM(mp.mvM(t, x)[0])
+    {
+    }
+
+    void update(double const s_eff)
+    {
+        GK = GK0 * std::exp(mK * GM0 * s_eff);
+        etaK = etaK0 * std::exp(mvK * GM0 * s_eff);
+        etaM = etaM0 * std::exp(mvM * GM0 * s_eff);
+    }
+
+    double const GM0;
+    double const KM0;
+    double const GK0;
+    double const etaK0;
+    double const etaM0;
+    double const mK;
+    double const mvK;
+    double const mvM;
+
+    // Solution dependent values.
+    double GK;
+    double etaK;
+    double etaM;
+};
+}
+
 template <int DisplacementDim>
 class Lubby2 final : public MechanicsBase<DisplacementDim>
 {
 public:
-    //
-    // Variables specific to the material model.
-    //
-    struct MaterialProperties
-    {
-        using P = ProcessLib::Parameter<double>;
-        MaterialProperties(P const& GK0_,
-                           P const& GM0_,
-                           P const& KM0_,
-                           P const& etaK0_,
-                           P const& etaM0_,
-                           P const& mK_,
-                           P const& mvK_,
-                           P const& mvM_)
-            : GK0(GK0_),
-              GM0(GM0_),
-              KM0(KM0_),
-              etaK0(etaK0_),
-              etaM0(etaM0_),
-              mK(mK_),
-              mvK(mvK_),
-              mvM(mvM_)
-        {
-        }
-
-        // basic material parameters
-        P const& GK0;
-        P const& GM0;
-        P const& KM0;
-        P const& etaK0;
-        P const& etaM0;
-        P const& mK;
-        P const& mvK;
-        P const& mvM;
-    };
-
     struct MaterialStateVariables
         : public MechanicsBase<DisplacementDim>::MaterialStateVariables
     {
@@ -105,6 +111,12 @@ public:
             eps_K_j.resize(KelvinVectorSize);
             eps_M_t.resize(KelvinVectorSize);
             eps_M_j.resize(KelvinVectorSize);
+        }
+
+        void loadState()
+        {
+            eps_K_j = eps_K_t;
+            eps_M_j = eps_M_t;
         }
 
         void pushBackState() override
@@ -123,13 +135,6 @@ public:
         /// iteration
         KelvinVector eps_M_t;
         KelvinVector eps_M_j;
-
-        // solution dependent values
-        double GM;
-        double KM;
-        double GK;
-        double etaK;
-        double etaM;
     };
 
     std::unique_ptr<
@@ -175,32 +180,28 @@ public:
             material_state_variables) override;
 
 private:
-    /// Updates Burgers material parameters in LUBBY2 fashion.
-    void updateBurgersProperties(double const t,
-                                 ProcessLib::SpatialPosition const& x,
-                                 double const s_eff,
-                                 MaterialStateVariables& _state);
-
     /// Calculates the 18x1 residual vector.
-    void calculateResidualBurgers(double const dt,
-                                  const KelvinVector& strain_curr,
-                                  const KelvinVector& stress_curr,
-                                  KelvinVector& strain_Kel_curr,
-                                  const KelvinVector& strain_Kel_t,
-                                  KelvinVector& strain_Max_curr,
-                                  const KelvinVector& strain_Max_t,
-                                  ResidualVector& res,
-                                  MaterialStateVariables const& _state);
+    void calculateResidualBurgers(
+        double const dt,
+        const KelvinVector& strain_curr,
+        const KelvinVector& stress_curr,
+        KelvinVector& strain_Kel_curr,
+        const KelvinVector& strain_Kel_t,
+        KelvinVector& strain_Max_curr,
+        const KelvinVector& strain_Max_t,
+        ResidualVector& res,
+        detail::LocalLubby2Properties<DisplacementDim> const& properties);
 
     /// Calculates the 18x18 Jacobian.
-    void calculateJacobianBurgers(double const t,
-                                  ProcessLib::SpatialPosition const& x,
-                                  double const dt,
-                                  JacobianMatrix& Jac,
-                                  double s_eff,
-                                  const KelvinVector& sig_i,
-                                  const KelvinVector& eps_K_i,
-                                  MaterialStateVariables const& _state);
+    void calculateJacobianBurgers(
+        double const t,
+        ProcessLib::SpatialPosition const& x,
+        double const dt,
+        JacobianMatrix& Jac,
+        double s_eff,
+        const KelvinVector& sig_i,
+        const KelvinVector& eps_K_i,
+        detail::LocalLubby2Properties<DisplacementDim> const& properties);
 
     /// Calculates the 18x6 derivative of the residuals with respect to total
     /// strain.

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -77,9 +77,10 @@ struct LocalLubby2Properties
 
     void update(double const s_eff)
     {
-        GK = GK0 * std::exp(mK * GM0 * s_eff);
-        etaK = etaK0 * std::exp(mvK * GM0 * s_eff);
-        etaM = etaM0 * std::exp(mvM * GM0 * s_eff);
+        double const GM0_s_eff = GM0 * s_eff;
+        GK = GK0 * std::exp(mK * GM0_s_eff);
+        etaK = etaK0 * std::exp(mvK * GM0_s_eff);
+        etaM = etaM0 * std::exp(mvM * GM0_s_eff);
     }
 
     double const GM0;

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -20,6 +20,42 @@ namespace MaterialLib
 {
 namespace Solids
 {
+//
+// Variables specific to the material model.
+//
+struct Lubby2MaterialProperties
+{
+    using P = ProcessLib::Parameter<double>;
+    Lubby2MaterialProperties(P const& GK0_,
+                             P const& GM0_,
+                             P const& KM0_,
+                             P const& etaK0_,
+                             P const& etaM0_,
+                             P const& mK_,
+                             P const& mvK_,
+                             P const& mvM_)
+        : GK0(GK0_),
+          GM0(GM0_),
+          KM0(KM0_),
+          etaK0(etaK0_),
+          etaM0(etaM0_),
+          mK(mK_),
+          mvK(mvK_),
+          mvM(mvM_)
+    {
+    }
+
+    // basic material parameters
+    P const& GK0;
+    P const& GM0;
+    P const& KM0;
+    P const& etaK0;
+    P const& etaM0;
+    P const& mK;
+    P const& mvK;
+    P const& mvM;
+};
+
 template <int DisplacementDim>
 class Lubby2 final : public MechanicsBase<DisplacementDim>
 {
@@ -121,7 +157,7 @@ public:
                                          Eigen::RowMajor>;
 
 public:
-    explicit Lubby2(MaterialProperties& material_properties)
+    explicit Lubby2(Lubby2MaterialProperties& material_properties)
         : _mp(material_properties)
     {
     }
@@ -190,7 +226,7 @@ private:
     }
 
 private:
-    MaterialProperties _mp;
+    Lubby2MaterialProperties _mp;
 };
 
 extern template class Lubby2<2>;


### PR DESCRIPTION
See second commit's message for some details.

Small restructuring: Moving the nested class MaterialProperties outside (Lubby2MaterialProperties) and introducing a new class to save temporary variables.