### PR TITLE
[Jenkins] Run ctest-large sequentially.

### DIFF
--- a/scripts/cmake/test/Test.cmake
+++ b/scripts/cmake/test/Test.cmake
@@ -55,7 +55,7 @@ add_custom_target(
     COMMAND ${CMAKE_CTEST_COMMAND} -T Test
     --force-new-ctest-process
     --output-on-failure --output-log Tests/ctest-large.log
-    ${CONFIG_PARAMETER} --parallel ${NUM_PROCESSORS} --test-action test
+    ${CONFIG_PARAMETER} --test-action test
     DEPENDS ogs vtkdiff ctest-large-cleanup
 )
 add_custom_target(

--- a/scripts/jenkins/gcc-tests-large.groovy
+++ b/scripts/jenkins/gcc-tests-large.groovy
@@ -16,9 +16,12 @@ node('envinf11w') {
     def image = docker.image('ogs6/gcc-gui:latest')
     image.pull()
     image.inside(defaultDockerArgs) {
-        stage('Configure') { configure.linux(cmakeOptions: defaultCMakeOptions, script: this) }
+        stage('Configure') { configure.linux(cmakeOptions: defaultCMakeOptions,
+                                             script: this) }
         stage('Build') { build.linux(script: this) }
-        stage('Test') { build.linux(script: this, target: 'tests ctest-large') }
+        stage('Test') { build.linux(cmd: 'make -j 1'
+                                    script: this,
+                                    target: 'tests ctest-large') }
     }
 
     stage('Post') {


### PR DESCRIPTION
- Do not run in parallel with unit tests
- ctest-large target run tests sequentially