### PR TITLE
Fixing eigen alignment

### DIFF
--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryConditionLocalAssembler.h
@@ -48,7 +48,10 @@ public:
 
 protected:
     IntegrationMethod const _integration_method;
-    std::vector<typename ShapeMatricesType::ShapeMatrices> const _shape_matrices;
+    std::vector<typename ShapeMatricesType::ShapeMatrices,
+                Eigen::aligned_allocator<
+                    typename ShapeMatricesType::ShapeMatrices>> const
+        _shape_matrices;
 };
 
 }  // ProcessLib

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
@@ -69,6 +69,9 @@ public:
 private:
     Parameter<double> const& _neumann_bc_parameter;
     typename Base::NodalVectorType _local_rhs;
+
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 }   // namespace ProcessLib

--- a/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
@@ -86,6 +86,9 @@ private:
 
     typename Base::NodalMatrixType _local_K;
     typename Base::NodalVectorType _local_rhs;
+
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 }  // ProcessLib

--- a/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFluxLocalAssembler.h
+++ b/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFluxLocalAssembler.h
@@ -76,7 +76,10 @@ public:
         std::size_t const n_integration_points =
             _integration_method.getNumberOfPoints();
 
-        std::vector<typename ShapeMatricesType::ShapeMatrices> shape_matrices;
+        std::vector<
+            typename ShapeMatricesType::ShapeMatrices,
+            Eigen::aligned_allocator<typename ShapeMatricesType::ShapeMatrices>>
+            shape_matrices;
         shape_matrices.reserve(n_integration_points);
         _detJ_times_integralMeasure.reserve(n_integration_points);
         for (std::size_t ip = 0; ip < n_integration_points; ++ip)

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -213,7 +213,8 @@ private:
     GroundwaterFlowProcessData const& _process_data;
 
     IntegrationMethod const _integration_method;
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
 
     std::vector<std::vector<double>> _darcy_velocities;
 };

--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -301,7 +301,9 @@ private:
 
     IntegrationMethod const _integration_method;
     std::vector<
-        IntegrationPointData<NodalRowVectorType, GlobalDimNodalMatrixType>>
+        IntegrationPointData<NodalRowVectorType, GlobalDimNodalMatrixType>,
+        Eigen::aligned_allocator<
+            IntegrationPointData<NodalRowVectorType, GlobalDimNodalMatrixType>>>
         _ip_data;
     std::vector<std::vector<double>> _darcy_velocities;
 };

--- a/ProcessLib/HeatConduction/HeatConductionFEM.h
+++ b/ProcessLib/HeatConduction/HeatConductionFEM.h
@@ -185,7 +185,8 @@ private:
     HeatConductionProcessData const& _process_data;
 
     IntegrationMethod const _integration_method;
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
 
     std::vector<std::vector<double>> _heat_fluxes;
 };

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -358,10 +358,11 @@ private:
 
     using BMatricesType =
         BMatrixPolicyType<ShapeFunctionDisplacement, DisplacementDim>;
-    std::vector<IntegrationPointData<
-        BMatricesType, ShapeMatricesTypeDisplacement, ShapeMatricesTypePressure,
-        DisplacementDim, ShapeFunctionDisplacement::NPOINTS>>
-        _ip_data;
+    using IpData =
+        IntegrationPointData<BMatricesType, ShapeMatricesTypeDisplacement,
+                             ShapeMatricesTypePressure, DisplacementDim,
+                             ShapeFunctionDisplacement::NPOINTS>;
+    std::vector<IpData, Eigen::aligned_allocator<IpData>> _ip_data;
 
     IntegrationMethod _integration_method;
     MeshLib::Element const& _element;

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -96,6 +96,8 @@ struct IntegrationPointData final
             t, x_position, dt, eps_prev, eps, sigma_eff_prev, sigma_eff, C,
             *material_state_variables);
     }
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture.h
@@ -103,7 +103,8 @@ private:
 
     HydroMechanicsProcessData<GlobalDim>& _process_data;
 
