### PR TITLE
[HPC] Partition PropertyVectors and read partitioned PropertyVectors

### DIFF
--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -326,6 +326,12 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
         }
         MeshLib::IO::writePropertyVectorMetaDataBinary(out, pvmd);
     }
+    for (const auto& partition : _partitions)
+    {
+        MeshLib::IO::PropertyVectorPartitionMetaData pvpmd;
+        pvpmd.number_of_tuples = partition.number_of_non_ghost_nodes;
+        MeshLib::IO::writePropertyVectorPartitionMetaData(out, pvpmd);
+    }
     out.close();
 }
 
@@ -349,6 +355,17 @@ void NodeWiseMeshPartitioner::readPropertiesConfigDataBinary(
             INFO("readPropertiesConfigMetaDataBinary:");
             MeshLib::IO::writePropertyVectorMetaData(*pvmd);
         }
+    }
+    auto pos = is.tellg();
+    for (std::size_t i(0); i < _npartitions; ++i) {
+        auto offset =
+            pos + static_cast<std::streampos>(
+                      i * sizeof(MeshLib::IO::PropertyVectorPartitionMetaData));
+        is.seekg(offset);
+        unsigned long number_of_tuples = 0;
+        is.read(reinterpret_cast<char*>(&number_of_tuples),
+                sizeof(unsigned long));
+        INFO("%u tuples in partition %u.", number_of_tuples, i);
     }
 }
 

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -336,6 +336,10 @@ NodeWiseMeshPartitioner::getNumberOfIntegerVariablesOfElements(
 void NodeWiseMeshPartitioner::writePropertiesBinary(
     const std::string& file_name_base) const
 {
+    auto const& properties(_partitioned_properties);
+    auto const& property_names(properties.getPropertyVectorNames());
+    if (property_names.empty())
+        return;
     const std::string fname_cfg = file_name_base +
                                   "_partitioned_properties_cfg" +
                                   std::to_string(_npartitions) + ".bin";
@@ -346,8 +350,6 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
                                   std::to_string(_npartitions) + ".bin";
     std::ofstream out_val(fname_val.c_str(), std::ios::binary | std::ios::out);
 
-    auto const& properties(_partitioned_properties);
-    auto const& property_names(properties.getPropertyVectorNames());
     std::size_t number_of_properties(property_names.size());
     out.write(reinterpret_cast<char*>(&number_of_properties),
               sizeof(number_of_properties));

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -336,11 +336,14 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
         }
         MeshLib::IO::writePropertyVectorMetaDataBinary(out, pvmd);
     }
+    unsigned long offset = 0;
     for (const auto& partition : _partitions)
     {
         MeshLib::IO::PropertyVectorPartitionMetaData pvpmd;
+        pvpmd.offset = offset;
         pvpmd.number_of_tuples = partition.number_of_non_ghost_nodes;
         MeshLib::IO::writePropertyVectorPartitionMetaData(out, pvpmd);
+        offset += pvpmd.number_of_tuples;
     }
     out.close();
     out_val.close();

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -432,6 +432,10 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
         MeshLib::IO::PropertyVectorPartitionMetaData pvpmd;
         pvpmd.offset = offset;
         pvpmd.number_of_tuples = partition.nodes.size();
+        INFO(
+            "Write meta data for PropertyVector: global offset %d, number "
+            "of tuples %d",
+            pvpmd.offset, pvpmd.number_of_tuples);
         MeshLib::IO::writePropertyVectorPartitionMetaData(out, pvpmd);
         offset += pvpmd.number_of_tuples;
     }
