### PR TITLE
[PCS/LIE/HM] add output of nodal w and aperture

### DIFF
--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -207,66 +207,53 @@ void HydroMechanicsProcess<GlobalDim>::initializeConcreteProcess(
         _local_assemblers, mesh.isAxiallySymmetric(), integration_order,
         _process_data);
 
-    auto mesh_prop_sigma_xx = const_cast<MeshLib::Mesh&>(mesh)
-                                  .getProperties()
-                                  .template createNewPropertyVector<double>(
-                                      "stress_xx", MeshLib::MeshItemType::Cell);
+    auto mesh_prop_sigma_xx = MeshLib::getOrCreateMeshProperty<double>(
+                                const_cast<MeshLib::Mesh&>(mesh),
+                                "stress_xx", MeshLib::MeshItemType::Cell, 1);
     mesh_prop_sigma_xx->resize(mesh.getNumberOfElements());
     _process_data.mesh_prop_stress_xx = mesh_prop_sigma_xx;
 
-    auto mesh_prop_sigma_yy = const_cast<MeshLib::Mesh&>(mesh)
-                                  .getProperties()
-                                  .template createNewPropertyVector<double>(
-                                      "stress_yy", MeshLib::MeshItemType::Cell);
+    auto mesh_prop_sigma_yy = MeshLib::getOrCreateMeshProperty<double>(
+                                const_cast<MeshLib::Mesh&>(mesh),
+                                "stress_yy", MeshLib::MeshItemType::Cell, 1);
     mesh_prop_sigma_yy->resize(mesh.getNumberOfElements());
     _process_data.mesh_prop_stress_yy = mesh_prop_sigma_yy;
 
-    auto mesh_prop_sigma_xy = const_cast<MeshLib::Mesh&>(mesh)
-                                  .getProperties()
-                                  .template createNewPropertyVector<double>(
-                                      "stress_xy", MeshLib::MeshItemType::Cell);
+    auto mesh_prop_sigma_xy = MeshLib::getOrCreateMeshProperty<double>(
+                                const_cast<MeshLib::Mesh&>(mesh),
+                                "stress_xy", MeshLib::MeshItemType::Cell, 1);
     mesh_prop_sigma_xy->resize(mesh.getNumberOfElements());
     _process_data.mesh_prop_stress_xy = mesh_prop_sigma_xy;
 
-    auto mesh_prop_epsilon_xx =
-        const_cast<MeshLib::Mesh&>(mesh)
-            .getProperties()
-            .template createNewPropertyVector<double>(
-                "strain_xx", MeshLib::MeshItemType::Cell);
+    auto mesh_prop_epsilon_xx = MeshLib::getOrCreateMeshProperty<double>(
+                                const_cast<MeshLib::Mesh&>(mesh),
+                                "strain_xx", MeshLib::MeshItemType::Cell, 1);
     mesh_prop_epsilon_xx->resize(mesh.getNumberOfElements());
     _process_data.mesh_prop_strain_xx = mesh_prop_epsilon_xx;
 
-    auto mesh_prop_epsilon_yy =
-        const_cast<MeshLib::Mesh&>(mesh)
-            .getProperties()
-            .template createNewPropertyVector<double>(
-                "strain_yy", MeshLib::MeshItemType::Cell);
+    auto mesh_prop_epsilon_yy = MeshLib::getOrCreateMeshProperty<double>(
+                                const_cast<MeshLib::Mesh&>(mesh),
+                                "strain_yy", MeshLib::MeshItemType::Cell, 1);
     mesh_prop_epsilon_yy->resize(mesh.getNumberOfElements());
     _process_data.mesh_prop_strain_yy = mesh_prop_epsilon_yy;
 
-    auto mesh_prop_epsilon_xy =
-        const_cast<MeshLib::Mesh&>(mesh)
-            .getProperties()
-            .template createNewPropertyVector<double>(
-                "strain_xy", MeshLib::MeshItemType::Cell);
+    auto mesh_prop_epsilon_xy = MeshLib::getOrCreateMeshProperty<double>(
+                                const_cast<MeshLib::Mesh&>(mesh),
+                                "strain_xy", MeshLib::MeshItemType::Cell, 1);
     mesh_prop_epsilon_xy->resize(mesh.getNumberOfElements());
     _process_data.mesh_prop_strain_xy = mesh_prop_epsilon_xy;
 
