### PR TITLE
Compute b matrices on the fly

### DIFF
--- a/ProcessLib/Deformation/LinearBMatrix.h
+++ b/ProcessLib/Deformation/LinearBMatrix.h
@@ -37,9 +37,9 @@ template <int DisplacementDim,
           typename N_Type,
           typename DNDX_Type>
 BMatrixType computeBMatrix(DNDX_Type const& dNdx,
-                           const bool is_axially_symmetric,
                            N_Type const& N,
-                           const double radius)
+                           const double radius,
+                           const bool is_axially_symmetric)
 {
     static_assert(0 < DisplacementDim && DisplacementDim <= 3,
                   "LinearBMatrix::computeBMatrix: DisplacementDim must be in "

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -328,8 +328,8 @@ public:
                                                                       N_u);
             auto const B = LinearBMatrix::computeBMatrix<
                 DisplacementDim, ShapeFunctionDisplacement::NPOINTS,
-                typename BMatricesType::BMatrixType>(
-                dNdx_u, _is_axially_symmetric, N_u, x_coord);
+                typename BMatricesType::BMatrixType>(dNdx_u, N_u, x_coord,
+                                                     _is_axially_symmetric);
 
             auto& eps = _ip_data[ip].eps;
             auto const& sigma_eff = _ip_data[ip].sigma_eff;

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -322,17 +322,14 @@ public:
             auto const& N_p = _ip_data[ip].N_p;
             auto const& dNdx_p = _ip_data[ip].dNdx_p;
 
-            typename BMatricesType::BMatrixType B(
-                KelvinVectorDimensions<DisplacementDim>(),
-                ShapeFunctionDisplacement::NPOINTS * DisplacementDim);
-
             auto const x_coord =
                 interpolateXCoordinate<ShapeFunctionDisplacement,
                                        ShapeMatricesTypeDisplacement>(_element,
                                                                       N_u);
-            LinearBMatrix::computeBMatrix<DisplacementDim,
-                                          ShapeFunctionDisplacement::NPOINTS>(
-                dNdx_u, B, _is_axially_symmetric, N_u, x_coord);
+            auto const B = LinearBMatrix::computeBMatrix<
+                DisplacementDim, ShapeFunctionDisplacement::NPOINTS,
+                typename BMatricesType::BMatrixType>(
+                dNdx_u, _is_axially_symmetric, N_u, x_coord);
 
             auto& eps = _ip_data[ip].eps;
             auto const& sigma_eff = _ip_data[ip].sigma_eff;

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -45,8 +45,7 @@ struct IntegrationPointData final
     // The default generated move-ctor is correctly generated for other
     // compilers.
     explicit IntegrationPointData(IntegrationPointData&& other)
-        : b_matrices(std::move(other.b_matrices)),
-          sigma_eff(std::move(other.sigma_eff)),
+        : sigma_eff(std::move(other.sigma_eff)),
           sigma_eff_prev(std::move(other.sigma_eff_prev)),
           eps(std::move(other.eps)),
           eps_prev(std::move(other.eps_prev)),
@@ -60,9 +59,11 @@ struct IntegrationPointData final
     typename ShapeMatrixTypeDisplacement::template MatrixType<
         DisplacementDim, NPoints * DisplacementDim>
         N_u_op;
-    typename BMatricesType::BMatrixType b_matrices;
     typename BMatricesType::KelvinVectorType sigma_eff, sigma_eff_prev;
     typename BMatricesType::KelvinVectorType eps, eps_prev;
+
+    typename ShapeMatrixTypeDisplacement::NodalRowVectorType N_u;
+    typename ShapeMatrixTypeDisplacement::GlobalDimNodalMatrixType dNdx_u;
 
     typename ShapeMatricesTypePressure::NodalRowVectorType N_p;
     typename ShapeMatricesTypePressure::GlobalDimNodalMatrixType dNdx_p;
@@ -87,8 +88,6 @@ struct IntegrationPointData final
         double const dt,
         DisplacementVectorType const& u)
     {
-        eps.noalias() = b_matrices * u;
-
         auto&& solution = solid_material.integrateStress(
             t, x_position, dt, eps_prev, eps, sigma_eff_prev,
             *material_state_variables);
@@ -182,12 +181,13 @@ public:
     HydroMechanicsLocalAssembler(
         MeshLib::Element const& e,
         std::size_t const /*local_matrix_size*/,
-        bool is_axially_symmetric,
+        bool const is_axially_symmetric,
         unsigned const integration_order,
         HydroMechanicsProcessData<DisplacementDim>& process_data)
         : _process_data(process_data),
           _integration_method(integration_order),
-          _element(e)
+          _element(e),
+          _is_axially_symmetric(is_axially_symmetric)
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();
@@ -211,22 +211,10 @@ public:
             // displacement (subscript u)
             _ip_data.emplace_back(*_process_data.material);
             auto& ip_data = _ip_data[ip];
-            auto const& sm = shape_matrices_u[ip];
+            auto const& sm_u = shape_matrices_u[ip];
             _ip_data[ip].integration_weight =
                 _integration_method.getWeightedPoint(ip).getWeight() *
-                sm.integralMeasure * shape_matrices_u[ip].detJ;
-            ip_data.b_matrices.resize(
-                kelvin_vector_size,
-                ShapeFunctionDisplacement::NPOINTS * DisplacementDim);
-
-            auto const x_coord =
-                interpolateXCoordinate<ShapeFunctionDisplacement,
-                                       ShapeMatricesTypeDisplacement>(
-                    e, shape_matrices_u[ip].N);
-            LinearBMatrix::computeBMatrix<DisplacementDim,
-                                          ShapeFunctionDisplacement::NPOINTS>(
-                shape_matrices_u[ip].dNdx, ip_data.b_matrices,
-                is_axially_symmetric, shape_matrices_u[ip].N, x_coord);
+                sm_u.integralMeasure * sm_u.detJ;
 
             ip_data.sigma_eff.resize(kelvin_vector_size);
             ip_data.sigma_eff_prev.resize(kelvin_vector_size);
@@ -240,7 +228,10 @@ public:
                 ip_data.N_u_op
                     .template block<1, displacement_size / DisplacementDim>(
                         i, i * displacement_size / DisplacementDim)
-                    .noalias() = shape_matrices_u[ip].N;
+                    .noalias() = sm_u.N;
+
+            ip_data.N_u = sm_u.N;
+            ip_data.dNdx_u = sm_u.dNdx;
 
             ip_data.N_p = shape_matrices_p[ip].N;
             ip_data.dNdx_p = shape_matrices_p[ip].dNdx;
@@ -324,10 +315,26 @@ public:
             auto const& w = _ip_data[ip].integration_weight;
 
             auto const& N_u_op = _ip_data[ip].N_u_op;
+
+            auto const& N_u = _ip_data[ip].N_u;
+            auto const& dNdx_u = _ip_data[ip].dNdx_u;
+
             auto const& N_p = _ip_data[ip].N_p;
             auto const& dNdx_p = _ip_data[ip].dNdx_p;
 
-            auto const& B = _ip_data[ip].b_matrices;
+            typename BMatricesType::BMatrixType B(
+                KelvinVectorDimensions<DisplacementDim>(),
+                ShapeFunctionDisplacement::NPOINTS * DisplacementDim);
+
+            auto const x_coord =
+                interpolateXCoordinate<ShapeFunctionDisplacement,
+                                       ShapeMatricesTypeDisplacement>(_element,
+                                                                      N_u);
+            LinearBMatrix::computeBMatrix<DisplacementDim,
+                                          ShapeFunctionDisplacement::NPOINTS>(
+                dNdx_u, B, _is_axially_symmetric, N_u, x_coord);
+
+            auto& eps = _ip_data[ip].eps;
             auto const& sigma_eff = _ip_data[ip].sigma_eff;
 
             double const S = _process_data.specific_storage(t, x_position)[0];
@@ -340,11 +347,13 @@ public:
             auto const porosity = _process_data.porosity(t, x_position)[0];
             auto const& b = _process_data.specific_body_force;
             auto const& identity2 = MaterialLib::SolidModels::Invariants<
-                kelvin_vector_size>::identity2;
+                KelvinVectorDimensions<DisplacementDim>::value>::identity2;
 
             //
             // displacement equation, displacement part
             //
+            eps.noalias() = B * u;
+
             auto C =
                 _ip_data[ip].updateConstitutiveRelation(t, x_position, dt, u);
 
@@ -606,6 +615,7 @@ private:
 
     IntegrationMethod _integration_method;
     MeshLib::Element const& _element;
+    bool const _is_axially_symmetric;
     SecondaryData<
         typename ShapeMatricesTypeDisplacement::ShapeMatrices::ShapeType>
         _secondary_data;

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
@@ -37,8 +37,9 @@ HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
         unsigned const integration_order,
         HydroMechanicsProcessData<GlobalDim>& process_data)
     : HydroMechanicsLocalAssemblerInterface(
-          e,
-          ShapeFunctionDisplacement::NPOINTS * GlobalDim + ShapeFunctionPressure::NPOINTS,
+          e, is_axially_symmetric,
+          ShapeFunctionDisplacement::NPOINTS * GlobalDim +
+              ShapeFunctionPressure::NPOINTS,
           dofIndex_to_localIndex),
       _process_data(process_data)
 {

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerInterface.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerInterface.h
@@ -33,10 +33,12 @@ class HydroMechanicsLocalAssemblerInterface
 {
 public:
     HydroMechanicsLocalAssemblerInterface(MeshLib::Element const& element,
+                                          bool const is_axially_symmetric,
                                           std::size_t n_local_size,
                                           std::vector<unsigned>
                                               dofIndex_to_localIndex)
         : _element(element),
+          _is_axially_symmetric(is_axially_symmetric),
           _dofIndex_to_localIndex(std::move(dofIndex_to_localIndex))
     {
         _local_u.resize(n_local_size);
@@ -112,6 +114,7 @@ protected:
         double const t, Eigen::VectorXd const& local_u) = 0;
 
     MeshLib::Element const& _element;
+    bool const _is_axially_symmetric;
 
 private:
     Eigen::VectorXd _local_u;

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
@@ -201,7 +201,7 @@ assembleBlockMatricesWithJacobian(
             LinearBMatrix::computeBMatrix<GlobalDim,
                                           ShapeFunctionDisplacement::NPOINTS,
                                           typename BMatricesType::BMatrixType>(
-                dNdx_u, _is_axially_symmetric, N_u, x_coord);
+                dNdx_u, N_u, x_coord, _is_axially_symmetric);
 
         auto const& eps_prev = ip_data.eps_prev;
         auto const& sigma_eff_prev = ip_data.sigma_eff_prev;
@@ -346,7 +346,7 @@ computeSecondaryVariableConcreteWithBlockVectors(
             LinearBMatrix::computeBMatrix<GlobalDim,
                                           ShapeFunctionDisplacement::NPOINTS,
                                           typename BMatricesType::BMatrixType>(
-                dNdx_u, _is_axially_symmetric, N_u, x_coord);
+                dNdx_u, N_u, x_coord, _is_axially_symmetric);
 
         eps.noalias() = B * u;
 

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/IntegrationPointDataMatrix.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/IntegrationPointDataMatrix.h
@@ -36,8 +36,8 @@ struct IntegrationPointDataMatrix final
     // compilers.
     explicit IntegrationPointDataMatrix(IntegrationPointDataMatrix&& other)
         : N_u(std::move(other.N_u)),
+          dNdx_u(std::move(other.dNdx_u)),
           H_u(std::move(other.H_u)),
-          b_matrices(std::move(other.b_matrices)),
           sigma_eff(std::move(other.sigma_eff)),
           sigma_eff_prev(std::move(other.sigma_eff_prev)),
           eps(std::move(other.eps)),
@@ -53,10 +53,10 @@ struct IntegrationPointDataMatrix final
     }
 
     typename ShapeMatrixTypeDisplacement::NodalRowVectorType N_u;
+    typename ShapeMatrixTypeDisplacement::GlobalDimNodalMatrixType dNdx_u;
     typename ShapeMatrixTypeDisplacement::template MatrixType<
         GlobalDim, NPoints * GlobalDim>
         H_u;
-    typename BMatricesType::BMatrixType b_matrices;
     typename BMatricesType::KelvinVectorType sigma_eff, sigma_eff_prev;
     typename BMatricesType::KelvinVectorType eps, eps_prev;
 

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/IntegrationPointDataMatrix.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/IntegrationPointDataMatrix.h
@@ -20,8 +20,8 @@ namespace LIE
 {
 namespace SmallDeformation
 {
-
-template <typename BMatricesType, int DisplacementDim>
+template <typename ShapeMatricesType, typename BMatricesType,
+          int DisplacementDim>
 struct IntegrationPointDataMatrix final
 {
     explicit IntegrationPointDataMatrix(
@@ -36,8 +36,7 @@ struct IntegrationPointDataMatrix final
     // The default generated move-ctor is correctly generated for other
     // compilers.
     explicit IntegrationPointDataMatrix(IntegrationPointDataMatrix&& other)
-        : _b_matrices(std::move(other._b_matrices)),
-          _sigma(std::move(other._sigma)),
+        : _sigma(std::move(other._sigma)),
           _sigma_prev(std::move(other._sigma_prev)),
           _eps(std::move(other._eps)),
           _eps_prev(std::move(other._eps_prev)),
@@ -49,7 +48,6 @@ struct IntegrationPointDataMatrix final
     }
 #endif  // _MSC_VER
 
-    typename BMatricesType::BMatrixType _b_matrices;
     typename BMatricesType::KelvinVectorType _sigma, _sigma_prev;
     typename BMatricesType::KelvinVectorType _eps, _eps_prev;
 
@@ -61,6 +59,9 @@ struct IntegrationPointDataMatrix final
     typename BMatricesType::KelvinMatrixType _C;
     double _detJ;
     double _integralMeasure;
+
+    typename ShapeMatricesType::NodalRowVectorType N;
+    typename ShapeMatricesType::GlobalDimNodalMatrixType dNdx;
 
     void pushBackState()
     {

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix-impl.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix-impl.h
@@ -130,7 +130,7 @@ assembleWithJacobian(
             LinearBMatrix::computeBMatrix<DisplacementDim,
                                           ShapeFunction::NPOINTS,
                                           typename BMatricesType::BMatrixType>(
-                dNdx, _is_axially_symmetric, N, x_coord);
+                dNdx, N, x_coord, _is_axially_symmetric);
 
         auto const& eps_prev = _ip_data[ip]._eps_prev;
         auto const& sigma_prev = _ip_data[ip]._sigma_prev;

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
@@ -42,7 +42,6 @@ public:
     using ShapeMatrices = typename ShapeMatricesType::ShapeMatrices;
     using BMatricesType = BMatrixPolicyType<ShapeFunction, DisplacementDim>;
 
-    using BMatrixType = typename BMatricesType::BMatrixType;
     using StiffnessMatrixType = typename BMatricesType::StiffnessMatrixType;
     using NodalForceVectorType = typename BMatricesType::NodalForceVectorType;
     using NodalDisplacementVectorType =
@@ -159,13 +158,15 @@ private:
 
     SmallDeformationProcessData<DisplacementDim>& _process_data;
 
-    std::vector<IntegrationPointDataMatrix<BMatricesType, DisplacementDim>,
-                Eigen::aligned_allocator<
-                    IntegrationPointDataMatrix<BMatricesType, DisplacementDim>>>
+    std::vector<IntegrationPointDataMatrix<ShapeMatricesType, BMatricesType,
+                                           DisplacementDim>,
+                Eigen::aligned_allocator<IntegrationPointDataMatrix<
+                    ShapeMatricesType, BMatricesType, DisplacementDim>>>
         _ip_data;
 
     IntegrationMethod _integration_method;
     MeshLib::Element const& _element;
+    bool const _is_axially_symmetric;
     SecondaryData<typename ShapeMatrices::ShapeType> _secondary_data;
 };
 

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
@@ -208,7 +208,7 @@ assembleWithJacobian(
             LinearBMatrix::computeBMatrix<DisplacementDim,
                                           ShapeFunction::NPOINTS,
                                           typename BMatricesType::BMatrixType>(
-                dNdx, _is_axially_symmetric, N, x_coord);
+                dNdx, N, x_coord, _is_axially_symmetric);
 
         // strain, stress
         auto const& eps_prev = ip_data._eps_prev;

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
@@ -42,11 +42,12 @@ namespace LIE
 {
 namespace SmallDeformation
 {
-
-template <typename ShapeFunction, typename IntegrationMethod,
+template <typename ShapeFunction,
+          typename IntegrationMethod,
           int DisplacementDim>
-SmallDeformationLocalAssemblerMatrixNearFracture<ShapeFunction, IntegrationMethod,
-                               DisplacementDim>::
+SmallDeformationLocalAssemblerMatrixNearFracture<ShapeFunction,
+                                                 IntegrationMethod,
+                                                 DisplacementDim>::
     SmallDeformationLocalAssemblerMatrixNearFracture(
         MeshLib::Element const& e,
         std::size_t const n_variables,
@@ -60,12 +61,18 @@ SmallDeformationLocalAssemblerMatrixNearFracture<ShapeFunction, IntegrationMetho
           dofIndex_to_localIndex),
       _process_data(process_data),
       _integration_method(integration_order),
-      _shape_matrices(
-          initShapeMatrices<ShapeFunction, ShapeMatricesType,
-                            IntegrationMethod, DisplacementDim>(
-              e, is_axially_symmetric, _integration_method)),
-      _element(e)
+      _element(e),
+      _is_axially_symmetric(is_axially_symmetric)
 {
+    std::vector<
+        ShapeMatrices,
+        Eigen::aligned_allocator<typename ShapeMatricesType::ShapeMatrices>>
+        shape_matrices = initShapeMatrices<ShapeFunction,
+                                           ShapeMatricesType,
+                                           IntegrationMethod,
+                                           DisplacementDim>(
+            e, is_axially_symmetric, _integration_method);
+
     unsigned const n_integration_points =
         _integration_method.getNumberOfPoints();
 
@@ -76,20 +83,11 @@ SmallDeformationLocalAssemblerMatrixNearFracture<ShapeFunction, IntegrationMetho
     {
         _ip_data.emplace_back(*_process_data._material);
         auto& ip_data = _ip_data[ip];
-        auto const& sm = _shape_matrices[ip];
+        auto const& sm = shape_matrices[ip];
+        ip_data.N = sm.N;
+        ip_data.dNdx = sm.dNdx;
         ip_data._detJ = sm.detJ;
         ip_data._integralMeasure = sm.integralMeasure;
-        ip_data._b_matrices.resize(
-            KelvinVectorDimensions<DisplacementDim>::value,
-            ShapeFunction::NPOINTS * DisplacementDim);
-
-        auto const x_coord =
-            interpolateXCoordinate<ShapeFunction, ShapeMatricesType>(e,
-                                                                     sm.N);
-        LinearBMatrix::computeBMatrix<DisplacementDim,
-                                      ShapeFunction::NPOINTS>(
-            sm.dNdx, ip_data._b_matrices, is_axially_symmetric, sm.N,
-            x_coord);
 
         ip_data._sigma.resize(KelvinVectorDimensions<DisplacementDim>::value);
         ip_data._sigma_prev.resize(
@@ -184,13 +182,15 @@ assembleWithJacobian(
     {
         x_position.setIntegrationPoint(ip);
 
-        auto const& sm = _shape_matrices[ip];
         auto &ip_data = _ip_data[ip];
         auto const& wp = _integration_method.getWeightedPoint(ip);
         auto const ip_factor = ip_data._detJ * wp.getWeight() * ip_data._integralMeasure;
 
+        auto const& N = ip_data.N;
+        auto const& dNdx = ip_data.dNdx;
+
         // levelset functions
-        auto const ip_physical_coords = computePhysicalCoordinates(_element, sm.N);
+        auto const ip_physical_coords = computePhysicalCoordinates(_element, N);
         std::vector<double> levelsets(n_fractures);
         for (unsigned i = 0; i < n_fractures; i++)
             levelsets[i] = calculateLevelSetFunction(*_fracture_props[i],
@@ -201,8 +201,16 @@ assembleWithJacobian(
         for (unsigned i=0; i<n_fractures; i++)
             nodal_total_u += levelsets[i] * vec_nodal_g[i];
 
+        auto const x_coord =
+            interpolateXCoordinate<ShapeFunction, ShapeMatricesType>(_element,
+                                                                     N);
+        auto const B =
+            LinearBMatrix::computeBMatrix<DisplacementDim,
+                                          ShapeFunction::NPOINTS,
+                                          typename BMatricesType::BMatrixType>(
+                dNdx, _is_axially_symmetric, N, x_coord);
+
         // strain, stress
-        auto const& B = ip_data._b_matrices;
         auto const& eps_prev = ip_data._eps_prev;
         auto const& sigma_prev = ip_data._sigma_prev;
 

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
@@ -161,17 +161,16 @@ private:
     SmallDeformationProcessData<DisplacementDim>& _process_data;
     std::vector<FractureProperty*> _fracture_props;
 
-    std::vector<IntegrationPointDataMatrix<BMatricesType, DisplacementDim>,
-                Eigen::aligned_allocator<
-                    IntegrationPointDataMatrix<BMatricesType, DisplacementDim>>>
+    std::vector<IntegrationPointDataMatrix<ShapeMatricesType, BMatricesType,
+                                           DisplacementDim>,
+                Eigen::aligned_allocator<IntegrationPointDataMatrix<
+                    ShapeMatricesType, BMatricesType, DisplacementDim>>>
         _ip_data;
 
     IntegrationMethod _integration_method;
-    std::vector<ShapeMatrices, Eigen::aligned_allocator<
-                                   typename ShapeMatricesType::ShapeMatrices>>
-        _shape_matrices;
 
     MeshLib::Element const& _element;
+    bool const _is_axially_symmetric;
     SecondaryData<typename ShapeMatrices::ShapeType> _secondary_data;
 };
 

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -235,15 +235,13 @@ public:
             auto const& N = _ip_data[ip].N;
             auto const& dNdx = _ip_data[ip].dNdx;
 
-            typename BMatricesType::BMatrixType B(
-                KelvinVectorDimensions<DisplacementDim>(),
-                ShapeFunction::NPOINTS * DisplacementDim);
             auto const x_coord =
                 interpolateXCoordinate<ShapeFunction, ShapeMatricesType>(
                     _element, N);
-            LinearBMatrix::computeBMatrix<DisplacementDim,
-                                          ShapeFunction::NPOINTS>(
-                dNdx, B, _is_axially_symmetric, N, x_coord);
+            auto const B = LinearBMatrix::computeBMatrix<
+                DisplacementDim, ShapeFunction::NPOINTS,
+                typename BMatricesType::BMatrixType>(
+                dNdx, _is_axially_symmetric, N, x_coord);
 
             auto const& eps_prev = _ip_data[ip].eps_prev;
             auto const& sigma_prev = _ip_data[ip].sigma_prev;

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -240,8 +240,8 @@ public:
                     _element, N);
             auto const B = LinearBMatrix::computeBMatrix<
                 DisplacementDim, ShapeFunction::NPOINTS,
-                typename BMatricesType::BMatrixType>(
-                dNdx, _is_axially_symmetric, N, x_coord);
+                typename BMatricesType::BMatrixType>(dNdx, N, x_coord,
+                                                     _is_axially_symmetric);
 
             auto const& eps_prev = _ip_data[ip].eps_prev;
             auto const& sigma_prev = _ip_data[ip].sigma_prev;

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -31,7 +31,8 @@ namespace ProcessLib
 {
 namespace SmallDeformation
 {
-template <typename BMatricesType, int DisplacementDim>
+template <typename BMatricesType, typename ShapeMatricesType,
+          int DisplacementDim>
 struct IntegrationPointData final
 {
     explicit IntegrationPointData(
@@ -46,7 +47,6 @@ struct IntegrationPointData final
     // The default generated move-ctor is correctly generated for other
     // compilers.
     explicit IntegrationPointData(IntegrationPointData&& other)
-        : b_matrices(std::move(other.b_matrices)),
           sigma(std::move(other.sigma)),
           sigma_prev(std::move(other.sigma_prev)),
           eps(std::move(other.eps)),
@@ -58,7 +58,6 @@ struct IntegrationPointData final
     }
 #endif  // _MSC_VER
 
-    typename BMatricesType::BMatrixType b_matrices;
     typename BMatricesType::KelvinVectorType sigma, sigma_prev;
     typename BMatricesType::KelvinVectorType eps, eps_prev;
 
@@ -68,6 +67,8 @@ struct IntegrationPointData final
         material_state_variables;
 
     double integration_weight;
+    typename ShapeMatricesType::NodalRowVectorType N;
+    typename ShapeMatricesType::GlobalDimNodalMatrixType dNdx;
 
     void pushBackState()
     {
@@ -153,12 +154,13 @@ public:
     SmallDeformationLocalAssembler(
         MeshLib::Element const& e,
         std::size_t const /*local_matrix_size*/,
-        bool is_axially_symmetric,
+        bool const is_axially_symmetric,
         unsigned const integration_order,
         SmallDeformationProcessData<DisplacementDim>& process_data)
         : _process_data(process_data),
           _integration_method(integration_order),
-          _element(e)
+          _element(e),
+          _is_axially_symmetric(is_axially_symmetric)
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();
@@ -179,25 +181,15 @@ public:
             _ip_data[ip].integration_weight =
                 _integration_method.getWeightedPoint(ip).getWeight() *
                 sm.integralMeasure * sm.detJ;
-            ip_data.b_matrices.resize(
-                KelvinVectorDimensions<DisplacementDim>::value,
-                ShapeFunction::NPOINTS * DisplacementDim);
 
-            auto const x_coord =
-                interpolateXCoordinate<ShapeFunction, ShapeMatricesType>(e,
-                                                                         sm.N);
-            LinearBMatrix::computeBMatrix<DisplacementDim,
-                                          ShapeFunction::NPOINTS>(
-                sm.dNdx, ip_data.b_matrices, is_axially_symmetric, sm.N,
-                x_coord);
+            ip_data.N = sm.N;
+            ip_data.dNdx = sm.dNdx;
 
-            ip_data.sigma.resize(
-                KelvinVectorDimensions<DisplacementDim>::value);
+            ip_data.sigma.resize(KelvinVectorDimensions<DisplacementDim>::value);
             ip_data.sigma_prev.resize(
                 KelvinVectorDimensions<DisplacementDim>::value);
             ip_data.eps.resize(KelvinVectorDimensions<DisplacementDim>::value);
-            ip_data.eps_prev.resize(
-                KelvinVectorDimensions<DisplacementDim>::value);
+            ip_data.eps_prev.resize(KelvinVectorDimensions<DisplacementDim>::value);
 
             _secondary_data.N[ip] = shape_matrices[ip].N;
         }
@@ -240,8 +232,19 @@ public:
         {
             x_position.setIntegrationPoint(ip);
             auto const& w = _ip_data[ip].integration_weight;
+            auto const& N = _ip_data[ip].N;
+            auto const& dNdx = _ip_data[ip].dNdx;
 
-            auto const& B = _ip_data[ip].b_matrices;
+            typename BMatricesType::BMatrixType B(
+                KelvinVectorDimensions<DisplacementDim>(),
+                ShapeFunction::NPOINTS * DisplacementDim);
+            auto const x_coord =
+                interpolateXCoordinate<ShapeFunction, ShapeMatricesType>(
+                    _element, N);
+            LinearBMatrix::computeBMatrix<DisplacementDim,
+                                          ShapeFunction::NPOINTS>(
+                dNdx, B, _is_axially_symmetric, N, x_coord);
+
             auto const& eps_prev = _ip_data[ip].eps_prev;
             auto const& sigma_prev = _ip_data[ip].sigma_prev;
 
@@ -286,9 +289,10 @@ public:
         std::vector<double>& nodal_values) const override
     {
         return ProcessLib::SmallDeformation::getNodalForces<
-            DisplacementDim, ShapeFunction::NPOINTS,
-            NodalDisplacementVectorType>(nodal_values, _integration_method,
-                                         _ip_data, _element.getID());
+            DisplacementDim, ShapeFunction, ShapeMatricesType,
+            NodalDisplacementVectorType, typename BMatricesType::BMatrixType>(
+            nodal_values, _integration_method, _ip_data, _element,
+            _is_axially_symmetric);
     }
 
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
@@ -413,14 +417,16 @@ private:
 
     SmallDeformationProcessData<DisplacementDim>& _process_data;
 
-    std::vector<IntegrationPointData<BMatricesType, DisplacementDim>,
-                Eigen::aligned_allocator<
-                    IntegrationPointData<BMatricesType, DisplacementDim>>>
+    std::vector<
+        IntegrationPointData<BMatricesType, ShapeMatricesType, DisplacementDim>,
+        Eigen::aligned_allocator<IntegrationPointData<
+            BMatricesType, ShapeMatricesType, DisplacementDim>>>
         _ip_data;
 
     IntegrationMethod _integration_method;
     MeshLib::Element const& _element;
     SecondaryData<typename ShapeMatrices::ShapeType> _secondary_data;
+    bool const _is_axially_symmetric;
 };
 
 template <typename ShapeFunction, typename IntegrationMethod,

--- a/ProcessLib/SmallDeformationCommon/Common.h
+++ b/ProcessLib/SmallDeformationCommon/Common.h
@@ -61,8 +61,8 @@ std::vector<double> const& getNodalForces(
         auto const B =
             LinearBMatrix::computeBMatrix<DisplacementDim,
                                           ShapeFunction::NPOINTS, BMatrixType>(
-                _ip_data[ip].dNdx, is_axially_symmetric, _ip_data[ip].N,
-                x_coord);
+                _ip_data[ip].dNdx, _ip_data[ip].N, x_coord,
+                is_axially_symmetric);
         auto& sigma = _ip_data[ip].sigma;
 
         local_b.noalias() += B.transpose() * sigma * w;

--- a/ProcessLib/SmallDeformationCommon/Common.h
+++ b/ProcessLib/SmallDeformationCommon/Common.h
@@ -55,14 +55,14 @@ std::vector<double> const& getNodalForces(
         x_position.setIntegrationPoint(ip);
         auto const& w = _ip_data[ip].integration_weight;
 
-        BMatrixType B(KelvinVectorDimensions<DisplacementDim>(),
-                      ShapeFunction::NPOINTS * DisplacementDim);
         auto const x_coord =
             interpolateXCoordinate<ShapeFunction, ShapeMatricesType>(
                 element, _ip_data[ip].N);
-        LinearBMatrix::computeBMatrix<DisplacementDim, ShapeFunction::NPOINTS>(
-            _ip_data[ip].dNdx, B, is_axially_symmetric, _ip_data[ip].N,
-            x_coord);
+        auto const B =
+            LinearBMatrix::computeBMatrix<DisplacementDim,
+                                          ShapeFunction::NPOINTS, BMatrixType>(
+                _ip_data[ip].dNdx, is_axially_symmetric, _ip_data[ip].N,
+                x_coord);
         auto& sigma = _ip_data[ip].sigma;
 
         local_b.noalias() += B.transpose() * sigma * w;


### PR DESCRIPTION
This results in significantly lower memory usage (e.g. 16.8MiB now vs. 22MiB before for SmallDeformation process on cube_1e3 mesh). The run-time is not different or maybe a little higher now, but I didn't measure very carefully.