@@ -606,6 +610,7 @@ void NodeWiseMeshPartitioner::writeNodesBinary(const std::string& file_name_base
     const std::string fname = file_name_base + "_partitioned_msh_nod"
                               + std::to_string(_npartitions) + ".bin";
     FILE* of_bin_nod = fopen(fname.c_str(), "wb");
+
     for (const auto& partition : _partitions)
     {
         std::vector<NodeStruct> nodes_buffer;

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -359,14 +359,11 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
     {
         MeshLib::IO::PropertyVectorMetaData pvmd;
         pvmd.property_name = name;
-        pvmd.is_int_type = false;
         {
             if (properties.existsPropertyVector<double>(name))
             {
                 auto* pv = properties.getPropertyVector<double>(name);
-                pvmd.is_int_type = false;
-                pvmd.is_data_type_signed = false;
-                pvmd.data_type_size_in_bytes = sizeof(double);
+                MeshLib::IO::fillPropertyVectorMetaDataTypeInfo<double>(pvmd);
                 pvmd.number_of_components = pv->getNumberOfComponents();
                 pvmd.number_of_tuples = pv->getNumberOfTuples();
                 writePropertyVectorValuesBinary(out_val, *pv);
@@ -376,9 +373,7 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
             if (properties.existsPropertyVector<float>(name))
             {
                 auto* pv = properties.getPropertyVector<float>(name);
-                pvmd.is_int_type = false;
-                pvmd.is_data_type_signed = false;
-                pvmd.data_type_size_in_bytes = sizeof(float);
+                MeshLib::IO::fillPropertyVectorMetaDataTypeInfo<float>(pvmd);
                 pvmd.number_of_components = pv->getNumberOfComponents();
                 pvmd.number_of_tuples = pv->getNumberOfTuples();
                 writePropertyVectorValuesBinary(out_val, *pv);
@@ -388,9 +383,7 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
             if (properties.existsPropertyVector<int>(name))
             {
                 auto* pv = properties.getPropertyVector<int>(name);
-                pvmd.is_int_type = true;
-                pvmd.is_data_type_signed = true;
-                pvmd.data_type_size_in_bytes = sizeof(int);
+                MeshLib::IO::fillPropertyVectorMetaDataTypeInfo<int>(pvmd);
                 pvmd.number_of_components = pv->getNumberOfComponents();
                 pvmd.number_of_tuples = pv->getNumberOfTuples();
                 writePropertyVectorValuesBinary(out_val, *pv);
@@ -400,9 +393,7 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
             if (properties.existsPropertyVector<unsigned>(name))
             {
                 auto* pv = properties.getPropertyVector<unsigned>(name);
-                pvmd.is_int_type = true;
-                pvmd.is_data_type_signed = false;
-                pvmd.data_type_size_in_bytes = sizeof(unsigned);
+                MeshLib::IO::fillPropertyVectorMetaDataTypeInfo<unsigned>(pvmd);
                 pvmd.number_of_components = pv->getNumberOfComponents();
                 pvmd.number_of_tuples = pv->getNumberOfTuples();
                 writePropertyVectorValuesBinary(out_val, *pv);

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -324,6 +324,26 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
         MeshLib::IO::writePropertyVectorMetaDataBinary(out, pvmd);
     }
     out.close();
+}
+
+void NodeWiseMeshPartitioner::readPropertiesConfigDataBinary(
+    const std::string& file_name_base) const
+{
+    const std::string fname = file_name_base + "_partitioned_properties_cfg"
+                              + std::to_string(_npartitions) + ".bin";
+    std::ifstream is(fname.c_str(), std::ios::binary | std::ios::in);
+    if (!is)
+    {
+        ERR("Could not open file '%s' in binary mode.", fname.c_str());
+    }
+    while (is)
+    {
+        boost::optional<MeshLib::IO::PropertyVectorMetaData> pvmd(
+            MeshLib::IO::readPropertyVectorMetaData(is));
+        if (pvmd) {
+            INFO("readPropertiesConfigMetaDataBinary:");
+            MeshLib::IO::writePropertyVectorMetaData(*pvmd);
+        }
     }
 }
 

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -266,9 +266,15 @@ NodeWiseMeshPartitioner::getNumberOfIntegerVariablesOfElements(
 void NodeWiseMeshPartitioner::writePropertiesBinary(
     const std::string& file_name_base) const
 {
-    const std::string fname = file_name_base + "_partitioned_properties_cfg"
-                              + std::to_string(_npartitions) + ".bin";
-    std::ofstream out(fname.c_str(), std::ios::binary | std::ios::out);
+    const std::string fname_cfg = file_name_base +
+                                  "_partitioned_properties_cfg" +
+                                  std::to_string(_npartitions) + ".bin";
+    std::ofstream out(fname_cfg.c_str(), std::ios::binary | std::ios::out);
+
+    const std::string fname_val = file_name_base +
+                                  "_partitioned_properties_val" +
+                                  std::to_string(_npartitions) + ".bin";
+    std::ofstream out_val(fname_val.c_str(), std::ios::binary | std::ios::out);
 
     auto const& properties(_mesh->getProperties());
     auto const& property_names(properties.getPropertyVectorNames());
@@ -289,6 +295,7 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
                 pvmd.data_type_size_in_bytes = sizeof(double);
                 pvmd.number_of_components = pv->getNumberOfComponents();
                 pvmd.number_of_tuples = pv->getNumberOfTuples();
+                writePropertyVectorValuesBinary(out_val, *pv);
             }
         }
         {
@@ -300,6 +307,7 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
                 pvmd.data_type_size_in_bytes = sizeof(float);
                 pvmd.number_of_components = pv->getNumberOfComponents();
                 pvmd.number_of_tuples = pv->getNumberOfTuples();
+                writePropertyVectorValuesBinary(out_val, *pv);
             }
         }
         {
@@ -311,6 +319,7 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
                 pvmd.data_type_size_in_bytes = sizeof(int);
                 pvmd.number_of_components = pv->getNumberOfComponents();
                 pvmd.number_of_tuples = pv->getNumberOfTuples();
+                writePropertyVectorValuesBinary(out_val, *pv);
             }
         }
         {
@@ -322,6 +331,7 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
                 pvmd.data_type_size_in_bytes = sizeof(unsigned);
                 pvmd.number_of_components = pv->getNumberOfComponents();
                 pvmd.number_of_tuples = pv->getNumberOfTuples();
+                writePropertyVectorValuesBinary(out_val, *pv);
             }
         }
         MeshLib::IO::writePropertyVectorMetaDataBinary(out, pvmd);
@@ -333,6 +343,7 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
         MeshLib::IO::writePropertyVectorPartitionMetaData(out, pvpmd);
     }
     out.close();
+    out_val.close();
 }
 
 void NodeWiseMeshPartitioner::readPropertiesConfigDataBinary(

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -376,10 +376,8 @@ void NodeWiseMeshPartitioner::readPropertiesConfigDataBinary(
             pos + static_cast<std::streampos>(
                       i * sizeof(MeshLib::IO::PropertyVectorPartitionMetaData));
         is.seekg(offset);
-        unsigned long number_of_tuples = 0;
-        is.read(reinterpret_cast<char*>(&number_of_tuples),
-                sizeof(unsigned long));
-        INFO("%u tuples in partition %u.", number_of_tuples, i);
+        boost::optional<MeshLib::IO::PropertyVectorPartitionMetaData> pvpmd(
+            MeshLib::IO::readPropertyVectorPartitionMetaData(is));
     }
 }
 

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -97,17 +97,8 @@ void NodeWiseMeshPartitioner::findNonGhostNodesInPartition(
     {
         if (_nodes_partition_ids[i] == part_id)
         {
-            if (is_mixed_high_order_linear_elems)
-            {  // TODO: Test it once there is a case
-                if (i < _mesh->getNumberOfBaseNodes())
-                    partition.nodes.push_back(nodes[i]);
-                else
-                    extra_nodes.push_back(nodes[i]);
-            }
-            else
-            {
-                partition.nodes.push_back(nodes[i]);
-            }
+            splitOfHigherOrderNode(nodes, is_mixed_high_order_linear_elems,
+                                   i, partition.nodes, extra_nodes);
         }
     }
     partition.number_of_non_ghost_base_nodes = partition.nodes.size();
@@ -168,20 +159,31 @@ void NodeWiseMeshPartitioner::findGhostNodesInPartition(
 
             if (_nodes_partition_ids[node_id] != part_id)
             {
-                if (is_mixed_high_order_linear_elems)
-                {
-                    if (node_id < _mesh->getNumberOfBaseNodes())
-                        partition.nodes.push_back(nodes[node_id]);
-                    else
-                        extra_nodes.push_back(nodes[node_id]);
-                }
-                else
-                {
-                    partition.nodes.push_back(nodes[node_id]);
-                }
+                splitOfHigherOrderNode(nodes, is_mixed_high_order_linear_elems,
+                                       node_id, partition.nodes, extra_nodes);
                 nodes_reserved[node_id] = true;
             }
         }
+    }
+}
+
+void NodeWiseMeshPartitioner::splitOfHigherOrderNode(
+    std::vector<MeshLib::Node*> const& nodes,
+    bool const is_mixed_high_order_linear_elems,
+    unsigned const node_id,
+    std::vector<MeshLib::Node*>& base_nodes,
+    std::vector<MeshLib::Node*>& extra_nodes)
+{
+    if (is_mixed_high_order_linear_elems)
+    {
+        if (node_id < _mesh->getNumberOfBaseNodes())
+            base_nodes.push_back(nodes[node_id]);
+        else
+            extra_nodes.push_back(nodes[node_id]);
+    }
+    else
+    {
+        base_nodes.push_back(nodes[node_id]);
     }
 }
 

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -26,7 +26,6 @@
 #include "MeshLib/IO/VtkIO/VtuInterface.h"
 #include "MeshLib/IO/MPI_IO/PropertyVectorMetaData.h"
 
