### PR TITLE
[MaL] EigenMatrix: set/add values even if 0.

### DIFF
--- a/MathLib/LinAlg/Eigen/EigenMatrix.h
+++ b/MathLib/LinAlg/Eigen/EigenMatrix.h
@@ -71,7 +71,7 @@ public:
     int setValue(IndexType row, IndexType col, double val)
     {
         assert(row < (IndexType) getNumberOfRows() && col < (IndexType) getNumberOfColumns());
-        if (val != 0.0) _mat.coeffRef(row, col) = val;
+        _mat.coeffRef(row, col) = val;
         return 0;
     }
 
@@ -79,7 +79,7 @@ public:
     /// inserted.
     int add(IndexType row, IndexType col, double val)
     {
-        if (val != 0.0) _mat.coeffRef(row, col) += val;
+        _mat.coeffRef(row, col) += val;
         return 0;
     }
 


### PR DESCRIPTION
Under certain circumstances the sparsity pattern will be destroyed and
adding/setting values would then result in an expensive reallocation.

Assume that in the first global iteration only one half of the values is
set to non-zero. Before the linear solver is called the sparse matrix is
compressed thus reducing the allocated space in each row. In the
subsequent iterations, which might add or set the other half of the
matrix values reallocations would be necessary.

~~I'll update the PR with explicit performance measurements later today. For a specific test (phase-field) the speedup is around 6.5 times (for every time-step). Of course there is some overhead for other processes because of additional `coeffRef() = value` calls; I'll quantify that later today.~~
See detailed benchmark details below in the comment.