-    std::vector<IntegrationPointDataType> _ip_data;
+    std::vector<IntegrationPointDataType,
+        Eigen::aligned_allocator<IntegrationPointDataType>> _ip_data;
 
     static const int pressure_index = 0;
     static const int pressure_size = ShapeFunctionPressure::NPOINTS;

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix.h
@@ -113,7 +113,9 @@ protected:
 
     HydroMechanicsProcessData<GlobalDim>& _process_data;
 
-    std::vector<IntegrationPointDataType> _ip_data;
+    std::vector<IntegrationPointDataType,
+                Eigen::aligned_allocator<IntegrationPointDataType>>
+        _ip_data;
 
     static const int pressure_index = 0;
     static const int pressure_size = ShapeFunctionPressure::NPOINTS;

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SecondaryData.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SecondaryData.h
@@ -21,7 +21,7 @@ namespace SmallDeformation
 template <typename ShapeMatrixType>
 struct SecondaryData
 {
-    std::vector<ShapeMatrixType> N;
+    std::vector<ShapeMatrixType, Eigen::aligned_allocator<ShapeMatrixType>> N;
 };
 
 }  // namespace SmallDeformation

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
@@ -152,10 +152,15 @@ private:
     SmallDeformationProcessData<DisplacementDim>& _process_data;
     FractureProperty const* _fracture_property = nullptr;
 
-    std::vector<IntegrationPointDataFracture<HMatricesType, DisplacementDim>> _ip_data;
+    std::vector<IntegrationPointDataFracture<HMatricesType, DisplacementDim>,
+                Eigen::aligned_allocator<IntegrationPointDataFracture<
+                    HMatricesType, DisplacementDim>>>
+        _ip_data;
 
     IntegrationMethod _integration_method;
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<
+                                   typename ShapeMatricesType::ShapeMatrices>>
+        _shape_matrices;
     MeshLib::Element const& _element;
     SecondaryData<typename ShapeMatrices::ShapeType> _secondary_data;
 };

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
@@ -159,7 +159,10 @@ private:
 
     SmallDeformationProcessData<DisplacementDim>& _process_data;
 
-    std::vector<IntegrationPointDataMatrix<BMatricesType, DisplacementDim>> _ip_data;
+    std::vector<IntegrationPointDataMatrix<BMatricesType, DisplacementDim>,
+                Eigen::aligned_allocator<
+                    IntegrationPointDataMatrix<BMatricesType, DisplacementDim>>>
+        _ip_data;
 
     IntegrationMethod _integration_method;
     MeshLib::Element const& _element;

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
@@ -161,10 +161,15 @@ private:
     SmallDeformationProcessData<DisplacementDim>& _process_data;
     std::vector<FractureProperty*> _fracture_props;
 
-    std::vector<IntegrationPointDataMatrix<BMatricesType, DisplacementDim>> _ip_data;
+    std::vector<IntegrationPointDataMatrix<BMatricesType, DisplacementDim>,
+                Eigen::aligned_allocator<
+                    IntegrationPointDataMatrix<BMatricesType, DisplacementDim>>>
+        _ip_data;
 
     IntegrationMethod _integration_method;
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<
+                                   typename ShapeMatricesType::ShapeMatrices>>
+        _shape_matrices;
 
     MeshLib::Element const& _element;
     SecondaryData<typename ShapeMatrices::ShapeType> _secondary_data;

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -123,7 +123,8 @@ private:
     MeshLib::Element const& _element;
 
     IntegrationMethod const _integration_method;
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
 
     std::vector<std::vector<double>> _darcy_velocities =
         std::vector<std::vector<double>>(

--- a/ProcessLib/RichardsFlow/RichardsFlowFEM.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowFEM.h
@@ -180,7 +180,8 @@ private:
     RichardsFlowProcessData const& _process_data;
 
     IntegrationMethod const _integration_method;
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
 
     std::vector<double> _saturation;
 };

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -87,7 +87,7 @@ namespace SmallDeformation
 template <typename ShapeMatrixType>
 struct SecondaryData
 {
-    std::vector<ShapeMatrixType> N;
+    std::vector<ShapeMatrixType, Eigen::aligned_allocator<ShapeMatrixType>> N;
 };
 
 struct SmallDeformationLocalAssemblerInterface
