### PR TITLE
Writing SWMM data categories

### DIFF
--- a/Applications/FileIO/SWMM/SWMMInterface.cpp
+++ b/Applications/FileIO/SWMM/SWMMInterface.cpp
@@ -914,21 +914,26 @@ std::size_t SwmmInterface::getNumberOfParameters(SwmmObject obj_type) const
     if (OpenSwmmOutFile(const_cast<char*>(outfile.c_str())) != 0)
         return 0;
 
+    std::size_t n_params(0);
     switch (obj_type)
     {
         case SwmmObject::SUBCATCHMENT:
-            return (n_obj_params[0] + SWMM_Npolluts);
+            n_params = n_obj_params[0] + SWMM_Npolluts;
+            break;
         case SwmmObject::NODE:
-            return (n_obj_params[1] + SWMM_Npolluts);
+            n_params = n_obj_params[1] + SWMM_Npolluts;
+            break;
         case SwmmObject::LINK:
-            return (n_obj_params[2] + SWMM_Npolluts);
+            n_params = n_obj_params[2] + SWMM_Npolluts;
+            break;
         case SwmmObject::SYSTEM:
-            return n_obj_params[3];
+            n_params = n_obj_params[3];
+            break;
         default:
             ERR ("Object type not recognised.");
     }
     CloseSwmmOutFile();
-    return 0;
+    return n_params;
 }
 
 std::size_t SwmmInterface::getNumberOfTimeSteps() const
@@ -1109,7 +1114,6 @@ std::vector<double> SwmmInterface::getArrayForObject(SwmmObject obj_type, std::s
         return data;
     }
 
