### PR TITLE
Face rule normals and vectors

### DIFF
--- a/MeshLib/Elements/FaceRule.cpp
+++ b/MeshLib/Elements/FaceRule.cpp
@@ -20,14 +20,24 @@ bool FaceRule::testElementNodeOrder(const Element* e)
 {
     MathLib::Vector3 up_vec (0,0,1);
     return (MathLib::scalarProduct(getSurfaceNormal(e), up_vec) < 0) ? true : false;
+
+MathLib::Vector3 FaceRule::getFirstSurfaceVector(Element const* const e)
+{
+    Node* const* const _nodes = e->getNodes();
+    return {*_nodes[1], *_nodes[0]};
+}
+
+MathLib::Vector3 FaceRule::getSecondSurfaceVector(Element const* const e)
+{
+    Node* const* const _nodes = e->getNodes();
+    return {*_nodes[1], *_nodes[2]};
 }
 
 MathLib::Vector3 FaceRule::getSurfaceNormal(const Element* e)
 {
-    Node * const * _nodes = e->getNodes();
-    const MathLib::Vector3 u (*_nodes[1], *_nodes[0]);
-    const MathLib::Vector3 v (*_nodes[1], *_nodes[2]);
-    return MathLib::crossProduct(u,v);
+    const MathLib::Vector3 u = getFirstSurfaceVector(e);
+    const MathLib::Vector3 v = getSecondSurfaceVector(e);
+    return MathLib::crossProduct(u, v);
 }
 
 } /* namespace */

