### PR TITLE
Potential memory leaks

### DIFF
--- a/Applications/DataExplorer/DataView/GeoTreeView.cpp
+++ b/Applications/DataExplorer/DataView/GeoTreeView.cpp
@@ -283,9 +283,13 @@ void GeoTreeView::loadFEMConditions()
 void GeoTreeView::saveFEMConditions()
 {
     TreeItem* item = static_cast<GeoTreeModel*>(model())->getItem(
-            this->selectionModel()->currentIndex());
-    QString fileName = QFileDialog::getSaveFileName(NULL,
-                        "Save FEM Conditions as", "", "OpenGeoSys FEM Condition file (*.cnd);; GeoSys Boundary Condition (*.bc);; GeoSys Initial Condition (*.ic);; GeoSys Source Condition (*.st)");
+        this->selectionModel()->currentIndex());
+    QString fileName =
+        QFileDialog::getSaveFileName(nullptr, "Save FEM Conditions as", "",
+                                     "OpenGeoSys FEM Condition file (*.cnd);; "
+                                     "GeoSys Boundary Condition (*.bc);; "
+                                     "GeoSys Initial Condition (*.ic);; "
+                                     "GeoSys Source Condition (*.st)");
     emit saveFEMConditionsRequested(item->data(0).toString(), fileName);
 }
 */

--- a/Applications/FileIO/SWMM/SWMMInterface.cpp
+++ b/Applications/FileIO/SWMM/SWMMInterface.cpp
@@ -416,7 +416,8 @@ bool SwmmInterface::convertSwmmInputToGeometry(std::string const& inp_file_name,
         return geometryCleanup(*points, *lines);
     }
 
-    std::map<std::string, std::size_t> *name_id_map (new std::map<std::string, std::size_t>);
+    std::unique_ptr<std::map<std::string, std::size_t>> name_id_map{
+        new std::map<std::string, std::size_t>};
     std::size_t const n_names (pnt_names.size());
     for (std::size_t i=0; i<n_names; ++i)
     {
@@ -456,7 +457,7 @@ bool SwmmInterface::convertSwmmInputToGeometry(std::string const& inp_file_name,
         }
     }
 
-    geo_objects.addPointVec(std::move(points), geo_name, name_id_map);
+    geo_objects.addPointVec(std::move(points), geo_name, std::move(name_id_map));
     if (!lines->empty())
     {
         if (lines->size() != line_names.size())
@@ -467,7 +468,8 @@ bool SwmmInterface::convertSwmmInputToGeometry(std::string const& inp_file_name,
                 delete ply;
             return false;
         }
-        std::map<std::string, std::size_t> *line_id_map (new std::map<std::string, std::size_t>);
+        std::unique_ptr<std::map<std::string, std::size_t>> line_id_map{
+            new std::map<std::string, std::size_t>};
         std::size_t const n_names (line_names.size());
         for (std::size_t i=0; i<n_names; ++i)
             line_id_map->insert(std::make_pair(line_names[i], i));
@@ -489,7 +491,8 @@ bool SwmmInterface::convertSwmmInputToGeometry(std::string const& inp_file_name,
                 line->addPoint(line->getPointID(0));
             }
         }
-        geo_objects.addPolylineVec(std::move(lines), geo_name, line_id_map);
+        geo_objects.addPolylineVec(std::move(lines), geo_name,
+                                   std::move(line_id_map));
     }
     return true;
 }

