### PR TITLE
Remove MSVC ifdefs for version less than 19.00 = VisualStudio2015

### DIFF
--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -152,20 +152,8 @@ public:
     class ParameterIterator : public SubtreeIterator
     {
     public:
-#if defined(_MSC_VER) && _MSC_VER < 1900
-        // 1900 == MSCV 14.0 == Visual Studio 2015
-        // according to this post: http://stackoverflow.com/a/70630
-        // This table: http://en.cppreference.com/w/cpp/compiler_support
-        // says that since MSVC 14.0 inheriting of constructors is supported.
-        //! Inherit the constructor
-        explicit ParameterIterator(Iterator it, std::string const& root,
-                                   ConfigTree const& parent)
-            : SubtreeIterator(it, root, parent)
-        {}
-#else
         //! Inherit the constructor
         using SubtreeIterator::SubtreeIterator;
-#endif
 
         ConfigTree operator*() {
             auto st = SubtreeIterator::operator*();
@@ -538,16 +526,7 @@ private:
      *
      * This method only acts as a helper method and throws std::runtime_error.
      */
-#if defined(_MSC_VER) && _MSC_VER < 1900
-    // 1900 == MSCV 14.0 == Visual Studio 2015
-    // according to this post: http://stackoverflow.com/a/70630
-    // This table: http://en.cppreference.com/w/cpp/compiler_support
-    // says that since MSVC 14.0 attributes are supported.
-    __declspec(noreturn)
-#else
-    [[noreturn]]
-#endif
-    void error(std::string const& message) const;
+    [[noreturn]] void error(std::string const& message) const;
 
     //! Called for printing warning messages. Will call the warning callback.
     //! This method only acts as a helper method.

--- a/MaterialLib/Fluid/FluidProperties/FluidProperties.h
+++ b/MaterialLib/Fluid/FluidProperties/FluidProperties.h
@@ -48,30 +48,11 @@ public:
         std::unique_ptr<MaterialLib::Fluid::FluidProperty>&& heat_capacity,
         std::unique_ptr<MaterialLib::Fluid::FluidProperty>&&
             thermal_conductivity)
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
-        // Up to the latest Visual Studio compiler, Visual Studio 2015
-        // list initialization inside member initializer list or non-static data
-        // member initializer is not implemented.
-        // See: https://msdn.microsoft.com/en-us/library/dn793970.aspx
         : _property_models{{std::move(density), std::move(viscosity),
                             std::move(heat_capacity),
                             std::move(thermal_conductivity)}}
     {
     }
-#else
-    {
-        // Move to the initialization list if MS visual studio compiler supports
-        _property_models[static_cast<unsigned>(FluidPropertyType::Density)] =
-            std::move(density);
-        _property_models[static_cast<unsigned>(FluidPropertyType::Viscosity)] =
-            std::move(viscosity);
-        _property_models[static_cast<unsigned>(
-            FluidPropertyType::HeatCapacity)] = std::move(heat_capacity);
-        _property_models[static_cast<unsigned>(
-            FluidPropertyType::ThermalConductivity)] =
-            std::move(thermal_conductivity);
-    }
-#endif
 
     virtual ~FluidProperties() = default;
 
@@ -101,10 +82,6 @@ public:
         const PropertyVariableType variable_type) const = 0;
 
 protected:
-#if defined(_MSC_VER) && _MSC_VER < 1900
-    std::array<std::unique_ptr<FluidProperty>, FluidPropertyTypeNumber>
-        _property_models;
-#else
     /** Fluid property models.
      *  0: density;
      *  1: viscosity;
@@ -115,7 +92,6 @@ protected:
      */
     const std::array<std::unique_ptr<FluidProperty>, FluidPropertyTypeNumber>
         _property_models;
-#endif
 };
 
 }  // end namespace

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -130,15 +130,6 @@ struct PhysicalStressWithInvariants final
     {
     }
 
