### PR TITLE
Use string equality operator for comparison; Simplify boolean expressions.

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -197,7 +197,7 @@ bool ProjectData::isMeshNameUniqueAndProvideUniqueName(std::string& name) const
             cpName = cpName + "-" + std::to_string(count);
 
         for (auto mesh : _mesh_vec)
-            if (cpName.compare(mesh->getName()) == 0)
+            if (cpName == mesh->getName())
                 isUnique = false;
     }
 

--- a/Applications/DataExplorer/Base/OGSError.cpp
+++ b/Applications/DataExplorer/Base/OGSError.cpp
@@ -41,8 +41,6 @@ bool OGSError::question(const QString &e, const QString &t)
     msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
     msgBox.setDefaultButton(QMessageBox::Cancel);
 
-    if (msgBox.exec() == QMessageBox::Ok)
-        return true;
-    return false;
+    return msgBox.exec() == QMessageBox::Ok;
 }
 

--- a/Applications/DataExplorer/DataView/CondFromRasterDialog.cpp
+++ b/Applications/DataExplorer/DataView/CondFromRasterDialog.cpp
@@ -87,7 +87,7 @@ void CondFromRasterDialog::accept()
 
     MeshLib::Mesh* mesh(nullptr);
     for (auto mesh_ : _msh_vec)
