### PR TITLE
Added two more tests for the staggered scheme with adaptive time stepping

### DIFF
--- a/ProcessLib/LiquidFlow/Tests.cmake
+++ b/ProcessLib/LiquidFlow/Tests.cmake
@@ -94,7 +94,6 @@ AddTest(
     mesh2D.vtu gravity_driven_pcs_1_ts_10_t_300.000000.vtu v_y_ref v_y
 )
 
-# Coupling
 AddTest(
     NAME Adaptive_dt_StaggeredTH_ThermalDensityDrivenFlow2D
     PATH StaggeredCoupledProcesses/TH/ThermalDensityDrivenFlow2D
@@ -111,6 +110,35 @@ AddTest(
     mesh2D.vtu gravity_driven_adaptive_dt_pcs_1_ts_11_t_300.000000.vtu v_y_ref v_y
 )
 
+AddTest(
+    NAME Adaptive_dt_ThermalConvectionFlow2D
+    PATH StaggeredCoupledProcesses/TH/ThermalConvection2D
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS quad_5500x5500_adaptive_dt.prj
+    WRAPPER time
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    ABSTOL 1.e-16 RELTOL 1e-16
+    DIFF_DATA
+    ConstViscosityThermalConvection_pcs_1_ts_231_t_50000000000.000000_non_const_mu.vtu  ConstViscosityThermalConvection_pcs_1_ts_231_t_50000000000.000000.vtu  pressure pressure
+    ConstViscosityThermalConvection_pcs_1_ts_231_t_50000000000.000000_non_const_mu.vtu  ConstViscosityThermalConvection_pcs_1_ts_231_t_50000000000.000000.vtu  temperature temperature
+)
+
+AddTest(
+    NAME Adaptive_dt_ThermalConvectionFlow2D_Constant_Viscosity
+    PATH StaggeredCoupledProcesses/TH/ThermalConvection2D
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS quad_5500x5500_adaptive_dt_constant_viscosity.prj
+    WRAPPER time
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    ABSTOL 1.e-16 RELTOL 1e-16
+    DIFF_DATA
+    ConstViscosityThermalConvection_pcs_1_ts_137_t_50000000000.000000_const_mu.vtu  ConstViscosityThermalConvection_pcs_1_ts_137_t_50000000000.000000.vtu  pressure pressure
+    ConstViscosityThermalConvection_pcs_1_ts_137_t_50000000000.000000_const_mu-vtu  ConstViscosityThermalConvection_pcs_1_ts_137_t_50000000000.000000.vtu  temperature temperature
+)
+
+#===============================================================================
 # PETSc/MPI
 AddTest(
     NAME LiquidFlow_LineDirichletNeumannBC
@@ -224,4 +252,31 @@ AddTest(
 #    mesh2D.vtu gravity_driven_pcs_1_ts_5_t_300_000000_0.vtu v_x_ref v_x
 #    mesh2D.vtu gravity_driven_pcs_1_ts_5_t_300_000000_0.vtu v_y_ref v_y
 
+)
+AddTest(
+    NAME Adaptive_dt_ThermalConvectionFlow2D
+    PATH StaggeredCoupledProcesses/TH/ThermalConvection2D
+    EXECUTABLE_ARGS quad_5500x5500_adaptive_dt.prj
+    WRAPPER mpirun
+    WRAPPER_ARGS -np 1
+    TESTER vtkdiff
+    REQUIREMENTS OGS_USE_MPI
+    ABSTOL 1.e-16 RELTOL 1e-16
+    DIFF_DATA
+    ConstViscosityThermalConvection_pcs_1_ts_231_t_50000000000.000000_non_const_mu  ConstViscosityThermalConvection_pcs_1_ts_231_t_50000000000.000000_0.vtu  pressure_mu pressure
+    ConstViscosityThermalConvection_pcs_1_ts_231_t_50000000000.000000_non_const_mu  ConstViscosityThermalConvection_pcs_1_ts_231_t_50000000000.000000_0.vtu  temperature temperature
+)
+
+AddTest(
+    NAME Adaptive_dt_ThermalConvectionFlow2D_Constant_Viscosity
+    PATH StaggeredCoupledProcesses/TH/ThermalConvection2D
+    EXECUTABLE_ARGS quad_5500x5500_adaptive_dt_constant_viscosity.prj
+    WRAPPER mpirun
+    WRAPPER_ARGS -np 1
+    TESTER vtkdiff
+    REQUIREMENTS OGS_USE_MPI
+    ABSTOL 1.e-16 RELTOL 1e-16
+    DIFF_DATA
+    ConstViscosityThermalConvection_pcs_1_ts_137_t_50000000000.000000_const_mu.vtu  ConstViscosityThermalConvection_pcs_1_ts_137_t_50000000000.000000_0.vtu  pressure pressure
+    ConstViscosityThermalConvection_pcs_1_ts_137_t_50000000000.000000_const_mu.vtu  ConstViscosityThermalConvection_pcs_1_ts_137_t_50000000000.000000_0.vtu  temperature temperature
 )


### PR DESCRIPTION
as tiled.

One test has temperature dependent liquid density and constant viscosity, another test gets both liquid density and viscosity being temperature dependent.


Difference from what in HT: Temperature dependent fluid density always gives thermal expansion coefficient in LiquidProcess. On the contrary,  thermal expansion coefficient  is not available in HTProcess.

**Temperature perturbation result of that with temperature dependent liquid density and constant viscosity:**

![t_pert](https://user-images.githubusercontent.com/1343839/27740470-6cacae44-5db2-11e7-9ced-139b745e2e15.png)
