### PR TITLE
Fix secondary variable computation in HT process

### DIFF
--- a/Documentation/ProjectFile/prj/processes/process/HT/fluid/i_fluid.md
+++ b/Documentation/ProjectFile/prj/processes/process/HT/fluid/i_fluid.md
@@ -1,1 +1,1 @@
-Tag that encloses the specification of the fluid properties density and viscosity.
+Defines fluid properties.

--- a/Documentation/ProjectFile/prj/processes/process/HT/fluid/t_density.md
+++ b/Documentation/ProjectFile/prj/processes/process/HT/fluid/t_density.md
@@ -1,1 +1,0 @@
-Configuration for the constitutive laws for the fluid density from MaterialLib.

--- a/Documentation/ProjectFile/prj/processes/process/HT/fluid/t_viscosity.md
+++ b/Documentation/ProjectFile/prj/processes/process/HT/fluid/t_viscosity.md
@@ -1,1 +1,0 @@
-A tag describing the viscosity law for the process at hand.

--- a/Documentation/ProjectFile/prj/processes/process/HT/t_specific_heat_capacity_fluid.md
+++ b/Documentation/ProjectFile/prj/processes/process/HT/t_specific_heat_capacity_fluid.md
@@ -1,1 +1,0 @@
-Specific heat capacity of the fluid.

--- a/MaterialLib/Fluid/SpecificHeatCapacity/CreateSpecificFluidHeatCapacityModel.cpp
+++ b/MaterialLib/Fluid/SpecificHeatCapacity/CreateSpecificFluidHeatCapacityModel.cpp
@@ -36,7 +36,7 @@ std::unique_ptr<FluidProperty> createSpecificFluidHeatCapacityModel(
     // TODO: add more models
 
     OGS_FATAL(
-        "The viscosity type %s is unavailable.\n"
+        "The specific heat capacity type %s is unavailable.\n"
         "The available type is \n\tConstant\n",
         type.data());
 }

--- a/ProcessLib/HT/CreateHTProcess.cpp
+++ b/ProcessLib/HT/CreateHTProcess.cpp
@@ -135,14 +135,22 @@ std::unique_ptr<Process> createHTProcess(
          thermal_conductivity_fluid.name.c_str());
 
     // Specific body force parameter.
-    Eigen::Vector3d specific_body_force;
+    Eigen::VectorXd specific_body_force;
     std::vector<double> const b =
         //! \ogs_file_param{prj__processes__process__HT__specific_body_force}
         config.getConfigParameter<std::vector<double>>("specific_body_force");
-    assert(!b.empty() && b.size() < 4);
+    assert(b.size() > 0 && b.size() < 4);
+    if (b.size() < mesh.getDimension())
+        OGS_FATAL(
+            "specific body force (gravity vector) has %d components, mesh "
+            "dimension is %d",
+            b.size(), mesh.getDimension());
     bool const has_gravity = MathLib::toVector(b).norm() > 0;
     if (has_gravity)