-    INFO ("Fetching \"%s\"-data...", getArrayName(obj_type, var_idx, SWMM_Npolluts).c_str());
     std::size_t const n_time_steps (static_cast<std::size_t>(SWMM_Nperiods));
     for (std::size_t i=0; i<n_time_steps; ++i)
     {
@@ -1263,6 +1267,19 @@ bool SwmmInterface::getLinkPointIds(std::vector<std::size_t> &inlets, std::vecto
     return true;
 }
 
+std::string SwmmInterface::swmmObjectTypeToString(SwmmObject const obj_type)
+{
+    if (obj_type == SwmmObject::NODE)
+        return "node";
+    if (obj_type == SwmmObject::LINK)
+        return "link";
+    if (obj_type == SwmmObject::SUBCATCHMENT)
+        return "subcatchment";
+    if (obj_type == SwmmObject::SYSTEM)
+        return "system";
+    return "undefined";
+}
+
 bool SwmmInterface::writeCsvForTimestep(std::string const& file_name, SwmmObject obj_type, std::size_t time_step) const
 {
     FileIO::CsvInterface csv;
@@ -1288,6 +1305,7 @@ bool SwmmInterface::writeCsvForTimestep(std::string const& file_name, SwmmObject
 bool SwmmInterface::writeCsvForObject(std::string const& file_name, SwmmObject obj_type, std::size_t obj_idx) const
 {
     FileIO::CsvInterface csv;
+    INFO ("Writing data for %s %d.", swmmObjectTypeToString(obj_type).c_str(), obj_idx);
     csv.addIndexVectorForWriting(getNumberOfTimeSteps());
     std::size_t const n_params (getNumberOfParameters(obj_type));
     for (std::size_t i=0; i<n_params; ++i)

--- a/Applications/FileIO/SWMM/SWMMInterface.cpp
+++ b/Applications/FileIO/SWMM/SWMMInterface.cpp
@@ -973,12 +973,14 @@ bool SwmmInterface::addResultsToMesh(MeshLib::Mesh &mesh, SwmmObject const swmm_
         return false;
     }
 
-    MeshLib::MeshItemType const item_type = (swmm_type == SwmmObject::NODE) ?
-        MeshLib::MeshItemType::Node : MeshLib::MeshItemType::Cell;
-    MeshLib::PropertyVector<double>* prop = MeshLib::getOrCreateMeshProperty<double>(mesh, vec_name, item_type, 1);
+    MeshLib::MeshItemType const item_type = (swmm_type == SwmmObject::NODE)
+                                                ? MeshLib::MeshItemType::Node
+                                                : MeshLib::MeshItemType::Cell;
+    MeshLib::PropertyVector<double>* prop =
+        MeshLib::getOrCreateMeshProperty<double>(mesh, vec_name, item_type, 1);
     if (!prop)
     {
-        ERR ("Error fetching array \"%s\".", vec_name.c_str());
+        ERR("Error fetching array \"%s\".", vec_name.c_str());
         return false;
     }
     std::copy(data.cbegin(), data.cend(), prop->begin());
@@ -1152,14 +1154,16 @@ std::string SwmmInterface::getArrayName(SwmmObject obj_type, std::size_t var_idx
         if (var_idx < n_obj_params[1])
             return node_vars[var_idx];
         if (var_idx < n_obj_params[1]+n_pollutants)
-            return std::string("Node_" + _pollutant_names[var_idx-n_obj_params[1]]);
+            return std::string("Node_" +
+                               _pollutant_names[var_idx - n_obj_params[1]]);
     }
     if (obj_type == SwmmObject::LINK)
     {
         if (var_idx < n_obj_params[2])
             return link_vars[var_idx];
         if (var_idx < n_obj_params[2]+n_pollutants)
-            return std::string("Link_" + _pollutant_names[var_idx-n_obj_params[2]]);
+            return std::string("Link_" +
+                               _pollutant_names[var_idx - n_obj_params[2]]);
     }
     if (obj_type == SwmmObject::SYSTEM && var_idx < n_obj_params[3])
     {
@@ -1305,7 +1309,8 @@ bool SwmmInterface::writeCsvForTimestep(std::string const& file_name, SwmmObject
 bool SwmmInterface::writeCsvForObject(std::string const& file_name, SwmmObject obj_type, std::size_t obj_idx) const
 {
     FileIO::CsvInterface csv;
-    INFO ("Writing data for %s %d.", swmmObjectTypeToString(obj_type).c_str(), obj_idx);
+    INFO("Writing data for %s %d.", swmmObjectTypeToString(obj_type).c_str(),
+         obj_idx);
     csv.addIndexVectorForWriting(getNumberOfTimeSteps());
     std::size_t const n_params (getNumberOfParameters(obj_type));
     for (std::size_t i=0; i<n_params; ++i)

--- a/Applications/FileIO/SWMM/SWMMInterface.h
+++ b/Applications/FileIO/SWMM/SWMMInterface.h
@@ -114,6 +114,9 @@ public:
     /// Checks if a SWMM output file exists for the current input
     bool existsSwmmOutputFile() const;
 
+    /// Returns a string with the name of the object type
+    static std::string swmmObjectTypeToString(SwmmObject const obj_type);
+
     /// Reading a SWMM input file and conversion into OGS geometry.
     static bool convertSwmmInputToGeometry(std::string const& inp_file_name,
         GeoLib::GEOObjects &geo_objects, bool add_subcatchments);

--- a/Applications/FileIO/SWMM/SWMMInterface.h
+++ b/Applications/FileIO/SWMM/SWMMInterface.h
@@ -70,7 +70,7 @@ public:
         std::string const& vec_name, std::vector<double> const& data);
 
     /// Returns the mesh generated from SWMM file content.
-    MeshLib::Mesh const& getMesh() const { return *_mesh; }
+    MeshLib::Mesh& getMesh() const { return *_mesh; }
 
     /// Returns the name of the data array for the given object type and parameter index.
     std::string getArrayName(SwmmObject obj_type, std::size_t var_idx) const;

--- a/Applications/Utils/SWMMConverter/SWMMConverter.cpp
+++ b/Applications/Utils/SWMMConverter/SWMMConverter.cpp
@@ -27,7 +27,8 @@
 int writeGeoOutput(std::string input_file, std::string output_file)
 {
     GeoLib::GEOObjects geo_objects;
-    if (!FileIO::SwmmInterface::convertSwmmInputToGeometry(input_file, geo_objects, true))
+    if (!FileIO::SwmmInterface::convertSwmmInputToGeometry(input_file,
+                                                           geo_objects, true))
         return -1;
 
     GeoLib::IO::BoostXmlGmlInterface xml(geo_objects);
@@ -36,34 +37,34 @@ int writeGeoOutput(std::string input_file, std::string output_file)
     return 0;
 }
 
-int addObjectsToMesh(
-    FileIO::SwmmInterface &swmm,
-    MeshLib::Mesh &mesh,
-    FileIO::SwmmObject const type,
-    std::size_t const timestep)
+int addObjectsToMesh(FileIO::SwmmInterface& swmm,
+                     MeshLib::Mesh& mesh,
+                     FileIO::SwmmObject const type,
+                     std::size_t const timestep)
 {
     std::size_t const n_node_params(swmm.getNumberOfParameters(type));
-    for (std::size_t j = 0; j<n_node_params; ++j)
+    for (std::size_t j = 0; j < n_node_params; ++j)
     {
         std::string const vec_name(swmm.getArrayName(type, j));
         if (vec_name.empty())
             return -2;
-        std::vector<double> data_vec = swmm.getArrayAtTimeStep(type, timestep, j);
+        std::vector<double> data_vec =
+            swmm.getArrayAtTimeStep(type, timestep, j);
         if (!swmm.addResultsToMesh(mesh, type, vec_name, data_vec))
             return -3;
     }
     return 0;
 }
 
-int writeMeshOutput(
-    std::string const& input_file,
-    std::string const& output_file,
-    bool const node_args,
-    bool const link_args)
+int writeMeshOutput(std::string const& input_file,
+                    std::string const& output_file,
+                    bool const node_args,
+                    bool const link_args)
 {
-    std::unique_ptr<FileIO::SwmmInterface> swmm = FileIO::SwmmInterface::create(input_file);
+    std::unique_ptr<FileIO::SwmmInterface> swmm =
+        FileIO::SwmmInterface::create(input_file);
     if (swmm == nullptr)
-    return -1;
+        return -1;
 
     MeshLib::Mesh& mesh = swmm->getMesh();
 
@@ -78,10 +79,11 @@ int writeMeshOutput(
     }
 
     std::string const basename = BaseLib::dropFileExtension(output_file);
-    std::string const extension = std::string("." + BaseLib::getFileExtension(output_file));
+    std::string const extension =
+        std::string("." + BaseLib::getFileExtension(output_file));
     std::size_t const n_time_steps(swmm->getNumberOfTimeSteps());
     INFO("Number of simulation time steps: %d", n_time_steps);
-    for (std::size_t i=0; i<n_time_steps; i++)
+    for (std::size_t i = 0; i < n_time_steps; i++)
     {
         if (node_args)
             addObjectsToMesh(*swmm, mesh, FileIO::SwmmObject::NODE, i);
@@ -96,31 +98,31 @@ int writeMeshOutput(
     return 0;
 }
 
-void writeObjectsOfSwmmTypeToCsv(
-    FileIO::SwmmInterface &swmm,
-    FileIO::SwmmObject const type,
-    std::string const& base,
-    std::string const& ext)
+void writeObjectsOfSwmmTypeToCsv(FileIO::SwmmInterface& swmm,
+                                 FileIO::SwmmObject const type,
+                                 std::string const& base,
+                                 std::string const& ext)
 {
     std::size_t n_objects = swmm.getNumberOfObjects(type);
-    std::string const& type_str (swmm.swmmObjectTypeToString(type));
-    for (std::size_t i = 0; i<n_objects; ++i)
+    std::string const& type_str(swmm.swmmObjectTypeToString(type));
+    for (std::size_t i = 0; i < n_objects; ++i)
     {
         std::string const obj_name = swmm.getName(type, i);
-        std::string const obj_file_name = std::string(base + "_" + type_str + "_" + obj_name + ext);
+        std::string const obj_file_name =
+            std::string(base + "_" + type_str + "_" + obj_name + ext);
         swmm.writeCsvForObject(obj_file_name, type, i);
     }
 }
 
-int writeCsvOutput(
-    std::string input_file,
-    std::string output_file,
-    bool const node_args,
-    bool const link_args,
-    bool const catchment_args,
-    bool const system_args)
+int writeCsvOutput(std::string input_file,
+                   std::string output_file,
+                   bool const node_args,
+                   bool const link_args,
+                   bool const catchment_args,
+                   bool const system_args)
 {
-    std::unique_ptr<FileIO::SwmmInterface> swmm = FileIO::SwmmInterface::create(input_file);
+    std::unique_ptr<FileIO::SwmmInterface> swmm =
+        FileIO::SwmmInterface::create(input_file);
     if (swmm == nullptr)
         return -1;
 
@@ -137,62 +139,79 @@ int writeCsvOutput(
     }
 
     std::string const basename = BaseLib::dropFileExtension(output_file);
-    std::string const extension = std::string("." + BaseLib::getFileExtension(output_file));
+    std::string const extension =
+        std::string("." + BaseLib::getFileExtension(output_file));
 
     if (node_args)
-        writeObjectsOfSwmmTypeToCsv(*swmm, FileIO::SwmmObject::NODE, basename, extension);
+        writeObjectsOfSwmmTypeToCsv(*swmm, FileIO::SwmmObject::NODE, basename,
+                                    extension);
 
     if (link_args)
-        writeObjectsOfSwmmTypeToCsv(*swmm, FileIO::SwmmObject::LINK, basename, extension);
+        writeObjectsOfSwmmTypeToCsv(*swmm, FileIO::SwmmObject::LINK, basename,
+                                    extension);
 
     if (catchment_args)
-        writeObjectsOfSwmmTypeToCsv(*swmm, FileIO::SwmmObject::SUBCATCHMENT, basename, extension);
+        writeObjectsOfSwmmTypeToCsv(*swmm, FileIO::SwmmObject::SUBCATCHMENT,
+                                    basename, extension);
 
     if (system_args)
     {
-        std::string const obj_file_name = std::string(basename + "_system" + extension);
+        std::string const obj_file_name =
+            std::string(basename + "_system" + extension);
         swmm->writeCsvForObject(obj_file_name, FileIO::SwmmObject::SYSTEM, 0);
     }
     return 0;
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
     ApplicationsLib::LogogSetup setup;
 
-    TCLAP::CmdLine cmd
-        ("Read files for the Storm Water Management Model (SWMM) and converts them into OGS data structures.", ' ', "0.1");
-    TCLAP::ValueArg<std::string> mesh_output_arg
-        ("m","mesh", "mesh output file (*.vtu)", false, "", "mesh output file");
+    TCLAP::CmdLine cmd(
+        "Read files for the Storm Water Management Model (SWMM) and converts "
+        "them into OGS data structures.",
+        ' ', "0.1");
+    TCLAP::ValueArg<std::string> mesh_output_arg(
+        "m", "mesh", "mesh output file (*.vtu)", false, "", "mesh output file");
     cmd.add(mesh_output_arg);
-    TCLAP::ValueArg<std::string> geo_output_arg
-        ("g","geo", "geometry output file (*.gml)", false, "", "geometry output file");
+    TCLAP::ValueArg<std::string> geo_output_arg(
+        "g", "geo", "geometry output file (*.gml)", false, "",
+        "geometry output file");
     cmd.add(geo_output_arg);
-    TCLAP::ValueArg<std::string> csv_output_arg
-        ("c", "csv", "csv output file (*.csv)", false, "", "CSV output file");
+    TCLAP::ValueArg<std::string> csv_output_arg(
+        "c", "csv", "csv output file (*.csv)", false, "", "CSV output file");
     cmd.add(csv_output_arg);
-    TCLAP::ValueArg<std::string> swmm_input_arg
-        ("i","input", "SWMM input file (*.inp)", true, "", "input file");
+    TCLAP::ValueArg<std::string> swmm_input_arg(
+        "i", "input", "SWMM input file (*.inp)", true, "", "input file");
     cmd.add(swmm_input_arg);
-    TCLAP::SwitchArg add_nodes_arg ("", "node_vars", "Read node variables and add to output mesh");
+    TCLAP::SwitchArg add_nodes_arg(
+        "", "node_vars", "Read node variables and add to output mesh");
     cmd.add(add_nodes_arg);
-    TCLAP::SwitchArg add_links_arg ("", "link_vars", "Read link variables and add to output mesh");
+    TCLAP::SwitchArg add_links_arg(
+        "", "link_vars", "Read link variables and add to output mesh");
     cmd.add(add_links_arg);
-    TCLAP::SwitchArg add_subcatchments_arg ("", "subcatchment_vars", "Read subcatchment variables and write to CSV-file");
+    TCLAP::SwitchArg add_subcatchments_arg(
+        "", "subcatchment_vars",
+        "Read subcatchment variables and write to CSV-file");
     cmd.add(add_subcatchments_arg);
-    TCLAP::SwitchArg add_system_arg ("", "system_vars", "Read system variables and write to CSV-file");
+    TCLAP::SwitchArg add_system_arg(
+        "", "system_vars", "Read system variables and write to CSV-file");
     cmd.add(add_system_arg);
-    cmd.parse( argc, argv );
+    cmd.parse(argc, argv);
 
-    if (!(geo_output_arg.isSet() || mesh_output_arg.isSet() || csv_output_arg.isSet()))
+    if (!(geo_output_arg.isSet() || mesh_output_arg.isSet() ||
+          csv_output_arg.isSet()))
     {
-        ERR ("No output format given. Please specify OGS geometry or mesh output file.");
+        ERR("No output format given. Please specify OGS geometry or mesh "
+            "output file.");
         return -1;
     }
 
-    if ((add_subcatchments_arg.getValue() || add_system_arg.getValue()) && !csv_output_arg.isSet())
+    if ((add_subcatchments_arg.getValue() || add_system_arg.getValue()) &&
+        !csv_output_arg.isSet())
     {
-        ERR("Please specify csv output file for exporting subcatchment or system parameters.");
+        ERR("Please specify csv output file for exporting subcatchment or "
+            "system parameters.");
         return -1;
     }
 
@@ -201,16 +220,15 @@ int main(int argc, char *argv[])
 
     if (mesh_output_arg.isSet())
         writeMeshOutput(swmm_input_arg.getValue(), mesh_output_arg.getValue(),
-            add_nodes_arg.getValue(), add_links_arg.getValue());
+                        add_nodes_arg.getValue(), add_links_arg.getValue());
 
     if (csv_output_arg.isSet())
-        writeCsvOutput(
-            swmm_input_arg.getValue(),
-            csv_output_arg.getValue(),
-            add_nodes_arg.getValue(),
-            add_links_arg.getValue(),
-            add_subcatchments_arg.getValue(),
-            add_system_arg.getValue());
+        writeCsvOutput(swmm_input_arg.getValue(),
+                       csv_output_arg.getValue(),
+                       add_nodes_arg.getValue(),
+                       add_links_arg.getValue(),
+                       add_subcatchments_arg.getValue(),
+                       add_system_arg.getValue());
 
     return 0;
 }

--- a/Applications/Utils/SWMMConverter/SWMMConverter.cpp
+++ b/Applications/Utils/SWMMConverter/SWMMConverter.cpp
@@ -111,6 +111,18 @@ int writeCsvOutput(std::string input_file, std::string output_file,
     if (swmm == nullptr)
         return -1;
 
+    if (!swmm->existsSwmmOutputFile())
+    {
+        INFO("No output file found, skipping data conversion to CSV.");
+        return -1;
+    }
+
+    if (!(node_args || link_args || catchment_args || system_args))
+    {
+        INFO("No data category selected. Nothing to write.");
+        return 0;
+    }
+
     std::string const basename = BaseLib::dropFileExtension(output_file);
     std::string const extension = std::string("." + BaseLib::getFileExtension(output_file));
 

--- a/Applications/Utils/SWMMConverter/SWMMConverter.cpp
+++ b/Applications/Utils/SWMMConverter/SWMMConverter.cpp
@@ -36,8 +36,11 @@ int writeGeoOutput(std::string input_file, std::string output_file)
     return 0;
 }
 
-int addObjectsToMesh(FileIO::SwmmInterface &swmm, MeshLib::Mesh &mesh,
-    FileIO::SwmmObject const type, std::size_t const timestep)
+int addObjectsToMesh(
+    FileIO::SwmmInterface &swmm,
+    MeshLib::Mesh &mesh,
+    FileIO::SwmmObject const type,
+    std::size_t const timestep)
 {
     std::size_t const n_node_params(swmm.getNumberOfParameters(type));
     for (std::size_t j = 0; j<n_node_params; ++j)
@@ -52,8 +55,11 @@ int addObjectsToMesh(FileIO::SwmmInterface &swmm, MeshLib::Mesh &mesh,
     return 0;
 }
 
-int writeMeshOutput(std::string const& input_file, std::string const& output_file,
-    bool const node_args, bool const link_args)
+int writeMeshOutput(
+    std::string const& input_file,
+    std::string const& output_file,
+    bool const node_args,
+    bool const link_args)
 {
     std::unique_ptr<FileIO::SwmmInterface> swmm = FileIO::SwmmInterface::create(input_file);
     if (swmm == nullptr)
@@ -90,8 +96,11 @@ int writeMeshOutput(std::string const& input_file, std::string const& output_fil
     return 0;
 }
 
-void writeObjectsOfSwmmTypeToCsv(FileIO::SwmmInterface &swmm, FileIO::SwmmObject const type,
-    std::string const& base, std::string const& ext)
+void writeObjectsOfSwmmTypeToCsv(
+    FileIO::SwmmInterface &swmm,
+    FileIO::SwmmObject const type,
+    std::string const& base,
+    std::string const& ext)
 {
     std::size_t n_objects = swmm.getNumberOfObjects(type);
     for (std::size_t i = 0; i<n_objects; ++i)
@@ -102,8 +111,13 @@ void writeObjectsOfSwmmTypeToCsv(FileIO::SwmmInterface &swmm, FileIO::SwmmObject
     }
 }
 
-int writeCsvOutput(std::string input_file, std::string output_file,
-    bool const node_args, bool const link_args, bool const catchment_args, bool const system_args)
+int writeCsvOutput(
+    std::string input_file,
+    std::string output_file,
+    bool const node_args,
+    bool const link_args,
+    bool const catchment_args,
+    bool const system_args)
 {
     std::unique_ptr<FileIO::SwmmInterface> swmm = FileIO::SwmmInterface::create(input_file);
     if (swmm == nullptr)

--- a/Applications/Utils/SWMMConverter/SWMMConverter.cpp
+++ b/Applications/Utils/SWMMConverter/SWMMConverter.cpp
@@ -55,12 +55,11 @@ int addObjectsToMesh(FileIO::SwmmInterface &swmm, MeshLib::Mesh &mesh,
 int writeMeshOutput(std::string const& input_file, std::string const& output_file,
     bool const node_args, bool const link_args)
 {
-    std::unique_ptr<FileIO::SwmmInterface> swmm = nullptr;
-    swmm = FileIO::SwmmInterface::create(input_file);
+    std::unique_ptr<FileIO::SwmmInterface> swmm = FileIO::SwmmInterface::create(input_file);
     if (swmm == nullptr)
     return -1;
 
-    MeshLib::Mesh mesh = swmm->getMesh();
+    MeshLib::Mesh& mesh = swmm->getMesh();
 
     bool const no_output_file = !swmm->existsSwmmOutputFile();
     if (!(node_args || link_args) || no_output_file)
@@ -106,8 +105,7 @@ void writeObjectsOfSwmmTypeToCsv(FileIO::SwmmInterface &swmm, FileIO::SwmmObject
 int writeCsvOutput(std::string input_file, std::string output_file,
     bool const node_args, bool const link_args, bool const catchment_args, bool const system_args)
 {
-    std::unique_ptr<FileIO::SwmmInterface> swmm = nullptr;
-    swmm = FileIO::SwmmInterface::create(input_file);
+    std::unique_ptr<FileIO::SwmmInterface> swmm = FileIO::SwmmInterface::create(input_file);
     if (swmm == nullptr)
         return -1;
 

--- a/Applications/Utils/SWMMConverter/SWMMConverter.cpp
+++ b/Applications/Utils/SWMMConverter/SWMMConverter.cpp
@@ -12,6 +12,7 @@
 
 #include "Applications/ApplicationsLib/LogogSetup.h"
 
+#include "BaseLib/FileTools.h"
 #include "BaseLib/StringTools.h"
 
 #include "GeoLib/GEOObjects.h"
@@ -23,109 +24,168 @@
 
 #include "Applications/FileIO/CsvInterface.h"
 
+int writeGeoOutput(std::string input_file, std::string output_file)
+{
+    GeoLib::GEOObjects geo_objects;
+    if (!FileIO::SwmmInterface::convertSwmmInputToGeometry(input_file, geo_objects, true))
+        return -1;
+
+    GeoLib::IO::BoostXmlGmlInterface xml(geo_objects);
+    xml.setNameForExport(BaseLib::extractBaseNameWithoutExtension(input_file));
+    xml.writeToFile(output_file);
+    return 0;
+}
+
+int addObjectsToMesh(FileIO::SwmmInterface &swmm, MeshLib::Mesh &mesh,
+    FileIO::SwmmObject const type, std::size_t const timestep)
+{
+    std::size_t const n_node_params(swmm.getNumberOfParameters(type));
+    for (std::size_t j = 0; j<n_node_params; ++j)
+    {
+        std::string const vec_name(swmm.getArrayName(type, j));
+        if (vec_name.empty())
+            return -2;
+        std::vector<double> data_vec = swmm.getArrayAtTimeStep(type, timestep, j);
+        if (!swmm.addResultsToMesh(mesh, type, vec_name, data_vec))
+            return -3;
+    }
+    return 0;
+}
+
+int writeMeshOutput(std::string const& input_file, std::string const& output_file,
+    bool const node_args, bool const link_args)
+{
+    std::unique_ptr<FileIO::SwmmInterface> swmm = nullptr;
+    swmm = FileIO::SwmmInterface::create(input_file);
+    if (swmm == nullptr)
+    return -1;
+
+    MeshLib::Mesh mesh = swmm->getMesh();
+
+    bool const no_output_file = !swmm->existsSwmmOutputFile();
+    if (!(node_args || link_args) || no_output_file)
+    {
+        if (no_output_file)
+            INFO("No output file found.");
+        MeshLib::IO::VtuInterface vtkIO(&mesh, 0, false);
+        vtkIO.writeToFile(output_file);
+        return 0;
+    }
+
+    std::string const basename = BaseLib::dropFileExtension(output_file);
+    std::string const extension = std::string("." + BaseLib::getFileExtension(output_file));
+    std::size_t const n_time_steps(swmm->getNumberOfTimeSteps());
+    INFO("Number of simulation time steps: %d", n_time_steps);
+    for (std::size_t i=0; i<n_time_steps; i++)
+    {
+        if (node_args)
+            addObjectsToMesh(*swmm, mesh, FileIO::SwmmObject::NODE, i);
+
+        if (link_args)
+            addObjectsToMesh(*swmm, mesh, FileIO::SwmmObject::LINK, i);
+
+        MeshLib::IO::VtuInterface vtkio(&mesh, 0, false);
+        std::string name(basename + BaseLib::tostring(i) + extension);
+        vtkio.writeToFile(name);
+    }
+    return 0;
+}
+
+void writeObjectsOfSwmmTypeToCsv(FileIO::SwmmInterface &swmm, FileIO::SwmmObject const type,
+    std::string const& base, std::string const& ext)
+{
+    std::size_t n_objects = swmm.getNumberOfObjects(type);
+    for (std::size_t i = 0; i<n_objects; ++i)
+    {
+        std::string const obj_name = swmm.getName(type, i);
+        std::string const obj_file_name = std::string(base + "_" + obj_name + ext);
+        swmm.writeCsvForObject(obj_file_name, type, i);
+    }
+}
+
+int writeCsvOutput(std::string input_file, std::string output_file,
+    bool const node_args, bool const link_args, bool const catchment_args, bool const system_args)
+{
+    std::unique_ptr<FileIO::SwmmInterface> swmm = nullptr;
+    swmm = FileIO::SwmmInterface::create(input_file);
+    if (swmm == nullptr)
+        return -1;
+
+    std::string const basename = BaseLib::dropFileExtension(output_file);
+    std::string const extension = std::string("." + BaseLib::getFileExtension(output_file));
+
+    if (node_args)
+        writeObjectsOfSwmmTypeToCsv(*swmm, FileIO::SwmmObject::NODE, basename, extension);
+
+    if (link_args)
+        writeObjectsOfSwmmTypeToCsv(*swmm, FileIO::SwmmObject::LINK, basename, extension);
+
+    if (catchment_args)
+        writeObjectsOfSwmmTypeToCsv(*swmm, FileIO::SwmmObject::SUBCATCHMENT, basename, extension);
+
+    if (system_args)
+    {
+        std::string const obj_file_name = std::string(basename + "_system" + extension);
+        swmm->writeCsvForObject(obj_file_name, FileIO::SwmmObject::SYSTEM, 0);
+    }
+    return 0;
+}
+
 int main(int argc, char *argv[])
 {
     ApplicationsLib::LogogSetup setup;
 
     TCLAP::CmdLine cmd
-        ("Read files for the Storm Water Management Model (SWMM) and converts them to OGS.", ' ', "0.1");
+        ("Read files for the Storm Water Management Model (SWMM) and converts them into OGS data structures.", ' ', "0.1");
     TCLAP::ValueArg<std::string> mesh_output_arg
         ("m","mesh", "mesh output file (*.vtu)", false, "", "mesh output file");
     cmd.add(mesh_output_arg);
     TCLAP::ValueArg<std::string> geo_output_arg
         ("g","geo", "geometry output file (*.gml)", false, "", "geometry output file");
     cmd.add(geo_output_arg);
+    TCLAP::ValueArg<std::string> csv_output_arg
+        ("c", "csv", "csv output file (*.csv)", false, "", "CSV output file");
+    cmd.add(csv_output_arg);
     TCLAP::ValueArg<std::string> swmm_input_arg
         ("i","input", "SWMM input file (*.inp)", true, "", "input file");
     cmd.add(swmm_input_arg);
+    TCLAP::SwitchArg add_nodes_arg ("", "node_vars", "Read node variables and add to output mesh");
+    cmd.add(add_nodes_arg);
+    TCLAP::SwitchArg add_links_arg ("", "link_vars", "Read link variables and add to output mesh");
+    cmd.add(add_links_arg);
+    TCLAP::SwitchArg add_subcatchments_arg ("", "subcatchment_vars", "Read subcatchment variables and write to CSV-file");
+    cmd.add(add_subcatchments_arg);
+    TCLAP::SwitchArg add_system_arg ("", "system_vars", "Read system variables and write to CSV-file");
+    cmd.add(add_system_arg);
     cmd.parse( argc, argv );
 
-    if (!(geo_output_arg.isSet() || mesh_output_arg.isSet()))
+    if (!(geo_output_arg.isSet() || mesh_output_arg.isSet() || csv_output_arg.isSet()))
     {
         ERR ("No output format given. Please specify OGS geometry or mesh output file.");
         return -1;
     }
 
+    if ((add_nodes_arg.getValue() || add_links_arg.getValue()) && !mesh_output_arg.isSet())
+    {
+        ERR("Please specify mesh output file for exporting node or link parameters.");
+        return -1;
+    }
+    if ((add_subcatchments_arg.getValue() || add_system_arg.getValue()) && !csv_output_arg.isSet())
+    {
+        ERR("Please specify csv output file for exporting subcatchment or system parameters.");
+        return -1;
+    }
+
     if (geo_output_arg.isSet())
-    {
-        GeoLib::GEOObjects geo_objects;
-        if (!FileIO::SwmmInterface::convertSwmmInputToGeometry(swmm_input_arg.getValue(), geo_objects, true))
-            return -1;
+        writeGeoOutput(swmm_input_arg.getValue(), geo_output_arg.getValue());
 
-        GeoLib::IO::BoostXmlGmlInterface xml(geo_objects);
-        xml.setNameForExport(BaseLib::extractBaseNameWithoutExtension(swmm_input_arg.getValue()));
-        xml.writeToFile(geo_output_arg.getValue());
-        return 0;
-    }
+    if (mesh_output_arg.isSet())
+        writeMeshOutput(swmm_input_arg.getValue(), mesh_output_arg.getValue(),
+            add_nodes_arg.getValue(), add_links_arg.getValue());
 
-    if (!mesh_output_arg.isSet())
-        return -1;
-
-    std::unique_ptr<FileIO::SwmmInterface> swmm = nullptr;
-    swmm = FileIO::SwmmInterface::create(swmm_input_arg.getValue());
-    if (swmm == nullptr)
-        return -1;
-
-    MeshLib::Mesh mesh = swmm->getMesh();
-    MeshLib::IO::VtuInterface vtkIO(&mesh, 0, false);
-    vtkIO.writeToFile(mesh_output_arg.getValue());
-
-    if (!swmm->existsSwmmOutputFile())
-    {
-        INFO ("No output file found.");
-        return 0;
-    }
-
-    INFO ("Simulation time steps: %d", swmm->getNumberOfTimeSteps());
-
-    // Example code: Writing node information to csv file
-    FileIO::CsvInterface csv;
-    csv.addIndexVectorForWriting(swmm->getNumberOfObjects(FileIO::SwmmObject::NODE));
-    std::vector<double> x;
-    std::vector<double> y;
-    std::vector<double> z;
-    swmm->getNodeCoordinateVectors(x,y,z);
-    csv.addVectorForWriting("x", x);
-    csv.addVectorForWriting("y", y);
-    csv.addVectorForWriting("z", z);
-    for (std::size_t i=0; i<9; ++i)
-    {
-        std::vector<double> data_vec = swmm->getArrayAtTimeStep(FileIO::SwmmObject::NODE, 10, i);
-        csv.addVectorForWriting(swmm->getArrayName(FileIO::SwmmObject::NODE, i), data_vec);
-    }
-    csv.writeToFile("d:/csvtest.csv");
-    INFO ("CSV written.");
-    std::cin.ignore();
-
-    for (std::size_t i=0; i<swmm->getNumberOfParameters(FileIO::SwmmObject::NODE); ++i)
-        INFO ("%d\t%s", i, swmm->getArrayName(FileIO::SwmmObject::NODE, i).c_str());
-    std::cin.ignore();
-
-    // Example code: Add simulated parameter to mesh for each timestep and write result
-    std::size_t n_time_steps (swmm->getNumberOfTimeSteps());
-    for (std::size_t i=0; i<n_time_steps; i++)
-    {
-        FileIO::SwmmObject type = FileIO::SwmmObject::NODE;
-        for (std::size_t j=6; j<9; ++j)
-        {
-            std::string vec_name (swmm->getArrayName(type, j));
-            if (vec_name.empty())
-                return -10;
-            std::vector<double> data_vec = swmm->getArrayAtTimeStep(type, i, j);
-            if (data_vec.empty())
-                return -20;
-            bool done = swmm->addResultsToMesh(mesh, type, vec_name, data_vec);
-            if (!done)
-                return -30;
-        }
-
-        MeshLib::IO::VtuInterface vtkio(&mesh, 0, false);
-        std::string name ("d:/swmmresults" + BaseLib::tostring(i) + ".vtu");
-        vtkio.writeToFile(name);
-        mesh.getProperties().removePropertyVector("P");
-        mesh.getProperties().removePropertyVector("NH4");
-        mesh.getProperties().removePropertyVector("CSB");
-    }
+    if (csv_output_arg.isSet())
+        writeCsvOutput(swmm_input_arg.getValue(), csv_output_arg.getValue(),
+            false, false, add_subcatchments_arg.getValue(), add_system_arg.getValue());
 
     return 0;
 }

--- a/Applications/Utils/SWMMConverter/SWMMConverter.cpp
+++ b/Applications/Utils/SWMMConverter/SWMMConverter.cpp
@@ -103,10 +103,11 @@ void writeObjectsOfSwmmTypeToCsv(
     std::string const& ext)
 {
     std::size_t n_objects = swmm.getNumberOfObjects(type);
+    std::string const& type_str (swmm.swmmObjectTypeToString(type));
     for (std::size_t i = 0; i<n_objects; ++i)
     {
         std::string const obj_name = swmm.getName(type, i);
-        std::string const obj_file_name = std::string(base + "_" + obj_name + ext);
+        std::string const obj_file_name = std::string(base + "_" + type_str + "_" + obj_name + ext);
         swmm.writeCsvForObject(obj_file_name, type, i);
     }
 }
@@ -189,11 +190,6 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    if ((add_nodes_arg.getValue() || add_links_arg.getValue()) && !mesh_output_arg.isSet())
-    {
-        ERR("Please specify mesh output file for exporting node or link parameters.");
-        return -1;
-    }
     if ((add_subcatchments_arg.getValue() || add_system_arg.getValue()) && !csv_output_arg.isSet())
     {
         ERR("Please specify csv output file for exporting subcatchment or system parameters.");
@@ -208,8 +204,13 @@ int main(int argc, char *argv[])
             add_nodes_arg.getValue(), add_links_arg.getValue());
 
     if (csv_output_arg.isSet())
-        writeCsvOutput(swmm_input_arg.getValue(), csv_output_arg.getValue(),
-            false, false, add_subcatchments_arg.getValue(), add_system_arg.getValue());
+        writeCsvOutput(
+            swmm_input_arg.getValue(),
+            csv_output_arg.getValue(),
+            add_nodes_arg.getValue(),
+            add_links_arg.getValue(),
+            add_subcatchments_arg.getValue(),
+            add_system_arg.getValue());
 
     return 0;
 }


### PR DESCRIPTION
This makes the SWMM converter slightly more usable for non-programmers. By default *all* node and link data is written into vtu-files (one for every timestep) and *all* subcatchment and system data is written into csv-files (one for every subcatchment/system)

For selective conversion of the data (only certain time steps, specific nodes/links/etc., assessment of pollutants, ...) it'd still be necessary to either adjust the source code or write a comprehensive user interface that accounts for such things.