### PR TITLE
Fix Visual Studio warnings

### DIFF
--- a/Applications/FileIO/FEFLOW/FEFLOWMeshInterface.cpp
+++ b/Applications/FileIO/FEFLOW/FEFLOWMeshInterface.cpp
@@ -380,7 +380,7 @@ void FEFLOWMeshInterface::readElevation(std::ifstream& in,
     std::size_t l = 0;
     unsigned mode = 0;  // 0: exit, 1: slice no, 2: elevation value, 3:
                         // continued line of mode 2
-    int pos_prev_line = 0;
+    std::streamoff pos_prev_line = 0;
     while (true)
     {
         pos_prev_line = in.tellg();

--- a/Applications/FileIO/FEFLOW/FEFLOWMeshInterface.cpp
+++ b/Applications/FileIO/FEFLOW/FEFLOWMeshInterface.cpp
@@ -482,7 +482,7 @@ MeshLib::Element* FEFLOWMeshInterface::readElement(
     switch (elem_type)
     {
         default:
-            for (unsigned k(0); k < n_nodes_of_element; ++k)
+            for (std::size_t k(0); k < n_nodes_of_element; ++k)
                 ele_nodes[k] = nodes[idx[k] - 1];
             break;
         case MeshLib::MeshElemType::HEXAHEDRON:

--- a/Applications/FileIO/Gmsh/GMSHAdaptiveMeshDensity.cpp
+++ b/Applications/FileIO/Gmsh/GMSHAdaptiveMeshDensity.cpp
@@ -115,7 +115,8 @@ void GMSHAdaptiveMeshDensity::getSteinerPoints (std::vector<GeoLib::Point*> & pn
             if ((*it)->getDepth() + additional_levels > max_depth) {
                 additional_levels = max_depth - (*it)->getDepth();
             }
-            const std::size_t n_pnts_per_quad_dim = 1 << additional_levels;
+            const std::size_t n_pnts_per_quad_dim = static_cast<std::size_t>(1)
+                                                    << additional_levels;
             const double delta ((ur[0] - ll[0]) / (2 * n_pnts_per_quad_dim));
             for (std::size_t i(0); i<n_pnts_per_quad_dim; i++) {
                 for (std::size_t j(0); j<n_pnts_per_quad_dim; j++) {

--- a/NumLib/TimeStepping/Algorithms/FixedTimeStepping.cpp
+++ b/NumLib/TimeStepping/Algorithms/FixedTimeStepping.cpp
@@ -80,7 +80,8 @@ FixedTimeStepping::newInstance(BaseLib::ConfigTree const& config)
     // append last delta_t until t_end is reached
     if (t_curr <= t_end)
     {
-        auto const repeat = std::ceil((t_end - t_curr) / delta_t);
+        auto const repeat =
+            static_cast<std::size_t>(std::ceil((t_end - t_curr) / delta_t));
         timesteps.resize(timesteps.size() + repeat, delta_t);
     }
 

--- a/ProcessLib/TES/TESLocalAssemblerInner-impl.h
+++ b/ProcessLib/TES/TESLocalAssemblerInner-impl.h
@@ -226,8 +226,10 @@ void TESLocalAssemblerInner<Traits>::assembleIntegrationPoint(
 {
     preEachAssembleIntegrationPoint(integration_point, localX, sm);
 
-    auto const N = sm.dNdx.cols();  // number of integration points
-    auto const D = sm.dNdx.rows();  // global dimension: 1, 2 or 3
+    auto const N =
+        static_cast<unsigned>(sm.dNdx.cols());  // number of integration points
+    auto const D =
+        static_cast<unsigned>(sm.dNdx.rows());  // global dimension: 1, 2 or 3
 
     assert(N * NODAL_DOF == local_M.cols());
 

--- a/Tests/NumLib/TestComponentNorms.cpp
+++ b/Tests/NumLib/TestComponentNorms.cpp
@@ -48,10 +48,10 @@ struct DOFTableData
     NumLib::LocalToGlobalIndexMap const dof_table;
 
 private:
-    static const std::size_t mesh_length;
+    static const double mesh_length;
     static const std::size_t mesh_elements_in_each_direction;
 };
-const std::size_t DOFTableData::mesh_length = 1;
+const double DOFTableData::mesh_length = 1;
 const std::size_t DOFTableData::mesh_elements_in_each_direction = 5;
 
 template <typename AccumulateCallback, typename AccumulateFinishCallback>


### PR DESCRIPTION
Fixes #973 

Warnings as reported by [Jenkins](https://jenkins.opengeosys.org/job/ufz/job/ogs/job/master/lastSuccessfulBuild/parsed_console/) in the ogs code were resolved.
One warning about "C4180	qualifier applied to function type has no meaning; ignored (compiling source file C:\Projects\ogs\Tests\MathLib\TestNonlinear1D.cpp)" is incorrect in my opinion because the `Function` type could be a pointer which needs a const qualifier in this case.