### PR TITLE
SmallDeformation process fixes (and updates)

### DIFF
--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -393,7 +393,10 @@ private:
 
         for (auto const& ip_data : _ip_data)
         {
-            cache.push_back(ip_data.eps[component]);
+            if (component < 3)  // xx, yy, zz components
+                cache.push_back(ip_data.eps[component]);
+            else  // mixed xy, yz, xz components
+                cache.push_back(ip_data.eps[component] / std::sqrt(2));
         }
 
         return cache;

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -315,14 +315,14 @@ public:
         return getIntPtSigma(cache, 3);
     }
 
-    std::vector<double> const& getIntPtSigmaXZ(
+    std::vector<double> const& getIntPtSigmaYZ(
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
         return getIntPtSigma(cache, 4);
     }
 
-    std::vector<double> const& getIntPtSigmaYZ(
+    std::vector<double> const& getIntPtSigmaXZ(
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -353,14 +353,14 @@ public:
         return getIntPtEpsilon(cache, 3);
     }
 
-    std::vector<double> const& getIntPtEpsilonXZ(
+    std::vector<double> const& getIntPtEpsilonYZ(
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
         return getIntPtEpsilon(cache, 4);
     }
 
-    std::vector<double> const& getIntPtEpsilonYZ(
+    std::vector<double> const& getIntPtEpsilonXZ(
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -139,6 +139,20 @@ private:
             makeExtrapolator(
                 getExtrapolator(), _local_assemblers,
                 &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonXY));
+        if (DisplacementDim == 3)
+        {
+            Base::_secondary_variables.addSecondaryVariable(
+                "epsilon_yz", 1,
+                makeExtrapolator(getExtrapolator(), _local_assemblers,
+                                 &SmallDeformationLocalAssemblerInterface::
+                                     getIntPtEpsilonYZ));
+
+            Base::_secondary_variables.addSecondaryVariable(
+                "epsilon_xz", 1,
+                makeExtrapolator(getExtrapolator(), _local_assemblers,
+                                 &SmallDeformationLocalAssemblerInterface::
+                                     getIntPtEpsilonXZ));
+        }
     }
 
     void assembleConcreteProcess(const double t, GlobalVector const& x,


### PR DESCRIPTION
Go commit-wise.

Some fixes are applied to style (`_`), some to better code (`integration_weight`), some to wrong coding (`eps_xz/yz`), some extend the output (`eps_xz/yz`)

If you copied this process, please check if the wrong lines creeped into your copy too...