### PR TITLE
Internal variables output

### DIFF
--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -749,21 +749,84 @@ SolidEhlers<DisplacementDim>::getInternalVariables() const
     return {
         {"damage.kappa_d", 1,
          [](typename MechanicsBase<
-             DisplacementDim>::MaterialStateVariables const& state) -> double {
+                DisplacementDim>::MaterialStateVariables const& state,
+            std::vector<double>& cache) -> std::vector<double> const& {
              assert(dynamic_cast<StateVariables<DisplacementDim> const*>(
                         &state) != nullptr);
              auto const& ehlers_state =
                  static_cast<StateVariables<DisplacementDim> const&>(state);
-             return ehlers_state.damage.kappa_d();
+
+             cache.resize(1);
+             cache.front() = ehlers_state.damage.kappa_d();
+             return cache;
          }},
         {"damage.value", 1,
          [](typename MechanicsBase<
-             DisplacementDim>::MaterialStateVariables const& state) -> double {
+                DisplacementDim>::MaterialStateVariables const& state,
+            std::vector<double>& cache) -> std::vector<double> const& {
              assert(dynamic_cast<StateVariables<DisplacementDim> const*>(
                         &state) != nullptr);
              auto const& ehlers_state =
                  static_cast<StateVariables<DisplacementDim> const&>(state);
-             return ehlers_state.damage.value();
+
+             cache.resize(1);
+             cache.front() = ehlers_state.damage.value();
+             return cache;
+         }},
+        {"eps_p.D", KelvinVector::RowsAtCompileTime,
+         [](typename MechanicsBase<
+                DisplacementDim>::MaterialStateVariables const& state,
+            std::vector<double>& cache) -> std::vector<double> const& {
+             assert(dynamic_cast<StateVariables<DisplacementDim> const*>(
+                        &state) != nullptr);
+             auto const& ehlers_state =
+                 static_cast<StateVariables<DisplacementDim> const&>(state);
+             auto const& D = ehlers_state.eps_p.D;
+
+             cache.resize(KelvinVector::RowsAtCompileTime);
+
+             // TODO make a general implementation for converting KelvinVectors
+             // back to symmetric rank-2 tensors.
+             for (typename KelvinVector::Index component = 0;
+                  component < KelvinVector::RowsAtCompileTime && component < 3;
+                  ++component)
+             {  // xx, yy, zz components
+                 cache[component] = D[component];
+             }
+             for (typename KelvinVector::Index component = 3;
+                  component < KelvinVector::RowsAtCompileTime;
+                  ++component)
+             {  // mixed xy, yz, xz components
+                 cache[component] = D[component] / std::sqrt(2);
+             }
+
+             return cache;
+         }},
+        {"eps_p.V", 1,
+         [](typename MechanicsBase<
+                DisplacementDim>::MaterialStateVariables const& state,
+            std::vector<double>& cache) -> std::vector<double> const& {
+             assert(dynamic_cast<StateVariables<DisplacementDim> const*>(
+                        &state) != nullptr);
+             auto const& ehlers_state =
+                 static_cast<StateVariables<DisplacementDim> const&>(state);
+
+             cache.resize(1);
+             cache.front() = ehlers_state.eps_p.V;
+             return cache;
+         }},
+        {"eps_p.eff", 1,
+         [](typename MechanicsBase<
+                DisplacementDim>::MaterialStateVariables const& state,
+            std::vector<double>& cache) -> std::vector<double> const& {
+             assert(dynamic_cast<StateVariables<DisplacementDim> const*>(
+                        &state) != nullptr);
+             auto const& ehlers_state =
+                 static_cast<StateVariables<DisplacementDim> const&>(state);
+
+             cache.resize(1);
+             cache.front() = ehlers_state.eps_p.eff;
+             return cache;
          }}};
 }
 

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -743,13 +743,11 @@ SolidEhlers<DisplacementDim>::integrateStress(
 }
 
 template <int DisplacementDim>
