### PR TITLE
First application of the staggered scheme: coupled thermal hydraulic processes

### DIFF
--- a/Documentation/ProjectFile/prj/processes/process/LIQUID_FLOW/material_property/solid/i_solid.md
+++ b/Documentation/ProjectFile/prj/processes/process/LIQUID_FLOW/material_property/solid/i_solid.md
@@ -1,0 +1,1 @@
+Property of solid phase of liquid flow process.

--- a/Documentation/ProjectFile/prj/processes/process/LIQUID_FLOW/material_property/solid/t_biot_constant.md
+++ b/Documentation/ProjectFile/prj/processes/process/LIQUID_FLOW/material_property/solid/t_biot_constant.md
@@ -1,0 +1,1 @@
+Biot's constant for the liquid thermal expansion computation.

--- a/Documentation/ProjectFile/prj/processes/process/LIQUID_FLOW/material_property/solid/t_thermal_expansion.md
+++ b/Documentation/ProjectFile/prj/processes/process/LIQUID_FLOW/material_property/solid/t_thermal_expansion.md
@@ -1,0 +1,1 @@
+Liquid thermal expansion.

--- a/ProcessLib/HeatConduction/HeatConductionFEM-impl.h
+++ b/ProcessLib/HeatConduction/HeatConductionFEM-impl.h
@@ -1,0 +1,161 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ *  \file   HeatConductionFEM-impl.h
+ *  Created on January 17, 2017, 3:41 PM
+ */
+
+#pragma once
+
+#include "HeatConductionFEM.h"
+
+namespace ProcessLib
+{
+namespace HeatConduction
+{
+template <typename ShapeFunction, typename IntegrationMethod,
+          unsigned GlobalDim>
+template <typename LiquidFlowVelocityCalculator>
+void LocalAssemblerData<ShapeFunction, IntegrationMethod, GlobalDim>::
+    assembleHeatTransportLiquidFlow(
+        double const t, int const material_id, SpatialPosition& pos,
+        int const gravitational_axis_id,
+        double const gravitational_acceleration, Eigen::MatrixXd const& perm,
+        ProcessLib::LiquidFlow::LiquidFlowMaterialProperties const&
+            liquid_flow_prop,
+        std::vector<double> const& local_x, std::vector<double> const& local_p,
+        std::vector<double>& local_M_data, std::vector<double>& local_K_data)
+{
+    auto const local_matrix_size = local_x.size();
+    // This assertion is valid only if all nodal d.o.f. use the same shape
+    // matrices.
+    assert(local_matrix_size == ShapeFunction::NPOINTS * NUM_NODAL_DOF);
+
+    auto local_M = MathLib::createZeroedMatrix<NodalMatrixType>(
+        local_M_data, local_matrix_size, local_matrix_size);
+    auto local_K = MathLib::createZeroedMatrix<NodalMatrixType>(
+        local_K_data, local_matrix_size, local_matrix_size);
+    const auto local_p_vec =
+        MathLib::toVector<NodalVectorType>(local_p, local_matrix_size);
+
+    unsigned const n_integration_points =
+        _integration_method.getNumberOfPoints();
+
+    const double porosity_variable = 0.;
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        pos.setIntegrationPoint(ip);
+        auto const& sm = _shape_matrices[ip];
+        auto const& wp = _integration_method.getWeightedPoint(ip);
+        double p = 0.;
+        NumLib::shapeFunctionInterpolate(local_p, sm.N, p);
+        double T = 0.;
+        NumLib::shapeFunctionInterpolate(local_x, sm.N, T);
+
+        // Material parameters of solid phase
+        auto const k_s = _process_data.thermal_conductivity(t, pos)[0];
+        auto const cp_s = _process_data.heat_capacity(t, pos)[0];
+        auto const rho_s = _process_data.density(t, pos)[0];
+
+        // Material parameters of fluid phase
+        double const cp_f = liquid_flow_prop.getHeatCapacity(p, T);
+        double const k_f = liquid_flow_prop.getThermalConductivity(p, T);
+        double const rho_f = liquid_flow_prop.getLiquidDensity(p, T);
+
+        // Material parameter of porosity
+        double const poro =
+            liquid_flow_prop.getPorosity(material_id, porosity_variable, T);
+
+        double const effective_cp =
+            (1.0 - poro) * cp_s * rho_s + poro * cp_f * rho_f;
+        double const effective_K = (1.0 - poro) * k_s + poro * k_f;
+
+        double const integration_factor =
+            sm.detJ * wp.getWeight() * sm.integralMeasure;
+
+        local_M.noalias() +=
+            effective_cp * sm.N.transpose() * sm.N * integration_factor;
+        local_K.noalias() +=
+            sm.dNdx.transpose() * effective_K * sm.dNdx * integration_factor;
+
+        // Compute fluid flow velocity
+        double const mu = liquid_flow_prop.getViscosity(p, T);  // Viscosity
+        GlobalDimVectorType const& darcy_velocity =
+            LiquidFlowVelocityCalculator::calculateVelocity(
+                local_p_vec, sm, perm, mu, rho_f * gravitational_acceleration,
+                gravitational_axis_id);
+        // Add the advection term
+        local_K.noalias() += cp_f * rho_f * sm.N.transpose() *
+                             (darcy_velocity.transpose() * sm.dNdx) *
+                             integration_factor;
+    }
+}
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          unsigned GlobalDim>
+void LocalAssemblerData<ShapeFunction, IntegrationMethod, GlobalDim>::
+    coupling_assemble(double const t, std::vector<double> const& local_x,
+                      std::vector<double>& local_M_data,
+                      std::vector<double>& local_K_data,
+                      std::vector<double>& /*local_b_data*/,
+                      LocalCouplingTerm const& coupled_term)
+{
+    auto it = coupled_term.coupled_processes.begin();
+    while (it != coupled_term.coupled_processes.end())
+    {
+        switch (it->first)
+        {
+            case ProcessLib::ProcessType::LiquidFlowProcess:
+            {
+                ProcessLib::LiquidFlow::LiquidFlowProcess const& pcs =
+                    static_cast<
+                        ProcessLib::LiquidFlow::LiquidFlowProcess const&>(
+                        it->second);
+                const auto liquid_flow_prop =
+                    pcs.getLiquidFlowMaterialProperties();
+
+                const auto local_p = coupled_term.local_coupled_xs.at(
+                    ProcessLib::ProcessType::LiquidFlowProcess);
+
+                SpatialPosition pos;
+                pos.setElementID(_element.getID());
+                const int material_id = liquid_flow_prop->getMaterialID(pos);
+
+                const Eigen::MatrixXd& perm = liquid_flow_prop->getPermeability(
+                    material_id, t, pos, _element.getDimension());
+
+                if (perm.size() == 1)
+                {
+                    assembleHeatTransportLiquidFlow<
+                        IsotropicLiquidFlowVelocityCalculator>(
+                        t, material_id, pos, pcs.getGravitationalAxisID(),
+                        pcs.getGravitationalacceleration(), perm,
+                        *liquid_flow_prop, local_x, local_p, local_M_data,
+                        local_K_data);
+                }
+                else
+                {
+                    assembleHeatTransportLiquidFlow<
+                        AnisotropicLiquidFlowVelocityCalculator>(
+                        t, material_id, pos, pcs.getGravitationalAxisID(),
+                        pcs.getGravitationalacceleration(), perm,
+                        *liquid_flow_prop, local_x, local_p, local_M_data,
+                        local_K_data);
+                }
+            }
+            break;
+            default:
+                OGS_FATAL(
+                    "This coupled process is not presented for "
+                    "HeatConduction process");
+        }
+        it++;
+    }
+}
+
+}  // namespace HeatConduction
+}  // namespace ProcessLib

