### PR TITLE
Eve module

### DIFF
--- a/scripts/cmake/Find.cmake
+++ b/scripts/cmake/Find.cmake
@@ -73,6 +73,9 @@ find_program(YARN yarn)
 find_program(PIP pip)
 find_package(PythonInterp)
 
+find_program(MODULE_CMD modulecmd
+    PATHS /usr/local/modules/3.2.10-1/Modules/3.2.10/bin)
+
 ######################
 ### Find libraries ###
 ######################

--- a/scripts/cmake/packaging/PackagingLinux.cmake
+++ b/scripts/cmake/packaging/PackagingLinux.cmake
@@ -16,5 +16,10 @@ if(MODULE_CMD)
     configure_file(${CMAKE_SOURCE_DIR}/scripts/cmake/packaging/module.in
         ${CMAKE_BINARY_DIR}/module
     )
-    install(FILES ${CMAKE_BINARY_DIR}/module DESTINATION .)
+    if(OGS_MODULEFILE)
+        get_filename_component(MODULE_DIR ${OGS_MODULEFILE} DIRECTORY)
+        get_filename_component(MODULE_NAME ${OGS_MODULEFILE} NAME)
+        install(FILES ${CMAKE_BINARY_DIR}/module DESTINATION ${MODULE_DIR}
+            RENAME ${MODULE_NAME})
+    endif()
 endif()

--- a/scripts/cmake/packaging/PackagingLinux.cmake
+++ b/scripts/cmake/packaging/PackagingLinux.cmake
@@ -2,3 +2,19 @@ set(CPACK_GENERATOR TGZ)
 # Adds the binaries location to the LD_LIBRARY_PATH
 set(CMAKE_INSTALL_RPATH \$ORIGIN/)
 
+if(MODULE_CMD)
+    message(STATUS "Found module cmd -> writing module file.")
+    execute_process(COMMAND ${MODULE_CMD} bash list --terse
+        ERROR_VARIABLE MODULE_LIST_OUTPUT
+    )
+    string(REPLACE "\n" ";" MODULE_LIST_OUTPUT ${MODULE_LIST_OUTPUT})
+    foreach(line ${MODULE_LIST_OUTPUT})
+        if(NOT line STREQUAL "Currently Loaded Modulefiles:")
+            set(MODULE_LOAD_STRING "${MODULE_LOAD_STRING}module load ${line}\n")
+        endif()
+    endforeach()
+    configure_file(${CMAKE_SOURCE_DIR}/scripts/cmake/packaging/module.in
+        ${CMAKE_BINARY_DIR}/module
+    )
+    install(FILES ${CMAKE_BINARY_DIR}/module DESTINATION .)
+endif()

--- a/scripts/cmake/packaging/module.in
+++ b/scripts/cmake/packaging/module.in
@@ -1,0 +1,9 @@
+#%Module1.0
+
+module-whatis OpenGeoSys @OGS_VERSION@
+
+append-path MODULEPATH /global/apps/modulefiles/
+
+@MODULE_LOAD_STRING@
+
+prepend-path PATH @CMAKE_INSTALL_PREFIX@/bin

--- a/scripts/cmake/packaging/module.in
+++ b/scripts/cmake/packaging/module.in
@@ -1,6 +1,7 @@
 #%Module1.0
 
 module-whatis OpenGeoSys @OGS_VERSION@
+conflict ogs
 
 append-path MODULEPATH /global/apps/modulefiles/
 

--- a/scripts/env/envinf1/cli.sh
+++ b/scripts/env/envinf1/cli.sh
@@ -3,6 +3,7 @@ export MODULEPATH=$MODULEPATH:/global/apps/modulefiles
 
 module load cmake/3.1.3-1
 module load gcc/4.8.1-3
+module load git/2.3.2-1
 
 # Libraries
 module load boost/1.62.0-1

--- a/scripts/jenkins/gcc-dynamic.groovy
+++ b/scripts/jenkins/gcc-dynamic.groovy
@@ -13,7 +13,8 @@ def helper = new ogs.helper()
 stage('Configure (envinf1)') {
     if (helper.isOriginMaster(this)) {
         defaultCMakeOptions +=
-            ' -DCMAKE_INSTALL_PREFIX=/global/apps/ogs/head/default'
+            ' -DCMAKE_INSTALL_PREFIX=/global/apps/ogs/head/default' +
+            ' -DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/default'
     }
     configure.linux(cmakeOptions: defaultCMakeOptions, env: 'envinf1/cli.sh', script: this)
     configure.linux(cmakeOptions: defaultCMakeOptions + '-DOGS_USE_PETSC=ON',

--- a/scripts/jenkins/gcc-dynamic.groovy
+++ b/scripts/jenkins/gcc-dynamic.groovy
@@ -11,6 +11,10 @@ def post = new ogs.post()
 def helper = new ogs.helper()
 
 stage('Configure (envinf1)') {
+    if (helper.isOriginMaster(this)) {
+        defaultCMakeOptions +=
+            ' -DCMAKE_INSTALL_PREFIX=/global/apps/ogs/head/default'
+    }
     configure.linux(cmakeOptions: defaultCMakeOptions, env: 'envinf1/cli.sh', script: this)
     configure.linux(cmakeOptions: defaultCMakeOptions + '-DOGS_USE_PETSC=ON',
         dir: 'build-petsc', env: 'envinf1/petsc.sh', script: this)
@@ -31,6 +35,10 @@ stage('Test (envinf1)') {
         build.linux(dir: 'build-petsc', env: 'envinf1/petsc.sh', script: this,
             target: 'tests ctest')
     }
+}
+
+stage('Deploy (envinf1)') {
+    build.linux(env: 'envinf1/cli.sh', script: this, target: 'install')
 }
 
 stage('Post (envinf1)') {


### PR DESCRIPTION
## Usage

```bash
export MODULEPATH=$MODULEPATH:/global/apps/modulefiles

module load ogs            # Loads head/standard
module load ogs/head/petsc # Loads head petsc config
module load ogs/6.0.9      # Loads version 6.0.9 standard config, not released yet
```

Tested on frontend1, frontend2 and envinf1.

## Notes

### Eve processors

| node | proc | `-march` gcc < 4.9 | `-march` gcc >= 4.9 |
| ----- | ---- | ------------------ | ------------------- |
frontend1 | `E5-2670 v2` | `core-avx-i` | `ivybridge`
frontend2 | `E5-2690 v4` | `core-avx2` | `broadwell `
envinf1 | `E5-2680 v2` | `core-avx-i` | `ivybridge`

frontend1 and envinf1 have the same architecture?