-std::vector<
-    std::pair<std::string,
-              typename MechanicsBase<DisplacementDim>::InternalVariableGetter>>
+std::vector<typename MechanicsBase<DisplacementDim>::InternalVariable>
 SolidEhlers<DisplacementDim>::getInternalVariables() const
 {
     return {
-        {"damage.kappa_d",
+        {"damage.kappa_d", 1,
          [](typename MechanicsBase<
              DisplacementDim>::MaterialStateVariables const& state) -> double {
              assert(dynamic_cast<StateVariables<DisplacementDim> const*>(
@@ -758,7 +756,7 @@ SolidEhlers<DisplacementDim>::getInternalVariables() const
                  static_cast<StateVariables<DisplacementDim> const&>(state);
              return ehlers_state.damage.kappa_d();
          }},
-        {"damage.value",
+        {"damage.value", 1,
          [](typename MechanicsBase<
              DisplacementDim>::MaterialStateVariables const& state) -> double {
              assert(dynamic_cast<StateVariables<DisplacementDim> const*>(

--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -742,6 +742,33 @@ SolidEhlers<DisplacementDim>::integrateStress(
         tangentStiffness)};
 }
 
+template <int DisplacementDim>
+std::vector<
+    std::pair<std::string,
+              typename MechanicsBase<DisplacementDim>::InternalVariableGetter>>
+SolidEhlers<DisplacementDim>::getInternalVariables() const
+{
+    return {
+        {"damage.kappa_d",
+         [](typename MechanicsBase<
+             DisplacementDim>::MaterialStateVariables const& state) -> double {
+             assert(dynamic_cast<StateVariables<DisplacementDim> const*>(
+                        &state) != nullptr);
+             auto const& ehlers_state =
+                 static_cast<StateVariables<DisplacementDim> const&>(state);
+             return ehlers_state.damage.kappa_d();
+         }},
+        {"damage.value",
+         [](typename MechanicsBase<
+             DisplacementDim>::MaterialStateVariables const& state) -> double {
+             assert(dynamic_cast<StateVariables<DisplacementDim> const*>(
+                        &state) != nullptr);
+             auto const& ehlers_state =
+                 static_cast<StateVariables<DisplacementDim> const&>(state);
+             return ehlers_state.damage.value();
+         }}};
+}
+
 }  // namespace Ehlers
 }  // namespace Solids
 }  // namespace MaterialLib

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -238,8 +238,7 @@ public:
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
             material_state_variables) override;
 
-    std::vector<std::pair<std::string, typename MechanicsBase<DisplacementDim>::
-                                           InternalVariableGetter>>
+    std::vector<typename MechanicsBase<DisplacementDim>::InternalVariable>
     getInternalVariables() const override;
 
 private:

--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -238,6 +238,10 @@ public:
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
             material_state_variables) override;
 
+    std::vector<std::pair<std::string, typename MechanicsBase<DisplacementDim>::
+                                           InternalVariableGetter>>
+    getInternalVariables() const override;
+
 private:
     NumLib::NewtonRaphsonSolverParameters const _nonlinear_solver_parameters;
 

--- a/MaterialLib/SolidModels/MechanicsBase.h
+++ b/MaterialLib/SolidModels/MechanicsBase.h
@@ -109,7 +109,8 @@ struct MechanicsBase
     /// Helper type for providing access to internal variables.
     struct InternalVariable
     {
-        using Getter = std::function<double(MaterialStateVariables const&)>;
+        using Getter = std::function<std::vector<double> const&(
+            MaterialStateVariables const&, std::vector<double>& /*cache*/)>;
 
         /// name of the internal variable
         std::string const name;

--- a/MaterialLib/SolidModels/MechanicsBase.h
+++ b/MaterialLib/SolidModels/MechanicsBase.h
@@ -106,11 +106,24 @@ struct MechanicsBase
                     KelvinVector const& sigma_prev,
                     MaterialStateVariables const& material_state_variables) = 0;
 
-    using InternalVariableGetter =
-        std::function<double(MaterialStateVariables const&)>;
+    /// Helper type for providing access to internal variables.
+    struct InternalVariable
+    {
+        using Getter = std::function<double(MaterialStateVariables const&)>;
 
-    virtual std::vector<std::pair<std::string, InternalVariableGetter>>
-    getInternalVariables() const
+        /// name of the internal variable
+        std::string const name;
+
+        /// number of components of the internal variable
+        unsigned const num_components;
+
+        /// function accessing the internal variable
+        Getter const getter;
+    };
+
+    /// Returns internal variables defined by the specific material model, if
+    /// any.
+    virtual std::vector<InternalVariable> getInternalVariables() const
     {
         return {};
     }

--- a/MaterialLib/SolidModels/MechanicsBase.h
+++ b/MaterialLib/SolidModels/MechanicsBase.h
@@ -10,8 +10,10 @@
 #pragma once
 
 #include <boost/optional.hpp>
+#include <functional>
 #include <memory>
 #include <tuple>
+#include <vector>
 
 #include "ProcessLib/Deformation/BMatrixPolicy.h"
 
@@ -103,6 +105,15 @@ struct MechanicsBase
                     KelvinVector const& eps,
                     KelvinVector const& sigma_prev,
                     MaterialStateVariables const& material_state_variables) = 0;
+
+    using InternalVariableGetter =
+        std::function<double(MaterialStateVariables const&)>;
+
+    virtual std::vector<std::pair<std::string, InternalVariableGetter>>
+    getInternalVariables() const
+    {
+        return {};
+    }
 
     virtual ~MechanicsBase() = default;
 };

--- a/ProcessLib/SmallDeformation/LocalAssemblerInterface.h
+++ b/ProcessLib/SmallDeformation/LocalAssemblerInterface.h
@@ -24,6 +24,13 @@ struct SmallDeformationLocalAssemblerInterface
     : public ProcessLib::LocalAssemblerInterface,
       public NumLib::ExtrapolatableElement
 {
+    virtual std::vector<double> const& getIntPtSigma(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+        std::vector<double>& cache) const = 0;
+
+    // TODO remove the component-wise methods.
     virtual std::vector<double> const& getIntPtSigmaXX(
         const double /*t*/,
         GlobalVector const& /*current_solution*/,
@@ -60,6 +67,13 @@ struct SmallDeformationLocalAssemblerInterface
         NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
 
+    virtual std::vector<double> const& getIntPtEpsilon(
+        const double /*t*/,
+        GlobalVector const& /*current_solution*/,
+        NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+        std::vector<double>& cache) const = 0;
+
+    // TODO remove the component-wise methods
     virtual std::vector<double> const& getIntPtEpsilonXX(
         const double /*t*/,
         GlobalVector const& /*current_solution*/,

--- a/ProcessLib/SmallDeformation/LocalAssemblerInterface.h
+++ b/ProcessLib/SmallDeformation/LocalAssemblerInterface.h
@@ -11,6 +11,7 @@
 
 #include <vector>
 
+#include "MaterialLib/SolidModels/MechanicsBase.h"
 #include "NumLib/Extrapolation/ExtrapolatableElement.h"
 #include "ProcessLib/LocalAssemblerInterface.h"
 
@@ -18,6 +19,7 @@ namespace ProcessLib
 {
 namespace SmallDeformation
 {
+template <int DisplacementDim>
 struct SmallDeformationLocalAssemblerInterface
     : public ProcessLib::LocalAssemblerInterface,
       public NumLib::ExtrapolatableElement
@@ -93,6 +95,13 @@ struct SmallDeformationLocalAssemblerInterface
         GlobalVector const& /*current_solution*/,
         NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
         std::vector<double>& cache) const = 0;
+
+    // TODO move to NumLib::ExtrapolatableElement
+    virtual unsigned getNumberOfIntegrationPoints() const = 0;
+
+    virtual typename MaterialLib::Solids::MechanicsBase<
+        DisplacementDim>::MaterialStateVariables const&
+    getMaterialStateVariablesAt(unsigned /*integration_point*/) const = 0;
 };
 
 }  // namespace SmallDeformation

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -13,7 +13,6 @@
 #include <vector>
 
 #include "MaterialLib/SolidModels/LinearElasticIsotropic.h"
-#include "MaterialLib/SolidModels/Lubby2.h"
 #include "MathLib/LinAlg/Eigen/EigenMapTools.h"
 #include "NumLib/Extrapolation/ExtrapolatableElement.h"
 #include "NumLib/Fem/FiniteElement/TemplateIsoparametric.h"
@@ -25,6 +24,7 @@
 #include "ProcessLib/Parameter/Parameter.h"
 #include "ProcessLib/Utils/InitShapeMatrices.h"
 
+#include "LocalAssemblerInterface.h"
 #include "SmallDeformationProcessData.h"
 
 namespace ProcessLib
@@ -76,7 +76,7 @@ struct SecondaryData
 template <typename ShapeFunction, typename IntegrationMethod,
           int DisplacementDim>
 class SmallDeformationLocalAssembler
-    : public SmallDeformationLocalAssemblerInterface
+    : public SmallDeformationLocalAssemblerInterface<DisplacementDim>
 {
 public:
     using ShapeMatricesType =
@@ -352,6 +352,18 @@ public:
     {
         assert(DisplacementDim == 3);
         return getIntPtEpsilon(cache, 5);
+    }
+
+    unsigned getNumberOfIntegrationPoints() const override
+    {
+        return static_cast<unsigned>(_ip_data.size());
+    }
+
+    typename MaterialLib::Solids::MechanicsBase<
+        DisplacementDim>::MaterialStateVariables const&
+    getMaterialStateVariablesAt(unsigned integration_point) const override
+    {
+        return *_ip_data[integration_point].material_state_variables;
     }
 
 private:

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -436,7 +436,7 @@ public:
 
     unsigned getNumberOfIntegrationPoints() const override
     {
-        return static_cast<unsigned>(_ip_data.size());
+        return _integration_method.getNumberOfPoints();
     }
 
     typename MaterialLib::Solids::MechanicsBase<

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
@@ -11,6 +11,7 @@
 
 #include <cassert>
 
+#include "BaseLib/Functional.h"
 #include "ProcessLib/Process.h"
 #include "ProcessLib/SmallDeformation/CreateLocalAssemblers.h"
 
@@ -70,79 +71,102 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
 
     Base::_secondary_variables.addSecondaryVariable(
         "sigma_xx",
-        makeExtrapolator(
-            1, getExtrapolator(), _local_assemblers,
-            &SmallDeformationLocalAssemblerInterface::getIntPtSigmaXX));
+        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
+                         &LocalAssemblerInterface::getIntPtSigmaXX));
 
     Base::_secondary_variables.addSecondaryVariable(
         "sigma_yy",
-        makeExtrapolator(
-            1, getExtrapolator(), _local_assemblers,
-            &SmallDeformationLocalAssemblerInterface::getIntPtSigmaYY));
+        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
+                         &LocalAssemblerInterface::getIntPtSigmaYY));
 
     Base::_secondary_variables.addSecondaryVariable(
         "sigma_zz",
-        makeExtrapolator(
-            1, getExtrapolator(), _local_assemblers,
-            &SmallDeformationLocalAssemblerInterface::getIntPtSigmaZZ));
+        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
+                         &LocalAssemblerInterface::getIntPtSigmaZZ));
 
     Base::_secondary_variables.addSecondaryVariable(
         "sigma_xy",
-        makeExtrapolator(
-            1, getExtrapolator(), _local_assemblers,
-            &SmallDeformationLocalAssemblerInterface::getIntPtSigmaXY));
+        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
+                         &LocalAssemblerInterface::getIntPtSigmaXY));
 
     if (DisplacementDim == 3)
     {
         Base::_secondary_variables.addSecondaryVariable(
             "sigma_xz",
-            makeExtrapolator(
-                1, getExtrapolator(), _local_assemblers,
-                &SmallDeformationLocalAssemblerInterface::getIntPtSigmaXZ));
+            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
+                             &LocalAssemblerInterface::getIntPtSigmaXZ));
 
         Base::_secondary_variables.addSecondaryVariable(
             "sigma_yz",
-            makeExtrapolator(
-                1, getExtrapolator(), _local_assemblers,
-                &SmallDeformationLocalAssemblerInterface::getIntPtSigmaYZ));
+            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
+                             &LocalAssemblerInterface::getIntPtSigmaYZ));
     }
 
     Base::_secondary_variables.addSecondaryVariable(
         "epsilon_xx",
-        makeExtrapolator(
-            1, getExtrapolator(), _local_assemblers,
-            &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonXX));
+        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
+                         &LocalAssemblerInterface::getIntPtEpsilonXX));
 
     Base::_secondary_variables.addSecondaryVariable(
         "epsilon_yy",
-        makeExtrapolator(
-            1, getExtrapolator(), _local_assemblers,
-            &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonYY));
+        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
+                         &LocalAssemblerInterface::getIntPtEpsilonYY));
 
     Base::_secondary_variables.addSecondaryVariable(
         "epsilon_zz",
-        makeExtrapolator(
-            1, getExtrapolator(), _local_assemblers,
-            &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonZZ));
+        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
+                         &LocalAssemblerInterface::getIntPtEpsilonZZ));
 
     Base::_secondary_variables.addSecondaryVariable(
         "epsilon_xy",
-        makeExtrapolator(
-            1, getExtrapolator(), _local_assemblers,
-            &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonXY));
+        makeExtrapolator(1, getExtrapolator(), _local_assemblers,
+                         &LocalAssemblerInterface::getIntPtEpsilonXY));
     if (DisplacementDim == 3)
     {
         Base::_secondary_variables.addSecondaryVariable(
             "epsilon_yz",
-            makeExtrapolator(
-                1, getExtrapolator(), _local_assemblers,
-                &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonYZ));
+            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
+                             &LocalAssemblerInterface::getIntPtEpsilonYZ));
 
         Base::_secondary_variables.addSecondaryVariable(
             "epsilon_xz",
-            makeExtrapolator(
-                1, getExtrapolator(), _local_assemblers,
-                &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonXZ));
+            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
+                             &LocalAssemblerInterface::getIntPtEpsilonXZ));
+    }
+
+    auto const int_vars = _process_data.material->getInternalVariables();
+    INFO("SmallDef has %lu internal vars.", int_vars.size());
+    for (auto const& name_fct : int_vars)
+    {
+        auto const& name = name_fct.first;
+        auto const& fct = name_fct.second;
+        INFO("internal var %s.", name.c_str());
+
+        auto getIntPtValues = BaseLib::easyBind(
+            [fct](LocalAssemblerInterface const& loc_asm,
+                  const double /*t*/,
+                  GlobalVector const& /*current_solution*/,
+                  NumLib::LocalToGlobalIndexMap const& /*dof_table*/,
+                  std::vector<double>& cache) -> std::vector<double> const& {
+                const unsigned num_int_pts =
+                    loc_asm.getNumberOfIntegrationPoints();
+
+                cache.clear();
+                cache.reserve(num_int_pts);
+
+                for (unsigned i = 0; i < num_int_pts; ++i)
+                {
+                    auto const& state = loc_asm.getMaterialStateVariablesAt(i);
+                    cache.push_back(fct(state));
+                }
+
+                return cache;
+            });
+
+        Base::_secondary_variables.addSecondaryVariable(
+            name,
+            makeExtrapolator(1, getExtrapolator(), _local_assemblers,
+                             std::move(getIntPtValues)));
     }
 }
 
