### PR TITLE
Local isotropic damage coupled to Ehlers plasticity

### DIFF
--- a/Documentation/ProjectFile/material/solid/constitutive_relation/Ehlers/damage_properties/i_damage_properties.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/Ehlers/damage_properties/i_damage_properties.md
@@ -1,0 +1,12 @@
+Damage properties for Ehlers with local isotropic damage. This is an optional
+subtree; when not set the "usual" Ehlers material model will be used without
+damage.
+
+For further information, refer to the implementation manual and to the following
+publication: Parisio, F and Laloui, L (2017). Plastic-damage modeling of
+saturated quasi-brittle shales. Int J Rock Mech Min Sci, 93:295-306
+\cite Parisio2017
+
+\attention This implementation does not contain strain regularization. The model
+should be used with care as pathological mesh-dependency may arise. To overcome
+this issue, the user can employ the non-local integral formulation.

--- a/Documentation/ProjectFile/material/solid/constitutive_relation/Ehlers/damage_properties/t_alpha_d.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/Ehlers/damage_properties/t_alpha_d.md
@@ -1,0 +1,2 @@
+alpha_d (>0) is a meterial parameter controlling the softening rate in the
+post-peak response.

--- a/Documentation/ProjectFile/material/solid/constitutive_relation/Ehlers/damage_properties/t_beta_d.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/Ehlers/damage_properties/t_beta_d.md
@@ -1,0 +1,1 @@
+beta_d [0;1] is a material parameter controlling the residual value of damage.

--- a/Documentation/ProjectFile/material/solid/constitutive_relation/Ehlers/damage_properties/t_h_d.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/Ehlers/damage_properties/t_h_d.md
@@ -1,0 +1,3 @@
+The h_d (>0) is a material parameter controlling the brittleness of the
+post-peak response. In particular, brittleness decrease with confinement when
+h_d>0.  Higher values of h_d imply higher brittleness decrease with confinement.

--- a/Documentation/bibliography.bib
+++ b/Documentation/bibliography.bib
@@ -89,3 +89,24 @@
   Timestamp                = {2015.06.01},
   Url                      = {http://www.sciencedirect.com/science/article/pii/S0045794902004157}
 }
+
+@article{Parisio2017,
+  title = "Plastic-damage modeling of saturated quasi-brittle shales ",
+  journal = "International Journal of Rock Mechanics and Mining Sciences ",
+  volume = "93",
+  number = "",
+  pages = "295 - 306",
+  year = "2017",
+  note = "",
+  issn = "1365-1609",
+  doi = "http://dx.doi.org/10.1016/j.ijrmms.2017.01.016",
+  url = "http://www.sciencedirect.com/science/article/pii/S1365160917300849",
+  author = "Francesco Parisio and Lyesse Laloui",
+  keywords = "shale modeling",
+  keywords = "plastic and damage mechanics",
+  keywords = "hydro-mechanics of saturated shales",
+  keywords = "code_aster",
+  keywords = "nuclear waste",
+  keywords = "Mont Terri ",
+  abstract = "Abstract The constitutive modeling of shales is an important topic in the geomechanics community as it is often encountered in advanced applications such as nuclear waste storage, \{CO2\} sequestration, and unconventional oil and gas exploitation. The goal of this work is to describe, within a unique plastic-damage framework, the full mechanical behavior of shales such as pre-peak hardening plasticity, non-linearity in the onset of inelastic strains, dilatancy, post-peak softening, and degradation of the elastic parameters. The model validation against three sets of triaxial experimental results on shale demonstrates its capability to reproduce the main mechanical characteristics. "
+}

