### PR TITLE
Enable vectorial output for secondary variables.

### DIFF
--- a/NumLib/Extrapolation/ExtrapolatableElementCollection.h
+++ b/NumLib/Extrapolation/ExtrapolatableElementCollection.h
@@ -37,6 +37,11 @@ public:
     /*! Returns integration point values of some property of a specific element.
      *
      * \param id ID of the element of which the property is queried.
+     * \param t The time used in the evaluation if time dependent quantities.
+     * \param current_solution The current solution of a ProcessLib::Process;
+     * more generally any nodal GlobalVector.
+     * \param dof_table The processes d.o.f. table used to get each element's
+     * local d.o.f. from \c current_solution.
      * \param cache Can be used to compute a property on-the-fly.
      *
      * \remark

--- a/NumLib/Extrapolation/ExtrapolatableElementCollection.h
+++ b/NumLib/Extrapolation/ExtrapolatableElementCollection.h
@@ -9,11 +9,17 @@
 
 #pragma once
 
+#include <functional>
 #include <vector>
+
+#include "MathLib/LinAlg/GlobalMatrixVectorTypes.h"
+
 #include "ExtrapolatableElement.h"
 
 namespace NumLib
 {
+class LocalToGlobalIndexMap;
+
 /*! Adaptor to get information needed by an Extrapolator from an "arbitrary"
  * collection of elements (e.g., local assemblers).
  *
@@ -50,7 +56,10 @@ public:
      * \endparblock
      */
     virtual std::vector<double> const& getIntegrationPointValues(
-        std::size_t const id, std::vector<double>& cache) const = 0;
+        std::size_t const id, const double t,
+        GlobalVector const& current_solution,
+        LocalToGlobalIndexMap const& dof_table,
+        std::vector<double>& cache) const = 0;
 
     //! Returns the number of elements whose properties shall be extrapolated.
     virtual std::size_t size() const = 0;
@@ -64,9 +73,9 @@ class ExtrapolatableLocalAssemblerCollection
 {
 public:
     //! LocalAssemblerCollection contains many LocalAssembler's.
-    using LocalAssembler = typename std::decay<decltype(
-        *std::declval<LocalAssemblerCollection>()[static_cast<std::size_t>(
-            0)])>::type;
+    using LocalAssembler =
+        typename std::decay<decltype(*std::declval<LocalAssemblerCollection>()
+                                         [static_cast<std::size_t>(0)])>::type;
 
     static_assert(std::is_base_of<ExtrapolatableElement, LocalAssembler>::value,
                   "Local assemblers used for extrapolation must be derived "
@@ -80,8 +89,12 @@ public:
      * For further information about the \c cache parameter see
      * ExtrapolatableElementCollection::getIntegrationPointValues().
      */
-    using IntegrationPointValuesMethod = std::vector<double> const& (
-        LocalAssembler::*)(std::vector<double>& cache) const;
+    using IntegrationPointValuesMethod =
+        std::function<std::vector<double> const&(
+            LocalAssembler const& loc_asm, const double t,
+            GlobalVector const& current_solution,
+            NumLib::LocalToGlobalIndexMap const& dof_table,
+            std::vector<double>& cache)>;
 
     /*! Constructs a new instance.
      *
@@ -92,9 +105,9 @@ public:
      */
     ExtrapolatableLocalAssemblerCollection(
         LocalAssemblerCollection const& local_assemblers,
-        IntegrationPointValuesMethod integration_point_values_method)
-        : _local_assemblers(local_assemblers)
-        , _integration_point_values_method(integration_point_values_method)
+        IntegrationPointValuesMethod const& integration_point_values_method)
+        : _local_assemblers(local_assemblers),
+          _integration_point_values_method{integration_point_values_method}
     {
     }
 
@@ -106,10 +119,14 @@ public:
     }
 
     std::vector<double> const& getIntegrationPointValues(
-        std::size_t const id, std::vector<double>& cache) const override
+        std::size_t const id, const double t,
+        GlobalVector const& current_solution,
+        LocalToGlobalIndexMap const& dof_table,
+        std::vector<double>& cache) const override
     {
         auto const& loc_asm = *_local_assemblers[id];
-        return (loc_asm.*_integration_point_values_method)(cache);
+        return _integration_point_values_method(loc_asm, t, current_solution,
+                                                dof_table, cache);
     }
 
     std::size_t size() const override { return _local_assemblers.size(); }

--- a/NumLib/Extrapolation/Extrapolator.h
+++ b/NumLib/Extrapolation/Extrapolator.h
@@ -17,6 +17,7 @@
 
 namespace NumLib
 {
+class LocalToGlobalIndexMap;
 
 //! Interface for classes that extrapolate integration point values to nodal
 //! values.
@@ -25,7 +26,11 @@ class Extrapolator
 public:
     //! Extrapolates the given \c property from the given local assemblers.
     virtual void extrapolate(
-            ExtrapolatableElementCollection const& extrapolatables) = 0;
+        const unsigned num_components,
+        ExtrapolatableElementCollection const& extrapolatables,
+        const double t,
+        GlobalVector const& current_solution,
+        LocalToGlobalIndexMap const& dof_table) = 0;
 
     /*! Computes residuals from the extrapolation of the given \c property.
      *
@@ -34,7 +39,11 @@ public:
      * \pre extrapolate() must have been called before with the same arguments.
      */
     virtual void calculateResiduals(
-            ExtrapolatableElementCollection const& extrapolatables) = 0;
+        const unsigned num_components,
+        ExtrapolatableElementCollection const& extrapolatables,
+        const double t,
+        GlobalVector const& current_solution,
+        LocalToGlobalIndexMap const& dof_table) = 0;
 
     //! Returns the extrapolated nodal values.
     //! \todo Maybe write directly to a MeshProperty.

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.cpp
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.cpp
@@ -121,8 +121,9 @@ void LocalLinearLeastSquaresExtrapolator::extrapolateElement(
             _integration_point_values_cache);
 
     auto const& N_0 = extrapolatables.getShapeMatrix(element_index, 0);
-    const unsigned num_nodes = N_0.cols();
-    const unsigned num_values = integration_point_values.size();
+    auto const num_nodes = static_cast<unsigned>(N_0.cols());
+    auto const num_values =
+        static_cast<unsigned>(integration_point_values.size());
 
     if (num_values % num_components != 0)
         OGS_FATAL(
@@ -249,7 +250,7 @@ void LocalLinearLeastSquaresExtrapolator::calculateResidualElement(
         element_index, t, current_solution, dof_table,
         _integration_point_values_cache);
 
-    const unsigned num_values = int_pt_vals.size();
+    auto const num_values = static_cast<unsigned>(int_pt_vals.size());
     if (num_values % num_components != 0)
         OGS_FATAL(
             "The number of computed integration point values is not divisable "
@@ -262,7 +263,7 @@ void LocalLinearLeastSquaresExtrapolator::calculateResidualElement(
 
     const auto& global_indices =
         _dof_table_single_component(element_index, 0).rows;
-    const unsigned num_nodes = global_indices.size();
+    const auto num_nodes = static_cast<unsigned>(global_indices.size());
 
     auto const& interpolation_matrix =
         _qr_decomposition_cache.find({num_nodes, num_int_pts})->second.A;
@@ -285,7 +286,8 @@ void LocalLinearLeastSquaresExtrapolator::calculateResidualElement(
                                  int_pt_vals_mat.row(comp).transpose())
                                     .squaredNorm();
 
-        auto const eidx = num_components * element_index + comp;
+        auto const eidx =
+            static_cast<GlobalIndexType>(num_components * element_index + comp);
         _residuals->set(eidx, std::sqrt(residual / num_int_pts));
     }
 }

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.cpp
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.cpp
@@ -288,7 +288,9 @@ void LocalLinearLeastSquaresExtrapolator::calculateResidualElement(
 
         auto const eidx =
             static_cast<GlobalIndexType>(num_components * element_index + comp);
-        _residuals->set(eidx, std::sqrt(residual / num_int_pts));
+        // The residual is set to the root mean square value.
+        auto const root_mean_square = std::sqrt(residual / num_int_pts);
+        _residuals->set(eidx, root_mean_square);
     }
 }
 

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.cpp
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.cpp
@@ -23,18 +23,7 @@ namespace NumLib
 {
 LocalLinearLeastSquaresExtrapolator::LocalLinearLeastSquaresExtrapolator(
     NumLib::LocalToGlobalIndexMap const& dof_table)
-    : _nodal_values(NumLib::GlobalVectorProvider::provider.getVector(
-          MathLib::MatrixSpecifications(dof_table.dofSizeWithoutGhosts(),
-                                        dof_table.dofSizeWithoutGhosts(),
-                                        &dof_table.getGhostIndices(),
-                                        nullptr))),
-#ifndef USE_PETSC
-      _residuals(dof_table.size()),
-#else
-      _residuals(dof_table.dofSizeWithoutGhosts(),
-                 dof_table.getGhostIndices(), false),
-#endif
-      _local_to_global(dof_table)
+    : _dof_table_single_component(dof_table)
 {
     /* Note in case the following assertion fails:
      * If you copied the extrapolation code, for your processes from
@@ -43,58 +32,112 @@ LocalLinearLeastSquaresExtrapolator::LocalLinearLeastSquaresExtrapolator(
      * likely too simplistic. You better adapt the extrapolation code from
      * some more advanced process, like the TES process.
      */
-    assert(dof_table.getNumberOfComponents() == 1 &&
-           "The d.o.f. table passed must be for one variable that has "
-           "only one component!");
+    if (dof_table.getNumberOfComponents() != 1)
+        OGS_FATAL(
+            "The d.o.f. table passed must be for one variable that has "
+            "only one component!");
 }
 
 void LocalLinearLeastSquaresExtrapolator::extrapolate(
-    ExtrapolatableElementCollection const& extrapolatables)
+    const unsigned num_components,
+    ExtrapolatableElementCollection const& extrapolatables,
+    const double t,
+    GlobalVector const& current_solution,
+    LocalToGlobalIndexMap const& dof_table)
 {
-    _nodal_values.setZero();
+    auto const num_nodal_dof_result =
+        _dof_table_single_component.dofSizeWithoutGhosts() * num_components;
+    if (!_nodal_values ||
+        static_cast<std::size_t>(_nodal_values->size()) != num_nodal_dof_result)
+    {
+        _nodal_values = MathLib::MatrixVectorTraits<GlobalVector>::newInstance(
+            MathLib::MatrixSpecifications{
+                num_nodal_dof_result, num_nodal_dof_result, nullptr, nullptr});
+    }
+    _nodal_values->setZero();
 
     // counts the writes to each nodal value, i.e., the summands in order to
     // compute the average afterwards
     auto counts =
-        MathLib::MatrixVectorTraits<GlobalVector>::newInstance(_nodal_values);
+        MathLib::MatrixVectorTraits<GlobalVector>::newInstance(*_nodal_values);
     counts->setZero();  // TODO BLAS?
 
     auto const size = extrapolatables.size();
-    for (std::size_t i=0; i<size; ++i) {
-        extrapolateElement(i, extrapolatables, *counts);
+    for (std::size_t i = 0; i < size; ++i)
+    {
+        extrapolateElement(i, num_components, extrapolatables, t,
+                           current_solution, dof_table, *counts);
     }
 
-    MathLib::LinAlg::componentwiseDivide(_nodal_values, _nodal_values, *counts);
+    MathLib::LinAlg::componentwiseDivide(*_nodal_values, *_nodal_values,
+                                         *counts);
 }
 
 void LocalLinearLeastSquaresExtrapolator::calculateResiduals(
-    ExtrapolatableElementCollection const& extrapolatables)
+    const unsigned num_components,
+    ExtrapolatableElementCollection const& extrapolatables,
+    const double t,
+    GlobalVector const& current_solution,
+    LocalToGlobalIndexMap const& dof_table)
 {
-    assert(static_cast<std::size_t>(_residuals.size()) ==
-           extrapolatables.size());
+    auto const num_element_dof_result = static_cast<GlobalIndexType>(
+        _dof_table_single_component.size() * num_components);
+
+    if (!_residuals || _residuals->size() != num_element_dof_result)
+    {
+#ifndef USE_PETSC
+        _residuals.reset(new GlobalVector{num_element_dof_result});
+#else
+        _residuals.reset(new GlobalVector{num_element_dof_result, false});
+#endif
+    }
+
+    if (static_cast<std::size_t>(num_element_dof_result) !=
+        extrapolatables.size() * num_components)
+    {
+        OGS_FATAL("mismatch in number of D.o.F.");
+    }
 
     auto const size = extrapolatables.size();
-    for (std::size_t i=0; i<size; ++i) {
-        calculateResidualElement(i, extrapolatables);
+    for (std::size_t i = 0; i < size; ++i)
+    {
+        calculateResidualElement(i, num_components, extrapolatables, t,
+                                 current_solution, dof_table);
     }
 }
 
 void LocalLinearLeastSquaresExtrapolator::extrapolateElement(
     std::size_t const element_index,
+    const unsigned num_components,
     ExtrapolatableElementCollection const& extrapolatables,
+    const double t,
+    GlobalVector const& current_solution,
+    LocalToGlobalIndexMap const& dof_table,
     GlobalVector& counts)
 {
     auto const& integration_point_values =
         extrapolatables.getIntegrationPointValues(
-            element_index, _integration_point_values_cache);
+            element_index, t, current_solution, dof_table,
+            _integration_point_values_cache);
 
     auto const& N_0 = extrapolatables.getShapeMatrix(element_index, 0);
-    const auto num_nodes = static_cast<unsigned>(N_0.cols());
-    const unsigned num_int_pts = integration_point_values.size();
+    const unsigned num_nodes = N_0.cols();
+    const unsigned num_values = integration_point_values.size();
 
-    assert(num_int_pts >= num_nodes &&
-           "Least squares is not possible if there are more nodes than"
-           "integration points.");
+    if (num_values % num_components != 0)
+        OGS_FATAL(
+            "The number of computed integration point values is not divisable "
+            "by the number of num_components. Maybe the computed property is "
+            "not a %d-component vector for each integration point.",
+            num_components);
+
+    // number of integration points in the element
+    const auto num_int_pts = num_values / num_components;
+
+    if (num_int_pts < static_cast<decltype(num_int_pts)>(num_nodes))
+        OGS_FATAL(
+            "Least squares is not possible if there are more nodes than"
+            "integration points.");
 
     auto const pair_it_inserted = _qr_decomposition_cache.emplace(
         std::make_pair(num_nodes, num_int_pts), CachedData{});
@@ -146,51 +189,108 @@ void LocalLinearLeastSquaresExtrapolator::extrapolateElement(
         OGS_FATAL("The cached and the passed shapematrices differ.");
     }
 
-    // TODO make gp_vals an Eigen::VectorXd const& ?
-    auto const integration_point_values_vec =
-        MathLib::toVector(integration_point_values);
-
-    // Apply the pre-computed pseudo-inverse.
-    Eigen::VectorXd const nodal_values =
-        cached_data.A_pinv * integration_point_values_vec;
-
     // TODO: for now always zeroth component is used. This has to be extended if
     // multi-component properties shall be extrapolated
-    auto const& global_indices = _local_to_global(element_index, 0).rows;
+    auto const& global_indices =
+        _dof_table_single_component(element_index, 0).rows;
 
-    // TODO does that give rise to PETSc problems?
-    _nodal_values.add(global_indices, nodal_values);
-    counts.add(global_indices, std::vector<double>(global_indices.size(), 1.0));
+    if (num_components == 1)
+    {
+        // TODO make gp_vals an Eigen::VectorXd const& ?
+        auto const integration_point_values_vec =
+            MathLib::toVector(integration_point_values);
+
+        // Apply the pre-computed pseudo-inverse.
+        Eigen::VectorXd const nodal_values =
+            cached_data.A_pinv * integration_point_values_vec;
+
+        // TODO does that give rise to PETSc problems?
+        _nodal_values->add(global_indices, nodal_values);
+        counts.add(global_indices,
+                   std::vector<double>(global_indices.size(), 1.0));
+    }
+    else
+    {
+        // TODO make gp_vals an Eigen::VectorXd const& ?
+        auto const integration_point_values_mat = MathLib::toMatrix(
+            integration_point_values, num_components, num_int_pts);
+
+        // Apply the pre-computed pseudo-inverse.
+        Eigen::MatrixXd const nodal_values =
+            cached_data.A_pinv * integration_point_values_mat.transpose();
+
+        std::vector<GlobalIndexType> indices;
+        indices.reserve(num_components * global_indices.size());
+
+        // component-wise in nodal_values_flat, location-wise ordering in
+        // _nodal_values
+        for (unsigned comp = 0; comp < num_components; ++comp)
+        {
+            for (auto i : global_indices)
+            {
+                indices.push_back(num_components * i + comp);
+            }
+        }
+
+        // Nodal_values are passed as a raw pointer, because PETScVector and
+        // EigenVector implementations differ slightly.
+        _nodal_values->add(indices, nodal_values.data());
+        counts.add(indices, std::vector<double>(indices.size(), 1.0));
+    }
 }
 
 void LocalLinearLeastSquaresExtrapolator::calculateResidualElement(
     std::size_t const element_index,
-    ExtrapolatableElementCollection const& extrapolatables)
+    const unsigned num_components,
+    ExtrapolatableElementCollection const& extrapolatables,
+    const double t,
+    GlobalVector const& current_solution,
+    LocalToGlobalIndexMap const& dof_table)
 {
     auto const& int_pt_vals = extrapolatables.getIntegrationPointValues(
-        element_index, _integration_point_values_cache);
+        element_index, t, current_solution, dof_table,
+        _integration_point_values_cache);
+
+    const unsigned num_values = int_pt_vals.size();
+    if (num_values % num_components != 0)
+        OGS_FATAL(
+            "The number of computed integration point values is not divisable "
+            "by the number of num_components. Maybe the computed property is "
+            "not a %d-component vector for each integration point.",
+            num_components);
+
+    // number of integration points in the element
+    const auto num_int_pts = num_values / num_components;
 
     // TODO: for now always zeroth component is used