-    PhysicalStressWithInvariants(PhysicalStressWithInvariants const&) = default;
-    PhysicalStressWithInvariants& operator=(
-        PhysicalStressWithInvariants const&) = default;
-#if defined(_MSC_VER) && (_MSC_VER >= 1900)
-    PhysicalStressWithInvariants(PhysicalStressWithInvariants&&) = default;
-    PhysicalStressWithInvariants& operator=(PhysicalStressWithInvariants&&) =
-        default;
-#endif  // _MSC_VER
-
     KelvinVector value;
     KelvinVector D;
     double I_1;

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -41,21 +41,6 @@ struct IntegrationPointData final
     {
     }
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-    // The default generated move-ctor is correctly generated for other
-    // compilers.
-    explicit IntegrationPointData(IntegrationPointData&& other)
-        : sigma_eff(std::move(other.sigma_eff)),
-          sigma_eff_prev(std::move(other.sigma_eff_prev)),
-          eps(std::move(other.eps)),
-          eps_prev(std::move(other.eps_prev)),
-          solid_material(other.solid_material),
-          material_state_variables(std::move(other.material_state_variables)),
-          integration_weight(std::move(other.integration_weight))
-    {
-    }
-#endif  // _MSC_VER
-
     typename ShapeMatrixTypeDisplacement::template MatrixType<
         DisplacementDim, NPoints * DisplacementDim>
         N_u_op;

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/IntegrationPointDataMatrix.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/IntegrationPointDataMatrix.h
@@ -32,22 +32,6 @@ struct IntegrationPointDataMatrix final
     {
     }
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-    // The default generated move-ctor is correctly generated for other
-    // compilers.
-    explicit IntegrationPointDataMatrix(IntegrationPointDataMatrix&& other)
-        : _sigma(std::move(other._sigma)),
-          _sigma_prev(std::move(other._sigma_prev)),
-          _eps(std::move(other._eps)),
-          _eps_prev(std::move(other._eps_prev)),
-          _solid_material(other._solid_material),
-          _material_state_variables(std::move(other._material_state_variables)),
-          _C(std::move(other._C)),
-          _detJ(std::move(other._detJ))
-    {
-    }
-#endif  // _MSC_VER
-
     typename BMatricesType::KelvinVectorType _sigma, _sigma_prev;
     typename BMatricesType::KelvinVectorType _eps, _eps_prev;
 

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -43,21 +43,6 @@ struct IntegrationPointData final
     {
     }
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-    // The default generated move-ctor is correctly generated for other
-    // compilers.
-    explicit IntegrationPointData(IntegrationPointData&& other)
-          sigma(std::move(other.sigma)),
-          sigma_prev(std::move(other.sigma_prev)),
-          eps(std::move(other.eps)),
-          eps_prev(std::move(other.eps_prev)),
-          solid_material(other.solid_material),
-          material_state_variables(std::move(other.material_state_variables)),
-          integration_weight(std::move(other.integration_weight))
-    {
-    }
-#endif  // _MSC_VER
-
     typename BMatricesType::KelvinVectorType sigma, sigma_prev;
     typename BMatricesType::KelvinVectorType eps, eps_prev;
 

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
@@ -43,22 +43,6 @@ struct IntegrationPointData final
     {
     }
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-    // The default generated move-ctor is correctly generated for other
-    // compilers.
-    explicit IntegrationPointData(IntegrationPointData&& other)
-        : sigma(std::move(other.sigma)),
-          sigma_prev(std::move(other.sigma_prev)),
-          eps(std::move(other.eps)),
-          eps_m(std::move(other.eps_m)),
-          eps_m_prev(std::move(other.eps_m_prev)),
-          solid_material(other.solid_material),
-          material_state_variables(std::move(other.material_state_variables)),
-          integration_weight(std::move(other.integration_weight)),
-    {
-    }
-#endif  // _MSC_VER
-
     typename ShapeMatrixType::NodalRowVectorType N;
     typename ShapeMatrixType::GlobalDimNodalMatrixType dNdx;
     typename BMatricesType::KelvinVectorType sigma, sigma_prev;


### PR DESCRIPTION
Just looking if the `#ifdefs` for old VisualStudio can be removed.