-    auto mesh_prop_velocity =
-        const_cast<MeshLib::Mesh&>(mesh)
-            .getProperties()
-            .template createNewPropertyVector<double>(
-                "velocity", MeshLib::MeshItemType::Cell, 3);
+    auto mesh_prop_velocity = MeshLib::getOrCreateMeshProperty<double>(
+                                const_cast<MeshLib::Mesh&>(mesh),
+                                "velocity", MeshLib::MeshItemType::Cell, 3);
     mesh_prop_velocity->resize(mesh.getNumberOfElements() * 3);
     _process_data.mesh_prop_velocity = mesh_prop_velocity;
 
     if (!_vec_fracture_elements.empty())
     {
-        auto mesh_prop_levelset =
-            const_cast<MeshLib::Mesh&>(mesh)
-                .getProperties()
-                .template createNewPropertyVector<double>(
-                    "levelset1", MeshLib::MeshItemType::Cell);
+        auto mesh_prop_levelset = MeshLib::getOrCreateMeshProperty<double>(
+                                    const_cast<MeshLib::Mesh&>(mesh),
+                                    "levelset1", MeshLib::MeshItemType::Cell, 1);
         mesh_prop_levelset->resize(mesh.getNumberOfElements());
         for (MeshLib::Element const* e : _mesh.getElements())
         {
@@ -279,23 +266,20 @@ void HydroMechanicsProcess<GlobalDim>::initializeConcreteProcess(
             (*mesh_prop_levelset)[e->getID()] = levelsets;
         }
 
-        auto mesh_prop_w_n = const_cast<MeshLib::Mesh&>(mesh)
-                                 .getProperties()
-                                 .template createNewPropertyVector<double>(
-                                     "w_n", MeshLib::MeshItemType::Cell);
+        auto mesh_prop_w_n = MeshLib::getOrCreateMeshProperty<double>(
+                                    const_cast<MeshLib::Mesh&>(mesh),
+                                    "w_n", MeshLib::MeshItemType::Cell, 1);
         mesh_prop_w_n->resize(mesh.getNumberOfElements());
-        auto mesh_prop_w_s = const_cast<MeshLib::Mesh&>(mesh)
-                                 .getProperties()
-                                 .template createNewPropertyVector<double>(
-                                     "w_s", MeshLib::MeshItemType::Cell);
+        auto mesh_prop_w_s = MeshLib::getOrCreateMeshProperty<double>(
+                                    const_cast<MeshLib::Mesh&>(mesh),
+                                    "w_s", MeshLib::MeshItemType::Cell, 1);
         mesh_prop_w_s->resize(mesh.getNumberOfElements());
         _process_data.mesh_prop_w_n = mesh_prop_w_n;
         _process_data.mesh_prop_w_s = mesh_prop_w_s;
 
-        auto mesh_prop_b = const_cast<MeshLib::Mesh&>(mesh)
-                               .getProperties()
-                               .template createNewPropertyVector<double>(
-                                   "aperture", MeshLib::MeshItemType::Cell);
+        auto mesh_prop_b = MeshLib::getOrCreateMeshProperty<double>(
+                                    const_cast<MeshLib::Mesh&>(mesh),
+                                    "aperture", MeshLib::MeshItemType::Cell, 1);
         mesh_prop_b->resize(mesh.getNumberOfElements());
         auto mesh_prop_matid =
             mesh.getProperties().getPropertyVector<int>("MaterialIDs");
@@ -312,53 +296,43 @@ void HydroMechanicsProcess<GlobalDim>::initializeConcreteProcess(
         }
         _process_data.mesh_prop_b = mesh_prop_b;
 
-        auto mesh_prop_k_f = const_cast<MeshLib::Mesh&>(mesh)
-                                 .getProperties()
-                                 .template createNewPropertyVector<double>(
-                                     "k_f", MeshLib::MeshItemType::Cell);
+
+        auto mesh_prop_k_f = MeshLib::getOrCreateMeshProperty<double>(
+                                    const_cast<MeshLib::Mesh&>(mesh),
+                                    "k_f", MeshLib::MeshItemType::Cell, 1);
         mesh_prop_k_f->resize(mesh.getNumberOfElements());
         _process_data.mesh_prop_k_f = mesh_prop_k_f;
 
-        auto mesh_prop_fracture_stress_shear =
-            const_cast<MeshLib::Mesh&>(mesh)
-                .getProperties()
-                .template createNewPropertyVector<double>(
-                    "f_stress_s", MeshLib::MeshItemType::Cell);
+        auto mesh_prop_fracture_stress_shear = MeshLib::getOrCreateMeshProperty<double>(
+                                    const_cast<MeshLib::Mesh&>(mesh),
+                                    "f_stress_s", MeshLib::MeshItemType::Cell, 1);
         mesh_prop_fracture_stress_shear->resize(mesh.getNumberOfElements());
         _process_data.mesh_prop_fracture_stress_shear =
             mesh_prop_fracture_stress_shear;
 
-        auto mesh_prop_fracture_stress_normal =
-            const_cast<MeshLib::Mesh&>(mesh)
-                .getProperties()
-                .template createNewPropertyVector<double>(
-                    "f_stress_n", MeshLib::MeshItemType::Cell);
+        auto mesh_prop_fracture_stress_normal = MeshLib::getOrCreateMeshProperty<double>(
+                                    const_cast<MeshLib::Mesh&>(mesh),
+                                    "f_stress_n", MeshLib::MeshItemType::Cell, 1);
         mesh_prop_fracture_stress_normal->resize(mesh.getNumberOfElements());
         _process_data.mesh_prop_fracture_stress_normal =
             mesh_prop_fracture_stress_normal;
 
-        auto mesh_prop_fracture_shear_failure =
-            const_cast<MeshLib::Mesh&>(mesh)
-                .getProperties()
-                .template createNewPropertyVector<double>(
-                    "f_shear_failure", MeshLib::MeshItemType::Cell);
+        auto mesh_prop_fracture_shear_failure = MeshLib::getOrCreateMeshProperty<double>(
+                                    const_cast<MeshLib::Mesh&>(mesh),
+                                    "f_shear_failure", MeshLib::MeshItemType::Cell, 1);
         mesh_prop_fracture_shear_failure->resize(mesh.getNumberOfElements());
         _process_data.mesh_prop_fracture_shear_failure =
             mesh_prop_fracture_shear_failure;
 
-        auto mesh_prop_nodal_w =
-            const_cast<MeshLib::Mesh&>(mesh)
-                .getProperties()
-                .template createNewPropertyVector<double>(
-                    "nodal_w", MeshLib::MeshItemType::Node, GlobalDim);
+        auto mesh_prop_nodal_w = MeshLib::getOrCreateMeshProperty<double>(
+                                    const_cast<MeshLib::Mesh&>(mesh),
+                                    "nodal_w", MeshLib::MeshItemType::Node, GlobalDim);
         mesh_prop_nodal_w->resize(mesh.getNumberOfNodes() * GlobalDim);
         _process_data.mesh_prop_nodal_w = mesh_prop_nodal_w;
 
-        auto mesh_prop_nodal_b =
-            const_cast<MeshLib::Mesh&>(mesh)
-                .getProperties()
-                .template createNewPropertyVector<double>(
-                    "nodal_aperture", MeshLib::MeshItemType::Node);
+        auto mesh_prop_nodal_b = MeshLib::getOrCreateMeshProperty<double>(
+                                    const_cast<MeshLib::Mesh&>(mesh),
+                                    "nodal_aperture", MeshLib::MeshItemType::Node, 1);
         mesh_prop_nodal_b->resize(mesh.getNumberOfNodes());
         _process_data.mesh_prop_nodal_b = mesh_prop_nodal_b;
     }

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -373,15 +373,7 @@ void HydroMechanicsProcess<GlobalDim>::computeSecondaryVariableConcrete(
         }
     }
 