-    const auto& global_indices = _local_to_global(element_index, 0).rows;
-
-    const unsigned num_int_pts = int_pt_vals.size();
+    const auto& global_indices =
+        _dof_table_single_component(element_index, 0).rows;
     const unsigned num_nodes = global_indices.size();
-
-    // filter nodal values of the current element
-    Eigen::VectorXd nodal_vals_element(num_nodes);
-    for (unsigned i = 0; i < num_nodes; ++i) {
-        // TODO PETSc negative indices?
-        nodal_vals_element[i] = _nodal_values[global_indices[i]];
-    }
 
     auto const& interpolation_matrix =
         _qr_decomposition_cache.find({num_nodes, num_int_pts})->second.A;
 
-    double const residual = (interpolation_matrix * nodal_vals_element -
-                             MathLib::toVector(int_pt_vals))
-                                .squaredNorm();
+    Eigen::VectorXd nodal_vals_element(num_nodes);
+    auto const int_pt_vals_mat =
+        MathLib::toMatrix(int_pt_vals, num_components, num_int_pts);
 
-    _residuals.set(element_index, std::sqrt(residual / num_int_pts));
+    for (unsigned comp = 0; comp < num_components; ++comp)
+    {
+        // filter nodal values of the current element
+        for (unsigned i = 0; i < num_nodes; ++i)
+        {
+            // TODO PETSc negative indices?
+            auto const idx = num_components * global_indices[i] + comp;
+            nodal_vals_element[i] = (*_nodal_values)[idx];
+        }
+
+        double const residual = (interpolation_matrix * nodal_vals_element -
+                                 int_pt_vals_mat.row(comp).transpose())
+                                    .squaredNorm();
+
+        auto const eidx = num_components * element_index + comp;
+        _residuals->set(eidx, std::sqrt(residual / num_int_pts));
+    }
 }
 
 }  // namespace NumLib

--- a/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
+++ b/NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h
@@ -28,12 +28,10 @@ namespace NumLib
  * the residuals are computed from the actual interpolation result that is being
  * returned by this class.
  *
- * Currently this class only supports interpolating single component variables.
- *
- * Furthermore, the number of integration points in each element must be greater
- * than or equal to the number of nodes of that element. This restriction is due to
- * the use of the least squares which requires an exact or overdetermined equation
- * system.
+ * The number of integration points in each element must be greater than or
+ * equal to the number of nodes of that element. This restriction is due
+ * to the use of the least squares which requires an exact or overdetermined
+ * equation system.
  * \endparblock
  */
 class LocalLinearLeastSquaresExtrapolator : public Extrapolator
@@ -114,12 +112,12 @@ private:
         Eigen::MatrixXd A_pinv;
     };
 
-    /*! Maps (#nodes, #int_pts) to (N_0, QR decomposition),
+    /*! Maps (\#nodes, \#int_pts) to (N_0, QR decomposition),
      * where N_0 is the shape matrix of the first integration point.
      *
-     * \note It is assumed that the pair (#nodes, #int_pts) uniquely identifies
-     * the set of all shape matrices N for a mesh element (i.e., only N, not
-     * dN/dx etc.).
+     * \note It is assumed that the pair (\#nodes, \#int_pts) uniquely
+     * identifies the set of all shape matrices N for a mesh element (i.e., only
+     * N, not dN/dx etc.).
      *
      * \todo Add the element dimension as identifying criterion, or change to
      * typeid.

--- a/ProcessLib/CachedSecondaryVariable.cpp
+++ b/ProcessLib/CachedSecondaryVariable.cpp
@@ -51,8 +51,8 @@ GlobalVector const& CachedSecondaryVariable::evalField(
     std::unique_ptr<GlobalVector>& /*result_cache*/
     ) const
 {
-    // _current_solution = &x;
-    // _dof_table = &dof_table;
+    (void)t, (void)x, (void)dof_table;
+    assert(t == _t && &x == _current_solution && &dof_table == _dof_table);
     return evalFieldNoArgs();
 }
 
@@ -64,10 +64,8 @@ GlobalVector const& CachedSecondaryVariable::evalFieldNoArgs() const
         return _cached_nodal_values;
     }
     DBUG("Recomputing %s.", _internal_variable_name.c_str());
-    // TODO fix
-    const double t = 0.0;
     _extrapolator.extrapolate(
-        1, *_extrapolatables, t, *_current_solution, *_dof_table);
+        1, *_extrapolatables, _t, *_current_solution, *_dof_table);
     auto const& nodal_values = _extrapolator.getNodalValues();
     MathLib::LinAlg::copy(nodal_values, _cached_nodal_values);
     _needs_recomputation = false;

--- a/ProcessLib/CachedSecondaryVariable.cpp
+++ b/ProcessLib/CachedSecondaryVariable.cpp
@@ -32,11 +32,12 @@ SecondaryVariableFunctions CachedSecondaryVariable::getExtrapolator()
 {
     // TODO copied from makeExtrapolator()
     auto const eval_residuals = [this](
+        const double t,
         GlobalVector const& x,
         NumLib::LocalToGlobalIndexMap const& dof_table,
         std::unique_ptr<GlobalVector> & /*result_cache*/
         ) -> GlobalVector const& {
-        _extrapolator.calculateResiduals(1, *_extrapolatables, x, dof_table);
+        _extrapolator.calculateResiduals(1, *_extrapolatables, t, x, dof_table);
         return _extrapolator.getElementResiduals();
     };
     return {1, BaseLib::easyBind(&CachedSecondaryVariable::evalField, this),
@@ -44,6 +45,7 @@ SecondaryVariableFunctions CachedSecondaryVariable::getExtrapolator()
 }
 
 GlobalVector const& CachedSecondaryVariable::evalField(
+    const double t,
     GlobalVector const& x,
     NumLib::LocalToGlobalIndexMap const& dof_table,
     std::unique_ptr<GlobalVector>& /*result_cache*/
@@ -62,8 +64,10 @@ GlobalVector const& CachedSecondaryVariable::evalFieldNoArgs() const
         return _cached_nodal_values;
     }
     DBUG("Recomputing %s.", _internal_variable_name.c_str());
+    // TODO fix
+    const double t = 0.0;
     _extrapolator.extrapolate(
-        1, *_extrapolatables, *_current_solution, *_dof_table);
+        1, *_extrapolatables, t, *_current_solution, *_dof_table);
     auto const& nodal_values = _extrapolator.getNodalValues();
     MathLib::LinAlg::copy(nodal_values, _cached_nodal_values);
     _needs_recomputation = false;