+    {
+        specific_body_force.resize(b.size());
         std::copy_n(b.data(), b.size(), specific_body_force.data());
+    }
 
     HTProcessData process_data{
         std::move(porous_media_properties),

--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -194,8 +194,14 @@ public:
 
             auto const specific_heat_capacity_solid =
                 _process_data.specific_heat_capacity_solid(t, pos)[0];
+
+            vars[static_cast<int>(
+                MaterialLib::Fluid::PropertyVariableType::T)] = T_int_pt;
+            vars[static_cast<int>(
+                MaterialLib::Fluid::PropertyVariableType::p)] = p_int_pt;
             auto const specific_heat_capacity_fluid =
-                _process_data.specific_heat_capacity_fluid(t, pos)[0];
+                _process_data.fluid_properties->getValue(
+                    MaterialLib::Fluid::FluidPropertyType::HeatCapacity, vars);
 
             auto const thermal_dispersivity_longitudinal =
                 _process_data.thermal_dispersivity_longitudinal(t, pos)[0];
@@ -211,16 +217,14 @@ public:
             auto Bp = local_b.template block<num_nodes, 1>(num_nodes, 0);
 
             // Use the fluid density model to compute the density
-            vars[static_cast<int>(
-                MaterialLib::Fluid::PropertyVariableType::T)] = T_int_pt;
-            vars[static_cast<int>(
-                MaterialLib::Fluid::PropertyVariableType::p)] = p_int_pt;
             auto const density_water_T =
-                _process_data.fluid_density->getValue(vars);
+                _process_data.fluid_properties->getValue(
+                    MaterialLib::Fluid::FluidPropertyType::Density, vars);
 
             // Use the viscosity model to compute the viscosity
             auto const viscosity =
-                _process_data.viscosity_model->getValue(vars);
+                _process_data.fluid_properties->getValue(
+                    MaterialLib::Fluid::FluidPropertyType::Viscosity, vars);
             GlobalDimMatrixType perm_over_visc =
                 intrinsic_permeability / viscosity;
 

--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -225,9 +225,8 @@ public:
                 MaterialLib::Fluid::FluidPropertyType::Density, vars);
 
             // Use the viscosity model to compute the viscosity
-            auto const viscosity =
-                _process_data.fluid_properties->getValue(
-                    MaterialLib::Fluid::FluidPropertyType::Viscosity, vars);
+            auto const viscosity = _process_data.fluid_properties->getValue(
+                MaterialLib::Fluid::FluidPropertyType::Viscosity, vars);
             GlobalDimMatrixType K_over_mu = intrinsic_permeability / viscosity;
 
             GlobalDimVectorType const velocity =

--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -136,13 +136,19 @@ public:
         auto local_b = MathLib::createZeroedVector<LocalVectorType>(
             local_b_data, local_matrix_size);
 
-        unsigned const n_integration_points =
-            _integration_method.getNumberOfPoints();
+        auto const num_nodes = ShapeFunction::NPOINTS;
+
+        auto Ktt = local_K.template block<num_nodes, num_nodes>(0, 0);
+        auto Mtt = local_M.template block<num_nodes, num_nodes>(0, 0);
+        auto Kpp =
+            local_K.template block<num_nodes, num_nodes>(num_nodes, num_nodes);
+        auto Mpp =
+            local_M.template block<num_nodes, num_nodes>(num_nodes, num_nodes);
+        auto Bp = local_b.template block<num_nodes, 1>(num_nodes, 0);
 
         SpatialPosition pos;
         pos.setElementID(_element.getID());
 
-        auto const num_nodes = ShapeFunction::NPOINTS;
         auto p_nodal_values =
             Eigen::Map<const NodalVectorType>(&local_x[num_nodes], num_nodes);
 
@@ -152,6 +158,9 @@ public:
             GlobalDimMatrixType::Identity(GlobalDim, GlobalDim));
 
         MaterialLib::Fluid::FluidProperty::ArrayType vars;