--- a/MeshLib/Elements/FaceRule.cpp
+++ b/MeshLib/Elements/FaceRule.cpp
@@ -15,11 +15,10 @@
 
 namespace MeshLib
 {
-
 bool FaceRule::testElementNodeOrder(const Element* e)
 {
-    MathLib::Vector3 up_vec (0,0,1);
-    return (MathLib::scalarProduct(getSurfaceNormal(e), up_vec) < 0) ? true : false;
+    return getSurfaceNormal(e)[2] < 0;
+}
 
 MathLib::Vector3 FaceRule::getFirstSurfaceVector(Element const* const e)
 {

--- a/MeshLib/Elements/FaceRule.h
+++ b/MeshLib/Elements/FaceRule.h
@@ -33,6 +33,12 @@ public:
      */
     static bool testElementNodeOrder(const Element* /*e*/);
 
+    /// \returns the first vector forming the surface' plane
+    static MathLib::Vector3 getFirstSurfaceVector(Element const* const e);
+
+    /// \returns the second vector forming the surface' plane
+    static MathLib::Vector3 getSecondSurfaceVector(Element const* const e);
+
     /// Returns the surface normal of a 2D element.
     static MathLib::Vector3 getSurfaceNormal(const Element* e);
 

--- a/ProcessLib/LIE/Common/FractureProperty.h
+++ b/ProcessLib/LIE/Common/FractureProperty.h
@@ -47,9 +47,9 @@ inline void setFractureProperty(unsigned dim, MeshLib::Element const& e,
     // a fracture is not curving
     for (int j=0; j<3; j++)
         frac_prop.point_on_fracture[j] = e.getNode(0)->getCoords()[j];
-    computeNormalVector(e, frac_prop.normal_vector);
+    computeNormalVector(e, dim, frac_prop.normal_vector);
     frac_prop.R.resize(dim, dim);
-    computeRotationMatrix(frac_prop.normal_vector, dim, frac_prop.R);
+    computeRotationMatrix(e, frac_prop.normal_vector, dim, frac_prop.R);
 }
 
 }  // namespace LIE

--- a/ProcessLib/LIE/Common/Utils.h
+++ b/ProcessLib/LIE/Common/Utils.h
@@ -18,11 +18,28 @@ namespace ProcessLib
 namespace LIE
 {
 
-/// compute a normal vector of the given element
-void computeNormalVector(MeshLib::Element const& e, Eigen::Vector3d & normal_vector);
+/// Compute a normal vector of the given element
+///
+/// Computed normal vector is oriented in the left direction of the given line
+/// element such that computeRotationMatrix() returns the indentity matrix for
+/// line elements parallel to a vector (1,0,0)
+void computeNormalVector(MeshLib::Element const& e, unsigned const global_dim,
+                         Eigen::Vector3d& normal_vector);
 
-/// compute a rotation matrix from global to local coordinates based on the given normal vector
-void computeRotationMatrix(Eigen::Vector3d const& normal_vector, int dim, Eigen::MatrixXd &matR);
+/// Compute a rotation matrix from global to local coordinates using the given
+/// elements' normal vector and based on the two vectors forming the element's
+/// surface plane.
+///
+/// In the 2D case (line element) the resulting y axis should be same as the
+/// given normal vector. In the 3D case (tri, quad, etc.) the resulting z-axis
+/// should be the same as the given normal vector.
+///
+/// \param e the element.
+/// \param n the element's normal.
+/// \param global_dim the space dimension in which the element is embedded.
+/// \param R the output rotation matrix.
+void computeRotationMatrix(MeshLib::Element const& e, Eigen::Vector3d const& n,
+                           unsigned const global_dim, Eigen::MatrixXd& R);
 
 /// compute physical coordinates from the given shape vector, i.e. from the natural coordinates
 template <typename Derived>

--- a/Tests/ProcessLib/TestLIE.cpp
+++ b/Tests/ProcessLib/TestLIE.cpp
@@ -63,13 +63,13 @@ TEST(LIE, rotationMatrixX)
     auto msh(createX());
     auto e(msh->getElement(0));
     Eigen::Vector3d nv;
-    ProcessLib::LIE::computeNormalVector(*e, nv);
+    ProcessLib::LIE::computeNormalVector(*e, 2, nv);
     ASSERT_EQ(0., nv[0]);
     ASSERT_EQ(1., nv[1]);
     ASSERT_EQ(0., nv[2]);
 
     Eigen::MatrixXd R(2,2);
-    ProcessLib::LIE::computeRotationMatrix(nv, 2, R);
+    ProcessLib::LIE::computeRotationMatrix(*e, nv, 2, R);
 
     ASSERT_NEAR(1., R(0,0), eps);
     ASSERT_NEAR(0., R(0,1), eps);
@@ -82,13 +82,13 @@ TEST(LIE, rotationMatrixY)
     auto msh(createY());
     auto e(msh->getElement(0));
     Eigen::Vector3d nv;
-    ProcessLib::LIE::computeNormalVector(*e, nv);
+    ProcessLib::LIE::computeNormalVector(*e, 2, nv);
     ASSERT_EQ(-1., nv[0]);
     ASSERT_EQ(0., nv[1]);
     ASSERT_EQ(0., nv[2]);
 
     Eigen::MatrixXd R(2,2);
-    ProcessLib::LIE::computeRotationMatrix(nv, 2, R);
+    ProcessLib::LIE::computeRotationMatrix(*e, nv, 2, R);
 
     ASSERT_NEAR(0., R(0,0), eps);
     ASSERT_NEAR(1., R(0,1), eps);
@@ -101,13 +101,13 @@ TEST(LIE, rotationMatrixXY)
     auto msh(createXY());
     auto e(msh->getElement(0));
     Eigen::Vector3d nv;
-    ProcessLib::LIE::computeNormalVector(*e, nv);
+    ProcessLib::LIE::computeNormalVector(*e, 2, nv);
     ASSERT_NEAR(-1./sqrt(2), nv[0], eps);
     ASSERT_NEAR(1./sqrt(2), nv[1], eps);
     ASSERT_EQ(0., nv[2]);
 
     Eigen::MatrixXd R(2,2);
-    ProcessLib::LIE::computeRotationMatrix(nv, 2, R);
+    ProcessLib::LIE::computeRotationMatrix(*e, nv, 2, R);
 
     ASSERT_NEAR(1./sqrt(2), R(0,0), eps);
     ASSERT_NEAR(1./sqrt(2), R(0,1), eps);

--- a/Tests/ProcessLib/TestLIE.cpp
+++ b/Tests/ProcessLib/TestLIE.cpp
@@ -15,6 +15,7 @@
 #include <Eigen/Eigen>
 
 #include "MeshLib/Elements/Line.h"
+#include "MeshLib/Elements/Tri.h"
 #include "MeshLib/Mesh.h"
 
 #include "ProcessLib/LIE/Common/Utils.h"
@@ -22,6 +23,19 @@
 
 namespace
 {
+std::unique_ptr<MeshLib::Mesh> createTriangle(
+    std::array<std::array<double, 3>, 3> const& points)
+{
+    MeshLib::Node** nodes = new MeshLib::Node*[3];
+    for (int i = 0; i < points.size(); ++i)
+        nodes[i] = new MeshLib::Node(points[i]);
+    MeshLib::Element* e = new MeshLib::Tri(nodes);
+
+    return std::unique_ptr<MeshLib::Mesh>(new MeshLib::Mesh(
+        "",
+        std::vector<MeshLib::Node*>{nodes[0], nodes[1], nodes[2]},
+        std::vector<MeshLib::Element*>{e}));
+}
 
 std::unique_ptr<MeshLib::Mesh> createLine(
     std::array<double, 3> const& a, std::array<double, 3> const& b)
@@ -56,6 +70,56 @@ std::unique_ptr<MeshLib::Mesh> createXY()
 
 const double eps = std::numeric_limits<double>::epsilon();
 
+}
+
+TEST(LIE, rotationMatrixXYTriangle)
+{
+    auto msh = createTriangle(
+        {{{{0.0, 0.0, 0.0}}, {{1.0, 0.0, 0.0}}, {{1.0, 1.0, 0.0}}}});
+    auto e(msh->getElement(0));
+    Eigen::Vector3d nv;
+    ProcessLib::LIE::computeNormalVector(*e, 3, nv);
+    ASSERT_EQ(0., nv[0]);
+    ASSERT_EQ(0., nv[1]);
+    ASSERT_EQ(-1., nv[2]);
+
+    Eigen::MatrixXd R(3, 3);
+    ProcessLib::LIE::computeRotationMatrix(*e, nv, 3, R);
+
+    ASSERT_NEAR(-1., R(0, 0), eps);
+    ASSERT_NEAR(0., R(0, 1), eps);
+    ASSERT_NEAR(0., R(0, 2), eps);
+    ASSERT_NEAR(0., R(1, 0), eps);
+    ASSERT_NEAR(1., R(1, 1), eps);
+    ASSERT_NEAR(0., R(1, 2), eps);
+    ASSERT_NEAR(0., R(2, 0), eps);
+    ASSERT_NEAR(0., R(2, 1), eps);
+    ASSERT_NEAR(-1., R(2, 2), eps);
+}
+
+TEST(LIE, rotationMatrixYZTriangle)
+{
+    auto msh = createTriangle(
+        {{{{0.0, 0.0, 0.0}}, {{0.0, 1.0, 0.0}}, {{0.0, 1.0, 1.0}}}});
+    auto e(msh->getElement(0));
+    Eigen::Vector3d nv;
+    ProcessLib::LIE::computeNormalVector(*e, 3, nv);
+    ASSERT_EQ(-1., nv[0]);
+    ASSERT_EQ(0., nv[1]);
+    ASSERT_EQ(0., nv[2]);
+
+    Eigen::MatrixXd R(3, 3);
+    ProcessLib::LIE::computeRotationMatrix(*e, nv, 3, R);
+
+    ASSERT_NEAR(0., R(0, 0), eps);
+    ASSERT_NEAR(-1., R(0, 1), eps);
+    ASSERT_NEAR(0., R(0, 2), eps);
+    ASSERT_NEAR(0., R(1, 0), eps);
+    ASSERT_NEAR(0., R(1, 1), eps);
+    ASSERT_NEAR(1., R(1, 2), eps);
+    ASSERT_NEAR(-1., R(2, 0), eps);
+    ASSERT_NEAR(0., R(2, 1), eps);
+    ASSERT_NEAR(0., R(2, 2), eps);
 }
 
 TEST(LIE, rotationMatrixX)

--- a/Tests/ProcessLib/TestLIE.cpp
+++ b/Tests/ProcessLib/TestLIE.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<MeshLib::Mesh> createY()
 std::unique_ptr<MeshLib::Mesh> createXY()
 {
     // 45degree inclined
-    return createLine({{0.0, 0.0, 0.0}}, {{2./sqrt(2), 2./sqrt(2), 0.0}});
+    return createLine({{0.0, 0.0, 0.0}}, {{2./std::sqrt(2), 2./std::sqrt(2), 0.0}});
 }
 
 const double eps = std::numeric_limits<double>::epsilon();
@@ -102,15 +102,15 @@ TEST(LIE, rotationMatrixXY)
     auto e(msh->getElement(0));
     Eigen::Vector3d nv;
     ProcessLib::LIE::computeNormalVector(*e, 2, nv);
-    ASSERT_NEAR(-1./sqrt(2), nv[0], eps);
-    ASSERT_NEAR(1./sqrt(2), nv[1], eps);
+    ASSERT_NEAR(-1./std::sqrt(2), nv[0], eps);
+    ASSERT_NEAR(1./std::sqrt(2), nv[1], eps);
     ASSERT_EQ(0., nv[2]);
 
     Eigen::MatrixXd R(2,2);
     ProcessLib::LIE::computeRotationMatrix(*e, nv, 2, R);
 
-    ASSERT_NEAR(1./sqrt(2), R(0,0), eps);
-    ASSERT_NEAR(1./sqrt(2), R(0,1), eps);
-    ASSERT_NEAR(-1./sqrt(2), R(1,0), eps);
-    ASSERT_NEAR(1./sqrt(2), R(1,1), eps);
+    ASSERT_NEAR(1./std::sqrt(2), R(0,0), eps);
+    ASSERT_NEAR(1./std::sqrt(2), R(0,1), eps);
+    ASSERT_NEAR(-1./std::sqrt(2), R(1,0), eps);
+    ASSERT_NEAR(1./std::sqrt(2), R(1,1), eps);
 }

--- a/Tests/ProcessLib/TestLIE.cpp
+++ b/Tests/ProcessLib/TestLIE.cpp
@@ -38,34 +38,17 @@ std::unique_ptr<MeshLib::Mesh> createTriangle(
 }
 
 std::unique_ptr<MeshLib::Mesh> createLine(
-    std::array<double, 3> const& a, std::array<double, 3> const& b)
+    std::array<std::array<double, 3>, 2> const& points)
 {
     MeshLib::Node** nodes = new MeshLib::Node*[2];
-    nodes[0] = new MeshLib::Node(a);
-    nodes[1] = new MeshLib::Node(b);
+    for (int i = 0; i < points.size(); ++i)
+        nodes[i] = new MeshLib::Node(points[i]);
     MeshLib::Element* e = new MeshLib::Line(nodes);
 
     return std::unique_ptr<MeshLib::Mesh>(
-                new MeshLib::Mesh("",
-                                  std::vector<MeshLib::Node*>{nodes[0], nodes[1]},
-                                  std::vector<MeshLib::Element*>{e})
-                );
-}
-
-std::unique_ptr<MeshLib::Mesh> createX()
-{
-    return createLine({{-1.0, 0.0, 0.0}}, {{1.0,  0.0, 0.0}});
-}
-
-std::unique_ptr<MeshLib::Mesh> createY()
-{
-    return createLine({{0.0, -1.0, 0.0}}, {{0.0,  1.0, 0.0}});
-}
-
-std::unique_ptr<MeshLib::Mesh> createXY()
-{
-    // 45degree inclined
-    return createLine({{0.0, 0.0, 0.0}}, {{2./std::sqrt(2), 2./std::sqrt(2), 0.0}});
+        new MeshLib::Mesh("",
+                          std::vector<MeshLib::Node*>{nodes[0], nodes[1]},
+                          std::vector<MeshLib::Element*>{e}));
 }
 
 const double eps = std::numeric_limits<double>::epsilon();
