### PR TITLE
[MeL] Another Properties::getPropertyVectorNames().

### DIFF
--- a/MeshLib/Properties.cpp
+++ b/MeshLib/Properties.cpp
@@ -49,6 +49,18 @@ std::vector<std::string> Properties::getPropertyVectorNames() const
     return names;
 }
 
+std::vector<std::string> Properties::getPropertyVectorNames(
+    MeshLib::MeshItemType t) const
+{
+    std::vector<std::string> names;
+    for (auto p : _properties)
+    {
+        if (p.second->getMeshItemType() == t)
+            names.push_back(p.first);
+    }
+    return names;
+}
+
 Properties Properties::excludeCopyProperties(
     std::vector<std::size_t> const& exclude_elem_ids,
     std::vector<std::size_t> const& exclude_node_ids) const

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -103,6 +103,8 @@ public:
     bool hasPropertyVector(std::string const& name) const;
 
     std::vector<std::string> getPropertyVectorNames() const;
+    std::vector<std::string> getPropertyVectorNames(
+        MeshLib::MeshItemType t) const;
 
     /** copy all PropertyVector objects stored in the (internal) map but only
      * those nodes/elements of a PropertyVector whose ids are not in the vectors


### PR DESCRIPTION
With the additional parameter 't' the returned names can be filtered by mesh item type of the `PropertyVector`.