### PR TITLE
[cmake] print test commands before run

### DIFF
--- a/scripts/cmake/test/AddTestTester.cmake
+++ b/scripts/cmake/test/AddTestTester.cmake
@@ -8,6 +8,8 @@ if(VIS_FILES AND VTKJS_CONVERTER)
     endforeach()
 endif()
 
+message(STATUS "running command checking test results: cd ${case_path} && ${TESTER_COMMAND}")
+
 if(WIN32)
     execute_process(
         COMMAND cmd /C ${TESTER_COMMAND}

--- a/scripts/cmake/test/AddTestWrapper.cmake
+++ b/scripts/cmake/test/AddTestWrapper.cmake
@@ -4,6 +4,17 @@ foreach(FILE ${FILES_TO_DELETE})
     file(REMOVE ${BINARY_PATH}/${FILE})
 endforeach()
 
+# taken from https://stackoverflow.com/a/7216542
+function(JOIN VALUES GLUE OUTPUT)
+  string (REGEX REPLACE "([^\\]|^);" "\\1${GLUE}" _TMP_STR "${VALUES}")
+  string (REGEX REPLACE "[\\](.)" "\\1" _TMP_STR "${_TMP_STR}") #fixes escaping
+  set (${OUTPUT} "${_TMP_STR}" PARENT_SCOPE)
+endfunction()
+
+JOIN("${WRAPPER_ARGS}" " " WRAPPER_ARGS_STR)
+JOIN("${EXECUTABLE_ARGS}" " " EXECUTABLE_ARGS_STR)
+
+message(STATUS "running command generating test results: cd ${case_path} && ${WRAPPER_COMMAND} ${WRAPPER_ARGS_STR} ${EXECUTABLE} ${EXECUTABLE_ARGS_STR}")
 execute_process(
     COMMAND ${WRAPPER_COMMAND} ${WRAPPER_ARGS} ${EXECUTABLE} ${EXECUTABLE_ARGS}
     WORKING_DIRECTORY ${case_path}


### PR DESCRIPTION
By this change it becomes easier to start a debugger for a specific invocation of ogs if some ctest fails, because now one can just copy & paste the specific command line from ctest's output.

Possible Output (the lines starting with, e.g., "136: --" are new):
```
$ ctest -R ogs-1D_HeatConduction_dirichlet -V
[...]
test 136
    Start 136: ogs-1D_HeatConduction_dirichlet

136: Test command: /usr/bin/cmake "-DEXECUTABLE=/home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/bin/ogs" "-DEXECUTABLE_ARGS=-o;/home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/Tests/Data/Parabolic/T/1D_dirichlet;line_60_heat.prj" "-Dcase_path=/home/lehmannc/prog/ogs6/github-chleh-PRs/src/Tests/Data/Parabolic/T/1D_dirichlet" "-DBINARY_PATH=/home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/Tests/Data/Parabolic/T/1D_dirichlet" "-DWRAPPER_COMMAND=" "-DWRAPPER_ARGS=" "-DFILES_TO_DELETE=/home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/Tests/Data/Parabolic/T/1D_dirichlet/1D_HeatConduction_dirichlet_stdout.log;temperature_analytical.vtu;line_60_heat_pcs_0_ts_65_t_5078125.000000.vtu;temperature_analytical.vtu;line_60_heat_pcs_0_ts_405_t_31640625.000000.vtu" "-DSTDOUT_FILE_PATH=/home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/Tests/Data/Parabolic/T/1D_dirichlet/1D_HeatConduction_dirichlet_stdout.log" "-P" "/home/lehmannc/prog/ogs6/github-chleh-PRs/src/scripts/cmake/test/AddTestWrapper.cmake"
136: Test timeout computed to be: 9.99988e+06
136: -- running command generating test results: cd /home/lehmannc/prog/ogs6/github-chleh-PRs/src/Tests/Data/Parabolic/T/1D_dirichlet &&   /home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/bin/ogs -o /home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/Tests/Data/Parabolic/T/1D_dirichlet line_60_heat.prj
1/2 Test #136: ogs-1D_HeatConduction_dirichlet ...........   Passed    0.21 sec
test 137
    Start 137: ogs-1D_HeatConduction_dirichlet-vtkdiff

137: Test command: /usr/bin/cmake "-Dcase_path=/home/lehmannc/prog/ogs6/github-chleh-PRs/src/Tests/Data/Parabolic/T/1D_dirichlet" "-DTESTER_COMMAND=/home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/bin/vtkdiff                 /home/lehmannc/prog/ogs6/github-chleh-PRs/src/Tests/Data/Parabolic/T/1D_dirichlet/temperature_analytical.vtu                 /home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/Tests/Data/Parabolic/T/1D_dirichlet/line_60_heat_pcs_0_ts_65_t_5078125.000000.vtu                 -a Temperature_Analytical_2months -b temperature                 --abs 1e-5 --rel 1e-5 && /home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/bin/vtkdiff                 /home/lehmannc/prog/ogs6/github-chleh-PRs/src/Tests/Data/Parabolic/T/1D_dirichlet/temperature_analytical.vtu                 /home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/Tests/Data/Parabolic/T/1D_dirichlet/line_60_heat_pcs_0_ts_405_t_31640625.000000.vtu                 -a Temperature_Analytical_1year -b temperature                 --abs 1e-5 --rel 1e-5" "-DVTKJS_CONVERTER=VTKJS_CONVERTER-NOTFOUND" "-DBINARY_PATH=/home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/Tests/Data/Parabolic/T/1D_dirichlet" "-DVTKJS_OUTPUT_PATH=/home/lehmannc/prog/ogs6/github-chleh-PRs/src/web/static/vis/Parabolic/T/1D_dirichlet" "-DVIS_FILES=" "-P" "/home/lehmannc/prog/ogs6/github-chleh-PRs/src/scripts/cmake/test/AddTestTester.cmake"
137: Test timeout computed to be: 9.99988e+06
137: -- running command checking test results: cd /home/lehmannc/prog/ogs6/github-chleh-PRs/src/Tests/Data/Parabolic/T/1D_dirichlet && /home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/bin/vtkdiff                 /home/lehmannc/prog/ogs6/github-chleh-PRs/src/Tests/Data/Parabolic/T/1D_dirichlet/temperature_analytical.vtu                 /home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/Tests/Data/Parabolic/T/1D_dirichlet/line_60_heat_pcs_0_ts_65_t_5078125.000000.vtu                 -a Temperature_Analytical_2months -b temperature                 --abs 1e-5 --rel 1e-5 && /home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/bin/vtkdiff                 /home/lehmannc/prog/ogs6/github-chleh-PRs/src/Tests/Data/Parabolic/T/1D_dirichlet/temperature_analytical.vtu                 /home/lehmannc/prog/ogs6/github-chleh-PRs/build-release-eigenlis/Tests/Data/Parabolic/T/1D_dirichlet/line_60_heat_pcs_0_ts_405_t_31640625.000000.vtu                 -a Temperature_Analytical_1year -b temperature                 --abs 1e-5 --rel 1e-5
2/2 Test #137: ogs-1D_HeatConduction_dirichlet-vtkdiff ...   Passed    0.03 sec
```