### PR TITLE
[CMake] Run git submodule sync in CMake

### DIFF
--- a/scripts/cmake/SubmoduleSetup.cmake
+++ b/scripts/cmake/SubmoduleSetup.cmake
@@ -25,6 +25,13 @@ if(OGS_BUILD_SWMM)
     list(APPEND REQUIRED_SUBMODULES ThirdParty/SwmmInterface)
 endif()
 
+# Sync submodules, which is required when a submodule changed its URL
+execute_process(
+    COMMAND ${GIT_TOOL_PATH} submodule sync
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_QUIET
+)
+
 foreach(SUBMODULE ${REQUIRED_SUBMODULES})
     execute_process(
         COMMAND ${GIT_TOOL_PATH} submodule status ${SUBMODULE}


### PR DESCRIPTION
This fixes submodule checkout errors when the submodules URL changed like this:

```
-- Updating submodule ThirdParty/cmake-modules
error: no such remote ref af334f92548b7349a1bb038d56ce91fc7b3d3d00
Fetched in submodule path 'ThirdParty/cmake-modules', but it did not contain af334f92548b7349a1bb038d56ce91fc7b3d3d00. Direct fetching of that commit failed.
```

Fixed also a CMake error when CVODE_KLU variable was not defined:

```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
CVODE_KLU
    linked by target "MathLib" in directory /home/naumov/w/ogs/s/MathLib

-- Configuring incomplete, errors occurred!
```


See #1827.