--- a/ProcessLib/HeatConduction/HeatConductionFEM.h
+++ b/ProcessLib/HeatConduction/HeatConductionFEM.h
@@ -80,10 +80,10 @@ public:
         (void)local_matrix_size;
     }
 
-    void assemble(double const t, std::vector<double> const& local_x,
+    void assemble_HeatConduction(double const t, std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
-                  std::vector<double>& /*local_b_data*/) override
+                  std::vector<double>& /*local_b_data*/)
     {
         auto const local_matrix_size = local_x.size();
         // This assertion is valid only if all nodal d.o.f. use the same shape
@@ -116,6 +116,25 @@ public:
                                  sm.N * sm.detJ * wp.getWeight() *
                                  sm.integralMeasure;
         }
+    }
+
+    void assemble(double const t, std::vector<double> const& local_x,
+                  std::vector<double>& local_M_data,
+                  std::vector<double>& local_K_data,
+                  std::vector<double>& local_b_data) override
+    {
+        assemble_HeatConduction(t, local_x, local_M_data, local_K_data,
+                                local_b_data);
+    }
+
+    void coupling_assemble(double const t, std::vector<double> const& local_x,
+                           std::vector<double>& local_M_data,
+                           std::vector<double>& local_K_data,
+                           std::vector<double>& local_b_data,
+                           LocalCouplingTerm const& coupled_term) override
+    {
+        assemble_HeatConduction(t, local_x, local_M_data, local_K_data,
+                                local_b_data);
     }
 
     void computeSecondaryVariableConcrete(

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -44,8 +44,8 @@ void HeatConductionProcess::preTimestepConcreteProcess(GlobalVector const& x,
     }
     else
     {
-        auto x0 = _x_previous_timestep.get();
-        MathLib::LinAlg::copy(x, *x0);
+        auto& x0 = *_x_previous_timestep;
+        MathLib::LinAlg::copy(x, x0);
     }
 }
 

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -33,6 +33,22 @@ HeatConductionProcess::HeatConductionProcess(
 {
 }
 
+void HeatConductionProcess::preTimestepConcreteProcess(GlobalVector const& x,
+                                            const double /*t*/,
+                                            const double /*delta_t*/)
+{
+    if (!_x_previous_timestep)
+    {
+        _x_previous_timestep =
+            MathLib::MatrixVectorTraits<GlobalVector>::newInstance(x);
+    }
+    else
+    {
+        auto x0 = _x_previous_timestep.get();
+        MathLib::LinAlg::copy(x, *x0);
+    }
+}
+
 void HeatConductionProcess::initializeConcreteProcess(
     NumLib::LocalToGlobalIndexMap const& dof_table,
     MeshLib::Mesh const& mesh,

--- a/ProcessLib/HeatConduction/HeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.h
@@ -41,6 +41,15 @@ public:
     void computeSecondaryVariableConcrete(double const t,
                                           GlobalVector const& x) override;
 
+    void preTimestepConcreteProcess(GlobalVector const& x, const double t,
+                                    const double delta_t) override;
+
+    // Get the solution of the previous time step.
+    virtual GlobalVector* getPreviousTimeStepSolution() const override
+    {
+        return _x_previous_timestep.get();
+    }
+
 private:
     void initializeConcreteProcess(
         NumLib::LocalToGlobalIndexMap const& dof_table,
@@ -63,6 +72,9 @@ private:
 
     std::vector<std::unique_ptr<HeatConductionLocalAssemblerInterface>>
         _local_assemblers;
+
+    /// Solution of the previous time step
+    std::unique_ptr<GlobalVector> _x_previous_timestep = nullptr;
 };
 
 }  // namespace HeatConduction

--- a/ProcessLib/LiquidFlow/CMakeLists.txt
+++ b/ProcessLib/LiquidFlow/CMakeLists.txt
@@ -77,6 +77,21 @@ AddTest(
     hex.vtu isotropic_gravity_driven3D_pcs_0_ts_1_t_1.000000.vtu analytic_pressure pressure
 )
 
+# Coupling
+AddTest(
+    NAME StaggeredTH_ThermalDensityDrivenFlow2D
+    PATH StaggeredCoupledProcesses/TH/ThermalDensityDrivenFlow2D
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS thermal_gravity_driven_flow2d.prj
+    WRAPPER time
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    ABSTOL 1e-20 RELTOL 1e-10
+    DIFF_DATA
+    mesh2D.vtu gravity_driven_pcs_1_ts_5_t_300.000000.vtu pressure_ref pressure
+    mesh2D.vtu gravity_driven_pcs_1_ts_5_t_300.000000.vtu temperature_ref temperature
+)
+
 # PETSc/MPI
 AddTest(
     NAME LiquidFlow_LineDirichletNeumannBC
@@ -153,4 +168,19 @@ AddTest(
     ABSTOL 1e-6 RELTOL 1e-6
     DIFF_DATA
     hex.vtu isotropic_gravity_driven3D_pcs_0_ts_1_t_1_000000_0.vtu analytic_pressure pressure
+)
+
+# Coupling
+AddTest(
+    NAME StaggeredTH_ThermalDensityDrivenFlow2D
+    PATH StaggeredCoupledProcesses/TH/ThermalDensityDrivenFlow2D
+    EXECUTABLE_ARGS thermal_gravity_driven_flow2d.prj
+    WRAPPER mpirun
+    WRAPPER_ARGS -np 1
+    TESTER vtkdiff
+    REQUIREMENTS OGS_USE_MPI
+    ABSTOL 1e-10 RELTOL 1e-10
+    DIFF_DATA
+    mesh2D.vtu gravity_driven_pcs_1_ts_5_t_300_000000_0.vtu pressure_ref pressure
+    mesh2D.vtu gravity_driven_pcs_1_ts_5_t_300_000000_0.vtu temperature_ref temperature
 )

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowMaterialProperties.cpp
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowMaterialProperties.cpp
@@ -105,12 +105,17 @@ createLiquidFlowMaterialProperties(
             "thermal_expansion", parameters, 1);
         DBUG("Use \'%s\' as solid thermal expansion.",
              solid_thermal_expansion.name.c_str());
+        auto& biot_constant = findParameter<double>(
+            *solid_config,
+            //! \ogs_file_param{prj__processes__process__LIQUID_FLOW__material_property__solid__biot_constant}
+            "biot_constant", parameters, 1);
         return std::unique_ptr<LiquidFlowMaterialProperties>(
             new LiquidFlowMaterialProperties(
                 std::move(fluid_properties),
                 std::move(intrinsic_permeability_models),
                 std::move(porosity_models), std::move(storage_models),
-                has_material_ids, material_ids, solid_thermal_expansion));
+                has_material_ids, material_ids, solid_thermal_expansion,
+                biot_constant));
     }
     else
     {
@@ -121,7 +126,8 @@ createLiquidFlowMaterialProperties(
                 std::move(fluid_properties),
                 std::move(intrinsic_permeability_models),
                 std::move(porosity_models), std::move(storage_models),
-                has_material_ids, material_ids, void_parameter));
+                has_material_ids, material_ids, void_parameter,
+                void_parameter));
     }
 }
 

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowMaterialProperties.cpp
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowMaterialProperties.cpp
@@ -61,9 +61,10 @@ createLiquidFlowMaterialProperties(
     auto const& porous_medium_configs =
         //! \ogs_file_param{prj__processes__process__LIQUID_FLOW__material_property__porous_medium}
         config.getConfigSubtree("porous_medium");
-    for (auto const& porous_medium_config :
-         //! \ogs_file_param{prj__processes__process__LIQUID_FLOW__material_property__porous_medium__porous_medium}
-         porous_medium_configs.getConfigSubtreeList("porous_medium"))
+    for (
+        auto const& porous_medium_config :
+        //! \ogs_file_param{prj__processes__process__LIQUID_FLOW__material_property__porous_medium__porous_medium}
+        porous_medium_configs.getConfigSubtreeList("porous_medium"))
     {
         //! \ogs_file_attr{prj__processes__process__LIQUID_FLOW__material_property__porous_medium__porous_medium__id}
         auto const id = porous_medium_config.getConfigAttribute<int>("id");

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowMaterialProperties.cpp
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowMaterialProperties.cpp
@@ -25,6 +25,9 @@
 #include "MaterialLib/Fluid/FluidPropertyHeaders.h"
 #include "MaterialLib/PorousMedium/PorousPropertyHeaders.h"
 
+#include "ProcessLib/Utils/ProcessUtils.h"
+#include "ProcessLib/Parameter/ConstantParameter.h"
+
 #include "LiquidFlowMaterialProperties.h"
 
 namespace ProcessLib
@@ -35,7 +38,9 @@ class LiquidFlowMaterialProperties;
 
 std::unique_ptr<LiquidFlowMaterialProperties>
 createLiquidFlowMaterialProperties(
-    BaseLib::ConfigTree const& config, bool const has_material_ids,
+    BaseLib::ConfigTree const& config,
+    std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    bool const has_material_ids,
     MeshLib::PropertyVector<int> const& material_ids)
 {
     DBUG("Reading material properties of liquid flow process.");
@@ -90,12 +95,34 @@ createLiquidFlowMaterialProperties(
     BaseLib::reorderVector(porosity_models, mat_ids);
     BaseLib::reorderVector(storage_models, mat_ids);
 
-    return std::unique_ptr<LiquidFlowMaterialProperties>(
-        new LiquidFlowMaterialProperties(
-            std::move(fluid_properties),
-            std::move(intrinsic_permeability_models),
-            std::move(porosity_models), std::move(storage_models),
-            has_material_ids, material_ids));
+    //! \ogs_file_param{prj__processes__process__LIQUID_FLOW__material_property__solid}
+    auto const solid_config = config.getConfigSubtreeOptional("solid");
+    if (solid_config)
+    {
+        auto& solid_thermal_expansion = findParameter<double>(
+            *solid_config,
+            //! \ogs_file_param{prj__processes__process__LIQUID_FLOW__material_property__solid__thermal_expansion}
+            "thermal_expansion", parameters, 1);
+        DBUG("Use \'%s\' as solid thermal expansion.",
+             solid_thermal_expansion.name.c_str());
+        return std::unique_ptr<LiquidFlowMaterialProperties>(
+            new LiquidFlowMaterialProperties(
+                std::move(fluid_properties),
+                std::move(intrinsic_permeability_models),
+                std::move(porosity_models), std::move(storage_models),
+                has_material_ids, material_ids, solid_thermal_expansion));
+    }
+    else
+    {
+        ConstantParameter<double> void_parameter("void_solid_thermal_expansion",
+                                                 0.);
+        return std::unique_ptr<LiquidFlowMaterialProperties>(
+            new LiquidFlowMaterialProperties(
+                std::move(fluid_properties),
+                std::move(intrinsic_permeability_models),
+                std::move(porosity_models), std::move(storage_models),
+                has_material_ids, material_ids, void_parameter));
+    }
 }
 
 }  // end of namespace

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowMaterialProperties.h
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowMaterialProperties.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 namespace BaseLib
 {
@@ -27,6 +28,8 @@ class PropertyVector;
 
 namespace ProcessLib
 {
+struct ParameterBase;
+
 namespace LiquidFlow
 {
 class LiquidFlowMaterialProperties;
@@ -40,7 +43,9 @@ class LiquidFlowMaterialProperties;
  */
 std::unique_ptr<LiquidFlowMaterialProperties>
 createLiquidFlowMaterialProperties(
-    BaseLib::ConfigTree const& config, bool const has_material_ids,
+    BaseLib::ConfigTree const& config,
+    std::vector<std::unique_ptr<ParameterBase>> const& parameters,
+    bool const has_material_ids,
     MeshLib::PropertyVector<int> const& material_ids);
 
 }  // end of namespace

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
@@ -14,6 +14,7 @@
 
 #include "LiquidFlowLocalAssembler.h"
 
+#include "MaterialLib/PhysicalConstant.h"
 #include "NumLib/Function/Interpolation.h"
 
 namespace ProcessLib
@@ -50,6 +51,33 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
 
 template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
+void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
+    coupling_assemble(double const t, std::vector<double> const& local_x,
+                      std::vector<double>& local_M_data,
+                      std::vector<double>& local_K_data,
+                      std::vector<double>& local_b_data,
+                      LocalCouplingTerm const& coupled_term)
+{
+    SpatialPosition pos;
+    pos.setElementID(_element.getID());
+    _material_properties->setMaterialID(pos);
+
+    const Eigen::MatrixXd& perm =
+        _material_properties->getPermeability(t, pos, _element.getDimension());
+    // Note: For Inclined 1D in 2D/3D or 2D element in 3D, the first item in
+    //  the assert must be changed to perm.rows() == _element->getDimension()
+    assert(perm.rows() == GlobalDim || perm.rows() == 1);
+
+    if (perm.size() == 1)  // isotropic or 1D problem.
+        local_assemble<IsotropicCalculator>(
+            t, local_x, local_M_data, local_K_data, local_b_data, pos, perm);
+    else
+        local_assemble<AnisotropicCalculator>(
+            t, local_x, local_M_data, local_K_data, local_b_data, pos, perm);
+}
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          unsigned GlobalDim>
 template <typename LaplacianGravityVelocityCalculator>
 void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
     local_assemble(const int material_id, double const t,
@@ -76,6 +104,8 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
     //       the integration loop for non-constant porosity and storage models.
     double porosity_variable = 0.;
     double storage_variable = 0.;
+    const double temperature =
+        MaterialLib::PhysicalConstant::CelsiusZeroInKelvin + 18.0;
     for (unsigned ip = 0; ip < n_integration_points; ip++)
     {
         auto const& sm = _shape_matrices[ip];
@@ -83,7 +113,6 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
 
         double p = 0.;
         NumLib::shapeFunctionInterpolate(local_x, sm.N, p);
-        // TODO : compute _temperature from the heat transport pcs
 
         const double integration_factor =
             sm.integralMeasure * sm.detJ * wp.getWeight();
@@ -91,15 +120,74 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
         // Assemble mass matrix, M
         local_M.noalias() += _material_properties.getMassCoefficient(
                                  material_id, t, pos, porosity_variable,
-                                 storage_variable, p, _temperature) *
+                                 storage_variable, p, temperature) *
                              sm.N.transpose() * sm.N * integration_factor;
 
         // Compute density:
         const double rho_g =
-            _material_properties.getLiquidDensity(p, _temperature) *
+            _material_properties.getLiquidDensity(p, temperature) *
             _gravitational_acceleration;
         // Compute viscosity:
-        const double mu = _material_properties.getViscosity(p, _temperature);
+        const double mu = _material_properties.getViscosity(p, temperature);
+
+        // Assemble Laplacian, K, and RHS by the gravitational term
+        LaplacianGravityVelocityCalculator::calculateLaplacianAndGravityTerm(
+            local_K, local_b, sm, perm, integration_factor, mu, rho_g,
+            _gravitational_axis_id);
+    }
+}
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          unsigned GlobalDim>
+template <typename LaplacianGravityVelocityCalculator>
+void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
+    local_assembleCoupledWithHeatTransport(
+        double const t, std::vector<double> const& local_x,
+        std::vector<double> const& local_T, std::vector<double>& local_M_data,
+        std::vector<double>& local_K_data, std::vector<double>& local_b_data,
+        SpatialPosition const& pos, Eigen::MatrixXd const& perm)
+{
+    auto const local_matrix_size = local_x.size();
+    assert(local_matrix_size == ShapeFunction::NPOINTS);
+
+    auto local_M = MathLib::createZeroedMatrix<NodalMatrixType>(
+        local_M_data, local_matrix_size, local_matrix_size);
+    auto local_K = MathLib::createZeroedMatrix<NodalMatrixType>(
+        local_K_data, local_matrix_size, local_matrix_size);
+    auto local_b = MathLib::createZeroedVector<NodalVectorType>(
+        local_b_data, local_matrix_size);
+
+    unsigned const n_integration_points =
+        _integration_method.getNumberOfPoints();
+
+    // TODO: The following two variables should be calculated inside the
+    //       the integration loop for non-constant porosity and storage models.
+    double porosity_variable = 0.;
+    double storage_variable = 0.;
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        auto const& sm = _shape_matrices[ip];
+        auto const& wp = _integration_method.getWeightedPoint(ip);
+
+        double p = 0.;
+        NumLib::shapeFunctionInterpolate(local_x, sm.N, p);
+        double T = 0.;
+        NumLib::shapeFunctionInterpolate(local_T, sm.N, T);
+
+        const double integration_factor =
+            sm.integralMeasure * sm.detJ * wp.getWeight();
+
+        // Assemble mass matrix, M
+        local_M.noalias() +=
+            _material_properties->getMassCoefficient(t, pos, porosity_variable,
+                                                     storage_variable, p, T) *
+            sm.N.transpose() * sm.N * integration_factor;
+
+        // Compute density:
+        const double rho_g = _material_properties->getLiquidDensity(p, T) *
+                             _gravitational_acceleration;
+        // Compute viscosity:
+        const double mu = _material_properties->getViscosity(p, T);
 
         // Assemble Laplacian, K, and RHS by the gravitational term
         LaplacianGravityVelocityCalculator::calculateLaplacianAndGravityTerm(
@@ -150,18 +238,59 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
     unsigned const n_integration_points =
         _integration_method.getNumberOfPoints();
 
+    const double temperature =
+        MaterialLib::PhysicalConstant::CelsiusZeroInKelvin + 18.0;
     for (unsigned ip = 0; ip < n_integration_points; ip++)
     {
         auto const& sm = _shape_matrices[ip];
         double p = 0.;
         NumLib::shapeFunctionInterpolate(local_x, sm.N, p);
-        // TODO : compute _temperature from the heat transport pcs
 
         const double rho_g =
-            _material_properties.getLiquidDensity(p, _temperature) *
+            _material_properties.getLiquidDensity(p, temperature) *
             _gravitational_acceleration;
         // Compute viscosity:
-        const double mu = _material_properties.getViscosity(p, _temperature);
+        const double mu = _material_properties.getViscosity(p, temperature);
+
+        LaplacianGravityVelocityCalculator::calculateVelocity(
+            _darcy_velocities, local_p_vec, sm, perm, ip, mu, rho_g,
+            _gravitational_axis_id);
+    }
+}
+
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          unsigned GlobalDim>
+template <typename LaplacianGravityVelocityCalculator>
+void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
+    computeSecondaryVariableCoupledWithHeatTransportLocal(
+        double const /*t*/,
+        std::vector<double> const& local_x,
+        std::vector<double> const& local_T,
+        SpatialPosition const& /*pos*/,
+        Eigen::MatrixXd const& perm)
+{
+    auto const local_matrix_size = local_x.size();
+    assert(local_matrix_size == ShapeFunction::NPOINTS);
+
+    const auto local_p_vec =
+        MathLib::toVector<NodalVectorType>(local_x, local_matrix_size);
+
+    unsigned const n_integration_points =
+        _integration_method.getNumberOfPoints();
+
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
+    {
+        auto const& sm = _shape_matrices[ip];
+        double p = 0.;
+        NumLib::shapeFunctionInterpolate(local_x, sm.N, p);
+        double T = 0.;
+        NumLib::shapeFunctionInterpolate(local_T, sm.N, T);
+
+        const double rho_g = _material_properties->getLiquidDensity(p, T) *
+                             _gravitational_acceleration;
+        // Compute viscosity:
+        const double mu = _material_properties->getViscosity(p, T);
 
         LaplacianGravityVelocityCalculator::calculateVelocity(
             _darcy_velocities, local_p_vec, sm, perm, ip, mu, rho_g,

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
@@ -60,20 +60,45 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
 {
     SpatialPosition pos;
     pos.setElementID(_element.getID());
-    _material_properties->setMaterialID(pos);
+    const int material_id = _material_properties.getMaterialID(pos);
 
-    const Eigen::MatrixXd& perm =
-        _material_properties->getPermeability(t, pos, _element.getDimension());
+    const Eigen::MatrixXd& perm = _material_properties.getPermeability(
+        material_id, t, pos, _element.getDimension());
     // Note: For Inclined 1D in 2D/3D or 2D element in 3D, the first item in
     //  the assert must be changed to perm.rows() == _element->getDimension()
     assert(perm.rows() == GlobalDim || perm.rows() == 1);
 
-    if (perm.size() == 1)  // isotropic or 1D problem.
-        local_assemble<IsotropicCalculator>(
-            t, local_x, local_M_data, local_K_data, local_b_data, pos, perm);
-    else
-        local_assemble<AnisotropicCalculator>(
-            t, local_x, local_M_data, local_K_data, local_b_data, pos, perm);
+    const double dt = coupled_term.dt;
+    auto it = coupled_term.coupled_processes.begin();
+    while (it != coupled_term.coupled_processes.end())
+    {
+        switch (it->first)
+        {
+            case ProcessLib::ProcessType::HeatConductionProcess:
+            {
+                const auto local_T0 = coupled_term.local_coupled_xs0.at(
+                    ProcessLib::ProcessType::HeatConductionProcess);
+                const auto local_T1 = coupled_term.local_coupled_xs.at(
+                    ProcessLib::ProcessType::HeatConductionProcess);
+
+                if (perm.size() == 1)  // isotropic or 1D problem.
+                    local_assembleCoupledWithHeatTransport<IsotropicCalculator>(
+                        material_id, t, dt, local_x, local_T0, local_T1,
+                        local_M_data, local_K_data, local_b_data, pos, perm);
+                else
+                    local_assembleCoupledWithHeatTransport<
+                        AnisotropicCalculator>(
+                        material_id, t, dt, local_x, local_T0, local_T1,
+                        local_M_data, local_K_data, local_b_data, pos, perm);
+            }
+            break;
+            default:
+                OGS_FATAL(
+                    "This coupled process is not presented for "
+                    "LiquidFlow process");
+        }
+        it++;
+    }
 }
 
 template <typename ShapeFunction, typename IntegrationMethod,
@@ -142,8 +167,9 @@ template <typename ShapeFunction, typename IntegrationMethod,
 template <typename LaplacianGravityVelocityCalculator>
 void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
     local_assembleCoupledWithHeatTransport(
-        double const t, std::vector<double> const& local_x,
-        std::vector<double> const& local_T, std::vector<double>& local_M_data,
+        const int material_id, double const t, double const dt,
+        std::vector<double> const& local_x, std::vector<double> const& local_T0,
+        std::vector<double> const& local_T1, std::vector<double>& local_M_data,
         std::vector<double>& local_K_data, std::vector<double>& local_b_data,
         SpatialPosition const& pos, Eigen::MatrixXd const& perm)
 {
@@ -171,28 +197,44 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
 
         double p = 0.;
         NumLib::shapeFunctionInterpolate(local_x, sm.N, p);
+        double T0 = 0.;
+        NumLib::shapeFunctionInterpolate(local_T0, sm.N, T0);
         double T = 0.;
-        NumLib::shapeFunctionInterpolate(local_T, sm.N, T);
+        NumLib::shapeFunctionInterpolate(local_T1, sm.N, T);
 
         const double integration_factor =
             sm.integralMeasure * sm.detJ * wp.getWeight();
 
         // Assemble mass matrix, M
-        local_M.noalias() +=
-            _material_properties->getMassCoefficient(t, pos, porosity_variable,
-                                                     storage_variable, p, T) *
-            sm.N.transpose() * sm.N * integration_factor;
+        local_M.noalias() += _material_properties.getMassCoefficient(
+                                 material_id, t, pos, porosity_variable,
+                                 storage_variable, p, T) *
+                             sm.N.transpose() * sm.N * integration_factor;
 
         // Compute density:
-        const double rho_g = _material_properties->getLiquidDensity(p, T) *
-                             _gravitational_acceleration;
+        const double rho = _material_properties.getLiquidDensity(p, T);
+        const double rho_g = rho * _gravitational_acceleration;
+
         // Compute viscosity:
-        const double mu = _material_properties->getViscosity(p, T);
+        const double mu = _material_properties.getViscosity(p, T);
 
         // Assemble Laplacian, K, and RHS by the gravitational term
         LaplacianGravityVelocityCalculator::calculateLaplacianAndGravityTerm(
             local_K, local_b, sm, perm, integration_factor, mu, rho_g,
             _gravitational_axis_id);
+
+        // Add the thermal expansion term
+        auto const solid_thermal_expansion =
+            _material_properties.getSolidThermalExpansion(t, pos);
+        auto const biot_constant =
+            _material_properties.getBiotConstant(t, pos);
+        auto const porosity = _material_properties.getPorosity(
+            material_id, porosity_variable, T);
+        const double eff_thermal_expansion =
+            3.0 * (biot_constant - porosity) * solid_thermal_expansion +
+            porosity * _material_properties.getdLiquidDensity_dT(p, T) / rho;
+        local_b.noalias() +=
+            eff_thermal_expansion * (T - T0) * integration_factor * sm.N / dt;
     }
 }
 
@@ -258,7 +300,6 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
     }
 }
 
-
 template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
 template <typename LaplacianGravityVelocityCalculator>
@@ -287,10 +328,10 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
         double T = 0.;
         NumLib::shapeFunctionInterpolate(local_T, sm.N, T);
 
-        const double rho_g = _material_properties->getLiquidDensity(p, T) *
+        const double rho_g = _material_properties.getLiquidDensity(p, T) *
                              _gravitational_acceleration;
         // Compute viscosity:
-        const double mu = _material_properties->getViscosity(p, T);
+        const double mu = _material_properties.getViscosity(p, T);
 
         LaplacianGravityVelocityCalculator::calculateVelocity(
             _darcy_velocities, local_p_vec, sm, perm, ip, mu, rho_g,

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -190,14 +190,11 @@ private:
 
     template <typename LaplacianGravityVelocityCalculator>
     void local_assembleCoupledWithHeatTransport(
-        double const t,
-        std::vector<double> const& local_x,
-        std::vector<double> const& local_T,
-        std::vector<double>& local_M_data,
-        std::vector<double>& local_K_data,
-        std::vector<double>& local_b_data,
-        SpatialPosition const& pos,
-        Eigen::MatrixXd const& perm);
+        const int material_id, double const t, double const dt,
+        std::vector<double> const& local_x, std::vector<double> const& local_T0,
+        std::vector<double> const& local_T1, std::vector<double>& local_M_data,
+        std::vector<double>& local_K_data, std::vector<double>& local_b_data,
+        SpatialPosition const& pos, Eigen::MatrixXd const& perm);
 
     template <typename LaplacianGravityVelocityCalculator>
     void computeSecondaryVariableLocal(double const /*t*/,

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -86,6 +86,12 @@ public:
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;
 
+    void coupling_assemble(double const t, std::vector<double> const& local_x,
+                           std::vector<double>& local_M_data,
+                           std::vector<double>& local_K_data,
+                           std::vector<double>& local_b_data,
+                           LocalCouplingTerm const& coupled_term) override;
+
     void computeSecondaryVariableConcrete(
         double const /*t*/, std::vector<double> const& local_x) override;
 
@@ -183,15 +189,34 @@ private:
                         Eigen::MatrixXd const& perm);
 
     template <typename LaplacianGravityVelocityCalculator>
+    void local_assembleCoupledWithHeatTransport(
+        double const t,
+        std::vector<double> const& local_x,
+        std::vector<double> const& local_T,
+        std::vector<double>& local_M_data,
+        std::vector<double>& local_K_data,
+        std::vector<double>& local_b_data,
+        SpatialPosition const& pos,
+        Eigen::MatrixXd const& perm);
+
+    template <typename LaplacianGravityVelocityCalculator>
     void computeSecondaryVariableLocal(double const /*t*/,
                                        std::vector<double> const& local_x,
                                        SpatialPosition const& pos,
                                        Eigen::MatrixXd const& perm);
 
+    template <typename LaplacianGravityVelocityCalculator>
+    void computeSecondaryVariableCoupledWithHeatTransportLocal(
+        double const /*t*/,
+        std::vector<double> const& local_x,
+        std::vector<double> const& local_T,
+        SpatialPosition const& pos,
+        Eigen::MatrixXd const& perm);
+
     const int _gravitational_axis_id;
     const double _gravitational_acceleration;
     const LiquidFlowMaterialProperties& _material_properties;
-    double _temperature;
+
 };
 
 }  // end of namespace

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -213,7 +213,6 @@ private:
     const int _gravitational_axis_id;
     const double _gravitational_acceleration;
     const LiquidFlowMaterialProperties& _material_properties;
-
 };
 
 }  // end of namespace

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -146,14 +146,14 @@ private:
         static void calculateLaplacianAndGravityTerm(
             Eigen::Map<NodalMatrixType>& local_K,
             Eigen::Map<NodalVectorType>& local_b, ShapeMatrices const& sm,
-            Eigen::MatrixXd const& perm, double const integration_factor,
-            double const mu, double const rho_g,
-            int const gravitational_axis_id);
+            Eigen::MatrixXd const& permeability,
+            double const integration_factor, double const mu,
+            double const rho_g, int const gravitational_axis_id);
 
         static void calculateVelocity(
             std::vector<std::vector<double>>& darcy_velocities,
             Eigen::Map<const NodalVectorType> const& local_p,
-            ShapeMatrices const& sm, Eigen::MatrixXd const& perm,
+            ShapeMatrices const& sm, Eigen::MatrixXd const& permeability,
             unsigned const ip, double const mu, double const rho_g,
             int const gravitational_axis_id);
     };
