### PR TITLE
Secondary variables output and restarting simulations.

### DIFF
--- a/Documentation/ProjectFile/prj/time_loop/processes/process/output/t_integration_point_data.md
+++ b/Documentation/ProjectFile/prj/time_loop/processes/process/output/t_integration_point_data.md
@@ -1,0 +1,1 @@
+\copydoc ProcessLib::ProcessOutput::output_integration_point_data

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -81,7 +81,7 @@ public:
 
     /// Checks if a property vector with given \c name and the given type
     /// exists.
-    /// @param name name if the requested property vector
+    /// @param name name of the requested property vector
     template <typename T>
     bool existsPropertyVector(std::string const& name) const;
 

--- a/ProcessLib/CMakeLists.txt
+++ b/ProcessLib/CMakeLists.txt
@@ -24,6 +24,10 @@ APPEND_SOURCE_FILES(SOURCES TwoPhaseFlowWithPP)
 add_subdirectory(TwoPhaseFlowWithPrho)
 APPEND_SOURCE_FILES(SOURCES TwoPhaseFlowWithPrho)
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS SmallDeformation/integration_point.proto)
+list(APPEND SOURCES ${PROTO_SRCS} ${PROTO_HDRS})
+
 add_subdirectory(SmallDeformation)
 APPEND_SOURCE_FILES(SOURCES SmallDeformation)
 

--- a/ProcessLib/CMakeLists.txt
+++ b/ProcessLib/CMakeLists.txt
@@ -24,9 +24,11 @@ APPEND_SOURCE_FILES(SOURCES TwoPhaseFlowWithPP)
 add_subdirectory(TwoPhaseFlowWithPrho)
 APPEND_SOURCE_FILES(SOURCES TwoPhaseFlowWithPrho)
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS SmallDeformation/integration_point.proto)
-list(APPEND SOURCES ${PROTO_SRCS} ${PROTO_HDRS})
+if(Protobuf_FOUND)
+    include_directories(${CMAKE_CURRENT_BINARY_DIR})
+    protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS SmallDeformation/integration_point.proto)
+    list(APPEND SOURCES ${PROTO_SRCS} ${PROTO_HDRS})
+endif() # Protobuf_FOUND
 
 add_subdirectory(SmallDeformation)
 APPEND_SOURCE_FILES(SOURCES SmallDeformation)
@@ -64,8 +66,11 @@ target_link_libraries(ProcessLib
     MeshGeoToolsLib
     NumLib # for shape matrices
     ${VTK_LIBRARIES}
-    ${PROTOBUF_LIBRARIES}
 )
+
+if(Protobuf_FOUND)
+    target_link_libraries(ProcessLib ${PROTOBUF_LIBRARIES})
+endif() # Protobuf_FOUND
 
 ADD_VTK_DEPENDENCY(ProcessLib)
 

--- a/ProcessLib/CMakeLists.txt
+++ b/ProcessLib/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(ProcessLib
     MeshGeoToolsLib
     NumLib # for shape matrices
     ${VTK_LIBRARIES}
+    ${PROTOBUF_LIBRARIES}
 )
 
 ADD_VTK_DEPENDENCY(ProcessLib)