--- a/MaterialLib/SolidModels/CreateEhlers.h
+++ b/MaterialLib/SolidModels/CreateEhlers.h
@@ -22,6 +22,32 @@ namespace Solids
 {
 namespace Ehlers
 {
+
+std::unique_ptr<EhlersDamageProperties> createDamageProperties(
+    std::vector<std::unique_ptr<ProcessLib::ParameterBase>> const& parameters,
+    BaseLib::ConfigTree const& config)
+{
+    //! \ogs_file_param_special{material__solid__constitutive_relation__Ehlers__damage_properties__alpha_d}
+    auto& alpha_d =
+        ProcessLib::findParameter<double>(config, "alpha_d", parameters, 1);
+
+    DBUG("Use \'%s\' as alpha_d.", alpha_d.name.c_str());
+
+    //! \ogs_file_param_special{material__solid__constitutive_relation__Ehlers__damage_properties__beta_d}
+    auto& beta_d =
+        ProcessLib::findParameter<double>(config, "beta_d", parameters, 1);
+
+    DBUG("Use \'%s\' as beta_d.", beta_d.name.c_str());
+
+    //! \ogs_file_param_special{material__solid__constitutive_relation__Ehlers__damage_properties__h_d}
+    auto& h_d = ProcessLib::findParameter<double>(config, "h_d", parameters, 1);
+
+    DBUG("Use \'%s\' as h_d.", h_d.name.c_str());
+
+    return std::unique_ptr<EhlersDamageProperties>{
+        new EhlersDamageProperties{alpha_d, beta_d, h_d}};
+}
+
 template <int DisplacementDim>
 std::unique_ptr<MechanicsBase<DisplacementDim>> createEhlers(
     std::vector<std::unique_ptr<ProcessLib::ParameterBase>> const& parameters,
@@ -132,8 +158,21 @@ std::unique_ptr<MechanicsBase<DisplacementDim>> createEhlers(
         alphap,        betap,        gammap, deltap,
         epsp,          paremeter_mp, kappa,  hardening_modulus};
 
+    // Damage properties.
+    std::unique_ptr<EhlersDamageProperties> ehlers_damage_properties;
+
+    auto const& ehlers_damage_config =
+        //! \ogs_file_param{material__solid__constitutive_relation__Ehlers__damage_properties}
+        config.getConfigSubtreeOptional("damage_properties");
+    if (ehlers_damage_config)
+    {
+        ehlers_damage_properties =
+            createDamageProperties(parameters, *ehlers_damage_config);
+    }
+
     return std::unique_ptr<MechanicsBase<DisplacementDim>>{
-        new SolidEhlers<DisplacementDim>{mp}};
+        new SolidEhlers<DisplacementDim>{mp,
+                                         std::move(ehlers_damage_properties)}};
 }
 
 }  // namespace Ehlers