@@ -167,40 +167,40 @@ private:
         static void calculateLaplacianAndGravityTerm(
             Eigen::Map<NodalMatrixType>& local_K,
             Eigen::Map<NodalVectorType>& local_b, ShapeMatrices const& sm,
-            Eigen::MatrixXd const& perm, double const integration_factor,
-            double const mu, double const rho_g,
-            int const gravitational_axis_id);
+            Eigen::MatrixXd const& permeability,
+            double const integration_factor, double const mu,
+            double const rho_g, int const gravitational_axis_id);
 
         static void calculateVelocity(
             std::vector<std::vector<double>>& darcy_velocities,
             Eigen::Map<const NodalVectorType> const& local_p,
-            ShapeMatrices const& sm, Eigen::MatrixXd const& perm,
+            ShapeMatrices const& sm, Eigen::MatrixXd const& permeability,
             unsigned const ip, double const mu, double const rho_g,
             int const gravitational_axis_id);
     };
 
     template <typename LaplacianGravityVelocityCalculator>
-    void local_assemble(const int material_id, double const t,
-                        std::vector<double> const& local_x,
-                        std::vector<double>& local_M_data,
-                        std::vector<double>& local_K_data,
-                        std::vector<double>& local_b_data,
-                        SpatialPosition const& pos,
-                        Eigen::MatrixXd const& perm);
+    void assembleMatrixAndVector(const int material_id, double const t,
+                                 std::vector<double> const& local_x,
+                                 std::vector<double>& local_M_data,
+                                 std::vector<double>& local_K_data,
+                                 std::vector<double>& local_b_data,
+                                 SpatialPosition const& pos,
+                                 Eigen::MatrixXd const& permeability);
 
     template <typename LaplacianGravityVelocityCalculator>