@@ -406,7 +406,10 @@ private:
 
     SmallDeformationProcessData<DisplacementDim>& _process_data;
 
-    std::vector<IntegrationPointData<BMatricesType, DisplacementDim>> _ip_data;
+    std::vector<IntegrationPointData<BMatricesType, DisplacementDim>,
+                Eigen::aligned_allocator<
+                    IntegrationPointData<BMatricesType, DisplacementDim>>>
+        _ip_data;
 
     IntegrationMethod _integration_method;
     MeshLib::Element const& _element;

--- a/ProcessLib/TES/TESLocalAssembler.h
+++ b/ProcessLib/TES/TESLocalAssembler.h
@@ -109,7 +109,8 @@ public:
 private:
     IntegrationMethod_ const _integration_method;
 
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
 
     using LAT = LocalAssemblerTraits<ShapeMatricesType, ShapeFunction::NPOINTS,
                                      NODAL_DOF, GlobalDim>;

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler.h
@@ -111,7 +111,8 @@ private:
     MeshLib::Element const& _element;
 
     IntegrationMethod const _integration_method;
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
 
     TwoPhaseFlowWithPPProcessData const& _process_data;
 

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler.h
@@ -155,10 +155,13 @@ private:
     MeshLib::Element const& _element;
 
     IntegrationMethod const _integration_method;
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
 
     TwoPhaseFlowWithPrhoProcessData const& _process_data;
-    std::vector<IntegrationPointData<NodalMatrixType>> _ip_data;
+    std::vector<IntegrationPointData<NodalMatrixType>,
+                Eigen::aligned_allocator<IntegrationPointData<NodalMatrixType>>>
+        _ip_data;
 
     std::vector<double> _saturation;  /// used for secondary variable output
     std::vector<double> _pressure_nonwetting;