@@ -190,8 +214,8 @@ void SmallDeformationProcess<DisplacementDim>::preTimestepConcreteProcess(
     _process_data.t = t;
 
     GlobalExecutor::executeMemberOnDereferenced(
-        &SmallDeformationLocalAssemblerInterface::preTimestep,
-        _local_assemblers, *_local_to_global_index_map, x, t, dt);
+        &LocalAssemblerInterface::preTimestep, _local_assemblers,
+        *_local_to_global_index_map, x, t, dt);
 }
 
 }  // namespace SmallDeformation

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
@@ -70,6 +70,14 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
     _nodal_forces->resize(DisplacementDim * mesh.getNumberOfNodes());
 
     Base::_secondary_variables.addSecondaryVariable(
+        "sigma",
+        makeExtrapolator(
+            ProcessLib::KelvinVectorType<DisplacementDim>::RowsAtCompileTime,
+            getExtrapolator(), _local_assemblers,
+            &LocalAssemblerInterface::getIntPtSigma));
+
+    // TODO remove the component-wise methods
+    Base::_secondary_variables.addSecondaryVariable(
         "sigma_xx",
         makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtSigmaXX));
@@ -103,6 +111,14 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
     }
 
     Base::_secondary_variables.addSecondaryVariable(
+        "epsilon",
+        makeExtrapolator(
+            ProcessLib::KelvinVectorType<DisplacementDim>::RowsAtCompileTime,
+            getExtrapolator(), _local_assemblers,
+            &LocalAssemblerInterface::getIntPtEpsilon));
+
+    // TODO remove the component-wise methods
+    Base::_secondary_variables.addSecondaryVariable(
         "epsilon_xx",
         makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtEpsilonXX));