-    void local_assembleCoupledWithHeatTransport(
+    void assembleWithCoupledWithHeatTransport(
         const int material_id, double const t, double const dt,
         std::vector<double> const& local_x, std::vector<double> const& local_T0,
         std::vector<double> const& local_T1, std::vector<double>& local_M_data,
         std::vector<double>& local_K_data, std::vector<double>& local_b_data,
-        SpatialPosition const& pos, Eigen::MatrixXd const& perm);
+        SpatialPosition const& pos, Eigen::MatrixXd const& permeability);
 
     template <typename LaplacianGravityVelocityCalculator>
     void computeSecondaryVariableLocal(double const /*t*/,
                                        std::vector<double> const& local_x,
                                        SpatialPosition const& pos,
-                                       Eigen::MatrixXd const& perm);
+                                       Eigen::MatrixXd const& permeability);
 
     template <typename LaplacianGravityVelocityCalculator>
     void computeSecondaryVariableCoupledWithHeatTransportLocal(
@@ -208,7 +208,7 @@ private:
         std::vector<double> const& local_x,
         std::vector<double> const& local_T,
         SpatialPosition const& pos,
-        Eigen::MatrixXd const& perm);
+        Eigen::MatrixXd const& permeability);
 
     const int _gravitational_axis_id;
     const double _gravitational_acceleration;