--- a/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
+++ b/Applications/Utils/MeshEdit/CreateBoundaryConditionsAlongPolylines.cpp
@@ -42,8 +42,8 @@ void convertMeshNodesToGeometry(std::vector<MeshLib::Node*> const& nodes,
     // copy data
     auto pnts = std::unique_ptr<std::vector<GeoLib::Point*>>(
         new std::vector<GeoLib::Point*>);
-    std::map<std::string, std::size_t>* pnt_names(
-        new std::map<std::string, std::size_t>);
+    std::unique_ptr<std::map<std::string, std::size_t>> pnt_names{
+        new std::map<std::string, std::size_t>};
     std::size_t cnt(0);
     for (std::size_t id: node_ids) {
         pnts->push_back(new GeoLib::Point(*(nodes[id]), cnt));
@@ -53,7 +53,7 @@ void convertMeshNodesToGeometry(std::vector<MeshLib::Node*> const& nodes,
     }
 
     // create data structures for geometry
-    geometry_sets.addPointVec(std::move(pnts), geo_name, pnt_names);
+    geometry_sets.addPointVec(std::move(pnts), geo_name, std::move(pnt_names));
 }
 
 void writeGroundwaterFlowPointBC(std::ostream& bc_out,
@@ -245,9 +245,8 @@ int main (int argc, char* argv[])
     double const eps (std::numeric_limits<double>::epsilon());
     auto surface_pnts = std::unique_ptr<std::vector<GeoLib::Point*>>(
         new std::vector<GeoLib::Point*>);
-    std::map<std::string, std::size_t> *name_id_map(
-        new std::map<std::string, std::size_t>
-    );
+    std::unique_ptr<std::map<std::string, std::size_t>> name_id_map{
+        new std::map<std::string, std::size_t>};
 
     // insert first point
     surface_pnts->push_back(
@@ -273,7 +272,8 @@ int main (int argc, char* argv[])
     }
 
     std::string surface_name(BaseLib::dropFileExtension(mesh_arg.getValue())+"-MeshNodesAlongPolylines");
-    geometry_sets.addPointVec(std::move(surface_pnts), surface_name, name_id_map, 1e-6);
+    geometry_sets.addPointVec(std::move(surface_pnts), surface_name,
+                              std::move(name_id_map), 1e-6);
 
     // write the BCs and the merged geometry set to file
     std::string const base_fname(

--- a/BaseLib/TemplateLogogFormatterSuppressedGCC-impl.h
+++ b/BaseLib/TemplateLogogFormatterSuppressedGCC-impl.h
@@ -80,7 +80,7 @@ TemplateLogogFormatterSuppressedGCC<T_SUPPPRESS_TOPIC_FLAG>
     }
 
     if ( target.GetNullTerminatesStrings() )
-        m_sMessageBuffer.append( (LOGOG_CHAR)NULL );
+        m_sMessageBuffer.append((LOGOG_CHAR)'\0');
 
     return m_sMessageBuffer;
 }

--- a/GeoLib/GEOObjects.cpp
+++ b/GeoLib/GEOObjects.cpp
@@ -12,12 +12,10 @@
  *
  */
 
-#include <fstream>
-
-#include <logog/include/logog.hpp>
-
-// GeoLib
 #include "GEOObjects.h"
+
+#include <fstream>
+#include <logog/include/logog.hpp>
 
 #include "Triangle.h"
 

--- a/GeoLib/GEOObjects.h
+++ b/GeoLib/GEOObjects.h
@@ -85,10 +85,11 @@ public:
      * @param pnt_names vector of the names corresponding to the points
      * @param eps relative tolerance value for testing of point uniqueness
      */
-    void addPointVec(std::unique_ptr<std::vector<Point*>> points,
-                     std::string& name,
-                     std::map<std::string, std::size_t>* pnt_names = nullptr,
-                     double eps = sqrt(std::numeric_limits<double>::epsilon()));
+    void addPointVec(
+        std::unique_ptr<std::vector<Point*>> points,
+        std::string& name,
+        std::unique_ptr<std::map<std::string, std::size_t>> pnt_names = nullptr,
+        double eps = sqrt(std::numeric_limits<double>::epsilon()));
 
     /**
      * Returns the point vector with the given name.
@@ -137,8 +138,9 @@ public:
      * @param ply_names map of names and ids that are corresponding to the polylines
      */
     void addPolylineVec(std::unique_ptr<std::vector<Polyline*>> lines,
-                                const std::string &name,
-                                std::map<std::string,std::size_t>* ply_names = nullptr);
+                        const std::string& name,
+                        std::unique_ptr<std::map<std::string, std::size_t>>
+                            ply_names = nullptr);
 
     /** copies the pointers to the polylines in the vector to the PolylineVec with provided name.
      * the pointers are managed by the GEOObjects, i.e. GEOObjects will delete the Polylines at the
@@ -179,8 +181,9 @@ public:
 
     /** Adds a vector of surfaces with the given name to GEOObjects. */
     void addSurfaceVec(std::unique_ptr<std::vector<Surface*>> surfaces,
-                               const std::string &name,
-                               std::map<std::string, std::size_t>* sfc_names = nullptr);
+                       const std::string& name,
+                       std::unique_ptr<std::map<std::string, std::size_t>>
+                           sfc_names = nullptr);
 
     /**
      * Copies the surfaces in the vector to the SurfaceVec with the given name.

--- a/GeoLib/IO/Legacy/OGSIOVer4.cpp
+++ b/GeoLib/IO/Legacy/OGSIOVer4.cpp
@@ -163,7 +163,6 @@ std::string readPolyline(std::istream &in,
         in >> line;
         if (line.find("$ID") != std::string::npos) // subkeyword found CC
             in >> line; // read value
-            //            id = strtol(line_string.data(), NULL, 0);
         //....................................................................
         if (line.find("$NAME") != std::string::npos) // subkeyword found
         {
@@ -292,7 +291,6 @@ std::string readSurface(std::istream &in,
         in >> line;
         if (line.find("$ID") != std::string::npos) // subkeyword found CC
             in >> line; // read value
-            //            id = strtol(line_string.data(), NULL, 0);
         //....................................................................
         if (line.find("$NAME") != std::string::npos) // subkeyword found
         {

--- a/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.cpp
@@ -68,7 +68,8 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
     for (auto st : doc->getConfigSubtreeList("points"))
     {
         readPoints(st, *points, *pnt_names);
-        _geo_objects.addPointVec(std::move(points), geo_name, pnt_names.release());
+        _geo_objects.addPointVec(std::move(points), geo_name,
+                                 std::move(pnt_names));
     }
 
     //! \ogs_file_param{gml__polylines}
@@ -92,11 +93,13 @@ bool BoostXmlGmlInterface::readFile(const std::string &fname)
     }
 
     if (!polylines->empty()) {
-        _geo_objects.addPolylineVec(std::move(polylines), geo_name, ply_names.release());
+        _geo_objects.addPolylineVec(std::move(polylines), geo_name,
+                                    std::move(ply_names));
     }
 
     if (!surfaces->empty()) {
-        _geo_objects.addSurfaceVec(std::move(surfaces), geo_name, sfc_names.release());
+        _geo_objects.addSurfaceVec(std::move(surfaces), geo_name,
+                                   std::move(sfc_names));
     }
 
     return true;

--- a/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
@@ -24,6 +24,32 @@
 #include "BaseLib/FileFinder.h"
 #include "GeoLib/Triangle.h"
 
+namespace
+{
+void deletePolylines(std::unique_ptr<std::vector<GeoLib::Polyline*>> polylines)
+{
+    for (GeoLib::Polyline* line : *polylines)
+        delete line;
+}
+
+void deleteSurfaces(std::unique_ptr<std::vector<GeoLib::Surface*>> surfaces)
+{
+    for (GeoLib::Surface* line : *surfaces)
+        delete line;
+}
+void deleteGeometry(std::unique_ptr<std::vector<GeoLib::Point*>> points,
+                    std::unique_ptr<std::vector<GeoLib::Polyline*>>
+                        polylines,
+                    std::unique_ptr<std::vector<GeoLib::Surface*>>
+                        surfaces)
+{
+    for (GeoLib::Point* point : *points)
+        delete point;
+    deletePolylines(std::move(polylines));
+    deleteSurfaces(std::move(surfaces));
+}
+}
+
 namespace GeoLib
 {
 namespace IO
@@ -220,34 +246,6 @@ void XmlGmlInterface::readSurfaces(
         surface = surface.nextSiblingElement();
     }
 }
-
-void XmlGmlInterface::deleteGeometry(
-    std::unique_ptr<std::vector<GeoLib::Point*>> points,
-    std::unique_ptr<std::vector<GeoLib::Polyline*>>
-        polylines,
-    std::unique_ptr<std::vector<GeoLib::Surface*>>
-        surfaces) const
-{
-    for (GeoLib::Point* point : *points)
-        delete point;
-    deletePolylines(std::move(polylines));
-    deleteSurfaces(std::move(surfaces));
-}
-
-void XmlGmlInterface::deletePolylines(
-    std::unique_ptr<std::vector<GeoLib::Polyline*>> polylines) const
-{
-    for (GeoLib::Polyline* line : *polylines)
-        delete line;
-}
-
-void XmlGmlInterface::deleteSurfaces(
-    std::unique_ptr<std::vector<GeoLib::Surface*>> surfaces) const
-{
-    for (GeoLib::Surface* line : *surfaces)
-        delete line;
-}
-
 bool XmlGmlInterface::write()
 {
     if (this->_exportName.empty())

--- a/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
@@ -140,15 +140,11 @@ int XmlGmlInterface::readFile(const QString &fileName)
         }
     }
 
-    if (polylines->empty())
-        deletePolylines(std::move(polylines));
-    else
+    if (!polylines->empty())
         _geo_objs.addPolylineVec(std::move(polylines), gliName,
                                  std::move(ply_names));
 
-    if (surfaces->empty())
-        deleteSurfaces(std::move(surfaces));
-    else
+    if (!surfaces->empty())
         _geo_objs.addSurfaceVec(std::move(surfaces), gliName,
                                 std::move(sfc_names));
     return 1;

--- a/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
@@ -34,8 +34,8 @@ void deletePolylines(std::unique_ptr<std::vector<GeoLib::Polyline*>> polylines)
 
 void deleteSurfaces(std::unique_ptr<std::vector<GeoLib::Surface*>> surfaces)
 {
-    for (GeoLib::Surface* line : *surfaces)
-        delete line;
+    for (GeoLib::Surface* surface : *surfaces)
+        delete surface;
 }
 void deleteGeometry(std::unique_ptr<std::vector<GeoLib::Point*>> points,
                     std::unique_ptr<std::vector<GeoLib::Polyline*>>

--- a/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
@@ -106,7 +106,7 @@ int XmlGmlInterface::readFile(const QString &fileName)
         {
             readPoints(type_node, points.get(), pnt_names.get());
 
-            // if names-map is empty, set it to NULL because it is not needed
+            // if names-map is empty, set it to nullptr because it is not needed
             if (pnt_names->empty())
             {
                 pnt_names.reset(nullptr);
@@ -120,7 +120,7 @@ int XmlGmlInterface::readFile(const QString &fileName)
                 type_node, polylines.get(), *_geo_objs.getPointVec(gliName),
                 _geo_objs.getPointVecObj(gliName)->getIDMap(), ply_names.get());
 
-            // if names-map is empty, set it to NULL because it is not needed
+            // if names-map is empty, set it to nullptr because it is not needed
             if (ply_names->empty())
             {
                 ply_names.reset(nullptr);
@@ -132,7 +132,7 @@ int XmlGmlInterface::readFile(const QString &fileName)
                 type_node, surfaces.get(), *_geo_objs.getPointVec(gliName),
                 _geo_objs.getPointVecObj(gliName)->getIDMap(), sfc_names.get());
 
-            // if names-map is empty, set it to NULL because it is not needed
+            // if names-map is empty, set it to nullptr because it is not needed
             if (sfc_names->empty())
             {
                 sfc_names.reset(nullptr);

--- a/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.h
+++ b/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.h
@@ -68,21 +68,6 @@ private:
                       const std::vector<std::size_t>& pnt_id_map,
                       std::map<std::string, std::size_t>* sfc_names);
 
-    /// Deletes all geometry data structures
-    void deleteGeometry(std::unique_ptr<std::vector<GeoLib::Point*>> points,
-                        std::unique_ptr<std::vector<GeoLib::Polyline*>>
-                            polylines,
-                        std::unique_ptr<std::vector<GeoLib::Surface*>>
-                            surfaces) const;
-
-    /// Cleans up polylines-vector as well as its content if necessary
-    void deletePolylines(
-        std::unique_ptr<std::vector<GeoLib::Polyline*>> polylines) const;
-
-    /// Cleans up surfaces-vector as well as its content if necessary
-    void deleteSurfaces(
-        std::unique_ptr<std::vector<GeoLib::Surface*>> surfaces) const;
-
     GeoLib::GEOObjects& _geo_objs;
     std::map<std::size_t, std::size_t> _idx_map;
 };

--- a/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.h
+++ b/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.h
@@ -50,41 +50,38 @@ protected:
 
 private:
     /// Reads GeoLib::Point-objects from an xml-file
-    void readPoints    ( const QDomNode &pointsRoot,
-                         std::vector<GeoLib::Point*>* points,
-                         std::map<std::string, std::size_t>* &pnt_names );
+    void readPoints(const QDomNode& pointsRoot,
+                    std::vector<GeoLib::Point*>* points,
+                    std::map<std::string, std::size_t>* pnt_names);
 
     /// Reads GeoLib::Polyline-objects from an xml-file
-    void readPolylines ( const QDomNode &polylinesRoot,
-                         std::vector<GeoLib::Polyline*>* polylines,
-                         std::vector<GeoLib::Point*> const& points,
-                         const std::vector<std::size_t> &pnt_id_map,
-                         std::map<std::string, std::size_t>* &ply_names );
+    void readPolylines(const QDomNode& polylinesRoot,
+                       std::vector<GeoLib::Polyline*>* polylines,
+                       std::vector<GeoLib::Point*> const& points,
+                       const std::vector<std::size_t>& pnt_id_map,
+                       std::map<std::string, std::size_t>* ply_names);
 
     /// Reads GeoLib::Surface-objects from an xml-file
-    void readSurfaces  ( const QDomNode &surfacesRoot,
-                         std::vector<GeoLib::Surface*>* surfaces,
-                         std::vector<GeoLib::Point*> const& points,
-                         const std::vector<std::size_t> &pnt_id_map,
-                         std::map<std::string, std::size_t>* &sfc_names );
+    void readSurfaces(const QDomNode& surfacesRoot,
+                      std::vector<GeoLib::Surface*>* surfaces,
+                      std::vector<GeoLib::Point*> const& points,
+                      const std::vector<std::size_t>& pnt_id_map,
+                      std::map<std::string, std::size_t>* sfc_names);
 
     /// Deletes all geometry data structures
-    void deleteGeometry(
-        std::unique_ptr<std::vector<GeoLib::Point*>> points,
-        std::unique_ptr<std::vector<GeoLib::Polyline*>> polylines,
-        std::unique_ptr<std::vector<GeoLib::Surface*>> surfaces,
-        std::map<std::string, std::size_t>* pnt_names,
-        std::map<std::string, std::size_t>* ply_names,
-        std::map<std::string, std::size_t>* sfc_names) const;
+    void deleteGeometry(std::unique_ptr<std::vector<GeoLib::Point*>> points,
+                        std::unique_ptr<std::vector<GeoLib::Polyline*>>
+                            polylines,
+                        std::unique_ptr<std::vector<GeoLib::Surface*>>
+                            surfaces) const;
 
     /// Cleans up polylines-vector as well as its content if necessary
     void deletePolylines(
-        std::unique_ptr<std::vector<GeoLib::Polyline*>> polylines,
-        std::map<std::string, std::size_t>* ply_names) const;
+        std::unique_ptr<std::vector<GeoLib::Polyline*>> polylines) const;
 
     /// Cleans up surfaces-vector as well as its content if necessary
-    void deleteSurfaces(std::unique_ptr<std::vector<GeoLib::Surface*>> surfaces,
-                        std::map<std::string, std::size_t>* sfc_names) const;
+    void deleteSurfaces(
+        std::unique_ptr<std::vector<GeoLib::Surface*>> surfaces) const;
 
     GeoLib::GEOObjects& _geo_objs;
     std::map<std::size_t, std::size_t> _idx_map;

--- a/GeoLib/PointVec.cpp
+++ b/GeoLib/PointVec.cpp
@@ -22,11 +22,11 @@
 
 namespace GeoLib
 {
-PointVec::PointVec(const std::string& name,
-                   std::unique_ptr<std::vector<Point*>> points,
-                   std::map<std::string, std::size_t>* name_id_map,
-                   PointType type, double rel_eps)
-    : TemplateVec<Point>(name, std::move(points), name_id_map),
+PointVec::PointVec(
+    const std::string& name, std::unique_ptr<std::vector<Point*>> points,
+    std::unique_ptr<std::map<std::string, std::size_t>> name_id_map,
+    PointType type, double rel_eps)
+    : TemplateVec<Point>(name, std::move(points), std::move(name_id_map)),
       _type(type),
       _aabb(_data_vec->begin(), _data_vec->end()),
       _rel_eps(rel_eps * std::sqrt(MathLib::sqrDist(_aabb.getMinPoint(),

--- a/GeoLib/PointVec.h
+++ b/GeoLib/PointVec.h
@@ -66,9 +66,13 @@ public:
      * real tolerance \f$tol\f$. Two points \f$p_0, p_1 \f$ are identical iff
      * \f$|p_1 - p_0| \le tol.\f$
      */