--- a/ProcessLib/CachedSecondaryVariable.cpp
+++ b/ProcessLib/CachedSecondaryVariable.cpp
@@ -36,10 +36,10 @@ SecondaryVariableFunctions CachedSecondaryVariable::getExtrapolator()
         NumLib::LocalToGlobalIndexMap const& dof_table,
         std::unique_ptr<GlobalVector> & /*result_cache*/
         ) -> GlobalVector const& {
-        _extrapolator.calculateResiduals(*_extrapolatables, x, dof_table);
+        _extrapolator.calculateResiduals(1, *_extrapolatables, x, dof_table);
         return _extrapolator.getElementResiduals();
     };
-    return {BaseLib::easyBind(&CachedSecondaryVariable::evalField, this),
+    return {1, BaseLib::easyBind(&CachedSecondaryVariable::evalField, this),
             eval_residuals};
 }
 
@@ -63,7 +63,7 @@ GlobalVector const& CachedSecondaryVariable::evalFieldNoArgs() const
     }
     DBUG("Recomputing %s.", _internal_variable_name.c_str());
     _extrapolator.extrapolate(
-        *_extrapolatables, *_current_solution, *_dof_table);
+        1, *_extrapolatables, *_current_solution, *_dof_table);
     auto const& nodal_values = _extrapolator.getNodalValues();
     MathLib::LinAlg::copy(nodal_values, _cached_nodal_values);
     _needs_recomputation = false;

--- a/ProcessLib/CachedSecondaryVariable.h
+++ b/ProcessLib/CachedSecondaryVariable.h
@@ -60,8 +60,19 @@ public:
     //! Returns extrapolation functions that compute the secondary variable.
     SecondaryVariableFunctions getExtrapolator();
 
-    //! Set that recomputation is necessary.
-    void expire() { _needs_recomputation = true; }
+    void setTime(const double t)
+    {
+        _t = t;
+        _needs_recomputation = true;
+    }
+
+    void updateCurrentSolution(GlobalVector const& x,
+                               NumLib::LocalToGlobalIndexMap const& dof_table)
+    {
+        _current_solution = &x;
+        _dof_table = &dof_table;
+        _needs_recomputation = true;
+    }
 
 private:
     //! Provides the value at the current index of the _context.
@@ -87,6 +98,7 @@ private:
     SecondaryVariableContext const& _context;
     std::string const _internal_variable_name;
 
+    double _t = 0.0;
     GlobalVector const* _current_solution = nullptr;
     NumLib::LocalToGlobalIndexMap const* _dof_table = nullptr;
 };

--- a/ProcessLib/CachedSecondaryVariable.h
+++ b/ProcessLib/CachedSecondaryVariable.h
@@ -69,6 +69,7 @@ private:
 
     //! Computes the secondary Variable.
     GlobalVector const& evalField(
+        const double t,
         GlobalVector const& x,
         NumLib::LocalToGlobalIndexMap const& dof_table,
         std::unique_ptr<GlobalVector>& /*result_cache*/

--- a/ProcessLib/CachedSecondaryVariable.h
+++ b/ProcessLib/CachedSecondaryVariable.h
@@ -69,8 +69,8 @@ private:
 
     //! Computes the secondary Variable.
     GlobalVector const& evalField(
-        GlobalVector const& /*x*/,
-        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+        GlobalVector const& x,
+        NumLib::LocalToGlobalIndexMap const& dof_table,
         std::unique_ptr<GlobalVector>& /*result_cache*/
         ) const;
 
@@ -85,6 +85,9 @@ private:
     std::unique_ptr<NumLib::ExtrapolatableElementCollection> _extrapolatables;
     SecondaryVariableContext const& _context;
     std::string const _internal_variable_name;
+
+    GlobalVector const* _current_solution = nullptr;
+    NumLib::LocalToGlobalIndexMap const* _dof_table = nullptr;
 };
 
 }  // namespace ProcessLib

--- a/ProcessLib/ComponentTransport/ComponentTransportFEM.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportFEM.h
@@ -50,12 +50,21 @@ class ComponentTransportLocalAssemblerInterface
 {
 public:
     virtual std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 };
 
@@ -320,6 +329,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_darcy_velocities.size() > 0);
@@ -327,6 +339,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_darcy_velocities.size() > 1);
@@ -334,6 +349,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_darcy_velocities.size() > 2);

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
@@ -45,24 +45,24 @@ void ComponentTransportProcess::initializeConcreteProcess(
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(
-        "darcy_velocity_x", 1,
-        makeExtrapolator(getExtrapolator(), _local_assemblers,
+        "darcy_velocity_x",
+        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &ComponentTransportLocalAssemblerInterface::
                              getIntPtDarcyVelocityX));
 
     if (mesh.getDimension() > 1)
     {
         _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_y", 1,
-            makeExtrapolator(getExtrapolator(), _local_assemblers,
+            "darcy_velocity_y",
+            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                              &ComponentTransportLocalAssemblerInterface::
                                  getIntPtDarcyVelocityY));
     }
     if (mesh.getDimension() > 2)
     {
         _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_z", 1,
-            makeExtrapolator(getExtrapolator(), _local_assemblers,
+            "darcy_velocity_z",
+            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                              &ComponentTransportLocalAssemblerInterface::
                                  getIntPtDarcyVelocityZ));
     }

--- a/ProcessLib/GlobalVectorFromNamedFunction.cpp
+++ b/ProcessLib/GlobalVectorFromNamedFunction.cpp
@@ -28,6 +28,7 @@ GlobalVectorFromNamedFunction::GlobalVectorFromNamedFunction(
 }
 
 GlobalVector const& GlobalVectorFromNamedFunction::call(
+    const double /*t*/,
     GlobalVector const& x,
     NumLib::LocalToGlobalIndexMap const& dof_table,
     std::unique_ptr<GlobalVector>& result)

--- a/ProcessLib/GlobalVectorFromNamedFunction.h
+++ b/ProcessLib/GlobalVectorFromNamedFunction.h
@@ -42,7 +42,7 @@ public:
     //! The signature of this method matches
     //! SecondaryVariableFunctions::Function, i.e., this method can be used to
     //! compute a secondary variable.
-    GlobalVector const& call(GlobalVector const& x,
+    GlobalVector const& call(const double t, GlobalVector const& x,
                              NumLib::LocalToGlobalIndexMap const& dof_table,
                              std::unique_ptr<GlobalVector>& result);
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -166,7 +166,7 @@ public:
                 local_x, ShapeFunction::NPOINTS);
 
         cache.clear();
-        auto cache_vec = MathLib::createZeroedMatrix<
+        auto cache_mat = MathLib::createZeroedMatrix<
             Eigen::Matrix<double, GlobalDim, Eigen::Dynamic, Eigen::RowMajor>>(
             cache, GlobalDim, num_intpts);
 
@@ -178,7 +178,7 @@ public:
             pos.setIntegrationPoint(i);
             auto const k = _process_data.hydraulic_conductivity(t, pos)[0];
             // dimensions: (d x 1) = (d x n) * (n x 1)
-            cache_vec.col(i).noalias() =
+            cache_mat.col(i).noalias() =
                 -k * _shape_matrices[i].dNdx * local_x_vec;
         }
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -155,8 +155,8 @@ public:
         NumLib::LocalToGlobalIndexMap const& dof_table,
         std::vector<double>& cache) const override
     {
-        // auto const num_nodes = ShapeFunction_::NPOINTS;
-        auto const num_intpts = _shape_matrices.size();
+        auto const n_integration_points =
+            _integration_method.getNumberOfPoints();
 
         auto const indices = NumLib::getIndices(_element.getID(), dof_table);
         assert(!indices.empty());
@@ -168,12 +168,12 @@ public:
         cache.clear();
         auto cache_mat = MathLib::createZeroedMatrix<
             Eigen::Matrix<double, GlobalDim, Eigen::Dynamic, Eigen::RowMajor>>(
-            cache, GlobalDim, num_intpts);
+            cache, GlobalDim, n_integration_points);
 
         SpatialPosition pos;
         pos.setElementID(_element.getID());
 
-        for (unsigned i = 0; i < num_intpts; ++i)
+        for (unsigned i = 0; i < n_integration_points; ++i)
         {
             pos.setIntegrationPoint(i);
             auto const k = _process_data.hydraulic_conductivity(t, pos)[0];

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -13,6 +13,7 @@
 
 #include "GroundwaterFlowProcessData.h"
 #include "MathLib/LinAlg/Eigen/EigenMapTools.h"
+#include "NumLib/DOF/DOFTableUtil.h"
 #include "NumLib/Extrapolation/ExtrapolatableElement.h"
 #include "NumLib/Fem/FiniteElement/TemplateIsoparametric.h"
 #include "NumLib/Fem/ShapeMatrixPolicy.h"
@@ -33,12 +34,21 @@ class GroundwaterFlowLocalAssemblerInterface
 {
 public:
     virtual std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 };
 
@@ -188,6 +198,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(!_darcy_velocities.empty());
@@ -195,6 +208,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_darcy_velocities.size() > 1);
@@ -202,6 +218,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_darcy_velocities.size() > 2);

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -51,22 +51,22 @@ void GroundwaterFlowProcess::initializeConcreteProcess(
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(
-        "darcy_velocity_x", 1,
+        "darcy_velocity_x",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &GroundwaterFlowLocalAssemblerInterface::getIntPtDarcyVelocityX));
 
     if (mesh.getDimension() > 1) {
         _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_y", 1,
-            makeExtrapolator(getExtrapolator(), _local_assemblers,
+            "darcy_velocity_y",
+            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                              &GroundwaterFlowLocalAssemblerInterface::
                                  getIntPtDarcyVelocityY));
     }
     if (mesh.getDimension() > 2) {
         _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_z", 1,
-            makeExtrapolator(getExtrapolator(), _local_assemblers,
+            "darcy_velocity_z",
+            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                              &GroundwaterFlowLocalAssemblerInterface::
                                  getIntPtDarcyVelocityZ));
     }

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -51,25 +51,10 @@ void GroundwaterFlowProcess::initializeConcreteProcess(
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(
-        "darcy_velocity_x",
+        "darcy_velocity",
         makeExtrapolator(
-            1, getExtrapolator(), _local_assemblers,
-            &GroundwaterFlowLocalAssemblerInterface::getIntPtDarcyVelocityX));
-
-    if (mesh.getDimension() > 1) {
-        _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_y",
-            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
-                             &GroundwaterFlowLocalAssemblerInterface::
-                                 getIntPtDarcyVelocityY));
-    }
-    if (mesh.getDimension() > 2) {
-        _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_z",
-            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
-                             &GroundwaterFlowLocalAssemblerInterface::
-                                 getIntPtDarcyVelocityZ));
-    }
+            mesh.getDimension(), getExtrapolator(), _local_assemblers,
+            &GroundwaterFlowLocalAssemblerInterface::getIntPtDarcyVelocity));
 }
 
 void GroundwaterFlowProcess::assembleConcreteProcess(const double t,
@@ -101,17 +86,6 @@ void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
         dx_dx, M, K, b, Jac, coupling_term);
-}
-
-
-void GroundwaterFlowProcess::computeSecondaryVariableConcrete(
-     const double t, GlobalVector const& x,
-     StaggeredCouplingTerm const& coupled_term)
-{
-    DBUG("Compute the velocity for GroundwaterFlowProcess.");
-    GlobalExecutor::executeMemberOnDereferenced(
-            &GroundwaterFlowLocalAssemblerInterface::computeSecondaryVariable,
-            _local_assemblers, *_local_to_global_index_map, t, x, coupled_term);
 }
 
 }   // namespace GroundwaterFlow

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -87,11 +87,6 @@ public:
         }
     }
 