@@ -124,7 +107,7 @@ TEST(LIE, rotationMatrixYZTriangle)
 
 TEST(LIE, rotationMatrixX)
 {
-    auto msh(createX());
+    auto msh = createLine({{{{-1.0, 0.0, 0.0}}, {{1.0, 0.0, 0.0}}}});
     auto e(msh->getElement(0));
     Eigen::Vector3d nv;
     ProcessLib::LIE::computeNormalVector(*e, 2, nv);
@@ -143,7 +126,7 @@ TEST(LIE, rotationMatrixX)
 
 TEST(LIE, rotationMatrixY)
 {
-    auto msh(createY());
+    auto msh = createLine({{{{0.0, -1.0, 0.0}}, {{0.0, 1.0, 0.0}}}});
     auto e(msh->getElement(0));
     Eigen::Vector3d nv;
     ProcessLib::LIE::computeNormalVector(*e, 2, nv);
@@ -162,7 +145,9 @@ TEST(LIE, rotationMatrixY)
 
 TEST(LIE, rotationMatrixXY)
 {
-    auto msh(createXY());
+    // 45degree inclined
+    auto msh = createLine(
+        {{{{0.0, 0.0, 0.0}}, {{2. / std::sqrt(2), 2. / std::sqrt(2), 0.0}}}});
     auto e(msh->getElement(0));
     Eigen::Vector3d nv;
     ProcessLib::LIE::computeNormalVector(*e, 2, nv);


### PR DESCRIPTION
Used in the LIE process and needed for its 3D extension.

Optionally we could move some dealing with normals _etc._ code from LIE/Common.h to MeshLib.