-    PointVec (const std::string& name, std::unique_ptr<std::vector<Point*>> points,
-              std::map<std::string, std::size_t>* name_id_map = nullptr,
-              PointType type = PointVec::PointType::POINT, double rel_eps = std::numeric_limits<double>::epsilon());
+    PointVec(const std::string& name,
+             std::unique_ptr<std::vector<Point*>>
+                 points,
+             std::unique_ptr<std::map<std::string, std::size_t>> name_id_map =
+                 nullptr,
+             PointType type = PointVec::PointType::POINT,
+             double rel_eps = std::numeric_limits<double>::epsilon());
 
     /**
      * Method adds a Point to the (internal) standard vector and takes the ownership.

--- a/GeoLib/PointVec.h
+++ b/GeoLib/PointVec.h
@@ -12,20 +12,18 @@
  *
  */
 
-// GeoLib
-#include "AABB.h"
-#include "Point.h"
-#include "Station.h"
+#pragma once
 
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
-#pragma once
-
-#include "TemplateVec.h"
+#include "AABB.h"
 #include "OctTree.h"
+#include "Point.h"
+#include "Station.h"
+#include "TemplateVec.h"
 
 namespace GeoLib
 {

--- a/GeoLib/StationBorehole.cpp
+++ b/GeoLib/StationBorehole.cpp
@@ -90,7 +90,7 @@ int StationBorehole::addStratigraphy(const std::string &path, StationBorehole* b
             addLayer(data[i], borehole);
 
         // check if a layer is missing
-        size = borehole->_soilName.size();
+        // size = borehole->_soilName.size();
         INFO("StationBorehole::addStratigraphy ToDo");
         //    for (std::size_t i=0; i<size; i++)
         //    {

--- a/GeoLib/TemplateVec.h
+++ b/GeoLib/TemplateVec.h
@@ -58,10 +58,10 @@ public:
      * the data_vec.
      */
     TemplateVec(std::string name, std::unique_ptr<std::vector<T*>> data_vec,
-                NameIdMap* elem_name_map = nullptr)
+                std::unique_ptr<NameIdMap> elem_name_map = nullptr)
         : _name(std::move(name)),
           _data_vec(std::move(data_vec)),
-          _name_id_map(elem_name_map)
+          _name_id_map(std::move(elem_name_map))
     {
         if (_data_vec == nullptr)
         {
@@ -69,7 +69,7 @@ public:
         }
 
         if (!_name_id_map)
-            _name_id_map = new NameIdMap;
+            _name_id_map.reset(new NameIdMap);
     }
 
     /**
@@ -78,7 +78,6 @@ public:
     virtual ~TemplateVec ()
     {
         for (std::size_t k(0); k < size(); k++) delete (*_data_vec)[k];
-        delete _name_id_map;
     }
 
     /** sets the name of the vector of geometric objects
@@ -238,6 +237,6 @@ protected:
     /**
      * store names associated with the element ids
      */
-    NameIdMap* _name_id_map;
+    std::unique_ptr<NameIdMap> _name_id_map;
 };
 } // end namespace GeoLib