--- a/MaterialLib/SolidModels/CreateEhlers.h
+++ b/MaterialLib/SolidModels/CreateEhlers.h
@@ -22,8 +22,7 @@ namespace Solids
 {
 namespace Ehlers
 {
-
-std::unique_ptr<EhlersDamageProperties> createDamageProperties(
+inline std::unique_ptr<EhlersDamageProperties> createDamageProperties(
     std::vector<std::unique_ptr<ProcessLib::ParameterBase>> const& parameters,
     BaseLib::ConfigTree const& config)
 {

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -480,12 +480,12 @@ void SolidEhlers<DisplacementDim>::updateDamage(
     state.kappa_d = state.kappa_d_prev;
 
     // Compute damage current step
-    double const eps_p_V_dot = state.eps_p_V - state.eps_p_V_prev;
-    if (eps_p_V_dot > 0)
+    double const del_eps_p_V = state.eps_p_V - state.eps_p_V_prev;
+    if (del_eps_p_V > 0)
     {
         double const h_d = _damage_properties->h_d(t, x)[0];
-        double const eps_p_eff_dot = state.eps_p_eff - state.eps_p_eff_prev;
-        double const r_s = eps_p_eff_dot / eps_p_V_dot;
+        double const del_eps_p_eff = state.eps_p_eff - state.eps_p_eff_prev;
+        double const r_s = del_eps_p_eff / del_eps_p_V;
 
         // Brittleness decrease with confinement for the nonlinear flow rule.
         // ATTENTION: For linear flow rule -> constant brittleness.
@@ -498,7 +498,7 @@ void SolidEhlers<DisplacementDim>::updateDamage(
         {
             x_s = 1 - 3 * h_d + 4 * h_d * std::sqrt(r_s);
         }
-        state.kappa_d += eps_p_eff_dot / x_s;
+        state.kappa_d += del_eps_p_eff / x_s;
     }
 
     double const alpha_d = _damage_properties->alpha_d(t, x)[0];

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -464,6 +464,50 @@ void calculatePlasticJacobian(
     // G_52, G_53, G_55 are zero
 }
 
+template <int DisplacementDim>
+void SolidEhlers<DisplacementDim>::updateDamage(
+    double const t, ProcessLib::SpatialPosition const& x,
+    typename MechanicsBase<DisplacementDim>::MaterialStateVariables&
+        material_state_variables)
+{
+    assert(dynamic_cast<MaterialStateVariables*>(&material_state_variables) !=
+           nullptr);
+    MaterialStateVariables& state =
+        static_cast<MaterialStateVariables&>(material_state_variables);
+
+    // Default case of the rate problem. Updated below if volumetric plastic
+    // strain rate is positive (dilatancy).
+    state.kappa_d = state.kappa_d_prev;
+
+    // Compute damage current step
+    double const eps_p_V_dot = state.eps_p_V - state.eps_p_V_prev;
+    if (eps_p_V_dot > 0)
+    {
+        double const h_d = _damage_properties->h_d(t, x)[0];
+        double const eps_p_eff_dot = state.eps_p_eff - state.eps_p_eff_prev;
+        double const r_s = eps_p_eff_dot / eps_p_V_dot;
+
+        // Brittleness decrease with confinement for the nonlinear flow rule.
+        // ATTENTION: For linear flow rule -> constant brittleness.
+        double x_s = 0;
+        if (r_s < 1)
+        {
+            x_s = 1 + h_d * r_s * r_s;
+        }
+        else
+        {
+            x_s = 1 - 3 * h_d + 4 * h_d * std::sqrt(r_s);
+        }
+        state.kappa_d += eps_p_eff_dot / x_s;
+    }
+
+    double const alpha_d = _damage_properties->alpha_d(t, x)[0];
+    double const beta_d = _damage_properties->beta_d(t, x)[0];
+
+    // Update internal damage variable.
+    state.damage = (1 - beta_d) * (1 - std::exp(-state.kappa_d / alpha_d));
+}
+
 /// Calculates the derivative of the residuals with respect to total
 /// strain. Implementation fully implicit only.
 template <int DisplacementDim>
@@ -551,8 +595,17 @@ bool SolidEhlers<DisplacementDim>::computeConstitutiveRelation(
     double const G = _mp.G(t, x)[0];
     double const K = _mp.K(t, x)[0];
 
+    KelvinVector sigma_eff_prev = sigma_prev;  // In case without damage the
+                                               // effective value is same as the
+                                               // previous one.
+    if (_damage_properties)
+    {
+        // Compute sigma_eff from damage total stress sigma, which is given by
+        // sigma_eff=sigma_prev / (1-damage)
+        sigma_eff_prev = sigma_prev / (1 - _state.damage_prev);
+    }
     KelvinVector sigma =
-        predict_sigma<DisplacementDim>(G, K, sigma_prev, eps, eps_prev, eps_V);
+        predict_sigma<DisplacementDim>(G, K, sigma_eff_prev, eps, eps_prev, eps_V);
 
     // update parameter
     _mp.calculateIsotropicHardening(t, x, _state.eps_p_eff);
@@ -644,6 +697,9 @@ bool SolidEhlers<DisplacementDim>::computeConstitutiveRelation(
         dresidual_deps.template block<KelvinVectorSize, KelvinVectorSize>(0, 0)
             .noalias() = calculateDResidualDEps<DisplacementDim>(K, G);
 
+        if (_damage_properties)
+            updateDamage(t, x, _state);
+
         // Extract consistent tangent.
         C.noalias() =
             _mp.G(t, x)[0] *
@@ -652,7 +708,11 @@ bool SolidEhlers<DisplacementDim>::computeConstitutiveRelation(
     }
 
     // Update sigma.
-    sigma_final.noalias() = G * sigma;
+    if (_damage_properties)
+        sigma_final = G * sigma * (1 - _state.damage);
+    else
+        sigma_final.noalias() = G * sigma;
+
     return true;
 }
 

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -39,6 +39,14 @@ namespace Solids
 namespace Ehlers
 {
 
+struct EhlersDamageProperties
+{
+    using P = ProcessLib::Parameter<double>;
+    P const& alpha_d;
+    P const& beta_d;
+    P const& h_d;
+};
+
 template <int DisplacementDim>
 class SolidEhlers final : public MechanicsBase<DisplacementDim>
 {
@@ -188,8 +196,11 @@ public:
     using KelvinMatrix = ProcessLib::KelvinMatrixType<DisplacementDim>;
 
 public:
-    explicit SolidEhlers(MaterialProperties const& material_properties)
-        : _mp(material_properties)
+    explicit SolidEhlers(
+        MaterialProperties const& material_properties,
+        std::unique_ptr<EhlersDamageProperties>&& damage_properties)
+        : _mp(material_properties),
+          _damage_properties(std::move(damage_properties))
     {
     }
 
@@ -207,6 +218,7 @@ public:
 
 private:
     MaterialProperties _mp;
+    std::unique_ptr<EhlersDamageProperties> _damage_properties;
 };
 
 }  // namespace Ehlers

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -143,6 +143,8 @@ public:
             eps_p_D = eps_p_D_prev;
             eps_p_V = eps_p_V_prev;
             eps_p_eff = eps_p_eff_prev;
+            kappa_d = kappa_d_prev;
+            damage = damage_prev;
             lambda = 0;
         }
 
@@ -151,6 +153,8 @@ public:
             eps_p_D_prev = eps_p_D;
             eps_p_V_prev = eps_p_V;
             eps_p_eff_prev = eps_p_eff;  // effective part of trace(eps_p)
+            kappa_d_prev = kappa_d;
+            damage_prev = damage;
             lambda = 0;
         }
 
@@ -159,13 +163,16 @@ public:
         KelvinVector eps_p_D;  ///< deviatoric plastic strain
         double eps_p_V = 0;    ///< volumetric strain
         double eps_p_eff = 0;  ///< effective plastic strain
+        double kappa_d = 0;    ///< damage driving variable
+        double damage = 0;     ///< isotropic damage variable
 
         // Initial values from previous timestep
         KelvinVector eps_p_D_prev;  ///< \copydoc eps_p_D
         double eps_p_V_prev = 0;    ///< \copydoc eps_p_V
         double eps_p_eff_prev = 0;  ///< \copydoc eps_p_eff
-
-        double lambda = 0;  ///< plastic multiplier
+        double kappa_d_prev = 0;    ///< \copydoc kappa_d
+        double damage_prev = 0;     ///< \copydoc damage
+        double lambda = 0;          ///< plastic multiplier
 
 #ifndef NDEBUG
         friend std::ostream& operator<<(std::ostream& os,
@@ -174,8 +181,12 @@ public:
             os << "State:\n"
                << "eps_p_D: " << m.eps_p_D << "\n"
                << "eps_p_eff: " << m.eps_p_eff << "\n"
+               << "kappa_d: " << m.kappa_d << "\n"
+               << "damage: " << m.damage << "\n"
                << "eps_p_D_prev: " << m.eps_p_D_prev << "\n"
                << "eps_p_eff_prev: " << m.eps_p_eff_prev << "\n"
+               << "kappa_d_prev: " << m.kappa_d_prev << "\n"
+               << "damage_prev: " << m.damage_prev << "\n"
                << "lambda: " << m.lambda << "\n";
             return os;
         }
@@ -215,6 +226,14 @@ public:
         KelvinMatrix& C,
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables&
             material_state_variables) override;
+
+private:
+    /// Computes the damage internal material variable explicitly based on the
+    /// results obtained from the local stress return algorithm.
+    void updateDamage(
+        double const t, ProcessLib::SpatialPosition const& x,
+        typename MechanicsBase<DisplacementDim>::MaterialStateVariables&
+            material_state_variables);
 
 private:
     MaterialProperties _mp;

--- a/MaterialLib/SolidModels/KelvinVector-impl.h
+++ b/MaterialLib/SolidModels/KelvinVector-impl.h
@@ -16,7 +16,7 @@ double Invariants<KelvinVectorSize>::equivalentStress(
     Eigen::Matrix<double, KelvinVectorSize, 1> const& deviatoric_v)
 {
     assert(std::abs(trace(deviatoric_v)) <
-           std::numeric_limits<double>::epsilon());
+           std::numeric_limits<double>::epsilon() * 100);
     return std::sqrt(3 * J2(deviatoric_v));
 }
 
@@ -25,7 +25,7 @@ double Invariants<KelvinVectorSize>::J2(
     Eigen::Matrix<double, KelvinVectorSize, 1> const& deviatoric_v)
 {
     assert(std::abs(trace(deviatoric_v)) <
-           std::numeric_limits<double>::epsilon());
+           std::numeric_limits<double>::epsilon() * 100);
     return 0.5 * deviatoric_v.transpose() * deviatoric_v;
 }
 
@@ -36,7 +36,7 @@ double Invariants<KelvinVectorSize>::J3(
     Eigen::Matrix<double, KelvinVectorSize, 1> const& deviatoric_v)
 {
     assert(std::abs(trace(deviatoric_v)) <
-           std::numeric_limits<double>::epsilon());
+           std::numeric_limits<double>::epsilon() * 100);
     return determinant(deviatoric_v);
 }
 

--- a/ProcessLib/SmallDeformation/CMakeLists.txt
+++ b/ProcessLib/SmallDeformation/CMakeLists.txt
@@ -156,3 +156,51 @@ AddTest(
     ring_plane_strain_1e4_solution.vtu ring_plane_strain_pcs_0_ts_1_t_1.000000.vtu sigma_rr sigma_rr
     ring_plane_strain_1e4_solution.vtu ring_plane_strain_pcs_0_ts_1_t_1.000000.vtu sigma_ff sigma_ff
 )
+
+# Mechanics; Small deformations, Ehlers-damage Uniaxial Tension (SDED)
+AddTest(
+    NAME Mechanics_PlasticModel_SDED_Ehlers_Damage_UniaxialTension
+    PATH Mechanics/EhlersDamage/UniaxialTension
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS data.prj
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    ABSTOL 5e-15 RELTOL 1e-13
+    DIFF_DATA
+    uc_01_pcs_0_ts_3276_t_3.276000.vtu uc_01_pcs_0_ts_3276_t_3.276000.vtu displacement displacement
+    uc_01_pcs_0_ts_3276_t_3.276000.vtu uc_01_pcs_0_ts_3276_t_3.276000.vtu sigma_yy sigma_yy
+    uc_01_pcs_0_ts_5000_t_5.000000.vtu uc_01_pcs_0_ts_5000_t_5.000000.vtu displacement displacement
+    uc_01_pcs_0_ts_5000_t_5.000000.vtu uc_01_pcs_0_ts_5000_t_5.000000.vtu sigma_yy sigma_yy
+)
+
+# Mechanics; Small deformations, Ehlers-damage Uniaxial Compression (SDED)
+AddTest(
+    NAME Mechanics_PlasticModel_SDED_Ehlers_Damage_UniaxialCompression
+    PATH Mechanics/EhlersDamage/UniaxialCompression
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS data.prj
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    ABSTOL 5e-15 RELTOL 1e-13
+    DIFF_DATA
+    uc_01_pcs_0_ts_3543_t_3.543000.vtu uc_01_pcs_0_ts_3543_t_3.543000.vtu displacement displacement
+    uc_01_pcs_0_ts_3543_t_3.543000.vtu uc_01_pcs_0_ts_3543_t_3.543000.vtu sigma_yy sigma_yy
+    uc_01_pcs_0_ts_5000_t_5.000000.vtu uc_01_pcs_0_ts_5000_t_5.000000.vtu displacement displacement
+    uc_01_pcs_0_ts_5000_t_5.000000.vtu uc_01_pcs_0_ts_5000_t_5.000000.vtu sigma_yy sigma_yy
+)
+
+# Mechanics; Small deformations, Ehlers-damage Triaxial Compression (SDED)
+AddTest(
+    NAME Mechanics_PlasticModel_SDED_Ehlers_Damage_TriaxialCompression
+    PATH Mechanics/EhlersDamage/TriaxialCompression
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS data.prj
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    ABSTOL 5e-15 RELTOL 1e-13
+    DIFF_DATA
+    uc_01_pcs_0_ts_2823_t_2.823000.vtu uc_01_pcs_0_ts_2823_t_2.823000.vtu displacement displacement
+    uc_01_pcs_0_ts_2823_t_2.823000.vtu uc_01_pcs_0_ts_2823_t_2.823000.vtu sigma_yy sigma_yy
+    uc_01_pcs_0_ts_5000_t_5.000000.vtu uc_01_pcs_0_ts_5000_t_5.000000.vtu displacement displacement
+    uc_01_pcs_0_ts_5000_t_5.000000.vtu uc_01_pcs_0_ts_5000_t_5.000000.vtu sigma_yy sigma_yy
+)

--- a/web/content/docs/benchmarks/EhlersDamage/EhlersDamage.md
+++ b/web/content/docs/benchmarks/EhlersDamage/EhlersDamage.md
@@ -1,0 +1,9 @@
++++
+author = "Francesco Parisio"
+title = "Ehlers plastic-damage coupled model"
++++
+
+## Introduction
+
+We implemented and isotropic damage evolution law coupled to Ehelers plastic theory. The yield surface is formulated in the effective stress space and damage grows as a function of plastic strain.
+For detailed reference, refer to the implementation manual.


### PR DESCRIPTION
An isotropic damage model has been coupled to the classical Ehlers plastic yield surface. For further references, see the implementation manual.

Closes: https://github.com/ufz/ogs/issues/1645
TODO:

- [x] Update documentation site.