-    void computeSecondaryVariableConcrete(double const t,
-                                          GlobalVector const& x,
-                                          StaggeredCouplingTerm const&
-                                          coupled_term) override;
-
 private:
     void initializeConcreteProcess(
         NumLib::LocalToGlobalIndexMap const& dof_table,

--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -280,7 +280,7 @@ public:
         auto const local_x = current_solution.get(indices);
 
         cache.clear();
-        auto cache_vec = MathLib::createZeroedMatrix<
+        auto cache_mat = MathLib::createZeroedMatrix<
             Eigen::Matrix<double, GlobalDim, Eigen::Dynamic, Eigen::RowMajor>>(
             cache, GlobalDim, num_intpts);
 
@@ -317,7 +317,7 @@ public:
                 MaterialLib::Fluid::FluidPropertyType::Viscosity, vars);
             GlobalDimMatrixType const K_over_mu = K / mu;
 
-            cache_vec.col(ip).noalias() = -K_over_mu * dNdx * p_nodal_values;
+            cache_mat.col(ip).noalias() = -K_over_mu * dNdx * p_nodal_values;
 
             if (_process_data.has_gravity)
             {
@@ -325,7 +325,7 @@ public:
                     MaterialLib::Fluid::FluidPropertyType::Density, vars);
                 auto const b = _process_data.specific_body_force;
                 // here it is assumed that the vector b is directed 'downwards'
-                cache_vec.col(ip).noalias() += K_over_mu * rho_w * b;
+                cache_mat.col(ip).noalias() += K_over_mu * rho_w * b;
             }
         }
 

--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -273,7 +273,8 @@ public:
         NumLib::LocalToGlobalIndexMap const& dof_table,
         std::vector<double>& cache) const override
     {
-        auto const num_intpts = _ip_data.size();
+        auto const n_integration_points =
+            _integration_method.getNumberOfPoints();
 
         auto const indices = NumLib::getIndices(_element.getID(), dof_table);
         assert(!indices.empty());
@@ -282,15 +283,12 @@ public:
         cache.clear();
         auto cache_mat = MathLib::createZeroedMatrix<
             Eigen::Matrix<double, GlobalDim, Eigen::Dynamic, Eigen::RowMajor>>(
-            cache, GlobalDim, num_intpts);
+            cache, GlobalDim, n_integration_points);
 
         SpatialPosition pos;
         pos.setElementID(_element.getID());
 
         MaterialLib::Fluid::FluidProperty::ArrayType vars;
-
-        unsigned const n_integration_points =
-            _integration_method.getNumberOfPoints();
 
         auto const p_nodal_values = Eigen::Map<const NodalVectorType>(
             &local_x[ShapeFunction::NPOINTS], ShapeFunction::NPOINTS);

--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -51,12 +51,21 @@ class HTLocalAssemblerInterface
 {
 public:
     virtual std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 };
 
@@ -325,6 +334,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(!_darcy_velocities.empty());
@@ -332,6 +344,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_darcy_velocities.size() > 1);
@@ -339,6 +354,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_darcy_velocities.size() > 2);

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -45,24 +45,24 @@ void HTProcess::initializeConcreteProcess(
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(
-        "darcy_velocity_x", 1,
-        makeExtrapolator(getExtrapolator(), _local_assemblers,
+        "darcy_velocity_x",
+        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &HTLocalAssemblerInterface::getIntPtDarcyVelocityX));
 
     if (mesh.getDimension() > 1)
     {
         _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_y", 1,
+            "darcy_velocity_y",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &HTLocalAssemblerInterface::getIntPtDarcyVelocityY));
     }
     if (mesh.getDimension() > 2)
     {
         _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_z", 1,
+            "darcy_velocity_z",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &HTLocalAssemblerInterface::getIntPtDarcyVelocityZ));
     }
 }

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -45,26 +45,10 @@ void HTProcess::initializeConcreteProcess(
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(
-        "darcy_velocity_x",
-        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
-                         &HTLocalAssemblerInterface::getIntPtDarcyVelocityX));
-
-    if (mesh.getDimension() > 1)
-    {
-        _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_y",
-            makeExtrapolator(
-                1, getExtrapolator(), _local_assemblers,
-                &HTLocalAssemblerInterface::getIntPtDarcyVelocityY));
-    }
-    if (mesh.getDimension() > 2)
-    {
-        _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_z",
-            makeExtrapolator(
-                1, getExtrapolator(), _local_assemblers,
-                &HTLocalAssemblerInterface::getIntPtDarcyVelocityZ));
-    }
+        "darcy_velocity",
+        makeExtrapolator(mesh.getDimension(), getExtrapolator(),
+                         _local_assemblers,
+                         &HTLocalAssemblerInterface::getIntPtDarcyVelocity));
 }
 
 void HTProcess::assembleConcreteProcess(const double t,
@@ -96,16 +80,6 @@ void HTProcess::assembleWithJacobianConcreteProcess(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
         dx_dx, M, K, b, Jac, coupling_term);
-}
-
-void HTProcess::computeSecondaryVariableConcrete(
-    double const t, GlobalVector const& x,
-    StaggeredCouplingTerm const& coupling_term)
-{
-    DBUG("Compute the Darcy velocity for HTProcess.");
-    GlobalExecutor::executeMemberOnDereferenced(
-        &HTLocalAssemblerInterface::computeSecondaryVariable, _local_assemblers,
-        *_local_to_global_index_map, t, x, coupling_term);
 }
 
 }  // namespace HT

--- a/ProcessLib/HT/HTProcess.h
+++ b/ProcessLib/HT/HTProcess.h
@@ -56,9 +56,6 @@ public:
 
     bool isLinear() const override { return false; }
     //! @}
-    void computeSecondaryVariableConcrete(
-        double const t, GlobalVector const& x,
-        StaggeredCouplingTerm const& coupling_term) override;
 
 private:
     void initializeConcreteProcess(

--- a/ProcessLib/HeatConduction/HeatConductionFEM.h
+++ b/ProcessLib/HeatConduction/HeatConductionFEM.h
@@ -37,12 +37,21 @@ class HeatConductionLocalAssemblerInterface
 {
 public:
     virtual std::vector<double> const& getIntPtHeatFluxX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtHeatFluxY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtHeatFluxZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 };
 
@@ -169,6 +178,9 @@ public:
     }
 
     std::vector<double> const& getIntPtHeatFluxX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(!_heat_fluxes.empty());
@@ -176,6 +188,9 @@ public:
     }
 
     std::vector<double> const& getIntPtHeatFluxY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_heat_fluxes.size() > 1);
@@ -183,6 +198,9 @@ public:
     }
 
     std::vector<double> const& getIntPtHeatFluxZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_heat_fluxes.size() > 2);

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -61,25 +61,25 @@ void HeatConductionProcess::initializeConcreteProcess(
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(
-        "heat_flux_x", 1,
+        "heat_flux_x",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &HeatConductionLocalAssemblerInterface::getIntPtHeatFluxX));
 
     if (mesh.getDimension() > 1)
     {
         _secondary_variables.addSecondaryVariable(
-            "heat_flux_y", 1,
+            "heat_flux_y",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &HeatConductionLocalAssemblerInterface::getIntPtHeatFluxY));
     }
     if (mesh.getDimension() > 2)
     {
         _secondary_variables.addSecondaryVariable(
-            "heat_flux_z", 1,
+            "heat_flux_z",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &HeatConductionLocalAssemblerInterface::getIntPtHeatFluxZ));
     }
 }

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -102,48 +102,93 @@ struct HydroMechanicsLocalAssemblerInterface
       public NumLib::ExtrapolatableElement
 {
     virtual std::vector<double> const& getIntPtSigmaXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 };
 
@@ -462,30 +507,45 @@ public:
     }
 
     std::vector<double> const& getIntPtSigmaXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 0);
     }
 
     std::vector<double> const& getIntPtSigmaYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 1);
     }
 
     std::vector<double> const& getIntPtSigmaZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 2);
     }
 
     std::vector<double> const& getIntPtSigmaXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 3);
     }
 
     std::vector<double> const& getIntPtSigmaXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -493,6 +553,9 @@ public:
     }
 
     std::vector<double> const& getIntPtSigmaYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -500,30 +563,45 @@ public:
     }
 
     std::vector<double> const& getIntPtEpsilonXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 0);
     }
 
     std::vector<double> const& getIntPtEpsilonYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 1);
     }
 
     std::vector<double> const& getIntPtEpsilonZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 2);
     }
 
     std::vector<double> const& getIntPtEpsilonXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 3);
     }
 
     std::vector<double> const& getIntPtEpsilonXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -531,6 +609,9 @@ public:
     }
 
     std::vector<double> const& getIntPtEpsilonYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -538,6 +619,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(!_darcy_velocities.empty());
@@ -545,6 +629,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_darcy_velocities.size() > 1);
@@ -552,6 +639,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_darcy_velocities.size() > 2);

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -114,83 +114,83 @@ private:
                 NumLib::ComponentOrder::BY_LOCATION);
 
         Base::_secondary_variables.addSecondaryVariable(
-            "sigma_xx", 1,
+            "sigma_xx",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &HydroMechanicsLocalAssemblerInterface::getIntPtSigmaXX));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "sigma_yy", 1,
+            "sigma_yy",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &HydroMechanicsLocalAssemblerInterface::getIntPtSigmaYY));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "sigma_zz", 1,
+            "sigma_zz",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &HydroMechanicsLocalAssemblerInterface::getIntPtSigmaZZ));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "sigma_xy", 1,
+            "sigma_xy",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &HydroMechanicsLocalAssemblerInterface::getIntPtSigmaXY));
 
         if (DisplacementDim == 3)
         {
             Base::_secondary_variables.addSecondaryVariable(
-                "sigma_xz", 1,
+                "sigma_xz",
                 makeExtrapolator(
-                    getExtrapolator(), _local_assemblers,
+                    1, getExtrapolator(), _local_assemblers,
                     &HydroMechanicsLocalAssemblerInterface::getIntPtSigmaXZ));
 
             Base::_secondary_variables.addSecondaryVariable(
-                "sigma_yz", 1,
+                "sigma_yz",
                 makeExtrapolator(
-                    getExtrapolator(), _local_assemblers,
+                    1, getExtrapolator(), _local_assemblers,
                     &HydroMechanicsLocalAssemblerInterface::getIntPtSigmaYZ));
         }
 
         Base::_secondary_variables.addSecondaryVariable(
-            "epsilon_xx", 1,
+            "epsilon_xx",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &HydroMechanicsLocalAssemblerInterface::getIntPtEpsilonXX));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "epsilon_yy", 1,
+            "epsilon_yy",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &HydroMechanicsLocalAssemblerInterface::getIntPtEpsilonYY));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "epsilon_zz", 1,
+            "epsilon_zz",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &HydroMechanicsLocalAssemblerInterface::getIntPtEpsilonZZ));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "epsilon_xy", 1,
+            "epsilon_xy",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &HydroMechanicsLocalAssemblerInterface::getIntPtEpsilonXY));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "velocity_x", 1,
-            makeExtrapolator(getExtrapolator(), _local_assemblers,
+            "velocity_x",
+            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                              &HydroMechanicsLocalAssemblerInterface::
                                  getIntPtDarcyVelocityX));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "velocity_y", 1,
-            makeExtrapolator(getExtrapolator(), _local_assemblers,
+            "velocity_y",
+            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                              &HydroMechanicsLocalAssemblerInterface::
                                  getIntPtDarcyVelocityY));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "velocity_z", 1,
-            makeExtrapolator(getExtrapolator(), _local_assemblers,
+            "velocity_z",
+            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                              &HydroMechanicsLocalAssemblerInterface::
                                  getIntPtDarcyVelocityZ));
     }

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
@@ -92,7 +92,6 @@ public:
 
     void postTimestepConcrete(std::vector<double> const& /*local_x*/) override;
 
-
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         const unsigned integration_point) const override
     {
@@ -103,30 +102,45 @@ public:
     }
 
     std::vector<double> const& getIntPtSigmaXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 0);
     }
 
     std::vector<double> const& getIntPtSigmaYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 1);
     }
 
     std::vector<double> const& getIntPtSigmaZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 2);
     }
 
     std::vector<double> const& getIntPtSigmaXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 3);
     }
 
     std::vector<double> const& getIntPtSigmaXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -134,6 +148,9 @@ public:
     }
 
     std::vector<double> const& getIntPtSigmaYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