--- a/MeshLib/MeshEditing/AddLayerToMesh.cpp
+++ b/MeshLib/MeshEditing/AddLayerToMesh.cpp
@@ -53,7 +53,9 @@ MeshLib::Element* extrudeElement(std::vector<MeshLib::Node*> const& subsfc_nodes
         return nullptr;
 
     const unsigned nElemNodes(sfc_elem.getNumberOfBaseNodes());
-    auto** new_nodes = new MeshLib::Node*[2 * nElemNodes];
+    auto new_nodes = std::unique_ptr<MeshLib::Node* []> {
+        new MeshLib::Node*[2 * nElemNodes]
+    };
 
     for (unsigned j=0; j<nElemNodes; ++j)
     {
@@ -65,11 +67,11 @@ MeshLib::Element* extrudeElement(std::vector<MeshLib::Node*> const& subsfc_nodes
     }
 
     if (sfc_elem.getGeomType() == MeshLib::MeshElemType::LINE)
-        return new MeshLib::Quad(new_nodes);
+        return new MeshLib::Quad(new_nodes.release());
     if (sfc_elem.getGeomType() == MeshLib::MeshElemType::TRIANGLE)
-        return new MeshLib::Prism(new_nodes);
+        return new MeshLib::Prism(new_nodes.release());
     if (sfc_elem.getGeomType() == MeshLib::MeshElemType::QUAD)
-        return new MeshLib::Hex(new_nodes);
+        return new MeshLib::Hex(new_nodes.release());
 
     return nullptr;
 }

--- a/MeshLib/MeshEditing/FlipElements.cpp
+++ b/MeshLib/MeshEditing/FlipElements.cpp
@@ -18,26 +18,30 @@
 
 namespace MeshLib
 {
-
-std::unique_ptr<MeshLib::Element> createFlippedElement(MeshLib::Element const& elem, std::vector<MeshLib::Node*> const& nodes)
+std::unique_ptr<MeshLib::Element> createFlippedElement(
+    MeshLib::Element const& elem, std::vector<MeshLib::Node*> const& nodes)
 {
-    if (elem.getDimension()>2)
+    if (elem.getDimension() > 2)
         return nullptr;
 
-    unsigned const n_nodes (elem.getNumberOfNodes());
-    auto** elem_nodes = new MeshLib::Node*[n_nodes];
-    for (unsigned i=0; i<n_nodes; ++i)
+    unsigned const n_nodes(elem.getNumberOfNodes());
+    auto elem_nodes =
+        std::unique_ptr<MeshLib::Node* []> { new MeshLib::Node*[n_nodes] };
+    for (unsigned i = 0; i < n_nodes; ++i)
         elem_nodes[i] = nodes[elem.getNode(i)->getID()];
     std::swap(elem_nodes[0], elem_nodes[1]);
 
     if (elem.getGeomType() == MeshElemType::LINE)
-        return std::unique_ptr<MeshLib::Line>(new MeshLib::Line(elem_nodes, elem.getID()));
+        return std::unique_ptr<MeshLib::Line>(
+            new MeshLib::Line(elem_nodes.release(), elem.getID()));
     else if (elem.getGeomType() == MeshElemType::TRIANGLE)
-        return std::unique_ptr<MeshLib::Tri>(new MeshLib::Tri(elem_nodes, elem.getID()));
+        return std::unique_ptr<MeshLib::Tri>(
+            new MeshLib::Tri(elem_nodes.release(), elem.getID()));
     else if (elem.getGeomType() == MeshElemType::QUAD)
     {
         std::swap(elem_nodes[2], elem_nodes[3]);
-        return std::unique_ptr<MeshLib::Quad>(new MeshLib::Quad(elem_nodes, elem.getID()));
+        return std::unique_ptr<MeshLib::Quad>(
+            new MeshLib::Quad(elem_nodes.release(), elem.getID()));
     }
     return nullptr;
 }

--- a/Tests/FileIO/TestGmlInterface.h
+++ b/Tests/FileIO/TestGmlInterface.h
@@ -52,7 +52,8 @@ public:
         auto points = std::unique_ptr<std::vector<GeoLib::Point*>>(
             new std::vector<GeoLib::Point*>(9));
 
-        auto cpy_name_id_map = new std::map<std::string, std::size_t>;
+        std::unique_ptr<std::map<std::string, std::size_t>> cpy_name_id_map{
+            new std::map<std::string, std::size_t>};
         std::size_t pos(0);
         for (auto p : test_pnts) {
             (*points)[pos] = new GeoLib::Point(p);
@@ -61,7 +62,8 @@ public:
             pos++;
         }
 
-        geo_objects.addPointVec(std::move(points), geo_name, cpy_name_id_map);
+        geo_objects.addPointVec(std::move(points), geo_name,
+                                std::move(cpy_name_id_map));
     }
 
     void checkPointProperties()
@@ -112,14 +114,16 @@ public:
 
         auto lines = std::unique_ptr<std::vector<GeoLib::Polyline*>>(
             new std::vector<GeoLib::Polyline*>(5));
-        auto* name_map = new std::map<std::string, std::size_t>;
+        auto name_map = std::unique_ptr<std::map<std::string, std::size_t>>{
+            new std::map<std::string, std::size_t>};
 
         createPolyline(pnt_vec, *(lines.get()), 0, {0, 1, 2}, *name_map, "left");
         createPolyline(pnt_vec, *(lines.get()), 1, {3, 4, 5}, *name_map, "center");
         createPolyline(pnt_vec, *(lines.get()), 2, {0, 3}, *name_map, "line1");
         createPolyline(pnt_vec, *(lines.get()), 3, {3, 6}, *name_map, "line2");
         createPolyline(pnt_vec, *(lines.get()), 4, {6, 7, 8}, *name_map, "right");
-        geo_objects.addPolylineVec(std::move(lines), geo_name, name_map);
+        geo_objects.addPolylineVec(std::move(lines), geo_name,
+                                   std::move(name_map));
     }
 
     void checkPolylineProperties()
