### PR TITLE
Restructure solid materials

### DIFF
--- a/MaterialLib/SolidModels/CreateEhlers.h
+++ b/MaterialLib/SolidModels/CreateEhlers.h
@@ -190,9 +190,8 @@ std::unique_ptr<SolidEhlers<DisplacementDim>> createEhlers(
     auto const nonlinear_solver_parameters =
         createNewtonRaphsonSolverParameters(nonlinear_solver_config);
 
-    return std::unique_ptr<SolidEhlers<DisplacementDim>>{
-        new SolidEhlers<DisplacementDim>{nonlinear_solver_parameters, mp,
-                                         std::move(ehlers_damage_properties)}};
+    return std::make_unique<SolidEhlers<DisplacementDim>>(
+        nonlinear_solver_parameters, mp, std::move(ehlers_damage_properties));
 }
 
 }  // namespace Ehlers

--- a/MaterialLib/SolidModels/Ehlers.cpp
+++ b/MaterialLib/SolidModels/Ehlers.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "Ehlers.h"
+#include "Ehlers-impl.h"
 
 namespace MaterialLib
 {

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -241,7 +241,8 @@ private:
     std::unique_ptr<DamagePropertiesParameters> _damage_properties;
 };
 
+extern template class SolidEhlers<2>;
+extern template class SolidEhlers<3>;
 }  // namespace Ehlers
 }  // namespace Solids
 }  // namespace MaterialLib
-#include "Ehlers-impl.h"

--- a/MaterialLib/SolidModels/LinearElasticIsotropic-impl.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic-impl.h
@@ -1,0 +1,55 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include "LinearElasticIsotropic.h"
+
+namespace MaterialLib
+{
+namespace Solids
+{
+template <int DisplacementDim>
+boost::optional<
+    std::tuple<typename LinearElasticIsotropic<DisplacementDim>::KelvinVector,
+               std::unique_ptr<typename MechanicsBase<
+                   DisplacementDim>::MaterialStateVariables>,
+               typename LinearElasticIsotropic<DisplacementDim>::KelvinMatrix>>
+LinearElasticIsotropic<DisplacementDim>::integrateStress(
+    double const t,
+    ProcessLib::SpatialPosition const& x,
+    double const /*dt*/,
+    KelvinVector const& eps_prev,
+    KelvinVector const& eps,
+    KelvinVector const& sigma_prev,
+    typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
+        material_state_variables)
+{
+    KelvinMatrix C = KelvinMatrix::Zero();
+
+    C.template topLeftCorner<3, 3>().setConstant(_mp.lambda(t, x));
+    C.noalias() += 2 * _mp.mu(t, x) * KelvinMatrix::Identity();
+
+    KelvinVector sigma = sigma_prev + C * (eps - eps_prev);
+
+    return {std::make_tuple(
+        sigma,
+        std::unique_ptr<
+            typename MechanicsBase<DisplacementDim>::MaterialStateVariables>{
+            new MaterialStateVariables{
+                static_cast<MaterialStateVariables const&>(
+                    material_state_variables)}},
+        C)};
+}
+
+extern template class LinearElasticIsotropic<2>;
+extern template class LinearElasticIsotropic<3>;
+
+}  // namespace Solids
+}  // namespace MaterialLib

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.cpp
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "LinearElasticIsotropic.h"
+#include "LinearElasticIsotropic-impl.h"
 
 namespace MaterialLib
 {

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.h
@@ -99,24 +99,7 @@ public:
         KelvinVector const& eps,
         KelvinVector const& sigma_prev,
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
-            material_state_variables) override
-    {
-        KelvinMatrix C = KelvinMatrix::Zero();
-
-        C.template topLeftCorner<3, 3>().setConstant(_mp.lambda(t, x));
-        C.noalias() += 2 * _mp.mu(t, x) * KelvinMatrix::Identity();
-
-        KelvinVector sigma = sigma_prev + C * (eps - eps_prev);
-
-        return {
-            std::make_tuple(sigma,
-                            std::unique_ptr<typename MechanicsBase<
-                                DisplacementDim>::MaterialStateVariables>{
-                                new MaterialStateVariables{
-                                    static_cast<MaterialStateVariables const&>(
-                                        material_state_variables)}},
-                            C)};
-    }
+            material_state_variables) override;
 
 private:
     MaterialProperties _mp;

--- a/MaterialLib/SolidModels/Lubby2.cpp
+++ b/MaterialLib/SolidModels/Lubby2.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "Lubby2.h"
+#include "Lubby2-impl.h"
 
 namespace MaterialLib
 {

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -233,5 +233,3 @@ extern template class Lubby2<3>;
 }  // namespace Lubby2
 }  // namespace Solids
 }  // namespace MaterialLib
-
-#include "Lubby2-impl.h"


### PR DESCRIPTION
 - Move template function definitions to `-impl.h` for LinearElastic (other models already have this done)
 - Add explicit instantiation declaration in the `.h` file
 - Include the definitions (the `-impl.h`) in the `.cpp`, where the templates are explicitly instantiated (do not include the `-impl.h` any longer in `.h`)

This saves a dozen or so of instantiations (for each mechanics process for the 2 and 3d cases).

For me ff8da7c compiles in about 1200s, while ufz/master (f14c072) compiles in 1240s. Not much difference, but still.