### PR TITLE
Rewrite solid material models

### DIFF
--- a/MaterialLib/SolidModels/CreateEhlers.h
+++ b/MaterialLib/SolidModels/CreateEhlers.h
@@ -41,7 +41,7 @@ createNewtonRaphsonSolverParameters(BaseLib::ConfigTree const& config)
     return {maximum_iterations, error_tolerance};
 }
 
-inline std::unique_ptr<EhlersDamageProperties> createDamageProperties(
+inline std::unique_ptr<DamagePropertiesParameters> createDamageProperties(
     std::vector<std::unique_ptr<ProcessLib::ParameterBase>> const& parameters,
     BaseLib::ConfigTree const& config)
 {
@@ -62,8 +62,8 @@ inline std::unique_ptr<EhlersDamageProperties> createDamageProperties(
 
     DBUG("Use \'%s\' as h_d.", h_d.name.c_str());
 
-    return std::make_unique<EhlersDamageProperties>(
-        EhlersDamageProperties{alpha_d, beta_d, h_d});
+    return std::make_unique<DamagePropertiesParameters>(
+        DamagePropertiesParameters{alpha_d, beta_d, h_d});
 }
 
 template <int DisplacementDim>
@@ -177,7 +177,7 @@ std::unique_ptr<MechanicsBase<DisplacementDim>> createEhlers(
         epsp,          paremeter_mp, kappa,  hardening_modulus};
 
     // Damage properties.
-    std::unique_ptr<EhlersDamageProperties> ehlers_damage_properties;
+    std::unique_ptr<DamagePropertiesParameters> ehlers_damage_properties;
 
     auto const& ehlers_damage_config =
         //! \ogs_file_param{material__solid__constitutive_relation__Ehlers__damage_properties}

--- a/MaterialLib/SolidModels/CreateEhlers.h
+++ b/MaterialLib/SolidModels/CreateEhlers.h
@@ -9,12 +9,8 @@
 
 #pragma once
 
-#include <logog/include/logog.hpp>
-
 #include "ProcessLib/Utils/ProcessUtils.h"  // required for findParameter
-
 #include "Ehlers.h"
-#include "MechanicsBase.h"
 
 namespace MaterialLib
 {
@@ -67,7 +63,7 @@ inline std::unique_ptr<DamagePropertiesParameters> createDamageProperties(
 }
 
 template <int DisplacementDim>
-std::unique_ptr<MechanicsBase<DisplacementDim>> createEhlers(
+std::unique_ptr<SolidEhlers<DisplacementDim>> createEhlers(
     std::vector<std::unique_ptr<ProcessLib::ParameterBase>> const& parameters,
     BaseLib::ConfigTree const& config)
 {
@@ -194,7 +190,7 @@ std::unique_ptr<MechanicsBase<DisplacementDim>> createEhlers(
     auto const nonlinear_solver_parameters =
         createNewtonRaphsonSolverParameters(nonlinear_solver_config);
 
-    return std::unique_ptr<MechanicsBase<DisplacementDim>>{
+    return std::unique_ptr<SolidEhlers<DisplacementDim>>{
         new SolidEhlers<DisplacementDim>{nonlinear_solver_parameters, mp,
                                          std::move(ehlers_damage_properties)}};
 }

--- a/MaterialLib/SolidModels/CreateEhlers.h
+++ b/MaterialLib/SolidModels/CreateEhlers.h
@@ -170,7 +170,7 @@ std::unique_ptr<MechanicsBase<DisplacementDim>> createEhlers(
 
     DBUG("Use \'%s\' as gammap.", gammap.name.c_str());
 
-    MaterialProperties mp{
+    MaterialPropertiesParameters mp{
         shear_modulus, bulk_modulus, alpha,  beta,
         gamma,         delta,        eps,    m,
         alphap,        betap,        gammap, deltap,

--- a/MaterialLib/SolidModels/CreateEhlers.h
+++ b/MaterialLib/SolidModels/CreateEhlers.h
@@ -170,7 +170,7 @@ std::unique_ptr<MechanicsBase<DisplacementDim>> createEhlers(
 
     DBUG("Use \'%s\' as gammap.", gammap.name.c_str());
 
-    typename SolidEhlers<DisplacementDim>::MaterialProperties mp{
+    MaterialProperties mp{
         shear_modulus, bulk_modulus, alpha,  beta,
         gamma,         delta,        eps,    m,
         alphap,        betap,        gammap, deltap,

--- a/MaterialLib/SolidModels/CreateLubby2.h
+++ b/MaterialLib/SolidModels/CreateLubby2.h
@@ -9,12 +9,9 @@
 
 #pragma once
 
-#include <logog/include/logog.hpp>
-
 #include "ProcessLib/Utils/ProcessUtils.h"  // required for findParameter
 
 #include "Lubby2.h"
-#include "MechanicsBase.h"
 
 namespace MaterialLib
 {
@@ -42,7 +39,7 @@ createNewtonRaphsonSolverParameters(BaseLib::ConfigTree const& config)
 }
 
 template <int DisplacementDim>
-std::unique_ptr<MechanicsBase<DisplacementDim>> createLubby2(
+std::unique_ptr<Lubby2<DisplacementDim>> createLubby2(
     std::vector<std::unique_ptr<ProcessLib::ParameterBase>> const& parameters,
     BaseLib::ConfigTree const& config)
 {
@@ -126,7 +123,7 @@ std::unique_ptr<MechanicsBase<DisplacementDim>> createLubby2(
     auto const nonlinear_solver_parameters =
         createNewtonRaphsonSolverParameters(nonlinear_solver_config);
 
-    return std::unique_ptr<MechanicsBase<DisplacementDim>>{
+    return std::unique_ptr<Lubby2<DisplacementDim>>{
         new Lubby2<DisplacementDim>{nonlinear_solver_parameters, mp}};
 }
 

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -621,8 +621,8 @@ newton(double const dt, MaterialProperties const& mp,
     };
 
     auto const update_jacobian = [&](JacobianMatrix& jacobian) {
-        calculatePlasticJacobian<DisplacementDim>(
-            dt, jacobian, s, solution[KelvinVectorSize * 2 + 2], mp);
+        jacobian = calculatePlasticJacobian<DisplacementDim>(
+            dt, s, solution[KelvinVectorSize * 2 + 2], mp);
     };
 
     auto const update_solution = [&](ResidualVectorType const& increment) {

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -85,12 +85,12 @@ struct MaterialProperties final
     double const hardening_coefficient;
 };
 
-/// Evaluated DamageProperties container.
-struct DamagePropertiesV
+/// Evaluated DamagePropertiesParameters container.
+struct DamageProperties
 {
-    DamagePropertiesV(double const t,
-                      ProcessLib::SpatialPosition const& x,
-                      DamageProperties const& dp)
+    DamageProperties(double const t,
+                     ProcessLib::SpatialPosition const& x,
+                     DamagePropertiesParameters const& dp)
         : alpha_d(dp.alpha_d(t, x)[0]),
           beta_d(dp.beta_d(t, x)[0]),
           h_d(dp.h_d(t, x)[0])
@@ -468,7 +468,7 @@ typename SolidEhlers<DisplacementDim>::JacobianMatrix calculatePlasticJacobian(
 inline Damage calculateDamage(double const eps_p_V_diff,
                               double const eps_p_eff_diff,
                               double kappa_d,
-                              DamagePropertiesV const& dp)
+                              DamageProperties const& dp)
 {
     // Default case of the rate problem. Updated below if volumetric plastic
     // strain rate is positive (dilatancy).
@@ -729,7 +729,7 @@ SolidEhlers<DisplacementDim>::integrateStress(
 
         if (_damage_properties)
         {
-            DamagePropertiesV damage_properties(t, x, *_damage_properties);
+            DamageProperties damage_properties(t, x, *_damage_properties);
             state.damage =
                 calculateDamage(state.eps_p.V - state.eps_p_prev.V,
                                 state.eps_p.eff - state.eps_p_prev.eff,

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -193,14 +193,13 @@ double yieldFunction(MaterialProperties const& mp,
     double const I_1_squared = boost::math::pow<2>(s.I_1);
     assert(s.J_2 != 0);
 
-    return std::sqrt(s.J_2 *
-                         std::pow(1 +
-                                      mp.gamma * s.J_3 /
-                                          boost::math::pow<3>(std::sqrt(s.J_2)),
-                                  mp.m) +
-                     mp.alpha / 2. * I_1_squared +
-                     boost::math::pow<2>(mp.delta) *
-                         boost::math::pow<2>(I_1_squared)) +
+    return std::sqrt(
+               s.J_2 *
+                   std::pow(1 + mp.gamma * s.J_3 / (s.J_2 * std::sqrt(s.J_2)),
+                            mp.m) +
+               mp.alpha / 2. * I_1_squared +
+               boost::math::pow<2>(mp.delta) *
+                   boost::math::pow<2>(I_1_squared)) +
            mp.beta * s.I_1 + mp.epsilon * I_1_squared - k;
 }
 
@@ -227,7 +226,7 @@ calculatePlasticResidual(
     auto const& P_dev = Invariants::deviatoric_projection;
     auto const& identity2 = Invariants::identity2;
 
-    double const theta = s.J_3 / boost::math::pow<3>(std::sqrt(s.J_2));
+    double const theta = s.J_3 / (s.J_2 * std::sqrt(s.J_2));
 
     typename SolidEhlers<DisplacementDim>::ResidualVectorType residual;
     // calculate stress residual
@@ -285,7 +284,7 @@ typename SolidEhlers<DisplacementDim>::JacobianMatrix calculatePlasticJacobian(
     auto const& P_dev = Invariants::deviatoric_projection;
     auto const& identity2 = Invariants::identity2;
 
-    double const theta = s.J_3 / boost::math::pow<3>(std::sqrt(s.J_2));
+    double const theta = s.J_3 / (s.J_2 * std::sqrt(s.J_2));
     OnePlusGamma_pTheta const one_gt{mp.gamma_p, theta, mp.m_p};
 
     // inverse of deviatoric stress tensor

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -739,13 +739,13 @@ SolidEhlers<DisplacementDim>::integrateStress(
     if (_damage_properties)
         sigma_final *= 1 - state.damage.value();
 
-    return {
-        {sigma_final,
-         std::unique_ptr<
-             typename MechanicsBase<DisplacementDim>::MaterialStateVariables>{
-             new StateVariables<DisplacementDim>{
-                 static_cast<StateVariables<DisplacementDim> const&>(state)}},
-         tangentStiffness}};
+    return {std::make_tuple(
+        sigma_final,
+        std::unique_ptr<
+            typename MechanicsBase<DisplacementDim>::MaterialStateVariables>{
+            new StateVariables<DisplacementDim>{
+                static_cast<StateVariables<DisplacementDim> const&>(state)}},
+        tangentStiffness)};
 }
 
 }  // namespace Ehlers

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -40,7 +40,8 @@ namespace Solids
 {
 namespace Ehlers
 {
-/// Evaluated MaterialPropertiesParameters container.
+/// Evaluated MaterialPropertiesParameters container, see its documentation for
+/// details.
 struct MaterialProperties final
 {
     MaterialProperties(double const t, ProcessLib::SpatialPosition const& x,
@@ -63,9 +64,8 @@ struct MaterialProperties final
           hardening_coefficient(mp.hardening_coefficient(t, x)[0])
     {
     }
-    // basic material parameters
-    double const G;  ///< shear modulus
-    double const K;  ///< bulk modulus
+    double const G;
+    double const K;
 
     double const alpha;
     double const beta;
@@ -85,7 +85,8 @@ struct MaterialProperties final
     double const hardening_coefficient;
 };
 
-/// Evaluated DamagePropertiesParameters container.
+/// Evaluated DamagePropertiesParameters container, see its documentation for
+/// details.
 struct DamageProperties
 {
     DamageProperties(double const t,

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -754,15 +754,12 @@ SolidEhlers<DisplacementDim>::integrateStress(
                 .template block<KelvinVectorSize, KelvinVectorSize>(0, 0);
     }
 
+    KelvinVector sigma_final = mp.G * sigma;
     if (_damage_properties)
-        return std::make_tuple(mp.G * sigma * (1 - state.damage.value()),
-                std::unique_ptr<typename MechanicsBase<
-                    DisplacementDim>::MaterialStateVariables>{
-                    new StateVariables<DisplacementDim>{state}},
-                tangentStiffness);
+        sigma_final *= 1 - state.damage.value();
 
     return {
-        mp.G * sigma,
+        sigma_final,
         std::unique_ptr<
             typename MechanicsBase<DisplacementDim>::MaterialStateVariables>{
             new StateVariables<DisplacementDim>{state}},

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -613,12 +613,11 @@ newton(double const dt, MaterialProperties const& mp,
         double const k_hardening =
             calculateIsotropicHardening(mp.kappa, mp.hardening_coefficient,
                                         solution[KelvinVectorSize * 2 + 1]);
-        calculatePlasticResidual<DisplacementDim>(
+        residual = calculatePlasticResidual<DisplacementDim>(
             eps_D, eps_V, s,
             solution.template segment<KelvinVectorSize>(KelvinVectorSize),
             eps_p_D_dot, solution[KelvinVectorSize * 2], eps_p_V_dot,
-            eps_p_eff_dot, solution[KelvinVectorSize * 2 + 2], k_hardening, mp,
-            residual);
+            eps_p_eff_dot, solution[KelvinVectorSize * 2 + 2], k_hardening, mp);
     };
 
     auto const update_jacobian = [&](JacobianMatrix& jacobian) {

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -592,35 +592,42 @@ newton(double const dt, MaterialProperties const& mp,
     // same matrix. This saves one decomposition.
     Eigen::FullPivLU<JacobianMatrix> linear_solver;
 
-    double lambda = 0;  // plastic multiplier
+    // Agglomerated solution vector construction.
+    ResidualVectorType solution;
+    solution << sigma, state.eps_p.D, state.eps_p.V, state.eps_p.eff, 0;
+
     auto const update_residual = [&](ResidualVectorType& residual) {
 
-        KelvinVector const eps_p_D_dot =
-            (state.eps_p.D - state.eps_p_prev.D) / dt;
-        double const eps_p_V_dot = (state.eps_p.V - state.eps_p_prev.V) / dt;
-        double const eps_p_eff_dot =
-            (state.eps_p.eff - state.eps_p_prev.eff) / dt;
+        auto const& eps_p_D =
+            solution.template segment<KelvinVectorSize>(KelvinVectorSize);
+        KelvinVector const eps_p_D_dot = (eps_p_D - state.eps_p_prev.D) / dt;
 
-        double const k_hardening = calculateIsotropicHardening(
-            mp.kappa, mp.hardening_coefficient, state.eps_p.eff);
+        double const& eps_p_V = solution[KelvinVectorSize * 2];
+        double const eps_p_V_dot = (eps_p_V - state.eps_p_prev.V) / dt;
+
+        double const& eps_p_eff = solution[KelvinVectorSize * 2 + 1];
+        double const eps_p_eff_dot = (eps_p_eff - state.eps_p_prev.eff) / dt;
+
+        double const k_hardening =
+            calculateIsotropicHardening(mp.kappa, mp.hardening_coefficient,
+                                        solution[KelvinVectorSize * 2 + 1]);
         calculatePlasticResidual<DisplacementDim>(
-            eps_D, eps_V, s, state.eps_p.D, eps_p_D_dot, state.eps_p.V,
-            eps_p_V_dot, eps_p_eff_dot, lambda, k_hardening, mp, residual);
+            eps_D, eps_V, s,
+            solution.template segment<KelvinVectorSize>(KelvinVectorSize),
+            eps_p_D_dot, solution[KelvinVectorSize * 2], eps_p_V_dot,
+            eps_p_eff_dot, solution[KelvinVectorSize * 2 + 2], k_hardening, mp,
+            residual);
     };
 
     auto const update_jacobian = [&](JacobianMatrix& jacobian) {
-        calculatePlasticJacobian<DisplacementDim>(dt, jacobian, s, lambda, mp);
+        calculatePlasticJacobian<DisplacementDim>(
+            dt, jacobian, s, solution[KelvinVectorSize * 2 + 2], mp);
     };
 
     auto const update_solution = [&](ResidualVectorType const& increment) {
-        sigma.noalias() +=
-            increment.template segment<KelvinVectorSize>(KelvinVectorSize * 0);
-        s = PhysicalStressWithInvariants<DisplacementDim>{mp.G * sigma};
-        state.eps_p.D.noalias() +=
-            increment.template segment<KelvinVectorSize>(KelvinVectorSize * 1);
-        state.eps_p.V += increment(KelvinVectorSize * 2);
-        state.eps_p.eff += increment(KelvinVectorSize * 2 + 1);
-        lambda += increment(KelvinVectorSize * 2 + 2);
+        solution += increment;
+        s = PhysicalStressWithInvariants<DisplacementDim>{
+            mp.G * solution.template segment<KelvinVectorSize>(0)};
     };
 
     auto newton_solver =
@@ -640,6 +647,9 @@ newton(double const dt, MaterialProperties const& mp,
     // This happens usually for the first iteration of the first timestep.
     if (*success_iterations == 0)
         linear_solver.compute(jacobian);
+
+    std::tie(sigma, state.eps_p, std::ignore) =
+        splitSolutionVector<ResidualVectorType, KelvinVector>(solution);
 
     return std::make_tuple(sigma, state, linear_solver);
 }

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -670,11 +670,11 @@ SolidEhlers<DisplacementDim>::integrateStress(
     typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
         material_state_variables)
 {
-    assert(dynamic_cast<MaterialStateVariables<DisplacementDim> const*>(
+    assert(dynamic_cast<StateVariables<DisplacementDim> const*>(
                &material_state_variables) != nullptr);
 
-    MaterialStateVariables<DisplacementDim> state =
-        static_cast<MaterialStateVariables<DisplacementDim> const&>(
+    StateVariables<DisplacementDim> state =
+        static_cast<StateVariables<DisplacementDim> const&>(
             material_state_variables);
     state.setInitialConditions();
 
@@ -759,14 +759,14 @@ SolidEhlers<DisplacementDim>::integrateStress(
         return std::make_tuple(mp.G * sigma * (1 - state.damage.value()),
                 std::unique_ptr<typename MechanicsBase<
                     DisplacementDim>::MaterialStateVariables>{
-                    new MaterialStateVariables<DisplacementDim>{state}},
+                    new StateVariables<DisplacementDim>{state}},
                 tangentStiffness);
 
     return {
         mp.G * sigma,
         std::unique_ptr<
             typename MechanicsBase<DisplacementDim>::MaterialStateVariables>{
-            new MaterialStateVariables<DisplacementDim>{state}},
+            new StateVariables<DisplacementDim>{state}},
         tangentStiffness};
 }
 

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -223,16 +223,18 @@ public:
     {
     }
 
-    bool computeConstitutiveRelation(
+    std::tuple<KelvinVector, std::unique_ptr<typename MechanicsBase<
+                                 DisplacementDim>::MaterialStateVariables>,
+               KelvinMatrix>
+    integrateStress(
         double const t,
         ProcessLib::SpatialPosition const& x,
         double const dt,
         KelvinVector const& eps_prev,
         KelvinVector const& eps,
         KelvinVector const& sigma_prev,
-        KelvinVector& sigma,
-        KelvinMatrix& C,
-        typename MechanicsBase<DisplacementDim>::MaterialStateVariables&
+        KelvinVector const& sigma,
+        typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
             material_state_variables) override;
 
 private:

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -235,7 +235,6 @@ public:
         KelvinVector const& eps_prev,
         KelvinVector const& eps,
         KelvinVector const& sigma_prev,
-        KelvinVector const& sigma,
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
             material_state_variables) override;
 

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -141,6 +141,15 @@ public:
         {
         }
 
+        MaterialStateVariables& operator=(MaterialStateVariables const&) =
+            default;
+        typename MechanicsBase<DisplacementDim>::MaterialStateVariables&
+        operator=(typename MechanicsBase<DisplacementDim>::
+                      MaterialStateVariables const& state) noexcept override
+        {
+            return operator=(static_cast<MaterialStateVariables const&>(state));
+        }
+
         void setInitialConditions()
         {
             eps_p_D = eps_p_D_prev;

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -133,16 +133,16 @@ private:
 };
 
 template <int DisplacementDim>
-struct MaterialStateVariables
+struct StateVariables
     : public MechanicsBase<DisplacementDim>::MaterialStateVariables
 {
-    MaterialStateVariables& operator=(MaterialStateVariables const&) = default;
+    StateVariables& operator=(StateVariables const&) = default;
     typename MechanicsBase<DisplacementDim>::MaterialStateVariables& operator=(
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
             state) noexcept override
     {
-        assert(dynamic_cast<MaterialStateVariables const*>(&state) != nullptr);
-        return operator=(static_cast<MaterialStateVariables const&>(state));
+        assert(dynamic_cast<StateVariables const*>(&state) != nullptr);
+        return operator=(static_cast<StateVariables const&>(state));
     }
 
     void setInitialConditions()
@@ -168,7 +168,7 @@ struct MaterialStateVariables
 
 #ifndef NDEBUG
     friend std::ostream& operator<<(
-        std::ostream& os, MaterialStateVariables<DisplacementDim> const& m)
+        std::ostream& os, StateVariables<DisplacementDim> const& m)
     {
         os << "State:\n"
            << "eps_p_D: " << m.eps_p.D << "\n"
@@ -205,8 +205,8 @@ public:
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables>
     createMaterialStateVariables() override
     {
-        return std::unique_ptr<MaterialStateVariables<DisplacementDim>>{
-            new MaterialStateVariables<DisplacementDim>};
+        return std::unique_ptr<StateVariables<DisplacementDim>>{
+            new StateVariables<DisplacementDim>};
     }
 
 public:

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -148,14 +148,12 @@ struct MaterialStateVariables
     void setInitialConditions()
     {
         eps_p = eps_p_prev;
-        lambda = 0;
         damage = damage_prev;
     }
 
     void pushBackState() override
     {
         eps_p_prev = eps_p;
-        lambda = 0;
         damage_prev = damage;
     }
 
@@ -166,7 +164,6 @@ struct MaterialStateVariables
 
     // Initial values from previous timestep
     PlasticStrain<KelvinVector> eps_p_prev;  ///< \copydoc eps_p
-    double lambda = 0;                       ///< plastic multiplier
     Damage damage_prev;                      ///< \copydoc damage
 
 #ifndef NDEBUG

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -19,18 +19,13 @@
 
 #pragma once
 
-#include <cfloat>
-#include <memory>
 #ifndef NDEBUG
 #include <ostream>
 #endif
 
-#include <Eigen/Dense>
-#include <logog/include/logog.hpp>
-#include <utility>
-
 #include "BaseLib/Error.h"
 #include "NumLib/NewtonRaphson.h"
+#include "ProcessLib/Parameter/Parameter.h"
 
 #include "KelvinVector.h"
 #include "MechanicsBase.h"

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -1,16 +1,15 @@
 /**
+ * \file
  * \copyright
  * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
  *            Distributed under a Modified BSD License.
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- */
-
-/*
+ *
  * Implementation of Ehler's single-surface model.
  * see Ehler's paper "A single-surface yield function for geomaterials" for more
- * details. \cite{Ehlers1995}
+ * details. \cite Ehlers1995
  *
  * Refer to "Single-surface benchmark of OpenGeoSys documentation
  * (https://docs.opengeosys.org/docs/benchmarks/small-deformations/mechanics-plasticity-single-surface)"
@@ -36,16 +35,13 @@ namespace Solids
 {
 namespace Ehlers
 {
-//
-// Variables specific to the material model.
-//
+/// material parameters in relation to Ehler's single-surface model see Ehler's
+/// paper "A single-surface yield function for geomaterials" for more details
+/// \cite Ehlers1995.
 struct MaterialPropertiesParameters
 {
     using P = ProcessLib::Parameter<double>;
 
-    /// material parameters in relation to Ehler's single-surface model
-    /// see Ehler's paper "A single-surface yield function for geomaterials"
-    /// for more details.
     MaterialPropertiesParameters(P const& G_, P const& K_, P const& alpha_,
                                  P const& beta_, P const& gamma_,
                                  P const& delta_, P const& epsilon_,
@@ -76,21 +72,22 @@ struct MaterialPropertiesParameters
     P const& G;  ///< shear modulus
     P const& K;  ///< bulk modulus
 
-    P const& alpha;  // material dependent parameter in relation to Ehlers model, refer to Ehlers, W. "A single-surface yield function for geomaterials." Archive of Applied Mechanics 65.4 (1995): 246-259 for more details.
-    P const& beta;  // copydoc alpha
-    P const& gamma;  // copydoc alpha
-    P const& delta;  // copydoc alpha
-    P const& epsilon;  // copydoc alpha
-    P const& m;  // copydoc alpha
+    P const& alpha;    ///< material dependent parameter in relation to Ehlers
+                       ///< model, refer to \cite Ehlers1995 .
+    P const& beta;     ///< \copydoc alpha
+    P const& gamma;    ///< \copydoc alpha
+    P const& delta;    ///< \copydoc alpha
+    P const& epsilon;  ///< \copydoc alpha
+    P const& m;        ///< \copydoc alpha
 
-    P const& alpha_p;  // copydoc alpha
-    P const& beta_p;  // copydoc alpha
-    P const& gamma_p;  // copydoc alpha
-    P const& delta_p;  // copydoc alpha
-    P const& epsilon_p;  // copydoc alpha
-    P const& m_p;  // copydoc alpha
+    P const& alpha_p;    ///< \copydoc alpha
+    P const& beta_p;     ///< \copydoc alpha
+    P const& gamma_p;    ///< \copydoc alpha
+    P const& delta_p;    ///< \copydoc alpha
+    P const& epsilon_p;  ///< \copydoc alpha
+    P const& m_p;        ///< \copydoc alpha
 
-    P const& kappa;  // hardening parameter
+    P const& kappa;  ///< hardening parameter
     P const& hardening_coefficient;
 };
 

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -44,19 +44,21 @@ namespace Ehlers
 //
 // Variables specific to the material model.
 //
-struct MaterialProperties
+struct MaterialPropertiesParameters
 {
     using P = ProcessLib::Parameter<double>;
 
     /// material parameters in relation to Ehler's single-surface model
     /// see Ehler's paper "A single-surface yield function for geomaterials"
     /// for more details.
-    MaterialProperties(P const& G_, P const& K_, P const& alpha_,
-                       P const& beta_, P const& gamma_, P const& delta_,
-                       P const& epsilon_, P const& m_, P const& alpha_p_,
-                       P const& beta_p_, P const& gamma_p_, P const& delta_p_,
-                       P const& epsilon_p_, P const& m_p_, P const& kappa_,
-                       P const& hardening_coefficient_)
+    MaterialPropertiesParameters(P const& G_, P const& K_, P const& alpha_,
+                                 P const& beta_, P const& gamma_,
+                                 P const& delta_, P const& epsilon_,
+                                 P const& m_, P const& alpha_p_,
+                                 P const& beta_p_, P const& gamma_p_,
+                                 P const& delta_p_, P const& epsilon_p_,
+                                 P const& m_p_, P const& kappa_,
+                                 P const& hardening_coefficient_)
         : G(G_),
           K(K_),
           alpha(alpha_),
@@ -215,7 +217,7 @@ public:
 public:
     explicit SolidEhlers(
         NumLib::NewtonRaphsonSolverParameters nonlinear_solver_parameters,
-        MaterialProperties material_properties,
+        MaterialPropertiesParameters material_properties,
         std::unique_ptr<EhlersDamageProperties>&& damage_properties)
         : _nonlinear_solver_parameters(std::move(nonlinear_solver_parameters)),
           _mp(std::move(material_properties)),
@@ -241,14 +243,18 @@ private:
     /// Computes the damage internal material variable explicitly based on the
     /// results obtained from the local stress return algorithm.
     void updateDamage(
-        double const t, ProcessLib::SpatialPosition const& x,
+        double const eps_p_V_diff,
+        double const eps_p_eff_diff,
+        Damage const& damage,
+        double const t,
+        ProcessLib::SpatialPosition const& x,
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables&
             material_state_variables);
 
 private:
     NumLib::NewtonRaphsonSolverParameters const _nonlinear_solver_parameters;
 
-    MaterialProperties _mp;
+    MaterialPropertiesParameters _mp;
     std::unique_ptr<EhlersDamageProperties> _damage_properties;
 };
 

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -107,7 +107,6 @@ struct EhlersDamageProperties
     P const& h_d;
 };
 
-
 struct Damage final
 {
     Damage() = default;
@@ -238,18 +237,6 @@ public:
         KelvinVector const& sigma,
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
             material_state_variables) override;
-
-private:
-    /// Computes the damage internal material variable explicitly based on the
-    /// results obtained from the local stress return algorithm.
-    void updateDamage(
-        double const eps_p_V_diff,
-        double const eps_p_eff_diff,
-        Damage const& damage,
-        double const t,
-        ProcessLib::SpatialPosition const& x,
-        typename MechanicsBase<DisplacementDim>::MaterialStateVariables&
-            material_state_variables);
 
 private:
     NumLib::NewtonRaphsonSolverParameters const _nonlinear_solver_parameters;

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -120,13 +120,21 @@ struct PlasticStrain final
     double eff = 0;  ///< effective plastic strain
 };
 
-struct Damage final
+class Damage final
 {
+public:
     Damage() = default;
-    Damage(double const kappa_d_, double const damage_)
-        : kappa_d(kappa_d_), damage(damage_){};
-    double kappa_d = 0;  ///< damage driving variable
-    double damage = 0;   ///< isotropic damage variable
+    Damage(double const kappa_d, double const value)
+        : _kappa_d(kappa_d), _value(value)
+    {
+    }
+
+    double kappa_d() const { return _kappa_d; }
+    double value() const { return _value; }
+
+private:
+    double _kappa_d = 0;  ///< damage driving variable
+    double _value = 0;    ///< isotropic damage variable
 };
 
 template <int DisplacementDim>
@@ -173,12 +181,12 @@ struct MaterialStateVariables
         os << "State:\n"
            << "eps_p_D: " << m.eps_p.D << "\n"
            << "eps_p_eff: " << m.eps_p.eff << "\n"
-           << "kappa_d: " << m.damage.kappa_d << "\n"
-           << "damage: " << m.damage.damage << "\n"
+           << "kappa_d: " << m.damage.kappa_d() << "\n"
+           << "damage: " << m.damage.value() << "\n"
            << "eps_p_D_prev: " << m.eps_p_prev.D << "\n"
            << "eps_p_eff_prev: " << m.eps_p_prev.eff << "\n"
-           << "kappa_d_prev: " << m.damage_prev.kappa_d << "\n"
-           << "damage_prev: " << m.damage_prev.damage << "\n"
+           << "kappa_d_prev: " << m.damage_prev.kappa_d() << "\n"
+           << "damage_prev: " << m.damage_prev.value() << "\n"
            << "lambda: " << m.lambda << "\n";
         return os;
     }

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -99,7 +99,7 @@ struct MaterialPropertiesParameters
     P const& hardening_coefficient;
 };
 
-struct EhlersDamageProperties
+struct DamagePropertiesParameters
 {
     using P = ProcessLib::Parameter<double>;
     P const& alpha_d;
@@ -218,7 +218,7 @@ public:
     explicit SolidEhlers(
         NumLib::NewtonRaphsonSolverParameters nonlinear_solver_parameters,
         MaterialPropertiesParameters material_properties,
-        std::unique_ptr<EhlersDamageProperties>&& damage_properties)
+        std::unique_ptr<DamagePropertiesParameters>&& damage_properties)
         : _nonlinear_solver_parameters(std::move(nonlinear_solver_parameters)),
           _mp(std::move(material_properties)),
           _damage_properties(std::move(damage_properties))
@@ -243,7 +243,7 @@ private:
     NumLib::NewtonRaphsonSolverParameters const _nonlinear_solver_parameters;
 
     MaterialPropertiesParameters _mp;
-    std::unique_ptr<EhlersDamageProperties> _damage_properties;
+    std::unique_ptr<DamagePropertiesParameters> _damage_properties;
 };
 
 }  // namespace Ehlers

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -41,6 +41,61 @@ namespace Solids
 {
 namespace Ehlers
 {
+//
+// Variables specific to the material model.
+//
+struct MaterialProperties
+{
+    using P = ProcessLib::Parameter<double>;
+
+    /// material parameters in relation to Ehler's single-surface model
+    /// see Ehler's paper "A single-surface yield function for geomaterials"
+    /// for more details.
+    MaterialProperties(P const& G_, P const& K_, P const& alpha_,
+                       P const& beta_, P const& gamma_, P const& delta_,
+                       P const& epsilon_, P const& m_, P const& alpha_p_,
+                       P const& beta_p_, P const& gamma_p_, P const& delta_p_,
+                       P const& epsilon_p_, P const& m_p_, P const& kappa_,
+                       P const& hardening_coefficient_)
+        : G(G_),
+          K(K_),
+          alpha(alpha_),
+          beta(beta_),
+          gamma(gamma_),
+          delta(delta_),
+          epsilon(epsilon_),
+          m(m_),
+          alpha_p(alpha_p_),
+          beta_p(beta_p_),
+          gamma_p(gamma_p_),
+          delta_p(delta_p_),
+          epsilon_p(epsilon_p_),
+          m_p(m_p_),
+          kappa(kappa_),
+          hardening_coefficient(hardening_coefficient_)
+    {
+    }
+    // basic material parameters
+    P const& G;  ///< shear modulus
+    P const& K;  ///< bulk modulus
+
+    P const& alpha;
+    P const& beta;
+    P const& gamma;
+    P const& delta;
+    P const& epsilon;
+    P const& m;
+
+    P const& alpha_p;
+    P const& beta_p;
+    P const& gamma_p;
+    P const& delta_p;
+    P const& epsilon_p;
+    P const& m_p;
+
+    P const& kappa;
+    P const& hardening_coefficient;
+};
 
 struct EhlersDamageProperties
 {
@@ -48,6 +103,16 @@ struct EhlersDamageProperties
     P const& alpha_d;
     P const& beta_d;
     P const& h_d;
+};
+
+
+struct Damage final
+{
+    Damage() = default;
+    Damage(double const kappa_d_, double const damage_)
+        : kappa_d(kappa_d_), damage(damage_){};
+    double kappa_d = 0;  ///< damage driving variable
+    double damage = 0;   ///< isotropic damage variable
 };
 
 template <int DisplacementDim>
@@ -66,73 +131,6 @@ public:
                                          JacobianResidualSize, Eigen::RowMajor>;
 
 public:
-    //
-    // Variables specific to the material model.
-    //
-    struct MaterialProperties
-    {
-        using P = ProcessLib::Parameter<double>;
-
-        using KelvinVector = ProcessLib::KelvinVectorType<DisplacementDim>;
-        using KelvinMatrix = ProcessLib::KelvinMatrixType<DisplacementDim>;
-
-        /// material parameters in relation to Ehler's single-surface model
-        /// see Ehler's paper "A single-surface yield function for geomaterials"
-        /// for more details.
-        MaterialProperties(P const& G_, P const& K_, P const& alpha_,
-                           P const& beta_, P const& gamma_, P const& delta_,
-                           P const& epsilon_, P const& m_, P const& alpha_p_,
-                           P const& beta_p_, P const& gamma_p_,
-                           P const& delta_p_, P const& epsilon_p_,
-                           P const& m_p_, P const& kappa_,
-                           P const& hardening_coefficient_)
-            : G(G_),
-              K(K_),
-              alpha(alpha_),
-              beta(beta_),
-              gamma(gamma_),
-              delta(delta_),
-              epsilon(epsilon_),
-              m(m_),
-              alpha_p(alpha_p_),
-              beta_p(beta_p_),
-              gamma_p(gamma_p_),
-              delta_p(delta_p_),
-              epsilon_p(epsilon_p_),
-              m_p(m_p_),
-              kappa(kappa_),
-              hardening_coefficient(hardening_coefficient_)
-        {
-        }
-        // basic material parameters
-        P const& G;  ///< shear modulus
-        P const& K;  ///< bulk modulus
-
-        P const& alpha;
-        P const& beta;
-        P const& gamma;
-        P const& delta;
-        P const& epsilon;
-        P const& m;
-
-        P const& alpha_p;
-        P const& beta_p;
-        P const& gamma_p;
-        P const& delta_p;
-        P const& epsilon_p;
-        P const& m_p;
-
-        P const& kappa;
-        P const& hardening_coefficient;
-        // Drucker-Prager: Import kappa and beta in terms of Drucker-Prager
-        // criterion solution dependent values
-        double k;
-
-        void calculateIsotropicHardening(double const t,
-                                         ProcessLib::SpatialPosition const& x,
-                                         const double e_pv_curr);
-    };
-
     struct MaterialStateVariables
         : public MechanicsBase<DisplacementDim>::MaterialStateVariables
     {
@@ -155,9 +153,8 @@ public:
             eps_p_D = eps_p_D_prev;
             eps_p_V = eps_p_V_prev;
             eps_p_eff = eps_p_eff_prev;
-            kappa_d = kappa_d_prev;
-            damage = damage_prev;
             lambda = 0;
+            damage = damage_prev;
         }
 
         void pushBackState() override
@@ -165,9 +162,8 @@ public:
             eps_p_D_prev = eps_p_D;
             eps_p_V_prev = eps_p_V;
             eps_p_eff_prev = eps_p_eff;  // effective part of trace(eps_p)
-            kappa_d_prev = kappa_d;
-            damage_prev = damage;
             lambda = 0;
+            damage_prev = damage;
         }
 
         using KelvinVector = ProcessLib::KelvinVectorType<DisplacementDim>;
@@ -175,16 +171,14 @@ public:
         KelvinVector eps_p_D;  ///< deviatoric plastic strain
         double eps_p_V = 0;    ///< volumetric strain
         double eps_p_eff = 0;  ///< effective plastic strain
-        double kappa_d = 0;    ///< damage driving variable
-        double damage = 0;     ///< isotropic damage variable
+        Damage damage;         ///< damage part of the state.
 
         // Initial values from previous timestep
         KelvinVector eps_p_D_prev;  ///< \copydoc eps_p_D
         double eps_p_V_prev = 0;    ///< \copydoc eps_p_V
         double eps_p_eff_prev = 0;  ///< \copydoc eps_p_eff
-        double kappa_d_prev = 0;    ///< \copydoc kappa_d
-        double damage_prev = 0;     ///< \copydoc damage
         double lambda = 0;          ///< plastic multiplier
+        Damage damage_prev;         ///< \copydoc damage
 
 #ifndef NDEBUG
         friend std::ostream& operator<<(std::ostream& os,
@@ -193,12 +187,12 @@ public:
             os << "State:\n"
                << "eps_p_D: " << m.eps_p_D << "\n"
                << "eps_p_eff: " << m.eps_p_eff << "\n"
-               << "kappa_d: " << m.kappa_d << "\n"
-               << "damage: " << m.damage << "\n"
+               << "kappa_d: " << m.damage.kappa_d << "\n"
+               << "damage: " << m.damage.damage << "\n"
                << "eps_p_D_prev: " << m.eps_p_D_prev << "\n"
                << "eps_p_eff_prev: " << m.eps_p_eff_prev << "\n"
-               << "kappa_d_prev: " << m.kappa_d_prev << "\n"
-               << "damage_prev: " << m.damage_prev << "\n"
+               << "kappa_d_prev: " << m.damage_prev.kappa_d << "\n"
+               << "damage_prev: " << m.damage_prev.damage << "\n"
                << "lambda: " << m.lambda << "\n";
             return os;
         }

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -76,21 +76,21 @@ struct MaterialPropertiesParameters
     P const& G;  ///< shear modulus
     P const& K;  ///< bulk modulus
 
-    P const& alpha;
-    P const& beta;
-    P const& gamma;
-    P const& delta;
-    P const& epsilon;
-    P const& m;
+    P const& alpha;  // material dependent parameter in relation to Ehlers model, refer to Ehlers, W. "A single-surface yield function for geomaterials." Archive of Applied Mechanics 65.4 (1995): 246-259 for more details.
+    P const& beta;  // copydoc alpha
+    P const& gamma;  // copydoc alpha
+    P const& delta;  // copydoc alpha
+    P const& epsilon;  // copydoc alpha
+    P const& m;  // copydoc alpha
 
-    P const& alpha_p;
-    P const& beta_p;
-    P const& gamma_p;
-    P const& delta_p;
-    P const& epsilon_p;
-    P const& m_p;
+    P const& alpha_p;  // copydoc alpha
+    P const& beta_p;  // copydoc alpha
+    P const& gamma_p;  // copydoc alpha
+    P const& delta_p;  // copydoc alpha
+    P const& epsilon_p;  // copydoc alpha
+    P const& m_p;  // copydoc alpha
 
-    P const& kappa;
+    P const& kappa;  // hardening parameter
     P const& hardening_coefficient;
 };
 

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -205,8 +205,7 @@ public:
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables>
     createMaterialStateVariables() override
     {
-        return std::unique_ptr<StateVariables<DisplacementDim>>{
-            new StateVariables<DisplacementDim>};
+        return std::make_unique<StateVariables<DisplacementDim>>();
     }
 
 public:

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -223,9 +223,10 @@ public:
     {
     }
 
-    std::tuple<KelvinVector, std::unique_ptr<typename MechanicsBase<
-                                 DisplacementDim>::MaterialStateVariables>,
-               KelvinMatrix>
+    boost::optional<
+        std::tuple<KelvinVector, std::unique_ptr<typename MechanicsBase<
+                                     DisplacementDim>::MaterialStateVariables>,
+                   KelvinMatrix>>
     integrateStress(
         double const t,
         ProcessLib::SpatialPosition const& x,

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -205,8 +205,7 @@ public:
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables>
     createMaterialStateVariables() override
     {
-        return std::unique_ptr<
-            typename MechanicsBase<DisplacementDim>::MaterialStateVariables>{
+        return std::unique_ptr<MaterialStateVariables<DisplacementDim>>{
             new MaterialStateVariables<DisplacementDim>};
     }
 

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.h
@@ -87,10 +87,10 @@ public:
     {
     }
 
-    std::tuple<KelvinVector,
-               std::unique_ptr<typename MechanicsBase<
-                   DisplacementDim>::MaterialStateVariables>,
-               KelvinMatrix>
+    boost::optional<std::tuple<KelvinVector,
+                               std::unique_ptr<typename MechanicsBase<
+                                   DisplacementDim>::MaterialStateVariables>,
+                               KelvinMatrix>>
     integrateStress(
         double const t,
         ProcessLib::SpatialPosition const& x,
@@ -108,14 +108,13 @@ public:
 
         KelvinVector sigma = sigma_prev + C * (eps - eps_prev);
 
-        return std::make_tuple(
-            sigma,
-            std::unique_ptr<typename MechanicsBase<
-                DisplacementDim>::MaterialStateVariables>{
-                new MaterialStateVariables{
-                    static_cast<MaterialStateVariables const&>(
-                        material_state_variables)}},
-            C);
+        return {{sigma,
+                 std::unique_ptr<typename MechanicsBase<
+                     DisplacementDim>::MaterialStateVariables>{
+                     new MaterialStateVariables{
+                         static_cast<MaterialStateVariables const&>(
+                             material_state_variables)}},
+                 C}};
     }
 
 private:

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.h
@@ -108,13 +108,14 @@ public:
 
         KelvinVector sigma = sigma_prev + C * (eps - eps_prev);
 
-        return {{sigma,
-                 std::unique_ptr<typename MechanicsBase<
-                     DisplacementDim>::MaterialStateVariables>{
-                     new MaterialStateVariables{
-                         static_cast<MaterialStateVariables const&>(
-                             material_state_variables)}},
-                 C}};
+        return {
+            std::make_tuple(sigma,
+                            std::unique_ptr<typename MechanicsBase<
+                                DisplacementDim>::MaterialStateVariables>{
+                                new MaterialStateVariables{
+                                    static_cast<MaterialStateVariables const&>(
+                                        material_state_variables)}},
+                            C)};
     }
 
 private:

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.h
@@ -57,6 +57,15 @@ public:
         : public MechanicsBase<DisplacementDim>::MaterialStateVariables
     {
         void pushBackState() override {}
+
+        MaterialStateVariables& operator=(MaterialStateVariables const&) =
+            default;
+        typename MechanicsBase<DisplacementDim>::MaterialStateVariables&
+        operator=(typename MechanicsBase<DisplacementDim>::
+                      MaterialStateVariables const& state) noexcept override
+        {
+            return operator=(static_cast<MaterialStateVariables const&>(state));
+        }
     };
 
     std::unique_ptr<

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.h
@@ -98,7 +98,6 @@ public:
         KelvinVector const& eps_prev,
         KelvinVector const& eps,
         KelvinVector const& sigma_prev,
-        KelvinVector const& /*sigma*/,
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
             material_state_variables) override
     {

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.h
@@ -9,9 +9,8 @@
 
 #pragma once
 
-#include <utility>
-
 #include "MechanicsBase.h"
+#include "ProcessLib/Parameter/Parameter.h"
 
 namespace MaterialLib
 {

--- a/MaterialLib/SolidModels/Lubby2-impl.h
+++ b/MaterialLib/SolidModels/Lubby2-impl.h
@@ -76,7 +76,6 @@ Lubby2<DisplacementDim>::integrateStress(
     KelvinVector const& /*eps_prev*/,
     KelvinVector const& eps,
     KelvinVector const& /*sigma_prev*/,
-    KelvinVector const& sigma,
     typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
         material_state_variables)
 {
@@ -165,7 +164,7 @@ Lubby2<DisplacementDim>::integrateStress(
         auto const success_iterations = newton_solver.solve(K_loc);
 
         if (!success_iterations)
-            return std::make_tuple(sigma, nullptr, KelvinMatrix::Zero());
+            return std::make_tuple(sigma_prev, nullptr, KelvinMatrix::Zero());
 
         // If the Newton loop didn't run, the linear solver will not be
         // initialized.

--- a/MaterialLib/SolidModels/Lubby2-impl.h
+++ b/MaterialLib/SolidModels/Lubby2-impl.h
@@ -180,13 +180,15 @@ Lubby2<DisplacementDim>::integrateStress(
 
     // Hydrostatic part for the stress and the tangent.
     double const eps_i_trace = Invariants::trace(eps);
-    return {
-        {local_lubby2_properties.GM0 * sigd_j +
-             local_lubby2_properties.KM0 * eps_i_trace * Invariants::identity2,
-         std::unique_ptr<
-             typename MechanicsBase<DisplacementDim>::MaterialStateVariables>{
-             new MaterialStateVariables{state}},
-         C}};
+    KelvinVector const sigma =
+        local_lubby2_properties.GM0 * sigd_j +
+        local_lubby2_properties.KM0 * eps_i_trace * Invariants::identity2;
+    return {std::make_tuple(
+        sigma,
+        std::unique_ptr<
+            typename MechanicsBase<DisplacementDim>::MaterialStateVariables>{
+            new MaterialStateVariables{state}},
+        C)};
 }
 
 template <int DisplacementDim>

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -118,6 +118,15 @@ public:
             eps_M_j.resize(KelvinVectorSize);
         }
 
+        MaterialStateVariables& operator=(MaterialStateVariables const&) =
+            default;
+        MaterialStateVariables& operator=(
+            typename MechanicsBase<DisplacementDim>::
+                MaterialStateVariables const& state) noexcept override
+        {
+            return operator=(static_cast<MaterialStateVariables const&>(state));
+        }
+
         void setInitialConditions()
         {
             eps_K_j = eps_K_t;

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -192,7 +192,6 @@ public:
         KelvinVector const& eps_prev,
         KelvinVector const& eps,
         KelvinVector const& sigma_prev,
-        KelvinVector const& sigma,
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
             material_state_variables) override;
 

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -9,11 +9,8 @@
 
 #pragma once
 
-#include <logog/include/logog.hpp>
-#include <utility>
-
-#include "BaseLib/Error.h"
 #include "NumLib/NewtonRaphson.h"
+#include "ProcessLib/Parameter/Parameter.h"
 
 #include "KelvinVector.h"
 #include "MechanicsBase.h"

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -184,16 +184,19 @@ public:
     {
     }
 
-    bool computeConstitutiveRelation(
+    std::tuple<KelvinVector,
+               std::unique_ptr<typename MechanicsBase<
+                   DisplacementDim>::MaterialStateVariables>,
+               KelvinMatrix>
+    integrateStress(
         double const t,
-        ProcessLib::SpatialPosition const& x_position,
+        ProcessLib::SpatialPosition const& x,
         double const dt,
         KelvinVector const& eps_prev,
         KelvinVector const& eps,
         KelvinVector const& sigma_prev,
-        KelvinVector& sigma,
-        KelvinMatrix& C,
-        typename MechanicsBase<DisplacementDim>::MaterialStateVariables&
+        KelvinVector const& sigma,
+        typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
             material_state_variables) override;
 
 private:
@@ -219,29 +222,6 @@ private:
         const KelvinVector& sig_i,
         const KelvinVector& eps_K_i,
         detail::LocalLubby2Properties<DisplacementDim> const& properties);
-
-    /// Calculates the 18x6 derivative of the residuals with respect to total
-    /// strain.
-    ///
-    /// Function definition can not be moved into implementation because of a
-    /// MSVC compiler errors. See
-    /// http://stackoverflow.com/questions/1484885/strange-vc-compile-error-c2244
-    /// and https://support.microsoft.com/en-us/kb/930198
-    Eigen::
-        Matrix<double, JacobianResidualSize, KelvinVectorSize, Eigen::RowMajor>
-        calculatedGdEBurgers() const
-    {
-        Eigen::Matrix<double,
-                      JacobianResidualSize,
-                      KelvinVectorSize,
-                      Eigen::RowMajor>
-            dGdE;
-        dGdE.setZero();
-        dGdE.template block<KelvinVectorSize, KelvinVectorSize>(0, 0)
-            .diagonal()
-            .setConstant(-2);
-        return dGdE;
-    }
 
 private:
     NumLib::NewtonRaphsonSolverParameters const _nonlinear_solver_parameters;

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -181,10 +181,10 @@ public:
     {
     }
 
-    std::tuple<KelvinVector,
-               std::unique_ptr<typename MechanicsBase<
-                   DisplacementDim>::MaterialStateVariables>,
-               KelvinMatrix>
+    boost::optional<std::tuple<KelvinVector,
+                               std::unique_ptr<typename MechanicsBase<
+                                   DisplacementDim>::MaterialStateVariables>,
+                               KelvinMatrix>>
     integrateStress(
         double const t,
         ProcessLib::SpatialPosition const& x,

--- a/MaterialLib/SolidModels/MechanicsBase.h
+++ b/MaterialLib/SolidModels/MechanicsBase.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <memory>
+#include <tuple>
 
 #include "ProcessLib/Deformation/BMatrixPolicy.h"
 #include "ProcessLib/Parameter/Parameter.h"
@@ -57,17 +58,17 @@ struct MechanicsBase
     /// constitutive relation compute function.
     /// Returns false in case of errors in the computation if Newton iterations
     /// did not converge, for example.
-    bool computeConstitutiveRelation(
-        double const t,
-        ProcessLib::SpatialPosition const& x,
-        double const dt,
-        Eigen::Matrix<double, Eigen::Dynamic, 1> const& eps_prev,
-        Eigen::Matrix<double, Eigen::Dynamic, 1> const& eps,
-        Eigen::Matrix<double, Eigen::Dynamic, 1> const& sigma_prev,
-        Eigen::Matrix<double, Eigen::Dynamic, 1>& sigma,
-        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
-            C,
-        MaterialStateVariables& material_state_variables)
+    std::tuple<KelvinVector,
+               std::unique_ptr<MaterialStateVariables>,
+               KelvinMatrix>
+    integrateStress(double const t,
+                    ProcessLib::SpatialPosition const& x,
+                    double const dt,
+                    Eigen::Matrix<double, Eigen::Dynamic, 1> const& eps_prev,
+                    Eigen::Matrix<double, Eigen::Dynamic, 1> const& eps,
+                    Eigen::Matrix<double, Eigen::Dynamic, 1> const& sigma_prev,
+                    Eigen::Matrix<double, Eigen::Dynamic, 1> const& sigma,
+                    MaterialStateVariables const& material_state_variables)
     {
         // TODO Avoid copies of data:
         // Using MatrixBase<Derived> not possible because template functions
@@ -77,23 +78,10 @@ struct MechanicsBase
         KelvinVector const eps_prev_{eps_prev};
         KelvinVector const eps_{eps};
         KelvinVector const sigma_prev_{sigma_prev};
-        KelvinVector sigma_{sigma};
-        KelvinMatrix C_{C};
+        KelvinVector const sigma_{sigma};
 
-        bool const result =
-            computeConstitutiveRelation(t,
-                                        x,
-                                        dt,
-                                        eps_prev_,
-                                        eps_,
-                                        sigma_prev_,
-                                        sigma_,
-                                        C_,
-                                        material_state_variables);
-
-        sigma = sigma_;
-        C = C_;
-        return result;
+        return integrateStress(
+            t, x, dt, eps_prev_, eps_, sigma_, sigma_prev_, material_state_variables);
     }
 
     /// Computation of the constitutive relation for specific material model.
@@ -102,16 +90,17 @@ struct MechanicsBase
     /// wrapper function.
     /// Returns false in case of errors in the computation if Newton iterations
     /// did not converge, for example.
-    virtual bool computeConstitutiveRelation(
-        double const t,
-        ProcessLib::SpatialPosition const& x,
-        double const dt,
-        KelvinVector const& eps_prev,
-        KelvinVector const& eps,
-        KelvinVector const& sigma_prev,
-        KelvinVector& sigma,
-        KelvinMatrix& C,
-        MaterialStateVariables& material_state_variables) = 0;
+    virtual std::tuple<KelvinVector,
+                       std::unique_ptr<MaterialStateVariables>,
+                       KelvinMatrix>
+    integrateStress(double const t,
+                    ProcessLib::SpatialPosition const& x,
+                    double const dt,
+                    KelvinVector const& eps_prev,
+                    KelvinVector const& eps,
+                    KelvinVector const& sigma_prev,
+                    KelvinVector const& sigma,
+                    MaterialStateVariables const& material_state_variables) = 0;
 
     virtual ~MechanicsBase() = default;
 };

--- a/MaterialLib/SolidModels/MechanicsBase.h
+++ b/MaterialLib/SolidModels/MechanicsBase.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
 #include <memory>
 #include <tuple>
 
@@ -60,11 +61,11 @@ struct MechanicsBase
 
     /// Dynamic size Kelvin vector and matrix wrapper for the polymorphic
     /// constitutive relation compute function.
-    /// Returns false in case of errors in the computation if Newton iterations
-    /// did not converge, for example.
-    std::tuple<KelvinVector,
-               std::unique_ptr<MaterialStateVariables>,
-               KelvinMatrix>
+    /// Returns nothing in case of errors in the computation if Newton
+    /// iterations did not converge, for example.
+    boost::optional<std::tuple<KelvinVector,
+                               std::unique_ptr<MaterialStateVariables>,
+                               KelvinMatrix>>
     integrateStress(double const t,
                     ProcessLib::SpatialPosition const& x,
                     double const dt,
@@ -90,11 +91,11 @@ struct MechanicsBase
     /// This should be implemented in the derived model. Fixed Kelvin vector and
     /// matrix size version; for dynamic size arguments there is an overloaded
     /// wrapper function.
-    /// Returns false in case of errors in the computation if Newton iterations
-    /// did not converge, for example.
-    virtual std::tuple<KelvinVector,
-                       std::unique_ptr<MaterialStateVariables>,
-                       KelvinMatrix>
+    /// Returns nothing in case of errors in the computation if Newton
+    /// iterations did not converge, for example.
+    virtual boost::optional<std::tuple<KelvinVector,
+                                       std::unique_ptr<MaterialStateVariables>,
+                                       KelvinMatrix>>
     integrateStress(double const t,
                     ProcessLib::SpatialPosition const& x,
                     double const dt,

--- a/MaterialLib/SolidModels/MechanicsBase.h
+++ b/MaterialLib/SolidModels/MechanicsBase.h
@@ -39,6 +39,9 @@ struct MechanicsBase
     struct MaterialStateVariables
     {
         virtual ~MaterialStateVariables() = default;
+        virtual MaterialStateVariables& operator=(
+            MaterialStateVariables const&) = default;
+
         virtual void pushBackState() = 0;
     };
 

--- a/MaterialLib/SolidModels/MechanicsBase.h
+++ b/MaterialLib/SolidModels/MechanicsBase.h
@@ -71,7 +71,6 @@ struct MechanicsBase
                     Eigen::Matrix<double, Eigen::Dynamic, 1> const& eps_prev,
                     Eigen::Matrix<double, Eigen::Dynamic, 1> const& eps,
                     Eigen::Matrix<double, Eigen::Dynamic, 1> const& sigma_prev,
-                    Eigen::Matrix<double, Eigen::Dynamic, 1> const& sigma,
                     MaterialStateVariables const& material_state_variables)
     {
         // TODO Avoid copies of data:
@@ -82,10 +81,9 @@ struct MechanicsBase
         KelvinVector const eps_prev_{eps_prev};
         KelvinVector const eps_{eps};
         KelvinVector const sigma_prev_{sigma_prev};
-        KelvinVector const sigma_{sigma};
 
         return integrateStress(
-            t, x, dt, eps_prev_, eps_, sigma_, sigma_prev_, material_state_variables);
+            t, x, dt, eps_prev_, eps_, sigma_prev_, material_state_variables);
     }
 
     /// Computation of the constitutive relation for specific material model.
@@ -103,7 +101,6 @@ struct MechanicsBase
                     KelvinVector const& eps_prev,
                     KelvinVector const& eps,
                     KelvinVector const& sigma_prev,
-                    KelvinVector const& sigma,
                     MaterialStateVariables const& material_state_variables) = 0;
 
     virtual ~MechanicsBase() = default;

--- a/MaterialLib/SolidModels/MechanicsBase.h
+++ b/MaterialLib/SolidModels/MechanicsBase.h
@@ -13,7 +13,11 @@
 #include <tuple>
 
 #include "ProcessLib/Deformation/BMatrixPolicy.h"
-#include "ProcessLib/Parameter/Parameter.h"
+
+namespace ProcessLib
+{
+class SpatialPosition;
+}
 
 namespace MeshLib
 {

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -90,17 +90,15 @@ struct IntegrationPointData final
     {
         eps.noalias() = b_matrices * u;
 
-        KelvinMatrixType<DisplacementDim> C;
-        std::unique_ptr<typename MaterialLib::Solids::MechanicsBase<
-            DisplacementDim>::MaterialStateVariables>
-            new_state;
-        std::tie(sigma_eff, new_state, C) = solid_material.integrateStress(
+        auto&& solution = solid_material.integrateStress(
             t, x_position, dt, eps_prev, eps, sigma_eff_prev,
             *material_state_variables);
 
-        if (!new_state)
+        if (!solution)
             OGS_FATAL("Computation of local constitutive relation failed.");
-        material_state_variables = std::move(new_state);
+
+        KelvinMatrixType<DisplacementDim> C;
+        std::tie(sigma_eff, material_state_variables, C) = std::move(*solution);
 
         return C;
     }

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
@@ -224,18 +224,15 @@ assembleBlockMatricesWithJacobian(
 
         eps.noalias() = B * u;
 
-        KelvinMatrixType<GlobalDim> C;
-        std::unique_ptr<typename MaterialLib::Solids::MechanicsBase<
-            GlobalDim>::MaterialStateVariables>
-            new_state;
-        std::tie(sigma_eff, new_state, C) =
-            _ip_data[ip].solid_material.integrateStress(
-                t, x_position, _process_data.dt, eps_prev, eps, sigma_eff_prev,
-                *state);
+        auto&& solution = _ip_data[ip].solid_material.integrateStress(
+            t, x_position, _process_data.dt, eps_prev, eps, sigma_eff_prev,
+            *state);
 
-        if (!new_state)
+        if (!solution)
             OGS_FATAL("Computation of local constitutive relation failed.");
-        state = std::move(new_state);
+
+        KelvinMatrixType<GlobalDim> C;
+        std::tie(sigma_eff, state, C) = std::move(*solution);
 
         q.noalias() = - k_over_mu * (dNdx_p * p + rho_fr * gravity_vec);
 
@@ -337,17 +334,15 @@ computeSecondaryVariableConcreteWithBlockVectors(
 
         eps.noalias() = B * u;
 
-        std::unique_ptr<typename MaterialLib::Solids::MechanicsBase<
-            GlobalDim>::MaterialStateVariables>
-            new_state;
-        std::tie(sigma_eff, new_state, ip_data.C) =
-            _ip_data[ip].solid_material.integrateStress(
-                t, x_position, _process_data.dt, eps_prev, eps, sigma_eff_prev,
-                *state);
+        auto&& solution = _ip_data[ip].solid_material.integrateStress(
+            t, x_position, _process_data.dt, eps_prev, eps, sigma_eff_prev,
+            *state);
 
-        if (!new_state)
+        if (!solution)
             OGS_FATAL("Computation of local constitutive relation failed.");
-        state = std::move(new_state);
+
+        KelvinMatrixType<GlobalDim> C;
+        std::tie(sigma_eff, state, C) = std::move(*solution);
 
         q.noalias() = - k_over_mu * (dNdx_p * p + rho_fr * gravity_vec);
     }

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix-impl.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix-impl.h
@@ -144,18 +144,14 @@ assembleWithJacobian(
             Eigen::Map<typename BMatricesType::NodalForceVectorType const>(
                 local_x.data(), ShapeFunction::NPOINTS * DisplacementDim);
 
-        KelvinMatrixType<DisplacementDim> C;
-        std::unique_ptr<typename MaterialLib::Solids::MechanicsBase<
-            DisplacementDim>::MaterialStateVariables>
-            new_state;
-        std::tie(sigma, new_state, C) =
-            _ip_data[ip]._solid_material.integrateStress(
-                t, x_position, _process_data.dt, eps_prev, eps, sigma_prev,
-                *state);
+        auto&& solution = _ip_data[ip]._solid_material.integrateStress(
+            t, x_position, _process_data.dt, eps_prev, eps, sigma_prev, *state);
 
-        if (!new_state)
+        if (!solution)
             OGS_FATAL("Computation of local constitutive relation failed.");
-        state = std::move(new_state);
+
+        KelvinMatrixType<DisplacementDim> C;
+        std::tie(sigma, state, C) = std::move(*solution);
 
         local_b.noalias() -=
             B.transpose() * sigma * detJ * wp.getWeight() * integralMeasure;

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -254,18 +254,15 @@ public:
                 Eigen::Map<typename BMatricesType::NodalForceVectorType const>(
                     local_x.data(), ShapeFunction::NPOINTS * DisplacementDim);
 
-            KelvinMatrixType<DisplacementDim> C;
-            std::unique_ptr<typename MaterialLib::Solids::MechanicsBase<
-                DisplacementDim>::MaterialStateVariables>
-                new_state;
-            std::tie(sigma, new_state, C) =
-                _ip_data[ip].solid_material.integrateStress(
-                    t, x_position, _process_data.dt, eps_prev, eps, sigma_prev,
-                    *state);
+            auto&& solution = _ip_data[ip].solid_material.integrateStress(
+                t, x_position, _process_data.dt, eps_prev, eps, sigma_prev,
+                *state);
 
-            if (!new_state)
+            if (!solution)
                 OGS_FATAL("Computation of local constitutive relation failed.");
-            state = std::move(new_state);
+
+            KelvinMatrixType<DisplacementDim> C;
+            std::tie(sigma, state, C) = std::move(*solution);
 
             local_b.noalias() -= B.transpose() * sigma * w;
             local_Jac.noalias() += B.transpose() * C * B * w;


### PR DESCRIPTION
Rewrite solid material models such that the internal material state variables are not modified but new values are returned. This simplifies introduction of finite difference scheme.

Behaviour w.r.t. the ctests has not changed.