-#include "MeshLib/Node.h"
 #include "MeshLib/Elements/Element.h"
 
 namespace ApplicationUtils
@@ -212,7 +211,7 @@ void NodeWiseMeshPartitioner::processProperties()
                             return sum + p.nodes.size();
                         });
 
-    INFO("*** total number of tuples after partitioning: %d ***",
+    INFO("total number of tuples after partitioning: %d ",
          total_number_of_tuples);
     // 1 create new PV
     // 2 resize the PV with total_number_of_tuples
@@ -223,42 +222,23 @@ void NodeWiseMeshPartitioner::processProperties()
     {
         if (original_properties.existsPropertyVector<double>(name))
         {
-            auto const& pv(original_properties.getPropertyVector<double>(name));
-            auto partitioned_pv =
-                _partitioned_properties.createNewPropertyVector<double>(
-                    name, pv->getMeshItemType(), pv->getNumberOfComponents());
-            partitioned_pv->resize(total_number_of_tuples *
-                                   pv->getNumberOfComponents());
-            std::size_t cnt(0);
-            for (auto p : _partitions)
-            {
-                for (std::size_t i = 0; i < p.nodes.size(); ++i)
-                {
-                    const auto global_id = p.nodes[i]->getID();
-                    (*partitioned_pv)[cnt+i] = (*pv)[global_id];
-                }
-                cnt += p.nodes.size();
-            }
+            copyPropertyVector<double>(name, total_number_of_tuples);
         }
-        if (original_properties.existsPropertyVector<int>(name))
+        else if (original_properties.existsPropertyVector<float>(name))
         {
-            auto const& pv(original_properties.getPropertyVector<int>(name));
-            auto partitioned_pv =
-                _partitioned_properties.createNewPropertyVector<int>(
-                    name, pv->getMeshItemType(), pv->getNumberOfComponents());
-            partitioned_pv->resize(total_number_of_tuples *
-                                   pv->getNumberOfComponents());
-            std::size_t cnt(0);
-            for (auto p : _partitions)
-            {
-                for (std::size_t i = 0; i < p.nodes.size(); ++i)
-                {
-                    const auto global_id = p.nodes[i]->getID();
-                    (*partitioned_pv)[cnt+i] = (*pv)[global_id];
-                }
-                cnt += p.nodes.size();
-            }
-
+            copyPropertyVector<float>(name, total_number_of_tuples);
+        }
+        else if (original_properties.existsPropertyVector<int>(name))
+        {
+            copyPropertyVector<int>(name, total_number_of_tuples);
+        }
+        else if (original_properties.existsPropertyVector<long>(name))
+        {
+            copyPropertyVector<long>(name, total_number_of_tuples);
+        }
+        else if (original_properties.existsPropertyVector<std::size_t>(name))
+        {
+            copyPropertyVector<std::size_t>(name, total_number_of_tuples);
         }
     }
 }

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -110,10 +110,12 @@ void NodeWiseMeshPartitioner::findElementsInPartition(
 {
     auto& partition = _partitions[part_id];
     std::vector<MeshLib::Element*> const& elements = _mesh->getElements();
+    std::vector<bool> _is_regular_element(elements.size(), false);
+
     for (std::size_t elem_id = 0; elem_id < elements.size(); elem_id++)
     {
         const auto* elem = elements[elem_id];
-        if (_elements_status[elem_id])
+        if (_is_regular_element[elem_id])
             continue;
 
         std::size_t non_ghost_node_number = 0;
@@ -131,7 +133,7 @@ void NodeWiseMeshPartitioner::findElementsInPartition(
         if (non_ghost_node_number == elem->getNumberOfNodes())
         {
             partition.regular_elements.push_back(elem);
-            _elements_status[elem_id] = true;
+            _is_regular_element[elem_id] = true;
         }
         else
         {

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -341,7 +341,7 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
     {
         MeshLib::IO::PropertyVectorPartitionMetaData pvpmd;
         pvpmd.offset = offset;
-        pvpmd.number_of_tuples = partition.number_of_non_ghost_nodes;
+        pvpmd.number_of_tuples = partition.nodes.size();
         MeshLib::IO::writePropertyVectorPartitionMetaData(out, pvpmd);
         offset += pvpmd.number_of_tuples;
     }

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -221,26 +221,19 @@ void NodeWiseMeshPartitioner::processProperties()
     auto property_names = original_properties.getPropertyVectorNames();
     for (auto const& name : property_names)
     {
-        if (original_properties.existsPropertyVector<double>(name))
-        {
-            copyPropertyVector<double>(name, total_number_of_tuples);
-        }
-        else if (original_properties.existsPropertyVector<float>(name))
-        {
-            copyPropertyVector<float>(name, total_number_of_tuples);
-        }
-        else if (original_properties.existsPropertyVector<int>(name))
-        {
-            copyPropertyVector<int>(name, total_number_of_tuples);
-        }
-        else if (original_properties.existsPropertyVector<long>(name))
-        {
-            copyPropertyVector<long>(name, total_number_of_tuples);
-        }
-        else if (original_properties.existsPropertyVector<std::size_t>(name))
-        {
+        bool success =
+            copyPropertyVector<double>(name, total_number_of_tuples) ||
+            copyPropertyVector<float>(name, total_number_of_tuples) ||
+            copyPropertyVector<int>(name, total_number_of_tuples) ||
+            copyPropertyVector<long>(name, total_number_of_tuples) ||
+            copyPropertyVector<unsigned>(name, total_number_of_tuples) ||
+            copyPropertyVector<unsigned long>(name, total_number_of_tuples) ||
             copyPropertyVector<std::size_t>(name, total_number_of_tuples);
-        }
+        if (!success)
+            WARN(
+                "processProperties: Could not create partitioned "
+                "PropertyVector '%s'.",
+                name.c_str());
     }
 }
 

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -468,6 +468,11 @@ void NodeWiseMeshPartitioner::readPropertiesConfigDataBinary(
         is.seekg(offset);
         boost::optional<MeshLib::IO::PropertyVectorPartitionMetaData> pvpmd(
             MeshLib::IO::readPropertyVectorPartitionMetaData(is));
+        if (pvpmd)
+        {
+            DBUG("[%u] offset: %u", i, pvpmd->offset);
+            DBUG("%u tuples in partition %u.", pvpmd->number_of_tuples, i);
+        }
     }
 }
 

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -272,6 +272,9 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
 
     auto const& properties(_mesh->getProperties());
     auto const& property_names(properties.getPropertyVectorNames());
+    std::size_t number_of_properties(property_names.size());
+    out.write(reinterpret_cast<char*>(&number_of_properties),
+              sizeof(number_of_properties));
     for (auto const& name : property_names)
     {
         MeshLib::IO::PropertyVectorMetaData pvmd;
@@ -336,7 +339,9 @@ void NodeWiseMeshPartitioner::readPropertiesConfigDataBinary(
     {
         ERR("Could not open file '%s' in binary mode.", fname.c_str());
     }
-    while (is)
+    std::size_t number_of_properties = 0;
+    is.read(reinterpret_cast<char*>(&number_of_properties), sizeof(std::size_t));
+    for (std::size_t i(0); i < number_of_properties; ++i)
     {
         boost::optional<MeshLib::IO::PropertyVectorMetaData> pvmd(
             MeshLib::IO::readPropertyVectorMetaData(is));

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -158,6 +158,12 @@ private:
                                    const bool is_mixed_high_order_linear_elems,
                                    std::vector<MeshLib::Node*>& extra_nodes);
 
+    void splitOfHigherOrderNode(std::vector<MeshLib::Node*> const& nodes,
+                                bool const is_mixed_high_order_linear_elems,
+                                unsigned const node_id,
+                                std::vector<MeshLib::Node*>& base_nodes,
+                                std::vector<MeshLib::Node*>& extra_nodes);
+
     void processPartition(std::size_t const part_id,
                           const bool is_mixed_high_order_linear_elems);
 

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -130,6 +130,9 @@ private:
 
     void writePropertiesBinary(std::string const& file_name_base) const;
 
+    void readPropertiesConfigDataBinary(
+        std::string const& file_name_base) const;
+
     /*!
          \brief Write the configuration data of the partition data in
                 binary files.

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -128,6 +128,8 @@ private:
                                     std::vector<IntegerType>& elem_info,
                                     IntegerType& counter);
 
+    void writePropertiesBinary(std::string const& file_name_base) const;
+
     /*!
          \brief Write the configuration data of the partition data in
                 binary files.
@@ -137,8 +139,8 @@ private:
                  element 2: The numbers of all ghost element integer
                             variables of each partitions.
     */
-    std::tuple< std::vector<IntegerType>, std::vector<IntegerType>>
-         writeConfigDataBinary(const std::string& file_name_base);
+    std::tuple<std::vector<IntegerType>, std::vector<IntegerType>>
+    writeConfigDataBinary(const std::string& file_name_base);
 
     /*!
          \brief Write the element integer variables of all partitions

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -130,6 +130,32 @@ private:
 
     void writePropertiesBinary(std::string const& file_name_base) const;
 
+    template <typename T>
+    void writePropertyVectorValuesBinary(
+        std::ostream& os, MeshLib::PropertyVector<T> const& pv) const
+    {
+        std::size_t number_of_components(pv.getNumberOfComponents());
+        std::size_t number_of_tuples(pv.getNumberOfTuples());
+        std::vector<T> property_vector_buffer;
+        property_vector_buffer.resize(number_of_tuples * number_of_components);
+        std::size_t cnt(0);
+        for (std::size_t part_id = 0; part_id < _partitions.size(); part_id++)
+        {
+            for (std::size_t i = 0; i < pv.getNumberOfTuples(); ++i)
+            {
+                if (_nodes_partition_ids[i] == part_id)
+                {
+                    for (std::size_t c(0); c < number_of_components; ++c)
+                        property_vector_buffer[cnt * number_of_components + c] =
+                            pv.getComponent(i, c);
+                    cnt++;
+                }
+            }
+        }
+        os.write(reinterpret_cast<char*>(property_vector_buffer.data()),
+                 number_of_components * number_of_tuples * sizeof(T));
+    }
+
     void readPropertiesConfigDataBinary(
         std::string const& file_name_base) const;
 

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -130,6 +130,32 @@ private:
 
     void writePropertiesBinary(std::string const& file_name_base) const;
 
+    /// 1 copy pointers to nodes belonging to the partition part_id
+    /// 2 collect non-linear element nodes belonging to the partition part_id in
+    /// extra_nodes
+    void findNonGhostNodesInPartition(
+        std::size_t const part_id,
+        const bool is_mixed_high_order_linear_elems,
+        std::vector<MeshLib::Node*>& extra_nodes);
+
+    /// 1 find elements belonging to the partition part_id:
+    /// fills vector partition.regular_elements
+    /// 2 find ghost elements belonging to the partition part_id
+    /// fills vector partition.ghost_elements
+    void findElementsInPartition(std::size_t const part_id,
+                                 const bool is_mixed_high_order_linear_elems);
+
+    /// Prerequisite: the ghost elements has to be found (using
+    /// findElementsInPartition).
+    /// Finds ghost nodes and non-linear element ghost nodes by walking over
+    /// ghost elements.
+    void findGhostNodesInPartition(std::size_t const part_id,
+                                   const bool is_mixed_high_order_linear_elems,
+                                   std::vector<MeshLib::Node*>& extra_nodes);
+
+    void processPartition(std::size_t const part_id,
+                          const bool is_mixed_high_order_linear_elems);
+
     template <typename T>
     void writePropertyVectorValuesBinary(
         std::ostream& os, MeshLib::PropertyVector<T> const& pv) const

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -56,8 +56,7 @@ public:
           _partitioned_properties(),
           _mesh(std::move(mesh)),
           _nodes_global_ids(_mesh->getNumberOfNodes()),
-          _nodes_partition_ids(_mesh->getNumberOfNodes()),
-          _elements_status(_mesh->getNumberOfElements(), false)
+          _nodes_partition_ids(_mesh->getNumberOfNodes())
     {
     }
 
@@ -101,9 +100,6 @@ private:
 
     /// Partition IDs of each nodes.
     std::vector<std::size_t> _nodes_partition_ids;
-
-    /// Flags to indicate that whether elements are processed or not.
-    std::vector<bool> _elements_status;
 
     // Renumber the global indices of nodes,
     /// \param is_mixed_high_order_linear_elems Flag to indicate whether the

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -204,9 +204,6 @@ private:
                  number_of_components * number_of_tuples * sizeof(T));
     }
 
-    void readPropertiesConfigDataBinary(
-        std::string const& file_name_base) const;
-
     /*!
          \brief Write the configuration data of the partition data in
                 binary files.

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -171,10 +171,13 @@ private:
     void processProperties();
 
     template <typename T>
-    void copyPropertyVector(std::string const& name,
+    bool copyPropertyVector(std::string const& name,
                             std::size_t const total_number_of_tuples)
     {
         auto const& original_properties(_mesh->getProperties());
+        if (!original_properties.existsPropertyVector<T>(name))
+            return false;
+
         auto const& pv(original_properties.getPropertyVector<T>(name));
         auto partitioned_pv =
             _partitioned_properties.createNewPropertyVector<T>(
@@ -191,6 +194,7 @@ private:
             }
             position_offset += p.nodes.size();
         }
+        return true;
     }
 
     template <typename T>

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -22,6 +22,7 @@
 
 #include "MeshLib/Mesh.h"
 #include "MeshLib/Node.h"
+#include "MeshLib/IO/MPI_IO/PropertyVectorMetaData.h"
 
 namespace ApplicationUtils
 {
@@ -209,6 +210,25 @@ private:
         os.write(reinterpret_cast<char*>(property_vector_buffer.data()),
                  number_of_components * number_of_tuples * sizeof(T));
     }
+
+    template <typename T>
+    bool writePropertyVectorBinary(std::string const& name,
+                                   std::ostream& out_val,
+                                   std::ostream& out_meta) const
+    {
+        if (!_partitioned_properties.existsPropertyVector<T>(name))
+            return false;
+
+        MeshLib::IO::PropertyVectorMetaData pvmd;
+        pvmd.property_name = name;
+        auto* pv = _partitioned_properties.getPropertyVector<T>(name);
+        pvmd.fillPropertyVectorMetaDataTypeInfo<T>();
+        pvmd.number_of_components = pv->getNumberOfComponents();
+        pvmd.number_of_tuples = pv->getNumberOfTuples();
+        writePropertyVectorValuesBinary(out_val, *pv);
+        MeshLib::IO::writePropertyVectorMetaDataBinary(out_meta, pvmd);
+        return true;
+     }
 
     /*!
          \brief Write the configuration data of the partition data in

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
@@ -218,6 +218,12 @@ MeshLib::Properties NodePartitionedMeshReader::readPropertiesBinary(
                 i);
         }
     }
+    for (std::size_t i(0); i < number_of_properties; ++i)
+    {
+        DBUG("[%d] +++++++++++++", _mpi_rank);
+        MeshLib::IO::writePropertyVectorMetaData(*(vec_pvmd[i]));
+        DBUG("[%d] +++++++++++++", _mpi_rank);
+    }
     auto pos = is.tellg();
     auto offset =
         pos +
@@ -233,8 +239,8 @@ MeshLib::Properties NodePartitionedMeshReader::readPropertiesBinary(
             "Could not read the partition meta data for the mpi process %d",
             _mpi_rank);
     }
-    DBUG("[%u] offset: %u", _mpi_rank, pvpmd->offset);
-    DBUG("%u tuples in partition %u.", pvpmd->number_of_tuples, _mpi_rank);
+    DBUG("[%d] offset in the PropertyVector: %d", _mpi_rank, pvpmd->offset);
+    DBUG("[%d] %d tuples in partition.", _mpi_rank, pvpmd->number_of_tuples);
     is.close();
 
     const std::string fname_val = file_name_base + "_partitioned_properties_val"
@@ -251,6 +257,10 @@ MeshLib::Properties NodePartitionedMeshReader::readPropertiesBinary(
     unsigned long global_offset = 0;
     for (std::size_t i(0); i < number_of_properties; ++i)
     {
+        INFO("[%d] global offset: %d, offset within the PropertyVector: %d.",
+             _mpi_rank, global_offset,
+             global_offset +
+                 pvpmd->offset * vec_pvmd[i]->data_type_size_in_bytes);
         if (vec_pvmd[i]->is_int_type)
         {
             if (vec_pvmd[i]->is_data_type_signed)

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
@@ -221,8 +221,8 @@ void NodePartitionedMeshReader::readPropertiesConfigDataBinary(
         static_cast<long>(_mpi_rank *
                           sizeof(MeshLib::IO::PropertyVectorPartitionMetaData));
     is.seekg(offset);
-    unsigned long number_of_tuples = 0;
-    is.read(reinterpret_cast<char*>(&number_of_tuples), sizeof(unsigned long));
+    boost::optional<MeshLib::IO::PropertyVectorPartitionMetaData> pvpmd(
+        MeshLib::IO::readPropertyVectorPartitionMetaData(is));
     INFO("%u tuples in partition %u.", number_of_tuples, _mpi_rank);
 }
 

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
@@ -100,17 +100,21 @@ private:
     } _mesh_info;
 
     /*!
-        \brief Create a new mesh of NodePartitionedMesh after reading and processing the data.
+        \brief Create a new mesh of NodePartitionedMesh after reading and
+       processing the data.
         \param mesh_name    Name assigned to the new mesh.
         \param mesh_nodes   Node data.
         \param glb_node_ids Global IDs of nodes.
         \param mesh_elems   Element data.
-        \return             True on success and false otherwise.
+        \param properties Collection of PropertyVector's assigned to the mesh.
+        \return Returns a pointer to a NodePartitionedMesh
      */
-    MeshLib::NodePartitionedMesh* newMesh(std::string const& mesh_name,
+    MeshLib::NodePartitionedMesh* newMesh(
+        std::string const& mesh_name,
         std::vector<MeshLib::Node*> const& mesh_nodes,
         std::vector<unsigned long> const& glb_node_ids,
-        std::vector<MeshLib::Element*> const& mesh_elems) const;
+        std::vector<MeshLib::Element*> const& mesh_elems,
+        MeshLib::Properties const& properties) const;
 
     /*!
         \brief Parallel reading of a binary file via MPI_File_read, and it is called by readBinary
@@ -158,18 +162,24 @@ private:
      */
     MeshLib::NodePartitionedMesh* readBinary(const std::string &file_name_base);
 
+    void readPropertiesConfigDataBinary(const std::string& file_name_base) const;
+
     /*!
         \brief Open ASCII files of node partitioned mesh data.
 
-        \param file_name_base  Name of file to be read, which must be a name with the
+        \param file_name_base  Name of file to be read, which must be a name
+       with the
                                path to the file and without file extension.
-        \param is_cfg          Input stream for the file contains configuration data.
+        \param is_cfg          Input stream for the file contains
+       configuration data.
         \param is_node         Input stream for the file contains node data.
-        \param is_elem         Input stream for the file contains element data.
+        \param is_elem         Input stream for the file contains element
+       data.
         \return                Return true if all files are good.
      */
-    bool openASCIIFiles(std::string const& file_name_base,std::ifstream& is_cfg,
-        std::ifstream& is_node, std::ifstream& is_elem) const;
+    bool openASCIIFiles(std::string const& file_name_base,
+                        std::ifstream& is_cfg, std::ifstream& is_node,
+                        std::ifstream& is_elem) const;
 
     /*!
         \brief Read mesh nodes from an ASCII file and cast to the corresponding rank.

--- a/MeshLib/IO/MPI_IO/PropertyVectorMetaData.h
+++ b/MeshLib/IO/MPI_IO/PropertyVectorMetaData.h
@@ -1,0 +1,136 @@
+/**
+ * \file
+ *
+ * \copyright
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ */
+
+#pragma once
+
+#include <string>
+#include <boost/optional.hpp>
+
+namespace MeshLib
+{
+namespace IO
+{
+
+struct PropertyVectorMetaData
+{
+    std::string property_name;
+    /// is_int_type is true if the type of the components is an integer type, if
+    /// it is a floating point number type the is_int_type is false
+    bool is_int_type;
+    /// if the component type is an integer number the flag is_data_type_signed
+    /// signals if it has a sign or not
+    bool is_data_type_signed;
+    unsigned long data_type_size_in_bytes;
+    unsigned long number_of_components;
+    unsigned long number_of_tuples;
+};
+
+inline void writePropertyVectorMetaDataBinary(
+    std::ostream& os, PropertyVectorMetaData const& pvmd)
+{
+    std::string::size_type s(pvmd.property_name.length());
+    os.write(reinterpret_cast<char*>(&s), sizeof(std::string::size_type));
+
+    os.write(
+        const_cast<char*>(
+            const_cast<PropertyVectorMetaData&>(pvmd).property_name.data()),
+        s);
+    os.write(reinterpret_cast<char*>(
+                 &const_cast<PropertyVectorMetaData&>(pvmd).is_int_type),
+             sizeof(bool));
+    os.write(reinterpret_cast<char*>(&const_cast<PropertyVectorMetaData&>(
+                 pvmd).is_data_type_signed),
+             sizeof(bool));
+    os.write(reinterpret_cast<char*>(&const_cast<PropertyVectorMetaData&>(
+                 pvmd).data_type_size_in_bytes),
+             sizeof(unsigned long));
+    os.write(reinterpret_cast<char*>(&const_cast<PropertyVectorMetaData&>(
+                 pvmd).number_of_components),
+             sizeof(unsigned long));
+    os.write(reinterpret_cast<char*>(
+                 &const_cast<PropertyVectorMetaData&>(pvmd).number_of_tuples),
+             sizeof(unsigned long));
+}
+
+inline void writePropertyVectorMetaData(PropertyVectorMetaData const& pvmd)
+{
+    DBUG("size of name: %d", pvmd.property_name.length());
+    DBUG("name: '%s'", pvmd.property_name.c_str());
+    DBUG("is_int_data_type: %d", pvmd.is_int_type);
+    DBUG("is_data_type_signed: %d", pvmd.is_data_type_signed);
+    DBUG("data_type_size_in_bytes: %d", pvmd.data_type_size_in_bytes);
+    DBUG("number of components: i%d", pvmd.number_of_components);
+    DBUG("number of tuples: %d", pvmd.number_of_tuples);
+}
+
+inline boost::optional<PropertyVectorMetaData> readPropertyVectorMetaData(
+    std::istream& is)
+{
+    // read the size of the name of the PropertyVector
+    std::string::size_type s = 0;
+    if (!is.read(reinterpret_cast<char*>(&s), sizeof(std::string::size_type)))
+        return boost::optional<PropertyVectorMetaData>();
+
+    PropertyVectorMetaData pvmd;
+    char *dummy = new char[s];
+    if (!is.read(dummy, s))
+        return boost::none;
+    pvmd.property_name = std::string(dummy, s);
+    delete [] dummy;
+
+    if(!is.read(reinterpret_cast<char*>(&pvmd.is_int_type), sizeof(bool)))
+        return boost::none;
+    if(!is.read(reinterpret_cast<char*>(&pvmd.is_data_type_signed), sizeof(bool)))
+        return boost::none;
+    if(!is.read(reinterpret_cast<char*>(&pvmd.data_type_size_in_bytes),
+            sizeof(unsigned long)))
+        return boost::none;
+    if(!is.read(reinterpret_cast<char*>(&pvmd.number_of_components),
+            sizeof(unsigned long)))
+        return boost::none;
+    if(!is.read(reinterpret_cast<char*>(&pvmd.number_of_tuples),
+            sizeof(unsigned long)))
+        return boost::none;
+    return boost::optional<PropertyVectorMetaData>(pvmd);
+}
+
+struct PropertyVectorPartitionMetaData
+{
+    unsigned long offset;
+    unsigned long number_of_tuples;
+};
+
+inline void writePropertyVectorPartitionMetaData(
+    std::ostream& os, PropertyVectorPartitionMetaData const& pvpmd)
+{
+    os.write(reinterpret_cast<char*>(
+                 &const_cast<PropertyVectorPartitionMetaData&>(pvpmd)
+                      .offset),
+             sizeof(unsigned long));
+    os.write(reinterpret_cast<char*>(
+                 &const_cast<PropertyVectorPartitionMetaData&>(pvpmd)
+                      .number_of_tuples),
+             sizeof(unsigned long));
+}
+
+inline boost::optional<PropertyVectorPartitionMetaData>
+readPropertyVectorPartitionMetaData(std::istream& is)
+{
+    PropertyVectorPartitionMetaData pvpmd;
+    if (!is.read(reinterpret_cast<char*>(&pvpmd.offset),
+                 sizeof(unsigned long)))
+        return boost::optional<PropertyVectorPartitionMetaData>();
+    if (!is.read(reinterpret_cast<char*>(&pvpmd.number_of_tuples),
+                 sizeof(unsigned long)))
+        return boost::optional<PropertyVectorPartitionMetaData>();
+    return boost::optional<PropertyVectorPartitionMetaData>(pvpmd);
+}
+}
+}

--- a/MeshLib/IO/MPI_IO/PropertyVectorMetaData.h
+++ b/MeshLib/IO/MPI_IO/PropertyVectorMetaData.h
@@ -30,6 +30,14 @@ struct PropertyVectorMetaData
     unsigned long data_type_size_in_bytes;
     unsigned long number_of_components;
     unsigned long number_of_tuples;
+
+    template <typename T>
+    void fillPropertyVectorMetaDataTypeInfo()
+    {
+        is_int_type = std::numeric_limits<T>::is_integer;
+        is_data_type_signed = std::numeric_limits<T>::is_signed;
+        data_type_size_in_bytes = sizeof(T);
+    }
 };
 
 inline void writePropertyVectorMetaDataBinary(


### PR DESCRIPTION
The PR adds the partitioning computed by metis also to the `PropertVector`s in the mesh and stores the meta data as well as the property values in separate binary files. The current PR contains the partitioning only for `PropertyVector`'s assigned to mesh nodes. The PR also includes the reading of the `PropertyVector`'s into a parallel running ogs.