### PR TITLE
Add output compression to project configuration.

### DIFF
--- a/Documentation/ProjectFile/prj/time_loop/output/t_compress_output.md
+++ b/Documentation/ProjectFile/prj/time_loop/output/t_compress_output.md
@@ -1,0 +1,1 @@
+\copydoc ProcessLib::Output::_output_file_compression

--- a/MeshLib/IO/VtkIO/VtuInterface-impl.h
+++ b/MeshLib/IO/VtkIO/VtuInterface-impl.h
@@ -48,8 +48,10 @@ bool VtuInterface::writeVTU(std::string const &file_name, const int num_partitio
 
     vtuWriter->SetInputConnection(vtkSource->GetOutputPort());
 
-    if(_use_compressor && num_partitions == 0)
+    if(_use_compressor)
         vtuWriter->SetCompressorTypeToZLib();
+    else
+        vtuWriter->SetCompressorTypeToNone();
 
     vtuWriter->SetDataMode(_data_mode);
     if (_data_mode == vtkXMLWriter::Appended)

--- a/ProcessLib/Output.cpp
+++ b/ProcessLib/Output.cpp
@@ -57,6 +57,8 @@ newInstance(const BaseLib::ConfigTree &config, std::string const& output_directo
         BaseLib::joinPaths(output_directory,
                            //! \ogs_file_param{prj__time_loop__output__prefix}
                            config.getConfigParameter<std::string>("prefix")),
+        //! \ogs_file_param{prj__time_loop__output__compress_output}
+        config.getConfigParameter("compress_output", true),
         output_iteration_results ? *output_iteration_results : false}};
 
     //! \ogs_file_param{prj__time_loop__output__timesteps}
@@ -118,8 +120,9 @@ void Output::doOutputAlways(Process const& process,
             + "_t_"  + std::to_string(t)
             + ".vtu";
     DBUG("output to %s", output_file_name.c_str());
-    doProcessOutput(output_file_name, x, process.getMesh(),
-                    process.getDOFTable(), process.getProcessVariables(),
+    doProcessOutput(output_file_name, _output_file_compression, x,
+                    process.getMesh(), process.getDOFTable(),
+                    process.getProcessVariables(),
                     process.getSecondaryVariables(), process_output);
     spd.pvd_file.addVTUFile(output_file_name, t);
 
@@ -180,8 +183,9 @@ void Output::doOutputNonlinearIteration(Process const& process,
             + "_nliter_" + std::to_string(iteration)
             + ".vtu";
     DBUG("output iteration results to %s", output_file_name.c_str());
-    doProcessOutput(output_file_name, x, process.getMesh(),
-                    process.getDOFTable(), process.getProcessVariables(),
+    doProcessOutput(output_file_name, _output_file_compression, x,
+                    process.getMesh(), process.getDOFTable(),
+                    process.getProcessVariables(),
                     process.getSecondaryVariables(), process_output);
 
     INFO("[time] Output took %g s.", time_output.elapsed());

--- a/ProcessLib/Output.h
+++ b/ProcessLib/Output.h
@@ -82,13 +82,18 @@ private:
         MeshLib::IO::PVDFile pvd_file;
     };
 
-    Output(std::string const& prefix, bool output_nonlinear_iteration_results)
+    Output(std::string const& prefix, bool const compress_output,
+           bool const output_nonlinear_iteration_results)
         : _output_file_prefix(prefix),
+          _output_file_compression(compress_output),
           _output_nonlinear_iteration_results(
               output_nonlinear_iteration_results)
     {}
 
     std::string const _output_file_prefix;
+
+    //! Enables or disables zlib-compression of the output files.
+    bool const _output_file_compression;
     bool const _output_nonlinear_iteration_results;
 
     //! Describes after which timesteps to write output.

--- a/ProcessLib/ProcessOutput.cpp
+++ b/ProcessLib/ProcessOutput.cpp
@@ -40,16 +40,15 @@ ProcessOutput::ProcessOutput(BaseLib::ConfigTree const& output_config)
     }
 }
 
-
-void doProcessOutput(
-        std::string const& file_name,
-        GlobalVector const& x,
-        MeshLib::Mesh& mesh,
-        NumLib::LocalToGlobalIndexMap const& dof_table,
-        std::vector<std::reference_wrapper<ProcessVariable>> const&
-        process_variables,
-        SecondaryVariableCollection secondary_variables,
-        ProcessOutput const& process_output)
+void doProcessOutput(std::string const& file_name,
+                     bool const compress_output,
+                     GlobalVector const& x,
+                     MeshLib::Mesh& mesh,
+                     NumLib::LocalToGlobalIndexMap const& dof_table,
+                     std::vector<std::reference_wrapper<ProcessVariable>> const&
+                         process_variables,
+                     SecondaryVariableCollection secondary_variables,
+                     ProcessOutput const& process_output)
 {
     DBUG("Process output.");
 
@@ -219,7 +218,8 @@ void doProcessOutput(
 
     // Write output file
     DBUG("Writing output to \'%s\'.", file_name.c_str());
-    MeshLib::IO::VtuInterface vtu_interface(&mesh, vtkXMLWriter::Binary, true);
+    MeshLib::IO::VtuInterface vtu_interface(&mesh, vtkXMLWriter::Binary,
+                                            compress_output);
     vtu_interface.writeToFile(file_name);
 }
 

--- a/ProcessLib/ProcessOutput.h
+++ b/ProcessLib/ProcessOutput.h
@@ -30,14 +30,14 @@ struct ProcessOutput final
 
 
 //! Writes output to the given \c file_name using the VTU file format.
-void doProcessOutput(
-        std::string const& file_name,
-        GlobalVector const& x,
-        MeshLib::Mesh& mesh,
-        NumLib::LocalToGlobalIndexMap const& dof_table,
-        std::vector<std::reference_wrapper<ProcessVariable>> const&
-        process_variables,
-        SecondaryVariableCollection secondary_variables,
-        ProcessOutput const& process_output);
+void doProcessOutput(std::string const& file_name,
+                     bool const compress_output,
+                     GlobalVector const& x,
+                     MeshLib::Mesh& mesh,
+                     NumLib::LocalToGlobalIndexMap const& dof_table,
+                     std::vector<std::reference_wrapper<ProcessVariable>> const&
+                         process_variables,
+                     SecondaryVariableCollection secondary_variables,
+                     ProcessOutput const& process_output);
 
 } // ProcessLib


### PR DESCRIPTION
The default value is to compress the vtu output, but for a lot of output in production code the compression takes around 1/6th of each timestep (with output). The optional `<compress_output>` option allows switching off the compression.

Some results for the GWF/cube_1e6.prj:
File size increases a lot, almost five-fold:
-rw-r--r-- 1 naumov users   179 597 443   Mar 27 23:37 cube_1e6_pcs_0_ts_1_t_1.000000.vtu
-rw-r--r-- 1 naumov users   36 323 990   Mar 28 00:45 cube_1e6_pcs_0_ts_1_t_1.000000.vtu

But the time goes down
from 28.086064819 seconds ( +-  0.88% )
to 23.330982410 seconds ( +-  1.07% ),
which is 83% of the original runtime ;) (It would be more efficient for a transient simulation even...)