@@ -157,7 +161,8 @@ public:
 
         auto sfcs = std::unique_ptr<std::vector<GeoLib::Surface*>>(
             new std::vector<GeoLib::Surface*>(2));
-        auto* sfc_names = new std::map<std::string, std::size_t>;
+        auto sfc_names = std::unique_ptr<std::map<std::string, std::size_t>>{
+            new std::map<std::string, std::size_t>};
         (*sfcs)[0] = new GeoLib::Surface(*points);
         (*sfcs)[0]->addTriangle(pnt_id_map[0], pnt_id_map[3], pnt_id_map[1]);
         (*sfcs)[0]->addTriangle(pnt_id_map[1], pnt_id_map[3], pnt_id_map[4]);
@@ -168,7 +173,8 @@ public:
         (*sfcs)[1]->addTriangle(pnt_id_map[3], pnt_id_map[6], pnt_id_map[8]);
         (*sfcs)[1]->addTriangle(pnt_id_map[3], pnt_id_map[8], pnt_id_map[5]);
         (*sfc_names)["SecondSurface"] = 1;
-        geo_objects.addSurfaceVec(std::move(sfcs), geo_name, sfc_names);
+        geo_objects.addSurfaceVec(std::move(sfcs), geo_name,
+                                  std::move(sfc_names));
     }
 
     void checkSurfaceProperties()

