### PR TITLE
Conan Mac Qt PCH fix

### DIFF
--- a/Applications/FileIO/CMakeLists.txt
+++ b/Applications/FileIO/CMakeLists.txt
@@ -1,13 +1,12 @@
 GET_SOURCE_FILES(SOURCES)
+APPEND_SOURCE_FILES(SOURCES Gmsh)
+
 if(NOT Shapelib_FOUND)
     list(REMOVE_ITEM SOURCES SHPInterface.h SHPInterface.cpp)
 endif()
-if(Qt5XmlPatterns_FOUND)
-    APPEND_SOURCE_FILES(SOURCES XmlIO/Qt)
-endif()
-APPEND_SOURCE_FILES(SOURCES Gmsh)
 
 if(Qt5XmlPatterns_FOUND)
+    APPEND_SOURCE_FILES(SOURCES XmlIO/Qt)
     APPEND_SOURCE_FILES(SOURCES FEFLOW)
 endif()
 
@@ -21,13 +20,6 @@ include(${PROJECT_SOURCE_DIR}/scripts/cmake/OGSEnabledElements.cmake)
 # Create the library
 add_library(ApplicationsFileIO ${SOURCES})
 target_link_libraries(ApplicationsFileIO DataHolderLib)
-
-if(Qt5XmlPatterns_FOUND)
-    target_link_libraries(ApplicationsFileIO Qt5::Xml Qt5::XmlPatterns)
-    if(WIN32 AND CMAKE_CROSSCOMPILING AND OPENSSL_FOUND)
-        target_link_libraries(ApplicationsFileIO Qt5::Network ${OPENSSL_LIBRARIES} ws2_32)
-    endif()
-endif()
 
 if(Shapelib_FOUND)
     target_link_libraries(ApplicationsFileIO ${Shapelib_LIBRARIES})

--- a/Applications/FileIO/FEFLOW/FEFLOWGeoInterface.cpp
+++ b/Applications/FileIO/FEFLOW/FEFLOWGeoInterface.cpp
@@ -15,7 +15,7 @@
 
 #include <QDomElement>
 #include <QString>
-#include <QtXml>
+#include <QtXml/QDomDocument>
 
 #include <logog/include/logog.hpp>
 

--- a/Documentation/README.txt.in
+++ b/Documentation/README.txt.in
@@ -1,0 +1,6 @@
+OGS binary package usage
+========================
+
+Start the appropriate executable in the *bin*-folder.
+
+@README_PLATFORM_INSTRUCTIONS@

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('jenkins-pipeline@1.0.4') _
+@Library('jenkins-pipeline@1.0.5') _
 
 def builders = [:]
 def helper = new ogs.helper()

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,25 +2,28 @@ from conans import ConanFile, CMake
 
 class OpenGeoSysConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-
-    requires = \
-        "Boost/[>=1.56.0]@lasote/stable", \
-        "Shapelib/1.3.0@bilke/stable", \
-        "VTK/[>=7.1]@bilke/stable", \
-        "Eigen3/3.2.9@bilke/stable", \
-        "libgeotiff/1.4.2@bilke/stable", \
-        "Qt/5.6.2@bilke/testing"
-
     generators = "cmake"
 
+    options = {"gui": [True, False]}
     default_options = \
+        "gui=False", \
         "Boost:header_only=True", \
         "Qt:xmlpatterns=True"
+
+    def requirements(self):
+        self.requires("Boost/[>=1.56.0]@lasote/stable")
+        self.requires("Eigen3/3.2.9@bilke/stable")
+        self.requires("VTK/[>=7.1]@bilke/stable")
+
+        if self.options.gui:
+            self.requires("Shapelib/1.3.0@bilke/stable")
+            self.requires("libgeotiff/1.4.2@bilke/stable")
+            self.requires("Qt/5.6.2@bilke/testing")
 
     def imports(self):
         self.copy(pattern="*.dll", dst="bin", src="bin")
         self.copy(pattern="*.dylib*", dst="bin", src="lib")
-        # self.copy(pattern="*.framework*", dst="bin", src="lib")
+        self.copy(pattern="*.framework*", dst="bin", src="lib")
         self.copy(pattern="*.dll", dst="bin/platforms", src="plugins/platforms")
         self.copy(pattern="*.dylib*", dst="bin/platforms", src="plugins/platforms")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,6 +23,7 @@ class OpenGeoSysConan(ConanFile):
     def imports(self):
         self.copy(pattern="*.dll", dst="bin", src="bin")
         self.copy(pattern="*.dylib*", dst="bin", src="lib")
+        self.copy(pattern="*.so*", dst="bin", src="lib")
         self.copy(pattern="*.framework*", dst="bin", src="lib")
         self.copy(pattern="*.dll", dst="bin/platforms", src="plugins/platforms")
         self.copy(pattern="*.dylib*", dst="bin/platforms", src="plugins/platforms")

--- a/scripts/cmake/packaging/Pack.cmake
+++ b/scripts/cmake/packaging/Pack.cmake
@@ -117,3 +117,6 @@ if(USE_CONAN)
     # Install Qt platform shared libraries
     install(DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/platforms DESTINATION bin OPTIONAL)
 endif()
+
+configure_file(Documentation/README.txt.in ${PROJECT_BINARY_DIR}/README.txt)
+install(FILES ${PROJECT_BINARY_DIR}/README.txt DESTINATION .)

--- a/scripts/cmake/packaging/PackagingLinux.cmake
+++ b/scripts/cmake/packaging/PackagingLinux.cmake
@@ -23,3 +23,8 @@ if(MODULE_CMD)
             RENAME ${MODULE_NAME})
     endif()
 endif()
+
+set(README_PLATFORM_INSTRUCTIONS
+    "When running the Data Explorer make sure to set the LD_LIBRARY_PATH path to the bin-folder. E.g.:\n\nLD_LIBRARY_PATH=$LD_LIBRARY_PATH:./ ./DataExplorer"
+    CACHE INTERNAL ""
+)

--- a/scripts/jenkins/gcc-conan.groovy
+++ b/scripts/jenkins/gcc-conan.groovy
@@ -41,6 +41,7 @@ image.inside(defaultDockerArgs) {
     stage('Data Explorer (Linux-Docker)') {
         configure.linux(
             cmakeOptions: defaultCMakeOptions + guiCMakeOptions,
+            conanOptions: "-o gui=True",
             keepDir: true,
             script: this,
             useConan: true

--- a/scripts/jenkins/msvc.groovy
+++ b/scripts/jenkins/msvc.groovy
@@ -33,6 +33,7 @@ withEnv(helper.getEnv(this)) {
     stage('Data Explorer (Win)') {
         configure.win(
             cmakeOptions: defaultCMakeOptions + ' ' + guiCMakeOptions, keepDir: true,
+            conanOptions: "-o gui=True",
             script: this
         )
         build.win(script: this)

--- a/scripts/jenkins/msvc32.groovy
+++ b/scripts/jenkins/msvc32.groovy
@@ -22,6 +22,7 @@ withEnv(helper.getEnv(this, 'x32')) {
         configure.win(
             arch: 'x86',
             cmakeOptions: defaultCMakeOptions + guiCMakeOptions,
+            conanOptions: "-o gui=True",
             script: this
         )
         build.win(script: this)


### PR DESCRIPTION
- Fixed Conan QtXml package linking with PCH on macOS
- added conditional Conan install option `-o gui=True` -> CLI devs do not need to download large Qt anymore, added instructions to [the docs](https://docs.opengeosys.org/docs/devguide/getting-started/build-configuration)
- Added a README.txt to the redistributable packages with usage instructions