-#ifdef USE_PETSC
-    // TODO It is also possible directly to copy the data for single process
-    // variable to a mesh property. It needs a vector of global indices and
-    // some PETSc magic to do so.
-    std::vector<double> x_copy(x.getLocalSize() + x.getGhostSize());
-#else
-    std::vector<double> x_copy(x.size());
-#endif
-    x.copyValues(x_copy);
+    MathLib::LinAlg::setLocalAccessibleVector(x);
 
     ProcessVariable& pv_g = this->getProcessVariables()[g_variable_id];
     auto& mesh_prop_g = pv_g.getOrCreateMeshProperty();
@@ -400,13 +392,8 @@ void HydroMechanicsProcess<GlobalDim>::computeSecondaryVariableConcrete(
                     mesh_id, MeshLib::MeshItemType::Node, node->getID());
 
                 auto const global_component_id = g_global_component_offset + component_id;
-                auto const index =
-                        _local_to_global_index_map->getLocalIndex(
-                            l, global_component_id, x.getRangeBegin(),
-                            x.getRangeEnd());
-
                 mesh_prop_g[node->getID() * num_comp + component_id] =
-                        x_copy[index];
+                        x[global_component_id];
             }
         }
     }

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcessData.h
@@ -140,6 +140,8 @@ struct HydroMechanicsProcessData
     MeshLib::PropertyVector<double>* mesh_prop_fracture_stress_shear = nullptr;
     MeshLib::PropertyVector<double>* mesh_prop_fracture_stress_normal = nullptr;
     MeshLib::PropertyVector<double>* mesh_prop_fracture_shear_failure = nullptr;
+    MeshLib::PropertyVector<double>* mesh_prop_nodal_w = nullptr;
+    MeshLib::PropertyVector<double>* mesh_prop_nodal_b = nullptr;
 };
 
 }  // namespace HydroMechanics


### PR DESCRIPTION
This PR extends LIE/HM so that it can output nodal values of fracture relative displacement in local coordinates (w) and fracture aperture (b). 