### PR TITLE
[Bug] Set return 0. for not drho/dT in LinearTemperatureDependentDensity

### DIFF
--- a/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
+++ b/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
@@ -61,8 +61,9 @@ public:
                      const PropertyVariableType var) const override
     {
         (void)var_vals;
-        (void)var;
-        return - _rho0 * _beta;
+        if (var != PropertyVariableType::T)
+            return 0.0;
+        return -_rho0 * _beta;
     }
 
 private:


### PR DESCRIPTION
There is a bug in ``LinearTemperatureDependentDensity->getdValue(..)``, which does not consider the cases of the derivative of the density with a non-temperature variable.  This PR fixes this bug.