+
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
 
         for (std::size_t ip(0); ip < n_integration_points; ip++)
         {
@@ -210,14 +219,6 @@ public:
                 _process_data.thermal_dispersivity_longitudinal(t, pos)[0];
             auto const thermal_dispersivity_transversal =
                 _process_data.thermal_dispersivity_transversal(t, pos)[0];
-
-            auto Ktt = local_K.template block<num_nodes, num_nodes>(0, 0);
-            auto Mtt = local_M.template block<num_nodes, num_nodes>(0, 0);
-            auto Kpp = local_K.template block<num_nodes, num_nodes>(num_nodes,
-                                                                    num_nodes);
-            auto Mpp = local_M.template block<num_nodes, num_nodes>(num_nodes,
-                                                                    num_nodes);
-            auto Bp = local_b.template block<num_nodes, 1>(num_nodes, 0);
 
             // Use the fluid density model to compute the density
             auto const density = _process_data.fluid_properties->getValue(

--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -148,6 +148,9 @@ public:
 
         auto const& b = _process_data.specific_body_force;
 
+        GlobalDimMatrixType const& I(
+            GlobalDimMatrixType::Identity(GlobalDim, GlobalDim));
+
         MaterialLib::Fluid::FluidProperty::ArrayType vars;
 
         for (std::size_t ip(0); ip < n_integration_points; ip++)
@@ -230,8 +233,6 @@ public:
                 -K_over_mu * (dNdx * p_nodal_values - density * b);
 
             double const velocity_magnitude = velocity.norm();
-            GlobalDimMatrixType const& I(
-                GlobalDimMatrixType::Identity(GlobalDim, GlobalDim));
             GlobalDimMatrixType const thermal_dispersivity =
                 fluid_reference_density * specific_heat_capacity_fluid *
                 (thermal_dispersivity_transversal * velocity_magnitude *

--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -175,7 +175,7 @@ public:
             auto const specific_storage =
                 _process_data.porous_media_properties.getSpecificStorage(t, pos)
                     .getValue(0.0);
-            auto const& intrinsic_permeability =
+            auto const intrinsic_permeability =
                 _process_data.porous_media_properties.getIntrinsicPermeability(
                     t, pos);
 

--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -146,7 +146,7 @@ public:
         auto p_nodal_values =
             Eigen::Map<const NodalVectorType>(&local_x[num_nodes], num_nodes);
 
-        auto const & b = _process_data.specific_body_force.head(GlobalDim);
+        auto const& b = _process_data.specific_body_force;
 
         MaterialLib::Fluid::FluidProperty::ArrayType vars;
 

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -98,6 +98,16 @@ void HTProcess::assembleWithJacobianConcreteProcess(
         dx_dx, M, K, b, Jac, coupling_term);
 }
 
+void HTProcess::computeSecondaryVariableConcrete(
+    double const t, GlobalVector const& x,
+    StaggeredCouplingTerm const& coupling_term)
+{
+    DBUG("Compute the Darcy velocity for HTProcess.");
+    GlobalExecutor::executeMemberOnDereferenced(
+        &HTLocalAssemblerInterface::computeSecondaryVariable, _local_assemblers,
+        *_local_to_global_index_map, t, x, coupling_term);
+}
+
 }  // namespace HT
 }  // namespace ProcessLib
 

--- a/ProcessLib/HT/HTProcess.h
+++ b/ProcessLib/HT/HTProcess.h
@@ -56,6 +56,9 @@ public:
 
     bool isLinear() const override { return false; }
     //! @}
