### PR TITLE
[Jenkins] Fix git commit status setter.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,8 +59,6 @@ builders['docs'] = {
 
 parallel builders
 
-node { step([$class: 'GitHubCommitStatusSetter']) }
-
 if (currentBuild.result == "SUCCESS" || currentBuild.result == "UNSTABLE") {
     if (helper.isOriginMaster(this)) {
         build job: 'OGS-6/clang-sanitizer', wait: false


### PR DESCRIPTION
It tried to set the commit status on GitHub on a non-existing commit as it falsely used the commit hash from the current Jenkins pipeline library ...?...

[This is a Jenkins bug](https://issues.jenkins-ci.org/browse/JENKINS-40150?jql=project%20%3D%20JENKINS%20AND%20component%20%3D%20github-plugin).

EDIT: Simply removing it seems to solve the problem as it then takes the status setter from the GitHub Branch Source plugin automatically which should be better suited.