### PR TITLE
Add FieldData to mesh properties

### DIFF
--- a/MeshLib/Location.cpp
+++ b/MeshLib/Location.cpp
@@ -21,6 +21,7 @@ std::ostream& operator<<(std::ostream& os, MeshItemType const& t)
     case MeshItemType::Edge: return os << "E";
     case MeshItemType::Face: return os << "F";
     case MeshItemType::Cell: return os << "C";
+    case MeshItemType::IntegrationPoint: return os << "I";
     };
     return os;
 }

--- a/MeshLib/Location.h
+++ b/MeshLib/Location.h
@@ -18,7 +18,7 @@
 namespace MeshLib
 {
 
-enum class MeshItemType { Node, Edge, Face, Cell };
+enum class MeshItemType { Node, Edge, Face, Cell, IntegrationPoint };
 
 std::ostream& operator<<(std::ostream& os, MeshItemType const& t);
 

--- a/MeshLib/MeshGenerators/VtkMeshConverter.cpp
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.cpp
@@ -205,6 +205,15 @@ void VtkMeshConverter::convertScalarArrays(vtkUnstructuredGrid &grid, MeshLib::M
     unsigned const n_cell_arrays = static_cast<unsigned>(cell_data->GetNumberOfArrays());
     for (unsigned i=0; i<n_cell_arrays; ++i)
         convertArray(*cell_data->GetArray(i), mesh.getProperties(), MeshLib::MeshItemType::Cell);
+
+    vtkFieldData* field_data = grid.GetFieldData();
+    unsigned const n_field_arrays =
+        static_cast<unsigned>(field_data->GetNumberOfArrays());
+    for (unsigned i = 0; i < n_field_arrays; ++i)
+        convertArray(
+            *vtkDataArray::SafeDownCast(field_data->GetAbstractArray(i)),
+            mesh.getProperties(),
+            MeshLib::MeshItemType::IntegrationPoint);
 }
 
 void VtkMeshConverter::convertArray(vtkDataArray &array, MeshLib::Properties &properties, MeshLib::MeshItemType type)

--- a/MeshLib/Vtk/VtkMappedMeshSource.cpp
+++ b/MeshLib/Vtk/VtkMappedMeshSource.cpp
@@ -99,6 +99,7 @@ int VtkMappedMeshSource::RequestData(vtkInformation *,
 
     output->GetPointData()->ShallowCopy(this->PointData.GetPointer());
     output->GetCellData()->ShallowCopy(this->CellData.GetPointer());
+    output->GetFieldData()->ShallowCopy(this->FieldData.GetPointer());
     return 1;
 }
 

--- a/MeshLib/Vtk/VtkMappedMeshSource.cpp
+++ b/MeshLib/Vtk/VtkMappedMeshSource.cpp
@@ -12,6 +12,8 @@
  *
  */
 
+#include <vector>
+
 #include "VtkMappedMeshSource.h"
 
 #include <vtkDemandDrivenPipeline.h>

--- a/MeshLib/Vtk/VtkMappedMeshSource.h
+++ b/MeshLib/Vtk/VtkMappedMeshSource.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 #include <vtkCellData.h>
 #include <vtkFieldData.h>
@@ -36,15 +35,6 @@
 #include "MeshLib/PropertyVector.h"
 
 #include "VtkMappedPropertyVectorTemplate.h"
-
-class vtkCellData;
-class vtkDataArrayCollection;
-class vtkPointData;
-class vtkPoints;
-namespace MeshLib {
-    class Mesh;
-    class Properties;
-}
 
 namespace MeshLib {
 

--- a/MeshLib/Vtk/VtkMappedMeshSource.h
+++ b/MeshLib/Vtk/VtkMappedMeshSource.h
@@ -26,8 +26,9 @@
 #include <vector>
 
 #include <vtkCellData.h>
-#include <vtkPointData.h>
+#include <vtkFieldData.h>
 #include <vtkNew.h>
+#include <vtkPointData.h>
 #include <vtkUnstructuredGrid.h>
 #include <vtkUnstructuredGridAlgorithm.h>
 
@@ -97,6 +98,8 @@ private:
             this->PointData->AddArray(dataArray.GetPointer());
         else if(propertyVector->getMeshItemType() == MeshLib::MeshItemType::Cell)
             this->CellData->AddArray(dataArray.GetPointer());
+        else if(propertyVector->getMeshItemType() == MeshLib::MeshItemType::IntegrationPoint)
+            this->FieldData->AddArray(dataArray.GetPointer());
 
         return true;
     }
@@ -109,6 +112,7 @@ private:
     vtkNew<vtkPoints> Points;
     vtkNew<vtkPointData> PointData;
     vtkNew<vtkCellData> CellData;
+    vtkNew<vtkFieldData> FieldData;
 };
 
 } // Namespace MeshLib

--- a/Tests/MeshLib/TestVtkMappedMeshSource.cpp
+++ b/Tests/MeshLib/TestVtkMappedMeshSource.cpp
@@ -35,7 +35,8 @@
 #include <vtkCellData.h>
 #include <vtkPointData.h>
 