--- a/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.cpp
@@ -55,6 +55,17 @@ double LiquidFlowMaterialProperties::getLiquidDensity(const double p,
         MaterialLib::Fluid::FluidPropertyType::Density, vars);
 }
 
+double LiquidFlowMaterialProperties::getdLiquidDensity_dT(const double p,
+                                                          const double T) const
+{
+    ArrayType vars;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
+    return _fluid_properties->getdValue(
+        MaterialLib::Fluid::FluidPropertyType::Density, vars,
+        MaterialLib::Fluid::PropertyVariableType::T);
+}
+
 double LiquidFlowMaterialProperties::getViscosity(const double p,
                                                   const double T) const
 {
@@ -63,6 +74,26 @@ double LiquidFlowMaterialProperties::getViscosity(const double p,
     vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
     return _fluid_properties->getValue(
         MaterialLib::Fluid::FluidPropertyType::Viscosity, vars);
+}
+
+double LiquidFlowMaterialProperties::getHeatCapacity(const double p,
+                                                     const double T) const
+{
+    ArrayType vars;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
+    return _fluid_properties->getValue(
+        MaterialLib::Fluid::FluidPropertyType::HeatCapacity, vars);
+}
+
+double LiquidFlowMaterialProperties::getThermalConductivity(
+    const double p, const double T) const
+{
+    ArrayType vars;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::T)] = T;
+    vars[static_cast<int>(MaterialLib::Fluid::PropertyVariableType::p)] = p;
+    return _fluid_properties->getValue(
+        MaterialLib::Fluid::FluidPropertyType::ThermalConductivity, vars);
 }
 
 double LiquidFlowMaterialProperties::getMassCoefficient(
@@ -92,6 +123,18 @@ Eigen::MatrixXd const& LiquidFlowMaterialProperties::getPermeability(
     const int /*dim*/) const
 {
     return _intrinsic_permeability_models[material_id];
+}
+
+double LiquidFlowMaterialProperties::getSolidThermalExpansion(
+    const double t, const SpatialPosition& pos) const
+{
+    return _solid_thermal_expansion(t, pos)[0];
+}
+
+double LiquidFlowMaterialProperties::getBiotConstant(
+    const double t, const SpatialPosition& pos) const
+{
+    return _biot_constant(t, pos)[0];
 }
 
 }  // end of namespace

