### PR TITLE
[PETSc/MPI] Handle parallel cell properties

### DIFF
--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -329,7 +329,7 @@ NodeWiseMeshPartitioner::getNumberOfIntegerVariablesOfElements(
     return nmb_element_idxs;
 }
 
-void NodeWiseMeshPartitioner::writePropertiesBinary(
+void NodeWiseMeshPartitioner::writeNodePropertiesBinary(
     const std::string& file_name_base) const
 {
     auto const& property_names(_partitioned_properties.getPropertyVectorNames());
@@ -360,7 +360,8 @@ void NodeWiseMeshPartitioner::writePropertiesBinary(
             writePropertyVectorBinary<std::size_t>(name, out_val, out);
         if (!success)
             OGS_FATAL(
-                "writePropertiesBinary: Could not write PropertyVector '%s'.",
+                "writeNodePropertiesBinary: Could not write PropertyVector "
+                "'%s'.",
                 name.c_str());
     }
     unsigned long offset = 0;
@@ -534,7 +535,7 @@ void NodeWiseMeshPartitioner::writeNodesBinary(const std::string& file_name_base
 
 void NodeWiseMeshPartitioner::writeBinary(const std::string& file_name_base)
 {
-    writePropertiesBinary(file_name_base);
+    writeNodePropertiesBinary(file_name_base);
     const auto elem_integers = writeConfigDataBinary(file_name_base);
 
     const std::vector<IntegerType>& num_elem_integers

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -206,7 +206,7 @@ void NodeWiseMeshPartitioner::processPartition(std::size_t const part_id,
                                extra_nodes.end());
 }
 
-void NodeWiseMeshPartitioner::processProperties()
+void NodeWiseMeshPartitioner::processNodeProperties()
 {
     std::size_t const total_number_of_tuples =
         std::accumulate(std::begin(_partitions), std::end(_partitions), 0,
@@ -214,7 +214,7 @@ void NodeWiseMeshPartitioner::processProperties()
                             return sum + p.nodes.size();
                         });
 
-    INFO("total number of tuples after partitioning: %d ",
+    DBUG("total number of node-based tuples after partitioning: %d ",
          total_number_of_tuples);
     // 1 create new PV
     // 2 resize the PV with total_number_of_tuples
@@ -225,13 +225,21 @@ void NodeWiseMeshPartitioner::processProperties()
     for (auto const& name : property_names)
     {
         bool success =
-            copyPropertyVector<double>(name, total_number_of_tuples) ||
-            copyPropertyVector<float>(name, total_number_of_tuples) ||
-            copyPropertyVector<int>(name, total_number_of_tuples) ||
-            copyPropertyVector<long>(name, total_number_of_tuples) ||
-            copyPropertyVector<unsigned>(name, total_number_of_tuples) ||
-            copyPropertyVector<unsigned long>(name, total_number_of_tuples) ||
-            copyPropertyVector<std::size_t>(name, total_number_of_tuples);
+            copyNodePropertyVector<double>(name, total_number_of_tuples) ||
+            copyNodePropertyVector<float>(name, total_number_of_tuples) ||
+            copyNodePropertyVector<int>(name, total_number_of_tuples) ||
+            copyNodePropertyVector<long>(name, total_number_of_tuples) ||
+            copyNodePropertyVector<unsigned>(name, total_number_of_tuples) ||
+            copyNodePropertyVector<unsigned long>(name,
+                                                  total_number_of_tuples) ||
+            copyNodePropertyVector<std::size_t>(name, total_number_of_tuples);
+        if (!success)
+            WARN(
+                "processNodeProperties: Could not create partitioned "
+                "PropertyVector '%s'.",
+                name.c_str());
+    }
+}
         if (!success)
             WARN(
                 "processProperties: Could not create partitioned "
@@ -251,7 +259,7 @@ void NodeWiseMeshPartitioner::partitionByMETIS(
 
     renumberNodeIndices(is_mixed_high_order_linear_elems);
 
-    processProperties();
+    processNodeProperties();
 }
 
 void NodeWiseMeshPartitioner::renumberNodeIndices(

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -220,7 +220,8 @@ void NodeWiseMeshPartitioner::processProperties()
     // 2 resize the PV with total_number_of_tuples
     // 3 copy the values according to the partition info
     auto const& original_properties(_mesh->getProperties());
-    auto property_names = original_properties.getPropertyVectorNames();
+    auto const property_names =
+        original_properties.getPropertyVectorNames(MeshLib::MeshItemType::Node);
     for (auto const& name : property_names)
     {
         bool success =
@@ -332,9 +333,13 @@ NodeWiseMeshPartitioner::getNumberOfIntegerVariablesOfElements(
 void NodeWiseMeshPartitioner::writeNodePropertiesBinary(
     const std::string& file_name_base) const
 {
-    auto const& property_names(_partitioned_properties.getPropertyVectorNames());
+    auto const& property_names(_partitioned_properties.getPropertyVectorNames(
+        MeshLib::MeshItemType::Node));
     if (property_names.empty())
         return;
+
+    std::size_t number_of_properties(property_names.size());
+
     const std::string fname_cfg = file_name_base +
                                   "_partitioned_node_properties_cfg" +
                                   std::to_string(_npartitions) + ".bin";
@@ -345,7 +350,6 @@ void NodeWiseMeshPartitioner::writeNodePropertiesBinary(
                                   std::to_string(_npartitions) + ".bin";
     std::ofstream out_val(fname_val.c_str(), std::ios::binary | std::ios::out);
 
-    std::size_t number_of_properties(property_names.size());
     out.write(reinterpret_cast<char*>(&number_of_properties),
               sizeof(number_of_properties));
     for (auto const& name : property_names)

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -336,12 +336,12 @@ void NodeWiseMeshPartitioner::writeNodePropertiesBinary(
     if (property_names.empty())
         return;
     const std::string fname_cfg = file_name_base +
-                                  "_partitioned_properties_cfg" +
+                                  "_partitioned_node_properties_cfg" +
                                   std::to_string(_npartitions) + ".bin";
     std::ofstream out(fname_cfg.c_str(), std::ios::binary | std::ios::out);
 
     const std::string fname_val = file_name_base +
-                                  "_partitioned_properties_val" +
+                                  "_partitioned_node_properties_val" +
                                   std::to_string(_npartitions) + ".bin";
     std::ofstream out_val(fname_val.c_str(), std::ios::binary | std::ios::out);
 

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -103,8 +103,7 @@ void NodeWiseMeshPartitioner::findNonGhostNodesInPartition(
         partition.number_of_non_ghost_base_nodes + extra_nodes.size();
 }
 
-void NodeWiseMeshPartitioner::findElementsInPartition(
-    std::size_t const part_id, const bool is_mixed_high_order_linear_elems)
+void NodeWiseMeshPartitioner::findElementsInPartition(std::size_t const part_id)
 {
     auto& partition = _partitions[part_id];
     std::vector<MeshLib::Element*> const& elements = _mesh->getElements();
@@ -193,7 +192,7 @@ void NodeWiseMeshPartitioner::processPartition(std::size_t const part_id,
     findNonGhostNodesInPartition(part_id, is_mixed_high_order_linear_elems,
                                  extra_nodes);
 
-    findElementsInPartition(part_id, is_mixed_high_order_linear_elems);
+    findElementsInPartition(part_id);
     findGhostNodesInPartition(part_id, is_mixed_high_order_linear_elems,
                               extra_nodes);
     auto& partition = _partitions[part_id];

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -132,6 +132,7 @@ private:
                                     IntegerType& counter);
 
     void writeNodePropertiesBinary(std::string const& file_name_base) const;
+    void writeCellPropertiesBinary(std::string const& file_name_base) const;
 
     /// 1 copy pointers to nodes belonging to the partition part_id
     /// 2 collect non-linear element nodes belonging to the partition part_id in

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -130,7 +130,7 @@ private:
                                     std::vector<IntegerType>& elem_info,
                                     IntegerType& counter);
 
-    void writePropertiesBinary(std::string const& file_name_base) const;
+    void writeNodePropertiesBinary(std::string const& file_name_base) const;
 
     /// 1 copy pointers to nodes belonging to the partition part_id
     /// 2 collect non-linear element nodes belonging to the partition part_id in

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -146,8 +146,7 @@ private:
     /// fills vector partition.regular_elements
     /// 2 find ghost elements belonging to the partition part_id
     /// fills vector partition.ghost_elements
-    void findElementsInPartition(std::size_t const part_id,
-                                 const bool is_mixed_high_order_linear_elems);
+    void findElementsInPartition(std::size_t const part_id);
 
     /// Prerequisite: the ghost elements has to be found (using
     /// findElementsInPartition).

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -164,10 +164,10 @@ private:
     void processPartition(std::size_t const part_id,
                           const bool is_mixed_high_order_linear_elems);
 
-    void processProperties();
+    void processNodeProperties();
 
     template <typename T>
-    bool copyPropertyVector(std::string const& name,
+    bool copyNodePropertyVector(std::string const& name,
                             std::size_t const total_number_of_tuples)
     {
         auto const& original_properties(_mesh->getProperties());

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
@@ -198,6 +198,12 @@ MeshLib::NodePartitionedMesh* NodePartitionedMeshReader::readBinary(
 MeshLib::Properties NodePartitionedMeshReader::readPropertiesBinary(
     const std::string& file_name_base) const
 {
+    return readNodePropertiesBinary(file_name_base);
+}
+
+MeshLib::Properties NodePartitionedMeshReader::readNodePropertiesBinary(
+    const std::string& file_name_base) const
+{
     const std::string fname_cfg = file_name_base +
                                   "_partitioned_properties_cfg" +
                                   std::to_string(_mpi_comm_size) + ".bin";

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
@@ -199,11 +199,12 @@ MeshLib::Properties NodePartitionedMeshReader::readPropertiesBinary(
     const std::string& file_name_base) const
 {
     MeshLib::Properties p;
-    readNodePropertiesBinary(file_name_base, MeshLib::MeshItemType::Node, p);
+    readPropertiesBinary(file_name_base, MeshLib::MeshItemType::Node, p);
+    readPropertiesBinary(file_name_base, MeshLib::MeshItemType::Cell, p);
     return p;
 }
 
-void NodePartitionedMeshReader::readNodePropertiesBinary(
+void NodePartitionedMeshReader::readPropertiesBinary(
     const std::string& file_name_base, MeshLib::MeshItemType t,
     MeshLib::Properties& p) const
 {

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
@@ -295,10 +295,10 @@ void NodePartitionedMeshReader::readDomainSpecificPartOfPropertyVectors(
             if (vec_pvmd[i]->is_data_type_signed)
             {
                 if (vec_pvmd[i]->data_type_size_in_bytes == sizeof(int))
-                    createPropertyVectorPart<int>(is, *vec_pvmd[i], pvpmd,
+                    createPropertyVectorPart<int>(is, *vec_pvmd[i], pvpmd, t,
                                                   global_offset, p);
                 if (vec_pvmd[i]->data_type_size_in_bytes == sizeof(long))
-                    createPropertyVectorPart<long>(is, *vec_pvmd[i], pvpmd,
+                    createPropertyVectorPart<long>(is, *vec_pvmd[i], pvpmd, t,
                                                    global_offset, p);
             }
             else
@@ -306,20 +306,20 @@ void NodePartitionedMeshReader::readDomainSpecificPartOfPropertyVectors(
                 if (vec_pvmd[i]->data_type_size_in_bytes ==
                     sizeof(unsigned int))
                     createPropertyVectorPart<unsigned int>(
-                        is, *vec_pvmd[i], pvpmd, global_offset, p);
+                        is, *vec_pvmd[i], pvpmd, t, global_offset, p);
                 if (vec_pvmd[i]->data_type_size_in_bytes ==
                     sizeof(unsigned long))
                     createPropertyVectorPart<unsigned long>(
-                        is, *vec_pvmd[i], pvpmd, global_offset, p);
+                        is, *vec_pvmd[i], pvpmd, t, global_offset, p);
             }
         }
         else
         {
             if (vec_pvmd[i]->data_type_size_in_bytes == sizeof(float))
-                createPropertyVectorPart<float>(is, *vec_pvmd[i], pvpmd,
+                createPropertyVectorPart<float>(is, *vec_pvmd[i], pvpmd, t,
                                                 global_offset, p);
             if (vec_pvmd[i]->data_type_size_in_bytes == sizeof(double))
-                createPropertyVectorPart<double>(is, *vec_pvmd[i], pvpmd,
+                createPropertyVectorPart<double>(is, *vec_pvmd[i], pvpmd, t,
                                                  global_offset, p);
         }
         global_offset += vec_pvmd[i]->data_type_size_in_bytes *

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
@@ -205,7 +205,7 @@ MeshLib::Properties NodePartitionedMeshReader::readNodePropertiesBinary(
     const std::string& file_name_base) const
 {
     const std::string fname_cfg = file_name_base +
-                                  "_partitioned_properties_cfg" +
+                                  "_partitioned_node_properties_cfg" +
                                   std::to_string(_mpi_comm_size) + ".bin";
     std::ifstream is(fname_cfg.c_str(), std::ios::binary | std::ios::in);
     if (!is)
@@ -257,8 +257,9 @@ MeshLib::Properties NodePartitionedMeshReader::readNodePropertiesBinary(
     DBUG("[%d] %d tuples in partition.", _mpi_rank, pvpmd->number_of_tuples);
     is.close();
 
-    const std::string fname_val = file_name_base + "_partitioned_properties_val"
-                              + std::to_string(_mpi_comm_size) + ".bin";
+    const std::string fname_val = file_name_base +
+                                  "_partitioned_node_properties_val" +
+                                  std::to_string(_mpi_comm_size) + ".bin";
     is.open(fname_val.c_str(), std::ios::binary | std::ios::in);
     if (!is)
     {

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
@@ -198,20 +198,25 @@ MeshLib::NodePartitionedMesh* NodePartitionedMeshReader::readBinary(
 MeshLib::Properties NodePartitionedMeshReader::readPropertiesBinary(
     const std::string& file_name_base) const
 {
-    return readNodePropertiesBinary(file_name_base);
+    MeshLib::Properties p;
+    readNodePropertiesBinary(file_name_base, MeshLib::MeshItemType::Node, p);
+    return p;
 }
 
-MeshLib::Properties NodePartitionedMeshReader::readNodePropertiesBinary(
-    const std::string& file_name_base) const
+void NodePartitionedMeshReader::readNodePropertiesBinary(
+    const std::string& file_name_base, MeshLib::MeshItemType t,
+    MeshLib::Properties& p) const
 {
-    const std::string fname_cfg = file_name_base +
-                                  "_partitioned_node_properties_cfg" +
+    std::string const item_type =
+        t == MeshLib::MeshItemType::Node ? "node" : "cell";
+    const std::string fname_cfg = file_name_base + "_partitioned_" + item_type +
+                                  "_properties_cfg" +
                                   std::to_string(_mpi_comm_size) + ".bin";
     std::ifstream is(fname_cfg.c_str(), std::ios::binary | std::ios::in);
     if (!is)
     {
         WARN("Could not open file '%s' in binary mode.", fname_cfg.c_str());
-        return MeshLib::Properties();
+        return;
     }
     std::size_t number_of_properties = 0;
     is.read(reinterpret_cast<char*>(&number_of_properties), sizeof(std::size_t));
@@ -257,8 +262,8 @@ MeshLib::Properties NodePartitionedMeshReader::readNodePropertiesBinary(
     DBUG("[%d] %d tuples in partition.", _mpi_rank, pvpmd->number_of_tuples);
     is.close();
 
-    const std::string fname_val = file_name_base +
-                                  "_partitioned_node_properties_val" +
+    const std::string fname_val = file_name_base + "_partitioned_" + item_type +
+                                  "_properties_val" +
                                   std::to_string(_mpi_comm_size) + ".bin";
     is.open(fname_val.c_str(), std::ios::binary | std::ios::in);
     if (!is)
@@ -266,25 +271,34 @@ MeshLib::Properties NodePartitionedMeshReader::readNodePropertiesBinary(
         ERR("Could not open file '%s' in binary mode.", fname_val.c_str());
     }
 
-    MeshLib::Properties p;
+    readDomainSpecificPartOfPropertyVectors(vec_pvmd, *pvpmd, t, is, p);
+}
 
-    // Read the specific parts of the PropertyVector values for this process.
+void NodePartitionedMeshReader::readDomainSpecificPartOfPropertyVectors(
+    std::vector<boost::optional<MeshLib::IO::PropertyVectorMetaData>> const&
+        vec_pvmd,
+    MeshLib::IO::PropertyVectorPartitionMetaData const& pvpmd,
+    MeshLib::MeshItemType t,
+    std::istream& is,
+    MeshLib::Properties& p) const
+{
     unsigned long global_offset = 0;
+    std::size_t const number_of_properties = vec_pvmd.size();
     for (std::size_t i(0); i < number_of_properties; ++i)
     {
-        INFO("[%d] global offset: %d, offset within the PropertyVector: %d.",
+        DBUG("[%d] global offset: %d, offset within the PropertyVector: %d.",
              _mpi_rank, global_offset,
              global_offset +
-                 pvpmd->offset * vec_pvmd[i]->data_type_size_in_bytes);
+                 pvpmd.offset * vec_pvmd[i]->data_type_size_in_bytes);
         if (vec_pvmd[i]->is_int_type)
         {
             if (vec_pvmd[i]->is_data_type_signed)
             {
                 if (vec_pvmd[i]->data_type_size_in_bytes == sizeof(int))
-                    createPropertyVectorPart<int>(is, *vec_pvmd[i], *pvpmd,
+                    createPropertyVectorPart<int>(is, *vec_pvmd[i], pvpmd,
                                                   global_offset, p);
                 if (vec_pvmd[i]->data_type_size_in_bytes == sizeof(long))
-                    createPropertyVectorPart<long>(is, *vec_pvmd[i], *pvpmd,
+                    createPropertyVectorPart<long>(is, *vec_pvmd[i], pvpmd,
                                                    global_offset, p);
             }
             else
@@ -292,32 +306,31 @@ MeshLib::Properties NodePartitionedMeshReader::readNodePropertiesBinary(
                 if (vec_pvmd[i]->data_type_size_in_bytes ==
                     sizeof(unsigned int))
                     createPropertyVectorPart<unsigned int>(
-                        is, *vec_pvmd[i], *pvpmd, global_offset, p);
+                        is, *vec_pvmd[i], pvpmd, global_offset, p);
                 if (vec_pvmd[i]->data_type_size_in_bytes ==
                     sizeof(unsigned long))
                     createPropertyVectorPart<unsigned long>(
-                        is, *vec_pvmd[i], *pvpmd, global_offset, p);
+                        is, *vec_pvmd[i], pvpmd, global_offset, p);
             }
         }
         else
         {
             if (vec_pvmd[i]->data_type_size_in_bytes == sizeof(float))
-                createPropertyVectorPart<float>(is, *vec_pvmd[i], *pvpmd,
+                createPropertyVectorPart<float>(is, *vec_pvmd[i], pvpmd,
                                                 global_offset, p);
             if (vec_pvmd[i]->data_type_size_in_bytes == sizeof(double))
-                createPropertyVectorPart<double>(is, *vec_pvmd[i], *pvpmd,
+                createPropertyVectorPart<double>(is, *vec_pvmd[i], pvpmd,
                                                  global_offset, p);
         }
         global_offset += vec_pvmd[i]->data_type_size_in_bytes *
                          vec_pvmd[i]->number_of_tuples *
                          vec_pvmd[i]->number_of_components;
     }
-
-    return p;
 }
 
-bool NodePartitionedMeshReader::openASCIIFiles(std::string const& file_name_base,
-    std::ifstream& is_cfg, std::ifstream& is_node, std::ifstream& is_elem) const
+bool NodePartitionedMeshReader::openASCIIFiles(
+    std::string const& file_name_base, std::ifstream& is_cfg,
+    std::ifstream& is_node, std::ifstream& is_elem) const
 {
     const std::string fname_header = file_name_base +  "_partitioned_";
     const std::string fname_num_p_ext = std::to_string(_mpi_comm_size) + ".msh";

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
@@ -168,8 +168,17 @@ private:
     MeshLib::Properties readPropertiesBinary(
         const std::string& file_name_base) const;
 
-    MeshLib::Properties readNodePropertiesBinary(
-        const std::string& file_name_base) const;
+    void readNodePropertiesBinary(const std::string& file_name_base,
+                                  MeshLib::MeshItemType t,
+                                  MeshLib::Properties& p) const;
+
+    void readDomainSpecificPartOfPropertyVectors(
+        std::vector<boost::optional<MeshLib::IO::PropertyVectorMetaData>> const&
+            vec_pvmd,
+        MeshLib::IO::PropertyVectorPartitionMetaData const& pvpmd,
+        MeshLib::MeshItemType t,
+        std::istream& is,
+        MeshLib::Properties& p) const;
 
     template <typename T>
     void createPropertyVectorPart(

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
@@ -168,9 +168,9 @@ private:
     MeshLib::Properties readPropertiesBinary(
         const std::string& file_name_base) const;
 
-    void readNodePropertiesBinary(const std::string& file_name_base,
-                                  MeshLib::MeshItemType t,
-                                  MeshLib::Properties& p) const;
+    void readPropertiesBinary(const std::string& file_name_base,
+                              MeshLib::MeshItemType t,
+                              MeshLib::Properties& p) const;
 
     void readDomainSpecificPartOfPropertyVectors(
         std::vector<boost::optional<MeshLib::IO::PropertyVectorMetaData>> const&

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
@@ -184,12 +184,11 @@ private:
     void createPropertyVectorPart(
         std::istream& is, MeshLib::IO::PropertyVectorMetaData const& pvmd,
         MeshLib::IO::PropertyVectorPartitionMetaData const& pvpmd,
-        unsigned long global_offset, MeshLib::Properties& p) const
+        MeshLib::MeshItemType t, unsigned long global_offset,
+        MeshLib::Properties& p) const
     {
-        MeshLib::PropertyVector<T>* pv =
-            p.createNewPropertyVector<T>(pvmd.property_name,
-                                         MeshLib::MeshItemType::Node,
-                                         pvmd.number_of_components);
+        MeshLib::PropertyVector<T>* pv = p.createNewPropertyVector<T>(
+            pvmd.property_name, t, pvmd.number_of_components);
         pv->resize(pvpmd.number_of_tuples * pvmd.number_of_components);
         // jump to the place for reading the specific part of the
         // PropertyVector

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
@@ -165,7 +165,11 @@ private:
      */
     MeshLib::NodePartitionedMesh* readBinary(const std::string &file_name_base);
 
-    MeshLib::Properties readPropertiesBinary(const std::string& file_name_base) const;
+    MeshLib::Properties readPropertiesBinary(
+        const std::string& file_name_base) const;
+
+    MeshLib::Properties readNodePropertiesBinary(
+        const std::string& file_name_base) const;
 
     template <typename T>
     void createPropertyVectorPart(

--- a/MeshLib/IO/MPI_IO/PropertyVectorMetaData.h
+++ b/MeshLib/IO/MPI_IO/PropertyVectorMetaData.h
@@ -74,7 +74,7 @@ inline void writePropertyVectorMetaData(PropertyVectorMetaData const& pvmd)
     DBUG("is_int_data_type: %d", pvmd.is_int_type);
     DBUG("is_data_type_signed: %d", pvmd.is_data_type_signed);
     DBUG("data_type_size_in_bytes: %d", pvmd.data_type_size_in_bytes);
-    DBUG("number of components: i%d", pvmd.number_of_components);
+    DBUG("number of components: %d", pvmd.number_of_components);
     DBUG("number of tuples: %d", pvmd.number_of_tuples);
 }
 


### PR DESCRIPTION
- Implementation the partition of cell properties in util partmesh (class `NodeWiseMeshPartitioner`)
- Implementation of functionality to read the parallelized cell properties in `NodePartitionedMeshReader`.