@@ -158,30 +158,45 @@ public:
     }
 
     std::vector<double> const& getIntPtEpsilonXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 0);
     }
 
     std::vector<double> const& getIntPtEpsilonYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 1);
     }
 
     std::vector<double> const& getIntPtEpsilonZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 2);
     }
 
     std::vector<double> const& getIntPtEpsilonXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 3);
     }
 
     std::vector<double> const& getIntPtEpsilonXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -189,6 +204,9 @@ public:
     }
 
     std::vector<double> const& getIntPtEpsilonYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerInterface.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerInterface.h
@@ -83,21 +83,39 @@ public:
     }
 
     virtual std::vector<double> const& getIntPtSigmaXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonXX(

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerInterface.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerInterface.h
@@ -119,21 +119,39 @@ public:
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
 private:

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
@@ -102,30 +102,45 @@ public:
     }
 
     std::vector<double> const& getIntPtSigmaXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 0);
     }
 
     std::vector<double> const& getIntPtSigmaYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 1);
     }
 
     std::vector<double> const& getIntPtSigmaZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 2);
     }
 
     std::vector<double> const& getIntPtSigmaXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 3);
     }
 
     std::vector<double> const& getIntPtSigmaXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -133,6 +148,9 @@ public:
     }
 
     std::vector<double> const& getIntPtSigmaYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
@@ -158,30 +158,45 @@ public:
     }
 
     std::vector<double> const& getIntPtEpsilonXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 0);
     }
 
     std::vector<double> const& getIntPtEpsilonYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 1);
     }
 
     std::vector<double> const& getIntPtEpsilonZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 2);
     }
 
     std::vector<double> const& getIntPtEpsilonXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 3);
     }
 
     std::vector<double> const& getIntPtEpsilonXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -189,6 +204,9 @@ public:
     }
 
     std::vector<double> const& getIntPtEpsilonYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
@@ -160,30 +160,45 @@ public:
     }
 
     std::vector<double> const& getIntPtEpsilonXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 0);
     }
 
     std::vector<double> const& getIntPtEpsilonYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 1);
     }
 
     std::vector<double> const& getIntPtEpsilonZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 2);
     }
 
     std::vector<double> const& getIntPtEpsilonXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 3);
     }
 
     std::vector<double> const& getIntPtEpsilonXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -191,6 +206,9 @@ public:
     }
 
     std::vector<double> const& getIntPtEpsilonYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
@@ -104,30 +104,45 @@ public:
     }
 
     std::vector<double> const& getIntPtSigmaXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 0);
     }
 
     std::vector<double> const& getIntPtSigmaYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 1);
     }
 
     std::vector<double> const& getIntPtSigmaZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 2);
     }
 
     std::vector<double> const& getIntPtSigmaXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 3);
     }
 
     std::vector<double> const& getIntPtSigmaXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -135,6 +150,9 @@ public:
     }
 
     std::vector<double> const& getIntPtSigmaYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -186,27 +186,27 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
             NumLib::ComponentOrder::BY_LOCATION);
 
     Base::_secondary_variables.addSecondaryVariable(
-        "sigma_xx", 1,
+        "sigma_xx",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtSigmaXX));
 
     Base::_secondary_variables.addSecondaryVariable(
-        "sigma_yy", 1,
+        "sigma_yy",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtSigmaYY));
 
     Base::_secondary_variables.addSecondaryVariable(
-        "sigma_zz", 1,
+        "sigma_zz",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtSigmaZZ));
 
     Base::_secondary_variables.addSecondaryVariable(
-        "sigma_xy", 1,
+        "sigma_xy",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtSigmaXY));
 
     if (DisplacementDim == 3)

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -212,54 +212,54 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
     if (DisplacementDim == 3)
     {
         Base::_secondary_variables.addSecondaryVariable(
-            "sigma_xz", 1,
+            "sigma_xz",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &SmallDeformationLocalAssemblerInterface::getIntPtSigmaXZ));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "sigma_yz", 1,
+            "sigma_yz",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &SmallDeformationLocalAssemblerInterface::getIntPtSigmaYZ));
     }
 
     Base::_secondary_variables.addSecondaryVariable(
-        "epsilon_xx", 1,
+        "epsilon_xx",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonXX));
 
     Base::_secondary_variables.addSecondaryVariable(
-        "epsilon_yy", 1,
+        "epsilon_yy",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonYY));
 
     Base::_secondary_variables.addSecondaryVariable(
-        "epsilon_zz", 1,
+        "epsilon_zz",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonZZ));
 
     Base::_secondary_variables.addSecondaryVariable(
-        "epsilon_xy", 1,
+        "epsilon_xy",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonXY));
 
     if (DisplacementDim == 3)
     {
         Base::_secondary_variables.addSecondaryVariable(
-            "epsilon_xz", 1,
+            "epsilon_xz",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonXZ));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "epsilon_yz", 1,
+            "epsilon_yz",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonYZ));
     }
 

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -40,12 +40,21 @@ class LiquidFlowLocalAssemblerInterface
 {
 public:
     virtual std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 };
 
@@ -114,6 +123,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(!_darcy_velocities.empty());
@@ -121,6 +133,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_darcy_velocities.size() > 1);
@@ -128,6 +143,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_darcy_velocities.size() > 2);

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -69,25 +69,25 @@ void LiquidFlowProcess::initializeConcreteProcess(
         *_material_properties);
 
     _secondary_variables.addSecondaryVariable(
-        "darcy_velocity_x", 1,
+        "darcy_velocity_x",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &LiquidFlowLocalAssemblerInterface::getIntPtDarcyVelocityX));
 
     if (mesh.getDimension() > 1)
     {
         _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_y", 1,
+            "darcy_velocity_y",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &LiquidFlowLocalAssemblerInterface::getIntPtDarcyVelocityY));
     }
     if (mesh.getDimension() > 2)
     {
         _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_z", 1,
+            "darcy_velocity_z",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &LiquidFlowLocalAssemblerInterface::getIntPtDarcyVelocityZ));
     }
 }

--- a/ProcessLib/Output.cpp
+++ b/ProcessLib/Output.cpp
@@ -121,7 +121,7 @@ void Output::doOutputAlways(Process const& process,
             + ".vtu";
     std::string const output_file_path = BaseLib::joinPaths(_output_directory, output_file_name);
     DBUG("output to %s", output_file_path.c_str());
-    doProcessOutput(output_file_path, _output_file_compression, x,
+    doProcessOutput(output_file_path, _output_file_compression, t, x,
                     process.getMesh(), process.getDOFTable(),
                     process.getProcessVariables(),
                     process.getSecondaryVariables(), process_output);
@@ -185,7 +185,7 @@ void Output::doOutputNonlinearIteration(Process const& process,
             + ".vtu";
     std::string const output_file_path = BaseLib::joinPaths(_output_directory, output_file_name);
     DBUG("output iteration results to %s", output_file_path.c_str());
-    doProcessOutput(output_file_path, _output_file_compression, x,
+    doProcessOutput(output_file_path, _output_file_compression, t, x,
                     process.getMesh(), process.getDOFTable(),
                     process.getProcessVariables(),
                     process.getSecondaryVariables(), process_output);

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -238,6 +238,12 @@ void Process::computeSparsityPattern()
 void Process::preTimestep(GlobalVector const& x, const double t,
                  const double delta_t)
 {
+    for (auto& cached_var : _cached_secondary_variables)
+    {
+        cached_var->setTime(t);
+        cached_var->updateCurrentSolution(x, *_local_to_global_index_map);
+    }
+
     MathLib::LinAlg::setLocalAccessibleVector(x);
     preTimestepConcreteProcess(x, t, delta_t);
     _boundary_conditions.preTimestep(t);
@@ -262,7 +268,7 @@ void Process::preIteration(const unsigned iter, const GlobalVector &x)
 {
     // In every new iteration cached values of secondary variables are expired.
     for (auto& cached_var : _cached_secondary_variables) {
-        cached_var->expire();
+        cached_var->updateCurrentSolution(x, *_local_to_global_index_map);
     }
 
     MathLib::LinAlg::setLocalAccessibleVector(x);

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -217,16 +217,14 @@ void Process::finishNamedFunctionsInitialization()
     for (auto const& named_function :
          _named_function_caller.getNamedFunctions()) {
         auto const& name = named_function.getName();
-        // secondary variables generated from named functions have the prefix
-        // "fct_".
         _secondary_variables.addSecondaryVariable(
-            "fct_" + name, 1,
-            {BaseLib::easyBind(
-                 &GlobalVectorFromNamedFunction::call,
-                 GlobalVectorFromNamedFunction(
-                     _named_function_caller.getSpecificFunctionCaller(name), _mesh,
-                     getSingleComponentDOFTable(),
-                     _secondary_variable_context)),
+            name,
+            {1, BaseLib::easyBind(
+                    &GlobalVectorFromNamedFunction::call,
+                    GlobalVectorFromNamedFunction(
+                        _named_function_caller.getSpecificFunctionCaller(name),
+                        _mesh, getSingleComponentDOFTable(),
+                        _secondary_variable_context)),
              nullptr});
     }
 }

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -241,7 +241,6 @@ void Process::preTimestep(GlobalVector const& x, const double t,
     for (auto& cached_var : _cached_secondary_variables)
     {
         cached_var->setTime(t);
-        cached_var->updateCurrentSolution(x, *_local_to_global_index_map);
     }
 
     MathLib::LinAlg::setLocalAccessibleVector(x);

--- a/ProcessLib/ProcessOutput.cpp
+++ b/ProcessLib/ProcessOutput.cpp
@@ -120,9 +120,8 @@ void doProcessOutput(std::string const& file_name,
     // the following section is for the output of secondary variables
 
     auto add_secondary_var = [&](SecondaryVariable const& var,
-                             std::string const& output_name)
-    {
-        assert(var.n_components == 1); // TODO implement other cases
+                                 std::string const& output_name) {
+        assert(var.fcts.num_components == 1);  // TODO implement other cases
 
         {
             DBUG("  secondary variable %s", output_name.c_str());
@@ -135,7 +134,8 @@ void doProcessOutput(std::string const& file_name,
                     var.fcts.eval_field(x, dof_table, result_cache);
 
             // Copy result
-            for (GlobalIndexType i = 0; i < nodal_values.size(); ++i) {
+            for (GlobalIndexType i = 0; i < nodal_values.size(); ++i)
+            {
                 assert(!std::isnan(nodal_values[i]));
                 (*result)[i] = nodal_values[i];
             }

--- a/ProcessLib/ProcessOutput.h
+++ b/ProcessLib/ProcessOutput.h
@@ -1,6 +1,6 @@
 /**
  * \copyright
- * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
  *            Distributed under a Modified BSD License.
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license

--- a/ProcessLib/ProcessOutput.h
+++ b/ProcessLib/ProcessOutput.h
@@ -1,6 +1,6 @@
 /**
  * \copyright
- * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
  *            Distributed under a Modified BSD License.
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
@@ -32,6 +32,7 @@ struct ProcessOutput final
 //! Writes output to the given \c file_name using the VTU file format.
 void doProcessOutput(std::string const& file_name,
                      bool const compress_output,
+                     const double t,
                      GlobalVector const& x,
                      MeshLib::Mesh& mesh,
                      NumLib::LocalToGlobalIndexMap const& dof_table,

--- a/ProcessLib/RichardsFlow/RichardsFlowFEM.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowFEM.h
@@ -56,15 +56,27 @@ class RichardsFlowLocalAssemblerInterface
 {
 public:
     virtual std::vector<double> const& getIntPtSaturation(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 };
 
@@ -294,6 +306,9 @@ public:
     }
 
     std::vector<double> const& getIntPtSaturation(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(!_saturation.empty());
@@ -301,6 +316,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(!_darcy_velocities.empty());
@@ -308,6 +326,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_darcy_velocities.size() > 1);
@@ -315,6 +336,9 @@ public:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(_darcy_velocities.size() > 2);

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
@@ -49,31 +49,31 @@ void RichardsFlowProcess::initializeConcreteProcess(
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(
-        "saturation", 1,
+        "saturation",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &RichardsFlowLocalAssemblerInterface::getIntPtSaturation));
 
     _secondary_variables.addSecondaryVariable(
-        "darcy_velocity_x", 1,
+        "darcy_velocity_x",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &RichardsFlowLocalAssemblerInterface::getIntPtDarcyVelocityX));
 
     if (mesh.getDimension() > 1)
     {
         _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_y", 1,
+            "darcy_velocity_y",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &RichardsFlowLocalAssemblerInterface::getIntPtDarcyVelocityY));
     }
     if (mesh.getDimension() > 2)
     {
         _secondary_variables.addSecondaryVariable(
-            "darcy_velocity_z", 1,
+            "darcy_velocity_z",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &RichardsFlowLocalAssemblerInterface::getIntPtDarcyVelocityZ));
     }
 }

--- a/ProcessLib/SecondaryVariable.cpp
+++ b/ProcessLib/SecondaryVariable.cpp
@@ -25,16 +25,15 @@ void SecondaryVariableCollection::addNameMapping(std::string const& internal_nam
 }
 
 void SecondaryVariableCollection::addSecondaryVariable(
-    std::string const& internal_name,
-    const unsigned num_components,
-    SecondaryVariableFunctions&& fcts)
+    std::string const& internal_name, SecondaryVariableFunctions&& fcts)
 {
     if (!_configured_secondary_variables
              .emplace(std::make_pair(
                  internal_name,
                  SecondaryVariable{internal_name /* TODO change */,
-                                   num_components, std::move(fcts)}))
-             .second) {
+                                   std::move(fcts)}))
+             .second)
+    {
         OGS_FATAL(
             "The secondary variable with internal name `%s' has already been "
             "set up.",

--- a/ProcessLib/SecondaryVariable.h
+++ b/ProcessLib/SecondaryVariable.h
@@ -89,7 +89,14 @@ struct SecondaryVariableFunctions final
     }
 
     const unsigned num_components;  //!< Number of components of the variable.
+
+    //! Computes the value of the field at every node of the underlying mesh.
     Function const eval_field;
+
+    //! If the secondary variable is extrapolated from integration points to
+    //! mesh nodes, this function computes the extrapolation residual. For
+    //! further information check the specific NumLib::Extrapolator
+    //! documentation.
     Function const eval_residuals;
 };
 
@@ -144,6 +151,7 @@ private:
 /*! Creates an object that computes a secondary variable via extrapolation of
  * integration point values.
  *
+ * \param num_components The number of components of the secondary variable.
  * \param extrapolator The extrapolator used for extrapolation.
  * \param local_assemblers The collection of local assemblers whose integration
  * point values will be extrapolated.

--- a/ProcessLib/SecondaryVariable.h
+++ b/ProcessLib/SecondaryVariable.h
@@ -155,25 +155,25 @@ SecondaryVariableFunctions makeExtrapolator(
 {
     auto const eval_field = [&extrapolator, &local_assemblers,
                              integration_point_values_method](
-        GlobalVector const& /*x*/,
-        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+        GlobalVector const& x,
+        NumLib::LocalToGlobalIndexMap const& dof_table,
         std::unique_ptr<GlobalVector> & /*result_cache*/
         ) -> GlobalVector const& {
         auto const extrapolatables = NumLib::makeExtrapolatable(
             local_assemblers, integration_point_values_method);
-        extrapolator.extrapolate(extrapolatables);
+        extrapolator.extrapolate(extrapolatables, x, dof_table);
         return extrapolator.getNodalValues();
     };
 
     auto const eval_residuals = [&extrapolator, &local_assemblers,
                                  integration_point_values_method](
-        GlobalVector const& /*x*/,
-        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+        GlobalVector const& x,
+        NumLib::LocalToGlobalIndexMap const& dof_table,
         std::unique_ptr<GlobalVector> & /*result_cache*/
         ) -> GlobalVector const& {
         auto const extrapolatables = NumLib::makeExtrapolatable(
             local_assemblers, integration_point_values_method);
-        extrapolator.calculateResiduals(extrapolatables);
+        extrapolator.calculateResiduals(extrapolatables, x, dof_table);
         return extrapolator.getElementResiduals();
     };
     return {eval_field, eval_residuals};

--- a/ProcessLib/SmallDeformation/LocalAssemblerInterface.h
+++ b/ProcessLib/SmallDeformation/LocalAssemblerInterface.h
@@ -23,39 +23,75 @@ struct SmallDeformationLocalAssemblerInterface
       public NumLib::ExtrapolatableElement
 {
     virtual std::vector<double> const& getIntPtSigmaXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 };
 

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -241,37 +241,55 @@ public:
     }
 
     std::vector<double> const& getIntPtSigmaXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 0);
     }
 
     std::vector<double> const& getIntPtSigmaYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 1);
     }
 
     std::vector<double> const& getIntPtSigmaZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 2);
     }
 
     std::vector<double> const& getIntPtSigmaXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 3);
     }
 