--- a/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.h
@@ -67,14 +67,16 @@ public:
         std::vector<std::unique_ptr<MaterialLib::PorousMedium::Storage>>&&
             storage_models,
         bool const has_material_ids,
-        MeshLib::PropertyVector<int> const& material_ids)
+        MeshLib::PropertyVector<int> const& material_ids,
+        Parameter<double> const& solid_thermal_expansion)
         : _has_material_ids(has_material_ids),
           _material_ids(material_ids),
           _fluid_properties(std::move(fluid_properties)),
           _intrinsic_permeability_models(
               std::move(intrinsic_permeability_models)),
           _porosity_models(std::move(porosity_models)),
-          _storage_models(std::move(storage_models))
+          _storage_models(std::move(storage_models)),
+          _solid_thermal_expansion(solid_thermal_expansion)
     {
     }
 
@@ -129,6 +131,7 @@ private:
     const std::vector<std::unique_ptr<MaterialLib::PorousMedium::Storage>>
         _storage_models;
 
+    Parameter<double> const& _solid_thermal_expansion;
     // Note: For the statistical data of porous media, they could be read from
     // vtu files directly. This can be done by using property vectors directly.
     // Such property vectors will be added here if they are needed.

--- a/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.h
@@ -68,7 +68,8 @@ public:
             storage_models,
         bool const has_material_ids,
         MeshLib::PropertyVector<int> const& material_ids,