-        if (mesh_->getName().compare(mesh_name) == 0)
+        if (mesh_->getName() == mesh_name)
         {
             mesh = mesh_;
             break;

--- a/Applications/DataExplorer/DataView/GeoTreeModel.cpp
+++ b/Applications/DataExplorer/DataView/GeoTreeModel.cpp
@@ -112,7 +112,7 @@ void GeoTreeModel::appendPolylines(const std::string &name, GeoLib::PolylineVec 
 {
     for (auto& list : _lists)
     {
-        if (name.compare(list->data(0).toString().toStdString()) == 0)
+        if (name == list->data(0).toString().toStdString())
             for (int j = 0; j < list->childCount(); j++)
             {
                 auto* parent = static_cast<GeoObjectListItem*>(list->child(j));
@@ -202,7 +202,7 @@ void GeoTreeModel::appendSurfaces(const std::string &name, GeoLib::SurfaceVec co
 {
     for (auto& list : _lists)
     {
-        if (name.compare(list->data(0).toString().toStdString()) == 0)
+        if (name == list->data(0).toString().toStdString())
         {
             int nChildren = list->childCount();
             for (int j = 0; j < nChildren; j++)
@@ -280,7 +280,7 @@ void GeoTreeModel::addChildren(GeoObjectListItem* sfcList,
 void GeoTreeModel::removeGeoList(const std::string &name, GeoLib::GEOTYPE type)
 {
     for (std::size_t i = 0; i < _lists.size(); i++)
-        if ( name.compare( _lists[i]->data(0).toString().toStdString() ) == 0 )
+        if (name == _lists[i]->data(0).toString().toStdString())
         {
             for (int j = 0; j < _lists[i]->childCount(); j++)
                 if (type ==
@@ -304,7 +304,7 @@ vtkPolyDataAlgorithm* GeoTreeModel::vtkSource(const std::string &name, GeoLib::G
     std::size_t nLists = _lists.size();
     for (std::size_t i = 0; i < nLists; i++)
     {
-        if ( name.compare( _lists[i]->data(0).toString().toStdString() ) == 0 )
+        if (name == _lists[i]->data(0).toString().toStdString())
             for (int j = 0; j < _lists[i]->childCount(); j++)
             {
                 auto* item =
@@ -340,14 +340,13 @@ void GeoTreeModel::setNameForItem(const std::string &name,
         geo_type_str = "";
     }
 
-    auto it = find_if(_lists.begin(), _lists.end(), [&name](GeoTreeItem* geo)
-    {
-        return (name.compare( geo->data(0).toString().toStdString() ) == 0);
+    auto it = find_if(_lists.begin(), _lists.end(), [&name](GeoTreeItem* geo) {
+        return (name == geo->data(0).toString().toStdString());
     });
 
     for (int i = 0; i < (*it)->childCount(); i++)
     {
-        if ( geo_type_str.compare( (*it)->child(i)->data(0).toString().toStdString() ) == 0 )
+        if (geo_type_str == (*it)->child(i)->data(0).toString().toStdString())
         {
             TreeItem* item = (*it)->child(i)->child(id);
             item->setData(col_idx, QString::fromStdString(item_name));

--- a/Applications/DataExplorer/DataView/MshModel.cpp
+++ b/Applications/DataExplorer/DataView/MshModel.cpp
@@ -107,7 +107,7 @@ const MeshLib::Mesh* MshModel::getMesh(const std::string &name) const
     for (int i = 0; i < _rootItem->childCount(); i++)
     {
         auto* item = static_cast<MshItem*>(_rootItem->child(i));
-        if (item->data(0).toString().toStdString().compare(name) == 0)
+        if (item->data(0).toString().toStdString() == name)
             return item->getMesh();
     }
 
@@ -132,7 +132,7 @@ bool MshModel::removeMesh(const std::string &name)
     for (int i = 0; i < _rootItem->childCount(); i++)
     {
         TreeItem* item = _rootItem->child(i);
-        if (item->data(0).toString().toStdString().compare(name) == 0)
+        if (item->data(0).toString().toStdString() == name)
         {
             beginResetModel();
             emit meshRemoved(this, this->index(i, 0, QModelIndex()));
@@ -195,7 +195,7 @@ vtkUnstructuredGridAlgorithm* MshModel::vtkSource(const std::string &name) const
     for (int i = 0; i < _rootItem->childCount(); i++)
     {
         auto* item = static_cast<MshItem*>(_rootItem->child(i));
-        if (item->data(0).toString().toStdString().compare(name) == 0)
+        if (item->data(0).toString().toStdString() == name)
             return item->vtkSource();
     }
 

--- a/Applications/DataExplorer/DataView/StationTreeModel.cpp
+++ b/Applications/DataExplorer/DataView/StationTreeModel.cpp
@@ -94,7 +94,7 @@ vtkPolyDataAlgorithm* StationTreeModel::vtkSource(const std::string &name) const
 {
     std::size_t nLists = _lists.size();
     for (std::size_t i = 0; i < nLists; i++)
-        if ( name.compare( _lists[i]->data(0).toString().toStdString() ) == 0 )
+        if (name == _lists[i]->data(0).toString().toStdString())
             return dynamic_cast<BaseItem*>(_lists[i]->getItem())->vtkSource();
     return nullptr;
 }
@@ -179,6 +179,6 @@ void StationTreeModel::removeStationList(QModelIndex index)
 void StationTreeModel::removeStationList(const std::string &name)
 {
     for (auto& list : _lists)
-        if (name.compare(list->data(0).toString().toStdString()) == 0)
+        if (name == list->data(0).toString().toStdString())
             removeStationList(createIndex(list->row(), 0, list));
 }

--- a/Applications/DataExplorer/VtkVis/VtkStationSource.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkStationSource.cpp
@@ -204,7 +204,7 @@ std::size_t VtkStationSource::GetIndexByName( std::string const& name )
     vtkIdType max_key(0);
     for (auto it = _id_map.begin(); it != _id_map.end(); ++it)
     {
-        if (name.compare(it->first) == 0)
+        if (name == it->first)
             return it->second;
         if (it->second > max_key)
             max_key = it->second;

--- a/Applications/DataExplorer/VtkVis/VtkStationSource.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkStationSource.cpp
@@ -86,9 +86,8 @@ int VtkStationSource::RequestData( vtkInformation* request,
             break;
         }
 
-    bool isBorehole =
-            (static_cast<GeoLib::Station*>((*_stations)[0])->type() ==
-    GeoLib::Station::StationType::BOREHOLE) ? true : false;
+    bool isBorehole = static_cast<GeoLib::Station*>((*_stations)[0])->type() ==
+                      GeoLib::Station::StationType::BOREHOLE;
 
     vtkSmartPointer<vtkInformation> outInfo = outputVector->GetInformationObject(0);
     vtkSmartPointer<vtkPolyData> output =

--- a/Applications/DataExplorer/VtkVis/VtkVisImageItem.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkVisImageItem.cpp
@@ -150,7 +150,7 @@ int VtkVisImageItem::callVTKWriter(vtkAlgorithm* algorithm, const std::string &f
         vtkSmartPointer<vtkXMLImageDataWriter> iWriter =
                 vtkSmartPointer<vtkXMLImageDataWriter>::New();
         iWriter->SetInputData(algID->GetOutputDataObject(0));
-        if (BaseLib::getFileExtension(filename).compare("vti") != 0)
+        if (BaseLib::getFileExtension(filename) != "vti")
             file_name_cpy.append(".vti");
         iWriter->SetFileName(file_name_cpy.c_str());
         return iWriter->Write();

--- a/Applications/DataExplorer/VtkVis/VtkVisPointSetItem.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkVisPointSetItem.cpp
@@ -234,7 +234,7 @@ int VtkVisPointSetItem::callVTKWriter(vtkAlgorithm* algorithm, const std::string
         vtkSmartPointer<vtkXMLPolyDataWriter> pdWriter =
                 vtkSmartPointer<vtkXMLPolyDataWriter>::New();
         pdWriter->SetInputData(algPD->GetOutputDataObject(0));
-        if (BaseLib::getFileExtension(filename).compare("vtp") != 0)
+        if (BaseLib::getFileExtension(filename) != "vtp")
             file_name_cpy.append(".vtp");
         pdWriter->SetFileName(file_name_cpy.c_str());
         return pdWriter->Write();
@@ -246,7 +246,7 @@ int VtkVisPointSetItem::callVTKWriter(vtkAlgorithm* algorithm, const std::string
         vtkSmartPointer<vtkXMLUnstructuredGridWriter> ugWriter =
                 vtkSmartPointer<vtkXMLUnstructuredGridWriter>::New();
         ugWriter->SetInputData(algUG->GetOutputDataObject(0));
-        if (BaseLib::getFileExtension(filename).compare("vtu") != 0)
+        if (BaseLib::getFileExtension(filename) != "vtu")
             file_name_cpy.append(".vtu");
         ugWriter->SetFileName(file_name_cpy.c_str());
         return ugWriter->Write();
@@ -330,7 +330,7 @@ bool VtkVisPointSetItem::activeAttributeExists(vtkDataSetAttributes* data, std::
     for (int i = 0; i < data->GetNumberOfArrays() && !arrayFound; i++)
     {
         std::string arrayName = data->GetArrayName(i);
-        if(arrayName.compare(name) == 0)
+        if (arrayName == name)
             arrayFound = true;
     }
     if (arrayFound)

--- a/Applications/DataHolderLib/Color.cpp
+++ b/Applications/DataHolderLib/Color.cpp
@@ -46,7 +46,7 @@ Color const getColor(const std::string &id, std::map<std::string, Color> &colors
 {
     for (auto it = colors.begin(); it != colors.end(); ++it)
     {
-        if (id.compare(it->first) == 0)
+        if (id == it->first)
             return it->second;
     }
     WARN("Key \"%s\" not found in color lookup table.", id.c_str());

--- a/Applications/FileIO/AsciiRasterInterface.cpp
+++ b/Applications/FileIO/AsciiRasterInterface.cpp
@@ -28,9 +28,9 @@ GeoLib::Raster* AsciiRasterInterface::readRaster(std::string const& fname)
 {
     std::string ext (BaseLib::getFileExtension(fname));
     std::transform(ext.begin(), ext.end(), ext.begin(), tolower);
-    if (ext.compare("asc") == 0)
+    if (ext == "asc")
         return getRasterFromASCFile(fname);
-    if (ext.compare("grd") == 0)
+    if (ext == "grd")
         return getRasterFromSurferFile(fname);
     return nullptr;
 }
@@ -73,26 +73,30 @@ bool AsciiRasterInterface::readASCHeader(std::ifstream &in, GeoLib::RasterHeader
     std::string tag, value;
 
     in >> tag;
-    if (tag.compare("ncols") == 0) {
+    if (tag == "ncols")
+    {
         in >> value;
         header.n_cols = atoi(value.c_str());
     } else return false;
 
     in >> tag;
-    if (tag.compare("nrows") == 0) {
+    if (tag == "nrows")
+    {
         in >> value;
         header.n_rows = atoi(value.c_str());
     } else return false;
 
     in >> tag;
-    if (tag.compare("xllcorner") == 0 || tag.compare("xllcenter") == 0) {
+    if (tag == "xllcorner" || tag == "xllcenter")
+    {
         in >> value;
         header.origin[0] =
             strtod(BaseLib::replaceString(",", ".", value).c_str(), nullptr);
     } else return false;
 
     in >> tag;
-    if (tag.compare("yllcorner") == 0 || tag.compare("yllcenter") == 0) {
+    if (tag == "yllcorner" || tag == "yllcenter")
+    {
         in >> value;
         header.origin[1] =
             strtod(BaseLib::replaceString(",", ".", value).c_str(), nullptr);
@@ -100,14 +104,16 @@ bool AsciiRasterInterface::readASCHeader(std::ifstream &in, GeoLib::RasterHeader
     header.origin[2] = 0;
 
     in >> tag;
-    if (tag.compare("cellsize") == 0) {
+    if (tag == "cellsize")
+    {
         in >> value;
         header.cell_size =
             strtod(BaseLib::replaceString(",", ".", value).c_str(), nullptr);
     } else return false;
 
     in >> tag;
-    if (tag.compare("NODATA_value") == 0 || tag.compare("nodata_value") == 0) {
+    if (tag == "NODATA_value" || tag == "nodata_value")
+    {
         in >> value;
         header.no_data =
             strtod(BaseLib::replaceString(",", ".", value).c_str(), nullptr);
@@ -163,7 +169,7 @@ bool AsciiRasterInterface::readSurferHeader(
 
     in >> tag;
 
-    if (tag.compare("DSAA") != 0)
+    if (tag != "DSAA")
     {
         ERR("Error in readSurferHeader() - No Surfer file.");
         return false;

--- a/Applications/FileIO/CsvInterface.cpp
+++ b/Applications/FileIO/CsvInterface.cpp
@@ -177,7 +177,7 @@ std::size_t CsvInterface::findColumn(std::string const& line, char delim, std::s
     std::size_t count(0);
     for (const auto& field : fields)
     {
-        if (field.compare(column_name) == 0)
+        if (field == column_name)
             break;
 
         count++;

--- a/Applications/FileIO/FEFLOW/FEFLOWGeoInterface.cpp
+++ b/Applications/FileIO/FEFLOW/FEFLOWGeoInterface.cpp
@@ -65,7 +65,7 @@ void FEFLOWGeoInterface::readFEFLOWFile(const std::string& filename,
         }
         //....................................................................
         // GRAVITY
-        else if (line_string.compare("GRAVITY") == 0)
+        else if (line_string == "GRAVITY")
         {
             getline(in, line_string);
             line_stream.str(line_string);
@@ -78,7 +78,7 @@ void FEFLOWGeoInterface::readFEFLOWFile(const std::string& filename,
         }
         //....................................................................
         // SUPERMESH
-        else if (line_string.compare("SUPERMESH") == 0)
+        else if (line_string == "SUPERMESH")
         {
             readSuperMesh(in, dimension, points, lines);
         }

--- a/Applications/FileIO/FEFLOW/FEFLOWMeshInterface.cpp
+++ b/Applications/FileIO/FEFLOW/FEFLOWMeshInterface.cpp
@@ -73,7 +73,7 @@ MeshLib::Mesh* FEFLOWMeshInterface::readFEFLOWFile(const std::string& filename)
         }
         //....................................................................
         // DIMENS
-        else if (line_string.compare("DIMENS") == 0)
+        else if (line_string == "DIMENS")
         {
             // DIMENS
             std::getline(in, line_string);
@@ -94,7 +94,7 @@ MeshLib::Mesh* FEFLOWMeshInterface::readFEFLOWFile(const std::string& filename)
         }
         //....................................................................
         // NODE (node index for elements)
-        else if (line_string.compare("NODE") == 0)
+        else if (line_string == "NODE")
         {
             assert(!vec_nodes.empty());
 
@@ -138,7 +138,7 @@ MeshLib::Mesh* FEFLOWMeshInterface::readFEFLOWFile(const std::string& filename)
                     readElement(fem_dim, eleType, line_string, vec_nodes));
             }
         }
-        else if (line_string.compare("VARNODE") == 0)
+        else if (line_string == "VARNODE")
         {
             assert(!vec_nodes.empty());
 
@@ -163,16 +163,16 @@ MeshLib::Mesh* FEFLOWMeshInterface::readFEFLOWFile(const std::string& filename)
         }
         //....................................................................
         // COOR
-        else if (line_string.compare("COOR") == 0)
+        else if (line_string == "COOR")
         {
             readNodeCoordinates(in, fem_class, fem_dim, vec_nodes);
         }
-        else if (line_string.compare("XYZCOOR") == 0)
+        else if (line_string == "XYZCOOR")
         {
             readNodeCoordinates(in, vec_nodes);
         }
         // ELEV_I
-        else if (line_string.compare("ELEV_I") == 0)
+        else if (line_string == "ELEV_I")
         {
             if (fem_class.dimension == 2)
                 continue;
@@ -180,7 +180,7 @@ MeshLib::Mesh* FEFLOWMeshInterface::readFEFLOWFile(const std::string& filename)
         }
         //....................................................................
         // GRAVITY
-        else if (line_string.compare("GRAVITY") == 0)
+        else if (line_string == "GRAVITY")
         {
             getline(in, line_string);
             line_stream.str(line_string);
@@ -193,13 +193,13 @@ MeshLib::Mesh* FEFLOWMeshInterface::readFEFLOWFile(const std::string& filename)
         }
         //....................................................................
         // ELEMENTALSETS
-        else if (line_string.compare("ELEMENTALSETS") == 0)
+        else if (line_string == "ELEMENTALSETS")
         {
             readELEMENTALSETS(in, vec_elementsets);
         }
         //....................................................................
         // SUPERMESH
-        else if (line_string.compare("SUPERMESH") == 0)
+        else if (line_string == "SUPERMESH")
         {
             FileIO::FEFLOWGeoInterface::readSuperMesh(
                 in, fem_class.dimension, points, lines);

--- a/Applications/FileIO/GMSInterface.cpp
+++ b/Applications/FileIO/GMSInterface.cpp
@@ -61,7 +61,7 @@ int GMSInterface::readBoreholesFromGMS(std::vector<GeoLib::Point*>* boreholes,
 
         if (fields.size() >= 5)
         {
-            if (fields.begin()->compare(cName) == 0) // add new layer
+            if (*fields.begin() == cName)  // add new layer
             {
                 it = fields.begin();
                 (*pnt)[0] = strtod((++it)->c_str(), nullptr);
@@ -151,7 +151,7 @@ void GMSInterface::writeBoreholesToGMS(const std::vector<GeoLib::Point*>* statio
         std::size_t nLayers = profile.size();
         for (std::size_t i = 1; i < nLayers; i++)
         {
-            if ((i > 1) && (soilNames[i].compare(soilNames[i - 1]) == 0))
+            if ((i > 1) && (soilNames[i] == soilNames[i - 1]))
                 continue;
             // idx = getSoilID(soilID, soilNames[i]);
             current_soil_name = soilNames[i];
@@ -175,7 +175,7 @@ void GMSInterface::writeBoreholesToGMS(const std::vector<GeoLib::Point*>* statio
 std::size_t GMSInterface::getSoilID(std::vector<std::string> &soilID, std::string &soilName)
 {
     for (std::size_t j = 0; j < soilID.size(); j++)
-        if (soilID[j].compare(soilName) == 0)
+        if (soilID[j] == soilName)
             return j;
     soilID.push_back(soilName);
     return soilID.size() - 1;
@@ -229,7 +229,7 @@ MeshLib::Mesh* GMSInterface::readGMS3DMMesh(const std::string &filename)
 
     // Read data from file
     getline(in, line); // "MESH3D"
-    if (line.compare("MESH3D") != 0)
+    if (line != "MESH3D")
     {
         ERR("GMSInterface::readGMS3DMMesh(): Could not read expected file header.");
         return nullptr;
@@ -271,7 +271,7 @@ MeshLib::Mesh* GMSInterface::readGMS3DMMesh(const std::string &filename)
         std::string element_id(line.substr(0,3));
         std::stringstream str(line);
 
-        if (element_id.compare("E6W") == 0) // Prism
+        if (element_id == "E6W")  // Prism
         {
             str >> dummy >> id >> node_idx[0] >> node_idx[1] >> node_idx[2] >>
             node_idx[3]
@@ -283,7 +283,7 @@ MeshLib::Mesh* GMSInterface::readGMS3DMMesh(const std::string &filename)
             elements.push_back(new MeshLib::Prism(prism_nodes));
             mat_ids.push_back(mat_id);
         }
-        else if (element_id.compare("E4T") == 0) // Tet
+        else if (element_id == "E4T")  // Tet
         {
             str >> dummy >> id >> node_idx[0] >> node_idx[1] >> node_idx[2] >>
             node_idx[3] >> mat_id;
@@ -294,7 +294,9 @@ MeshLib::Mesh* GMSInterface::readGMS3DMMesh(const std::string &filename)
             elements.push_back(new MeshLib::Tet(tet_nodes));
             mat_ids.push_back(mat_id);
         }
-        else if ((element_id.compare("E4P") == 0) || (element_id.compare("E5P") == 0)) // Pyramid (both do exist for some reason)
+        else if ((element_id == "E4P") ||
+                 (element_id ==
+                  "E5P"))  // Pyramid (both do exist for some reason)
         {
             str >> dummy >> id >> node_idx[0] >> node_idx[1] >> node_idx[2] >>
             node_idx[3] >> node_idx[4] >> mat_id;
@@ -305,7 +307,7 @@ MeshLib::Mesh* GMSInterface::readGMS3DMMesh(const std::string &filename)
             elements.push_back(new MeshLib::Pyramid(pyramid_nodes));
             mat_ids.push_back(mat_id);
         }
-        else if (element_id.compare("ND ") == 0) // Node
+        else if (element_id == "ND ")  // Node
 
             continue; // skip because nodes have already been read
         else //default

--- a/Applications/FileIO/Gmsh/GmshReader.cpp
+++ b/Applications/FileIO/Gmsh/GmshReader.cpp
@@ -167,12 +167,14 @@ MeshLib::Mesh* readGMSHMesh(std::string const& fname)
     }
 
     getline(in, line); // version-number file-type data-size
-    if (line.substr(0,3).compare("2.2") != 0) {
+    if (line.substr(0, 3) != "2.2")
+    {
         WARN("Wrong gmsh file format version.");
         return nullptr;
     }
 
-    if (line.substr(4,1).compare("0") != 0) {
+    if (line.substr(4, 1) != "0")
+    {
         WARN("Currently reading gmsh binary file type is not supported.");
         return nullptr;
     }

--- a/Applications/FileIO/Gmsh/GmshReader.cpp
+++ b/Applications/FileIO/Gmsh/GmshReader.cpp
@@ -173,7 +173,7 @@ MeshLib::Mesh* readGMSHMesh(std::string const& fname)
         return nullptr;
     }
 
-    if (line.substr(4, 1) != "0")
+    if (line[4] != '0')
     {
         WARN("Currently reading gmsh binary file type is not supported.");
         return nullptr;

--- a/Applications/FileIO/PetrelInterface.cpp
+++ b/Applications/FileIO/PetrelInterface.cpp
@@ -202,7 +202,7 @@ void PetrelInterface::readPetrelWellTraceData(std::istream &in)
     // read yet another header line
     in.getline(buffer, MAX_COLS_PER_ROW);
     line = buffer;
-    while (line.substr(0, 1).compare("#") == 0)
+    while (line.substr(0, 1) == "#")
     {
         in.getline(buffer, MAX_COLS_PER_ROW);
         line = buffer;
@@ -222,7 +222,7 @@ void PetrelInterface::readPetrelWellTraceData(std::istream &in)
     line = buffer;
     while (in)
     {
-        if (line.size() > 1 && line.substr(0, 1).compare("#") != 0)
+        if (line.size() > 1 && line.substr(0, 1) != "#")
         {
             std::stringstream stream(line);
             stream >> md;

--- a/Applications/FileIO/PetrelInterface.cpp
+++ b/Applications/FileIO/PetrelInterface.cpp
@@ -202,7 +202,7 @@ void PetrelInterface::readPetrelWellTraceData(std::istream &in)
     // read yet another header line
     in.getline(buffer, MAX_COLS_PER_ROW);
     line = buffer;
-    while (line.substr(0, 1) == "#")
+    while (line[0] == '#')
     {
         in.getline(buffer, MAX_COLS_PER_ROW);
         line = buffer;
@@ -222,7 +222,7 @@ void PetrelInterface::readPetrelWellTraceData(std::istream &in)
     line = buffer;
     while (in)
     {
-        if (line.size() > 1 && line.substr(0, 1) != "#")
+        if (line.size() > 1 && line[0] != '#')
         {
             std::stringstream stream(line);
             stream >> md;

--- a/Applications/FileIO/TetGenInterface.cpp
+++ b/Applications/FileIO/TetGenInterface.cpp
@@ -416,7 +416,7 @@ bool TetGenInterface::parseElementsFileHeader(std::string &line,
     pos_end = line.find_first_of(" \t\n", pos_beg);
     if (pos_end == std::string::npos)
         pos_end = line.size();
-    region_attribute = (line.substr(pos_beg, pos_end - pos_beg)) == "1";
+    region_attribute = line.substr(pos_beg, pos_end - pos_beg) == "1";
 
     return true;
 }

--- a/Applications/FileIO/TetGenInterface.cpp
+++ b/Applications/FileIO/TetGenInterface.cpp
@@ -107,7 +107,7 @@ std::size_t TetGenInterface::getNFacets(std::ifstream &input)
         auto it = fields.begin();
         const auto nFacets(BaseLib::str2number<std::size_t>(*it));
         if (fields.size() > 1)
-            _boundary_markers = (BaseLib::str2number<std::size_t> (*(++it)) == 0) ? false : true;
+            _boundary_markers = BaseLib::str2number<std::size_t>(*(++it)) != 0;
         return nFacets;
     }
     return 0;
@@ -293,7 +293,7 @@ bool TetGenInterface::parseNodesFileHeader(std::string &line,
     }
 
     n_attributes = BaseLib::str2number<std::size_t> (*(++it));
-    boundary_markers = (*(++it) == "1") ? true : false;
+    boundary_markers = *(++it) == "1";
 
     return true;
 }
@@ -416,10 +416,7 @@ bool TetGenInterface::parseElementsFileHeader(std::string &line,
     pos_end = line.find_first_of(" \t\n", pos_beg);
     if (pos_end == std::string::npos)
         pos_end = line.size();
-    if ((line.substr(pos_beg, pos_end - pos_beg)) == "1")
-        region_attribute = true;
-    else
-        region_attribute = false;
+    region_attribute = (line.substr(pos_beg, pos_end - pos_beg)) == "1";
 
     return true;
 }

--- a/Applications/FileIO/TetGenInterface.cpp
+++ b/Applications/FileIO/TetGenInterface.cpp
@@ -49,7 +49,7 @@ bool TetGenInterface::readTetGenGeometry (std::string const& geo_fname,
         return false;
     }
     std::string ext (BaseLib::getFileExtension(geo_fname));
-    if (ext.compare("smesh") != 0)
+    if (ext != "smesh")
     {
         ERR ("TetGenInterface::readTetGenGeometry() - unknown file type (only *.smesh is supported).");
         return false;
@@ -293,7 +293,7 @@ bool TetGenInterface::parseNodesFileHeader(std::string &line,
     }
 
     n_attributes = BaseLib::str2number<std::size_t> (*(++it));
-    boundary_markers = ((++it)->compare("1") == 0) ? true : false;
+    boundary_markers = (*(++it) == "1") ? true : false;
 
     return true;
 }
@@ -416,7 +416,7 @@ bool TetGenInterface::parseElementsFileHeader(std::string &line,
     pos_end = line.find_first_of(" \t\n", pos_beg);
     if (pos_end == std::string::npos)
         pos_end = line.size();
-    if ((line.substr(pos_beg, pos_end - pos_beg)).compare("1") == 0)
+    if ((line.substr(pos_beg, pos_end - pos_beg)) == "1")
         region_attribute = true;
     else
         region_attribute = false;

--- a/Applications/Utils/FileConverter/ConvertSHPToGLI.cpp
+++ b/Applications/Utils/FileConverter/ConvertSHPToGLI.cpp
@@ -214,14 +214,14 @@ int main (int argc, char* argv[])
             fname += ".gml";
 
         INFO("Writing to %s.", fname.c_str());
-        convertPoints (dbf_handle,
-                       fname,
-                       x_id,
-                       y_id,
-                       z_id,
-                       name_component_ids,
-                       fname_base,
-                       station == 0 ? true : false);
+        convertPoints(dbf_handle,
+                      fname,
+                      x_id,
+                      y_id,
+                      z_id,
+                      name_component_ids,
+                      fname_base,
+                      station == 0);
         DBFClose (dbf_handle);
         INFO("\tok.");
     } else {

--- a/Applications/Utils/MeshEdit/moveMeshNodes.cpp
+++ b/Applications/Utils/MeshEdit/moveMeshNodes.cpp
@@ -98,7 +98,7 @@ int main (int argc, char* argv[])
 
     bool is_keyword(false);
     for (auto & keyword : keywords)
-        if (current_key.compare(keyword)==0)
+        if (current_key == keyword)
         {
             is_keyword = true;
             break;
@@ -122,7 +122,7 @@ int main (int argc, char* argv[])
     // Start keyword-specific selection of nodes
 
     // moves the elevation of all nodes by value
-    if (current_key.compare("-ALL")==0)
+    if (current_key == "-ALL")
     {
         if (argc < 5)
         {
@@ -130,7 +130,7 @@ int main (int argc, char* argv[])
             return EXIT_FAILURE;
         }
         const std::string dir(argv[3]);
-        unsigned idx = (dir.compare("x") == 0) ? 0 : (dir.compare("y") == 0) ? 1 : 2;
+        unsigned idx = (dir == "x") ? 0 : (dir == "y") ? 1 : 2;
         const double value(strtod(argv[4],0));
         INFO("Moving all mesh nodes by %g in direction %d (%s)...", value, idx,
              dir.c_str());
@@ -144,7 +144,7 @@ int main (int argc, char* argv[])
     }
 
     // maps the elevation of mesh nodes according to a ground truth mesh whenever nodes exist within max_dist
-    if (current_key.compare("-MESH")==0)
+    if (current_key == "-MESH")
     {
         if (argc < 5)
         {
@@ -183,7 +183,7 @@ int main (int argc, char* argv[])
 
     // a simple lowpass filter for the elevation of mesh nodes using the elevation of each node
     // weighted by 2 and the elevation of each connected node weighted by 1
-    if (current_key.compare("-LOWPASS")==0)
+    if (current_key == "-LOWPASS")
     {
         const std::size_t nNodes(mesh->getNumberOfNodes());
         std::vector<MeshLib::Node*> nodes (mesh->getNodes());

--- a/Applications/Utils/OGSFileConverter/OGSFileConverter.cpp
+++ b/Applications/Utils/OGSFileConverter/OGSFileConverter.cpp
@@ -89,7 +89,9 @@ void OGSFileConverter::convertGLI2GML(const QStringList &input, const QString &o
 
         GeoLib::IO::Legacy::readGLIFileV4(input_string.toStdString(),
                                           geo_objects, unique_name, errors);
-        if (errors.empty() || (errors.size()==1 && errors[0].compare("[readSurface] polyline for surface not found!")==0))
+        if (errors.empty() ||
+            (errors.size() == 1 &&
+             errors[0] == "[readSurface] polyline for surface not found!"))
         {
             std::string const geo_name =
                 BaseLib::extractBaseName(input_string.toStdString());

--- a/GeoLib/AnalyticalGeometry.cpp
+++ b/GeoLib/AnalyticalGeometry.cpp
@@ -135,10 +135,7 @@ bool lineSegmentIntersect(GeoLib::LineSegment const& s0,
                                             std::size_t i)
     {
         // check if p is located at v=(a,b): (ap = t*v, t in [0,1])
-        if (0.0 <= ap[i] / v[i] && ap[i] / v[i] <= 1.0) {
-            return true;
-        }
-        return false;
+        return 0.0 <= ap[i] / v[i] && ap[i] / v[i] <= 1.0;
     };
 
     if (parallel(v,w)) { // original line segments (a,b) and (c,d) are parallel
@@ -403,8 +400,7 @@ std::vector<MathLib::Point3d> lineSegmentIntersect2d(
         auto isPointOnSegment = [](double q, double p0, double p1)
         {
             double const t((q - p0) / (p1 - p0));
-            if (0 <= t && t <= 1) return true;
-            return false;
+            return 0 <= t && t <= 1;
         };
 
         // check if c in (ab)

--- a/GeoLib/GEOObjects.cpp
+++ b/GeoLib/GEOObjects.cpp
@@ -150,7 +150,7 @@ bool GEOObjects::appendPolylineVec(const std::vector<Polyline*>& polylines,
     std::size_t idx (0);
     bool nfound (true);
     for (idx = 0; idx < _ply_vecs.size() && nfound; idx++)
-        if ((_ply_vecs[idx]->getName()) == name)
+        if (_ply_vecs[idx]->getName() == name)
             nfound = false;
 
     if (!nfound)
@@ -222,7 +222,7 @@ bool GEOObjects::appendSurfaceVec(const std::vector<Surface*>& surfaces,
     std::size_t idx (0);
     bool nfound (true);
     for (idx = 0; idx < _sfc_vecs.size() && nfound; idx++)
-        if ((_sfc_vecs[idx]->getName()) == name)
+        if (_sfc_vecs[idx]->getName() == name)
             nfound = false;
 
     if (!nfound)
@@ -318,12 +318,12 @@ bool GEOObjects::isPntVecUsed (const std::string &name) const
     // search dependent data structures (Polyline)
     for (auto polyline : _ply_vecs)
     {
-        if ((polyline->getName()) == name)
+        if (polyline->getName() == name)
             return true;
     }
     for (auto surface : _sfc_vecs)
     {
-        if ((surface->getName()) == name)
+        if (surface->getName() == name)
             return true;
     }
 

--- a/GeoLib/GEOObjects.cpp
+++ b/GeoLib/GEOObjects.cpp
@@ -83,7 +83,7 @@ bool GEOObjects::removePointVec(std::string const& name)
     }
 
     for (auto it(_pnt_vecs.begin()); it != _pnt_vecs.end(); ++it)
-        if ((*it)->getName().compare(name) == 0)
+        if ((*it)->getName() == name)
         {
             _callbacks->removePointVec(name);
             delete *it;
@@ -107,7 +107,7 @@ const std::vector<GeoLib::Point*>* GEOObjects::getStationVec(
 {
     for (auto point : _pnt_vecs)
     {
-        if (point->getName().compare(name) == 0 &&
+        if (point->getName() == name &&
             point->getType() == PointVec::PointType::STATION)
         {
             return point->getVector();
@@ -150,7 +150,7 @@ bool GEOObjects::appendPolylineVec(const std::vector<Polyline*>& polylines,
     std::size_t idx (0);
     bool nfound (true);
     for (idx = 0; idx < _ply_vecs.size() && nfound; idx++)
-        if ( (_ply_vecs[idx]->getName()).compare (name) == 0 )
+        if ((_ply_vecs[idx]->getName()) == name)
             nfound = false;
 
     if (!nfound)
@@ -171,7 +171,7 @@ const std::vector<Polyline*>* GEOObjects::getPolylineVec(const std::string &name
 {
     std::size_t size (_ply_vecs.size());
     for (std::size_t i = 0; i < size; i++)
-        if (_ply_vecs[i]->getName().compare(name) == 0)
+        if (_ply_vecs[i]->getName() == name)
             return _ply_vecs[i]->getVector();
 
     DBUG("GEOObjects::getPolylineVec() - No entry found with name \"%s\".", name.c_str());
@@ -182,7 +182,7 @@ const PolylineVec* GEOObjects::getPolylineVecObj(const std::string &name) const
 {
     std::size_t size (_ply_vecs.size());
     for (std::size_t i = 0; i < size; i++)
-        if (_ply_vecs[i]->getName().compare(name) == 0)
+        if (_ply_vecs[i]->getName() == name)
             return _ply_vecs[i];
 
     DBUG("GEOObjects::getPolylineVecObj() - No entry found with name \"%s\".", name.c_str());
@@ -193,7 +193,7 @@ bool GEOObjects::removePolylineVec(std::string const& name)
 {
     _callbacks->removePolylineVec(name);
     for (auto it = _ply_vecs.begin(); it != _ply_vecs.end(); ++it)
-        if ((*it)->getName().compare(name) == 0)
+        if ((*it)->getName() == name)
         {
             delete *it;
             _ply_vecs.erase(it);
@@ -222,7 +222,7 @@ bool GEOObjects::appendSurfaceVec(const std::vector<Surface*>& surfaces,
     std::size_t idx (0);
     bool nfound (true);
     for (idx = 0; idx < _sfc_vecs.size() && nfound; idx++)
-        if ( (_sfc_vecs[idx]->getName()).compare (name) == 0 )
+        if ((_sfc_vecs[idx]->getName()) == name)
             nfound = false;
 
     if (!nfound)
@@ -249,7 +249,7 @@ const std::vector<Surface*>* GEOObjects::getSurfaceVec(const std::string &name) 
 {
     std::size_t size (_sfc_vecs.size());
     for (std::size_t i = 0; i < size; i++)
-        if (_sfc_vecs[i]->getName().compare(name) == 0)
+        if (_sfc_vecs[i]->getName() == name)
             return _sfc_vecs[i]->getVector();
     DBUG("GEOObjects::getSurfaceVec() - No entry found with name \"%s\".", name.c_str());
     return nullptr;
@@ -259,7 +259,7 @@ bool GEOObjects::removeSurfaceVec(const std::string &name)
 {
     _callbacks->removeSurfaceVec(name);
     for (auto it(_sfc_vecs.begin()); it != _sfc_vecs.end(); ++it)
-        if ((*it)->getName().compare (name) == 0)
+        if ((*it)->getName() == name)
         {
             delete *it;
             _sfc_vecs.erase (it);
@@ -274,7 +274,7 @@ const SurfaceVec* GEOObjects::getSurfaceVecObj(const std::string &name) const
 {
     std::size_t size (_sfc_vecs.size());
     for (std::size_t i = 0; i < size; i++)
-        if (_sfc_vecs[i]->getName().compare(name) == 0)
+        if (_sfc_vecs[i]->getName() == name)
             return _sfc_vecs[i];
     DBUG("GEOObjects::getSurfaceVecObj() - No entry found with name \"%s\".", name.c_str());
     return nullptr;
@@ -298,7 +298,7 @@ bool GEOObjects::isUniquePointVecName(std::string &name)
             cpName = cpName + "-" + std::to_string(count);
 
         for (auto& point : _pnt_vecs)
-            if (cpName.compare(point->getName()) == 0)
+            if (cpName == point->getName())
                 isUnique = false;
     }
 
@@ -318,12 +318,12 @@ bool GEOObjects::isPntVecUsed (const std::string &name) const
     // search dependent data structures (Polyline)
     for (auto polyline : _ply_vecs)
     {
-        if ((polyline->getName()).compare(name) == 0)
+        if ((polyline->getName()) == name)
             return true;
     }
     for (auto surface : _sfc_vecs)
     {
-        if ((surface->getName()).compare(name) == 0)
+        if ((surface->getName()) == name)
             return true;
     }
 
@@ -578,11 +578,11 @@ std::size_t GEOObjects::exists(const std::string &geometry_name) const
 {
     std::size_t const size (_pnt_vecs.size());
     for (std::size_t i = 0; i < size; i++)
-        if (_pnt_vecs[i]->getName().compare(geometry_name) == 0)
+        if (_pnt_vecs[i]->getName() == geometry_name)
             return i;
 
     // HACK for enabling conversion of files without loading the associated geometry
-    if (size>0 && _pnt_vecs[0]->getName().compare("conversionTestRun#1")==0)
+    if (size > 0 && _pnt_vecs[0]->getName() == "conversionTestRun#1")
         return 1;
 
     return std::numeric_limits<std::size_t>::max();

--- a/GeoLib/IO/Legacy/OGSIOVer4.cpp
+++ b/GeoLib/IO/Legacy/OGSIOVer4.cpp
@@ -70,10 +70,7 @@ std::string readPoints(std::istream &in, std::vector<GeoLib::Point*>* pnt_vec,
         {
             if (cnt == 0)
             {
-                if (id == 0)
-                    zero_based_indexing = true;
-                else
-                    zero_based_indexing = false;
+                zero_based_indexing = id == 0;
             }
             pnt_vec->push_back(new GeoLib::Point(x, y, z, id));
 
@@ -519,10 +516,7 @@ bool readGLIFileV4(const std::string& fname,
             std::move(sfc_vec), unique_name,
             std::move(sfc_names));  // KR: insert into GEOObjects if not empty
 
-    if (errors.empty())
-        return true;
-
-    return false;
+    return errors.empty();
 }
 
 std::size_t writeTINSurfaces(std::ofstream &os, GeoLib::SurfaceVec const* sfcs_vec, std::size_t sfc_count, std::string const& path)

--- a/GeoLib/IO/XmlIO/Qt/XmlStnInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlStnInterface.cpp
@@ -340,7 +340,7 @@ int XmlStnInterface::rapidReadFile(const std::string &fileName)
     doc.parse<0>(buffer);
 
     // parse content
-    if (std::string(doc.first_node()->name()).compare("OpenGeoSysSTN") != 0)
+    if (std::string(doc.first_node()->name()) != "OpenGeoSysSTN")
     {
         ERR("XmlStnInterface::readFile() - Unexpected XML root.");
         return 0;
@@ -358,9 +358,9 @@ int XmlStnInterface::rapidReadFile(const std::string &fileName)
              list_item = list_item->next_sibling())
         {
             std::string b(list_item->name());
-            if (b.compare("stations") == 0)
+            if (b == "stations")
                 this->rapidReadStations(list_item, stations.get(), fileName);
-            if (b.compare("boreholes") == 0)
+            if (b == "boreholes")
                 this->rapidReadStations(list_item, stations.get(), fileName);
         }
 
@@ -401,7 +401,7 @@ void XmlStnInterface::rapidReadStations(const rapidxml::xml_node<>* station_root
                     strtod(station_node->first_node("value")->value(), nullptr);
             /* add other station features here */
 
-            if (std::string(station_node->name()).compare("station") == 0)
+            if (std::string(station_node->name()) == "station")
             {
                 auto* s = new GeoLib::Station(
                     strtod(station_node->first_attribute("x")->value(),
@@ -417,7 +417,7 @@ void XmlStnInterface::rapidReadStations(const rapidxml::xml_node<>* station_root
                                                     file_name));
                 stations->push_back(s);
             }
-            else if (std::string(station_node->name()).compare("borehole") == 0)
+            else if (std::string(station_node->name()) == "borehole")
             {
                 if (station_node->first_node("bdepth"))
                     borehole_depth = strtod(

--- a/GeoLib/IO/XmlIO/Qt/XmlStnInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlStnInterface.cpp
@@ -211,9 +211,8 @@ bool XmlStnInterface::write()
     root.setAttribute( "xsi:noNamespaceSchemaLocation", "http://www.opengeosys.org/images/xsd/OpenGeoSysSTN.xsd" );
 
     const std::vector<GeoLib::Point*>* stations (_geo_objs.getStationVec(_exportName));
-    bool isBorehole =
-            (static_cast<GeoLib::Station*>((*stations)[0])->type() ==
-             GeoLib::Station::StationType::BOREHOLE) ? true : false;
+    bool isBorehole = static_cast<GeoLib::Station*>((*stations)[0])->type() ==
+                      GeoLib::Station::StationType::BOREHOLE;
 
     doc.appendChild(root);
     QDomElement stationListTag = doc.createElement("stationlist");

--- a/GeoLib/IO/XmlIO/Rapid/RapidStnInterface.cpp
+++ b/GeoLib/IO/XmlIO/Rapid/RapidStnInterface.cpp
@@ -51,7 +51,7 @@ std::vector<GeoLib::Point*> *RapidStnInterface::readStationFile(const std::strin
     doc.parse<0>(buffer);
 
     // parse content
-    if (std::string(doc.first_node()->name()).compare("OpenGeoSysSTN") != 0)
+    if (std::string(doc.first_node()->name()) != "OpenGeoSysSTN")
     {
         ERR("XmlStnInterface::readFile() - Unexpected XML root.");
         return nullptr;
@@ -66,9 +66,9 @@ std::vector<GeoLib::Point*> *RapidStnInterface::readStationFile(const std::strin
         for (rapidxml::xml_node<>* list_item = station_list->first_node(); list_item; list_item = list_item->next_sibling())
         {
             std::string b(list_item->name());
-            if (b.compare("stations") == 0)
+            if (b == "stations")
                 RapidStnInterface::readStations(list_item, stations, fileName);
-            if (b.compare("boreholes") == 0)
+            if (b == "boreholes")
                 RapidStnInterface::readStations(list_item, stations, fileName);
         }
     }
@@ -160,7 +160,7 @@ void RapidStnInterface::readStations(const rapidxml::xml_node<>* station_root, s
                     strtod(station_node->first_node("value")->value(), nullptr);
             /* add other station features here */
 
-            if (std::string(station_node->name()).compare("station") == 0)
+            if (std::string(station_node->name()) == "station")
             {
                 auto* s = new GeoLib::Station(
                     strtod(station_node->first_attribute("x")->value(),
@@ -174,7 +174,7 @@ void RapidStnInterface::readStations(const rapidxml::xml_node<>* station_root, s
                     s->addSensorDataFromCSV(BaseLib::copyPathToFileName(sensor_data_file_name, file_name));
                 stations->push_back(s);
             }
-            else if (std::string(station_node->name()).compare("borehole") == 0)
+            else if (std::string(station_node->name()) == "borehole")
             {
                 if (station_node->first_node("bdepth"))
                     borehole_depth = strtod(

--- a/GeoLib/IO/readGeometryFromFile.cpp
+++ b/GeoLib/IO/readGeometryFromFile.cpp
@@ -27,7 +27,8 @@ namespace IO
 void
 readGeometryFromFile(std::string const& fname, GeoLib::GEOObjects & geo_objs)
 {
-    if (BaseLib::getFileExtension(fname).compare("gml") == 0) {
+    if (BaseLib::getFileExtension(fname) == "gml")
+    {
         GeoLib::IO::BoostXmlGmlInterface xml(geo_objs);
         xml.readFile(fname);
     } else {

--- a/GeoLib/Polygon.cpp
+++ b/GeoLib/Polygon.cpp
@@ -183,9 +183,9 @@ bool Polygon::containsSegment(GeoLib::LineSegment const& segment) const
         if (!isPntInPolygon(GeoLib::Point(0.5*(s[k][0]+s[k+1][0]), 0.5*(s[k][1]+s[k+1][1]), 0.5*(s[k][2]+s[k+1][2]))))
         return false;
     }
-    if (!isPntInPolygon(GeoLib::Point(0.5*(s[0][0]+b[0]), 0.5*(s[0][1]+b[1]), 0.5*(s[0][2]+b[2]))))
-        return false;
-    return true;
+    return isPntInPolygon(GeoLib::Point(0.5 * (s[0][0] + b[0]),
+                                        0.5 * (s[0][1] + b[1]),
+                                        0.5 * (s[0][2] + b[2])));
 }
 
 bool Polygon::isPolylineInPolygon(const Polyline& ply) const

--- a/GeoLib/Polyline.cpp
+++ b/GeoLib/Polyline.cpp
@@ -192,10 +192,7 @@ bool Polyline::isClosed() const
     if (_ply_pnt_ids.size() < 3)
         return false;
 
-    if (_ply_pnt_ids.front() == _ply_pnt_ids.back())
-        return true;
-
-    return false;
+    return _ply_pnt_ids.front() == _ply_pnt_ids.back();
 }
 
 bool Polyline::isCoplanar() const

--- a/GeoLib/Raster.cpp
+++ b/GeoLib/Raster.cpp
@@ -175,10 +175,11 @@ double Raster::interpolateValueAtPoint(MathLib::Point3d const& pnt) const
 
 bool Raster::isPntOnRaster(MathLib::Point3d const& pnt) const
 {
-    if ((pnt[0]<_header.origin[0]) || (pnt[0]>_header.origin[0]+(_header.n_cols*_header.cell_size)) ||
-        (pnt[1]<_header.origin[1]) || (pnt[1]>_header.origin[1]+(_header.n_rows*_header.cell_size)))
-        return false;
-    return true;
+    return !(
+        (pnt[0] < _header.origin[0]) ||
+        (pnt[0] > _header.origin[0] + (_header.n_cols * _header.cell_size)) ||
+        (pnt[1] < _header.origin[1]) ||
+        (pnt[1] > _header.origin[1] + (_header.n_rows * _header.cell_size)));
 }
 
 } // end namespace GeoLib

--- a/GeoLib/SensorData.cpp
+++ b/GeoLib/SensorData.cpp
@@ -168,10 +168,11 @@ std::string SensorData::convertSensorDataType2String(SensorDataType t)
 
 SensorDataType SensorData::convertString2SensorDataType(const std::string &s)
 {
-    if ((s.compare("Evaporation")==0) || (s.compare("EVAPORATION")==0)) return SensorDataType::EVAPORATION;
-    if ((s.compare("Precipitation") == 0) || (s.compare("PRECIPITATION") == 0))
+    if ((s == "Evaporation") || (s == "EVAPORATION"))
+        return SensorDataType::EVAPORATION;
+    if ((s == "Precipitation") || (s == "PRECIPITATION"))
         return SensorDataType::PRECIPITATION;
-    if ((s.compare("Temperature") == 0) || (s.compare("TEMPERATURE") == 0))
+    if ((s == "Temperature") || (s == "TEMPERATURE"))
         return SensorDataType::TEMPERATURE;
     return SensorDataType::OTHER;
 }

--- a/GeoLib/SensorData.cpp
+++ b/GeoLib/SensorData.cpp
@@ -168,11 +168,11 @@ std::string SensorData::convertSensorDataType2String(SensorDataType t)
 
 SensorDataType SensorData::convertString2SensorDataType(const std::string &s)
 {
-    if ((s == "Evaporation") || (s == "EVAPORATION"))
+    if (s == "Evaporation" || s == "EVAPORATION")
         return SensorDataType::EVAPORATION;
-    if ((s == "Precipitation") || (s == "PRECIPITATION"))
+    if (s == "Precipitation" || s == "PRECIPITATION")
         return SensorDataType::PRECIPITATION;
-    if ((s == "Temperature") || (s == "TEMPERATURE"))
+    if (s == "Temperature" || s == "TEMPERATURE")
         return SensorDataType::TEMPERATURE;
     return SensorDataType::OTHER;
 }

--- a/GeoLib/StationBorehole.cpp
+++ b/GeoLib/StationBorehole.cpp
@@ -115,7 +115,9 @@ int StationBorehole::addLayer(std::list<std::string> fields, StationBorehole* bo
 {
     if (fields.size() >= 4) /* check if there are enough fields to create a borehole object */
     {
-        if (fields.front().compare(borehole->_name) == 0) /* check if the name of the borehole matches the name in the data */
+        if (fields.front() == borehole->_name) /* check if the name of the
+                                                  borehole matches the name in
+                                                  the data */
         {
             fields.pop_front();
 
@@ -173,7 +175,7 @@ int StationBorehole::addStratigraphies(const std::string &path, std::vector<Poin
             if (fields.size() >= 4)
             {
                 name = static_cast<StationBorehole*>((*boreholes)[it])->_name;
-                if ( fields.front().compare(name) != 0 )
+                if (fields.front() != name)
                     if (it < boreholes->size() - 1)
                         it++;
 
@@ -248,7 +250,7 @@ StationBorehole* StationBorehole::createStation(const std::string &name,
     (*station)[1]   = y;
     (*station)[2]   = z;
     station->_depth = depth;
-    if (date.compare("0000-00-00") != 0)
+    if (date != "0000-00-00")
         station->_date  = BaseLib::xmlDate2int(date);
     return station;
 }

--- a/GeoLib/Triangle.cpp
+++ b/GeoLib/Triangle.cpp
@@ -63,12 +63,8 @@ bool Triangle::containsPoint2D (Point const& pnt) const
     const double upper (1+delta);
 
     // check if u0 and u1 fulfills the condition (with some delta)
-    if (-delta <= y[0] && y[0] <= upper && -delta <= y[1] && y[1] <= upper &&
-        y[0] + y[1] <= upper)
-    {
-        return true;
-    }
-    return false;
+    return -delta <= y[0] && y[0] <= upper && -delta <= y[1] && y[1] <= upper &&
+           y[0] + y[1] <= upper;
 }
 
 void getPlaneCoefficients(Triangle const& tri, double c[3])

--- a/MathLib/GeometricBasics.cpp
+++ b/MathLib/GeometricBasics.cpp
@@ -73,9 +73,7 @@ bool isPointInTetrahedron(MathLib::Point3d const& p, MathLib::Point3d const& a,
             return false;
         // if p is on the same side of abc as d
         double const d4 (MathLib::orientation3d(p, a, b, c));
-        if (!(d0_sign == (d4>=0) || std::abs(d4) < eps))
-            return false;
-        return true;
+        return d0_sign == (d4 >= 0) || std::abs(d4) < eps;
     }
     return false;
 }
@@ -164,9 +162,7 @@ bool barycentricPointInTriangle(MathLib::Point3d const& p,
     if (beta < -eps_pnt_out_of_tri || beta > 1 + eps_pnt_out_of_tri)
         return false;
     double const gamma(1 - alpha - beta);
-    if (gamma < -eps_pnt_out_of_tri || gamma > 1 + eps_pnt_out_of_tri)
-        return false;
-    return true;
+    return !(gamma < -eps_pnt_out_of_tri || gamma > 1 + eps_pnt_out_of_tri);
 }
 
 bool isPointInTriangleXY(MathLib::Point3d const& p,
@@ -186,12 +182,7 @@ bool isPointInTriangleXY(MathLib::Point3d const& p,
     gauss.solve(mat, y, true);
 
     // check if u0 and u1 fulfills the condition
-    if (0 <= y[0] && y[0] <= 1 && 0 <= y[1] && y[1] <= 1 && y[0] + y[1] <= 1)
-    {
-        return true;
-    }
-    return false;
-
+    return 0 <= y[0] && y[0] <= 1 && 0 <= y[1] && y[1] <= 1 && y[0] + y[1] <= 1;
 }
 
 bool dividedByPlane(const MathLib::Point3d& a, const MathLib::Point3d& b,

--- a/MeshLib/MeshEnums.cpp
+++ b/MeshLib/MeshEnums.cpp
@@ -60,21 +60,21 @@ const std::string MeshElemType2StringShort(const MeshElemType t)
 
 MeshElemType String2MeshElemType(const std::string &s)
 {
-    if ((s.compare("point") == 0) || (s.compare("Point") == 0))
+    if ((s == "point") || (s == "Point"))
         return MeshElemType::POINT;
-    if ((s.compare("line") == 0) || (s.compare("Line") == 0))
+    if ((s == "line") || (s == "Line"))
         return MeshElemType::LINE;
-    if ((s.compare("quad") == 0) || (s.compare("Quadrilateral") == 0))
+    if ((s == "quad") || (s == "Quadrilateral"))
         return MeshElemType::QUAD;
-    if ((s.compare("hex")  == 0) || (s.compare("Hexahedron") == 0))
+    if ((s == "hex") || (s == "Hexahedron"))
         return MeshElemType::HEXAHEDRON;
-    if ((s.compare("tri")  == 0) || (s.compare("Triangle") == 0))
+    if ((s == "tri") || (s == "Triangle"))
         return MeshElemType::TRIANGLE;
-    if ((s.compare("tet")  == 0) || (s.compare("Tetrahedron") == 0))
+    if ((s == "tet") || (s == "Tetrahedron"))
         return MeshElemType::TETRAHEDRON;
-    if ((s.compare("pris") == 0) || (s.compare("Prism") == 0))
+    if ((s == "pris") || (s == "Prism"))
         return MeshElemType::PRISM;
-    if ((s.compare("pyra") == 0) || (s.compare("Pyramid") == 0))
+    if ((s == "pyra") || (s == "Pyramid"))
         return MeshElemType::PYRAMID;
     return MeshElemType::INVALID;
 }

--- a/MeshLib/MeshEnums.cpp
+++ b/MeshLib/MeshEnums.cpp
@@ -60,21 +60,21 @@ const std::string MeshElemType2StringShort(const MeshElemType t)
 
 MeshElemType String2MeshElemType(const std::string &s)
 {
-    if ((s == "point") || (s == "Point"))
+    if (s == "point" || s == "Point")
         return MeshElemType::POINT;
-    if ((s == "line") || (s == "Line"))
+    if (s == "line" || s == "Line")
         return MeshElemType::LINE;
-    if ((s == "quad") || (s == "Quadrilateral"))
+    if (s == "quad" || s == "Quadrilateral")
         return MeshElemType::QUAD;
-    if ((s == "hex") || (s == "Hexahedron"))
+    if (s == "hex" || s == "Hexahedron")
         return MeshElemType::HEXAHEDRON;
-    if ((s == "tri") || (s == "Triangle"))
+    if (s == "tri" || s == "Triangle")
         return MeshElemType::TRIANGLE;
-    if ((s == "tet") || (s == "Tetrahedron"))
+    if (s == "tet" || s == "Tetrahedron")
         return MeshElemType::TETRAHEDRON;
-    if ((s == "pris") || (s == "Prism"))
+    if (s == "pris" || s == "Prism")
         return MeshElemType::PRISM;
-    if ((s == "pyra") || (s == "Pyramid"))
+    if (s == "pyra" || s == "Pyramid")
         return MeshElemType::PYRAMID;
     return MeshElemType::INVALID;
 }

--- a/MeshLib/Properties.cpp
+++ b/MeshLib/Properties.cpp
@@ -32,11 +32,7 @@ void Properties::removePropertyVector(std::string const& name)
 
 bool Properties::hasPropertyVector(std::string const& name) const
 {
-    auto it(_properties.find(name));
-    if (it == _properties.end()) {
-        return false;
-    }
-    return true;
+    return _properties.find(name) != _properties.end();
 }
 
 std::vector<std::string> Properties::getPropertyVectorNames() const

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.cpp
@@ -68,7 +68,7 @@ void ConvergenceCriterionPerComponentResidual::checkResidual(
     bool satisfied_abs = true;
     // Make sure that in the first iteration the relative residual tolerance is
     // not satisfied.
-    bool satisfied_rel = _is_first_iteration ? false : true;
+    bool satisfied_rel = !_is_first_iteration;
 
     for (unsigned global_component = 0; global_component < _abstols.size();
          ++global_component)

--- a/Tests/GeoLib/TestLineSegmentIntersect2d.cpp
+++ b/Tests/GeoLib/TestLineSegmentIntersect2d.cpp
@@ -72,10 +72,7 @@ TEST_F(LineSegmentIntersect2dTest, RandomSegmentOrientationIntersecting)
                 {(s0.getBeginPoint()[0] + s0.getEndPoint()[0]) / 2,
                  (s0.getBeginPoint()[1] + s0.getEndPoint()[1]) / 2, 0.0}}};
             const double sqr_dist(MathLib::sqrDist(ipnts[0], center));
-            if (sqr_dist < std::numeric_limits<double>::epsilon())
-                return true;
-
-            return false;
+            return sqr_dist < std::numeric_limits<double>::epsilon();
         }
         return ipnts.size() == 2;
     };


### PR DESCRIPTION
See each commit's message for details.

Originally only the string comparison was suggested, but that was sometimes used in unnecessary complicated boolean expressions.