--- a/ProcessLib/IntegrationPointSerialization.h
+++ b/ProcessLib/IntegrationPointSerialization.h
@@ -1,0 +1,28 @@
+/**
+ * \file
+ *
+ * \copyright
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+namespace ProcessLib
+{
+
+/// Interface for serialization of process specific integration point data. The
+/// interface requires a write and a read functions to be implemented in such a
+/// way that so called round-trip is possible.
+struct IntegrationPointSerialization
+{
+    virtual std::size_t writeIntegrationPointData(std::vector<char>& data) = 0;
+    virtual void readIntegrationPointData(std::vector<char> const& data) = 0;
+
+    virtual ~IntegrationPointSerialization() = default;
+};
+
+}   // namespace ProcessLib

--- a/ProcessLib/Output.cpp
+++ b/ProcessLib/Output.cpp
@@ -119,7 +119,8 @@ void Output::doOutputAlways(Process const& process,
     DBUG("output to %s", output_file_name.c_str());
     doProcessOutput(output_file_name, x, process.getMesh(),
                     process.getDOFTable(), process.getProcessVariables(),
-                    process.getSecondaryVariables(), process_output);
+                    process.getSecondaryVariables(),
+                    process.integration_point_writer, process_output);
     spd.pvd_file.addVTUFile(output_file_name, t);
 
     INFO("[time] Output of timestep %d took %g s.", timestep,
@@ -173,7 +174,8 @@ void Output::doOutputNonlinearIteration(Process const& process,
     DBUG("output iteration results to %s", output_file_name.c_str());
     doProcessOutput(output_file_name, x, process.getMesh(),
                     process.getDOFTable(), process.getProcessVariables(),
-                    process.getSecondaryVariables(), process_output);
+                    process.getSecondaryVariables(),
+                    process.integration_point_writer, process_output);
 
     INFO("[time] Output took %g s.", time_output.elapsed());
 }

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -109,6 +109,8 @@ void Process::setInitialConditions(double const t, GlobalVector& x)
             }
         }
     }
+
+    setInitialConditionsConcreteProcess(t, x);
 }
 
 MathLib::MatrixSpecifications Process::getMatrixSpecifications() const

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -124,7 +124,9 @@ public:
     }
 
     /// Fills given property vector with raw integration point data.
-    std::function<std::size_t (MeshLib::PropertyVector<char>&)> ip_writer;
+    std::function<std::size_t(MeshLib::PropertyVector<char>&,
+                              MeshLib::PropertyVector<std::size_t>& offsets)>
+        integration_point_writer;
 
 protected:
     NumLib::Extrapolator& getExtrapolator() const

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -146,6 +146,10 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) = 0;
 
+    virtual void setInitialConditionsConcreteProcess(const double /*t*/,
+                                                     GlobalVector const& /*x*/)
+    {
+    }
     virtual void assembleConcreteProcess(const double t, GlobalVector const& x,
                                          GlobalMatrix& M, GlobalMatrix& K,
                                          GlobalVector& b,

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -123,6 +123,9 @@ public:
         return std::vector<double>{};
     }
 
+    /// Fills given property vector with raw integration point data.
+    std::function<std::size_t (MeshLib::PropertyVector<char>&)> ip_writer;
+
 protected:
     NumLib::Extrapolator& getExtrapolator() const
     {

--- a/ProcessLib/ProcessOutput.cpp
+++ b/ProcessLib/ProcessOutput.cpp
@@ -87,16 +87,16 @@ ProcessOutput::ProcessOutput(BaseLib::ConfigTree const& output_config)
     }
 }
 
-
-void doProcessOutput(
-        std::string const& file_name,
-        GlobalVector const& x,
-        MeshLib::Mesh& mesh,
-        NumLib::LocalToGlobalIndexMap const& dof_table,
-        std::vector<std::reference_wrapper<ProcessVariable>> const&
-        process_variables,
-        SecondaryVariableCollection secondary_variables,
-        ProcessOutput const& process_output)
+void doProcessOutput(std::string const& file_name,
+                     GlobalVector const& x,
+                     MeshLib::Mesh& mesh,
+                     NumLib::LocalToGlobalIndexMap const& dof_table,
+                     std::vector<std::reference_wrapper<ProcessVariable>> const&
+                         process_variables,
+                     SecondaryVariableCollection secondary_variables,
+                     std::function<std::size_t(MeshLib::PropertyVector<char>&)>
+                         ip_writer,
+                     ProcessOutput const& process_output)
 {
     DBUG("Process output.");
 

--- a/ProcessLib/ProcessOutput.cpp
+++ b/ProcessLib/ProcessOutput.cpp
@@ -23,6 +23,8 @@ std::size_t countMeshItems(MeshLib::Mesh const& mesh,
             return mesh.getNumberOfElements();
         case MeshLib::MeshItemType::Node:
             return mesh.getNumberOfNodes();
+        case MeshLib::MeshItemType::IntegrationPoint:
+            return 0;
         default:
             break;  // avoid compiler warning
     }
@@ -50,7 +52,8 @@ MeshLib::PropertyVector<T>* getOrCreateMeshProperty(
             property_name, type);
         result->resize(N);
     }