-        Parameter<double> const& solid_thermal_expansion)
+        Parameter<double> const& solid_thermal_expansion,
+        Parameter<double> const& biot_constant)
         : _has_material_ids(has_material_ids),
           _material_ids(material_ids),
           _fluid_properties(std::move(fluid_properties)),
@@ -76,7 +77,8 @@ public:
               std::move(intrinsic_permeability_models)),
           _porosity_models(std::move(porosity_models)),
           _storage_models(std::move(storage_models)),
-          _solid_thermal_expansion(solid_thermal_expansion)
+          _solid_thermal_expansion(solid_thermal_expansion),
+          _biot_constant(biot_constant)
     {
     }
 
@@ -111,7 +113,24 @@ public:
 
     double getLiquidDensity(const double p, const double T) const;
 
+    double getdLiquidDensity_dT(const double p, const double T) const;
+
     double getViscosity(const double p, const double T) const;
+
+    double getHeatCapacity(const double p, const double T) const;
+
+    double getThermalConductivity(const double p, const double T) const;
+
+    double getPorosity(const int material_id, const double porosity_variable,
+                       const double T) const
+    {
+        return _porosity_models[material_id]->getValue(porosity_variable, T);
+    }
+
+    double getSolidThermalExpansion(const double t,
+                                    const SpatialPosition& pos) const;
+
+    double getBiotConstant(const double t, const SpatialPosition& pos) const;
 
 private:
     /// A flag to indicate whether the reference member, _material_ids,
@@ -132,6 +151,7 @@ private:
         _storage_models;
 
     Parameter<double> const& _solid_thermal_expansion;
+    Parameter<double> const& _biot_constant;
     // Note: For the statistical data of porous media, they could be read from
     // vtu files directly. This can be done by using property vectors directly.
     // Such property vectors will be added here if they are needed.

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -47,7 +47,7 @@ LiquidFlowProcess::LiquidFlowProcess(
       _gravitational_axis_id(gravitational_axis_id),
       _gravitational_acceleration(gravitational_acceleration),
       _material_properties(createLiquidFlowMaterialProperties(
-          config, has_material_ids, material_ids))
+          config, parameters, has_material_ids, material_ids))
 {
     DBUG("Create Liquid flow process.");
 }
@@ -88,13 +88,10 @@ void LiquidFlowProcess::initializeConcreteProcess(
     }
 }
 
