### PR TITLE
Tests large and Eigen 3.3

### DIFF
--- a/scripts/jenkins/gcc-tests-large.groovy
+++ b/scripts/jenkins/gcc-tests-large.groovy
@@ -2,6 +2,7 @@ def defaultDockerArgs = '-v /home/jenkins/.ccache:/usr/src/.ccache'
 def defaultCMakeOptions =
     '-DCMAKE_BUILD_TYPE=Release ' +
     '-DOGS_LIB_BOOST=System ' +
+    '-DOGS_LIB_EIGEN=System ' +
     '-DOGS_LIB_VTK=System ' +
     '-DOGS_USE_LIS=ON'
 
@@ -10,7 +11,7 @@ def build = new ogs.build()
 def post = new ogs.post()
 def helper = new ogs.helper()
 
-node('docker') {
+node('envinf11w') {
     checkout scm
     def image = docker.image('ogs6/gcc-gui:latest')
     image.pull()

--- a/scripts/jenkins/gcc.groovy
+++ b/scripts/jenkins/gcc.groovy
@@ -2,6 +2,7 @@ def defaultDockerArgs = '-v /home/jenkins/.ccache:/usr/src/.ccache'
 def defaultCMakeOptions =
     '-DCMAKE_BUILD_TYPE=Release ' +
     '-DOGS_LIB_BOOST=System ' +
+    '-DOGS_LIB_EIGEN=Local ' +
     '-DOGS_LIB_VTK=System '
 
 def guiCMakeOptions =


### PR DESCRIPTION
- Regular gcc job uses Eigen 3.2.8 (downloaded locally)
- [tests-large gcc job](https://jenkins.opengeosys.org/job/OGS-6/job/gcc-tests-large/) uses Eigen 3.3 (system installed package, job runs nightly)