-    assert(result && result->size() == N);
+    assert(type == MeshLib::MeshItemType::IntegrationPoint ||
+           result && result->size() == N);
 
     return result;
 };

--- a/ProcessLib/ProcessOutput.cpp
+++ b/ProcessLib/ProcessOutput.cpp
@@ -113,6 +113,7 @@ void doProcessOutput(std::string const& file_name,
 
     auto const& output_variables = process_output.output_variables;
     std::set<std::string> already_output;
+    already_output.insert("integration_point");
 
     int global_component_offset = 0;
     int global_component_offset_next = 0;
@@ -228,6 +229,15 @@ void doProcessOutput(std::string const& file_name,
 #else
     (void) secondary_variables;
 #endif // USE_PETSC
+
+    // Integration point data
+    if (std::find(std::begin(output_variables), std::end(output_variables),
+                  "integration_point") != std::end(output_variables))
+    {
+        auto result = getOrCreateMeshProperty<char>(
+            mesh, "integration_point_data",
+            MeshLib::MeshItemType::IntegrationPoint);
+    }
 
     // Write output file
     DBUG("Writing output to \'%s\'.", file_name.c_str());

--- a/ProcessLib/ProcessOutput.cpp
+++ b/ProcessLib/ProcessOutput.cpp
@@ -41,7 +41,7 @@ MeshLib::PropertyVector<T>* getOrCreateMeshProperty(
 
     auto const N = countMeshItems(mesh, type);
 
-    if (mesh.getProperties().existsPropertyVector<double>(property_name))
+    if (mesh.getProperties().existsPropertyVector<T>(property_name))
     {
         result = mesh.getProperties().template getPropertyVector<T>(
             property_name);

--- a/ProcessLib/ProcessOutput.cpp
+++ b/ProcessLib/ProcessOutput.cpp
@@ -29,23 +29,24 @@ std::size_t countMeshItems(MeshLib::Mesh const& mesh,
     return 0;
 };
 
-MeshLib::PropertyVector<double>* getOrCreateMeshProperty(
+template <typename T>
+MeshLib::PropertyVector<T>* getOrCreateMeshProperty(
     MeshLib::Mesh& mesh, std::string const& property_name,
     MeshLib::MeshItemType type)
 {
     // Get or create a property vector for results.
-    MeshLib::PropertyVector<double>* result = nullptr;
+    MeshLib::PropertyVector<T>* result = nullptr;
 
     auto const N = countMeshItems(mesh, type);
 
     if (mesh.getProperties().existsPropertyVector<double>(property_name))
     {
-        result = mesh.getProperties().template getPropertyVector<double>(
+        result = mesh.getProperties().template getPropertyVector<T>(
             property_name);
     }
     else
     {
-        result = mesh.getProperties().template createNewPropertyVector<double>(
+        result = mesh.getProperties().template createNewPropertyVector<T>(
             property_name, type);
         result->resize(N);
     }
@@ -171,7 +172,7 @@ void doProcessOutput(
         {
             DBUG("  secondary variable %s", output_name.c_str());
 
-            auto result = getOrCreateMeshProperty(
+            auto result = getOrCreateMeshProperty<double>(
                 mesh, output_name, MeshLib::MeshItemType::Node);
             assert(result->size() == mesh.getNumberOfNodes());
 
@@ -192,7 +193,7 @@ void doProcessOutput(
             DBUG("  secondary variable %s residual", output_name.c_str());
             auto const& property_name_res = output_name + "_residual";
 
-            auto result = getOrCreateMeshProperty(
+            auto result = getOrCreateMeshProperty<double>(
                 mesh, property_name_res, MeshLib::MeshItemType::Cell);
             assert(result->size() == mesh.getNumberOfElements());
 

--- a/ProcessLib/ProcessOutput.cpp
+++ b/ProcessLib/ProcessOutput.cpp
@@ -85,6 +85,10 @@ ProcessOutput::ProcessOutput(BaseLib::ConfigTree const& output_config)
     {
         output_residuals = *out_resid;
     }
+
+    output_integration_point_data =
+        //! \ogs_file_param{prj__time_loop__processes__process__output__integration_point_data}
+        output_config.getConfigParameter("integration_point_data", false);
 }
 
 void doProcessOutput(

--- a/ProcessLib/ProcessOutput.cpp
+++ b/ProcessLib/ProcessOutput.cpp
@@ -231,12 +231,12 @@ void doProcessOutput(std::string const& file_name,
 #endif // USE_PETSC
 
     // Integration point data
-    if (std::find(std::begin(output_variables), std::end(output_variables),
-                  "integration_point") != std::end(output_variables))
+    if (ip_writer)
     {
         auto result = getOrCreateMeshProperty<char>(
             mesh, "integration_point_data",
             MeshLib::MeshItemType::IntegrationPoint);
+        ip_writer(*result);
     }
 
     // Write output file

--- a/ProcessLib/ProcessOutput.h
+++ b/ProcessLib/ProcessOutput.h
@@ -30,15 +30,17 @@ struct ProcessOutput final
 
 
 //! Writes output to the given \c file_name using the VTU file format.
-void doProcessOutput(std::string const& file_name,
-                     GlobalVector const& x,
-                     MeshLib::Mesh& mesh,
-                     NumLib::LocalToGlobalIndexMap const& dof_table,
-                     std::vector<std::reference_wrapper<ProcessVariable>> const&
-                         process_variables,
-                     SecondaryVariableCollection secondary_variables,
-                     std::function<std::size_t(MeshLib::PropertyVector<char>&)>
-                         ip_writer,
-                     ProcessOutput const& process_output);
+void doProcessOutput(
+    std::string const& file_name,
+    GlobalVector const& x,
+    MeshLib::Mesh& mesh,
+    NumLib::LocalToGlobalIndexMap const& dof_table,
+    std::vector<std::reference_wrapper<ProcessVariable>> const&
+        process_variables,
+    SecondaryVariableCollection secondary_variables,
+    std::function<std::size_t(MeshLib::PropertyVector<char>&,
+                              MeshLib::PropertyVector<std::size_t>&)>
+        integration_point_writer,
+    ProcessOutput const& process_output);
 
 } // ProcessLib

--- a/ProcessLib/ProcessOutput.h
+++ b/ProcessLib/ProcessOutput.h
@@ -30,14 +30,15 @@ struct ProcessOutput final
 
 
 //! Writes output to the given \c file_name using the VTU file format.
-void doProcessOutput(
-        std::string const& file_name,
-        GlobalVector const& x,
-        MeshLib::Mesh& mesh,
-        NumLib::LocalToGlobalIndexMap const& dof_table,
-        std::vector<std::reference_wrapper<ProcessVariable>> const&
-        process_variables,
-        SecondaryVariableCollection secondary_variables,
-        ProcessOutput const& process_output);
+void doProcessOutput(std::string const& file_name,
+                     GlobalVector const& x,
+                     MeshLib::Mesh& mesh,
+                     NumLib::LocalToGlobalIndexMap const& dof_table,
+                     std::vector<std::reference_wrapper<ProcessVariable>> const&
+                         process_variables,
+                     SecondaryVariableCollection secondary_variables,
+                     std::function<std::size_t(MeshLib::PropertyVector<char>&)>
+                         ip_writer,
+                     ProcessOutput const& process_output);
 
 } // ProcessLib

--- a/ProcessLib/ProcessOutput.h
+++ b/ProcessLib/ProcessOutput.h
@@ -26,6 +26,10 @@ struct ProcessOutput final
 
     //! Tells if also to output extrapolation residuals.
     bool output_residuals = false;
+
+    //! Checks if an integration point writer is available and calls it for
+    //! output of process specific integration point data.
+    bool output_integration_point_data = false;
 };
 
 

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -29,7 +29,9 @@
 
 #include "SmallDeformationProcessData.h"
 
+#ifdef PROTOBUF_FOUND
 #include "integration_point.pb.h"
+#endif  // PROTOBUF_FOUND
 
 namespace ProcessLib
 {
@@ -295,6 +297,7 @@ public:
 
     void readIntegrationPointData(std::vector<char> const& data) override
     {
+#ifdef PROTOBUF_FOUND
         SmallDeformationFEM::ElementData element_data;
         if (!element_data.ParseFromArray(data.data(), data.size()))
             OGS_FATAL("Parsing ElementData protobuf failed.");
@@ -337,10 +340,14 @@ public:
             for (int i = 0; i < _ip_data[ip]._eps.size(); ++i)
                 _ip_data[ip]._eps[i] = eps.value(i);
         }
+#else   // PROTOBUF_FOUND
+        (void)data; // Unused argument
+#endif  // PROTOBUF_FOUND
     }
 
     std::size_t writeIntegrationPointData(std::vector<char>& data) override
     {
+#ifdef PROTOBUF_FOUND
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();
 
@@ -369,6 +376,12 @@ public:
         element_data.SerializeToArray(data.data(), element_data.ByteSize());
 
         return element_data.ByteSize();
+#else   // PROTOBUF_FOUND
+        (void)data; // Unused argument
+        return 0;   // Dummy value needed for compilation. Code is not executed
+                    // because the integration_point_writer is not created in
+                    // absence of protobuffer.
+#endif  // PROTOBUF_FOUND
     };
 
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -140,11 +140,13 @@ private:
                 getExtrapolator(), _local_assemblers,
                 &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonXY));
 
+#ifdef PROTOBUF_FOUND
         Base::integration_point_writer = [this](
             MeshLib::PropertyVector<char>& output,
             MeshLib::PropertyVector<std::size_t>& offsets) {
             return writeIntegrationPointData(output, offsets);
         };
+#endif  // PROTOBUF_FOUND
     }
 
     std::size_t writeIntegrationPointData(MeshLib::PropertyVector<char>& output,

--- a/ProcessLib/SmallDeformation/integration_point.proto
+++ b/ProcessLib/SmallDeformation/integration_point.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package SmallDeformationFEM;
+
+enum Dimension {
+    UNDEFINED = 0;
+    ONE = 1;
+    TWO = 2;
+    THREE = 3;
+}
+
+// Kelvin vector for 1D, 2D, or 3D problems allowing a size check of the stored
+// 'value' array.
+message KelvinVector {
+    Dimension dimension = 1;
+    repeated double value = 2;
+}
+
+// Storing arrays of data (sigma, eps, damage, etc.) for all integration points.
+message ElementData {
+    uint64 id = 1;  // For sanity checks.
+    uint32 n_integration_points = 2;    // Length of the following arrays.
+    repeated KelvinVector sigma = 3;
+    repeated KelvinVector eps = 4;
+}

--- a/scripts/cmake/Find.cmake
+++ b/scripts/cmake/Find.cmake
@@ -178,3 +178,7 @@ find_package(CVODE)
 if(CVODE_FOUND)
     add_definitions(-DCVODE_FOUND)
 endif() # CVODE_FOUND
+
+## Google's protobuf library
+find_package(Protobuf)
+include_directories(SYSTEM ${PROTOBUF_INCLUDE_DIRS})

--- a/scripts/cmake/Find.cmake
+++ b/scripts/cmake/Find.cmake
@@ -181,4 +181,7 @@ endif() # CVODE_FOUND
 
 ## Google's protobuf library
 find_package(Protobuf)
-include_directories(SYSTEM ${PROTOBUF_INCLUDE_DIRS})
+if(Protobuf_FOUND)
+    include_directories(SYSTEM ${PROTOBUF_INCLUDE_DIRS})
+    add_definitions(-DPROTOBUF_FOUND)
+endif() # Protobuf_FOUND


### PR DESCRIPTION
Continuing #1691 this PR adds infrastructure for saving and reading of integration point data as field data stored in the output vtu file. Exemplary shown in SmallDeformation process.

Google's protobuffer library for the binary data description is used; this allows to use the same description from other programms (*e.g.* python -> paraview) to read the data.

Main purpose of this PR is the infrastructure and allow users to restart a simulation setting the internal integration point data correctly.

Future work:
 - generalization of integration point data output for various quantities (velocities, internal material properties)
 - visualization of the stored data through vtk and possibly paraview (via plugin), or with dedicated post-processing tool.

closes #1660 

TODO:
 - [ ] Update docu (code and doxygen keywords)
 - [x] Make (for now) the protobuf optional.
 - [ ] Add protobuf description to the vtu file (if possible).