### PR TITLE
Decouple ProcessLib from DataExplorer

### DIFF
--- a/Applications/DataExplorer/CMakeLists.txt
+++ b/Applications/DataExplorer/CMakeLists.txt
@@ -9,7 +9,6 @@ endif()
 
 if(VTKFBXCONVERTER_FOUND)
     add_definitions(-DVTKFBXCONVERTER_FOUND)
-    include_directories(${VTKFBXCONVERTER_INCLUDE_DIRS})
 endif()
 
 # Add subprojects

--- a/Applications/DataExplorer/DataExplorer.cmake
+++ b/Applications/DataExplorer/DataExplorer.cmake
@@ -7,15 +7,6 @@ set(SOURCES
 
 set(SOURCE_DIR_REL ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 include_directories(
-    ${SOURCE_DIR_REL}/Applications/Utils/OGSFileConverter
-    ${SOURCE_DIR_REL}/Applications/FileIO
-    ${SOURCE_DIR_REL}/BaseLib
-    ${SOURCE_DIR_REL}/MathLib
-    ${SOURCE_DIR_REL}/GeoLib
-    ${SOURCE_DIR_REL}/FileIO
-    ${SOURCE_DIR_REL}/MeshLib
-    ${SOURCE_DIR_REL}/MeshLibGEOTOOLS
-    ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/Base
     ${CMAKE_CURRENT_SOURCE_DIR}/DataView
     ${CMAKE_CURRENT_SOURCE_DIR}/DataView/StratView

--- a/Applications/DataExplorer/DataExplorer.cmake
+++ b/Applications/DataExplorer/DataExplorer.cmake
@@ -49,7 +49,6 @@ target_link_libraries(DataExplorer
     GeoLib
     MeshGeoToolsLib
     MeshLib
-    ApplicationsLib
     ApplicationsFileIO
     DataHolderLib
     OGSFileConverterLib

--- a/Applications/DataExplorer/DataView/GeoTreeModel.h
+++ b/Applications/DataExplorer/DataView/GeoTreeModel.h
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include <vtkPolyDataAlgorithm.h>
 #include <vector>
 
-#include "GeoType.h"
-#include "PointVec.h"
-#include "PolylineVec.h"
-#include "SurfaceVec.h"
+#include "GeoLib/GeoType.h"
+#include "GeoLib/PointVec.h"
+#include "GeoLib/PolylineVec.h"
+#include "GeoLib/SurfaceVec.h"
 #include "TreeModel.h"
-#include <vtkPolyDataAlgorithm.h>
 
 namespace GeoLib
 {

--- a/Applications/DataExplorer/DataView/GeoTreeView.h
+++ b/Applications/DataExplorer/DataView/GeoTreeView.h
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include "GeoType.h"
-
 #include <QContextMenuEvent>
 #include <QTreeView>
+
+#include "GeoLib/GeoType.h"
 
 class vtkPolyDataAlgorithm;
 

--- a/Applications/DataExplorer/DataView/LineEditDialog.h
+++ b/Applications/DataExplorer/DataView/LineEditDialog.h
@@ -15,9 +15,9 @@
 #pragma once
 
 #include "ui_LineEdit.h"
-#include <QDialog>
 
-#include "PolylineVec.h"
+#include <QDialog>
+#include "GeoLib/PolylineVec.h"
 
 class QStringListModel;
 

--- a/Applications/DataExplorer/DataView/MeshQualitySelectionDialog.h
+++ b/Applications/DataExplorer/DataView/MeshQualitySelectionDialog.h
@@ -14,9 +14,10 @@
 
 #pragma once
 
-#include "MeshEnums.h"
 #include "ui_MeshQualitySelection.h"
+
 #include <QDialog>
+#include "MeshLib/MeshEnums.h"
 
 class VtkMeshSource;
 

--- a/Applications/DataExplorer/DataView/ModelTreeItem.h
+++ b/Applications/DataExplorer/DataView/ModelTreeItem.h
@@ -14,8 +14,9 @@
 
 #pragma once
 
+#include "GeoLib/Station.h"
+
 #include "BaseItem.h"
-#include "Station.h"
 #include "TreeItem.h"
 
 /**

--- a/Applications/DataExplorer/DataView/MshView.h
+++ b/Applications/DataExplorer/DataView/MshView.h
@@ -13,9 +13,9 @@
  */
 #pragma once
 
-#include "Point.h"
-#include "GeoType.h"
 #include <QTreeView>
+#include "GeoLib/GeoType.h"
+#include "GeoLib/Point.h"
 
 class MshModel;
 class vtkUnstructuredGridAlgorithm;

--- a/Applications/DataExplorer/DataView/SetNameDialog.h
+++ b/Applications/DataExplorer/DataView/SetNameDialog.h
@@ -14,9 +14,8 @@
 
 #pragma once
 
-#include "GeoType.h"
-
 #include <QDialog>
+#include "GeoLib/GeoType.h"
 
 class QDialogButtonBox;
 class QLabel;

--- a/Applications/DataExplorer/DataView/StationTreeModel.h
+++ b/Applications/DataExplorer/DataView/StationTreeModel.h
@@ -14,12 +14,13 @@
 
 #pragma once
 
+#include <vtkPolyDataAlgorithm.h>
 #include <vector>
 
+#include "GeoLib/Point.h"
+
 #include "ModelTreeItem.h"
-#include "Point.h"
 #include "TreeModel.h"
-#include <vtkPolyDataAlgorithm.h>
 
 namespace GeoLib
 {

--- a/Applications/DataExplorer/DataView/StationTreeView.h
+++ b/Applications/DataExplorer/DataView/StationTreeView.h
@@ -14,10 +14,9 @@
 
 #pragma once
 
-#include "Station.h"
-
 #include <QContextMenuEvent>
 #include <QTreeView>
+#include "GeoLib/Station.h"
 
 class vtkPolyDataAlgorithm;
 

--- a/Applications/DataExplorer/VtkVis/VisPrefsDialog.h
+++ b/Applications/DataExplorer/VtkVis/VisPrefsDialog.h
@@ -14,9 +14,10 @@
 
 #pragma once
 
-#include "Point.h"
 #include "ui_VisPrefs.h"
+
 #include <QDialog>
+#include "GeoLib/Point.h"
 
 class VtkVisPipeline;
 class VisualizationWidget;

--- a/Applications/DataExplorer/VtkVis/VtkStationSource.h
+++ b/Applications/DataExplorer/VtkVis/VtkStationSource.h
@@ -16,8 +16,8 @@
 
 #include <vtkPolyDataAlgorithm.h>
 
-#include "Station.h"
 #include "Applications/DataHolderLib/Color.h"
+#include "GeoLib/Station.h"
 #include "VtkAlgorithmProperties.h"
 
 /**

--- a/Applications/DataExplorer/VtkVis/VtkVisPipeline.h
+++ b/Applications/DataExplorer/VtkVis/VtkVisPipeline.h
@@ -17,11 +17,11 @@
 #include <QMap>
 #include <QVector>
 
-#include "GeoType.h"
-#include "MeshEnums.h"
-#include "Point.h"
-#include "TreeModel.h"
 #include "Applications/DataHolderLib/Color.h"
+#include "GeoLib/GeoType.h"
+#include "GeoLib/Point.h"
+#include "MeshLib/MeshEnums.h"
+#include "TreeModel.h"
 
 class vtkAlgorithm;
 class vtkDataSet;

--- a/Applications/DataExplorer/VtkVis/VtkVisPipelineItem.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkVisPipelineItem.cpp
@@ -35,10 +35,9 @@
 #include <QMessageBox>
 
 #ifdef VTKFBXCONVERTER_FOUND
-#include "ThirdParty/VtkFbxConverter/VtkFbxConverter.h"
-#include "Common.h"
 #include <fbxsdk.h>
-
+#include "ThirdParty/VtkFbxConverter/Common.h"
+#include "ThirdParty/VtkFbxConverter/VtkFbxConverter.h"
 
 extern FbxManager* lSdkManager;
 extern FbxScene* lScene;

--- a/Applications/DataExplorer/VtkVis/VtkVisPipelineItem.h
+++ b/Applications/DataExplorer/VtkVis/VtkVisPipelineItem.h
@@ -14,15 +14,14 @@
 
 #pragma once
 
-// ** INCLUDES **
-#include "BuildInfo.h"
-#include "TreeItem.h"
-
 #include <QList>
 #include <QMap>
-//#include <QObject>
 #include <QString>
 #include <QVariant>
+
+#include "BaseLib/BuildInfo.h"
+
+#include "TreeItem.h"
 
 class QStringList;
 class vtkAlgorithm;

--- a/Applications/DataExplorer/main.cpp
+++ b/Applications/DataExplorer/main.cpp
@@ -1,10 +1,9 @@
 #include "mainwindow.h"
 
-#include <memory>
 #include <QApplication>
-
 #include <logog/include/logog.hpp>
-#include "LogogSimpleFormatter.h"
+#include <memory>
+
 #ifdef VTKFBXCONVERTER_FOUND
 #include <fbxsdk.h>
 #include "ThirdParty/VtkFbxConverter/Common.h"
@@ -15,6 +14,7 @@ FbxScene* lScene = nullptr;
 #include <vtkSmartPointer.h>
 
 #include "BaseLib/BuildInfo.h"
+#include "BaseLib/LogogSimpleFormatter.h"
 #include "VtkVis/VtkConsoleOutputWindow.h"
 
 int main(int argc, char* argv[])

--- a/Applications/DataExplorer/main.cpp
+++ b/Applications/DataExplorer/main.cpp
@@ -7,7 +7,7 @@
 #include "LogogSimpleFormatter.h"
 #ifdef VTKFBXCONVERTER_FOUND
 #include <fbxsdk.h>
-#include "Common.h"
+#include "ThirdParty/VtkFbxConverter/Common.h"
 FbxManager* lSdkManager = nullptr;
 FbxScene* lScene = nullptr;
 #endif

--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -16,73 +16,6 @@
 
 #include <logog/include/logog.hpp>
 
-// BaseLib
-#include "BaseLib/BuildInfo.h"
-#include "BaseLib/FileTools.h"
-#include "BaseLib/Histogram.h"
-
-// GeoLib
-#include "Raster.h"
-#include "GeoLib/IO/Legacy/OGSIOVer4.h"
-#include "GeoLib/DuplicateGeometry.h"
-
-// MeshGeoLib
-#include "MeshGeoToolsLib/GeoMapper.h"
-
-//dialogs
-#include "CreateStructuredGridDialog.h"
-#include "DataExplorerSettingsDialog.h"
-#include "DiagramPrefsDialog.h"
-#include "GeoOnMeshMappingDialog.h"
-#include "GMSHPrefsDialog.h"
-#include "LicenseDialog.h"
-#include "LineEditDialog.h"
-#include "MergeGeometriesDialog.h"
-#include "MeshAnalysisDialog.h"
-#include "MeshElementRemovalDialog.h"
-#include "MeshQualitySelectionDialog.h"
-#include "NetCdfConfigureDialog.h"
-#include "SetNameDialog.h"
-#include "SHPImportDialog.h"
-#include "VtkAddFilterDialog.h"
-
-#include "GeoTreeModel.h"
-#include "LastSavedFileDirectory.h"
-#include "OGSError.h"
-#include "RecentFiles.h"
-#include "StationTreeModel.h"
-#include "TreeModelIterator.h"
-#include "VtkBGImageSource.h"
-#include "VtkGeoImageSource.h"
-#include "VtkRaster.h"
-#include "VtkVisPipelineItem.h"
-
-#include "MeshLib/Vtk/VtkMappedMeshSource.h"
-
-// FileIO includes
-#include "GMSInterface.h"
-#include "Applications/FileIO/FEFLOW/FEFLOWMeshInterface.h"
-#include "MeshLib/IO/Legacy/MeshIO.h"
-#include "MeshLib/IO/readMeshFromFile.h"
-#include "Applications/FileIO/AsciiRasterInterface.h"
-#include "Applications/FileIO/PetrelInterface.h"
-#include "Applications/FileIO/Gmsh/GmshReader.h"
-#include "Applications/FileIO/TetGenInterface.h"
-#include "Applications/FileIO/XmlIO/Qt/XmlGspInterface.h"
-#include "Applications/FileIO/Gmsh/GMSHInterface.h"
-#include "Applications/FileIO/FEFLOW/FEFLOWGeoInterface.h"
-#include "Applications/FileIO/Gmsh/GMSHInterface.h"
-#include "GeoLib/IO/XmlIO/Qt/XmlGmlInterface.h"
-#include "GeoLib/IO/XmlIO/Qt/XmlStnInterface.h"
-
-// MeshLib
-#include "Node.h"
-#include "Mesh.h"
-#include "Elements/Element.h"
-#include "MeshSurfaceExtraction.h"
-#include "convertMeshToGeo.h"
-#include "MeshQuality/ElementQualityInterface.h"
-
 // Qt includes
 #include <QDesktopWidget>
 #include <QFileDialog>
@@ -96,9 +29,62 @@
 #include <vtkRenderer.h>
 #include <vtkVRMLExporter.h>
 
+#include "Applications/FileIO/AsciiRasterInterface.h"
+#include "Applications/FileIO/FEFLOW/FEFLOWGeoInterface.h"
+#include "Applications/FileIO/FEFLOW/FEFLOWMeshInterface.h"
+#include "Applications/FileIO/GMSInterface.h"
+#include "Applications/FileIO/Gmsh/GMSHInterface.h"
+#include "Applications/FileIO/Gmsh/GmshReader.h"
+#include "Applications/FileIO/PetrelInterface.h"
+#include "Applications/FileIO/TetGenInterface.h"
+#include "Applications/FileIO/XmlIO/Qt/XmlGspInterface.h"
 #include "Applications/Utils/OGSFileConverter/OGSFileConverter.h"
-
 #include "BaseLib/BuildInfo.h"
+#include "BaseLib/FileTools.h"
+#include "BaseLib/Histogram.h"
+#include "GeoLib/DuplicateGeometry.h"
+#include "GeoLib/IO/Legacy/OGSIOVer4.h"
+#include "GeoLib/IO/XmlIO/Qt/XmlGmlInterface.h"
+#include "GeoLib/IO/XmlIO/Qt/XmlStnInterface.h"
+#include "GeoLib/Raster.h"
+#include "MeshGeoToolsLib/GeoMapper.h"
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/IO/Legacy/MeshIO.h"
+#include "MeshLib/IO/readMeshFromFile.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshQuality/ElementQualityInterface.h"
+#include "MeshLib/MeshSurfaceExtraction.h"
+#include "MeshLib/Node.h"
+#include "MeshLib/Vtk/VtkMappedMeshSource.h"
+#include "MeshLib/convertMeshToGeo.h"
+
+// Dialogs
+#include "CreateStructuredGridDialog.h"
+#include "DataExplorerSettingsDialog.h"
+#include "DiagramPrefsDialog.h"
+#include "GMSHPrefsDialog.h"
+#include "GeoOnMeshMappingDialog.h"
+#include "LicenseDialog.h"
+#include "LineEditDialog.h"
+#include "MergeGeometriesDialog.h"
+#include "MeshAnalysisDialog.h"
+#include "MeshElementRemovalDialog.h"
+#include "MeshQualitySelectionDialog.h"
+#include "NetCdfConfigureDialog.h"
+#include "SHPImportDialog.h"
+#include "SetNameDialog.h"
+#include "VtkAddFilterDialog.h"
+
+#include "GeoTreeModel.h"
+#include "LastSavedFileDirectory.h"
+#include "OGSError.h"
+#include "RecentFiles.h"
+#include "StationTreeModel.h"
+#include "TreeModelIterator.h"
+#include "VtkBGImageSource.h"
+#include "VtkGeoImageSource.h"
+#include "VtkRaster.h"
+#include "VtkVisPipelineItem.h"
 
 using namespace FileIO;
 

--- a/Applications/FileIO/CMakeLists.txt
+++ b/Applications/FileIO/CMakeLists.txt
@@ -21,7 +21,7 @@ include(${PROJECT_SOURCE_DIR}/scripts/cmake/OGSEnabledElements.cmake)
 add_library(ApplicationsFileIO ${SOURCES})
 target_link_libraries(ApplicationsFileIO
     PUBLIC BaseLib DataHolderLib GeoLib MathLib logog
-    PRIVATE ApplicationsLib MeshLib
+    PRIVATE MeshLib
 )
 
 if(Shapelib_FOUND)

--- a/Applications/FileIO/SWMM/SWMMInterface.cpp
+++ b/Applications/FileIO/SWMM/SWMMInterface.cpp
@@ -27,8 +27,6 @@
 
 #include "Applications/FileIO/CsvInterface.h"
 
-#include "Applications/ApplicationsLib/LogogSetup.h"
-
 #include "ThirdParty/SWMMInterface/swmm5_iface.h"
 
 

--- a/Applications/Utils/OGSFileConverter/OGSFileConverter.cpp
+++ b/Applications/Utils/OGSFileConverter/OGSFileConverter.cpp
@@ -18,15 +18,16 @@
 
 #include <QFileInfo>
 
-#include "FileListDialog.h"
 #include "Applications/DataExplorer/Base/OGSError.h"
 #include "BaseLib/FileTools.h"
 #include "BaseLib/StringTools.h"
+#include "FileListDialog.h"
 #include "GeoLib/GEOObjects.h"
 #include "GeoLib/IO/Legacy/OGSIOVer4.h"
 #include "GeoLib/IO/XmlIO/Qt/XmlGmlInterface.h"
 #include "MeshLib/IO/Legacy/MeshIO.h"
 #include "MeshLib/IO/VtkIO/VtuInterface.h"
+#include "MeshLib/Mesh.h"
 
 OGSFileConverter::OGSFileConverter(QWidget* parent)
     : QDialog(parent)

--- a/Applications/Utils/OGSFileConverter/OGSFileConverter.cpp
+++ b/Applications/Utils/OGSFileConverter/OGSFileConverter.cpp
@@ -19,7 +19,6 @@
 #include <QFileInfo>
 
 #include "FileListDialog.h"
-#include "Applications/ApplicationsLib/ProjectData.h"
 #include "Applications/DataExplorer/Base/OGSError.h"
 #include "BaseLib/FileTools.h"
 #include "BaseLib/StringTools.h"


### PR DESCRIPTION
The ProcessLib was coupled through the ApplicationsLib, and the latter is not used in the DataExplorer.

Remove some of the default include dirs (as in the rest of the project) but internal DataExplorer dirs.
Reorder includes in files, which were changed, with clang-format.