### PR TITLE
Change Properties

### DIFF
--- a/Applications/DataExplorer/DataView/ElementTreeModel.cpp
+++ b/Applications/DataExplorer/DataView/ElementTreeModel.cpp
@@ -67,9 +67,12 @@ void ElementTreeModel::setElement(vtkUnstructuredGridAlgorithm const*const grid,
     TreeItem* typeItem = new TreeItem(typeData, elemItem);
     elemItem->appendChild(typeItem);
 
+    MeshLib::PropertyVector<int> const*const mat_ids =
+        mesh->getProperties().existsPropertyVector<int>("MaterialIDs")
+            ? mesh->getProperties().getPropertyVector<int>("MaterialIDs")
+            : nullptr;
+    QString matIdString = !mat_ids ? QString("not defined") : QString::number((*mat_ids)[elem->getID()]);
     QList<QVariant> materialData;
-    auto materialIds = mesh->getProperties().getPropertyVector<int>("MaterialIDs");
-    QString matIdString = !materialIds ? QString("not defined") : QString::number((*materialIds)[elem->getID()]);
     materialData << "MaterialID: " << matIdString;
     TreeItem* matItem = new TreeItem(materialData, elemItem);
     elemItem->appendChild(matItem);

--- a/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
@@ -171,14 +171,14 @@ void MeshElementRemovalDialog::on_materialIDCheckBox_toggled(bool is_checked)
         materialListWidget->clear();
         _matIDIndex = _currentIndex;
         auto mesh = _project.getMesh(meshNameComboBox->currentText().toStdString());
-        auto const* const mat_ids =
-            mesh->getProperties().getPropertyVector<int>("MaterialIDs");
-        if (!mat_ids)
+        if (!mesh->getProperties().existsPropertyVector<int>("MaterialIDs"))
         {
             INFO("Properties \"MaterialIDs\" not found in the mesh \"%s\".",
                 mesh->getName().c_str());
             return;
         }
+        auto const* const mat_ids =
+            mesh->getProperties().getPropertyVector<int>("MaterialIDs");
         if (mat_ids->size() != mesh->getNumberOfElements())
         {
             INFO(
@@ -205,10 +205,10 @@ void MeshElementRemovalDialog::on_meshNameComboBox_currentIndexChanged(int idx)
     this->materialListWidget->clearSelection();
     if (this->boundingBoxCheckBox->isChecked()) this->on_boundingBoxCheckBox_toggled(true);
     auto mesh = _project.getMesh(meshNameComboBox->currentText().toStdString());
-    auto const* const materialIds =
-        mesh->getProperties().getPropertyVector<int>("MaterialIDs");
-    if (materialIds)
+    if (mesh->getProperties().existsPropertyVector<int>("MaterialIDs"))
     {
+        auto const* const materialIds =
+            mesh->getProperties().getPropertyVector<int>("MaterialIDs");
         if (materialIds->size() != mesh->getNumberOfElements())
         {
             ERR ("Incorrect mesh structure: Number of Material IDs does not match number of mesh elements.");

--- a/Applications/FileIO/SHPInterface.cpp
+++ b/Applications/FileIO/SHPInterface.cpp
@@ -237,10 +237,12 @@ bool SHPInterface::write2dMeshToSHP(const std::string &file_name, const MeshLib:
         {
             // write element ID and material group to DBF-file
             DBFWriteIntegerAttribute(hDBF, polygon_id, elem_id_field, i);
-            auto materialIds = mesh.getProperties().getPropertyVector<int>("MaterialIDs");
-            if (materialIds)
+            if (mesh.getProperties().existsPropertyVector<int>("MaterialIDs"))
+            {
+                auto const* const materialIds =
+                    mesh.getProperties().getPropertyVector<int>("MaterialIDs");
                 DBFWriteIntegerAttribute(hDBF, polygon_id, mat_field, (*materialIds)[i]);
-
+            }
             unsigned nNodes (e->getNumberOfBaseNodes());
             padfX = new double[nNodes+1];
             padfY = new double[nNodes+1];

--- a/Applications/FileIO/TetGenInterface.cpp
+++ b/Applications/FileIO/TetGenInterface.cpp
@@ -614,14 +614,15 @@ void TetGenInterface::write2dElements(std::ofstream &out,
     out << nTotalTriangles << " 1\n";
 
     const std::vector<MeshLib::Element*> &elements = mesh.getElements();
-    auto const* const materialIds =
-        mesh.getProperties().getPropertyVector<int>("MaterialIDs");
+    MeshLib::PropertyVector<int> const*const mat_ids =
+        mesh.getProperties().existsPropertyVector<int>("MaterialIDs")
+            ? mesh.getProperties().getPropertyVector<int>("MaterialIDs")
+            : nullptr;
     const std::size_t nElements (elements.size());
     unsigned element_count(0);
     for (std::size_t i=0; i<nElements; ++i)
     {
-        std::string matId =
-            materialIds ? std::to_string((*materialIds)[i]) : "";
+        std::string const matId = mat_ids ? std::to_string((*mat_ids)[i]) : "";
         this->writeElementToFacets(out, *elements[i], element_count, matId);
     }
 }

--- a/Applications/Utils/FileConverter/generateMatPropsFromMatID.cpp
+++ b/Applications/Utils/FileConverter/generateMatPropsFromMatID.cpp
@@ -51,12 +51,12 @@ int main (int argc, char* argv[])
         INFO("Could not read mesh from file \"%s\".", mesh_arg.getValue().c_str());
         return EXIT_FAILURE;
     }
-    auto materialIds = mesh->getProperties().getPropertyVector<int>("MaterialIDs");
-    if (!materialIds)
+    if (!mesh->getProperties().existsPropertyVector<int>("MaterialIDs"))
     {
         ERR("Mesh contains no int-property vector named \"MaterialIds\".");
         return EXIT_FAILURE;
     }
+    auto materialIds = mesh->getProperties().getPropertyVector<int>("MaterialIDs");
 
     std::size_t const n_properties(materialIds->size());
     if (n_properties != mesh->getNumberOfElements()) {

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -79,12 +79,13 @@ template <typename PT>
 void resetMeshElementProperty(MeshLib::Mesh &mesh, GeoLib::Polygon const& polygon,
     std::string const& property_name, PT new_property_value)
 {
-    auto* const pv = mesh.getProperties().getPropertyVector<PT>(property_name);
-    if (!pv) {
+    if (!mesh.getProperties().existsPropertyVector<PT>(property_name))
+    {
         WARN("Did not find a PropertyVector with name \"%s\".",
             property_name.c_str());
         return;
     }
+    auto* const pv = mesh.getProperties().getPropertyVector<PT>(property_name);
 
     if (pv->getMeshItemType() != MeshLib::MeshItemType::Cell)
     {
@@ -204,8 +205,12 @@ int main (int argc, char* argv[])
         char new_property_val(char_property_arg.getValue());
 
         // check if PropertyVector exists
-        auto* pv = mesh->getProperties().getPropertyVector<char>(property_name);
-        if (!pv)
+        MeshLib::PropertyVector<char>* pv(nullptr);
+        if (mesh->getProperties().existsPropertyVector<char>(property_name))
+        {
+            pv = mesh->getProperties().getPropertyVector<char>(property_name);
+        }
+        else
         {
             pv = mesh->getProperties().createNewPropertyVector<char>(
                 property_name, MeshLib::MeshItemType::Cell, 1);

--- a/Applications/Utils/MeshEdit/queryMesh.cpp
+++ b/Applications/Utils/MeshEdit/queryMesh.cpp
@@ -48,8 +48,6 @@ int main(int argc, char *argv[])
     if (!mesh)
         return EXIT_FAILURE;
 
-    auto materialIds = mesh->getProperties().getPropertyVector<int>("MaterialIDs");
-
     std::vector<std::size_t> selected_node_ids;
     if  (showNodeWithMaxEle_arg.getValue())
     {
@@ -63,6 +61,10 @@ int main(int argc, char *argv[])
     }
     selected_node_ids.insert(selected_node_ids.end(), nodeId_arg.getValue().begin(), nodeId_arg.getValue().end());
 
+    MeshLib::PropertyVector<int> const*const materialIds =
+        mesh->getProperties().existsPropertyVector<int>("MaterialIDs")
+            ? mesh->getProperties().getPropertyVector<int>("MaterialIDs")
+            : nullptr;
     for (auto ele_id : eleId_arg.getValue())
     {
         std::stringstream out;

--- a/Applications/Utils/ModelPreparation/ComputeNodeAreasFromSurfaceMesh.cpp
+++ b/Applications/Utils/ModelPreparation/ComputeNodeAreasFromSurfaceMesh.cpp
@@ -82,12 +82,11 @@ int main (int argc, char* argv[])
          surface_mesh->getNumberOfElements());
     // ToDo check if mesh is read correct and if the mesh is a surface mesh
 
+    MeshLib::PropertyVector<std::size_t>* orig_node_ids(nullptr);
     // check if a node property containing the subsurface ids is available
-    auto* orig_node_ids =
-        surface_mesh->getProperties().getPropertyVector<std::size_t>(
-            id_prop_name.getValue());
     // if the node property is not available generate it
-    if (!orig_node_ids)
+    if (!surface_mesh->getProperties().existsPropertyVector<std::size_t>(
+            id_prop_name.getValue()))
     {
         orig_node_ids =
             surface_mesh->getProperties().createNewPropertyVector<std::size_t>(
@@ -99,6 +98,12 @@ int main (int argc, char* argv[])
         }
         orig_node_ids->resize(surface_mesh->getNumberOfNodes());
         std::iota(orig_node_ids->begin(), orig_node_ids->end(), 0);
+    }
+    else
+    {
+        orig_node_ids =
+            surface_mesh->getProperties().getPropertyVector<std::size_t>(
+                id_prop_name.getValue());
     }
 
     std::vector<double> areas(

--- a/Applications/Utils/ModelPreparation/createNeumannBc.cpp
+++ b/Applications/Utils/ModelPreparation/createNeumannBc.cpp
@@ -38,16 +38,15 @@ std::vector<double> getSurfaceIntegratedValuesForNodes(
         return std::vector<double>();
     }
 
-    auto const* const elem_pv =
-        mesh.getProperties().getPropertyVector<double>(prop_name);
-    if (!elem_pv)
+    if (!mesh.getProperties().existsPropertyVector<double>(prop_name))
     {
         ERR("Need element property, but the property \"%s\" is not "
             "available.",
             prop_name.c_str());
         return std::vector<double>();
     }
-
+    auto const* const elem_pv =
+        mesh.getProperties().getPropertyVector<double>(prop_name);
 
     std::vector<double> integrated_node_area_vec;
     double total_area(0);

--- a/MeshGeoToolsLib/AppendLinesAlongPolyline.cpp
+++ b/MeshGeoToolsLib/AppendLinesAlongPolyline.cpp
@@ -34,11 +34,12 @@ std::unique_ptr<MeshLib::Mesh> appendLinesAlongPolylines(
 
     std::vector<int> new_mat_ids;
     {
-        auto mat_ids = mesh.getProperties().getPropertyVector<int>("MaterialIDs");
-        if (mat_ids) {
-            new_mat_ids.reserve((*mat_ids).size());
-            std::copy((*mat_ids).cbegin(), (*mat_ids).cend(),
-                std::back_inserter(new_mat_ids));
+        if (mesh.getProperties().existsPropertyVector<int>("MaterialIDs")) {
+            auto ids =
+                mesh.getProperties().getPropertyVector<int>("MaterialIDs");
+            new_mat_ids.reserve(ids->size());
+            std::copy(ids->cbegin(), ids->cend(),
+                      std::back_inserter(new_mat_ids));
         }
     }
     int max_matID(0);

--- a/MeshLib/ElementStatus.cpp
+++ b/MeshLib/ElementStatus.cpp
@@ -34,8 +34,10 @@ ElementStatus::ElementStatus(Mesh const* const mesh,
                              std::vector<int> const& vec_inactive_matIDs)
     : ElementStatus(mesh, !vec_inactive_matIDs.empty())
 {
-    auto materialIds = mesh->getProperties().getPropertyVector<int>("MaterialIDs");
-    if (materialIds) {
+    if (mesh->getProperties().existsPropertyVector<int>("MaterialIDs"))
+    {
+        auto* const materialIds =
+            mesh->getProperties().getPropertyVector<int>("MaterialIDs");
         for (auto material_id : vec_inactive_matIDs) {
             for (auto e : _mesh->getElements()) {
                 if ((*materialIds)[e->getID()] == material_id) {

--- a/MeshLib/IO/Legacy/MeshIO.cpp
+++ b/MeshLib/IO/Legacy/MeshIO.cpp
@@ -281,10 +281,16 @@ bool MeshIO::write()
     _out << "$ELEMENTS\n"
         << "  ";
 
-    auto const* const materials =
-        _mesh->getProperties().getPropertyVector<int>("MaterialIDs");
-    writeElements(_mesh->getElements(), materials, _out);
-
+    if (!_mesh->getProperties().existsPropertyVector<int>("MaterialIDs"))
+    {
+        writeElements(_mesh->getElements(), nullptr, _out);
+    }
+    else
+    {
+        writeElements(
+            _mesh->getElements(),
+            _mesh->getProperties().getPropertyVector<int>("MaterialIDs"), _out);
+    }
     _out << "#STOP\n";
 
     return true;

--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -323,6 +323,12 @@ void scaleMeshPropertyVector(MeshLib::Mesh & mesh,
                              std::string const& property_name,
                              double factor)
 {
+    if (!mesh.getProperties().existsPropertyVector<double>(property_name))
+    {
+        WARN("Did not find PropertyVector '%s' for scaling.",
+             property_name.c_str());
+        return;
+    }
     for (auto& v :
          *mesh.getProperties().getPropertyVector<double>(property_name))
         v *= factor;

--- a/MeshLib/MeshEditing/ConvertToLinearMesh.cpp
+++ b/MeshLib/MeshEditing/ConvertToLinearMesh.cpp
@@ -74,9 +74,9 @@ std::unique_ptr<MeshLib::Mesh> convertToLinearMesh(MeshLib::Mesh const& org_mesh
     MeshLib::Properties const& src_properties = org_mesh.getProperties();
     for (auto name : src_properties.getPropertyVectorNames())
     {
-        auto const* src_prop = src_properties.getPropertyVector<double>(name);
-        if (!src_prop)
+        if (!src_properties.existsPropertyVector<double>(name))
             continue;
+        auto const* src_prop = src_properties.getPropertyVector<double>(name);
         if (src_prop->getMeshItemType() != MeshLib::MeshItemType::Node)
             continue;
 

--- a/MeshLib/MeshEditing/ElementValueModification.cpp
+++ b/MeshLib/MeshEditing/ElementValueModification.cpp
@@ -28,13 +28,12 @@ bool ElementValueModification::replace(MeshLib::Mesh &mesh,
     std::string const& property_name, int const old_value, int const new_value,
     bool replace_if_exists)
 {
-    auto* const property_value_vec =
-        mesh.getProperties().getPropertyVector<int>(property_name);
-
-    if (!property_value_vec)
+    if (!mesh.getProperties().existsPropertyVector<int>(property_name))
     {
         return false;
     }
+    auto* const property_value_vec =
+        mesh.getProperties().getPropertyVector<int>(property_name);
 
     const std::size_t n_property_tuples(
         property_value_vec->getNumberOfTuples());

--- a/MeshLib/MeshEditing/Mesh2MeshPropertyInterpolation.cpp
+++ b/MeshLib/MeshEditing/Mesh2MeshPropertyInterpolation.cpp
@@ -51,9 +51,13 @@ bool Mesh2MeshPropertyInterpolation::setPropertiesForMesh(Mesh& dest_mesh) const
         return false;
     }
 
-    auto* dest_properties =
-        dest_mesh.getProperties().getPropertyVector<double>(_property_name);
-    if (!dest_properties)
+    MeshLib::PropertyVector<double>* dest_properties;
+    if (dest_mesh.getProperties().existsPropertyVector<double>(_property_name))
+    {
+        dest_properties =
+            dest_mesh.getProperties().getPropertyVector<double>(_property_name);
+    }
+    else
     {
         INFO("Create new PropertyVector \"%s\" of type double.",
              _property_name.c_str());
@@ -140,14 +144,14 @@ void Mesh2MeshPropertyInterpolation::interpolateElementPropertiesToNodePropertie
     std::vector<double> &interpolated_properties) const
 {
     // fetch the source of property values
-    auto const* elem_props =
-        _src_mesh.getProperties().getPropertyVector<double>(_property_name);
-    if (!elem_props)
+    if (!_src_mesh.getProperties().existsPropertyVector<double>(_property_name))
     {
         WARN("Did not find PropertyVector<double> \"%s\".",
              _property_name.c_str());
         return;
     }
+    auto const* elem_props =
+        _src_mesh.getProperties().getPropertyVector<double>(_property_name);
 
     std::vector<MeshLib::Node*> const& src_nodes(_src_mesh.getNodes());
     const std::size_t n_src_nodes(src_nodes.size());

--- a/MeshLib/MeshEditing/MeshRevision.cpp
+++ b/MeshLib/MeshEditing/MeshRevision.cpp
@@ -63,15 +63,16 @@ MeshLib::Mesh* MeshRevision::simplifyMesh(const std::string &new_mesh_name,
     // original data
     std::vector<MeshLib::Element*> const& elements(this->_mesh.getElements());
     MeshLib::Properties const& properties(_mesh.getProperties());
-    auto const* const material_vec =
-        properties.getPropertyVector<int>("MaterialIDs");
 
     // data structures for the new mesh
     std::vector<MeshLib::Node*> new_nodes = this->constructNewNodesArray(this->collapseNodeIndices(eps));
     std::vector<MeshLib::Element*> new_elements;
     MeshLib::Properties new_properties;
     PropertyVector<int>* new_material_vec = nullptr;
-    if (material_vec) {
+    PropertyVector<int> const* material_vec = nullptr;
+    if (properties.existsPropertyVector<int>("MaterialIDs"))
+    {
+        material_vec = properties.getPropertyVector<int>("MaterialIDs");
         new_material_vec = new_properties.createNewPropertyVector<int>(
             "MaterialIDs", MeshItemType::Cell, 1);
     }
@@ -94,10 +95,10 @@ MeshLib::Mesh* MeshRevision::simplifyMesh(const std::string &new_mesh_name,
                     this->cleanUp(new_nodes, new_elements);
                     return nullptr;
                 }
-                if (!material_vec)
-                    continue;
-                new_material_vec->insert(new_material_vec->end(),
-                    n_new_elements, (*material_vec)[k]);
+                if (material_vec)
+                    new_material_vec->insert(new_material_vec->end(),
+                                             n_new_elements,
+                                             (*material_vec)[k]);
             } else {
                 new_elements.push_back(MeshLib::copyElement(elem, new_nodes));
                 // copy material values

--- a/MeshLib/MeshInformation.h
+++ b/MeshLib/MeshInformation.h
@@ -37,10 +37,10 @@ public:
     static std::pair<T, T> const
         getValueBounds(MeshLib::Mesh const& mesh, std::string const& name)
     {
+        if (!mesh.getProperties().existsPropertyVector<T>(name))
+            return {std::numeric_limits<T>::max(), std::numeric_limits<T>::max()};
         auto const* const data_vec =
             mesh.getProperties().getPropertyVector<T>(name);
-        if (!data_vec)
-            return {std::numeric_limits<T>::max(), std::numeric_limits<T>::max()};
         if (data_vec->empty()) {
             INFO("Mesh does not contain values for the property \"%s\".", name.c_str());
             return {std::numeric_limits<T>::max(), std::numeric_limits<T>::max()};

--- a/MeshLib/MeshSearch/ElementSearch.h
+++ b/MeshLib/MeshSearch/ElementSearch.h
@@ -47,14 +47,15 @@ public:
         PROPERTY_TYPE const property_value,
         std::string const& property_name = "MaterialIDs")
     {
-        auto const* const pv =
-            _mesh.getProperties().getPropertyVector<PROPERTY_TYPE>(
-                property_name);
-        if (!pv)
+        if (!_mesh.getProperties().existsPropertyVector<PROPERTY_TYPE>(
+                property_name))
         {
             WARN("Property \"%s\" not found in mesh.", property_name.c_str());
             return 0;
         }
+        auto const* const pv =
+            _mesh.getProperties().getPropertyVector<PROPERTY_TYPE>(
+                property_name);
 
         if (pv->getMeshItemType() != MeshLib::MeshItemType::Cell)
         {

--- a/MeshLib/Properties-impl.h
+++ b/MeshLib/Properties-impl.h
@@ -96,11 +96,17 @@ PropertyVector<T> const* Properties::getPropertyVector(
         _properties.find(name));
     if (it == _properties.end())
     {
-        ERR("A property with the specified name \"%s\" is not available.",
+        OGS_FATAL(
+            "The PropertyVector '%s' is not available in the mesh.",
             name.c_str());
-        return nullptr;
     }
-
+    if (!dynamic_cast<PropertyVector<T> const*>(it->second))
+    {
+        OGS_FATAL(
+            "The PropertyVector '%s' has a different type than the requested "
+            "PropertyVector.",
+            name.c_str());
+    }
     return dynamic_cast<PropertyVector<T> const*>(it->second);
 }
 
@@ -111,11 +117,17 @@ PropertyVector<T>* Properties::getPropertyVector(std::string const& name)
         _properties.find(name));
     if (it == _properties.end())
     {
-        ERR("A property with the specified name \"%s\" is not available.",
+        OGS_FATAL(
+            "A PropertyVector with the specified name '%s' is not available.",
             name.c_str());
-        return nullptr;
     }
-
+    if (!dynamic_cast<PropertyVector<T>*>(it->second))
+    {
+        OGS_FATAL(
+            "The PropertyVector '%s' has a different type than the requested "
+            "PropertyVector.",
+            name.c_str());
+    }
     return dynamic_cast<PropertyVector<T>*>(it->second);
 }
 

--- a/MeshLib/Properties-impl.h
+++ b/MeshLib/Properties-impl.h
@@ -75,6 +75,20 @@ PropertyVector<T>* Properties::createNewPropertyVector(
 }
 
 template <typename T>
+bool Properties::existsPropertyVector(std::string const& name) const
+{
+    std::map<std::string, PropertyVectorBase*>::const_iterator it(
+        _properties.find(name));
+    // Check that a PropertyVector with the approriate name exists.
+    if (it == _properties.end())
+    {
+        return false;
+    }
+    // Check that the PropertyVector has the correct data type.
+    return dynamic_cast<PropertyVector<T> const*>(it->second) != nullptr;
+}
+
+template <typename T>
 PropertyVector<T> const* Properties::getPropertyVector(
     std::string const& name) const
 {

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -79,6 +79,12 @@ public:
         MeshItemType mesh_item_type,
         std::size_t n_components = 1);
 
+    /// Checks if a property vector with given \c name and the given type
+    /// exists.
+    /// @param name name if the requested property vector
+    template <typename T>
+    bool existsPropertyVector(std::string const& name) const;
+
     /// Returns a property vector with given \c name or nullptr if no such
     /// property vector exists.
     template <typename T>

--- a/MeshLib/Vtk/VtkMappedMeshSource.h
+++ b/MeshLib/Vtk/VtkMappedMeshSource.h
@@ -76,9 +76,9 @@ private:
     bool addProperty(MeshLib::Properties const& properties,
                      std::string const& prop_name) const
     {
-        auto* const propertyVector = properties.getPropertyVector<T>(prop_name);
-        if(!propertyVector)
+        if (!properties.existsPropertyVector<T>(prop_name))
             return false;
+        auto* const propertyVector = properties.getPropertyVector<T>(prop_name);
 
         vtkNew<VtkMappedPropertyVectorTemplate<T> > dataArray;
         dataArray->SetPropertyVector(const_cast<MeshLib::PropertyVector<T> &>(*propertyVector));

--- a/MeshLib/convertMeshToGeo.cpp
+++ b/MeshLib/convertMeshToGeo.cpp
@@ -63,7 +63,10 @@ bool convertMeshToGeo(const MeshLib::Mesh &mesh, GeoLib::GEOObjects &geo_objects
     const std::vector<MeshLib::Element*> &elements = mesh.getElements();
     const std::size_t nElems (mesh.getNumberOfElements());
 
-    auto const materialIds = mesh.getProperties().getPropertyVector<int>(mat_name);
+    MeshLib::PropertyVector<int> const*const materialIds =
+        mesh.getProperties().existsPropertyVector<int>("MaterialIDs")
+            ? mesh.getProperties().getPropertyVector<int>("MaterialIDs")
+            : nullptr;
 
     for (unsigned i=0; i<nElems; ++i)
     {

--- a/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.cpp
+++ b/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFlux.cpp
@@ -46,14 +46,9 @@ CalculateSurfaceFlux::CalculateSurfaceFlux(
     auto const bulk_element_ids =
         boundary_mesh.getProperties().template getPropertyVector<std::size_t>(
             "OriginalSubsurfaceElementIDs");
-    if (!bulk_element_ids)
-        OGS_FATAL(
-            "OriginalSubsurfaceElementIDs boundary mesh property not found.");
     auto const bulk_face_ids =
         boundary_mesh.getProperties().template getPropertyVector<std::size_t>(
             "OriginalFaceIDs");
-    if (!bulk_face_ids)
-        OGS_FATAL("OriginalFaceIDs boundary mesh property not found.");
 
     ProcessLib::createLocalAssemblers<CalculateSurfaceFluxLocalAssembler>(
         boundary_mesh.getDimension() + 1,  // or bulk_mesh.getDimension()?

--- a/ProcessLib/HT/CreatePorousMediaProperties.cpp
+++ b/ProcessLib/HT/CreatePorousMediaProperties.cpp
@@ -72,10 +72,10 @@ PorousMediaProperties createPorousMediaProperties(
     BaseLib::reorderVector(storage_models, mat_ids);
 
     std::vector<int> material_ids(mesh.getNumberOfElements());
-    auto const& mesh_material_ids =
-        mesh.getProperties().getPropertyVector<int>("MaterialIDs");
-    if (mesh_material_ids)
+    if (mesh.getProperties().existsPropertyVector<int>("MaterialIDs"))
     {
+        auto const& mesh_material_ids =
+            mesh.getProperties().getPropertyVector<int>("MaterialIDs");
         material_ids.reserve(mesh_material_ids->size());
         std::copy(mesh_material_ids->cbegin(), mesh_material_ids->cend(),
                   material_ids.begin());

--- a/ProcessLib/LIE/Common/MeshUtils.cpp
+++ b/ProcessLib/LIE/Common/MeshUtils.cpp
@@ -87,9 +87,8 @@ void getFractureMatrixDataInMesh(
          vec_matrix_elements.size(), all_fracture_elements.size());
 
     // get fracture material IDs
-    auto opt_material_ids(mesh.getProperties().getPropertyVector<int>("MaterialIDs"));
-    if (!opt_material_ids)
-        OGS_FATAL("MaterialIDs propery vector not found in a mesh");
+    auto opt_material_ids(
+        mesh.getProperties().getPropertyVector<int>("MaterialIDs"));
     for (MeshLib::Element* e : all_fracture_elements)
         vec_fracture_mat_IDs.push_back((*opt_material_ids)[e->getID()]);
     BaseLib::makeVectorUnique(vec_fracture_mat_IDs);

--- a/ProcessLib/LIE/Common/PostUtils.cpp
+++ b/ProcessLib/LIE/Common/PostUtils.cpp
@@ -121,9 +121,10 @@ void PostProcessTool::createProperties()
     MeshLib::Properties const& src_properties = _org_mesh.getProperties();
     for (auto name : src_properties.getPropertyVectorNames())
     {
-        auto const* src_prop = src_properties.getPropertyVector<T>(name);
-        if (!src_prop)
+        if (!src_properties.existsPropertyVector<T>(name))
             continue;
+        auto const* src_prop = src_properties.getPropertyVector<T>(name);
+
         auto const n_src_comp = src_prop->getNumberOfComponents();
         // convert 2D vector to 3D. Otherwise Paraview Calculator filter does not recognize
         // it as a vector
@@ -159,11 +160,10 @@ void PostProcessTool::copyProperties()
     MeshLib::Properties const& src_properties = _org_mesh.getProperties();
     for (auto name : src_properties.getPropertyVectorNames())
     {
-        auto const* src_prop = src_properties.getPropertyVector<T>(name);
-        if (!src_prop)
+        if (!src_properties.existsPropertyVector<T>(name))
             continue;
+        auto const* src_prop = src_properties.getPropertyVector<T>(name);
         auto* dest_prop = _output_mesh->getProperties().getPropertyVector<T>(name);
-        assert(dest_prop);
 
         if (src_prop->getMeshItemType() == MeshLib::MeshItemType::Node)
         {

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -106,8 +106,6 @@ SmallDeformationProcess<DisplacementDim>::SmallDeformationProcess(
 
     MeshLib::PropertyVector<int> const* material_ids(
         mesh.getProperties().getPropertyVector<int>("MaterialIDs"));
-    if (!material_ids)
-        OGS_FATAL("MaterialIDs property not found in a mesh");
     _process_data._mesh_prop_materialIDs = material_ids;
 }
 

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.cpp
@@ -78,12 +78,12 @@ std::unique_ptr<Process> createLiquidFlowProcess(
     //! \ogs_file_param{prj__processes__process__LIQUID_FLOW__material_property}
     auto const& mat_config = config.getConfigSubtree("material_property");
 
-    auto const& mat_ids =
-        mesh.getProperties().getPropertyVector<int>("MaterialIDs");
-    if (mat_ids)
+    if (mesh.getProperties().existsPropertyVector<int>("MaterialIDs"))
     {
         INFO("The liquid flow is in heterogeneous porous media.");
         const bool has_material_ids = true;
+        auto const& mat_ids =
+            mesh.getProperties().getPropertyVector<int>("MaterialIDs");
         return std::unique_ptr<Process>{new LiquidFlowProcess{
             mesh, std::move(jacobian_assembler), parameters, integration_order,
             std::move(process_variables), std::move(secondary_variables),

--- a/ProcessLib/Parameter/GroupBasedParameter.cpp
+++ b/ProcessLib/Parameter/GroupBasedParameter.cpp
@@ -29,9 +29,6 @@ std::unique_ptr<ParameterBase> createGroupBasedParameter(
 
     auto const& group_id_property =
         mesh.getProperties().getPropertyVector<int>(group_id_property_name);
-    if (!group_id_property) {
-        OGS_FATAL("The required property %s does not exist in the given mesh", group_id_property_name.c_str());
-    }
 
     // parse mapping data
     typedef std::vector<double> Values;

--- a/ProcessLib/Parameter/MeshElementParameter.cpp
+++ b/ProcessLib/Parameter/MeshElementParameter.cpp
@@ -24,18 +24,9 @@ std::unique_ptr<ParameterBase> createMeshElementParameter(
     auto const field_name = config.getConfigParameter<std::string>("field_name");
     DBUG("Using field_name %s", field_name.c_str());
 
-    if (!mesh.getProperties().hasPropertyVector(field_name)) {
-        OGS_FATAL("The required property %s does not exists in the mesh.",
-                  field_name.c_str());
-    }
-
     // TODO other data types than only double
     auto const& property =
         mesh.getProperties().getPropertyVector<double>(field_name);
-    if (!property) {
-        OGS_FATAL("The mesh property `%s' is not of the requested type.",
-                  field_name.c_str());
-    }
 
     if (property->getMeshItemType() != MeshLib::MeshItemType::Cell) {
         OGS_FATAL("The mesh property `%s' is not an element property.",

--- a/ProcessLib/Parameter/MeshNodeParameter.cpp
+++ b/ProcessLib/Parameter/MeshNodeParameter.cpp
@@ -24,18 +24,9 @@ std::unique_ptr<ParameterBase> createMeshNodeParameter(
     auto const field_name = config.getConfigParameter<std::string>("field_name");
     DBUG("Using field_name %s", field_name.c_str());
 
-    if (!mesh.getProperties().hasPropertyVector(field_name)) {
-        OGS_FATAL("The required property %s does not exists in the mesh.",
-                  field_name.c_str());
-    }
-
     // TODO other data types than only double
     auto const& property =
         mesh.getProperties().getPropertyVector<double>(field_name);
-    if (!property) {
-        OGS_FATAL("The mesh property `%s' is not of the requested type.",
-                  field_name.c_str());
-    }
 
     if (property->getMeshItemType() != MeshLib::MeshItemType::Node) {
         OGS_FATAL("The mesh property `%s' is not a nodal property.",

--- a/ProcessLib/ProcessOutput.cpp
+++ b/ProcessLib/ProcessOutput.cpp
@@ -139,7 +139,7 @@ void doProcessOutput(
 
         auto const N = count_mesh_items(mesh, type);
 
-        if (mesh.getProperties().hasPropertyVector(property_name))
+        if (mesh.getProperties().existsPropertyVector<double>(property_name))
         {
             result = mesh.getProperties().template
                      getPropertyVector<double>(property_name);

--- a/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.cpp
@@ -75,17 +75,16 @@ std::unique_ptr<Process> CreateTwoPhaseFlowWithPPProcess(
     //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property}
     auto const& mat_config = config.getConfigSubtree("material_property");
 
-    auto const& mat_ids =
-        mesh.getProperties().getPropertyVector<int>("MaterialIDs");
-
     std::unique_ptr<
         MaterialLib::TwoPhaseFlowWithPP::TwoPhaseFlowWithPPMaterialProperties>
         material = nullptr;
 
-    if (mat_ids)
+    if (mesh.getProperties().existsPropertyVector<int>("MaterialIDs"))
     {
         INFO("The twophase flow is in heterogeneous porous media.");
         const bool has_material_ids = true;
+        auto const& mat_ids =
+            mesh.getProperties().getPropertyVector<int>("MaterialIDs");
         material = MaterialLib::TwoPhaseFlowWithPP::
             CreateTwoPhaseFlowMaterialProperties(mat_config, has_material_ids,
                                                  *mat_ids);

--- a/ProcessLib/TwoPhaseFlowWithPrho/CreateTwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/CreateTwoPhaseFlowWithPrhoProcess.cpp
@@ -83,15 +83,12 @@ std::unique_ptr<Process> createTwoPhaseFlowWithPrhoProcess(
     //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PRHO__material_property}
     auto const& mat_config = config.getConfigSubtree("material_property");
 
-    auto const& mat_ids =
-        mesh.getProperties().getPropertyVector<int>("MaterialIDs");
-
-    std::unique_ptr<TwoPhaseFlowWithPrhoMaterialProperties> material = nullptr;
-
     boost::optional<MeshLib::PropertyVector<int> const&> material_ids;
-    if (mat_ids != nullptr)
+    if (mesh.getProperties().existsPropertyVector<int>("MaterialIDs"))
     {
         INFO("The twophase flow is in heterogeneous porous media.");
+        auto const& mat_ids =
+            mesh.getProperties().getPropertyVector<int>("MaterialIDs");
         material_ids = *mat_ids;
     }
     else
@@ -99,7 +96,7 @@ std::unique_ptr<Process> createTwoPhaseFlowWithPrhoProcess(
         INFO("The twophase flow is in homogeneous porous media.");
     }
 
-    material =
+    std::unique_ptr<TwoPhaseFlowWithPrhoMaterialProperties> material =
         createTwoPhaseFlowPrhoMaterialProperties(mat_config, material_ids);
 
     TwoPhaseFlowWithPrhoProcessData process_data{

--- a/Tests/MeshLib/MeshProperties.cpp
+++ b/Tests/MeshLib/MeshProperties.cpp
@@ -122,19 +122,15 @@ TEST_F(MeshLibProperties, AddDoubleProperties)
         ASSERT_EQ(static_cast<double>(k+1), (*double_properties)[k]);
     }
 
+    ASSERT_TRUE(mesh->getProperties().existsPropertyVector<double>(prop_name));
     auto* const double_properties_cpy =
         mesh->getProperties().getPropertyVector<double>(prop_name);
-    ASSERT_FALSE(!double_properties_cpy);
-
     for (std::size_t k(0); k<size; k++) {
         ASSERT_EQ((*double_properties)[k], (*double_properties_cpy)[k]);
     }
 
     mesh->getProperties().removePropertyVector(prop_name);
-    auto* const removed_double_properties =
-        mesh->getProperties().getPropertyVector<double>(prop_name);
-
-    ASSERT_TRUE(!removed_double_properties);
+    ASSERT_FALSE(mesh->getProperties().existsPropertyVector<double>(prop_name));
 }
 
 TEST_F(MeshLibProperties, AddDoublePointerProperties)
@@ -204,10 +200,8 @@ TEST_F(MeshLibProperties, AddDoublePointerProperties)
     }
 
     mesh->getProperties().removePropertyVector(prop_name);
-    auto const* const removed_group_properties =
-        mesh->getProperties().getPropertyVector<double*>(prop_name);
-
-    ASSERT_TRUE(!removed_group_properties);
+    ASSERT_FALSE(
+        mesh->getProperties().existsPropertyVector<double*>(prop_name));
 }
 
 TEST_F(MeshLibProperties, AddArrayPointerProperties)
@@ -285,11 +279,10 @@ TEST_F(MeshLibProperties, AddArrayPointerProperties)
     }
 
     mesh->getProperties().removePropertyVector(prop_name);
-    auto const* const removed_group_properties =
-        mesh->getProperties().getPropertyVector<std::array<double, 3>*>(
+    auto exists =
+        mesh->getProperties().existsPropertyVector<std::array<double, 3>*>(
             prop_name);
-
-    ASSERT_TRUE(!removed_group_properties);
+    ASSERT_FALSE(exists);
 }
 
 TEST_F(MeshLibProperties, AddVariousDifferentProperties)


### PR DESCRIPTION
PR contains
- The method `Properties::getPropertyVector` is more strict and doesn't return a `nullptr`, it crashes instead.
- The new method `Properties::existsPropertyVector` checks if a `PropertyVector` with a given name **and** a given data type is available.
- Occurrence of `getPropertyVector` are substituted by a check with `existsPropertyVector` and a fetch with `getPropertyVector`.
- Some checks aren't necessary anymore since they are done within the `getPropertyVector` implementation.

This fixes some details of issue #1726.