--- a/ProcessLib/Utils/InitShapeMatrices.h
+++ b/ProcessLib/Utils/InitShapeMatrices.h
@@ -18,11 +18,15 @@ namespace ProcessLib
 {
 template <typename ShapeFunction, typename ShapeMatricesType,
           typename IntegrationMethod, unsigned GlobalDim>
-std::vector<typename ShapeMatricesType::ShapeMatrices> initShapeMatrices(
-    MeshLib::Element const& e, bool is_axially_symmetric,
-    IntegrationMethod const& integration_method)
+std::vector<typename ShapeMatricesType::ShapeMatrices,
+            Eigen::aligned_allocator<typename ShapeMatricesType::ShapeMatrices>>
+initShapeMatrices(MeshLib::Element const& e, bool is_axially_symmetric,
+                  IntegrationMethod const& integration_method)
 {
-    std::vector<typename ShapeMatricesType::ShapeMatrices> shape_matrices;
+    std::vector<
+        typename ShapeMatricesType::ShapeMatrices,
+        Eigen::aligned_allocator<typename ShapeMatricesType::ShapeMatrices>>
+        shape_matrices;
 
     using FemType = NumLib::TemplateIsoparametric<
         ShapeFunction, ShapeMatricesType>;

--- a/Tests/NumLib/TestExtrapolation.cpp
+++ b/Tests/NumLib/TestExtrapolation.cpp
@@ -32,11 +32,12 @@
 
 namespace
 {
-template<typename ShapeMatrices>
+template <typename ShapeMatrices>
 void interpolateNodalValuesToIntegrationPoints(
-        std::vector<double> const& local_nodal_values,
-        std::vector<ShapeMatrices> const& shape_matrices,
-        std::vector<double>& interpolated_values)
+    std::vector<double> const& local_nodal_values,
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>> const&
+        shape_matrices,
+    std::vector<double>& interpolated_values)
 {
     for (unsigned ip=0; ip<shape_matrices.size(); ++ip)
     {
@@ -116,7 +117,8 @@ public:
     }
 
 private:
-    std::vector<ShapeMatrices> _shape_matrices;
+    std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
+        _shape_matrices;
     std::vector<double> _int_pt_values;
 };
 

--- a/Tests/NumLib/TestFe.cpp
+++ b/Tests/NumLib/TestFe.cpp
@@ -155,6 +155,9 @@ class NumLibFemIsoTest : public ::testing::Test, public T::TestFeType
     std::vector<const MeshLib::Node*> vec_nodes;
     std::vector<const MeshElementType*> vec_eles;
     MeshElementType* mesh_element;
+
+ public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 }; // NumLibFemIsoTest
 
 template <class T>

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,14 +7,13 @@ class OpenGeoSysConan(ConanFile):
         "Boost/[>=1.56.0]@lasote/stable", \
         "Shapelib/1.3.0@bilke/stable", \
         "VTK/[>=6.3,<7.1]@bilke/stable", \
-        "Eigen3/3.2.8@bilke/stable", \
+        "Eigen3/3.2.9@bilke/stable", \
         "libgeotiff/1.4.2@bilke/stable", \
         "Qt/5.6.2@bilke/testing"
 
     generators = "cmake"
 
     default_options = \
-        "Boost:shared=False", \
         "Boost:header_only=True", \
         "Qt:xmlpatterns=True"
 

--- a/scripts/cmake/ExternalProjectEigen.cmake
+++ b/scripts/cmake/ExternalProjectEigen.cmake
@@ -5,12 +5,12 @@ if(USE_CONAN)
 endif()
 
 if(OGS_LIB_EIGEN STREQUAL "System")
-    find_package(Eigen3 3.2.8 REQUIRED)
+    find_package(Eigen3 3.2.9 REQUIRED)
     if(NOT EIGEN3_FOUND)
         message(FATAL_ERROR "Aborting CMake because system Eigen was not found!")
     endif()
 elseif(OGS_LIB_EIGEN STREQUAL "Default")
-    find_package(Eigen3 3.2.8)
+    find_package(Eigen3 3.2.9)
 endif()
 
 # First check for system Eigen

--- a/scripts/cmake/ThirdPartyLibVersions.cmake
+++ b/scripts/cmake/ThirdPartyLibVersions.cmake
@@ -3,8 +3,8 @@ string(REPLACE "." "_" OGS_BOOST_VERSION_UNDERLINE ${OGS_BOOST_VERSION})
 set(OGS_BOOST_URL "http://opengeosys.s3.amazonaws.com/ogs6-lib-sources/boost_${OGS_BOOST_VERSION_UNDERLINE}.tar.bz2")
 set(OGS_BOOST_MD5 "a744cf167b05d72335f27c88115f211d")
 
-set(OGS_EIGEN_URL "http://opengeosys.s3.amazonaws.com/ogs6-lib-sources/eigen-3.2.8.tar.gz")
-set(OGS_EIGEN_MD5 "135d8d43aaee5fb54cf5f3e981b1a6db")
+set(OGS_EIGEN_URL "http://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz")
+set(OGS_EIGEN_MD5 "6a578dba42d1c578d531ab5b6fa3f741")
 
 set(OGS_VTK_VERSION 6.3.0)
 set(OGS_VTK_URL "http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz")

--- a/scripts/env/envinf1/cli.sh
+++ b/scripts/env/envinf1/cli.sh
@@ -6,7 +6,7 @@ module load gcc/4.8.1-3
 
 # Libraries
 module load boost/1.62.0-1
-module load eigen/3.2.8-1-cmake
+module load eigen/3.2.9-1-cmake
 module load vtk/6.3.0_openmpi-1.8.4-noqt-1
 
 # Tools


### PR DESCRIPTION
TODO: 
 - [x] Fix compilation problems.

Starting with Eigen-3.3 the alignment issue came up again and is solved here.
Without the proper alignment in Release mode there are segv's and undefined memory usage problems.

I tried to minimize set of changes, so not every structure got a special new-operator (we might have to extend this if errors happen).

I have changed some of the tests (and found some errors there) to run successfully on my computer with Eigen-3.2.10 and Eigen-3.3.2 and LIS-1.7.24.
~~Lars will setup a test in Jenkins using eigen-3.3 in nearest future.~~ See https://github.com/ufz/ogs/pull/1687 for the eigen-3.3 changes.

One problem I could not solve is the failing LIS-BiCG solver for the `ogs-Mechanics_SDE_cube_1e0` benchmark. I changed the solver to CG, which is fine in this case because the matrices are symmetric.