-// Creates a mesh with double and int point and cell properties
+// Creates a mesh with different types of data (double, int, etc.) and point,
+// cell, or integration point properties.
 class InSituMesh : public ::testing::Test
 {
     public:
@@ -62,6 +63,14 @@ class InSituMesh : public ::testing::Test
         std::iota(
             cell_double_properties->begin(), cell_double_properties->end(), 1);
 
+        std::string const field_prop_name("FieldDoubleProperty");
+        auto* const field_double_properties =
+            mesh->getProperties().createNewPropertyVector<double>(
+                field_prop_name, MeshLib::MeshItemType::IntegrationPoint);
+        field_double_properties->resize(mesh->getNumberOfElements() * 2);
+        std::iota(
+            field_double_properties->begin(), field_double_properties->end(), 1);
+
         std::string const point_int_prop_name("PointIntProperty");
         auto* const point_int_properties =
             mesh->getProperties().createNewPropertyVector<int>(
@@ -76,6 +85,13 @@ class InSituMesh : public ::testing::Test
                 cell_int_prop_name, MeshLib::MeshItemType::Cell);
         cell_int_properties->resize(mesh->getNumberOfElements());
         std::iota(cell_int_properties->begin(), cell_int_properties->end(), 1);
+
+        std::string const field_int_prop_name("FieldIntProperty");
+        auto* const field_int_properties =
+            mesh->getProperties().createNewPropertyVector<int>(
+                field_int_prop_name, MeshLib::MeshItemType::IntegrationPoint);
+        field_int_properties->resize(mesh->getNumberOfElements() * 2);
+        std::iota(field_int_properties->begin(), field_int_properties->end(), 1);
 
         std::string const point_unsigned_prop_name("PointUnsignedProperty");
         auto point_unsigned_properties =
@@ -93,6 +109,15 @@ class InSituMesh : public ::testing::Test
         cell_unsigned_properties->resize(mesh->getNumberOfElements());
         std::iota(cell_unsigned_properties->begin(),
                   cell_unsigned_properties->end(),
+                  1);
+
+        std::string const field_unsigned_prop_name("FieldUnsignedProperty");
+        auto field_unsigned_properties =
+            mesh->getProperties().createNewPropertyVector<unsigned>(
+                field_unsigned_prop_name, MeshLib::MeshItemType::IntegrationPoint);
+        field_unsigned_properties->resize(mesh->getNumberOfElements() * 2);
+        std::iota(field_unsigned_properties->begin(),
+                  field_unsigned_properties->end(),
                   1);
 
         std::string const material_ids_name("MaterialIDs");
@@ -207,6 +232,31 @@ TEST_F(InSituMesh, DISABLED_MappedMeshSourceRoundtrip)
     ASSERT_EQ(range[0], 1.0);
     ASSERT_EQ(range[1], 1 + mesh->getNumberOfElements() - 1);
 
+    // Field data arrays
+    vtkDataArray* fieldDoubleArray = vtkDataArray::SafeDownCast(
+        output->GetFieldData()->GetAbstractArray("FieldDoubleProperty"));
+    ASSERT_EQ(fieldDoubleArray->GetSize(), mesh->getNumberOfElements() * 2);
+    ASSERT_EQ(fieldDoubleArray->GetComponent(0, 0), 1.0);
+    range = fieldDoubleArray->GetRange(0);
+    ASSERT_EQ(range[0], 1.0);
+    ASSERT_EQ(range[1],  mesh->getNumberOfElements() * 2);
+
+    vtkDataArray* fieldIntArray = vtkDataArray::SafeDownCast(
+        output->GetFieldData()->GetAbstractArray("FieldIntProperty"));
+    ASSERT_EQ(fieldIntArray->GetSize(), mesh->getNumberOfElements() * 2);
+    ASSERT_EQ(fieldIntArray->GetComponent(0, 0), 1.0);
+    range = fieldIntArray->GetRange(0);
+    ASSERT_EQ(range[0], 1.0);
+    ASSERT_EQ(range[1], mesh->getNumberOfElements() * 2);
+
+    vtkDataArray* fieldUnsignedArray = vtkDataArray::SafeDownCast(
+        output->GetFieldData()->GetAbstractArray("FieldUnsignedProperty"));
+    ASSERT_EQ(fieldUnsignedArray->GetSize(), mesh->getNumberOfElements() * 2);
+    ASSERT_EQ(fieldUnsignedArray->GetComponent(0, 0), 1.0);
+    range = fieldUnsignedArray->GetRange(0);
+    ASSERT_EQ(range[0], 1.0);
+    ASSERT_EQ(range[1], mesh->getNumberOfElements() * 2);
+
     // -- Write VTK mesh to file (in all combinations of binary, appended and compressed)
     // atm vtkXMLWriter::Appended does not work, see http://www.paraview.org/Bug/view.php?id=13382
     for(int dataMode : { vtkXMLWriter::Ascii, vtkXMLWriter::Binary })
@@ -228,6 +278,7 @@ TEST_F(InSituMesh, DISABLED_MappedMeshSourceRoundtrip)
             // Both VTK meshes should be identical
             ASSERT_EQ(vtkMesh->GetNumberOfPoints(), output->GetNumberOfPoints());
             ASSERT_EQ(vtkMesh->GetNumberOfCells(), output->GetNumberOfCells());
+            ASSERT_EQ(vtkMesh->GetFieldData()->GetNumberOfArrays(), output->GetFieldData()->GetNumberOfArrays());
             ASSERT_EQ(vtkMesh->GetPointData()->GetScalars("PointDoubleProperty")->GetNumberOfTuples(),
                 pointDoubleArray->GetNumberOfTuples());
             ASSERT_EQ(vtkMesh->GetPointData()->GetScalars("PointIntProperty")->GetNumberOfTuples(),


### PR DESCRIPTION
This is a preparation to output of secondary variables, especially of integration-point-data and of internal material model states.

In general any data (available to the local assemblers) can be written as a MeshLib::Property on the new `MeshItemType` `IntegrationPoint`. (Maybe IntegrationPoint is not a good name though.)
The mesh properties stored as `IntegrationPoint` type are written to vtk's FieldData.

Tests for creating/reading the mesh property and a vtk import/export *i.e.* roundtrip are implemented.