-    std::vector<double> const& getIntPtSigmaYZ(
+    std::vector<double> const& getIntPtSigmaXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
         return getIntPtSigma(cache, 4);
     }
 
-    std::vector<double> const& getIntPtSigmaXZ(
+    std::vector<double> const& getIntPtSigmaYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -279,30 +297,45 @@ public:
     }
 
     std::vector<double> const& getIntPtEpsilonXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 0);
     }
 
     std::vector<double> const& getIntPtEpsilonYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 1);
     }
 
     std::vector<double> const& getIntPtEpsilonZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 2);
     }
 
     std::vector<double> const& getIntPtEpsilonXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 3);
     }
 
     std::vector<double> const& getIntPtEpsilonYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -310,6 +343,9 @@ public:
     }
 
     std::vector<double> const& getIntPtEpsilonXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
@@ -69,79 +69,79 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
     _nodal_forces->resize(DisplacementDim * mesh.getNumberOfNodes());
 
     Base::_secondary_variables.addSecondaryVariable(
-        "sigma_xx", 1,
+        "sigma_xx",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtSigmaXX));
 
     Base::_secondary_variables.addSecondaryVariable(
-        "sigma_yy", 1,
+        "sigma_yy",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtSigmaYY));
 
     Base::_secondary_variables.addSecondaryVariable(
-        "sigma_zz", 1,
+        "sigma_zz",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtSigmaZZ));
 
     Base::_secondary_variables.addSecondaryVariable(
-        "sigma_xy", 1,
+        "sigma_xy",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtSigmaXY));
 
     if (DisplacementDim == 3)
     {
         Base::_secondary_variables.addSecondaryVariable(
-            "sigma_xz", 1,
+            "sigma_xz",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &SmallDeformationLocalAssemblerInterface::getIntPtSigmaXZ));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "sigma_yz", 1,
+            "sigma_yz",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &SmallDeformationLocalAssemblerInterface::getIntPtSigmaYZ));
     }
 
     Base::_secondary_variables.addSecondaryVariable(
-        "epsilon_xx", 1,
+        "epsilon_xx",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonXX));
 
     Base::_secondary_variables.addSecondaryVariable(
-        "epsilon_yy", 1,
+        "epsilon_yy",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonYY));
 
     Base::_secondary_variables.addSecondaryVariable(
-        "epsilon_zz", 1,
+        "epsilon_zz",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonZZ));
 
     Base::_secondary_variables.addSecondaryVariable(
-        "epsilon_xy", 1,
+        "epsilon_xy",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonXY));
     if (DisplacementDim == 3)
     {
         Base::_secondary_variables.addSecondaryVariable(
-            "epsilon_yz", 1,
+            "epsilon_yz",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonYZ));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "epsilon_xz", 1,
+            "epsilon_xz",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonXZ));
     }
 }

--- a/ProcessLib/TES/TESLocalAssembler-impl.h
+++ b/ProcessLib/TES/TESLocalAssembler-impl.h
@@ -264,14 +264,12 @@ TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
     assert(!indices.empty());
     auto const local_x = current_solution.get(indices);
     // local_x is ordered by component, local_x_mat is row major
-    // TODO fixed size matrix ShapeFunction_::NPOINTS columns. Conflicts with
-    // RowMajor for (presumably) 0D element.
     auto const local_x_mat = MathLib::toMatrix<
         Eigen::Matrix<double, NODAL_DOF, Eigen::Dynamic, Eigen::RowMajor>>(
         local_x, NODAL_DOF, ShapeFunction_::NPOINTS);
 
     cache.clear();
-    auto cache_vec = MathLib::createZeroedMatrix<
+    auto cache_mat = MathLib::createZeroedMatrix<
         Eigen::Matrix<double, GlobalDim, Eigen::Dynamic, Eigen::RowMajor>>(
         cache, GlobalDim, num_intpts);
 
@@ -283,7 +281,7 @@ TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
         const double eta_GR = fluid_viscosity(p, T, x);
 
         auto const& k = _d.getAssemblyParameters().solid_perm_tensor;
-        cache_vec.col(i).noalias() =
+        cache_mat.col(i).noalias() =
             k * (_shape_matrices[i].dNdx *
                  local_x_mat.row(COMPONENT_ID_PRESSURE).transpose()) /
             -eta_GR;

--- a/ProcessLib/TES/TESLocalAssembler-impl.h
+++ b/ProcessLib/TES/TESLocalAssembler-impl.h
@@ -257,8 +257,7 @@ TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
                           NumLib::LocalToGlobalIndexMap const& dof_table,
                           std::vector<double>& cache) const
 {
-    // auto const num_nodes = ShapeFunction_::NPOINTS;
-    auto const num_intpts = _shape_matrices.size();
+    auto const n_integration_points = _integration_method.getNumberOfPoints();
 
     auto const indices = NumLib::getIndices(_element.getID(), dof_table);
     assert(!indices.empty());
@@ -271,9 +270,9 @@ TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
     cache.clear();
     auto cache_mat = MathLib::createZeroedMatrix<
         Eigen::Matrix<double, GlobalDim, Eigen::Dynamic, Eigen::RowMajor>>(
-        cache, GlobalDim, num_intpts);
+        cache, GlobalDim, n_integration_points);
 