+    void computeSecondaryVariableConcrete(
+        double const t, GlobalVector const& x,
+        StaggeredCouplingTerm const& coupling_term) override;
 
 private:
     void initializeConcreteProcess(

--- a/ProcessLib/HT/HTProcessData.h
+++ b/ProcessLib/HT/HTProcessData.h
@@ -12,10 +12,7 @@
 #include <memory>
 #include <utility>
 
-#include "MaterialLib/Fluid/FluidProperty.h"
-#include "MaterialLib/PorousMedium/Porosity/Porosity.h"
-#include "MaterialLib/PorousMedium/Storage/Storage.h"
-
+#include "MaterialLib/Fluid/FluidProperties/FluidProperties.h"
 #include "PorousMediaProperties.h"
 
 namespace ProcessLib
@@ -29,25 +26,22 @@ struct HTProcessData
 {
     HTProcessData(
         PorousMediaProperties&& porous_media_properties_,
-        std::unique_ptr<MaterialLib::Fluid::FluidProperty>&& viscosity_model_,
         ProcessLib::Parameter<double> const& density_solid_,
         ProcessLib::Parameter<double> const& fluid_reference_density_,
-        std::unique_ptr<MaterialLib::Fluid::FluidProperty>&& fluid_density_,
+        std::unique_ptr<MaterialLib::Fluid::FluidProperties>&&
+            fluid_properties_,
         ProcessLib::Parameter<double> const& thermal_dispersivity_longitudinal_,
         ProcessLib::Parameter<double> const& thermal_dispersivity_transversal_,
         ProcessLib::Parameter<double> const& specific_heat_capacity_solid_,
-        ProcessLib::Parameter<double> const& specific_heat_capacity_fluid_,
         ProcessLib::Parameter<double> const& thermal_conductivity_solid_,
         ProcessLib::Parameter<double> const& thermal_conductivity_fluid_,
         Eigen::VectorXd specific_body_force_,
         bool const has_gravity_)
         : porous_media_properties(std::move(porous_media_properties_)),
-          viscosity_model(std::move(viscosity_model_)),
           density_solid(density_solid_),
           fluid_reference_density(fluid_reference_density_),
-          fluid_density(std::move(fluid_density_)),
+          fluid_properties(std::move(fluid_properties_)),
           specific_heat_capacity_solid(specific_heat_capacity_solid_),
-          specific_heat_capacity_fluid(specific_heat_capacity_fluid_),
           thermal_dispersivity_longitudinal(thermal_dispersivity_longitudinal_),
           thermal_dispersivity_transversal(thermal_dispersivity_transversal_),
           thermal_conductivity_solid(thermal_conductivity_solid_),
@@ -59,12 +53,10 @@ struct HTProcessData
 
     HTProcessData(HTProcessData&& other)
         : porous_media_properties(std::move(other.porous_media_properties)),
-          viscosity_model(other.viscosity_model.release()),
           density_solid(other.density_solid),
           fluid_reference_density(other.fluid_reference_density),
-          fluid_density(other.fluid_density.release()),
+          fluid_properties(other.fluid_properties.release()),
           specific_heat_capacity_solid(other.specific_heat_capacity_solid),
-          specific_heat_capacity_fluid(other.specific_heat_capacity_fluid),
           thermal_dispersivity_longitudinal(
               other.thermal_dispersivity_longitudinal),
           thermal_dispersivity_transversal(
@@ -86,12 +78,10 @@ struct HTProcessData
     void operator=(HTProcessData&&) = delete;
 
     PorousMediaProperties porous_media_properties;
-    std::unique_ptr<MaterialLib::Fluid::FluidProperty> viscosity_model;
     Parameter<double> const& density_solid;
     Parameter<double> const& fluid_reference_density;
-    std::unique_ptr<MaterialLib::Fluid::FluidProperty> fluid_density;
+    std::unique_ptr<MaterialLib::Fluid::FluidProperties> fluid_properties;
     Parameter<double> const& specific_heat_capacity_solid;
-    Parameter<double> const& specific_heat_capacity_fluid;
     Parameter<double> const& thermal_dispersivity_longitudinal;
     Parameter<double> const& thermal_dispersivity_transversal;
     Parameter<double> const& thermal_conductivity_solid;

--- a/ProcessLib/HT/HTProcessData.h
+++ b/ProcessLib/HT/HTProcessData.h
@@ -39,7 +39,7 @@ struct HTProcessData
         ProcessLib::Parameter<double> const& specific_heat_capacity_fluid_,
         ProcessLib::Parameter<double> const& thermal_conductivity_solid_,
         ProcessLib::Parameter<double> const& thermal_conductivity_fluid_,
-        Eigen::Vector3d specific_body_force_,
+        Eigen::VectorXd specific_body_force_,
         bool const has_gravity_)
         : porous_media_properties(std::move(porous_media_properties_)),
           viscosity_model(std::move(viscosity_model_)),
@@ -96,7 +96,7 @@ struct HTProcessData
     Parameter<double> const& thermal_dispersivity_transversal;
     Parameter<double> const& thermal_conductivity_solid;
     Parameter<double> const& thermal_conductivity_fluid;
-    Eigen::Vector3d const specific_body_force;
+    Eigen::VectorXd const specific_body_force;
     bool const has_gravity;
 };
 


### PR DESCRIPTION
Also included:
- Use `FluidProperties` and `createFluidProperties` for handling of fluid density, viscosity and specific heat capacity.
- Improvements of readability.
- Small optimizations.

ToDo:
- [ ] Check (maybe together with @fabienma or @waltherm) the correctness of the darcy velocity.