### PR TITLE
[Jenkins] Use Visual Studio 2017 as default

### DIFF
--- a/Applications/DataExplorer/DataExplorer.cmake
+++ b/Applications/DataExplorer/DataExplorer.cmake
@@ -15,20 +15,26 @@ include_directories(
     ${SOURCE_DIR_REL}/FileIO
     ${SOURCE_DIR_REL}/MeshLib
     ${SOURCE_DIR_REL}/MeshLibGEOTOOLS
-    ${CMAKE_CURRENT_BINARY_DIR}/../Utils/OGSFileConverter
-    ${CMAKE_CURRENT_BINARY_DIR}/Base
-    ${CMAKE_CURRENT_BINARY_DIR}/DataView
-    ${CMAKE_CURRENT_BINARY_DIR}/DataView/StratView
-    ${CMAKE_CURRENT_BINARY_DIR}/DataView/DiagramView
-    ${CMAKE_CURRENT_BINARY_DIR}/VtkVis
-    ${CMAKE_CURRENT_BINARY_DIR}/VtkAct
-    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/Base
     ${CMAKE_CURRENT_SOURCE_DIR}/DataView
     ${CMAKE_CURRENT_SOURCE_DIR}/DataView/StratView
     ${CMAKE_CURRENT_SOURCE_DIR}/DataView/DiagramView
     ${CMAKE_CURRENT_SOURCE_DIR}/VtkVis
     ${CMAKE_CURRENT_SOURCE_DIR}/VtkAct
+
+    # Qt generated file includes
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}/../Utils/OGSFileConverter
+    ${CMAKE_CURRENT_BINARY_DIR}/DataView
+    ${CMAKE_CURRENT_BINARY_DIR}/DataView/DiagramView
+    ${CMAKE_CURRENT_BINARY_DIR}/VtkVis
+
+    # Workaround for CMake 3.8
+    ${CMAKE_CURRENT_BINARY_DIR}/../Utils/OGSFileConverter/OGSFileConverterLib_autogen/include
+    ${CMAKE_CURRENT_BINARY_DIR}/DataView/DiagramView/QtDiagramView_autogen/include
+    ${CMAKE_CURRENT_BINARY_DIR}/DataView/QtDataView_autogen/include
+    ${CMAKE_CURRENT_BINARY_DIR}/VtkVis/VtkVis_autogen/include
 )
 
 # Put moc files in a project folder

--- a/Applications/DataExplorer/DataView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/CMakeLists.txt
@@ -100,21 +100,27 @@ source_group("UI Files" FILES ${UIS})
 set(SOURCE_DIR_REL ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 set(GUI_SOURCE_DIR_REL ${CMAKE_CURRENT_SOURCE_DIR}/..)
 include_directories(
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}/../Base
-    ${CMAKE_CURRENT_BINARY_DIR}/DiagramView
-    ${CMAKE_CURRENT_BINARY_DIR}/StratView
     ${SOURCE_DIR_REL}/Applications/FileIO
     ${SOURCE_DIR_REL}/BaseLib
     ${SOURCE_DIR_REL}/MathLib
     ${SOURCE_DIR_REL}/GeoLib
     ${SOURCE_DIR_REL}/MeshGeoToolsLib
     ${SOURCE_DIR_REL}/MeshLib
+    ${GUI_SOURCE_DIR_REL}/Base
+    ${GUI_SOURCE_DIR_REL}/VtkVis
+
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/DiagramView
     ${CMAKE_CURRENT_SOURCE_DIR}/StratView
-    ${GUI_SOURCE_DIR_REL}/Base
-    ${GUI_SOURCE_DIR_REL}/VtkVis
+
+    # Qt generated file includes
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}/DiagramView
+    ${CMAKE_CURRENT_BINARY_DIR}/StratView
+
+    # Workaround for CMake 3.8
+    ${CMAKE_CURRENT_BINARY_DIR}/DiagramView/QtDiagramView_autogen/include
+    ${CMAKE_CURRENT_BINARY_DIR}/StratView/QtStratView_autogen/include
 )
 
 if(GEOTIFF_FOUND)
@@ -127,14 +133,15 @@ add_library(QtDataView
     ${UIS}
 )
 
-target_link_libraries(QtDataView Qt5::Core Qt5::Gui)
 target_link_libraries(QtDataView
+    Qt5::Core
+    Qt5::Gui
     ApplicationsFileIO
     DataHolderLib
     QtBase
+    QtDiagramView
     QtStratView
 )
-add_dependencies(QtDataView QtDiagramView QtStratView)
 
 ADD_VTK_DEPENDENCY(QtDataView)
 

--- a/Applications/DataExplorer/VtkVis/CMakeLists.txt
+++ b/Applications/DataExplorer/VtkVis/CMakeLists.txt
@@ -111,8 +111,12 @@ include_directories(
     ${GUI_SOURCE_DIR_REL}/DataView
     ${GUI_SOURCE_DIR_REL}/VtkModules/Qt
 
+    # Qt generated file includes
     ${CMAKE_CURRENT_BINARY_DIR}/../../BaseLib
     ${CMAKE_CURRENT_BINARY_DIR}/../DataView
+
+    # Workaround for CMake 3.8
+    ${CMAKE_CURRENT_BINARY_DIR}/../DataView/QtDataView_autogen/include
 )
 
 add_library(VtkVis

--- a/Applications/Utils/OGSFileConverter/CMakeLists.txt
+++ b/Applications/Utils/OGSFileConverter/CMakeLists.txt
@@ -16,7 +16,6 @@ set(SOURCES
 find_package(Qt5 QUIET REQUIRED Gui Widgets Xml XmlPatterns)
 
 include_directories(
-    ${CMAKE_BINARY_DIR}/Applications/Utils/OGSFileConverter
     ${CMAKE_SOURCE_DIR}/BaseLib
     ${CMAKE_SOURCE_DIR}/FileIO
     ${CMAKE_SOURCE_DIR}/GeoLib
@@ -24,6 +23,12 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/Applications/DataExplorer/Base
     ${CMAKE_SOURCE_DIR}/Applications/DataExplorer/DataView
     ${CMAKE_SOURCE_DIR}/Applications/DataExplorer/VtkVis
+
+    # Qt generated file includes
+    ${CMAKE_BINARY_DIR}/Applications/Utils/OGSFileConverter
+
+    # Workaround for CMake 3.8
+    ${CMAKE_CURRENT_BINARY_DIR}/OGSFileConverterLib_autogen/include
 )
 
 file(GLOB_RECURSE UIS *.ui)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('jenkins-pipeline@1.0.2') _
+@Library('jenkins-pipeline@1.0.4') _
 
 def builders = [:]
 def helper = new ogs.helper()


### PR DESCRIPTION
Updated pipeline lib to [1.0.4](https://gitlab.opengeosys.org/bilke/jenkins-library/tags/1.0.4)

This uses VS 2017 as default. After installing VS 2017 on win1 VS 2015 was broken :rage2: . I was able to restore VS 2015 compilation but without Ninja only which increased built times extraordinary.. :rage4:  So as a pragmatic solution I switched to VS 2017.

The only good thing here is that VS 2017 (finally) is binary compatible with VS 2015 so we can reuse Conan packages originally built with VS 2015..

Note to self: Checkout and maybe implement CMake [transitive dependencies](https://cmake.org/cmake/help/v3.8/manual/cmake-buildsystem.7.html#transitive-usage-requirements)..