-    for (unsigned i = 0; i < num_intpts; ++i)
+    for (unsigned i = 0; i < n_integration_points; ++i)
     {
         double p, T, x;
         NumLib::shapeFunctionInterpolate(local_x, _shape_matrices[i].N, p, T,

--- a/ProcessLib/TES/TESLocalAssembler-impl.h
+++ b/ProcessLib/TES/TESLocalAssembler-impl.h
@@ -184,18 +184,24 @@ void TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::assemble(
 
 template <typename ShapeFunction_, typename IntegrationMethod_,
           unsigned GlobalDim>
-std::vector<double> const& TESLocalAssembler<
-    ShapeFunction_, IntegrationMethod_,
-    GlobalDim>::getIntPtSolidDensity(std::vector<double>& /*cache*/) const
+std::vector<double> const&
+TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
+    getIntPtSolidDensity(const double /*t*/,
+                         GlobalVector const& /*current_solution*/,
+                         NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+                         std::vector<double>& /*cache*/) const
 {
     return _d.getData().solid_density;
 }
 
 template <typename ShapeFunction_, typename IntegrationMethod_,
           unsigned GlobalDim>
-std::vector<double> const& TESLocalAssembler<
-    ShapeFunction_, IntegrationMethod_,
-    GlobalDim>::getIntPtLoading(std::vector<double>& cache) const
+std::vector<double> const&
+TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
+    getIntPtLoading(const double /*t*/,
+                    GlobalVector const& /*current_solution*/,
+                    NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+                    std::vector<double>& cache) const
 {
     auto const rho_SR = _d.getData().solid_density;
     auto const rho_SR_dry = _d.getAssemblyParameters().rho_SR_dry;
@@ -204,7 +210,7 @@ std::vector<double> const& TESLocalAssembler<
     cache.reserve(rho_SR.size());
 
     for (auto const rho : rho_SR) {
-        cache.push_back(rho/rho_SR_dry - 1.0);
+        cache.push_back(rho / rho_SR_dry - 1.0);
     }
 
     return cache;
@@ -214,7 +220,10 @@ template <typename ShapeFunction_, typename IntegrationMethod_,
           unsigned GlobalDim>
 std::vector<double> const&
 TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
-    getIntPtReactionDampingFactor(std::vector<double>& cache) const
+    getIntPtReactionDampingFactor(
+        const double /*t*/, GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+        std::vector<double>& cache) const
 {
     auto const fac = _d.getData().reaction_adaptor->getReactionDampingFactor();
     auto const num_integration_points = _d.getData().solid_density.size();
@@ -227,27 +236,36 @@ TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
 
 template <typename ShapeFunction_, typename IntegrationMethod_,
           unsigned GlobalDim>
-std::vector<double> const& TESLocalAssembler<
-    ShapeFunction_, IntegrationMethod_,
-    GlobalDim>::getIntPtReactionRate(std::vector<double>& /*cache*/) const
+std::vector<double> const&
+TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
+    getIntPtReactionRate(const double /*t*/,
+                         GlobalVector const& /*current_solution*/,
+                         NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+                         std::vector<double>& /*cache*/) const
 {
     return _d.getData().reaction_rate;
 }
 
 template <typename ShapeFunction_, typename IntegrationMethod_,
           unsigned GlobalDim>
-std::vector<double> const& TESLocalAssembler<
-    ShapeFunction_, IntegrationMethod_,
-    GlobalDim>::getIntPtDarcyVelocityX(std::vector<double>& /*cache*/) const
+std::vector<double> const&
+TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
+    getIntPtDarcyVelocityX(const double /*t*/,
+                           GlobalVector const& /*current_solution*/,
+                           NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+                           std::vector<double>& /*cache*/) const
 {
     return _d.getData().velocity[0];
 }
 
 template <typename ShapeFunction_, typename IntegrationMethod_,
           unsigned GlobalDim>
-std::vector<double> const& TESLocalAssembler<
-    ShapeFunction_, IntegrationMethod_,
-    GlobalDim>::getIntPtDarcyVelocityY(std::vector<double>& /*cache*/) const
+std::vector<double> const&
+TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
+    getIntPtDarcyVelocityY(const double /*t*/,
+                           GlobalVector const& /*current_solution*/,
+                           NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+                           std::vector<double>& /*cache*/) const
 {
     assert(_d.getData().velocity.size() > 1);
     return _d.getData().velocity[1];
@@ -255,9 +273,12 @@ std::vector<double> const& TESLocalAssembler<
 
 template <typename ShapeFunction_, typename IntegrationMethod_,
           unsigned GlobalDim>
-std::vector<double> const& TESLocalAssembler<
-    ShapeFunction_, IntegrationMethod_,
-    GlobalDim>::getIntPtDarcyVelocityZ(std::vector<double>& /*cache*/) const
+std::vector<double> const&
+TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
+    getIntPtDarcyVelocityZ(const double /*t*/,
+                           GlobalVector const& /*current_solution*/,
+                           NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+                           std::vector<double>& /*cache*/) const
 {
     assert(_d.getData().velocity.size() > 2);
     return _d.getData().velocity[2];

--- a/ProcessLib/TES/TESLocalAssembler.h
+++ b/ProcessLib/TES/TESLocalAssembler.h
@@ -55,19 +55,7 @@ public:
         NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
-    virtual std::vector<double> const& getIntPtDarcyVelocityX(
-        const double /*t*/,
-        GlobalVector const& /*current_solution*/,
-        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
-        std::vector<double>& /*cache*/) const = 0;
-
-    virtual std::vector<double> const& getIntPtDarcyVelocityY(
-        const double /*t*/,
-        GlobalVector const& /*current_solution*/,
-        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
-        std::vector<double>& /*cache*/) const = 0;
-
-    virtual std::vector<double> const& getIntPtDarcyVelocityZ(
+    virtual std::vector<double> const& getIntPtDarcyVelocity(
         const double /*t*/,
         GlobalVector const& /*current_solution*/,
         NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
@@ -131,25 +119,15 @@ public:
         NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override;
 
-    std::vector<double> const& getIntPtDarcyVelocityX(
-        const double /*t*/,
-        GlobalVector const& /*current_solution*/,
-        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
-        std::vector<double>& /*cache*/) const override;
-
-    std::vector<double> const& getIntPtDarcyVelocityY(
-        const double /*t*/,
-        GlobalVector const& /*current_solution*/,
-        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
-        std::vector<double>& /*cache*/) const override;
-
-    std::vector<double> const& getIntPtDarcyVelocityZ(
+    std::vector<double> const& getIntPtDarcyVelocity(
         const double /*t*/,
         GlobalVector const& /*current_solution*/,
         NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override;
 
 private:
+    MeshLib::Element const& _element;
+
     IntegrationMethod_ const _integration_method;
 
     std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>

--- a/ProcessLib/TES/TESLocalAssembler.h
+++ b/ProcessLib/TES/TESLocalAssembler.h
@@ -32,24 +32,45 @@ public:
                              std::vector<double> const& local_x_prev_ts) = 0;
 
     virtual std::vector<double> const& getIntPtSolidDensity(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtLoading(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtReactionDampingFactor(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtReactionRate(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 };
 
@@ -87,25 +108,47 @@ public:
                      std::vector<double> const& local_x_prev_ts) override;
 
     std::vector<double> const& getIntPtSolidDensity(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override;
 
     std::vector<double> const& getIntPtLoading(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override;
 
     std::vector<double> const& getIntPtReactionDampingFactor(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override;
 
     std::vector<double> const& getIntPtReactionRate(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override;
 
     std::vector<double> const& getIntPtDarcyVelocityX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override;
 
     std::vector<double> const& getIntPtDarcyVelocityY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override;
 
     std::vector<double> const& getIntPtDarcyVelocityZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override;
+
 private:
     IntegrationMethod_ const _integration_method;
 

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -152,17 +152,21 @@ void TESProcess::initializeConcreteProcess(
 void TESProcess::initializeSecondaryVariables()
 {
     // adds a secondary variables to the collection of all secondary variables.
-    auto add2nd = [&](std::string const& var_name, unsigned const n_components,
+    auto add2nd = [&](std::string const& var_name,
                       SecondaryVariableFunctions&& fcts) {
-        _secondary_variables.addSecondaryVariable(var_name, n_components,
-                                                  std::move(fcts));
+        _secondary_variables.addSecondaryVariable(var_name, std::move(fcts));
     };
 
     // creates an extrapolator
-    auto makeEx =
-        [&](std::vector<double> const& (TESLocalAssemblerInterface::*method)(
-            std::vector<double>&)const) -> SecondaryVariableFunctions {
-        return ProcessLib::makeExtrapolator(getExtrapolator(),
+    auto makeEx = [&](
+        unsigned const n_components,
+        std::vector<double> const& (TESLocalAssemblerInterface::*method)(
+            const double /*t*/,
+            GlobalVector const& /*current_solution*/,
+            NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+            std::vector<double>& /*cache*/)
+            const) -> SecondaryVariableFunctions {
+        return ProcessLib::makeExtrapolator(n_components, getExtrapolator(),
                                             _local_assemblers, method);
     };
 
@@ -192,32 +196,33 @@ void TESProcess::initializeSecondaryVariables()
     for (auto&& fct : solid_density->getNamedFunctions())
         _named_function_caller.addNamedFunction(std::move(fct));
 
-    add2nd("solid_density", 1, solid_density->getExtrapolator());
+    add2nd("solid_density", solid_density->getExtrapolator());
 
     _cached_secondary_variables.emplace_back(std::move(solid_density));
     // /////////////////////////////////////////////////////////////////////////
 
-    add2nd("reaction_rate", 1,
-           makeEx(&TESLocalAssemblerInterface::getIntPtReactionRate));
+    add2nd("reaction_rate",
+           makeEx(1, &TESLocalAssemblerInterface::getIntPtReactionRate));
 
-    add2nd("velocity_x", 1,
-           makeEx(&TESLocalAssemblerInterface::getIntPtDarcyVelocityX));
+    add2nd("velocity_x",
+           makeEx(1, &TESLocalAssemblerInterface::getIntPtDarcyVelocityX));
     if (_mesh.getDimension() >= 2)
-        add2nd("velocity_y", 1,
-               makeEx(&TESLocalAssemblerInterface::getIntPtDarcyVelocityY));
+        add2nd("velocity_y",
+               makeEx(1, &TESLocalAssemblerInterface::getIntPtDarcyVelocityY));
     if (_mesh.getDimension() >= 3)
-        add2nd("velocity_z", 1,
-               makeEx(&TESLocalAssemblerInterface::getIntPtDarcyVelocityZ));
+        add2nd("velocity_z",
+               makeEx(1, &TESLocalAssemblerInterface::getIntPtDarcyVelocityZ));
 
-    add2nd("loading", 1, makeEx(&TESLocalAssemblerInterface::getIntPtLoading));
-    add2nd("reaction_damping_factor", 1,
-          makeEx(&TESLocalAssemblerInterface::getIntPtReactionDampingFactor));
+    add2nd("loading", makeEx(1, &TESLocalAssemblerInterface::getIntPtLoading));
+    add2nd(
+        "reaction_damping_factor",
+        makeEx(1, &TESLocalAssemblerInterface::getIntPtReactionDampingFactor));
 
-    add2nd("relative_humidity", 1,
-           {BaseLib::easyBind(&TESProcess::computeRelativeHumidity, this),
+    add2nd("relative_humidity",
+           {1, BaseLib::easyBind(&TESProcess::computeRelativeHumidity, this),
             nullptr});
-    add2nd("equilibrium_loading", 1,
-           {BaseLib::easyBind(&TESProcess::computeEquilibriumLoading, this),
+    add2nd("equilibrium_loading",
+           {1, BaseLib::easyBind(&TESProcess::computeEquilibriumLoading, this),
             nullptr});
 }
 
@@ -316,8 +321,8 @@ NumLib::IterationResult TESProcess::postIterationConcreteProcess(
     return NumLib::IterationResult::SUCCESS;
 }
 
-GlobalVector const&
-TESProcess::computeVapourPartialPressure(
+GlobalVector const& TESProcess::computeVapourPartialPressure(
+    const double /*t*/,
     GlobalVector const& x,
     NumLib::LocalToGlobalIndexMap const& dof_table,
     std::unique_ptr<GlobalVector>& result_cache)
@@ -348,8 +353,8 @@ TESProcess::computeVapourPartialPressure(
     return *result_cache;
 }
 
-GlobalVector const&
-TESProcess::computeRelativeHumidity(
+GlobalVector const& TESProcess::computeRelativeHumidity(
+    double const /*t*/,
     GlobalVector const& x,
     NumLib::LocalToGlobalIndexMap const& dof_table,
     std::unique_ptr<GlobalVector>& result_cache)
@@ -385,8 +390,8 @@ TESProcess::computeRelativeHumidity(
     return *result_cache;
 }
 
-GlobalVector const&
-TESProcess::computeEquilibriumLoading(
+GlobalVector const& TESProcess::computeEquilibriumLoading(
+    double const /*t*/,
     GlobalVector const& x,
     NumLib::LocalToGlobalIndexMap const& dof_table,
     std::unique_ptr<GlobalVector>& result_cache)

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -204,14 +204,9 @@ void TESProcess::initializeSecondaryVariables()
     add2nd("reaction_rate",
            makeEx(1, &TESLocalAssemblerInterface::getIntPtReactionRate));
 
-    add2nd("velocity_x",
-           makeEx(1, &TESLocalAssemblerInterface::getIntPtDarcyVelocityX));
-    if (_mesh.getDimension() >= 2)
-        add2nd("velocity_y",
-               makeEx(1, &TESLocalAssemblerInterface::getIntPtDarcyVelocityY));
-    if (_mesh.getDimension() >= 3)
-        add2nd("velocity_z",
-               makeEx(1, &TESLocalAssemblerInterface::getIntPtDarcyVelocityZ));
+    add2nd("darcy_velocity",
+           makeEx(_mesh.getDimension(),
+                  &TESLocalAssemblerInterface::getIntPtDarcyVelocity));
 
     add2nd("loading", makeEx(1, &TESLocalAssemblerInterface::getIntPtLoading));
     add2nd(

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -69,16 +69,19 @@ private:
         StaggeredCouplingTerm const& coupling_term) override;
 
     GlobalVector const& computeVapourPartialPressure(
+        const double t,
         GlobalVector const& x,
         NumLib::LocalToGlobalIndexMap const& dof_table,
         std::unique_ptr<GlobalVector>& result_cache);
 
     GlobalVector const& computeRelativeHumidity(
+        const double t,
         GlobalVector const& x,
         NumLib::LocalToGlobalIndexMap const& dof_table,
         std::unique_ptr<GlobalVector>& result_cache);
 
     GlobalVector const& computeEquilibriumLoading(
+        const double t,
         GlobalVector const& x,
         NumLib::LocalToGlobalIndexMap const& dof_table,
         std::unique_ptr<GlobalVector>& result_cache);

--- a/ProcessLib/TES/Tests.cmake
+++ b/ProcessLib/TES/Tests.cmake
@@ -12,7 +12,6 @@ AddTest(
     tes_zeolite_discharge_small_ts_19_t_0_100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu temperature temperature
     tes_zeolite_discharge_small_ts_19_t_0_100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu vapour_partial_pressure vapour_partial_pressure
     tes_zeolite_discharge_small_ts_19_t_0_100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu solid_density solid_density
-    tes_zeolite_discharge_small_ts_19_t_0_100000.vtu tes_zeolite_discharge_small_pcs_0_ts_19_t_0.100000.vtu solid_density fct_solid_density
 )
 
 AddTest(
@@ -28,7 +27,6 @@ AddTest(
     tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu temperature temperature
     tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu vapour_partial_pressure vapour_partial_pressure
     tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu solid_density solid_density
-    tes_zeolite_discharge_large_pcs_0_ts_28_t_1_000000.vtu tes_zeolite_discharge_large_pcs_0_ts_28_t_1.000000.vtu solid_density fct_solid_density
 )
 
 AddTest(

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPLocalAssembler.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPLocalAssembler.h
@@ -59,9 +59,15 @@ class ThermalTwoPhaseFlowWithPPLocalAssemblerInterface
 {
 public:
     virtual std::vector<double> const& getIntPtSaturation(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtWettingPressure(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 };
 
@@ -138,6 +144,9 @@ public:
     }
 
     std::vector<double> const& getIntPtSaturation(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(!_saturation.empty());
@@ -145,6 +154,9 @@ public:
     }
 
     std::vector<double> const& getIntPtWettingPressure(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(!_pressure_wetting.empty());

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
@@ -57,14 +57,14 @@ void ThermalTwoPhaseFlowWithPPProcess::initializeConcreteProcess(
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(
-        "saturation", 1,
-        makeExtrapolator(getExtrapolator(), _local_assemblers,
+        "saturation",
+        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &ThermalTwoPhaseFlowWithPPLocalAssemblerInterface::
                              getIntPtSaturation));
 
     _secondary_variables.addSecondaryVariable(
-        "pressure_wetting", 1,
-        makeExtrapolator(getExtrapolator(), _local_assemblers,
+        "pressure_wetting",
+        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &ThermalTwoPhaseFlowWithPPLocalAssemblerInterface::
                              getIntPtWettingPressure));
 }

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
@@ -102,39 +102,75 @@ struct ThermoMechanicsLocalAssemblerInterface
       public NumLib::ExtrapolatableElement
 {
     virtual std::vector<double> const& getIntPtSigmaXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtSigmaYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
     virtual std::vector<double> const& getIntPtEpsilonYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 };
 
@@ -385,30 +421,45 @@ public:
     }
 
     std::vector<double> const& getIntPtSigmaXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 0);
     }
 
     std::vector<double> const& getIntPtSigmaYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 1);
     }
 
     std::vector<double> const& getIntPtSigmaZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 2);
     }
 
     std::vector<double> const& getIntPtSigmaXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtSigma(cache, 3);
     }
 
     std::vector<double> const& getIntPtSigmaYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -416,6 +467,9 @@ public:
     }
 
     std::vector<double> const& getIntPtSigmaXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -423,30 +477,45 @@ public:
     }
 
     std::vector<double> const& getIntPtEpsilonXX(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 0);
     }
 
     std::vector<double> const& getIntPtEpsilonYY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 1);
     }
 
     std::vector<double> const& getIntPtEpsilonZZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 2);
     }
 
     std::vector<double> const& getIntPtEpsilonXY(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         return getIntPtEpsilon(cache, 3);
     }
 
     std::vector<double> const& getIntPtEpsilonYZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);
@@ -454,6 +523,9 @@ public:
     }
 
     std::vector<double> const& getIntPtEpsilonXZ(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
         assert(DisplacementDim == 3);

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
@@ -79,77 +79,77 @@ private:
                 NumLib::ComponentOrder::BY_LOCATION));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "sigma_xx", 1,
+            "sigma_xx",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &ThermoMechanicsLocalAssemblerInterface::getIntPtSigmaXX));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "sigma_yy", 1,
+            "sigma_yy",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &ThermoMechanicsLocalAssemblerInterface::getIntPtSigmaYY));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "sigma_zz", 1,
+            "sigma_zz",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &ThermoMechanicsLocalAssemblerInterface::getIntPtSigmaZZ));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "sigma_xy", 1,
+            "sigma_xy",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &ThermoMechanicsLocalAssemblerInterface::getIntPtSigmaXY));
 
         if (DisplacementDim == 3)
         {
             Base::_secondary_variables.addSecondaryVariable(
-                "sigma_xz", 1,
+                "sigma_xz",
                 makeExtrapolator(
-                    getExtrapolator(), _local_assemblers,
+                    1, getExtrapolator(), _local_assemblers,
                     &ThermoMechanicsLocalAssemblerInterface::getIntPtSigmaXZ));
 
             Base::_secondary_variables.addSecondaryVariable(
-                "sigma_yz", 1,
+                "sigma_yz",
                 makeExtrapolator(
-                    getExtrapolator(), _local_assemblers,
+                    1, getExtrapolator(), _local_assemblers,
                     &ThermoMechanicsLocalAssemblerInterface::getIntPtSigmaYZ));
         }
         Base::_secondary_variables.addSecondaryVariable(
-            "epsilon_xx", 1,
+            "epsilon_xx",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &ThermoMechanicsLocalAssemblerInterface::getIntPtEpsilonXX));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "epsilon_yy", 1,
+            "epsilon_yy",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &ThermoMechanicsLocalAssemblerInterface::getIntPtEpsilonYY));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "epsilon_zz", 1,
+            "epsilon_zz",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &ThermoMechanicsLocalAssemblerInterface::getIntPtEpsilonZZ));
 
         Base::_secondary_variables.addSecondaryVariable(
-            "epsilon_xy", 1,
+            "epsilon_xy",
             makeExtrapolator(
-                getExtrapolator(), _local_assemblers,
+                1, getExtrapolator(), _local_assemblers,
                 &ThermoMechanicsLocalAssemblerInterface::getIntPtEpsilonXY));
         if (DisplacementDim == 3)
         {
             Base::_secondary_variables.addSecondaryVariable(
-                "epsilon_yz", 1,
-                makeExtrapolator(getExtrapolator(), _local_assemblers,
+                "epsilon_yz",
+                makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                                  &ThermoMechanicsLocalAssemblerInterface::
                                      getIntPtEpsilonYZ));
 
             Base::_secondary_variables.addSecondaryVariable(
-                "epsilon_xz", 1,
-                makeExtrapolator(getExtrapolator(), _local_assemblers,
+                "epsilon_xz",
+                makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                                  &ThermoMechanicsLocalAssemblerInterface::
                                      getIntPtEpsilonXZ));
         }

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler.h
@@ -59,9 +59,15 @@ class TwoPhaseFlowWithPPLocalAssemblerInterface
 {
 public:
     virtual std::vector<double> const& getIntPtSaturation(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtWetPressure(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 };
 
@@ -135,6 +141,9 @@ public:
     }
 
     std::vector<double> const& getIntPtSaturation(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(!_saturation.empty());
@@ -142,6 +151,9 @@ public:
     }
 
     std::vector<double> const& getIntPtWetPressure(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(!_pressure_wet.empty());

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
@@ -56,16 +56,16 @@ void TwoPhaseFlowWithPPProcess::initializeConcreteProcess(
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(
-        "saturation", 1,
+        "saturation",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &TwoPhaseFlowWithPPLocalAssemblerInterface::getIntPtSaturation));
 
     _secondary_variables.addSecondaryVariable(
-        "pressure_wet", 1,
-        makeExtrapolator(getExtrapolator(), _local_assemblers,
-                         &TwoPhaseFlowWithPPLocalAssemblerInterface::
-                             getIntPtWetPressure));
+        "pressure_wet",
+        makeExtrapolator(
+            1, getExtrapolator(), _local_assemblers,
+            &TwoPhaseFlowWithPPLocalAssemblerInterface::getIntPtWetPressure));
 }
 
 void TwoPhaseFlowWithPPProcess::assembleConcreteProcess(const double t,

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler.h
@@ -61,9 +61,15 @@ class TwoPhaseFlowWithPrhoLocalAssemblerInterface
 {
 public:
     virtual std::vector<double> const& getIntPtSaturation(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 
     virtual std::vector<double> const& getIntPtNonWettingPressure(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const = 0;
 };
 
@@ -138,6 +144,9 @@ public:
     }
 
     std::vector<double> const& getIntPtSaturation(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(!_saturation.empty());
@@ -145,6 +154,9 @@ public:
     }
 
     std::vector<double> const& getIntPtNonWettingPressure(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& /*cache*/) const override
     {
         assert(!_pressure_nonwetting.empty());

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
@@ -56,14 +56,14 @@ void TwoPhaseFlowWithPrhoProcess::initializeConcreteProcess(
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
     _secondary_variables.addSecondaryVariable(
-        "saturation", 1,
+        "saturation",
         makeExtrapolator(
-            getExtrapolator(), _local_assemblers,
+            1, getExtrapolator(), _local_assemblers,
             &TwoPhaseFlowWithPrhoLocalAssemblerInterface::getIntPtSaturation));
 
     _secondary_variables.addSecondaryVariable(
-        "pressure_nonwetting", 1,
-        makeExtrapolator(getExtrapolator(), _local_assemblers,
+        "pressure_nonwetting",
+        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &TwoPhaseFlowWithPrhoLocalAssemblerInterface::
                              getIntPtNonWettingPressure));
 }


### PR DESCRIPTION
This PR adds the possibility to extrapolate vectorial integration point quantities to mesh nodes (extrapolation proceeds component-wise).

Furthermore, now more data is passed to the `getIntPt...()` methods:
```cpp
std::vector<double> const& getIntPtDarcyVelocity(
    const double t,
    GlobalVector const& current_solution,
    NumLib::LocalToGlobalIndexMap const& dof_table,
    std::vector<double>& cache) const override
{
...
}
```
Namely time, current solution and the processes DOF table. That allows for on-demand computation of secondary variables. In particulary, e.g., the Darcy velocity does not have to be saved inside the local assemblers anymore, just in order to write it to VTU files in the end, but can be computed from the pressure solution.

Furthermore the function pointers computing integration point values now have become full `std::function`s (see [here](https://github.com/ufz/ogs/compare/master...chleh:vector-extrapolation?expand=1#diff-86bffb51b4ee67d7d0e5a81132e8d0b7R92)), which makes them much more flexible.
This feature is a necessary prerequisite for being able to output secondary (internal) variables, which are defined by individual material models. Being able to output those secondary variables is a long-awaited feature. Soon there will be a follow-up PR implementing this.

Due to this PR the amount of C++ code needed to define a secondary variable will decrease a bit. Additionally, in the prj files less outputs have to be specified.

Limitations
---------------

2D vector fields are written as two-component vectors to the vtu file. Unfortunately paraview does not treat 2D fields as vector fields (AFAIK). Suggestions for improving this are welcome. Though, those suggestions will not be included into this PR.

TODO
------------

Many processes have not been refactored to produce vectorial output. I'll leave that for later. I'd be happy if someone could help with that, e.g., updating test reference results. See also https://github.com/chleh/ogs6/tree/vector-extrapolation-PART2.

 Closes #1552.

This is now a follow-up of #1879.