--- a/Tests/GeoLib/TestGEOObjectsMerge.cpp
+++ b/Tests/GeoLib/TestGEOObjectsMerge.cpp
@@ -23,7 +23,8 @@ void createSetOfTestPointsAndAssociatedNames(GeoLib::GEOObjects & geo_objs, std:
 {
     auto pnts = std::unique_ptr<std::vector<GeoLib::Point*>>(
         new std::vector<GeoLib::Point*>);
-    auto* pnt_name_map(new std::map<std::string, std::size_t>);
+    std::unique_ptr<std::map<std::string, std::size_t>> pnt_name_map{
+        new std::map<std::string, std::size_t>};
 
     const std::size_t pnts_per_edge(8);
     for (std::size_t k(0); k < pnts_per_edge; k++) {
@@ -42,7 +43,7 @@ void createSetOfTestPointsAndAssociatedNames(GeoLib::GEOObjects & geo_objs, std:
         }
     }
 
-    geo_objs.addPointVec(std::move(pnts), name, pnt_name_map);
+    geo_objs.addPointVec(std::move(pnts), name, std::move(pnt_name_map));
 }
 
 TEST(GeoLib, GEOObjectsMergePoints)
@@ -178,9 +179,10 @@ TEST(GeoLib, GEOObjectsMergePolylinesWithNames)
     auto plys_0 = std::unique_ptr<std::vector<GeoLib::Polyline*>>(
         new std::vector<GeoLib::Polyline*>);
     plys_0->push_back(ply_00);
-    auto* names_map_0(new std::map<std::string, std::size_t>);
+    std::unique_ptr<std::map<std::string, std::size_t>> names_map_0{
+        new std::map<std::string, std::size_t>};
     names_map_0->insert(std::pair<std::string, std::size_t>("Polyline0FromGeometry0", 0));
-    geo_objs.addPolylineVec(std::move(plys_0), geometry_0, names_map_0);
+    geo_objs.addPolylineVec(std::move(plys_0), geometry_0, std::move(names_map_0));
     names.push_back(geometry_0);
 
     auto pnts_1 = std::unique_ptr<std::vector<GeoLib::Point*>>(
@@ -208,10 +210,12 @@ TEST(GeoLib, GEOObjectsMergePolylinesWithNames)
         new std::vector<GeoLib::Polyline*>);
     plys_1->push_back(ply_10);
     plys_1->push_back(ply_11);
-    auto* names_map_1(new std::map<std::string, std::size_t>);
+    std::unique_ptr<std::map<std::string, std::size_t>> names_map_1{
+        new std::map<std::string, std::size_t>};
     names_map_1->insert(std::pair<std::string, std::size_t>("Polyline0FromGeometry1", 0));
     names_map_1->insert(std::pair<std::string, std::size_t>("Polyline1FromGeometry1", 1));
-    geo_objs.addPolylineVec(std::move(plys_1), geometry_1, names_map_1);
+    geo_objs.addPolylineVec(
+        std::move(plys_1), geometry_1, std::move(names_map_1));
     names.push_back(geometry_1);
 
     // *** merge geometries


### PR DESCRIPTION
Main interface change in TemplateVec is the usage of unique pointer for the name-id map.
The potential memory leakage is reported by clang's static code analyzer (clang-tidy clang-analyzer-cplusplus.NewDeleteLeaks).

I suggest commit-wise review.