@@ -134,6 +150,7 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
                              &LocalAssemblerInterface::getIntPtEpsilonXZ));
     }
 
+    // enable output of internal variables defined by material models
     auto const internal_variables =
         _process_data.material->getInternalVariables();
     for (auto const& internal_variable : internal_variables)

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
@@ -134,12 +134,13 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
                              &LocalAssemblerInterface::getIntPtEpsilonXZ));
     }
 
-    auto const int_vars = _process_data.material->getInternalVariables();
-    INFO("SmallDef has %lu internal vars.", int_vars.size());
-    for (auto const& name_fct : int_vars)
+    auto const internal_variables =
+        _process_data.material->getInternalVariables();
+    INFO("SmallDef has %lu internal vars.", internal_variables.size());
+    for (auto const& internal_variable : internal_variables)
     {
-        auto const& name = name_fct.first;
-        auto const& fct = name_fct.second;
+        auto const& name = internal_variable.name;
+        auto const& fct = internal_variable.getter;
         INFO("internal var %s.", name.c_str());
 
         auto getIntPtValues = BaseLib::easyBind(

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -41,7 +41,8 @@ public:
     //! @}
 
 private:
-    using LocalAssemblerInterface = SmallDeformationLocalAssemblerInterface;
+    using LocalAssemblerInterface =
+        SmallDeformationLocalAssemblerInterface<DisplacementDim>;
 
     void initializeConcreteProcess(
         NumLib::LocalToGlobalIndexMap const& dof_table,


### PR DESCRIPTION
... for SmallDeformation process with Ehlers/Damage model.

follow-up of #1874.

This PR implements nodal output of material-model-defined internal variables at the example of the SD process.
I do not plan to implement more such output functionality now. Instead this PR can serve as a starting point for others.

TODO:
* [ ] remove component-wise output of stress and strain from small deformation process
* [ ] update SmallDeformation ctests to use vectorial stress/strain and to test that damage and plastic strain are computed correctly.

It would be nice if somebody could help me with the TODOs above, since SmallDeformation is not my main business.