-void LiquidFlowProcess::assembleConcreteProcess(const double t,
-                                                GlobalVector const& x,
-                                                GlobalMatrix& M,
-                                                GlobalMatrix& K,
-                                                GlobalVector& b,
-                                                StaggeredCouplingTerm const&
-                                                coupling_term)
+void LiquidFlowProcess::assembleConcreteProcess(
+    const double t, GlobalVector const& x,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+    StaggeredCouplingTerm const& coupling_term)
 {
     DBUG("Assemble LiquidFlowProcess.");
     // Call global assembler for each local assembly item.

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -18,6 +18,7 @@
 
 #include "ProcessLib/Utils/CreateLocalAssemblers.h"
 #include "LiquidFlowLocalAssembler.h"
+#include "LiquidFlowMaterialProperties.h"
 
 #include "MaterialLib/PorousMedium/Porosity/Porosity.h"
 #include "MaterialLib/PorousMedium/Storage/Storage.h"

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -90,9 +90,8 @@ void LiquidFlowProcess::initializeConcreteProcess(
 }
 
 void LiquidFlowProcess::assembleConcreteProcess(
-    const double t, GlobalVector const& x,
-    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
-    StaggeredCouplingTerm const& coupling_term)
+    const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
+    GlobalVector& b, StaggeredCouplingTerm const& coupling_term)
 {
     DBUG("Assemble LiquidFlowProcess.");
     // Call global assembler for each local assembly item.

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -77,6 +77,16 @@ public:
 
     bool isLinear() const override { return true; }
 
+    int getGravitationalAxisID() const
+    {
+        return _gravitational_axis_id;
+    }
+
+    LiquidFlowMaterialProperties* getLiquidFlowMaterialProperties() const
+    {
+        return _material_properties.get();
+    }
+
 private:
     void initializeConcreteProcess(
         NumLib::LocalToGlobalIndexMap const& dof_table,

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -82,11 +82,9 @@ private:
         NumLib::LocalToGlobalIndexMap const& dof_table,
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b,
-                                 StaggeredCouplingTerm const& coupling_term
-                                ) override;
+    void assembleConcreteProcess(
+        const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
+        GlobalVector& b, StaggeredCouplingTerm const& coupling_term) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -77,7 +77,7 @@ public:
 
     bool isLinear() const override { return true; }
     int getGravitationalAxisID() const { return _gravitational_axis_id; }
-    double getGravitationalacceleration() const
+    double getGravitationalAcceleration() const
     {
         return _gravitational_acceleration;
     }

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -17,9 +17,6 @@
 #include "NumLib/DOF/LocalToGlobalIndexMap.h"
 #include "ProcessLib/Process.h"
 
-#include "LiquidFlowMaterialProperties.h"
-#include "LiquidFlowLocalAssembler.h"
-
 #include "MaterialLib/Fluid/FluidProperties/FluidProperties.h"
 
 namespace MeshLib
@@ -34,6 +31,9 @@ namespace ProcessLib
 {
 namespace LiquidFlow
 {
+class LiquidFlowLocalAssemblerInterface;
+class LiquidFlowMaterialProperties;
+
 /**
  * \brief A class to simulate the liquid flow process in porous media described
  * by
@@ -76,12 +76,7 @@ public:
                                           GlobalVector const& x) override;
 
     bool isLinear() const override { return true; }
-
-    int getGravitationalAxisID() const
-    {
-        return _gravitational_axis_id;
-    }
-
+    int getGravitationalAxisID() const { return _gravitational_axis_id; }
     double getGravitationalacceleration() const
     {
         return _gravitational_acceleration;

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -82,6 +82,11 @@ public:
         return _gravitational_axis_id;
     }
 
+    double getGravitationalacceleration() const
+    {
+        return _gravitational_acceleration;
+    }
+
     LiquidFlowMaterialProperties* getLiquidFlowMaterialProperties() const
     {
         return _material_properties.get();

--- a/Tests/ProcessLib/LiquidFlow/TestLiquidFlowMaterialProperties.cpp
+++ b/Tests/ProcessLib/LiquidFlow/TestLiquidFlowMaterialProperties.cpp
@@ -21,6 +21,7 @@
 #include "MeshLib/MeshGenerators/MeshGenerator.h"
 
 #include "ProcessLib/Parameter/SpatialPosition.h"
+#include "ProcessLib/Parameter/Parameter.h"
 #include "ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.h"
 #include "ProcessLib/LiquidFlow/CreateLiquidFlowMaterialProperties.h"
 
@@ -79,8 +80,10 @@ TEST(MaterialProcessLibLiquidFlow, checkLiquidFlowMaterialProperties)
             "MaterialIDs", MeshLib::MeshItemType::Cell, 1);
 
     const bool has_material_ids = false;
+
+    std::vector<std::unique_ptr<ProcessLib::ParameterBase>> parameters;
     const auto lprop = createLiquidFlowMaterialProperties(
-        sub_config, has_material_ids, *dummy_property_vector);
+        sub_config, parameters, has_material_ids, *dummy_property_vector);
 
     ProcessLib::SpatialPosition pos;
     pos.setElementID(0);

--- a/Tests/ProcessLib/LiquidFlow/TestLiquidFlowMaterialProperties.cpp
+++ b/Tests/ProcessLib/LiquidFlow/TestLiquidFlowMaterialProperties.cpp
@@ -82,14 +82,15 @@ TEST(MaterialProcessLibLiquidFlow, checkLiquidFlowMaterialProperties)
     const bool has_material_ids = false;
 
     std::vector<std::unique_ptr<ProcessLib::ParameterBase>> parameters;
-    const auto lprop = createLiquidFlowMaterialProperties(
+    const auto liquid_properties = createLiquidFlowMaterialProperties(
         sub_config, parameters, has_material_ids, *dummy_property_vector);
 
     ProcessLib::SpatialPosition pos;
     pos.setElementID(0);
 
     // Check permeability
-    const Eigen::MatrixXd& perm = lprop->getPermeability(0, 0., pos, 1);
+    const Eigen::MatrixXd& perm =
+        liquid_properties->getPermeability(0, 0., pos, 1);
     ASSERT_EQ(2.e-10, perm(0, 0));
     ASSERT_EQ(0., perm(0, 1));
     ASSERT_EQ(0., perm(0, 2));
@@ -103,6 +104,6 @@ TEST(MaterialProcessLibLiquidFlow, checkLiquidFlowMaterialProperties)
     const double T = 273.15 + 60.0;
     const double p = 1.e+6;
     const double mass_coef =
-        lprop->getMassCoefficient(0, 0., pos, p, T, 0., 0.);
+        liquid_properties->getMassCoefficient(0, 0., pos, p, T, 0., 0.);
     ASSERT_NEAR(0.000100000093, mass_coef, 1.e-10);
 }


### PR DESCRIPTION
This PR extends the merged implementation of the staggered scheme (PR: #1672) to  coupled thermal hydraulic processes.

A test is provided for verification of the implemation. The test have been verify with OGS5. There is a slightly difference between the solution values by ogs6 and OGS5. The difference is caused by the different calculation approaches of thermal expansion coefficient of fluid. With the same linear temperature dependent fluid density model of the test, OGS5 uses the thermal expansion constant directly, while in ogs6,  the  thermal expansion coefficient is calculated by drho_w/dT/rho_w. 

Follow up PR: coupling term in the calculation of the secondary variables. 

Closes https://github.com/ufz/ogs/issues/1709