### PR TITLE
Nonuniform Neumann BCs

### DIFF
--- a/Documentation/ProjectFile/prj/process_variables/process_variable/boundary_conditions/boundary_condition/NonuniformNeumann/c_NonuniformNeumann.md
+++ b/Documentation/ProjectFile/prj/process_variables/process_variable/boundary_conditions/boundary_condition/NonuniformNeumann/c_NonuniformNeumann.md
@@ -1,0 +1,1 @@
+Declares a Neumann boundary condition that is non-uniform in space.

--- a/Documentation/ProjectFile/prj/process_variables/process_variable/boundary_conditions/boundary_condition/NonuniformNeumann/t_field_name.md
+++ b/Documentation/ProjectFile/prj/process_variables/process_variable/boundary_conditions/boundary_condition/NonuniformNeumann/t_field_name.md
@@ -1,0 +1,5 @@
+This specifies a nodal field defined on the surface mesh (see the \c mesh
+parameter of the nonuniform Neumann BC).
+
+From that nodal field the flux values, which are applied via this Neumann BC,
+are read.

--- a/Documentation/ProjectFile/prj/process_variables/process_variable/boundary_conditions/boundary_condition/NonuniformNeumann/t_mesh.md
+++ b/Documentation/ProjectFile/prj/process_variables/process_variable/boundary_conditions/boundary_condition/NonuniformNeumann/t_mesh.md
@@ -1,0 +1,8 @@
+Path to the surface mesh vtu file.
+
+The surface mesh must contain a nodal integer-valued field (unsigned 64bit)
+named \c OriginalSubsurfaceNodeIDs. That field establishes the mapping between
+the nodes of the surface mesh to some notes in the bulk mesh.
+\warning It is not checked if the surface mesh and the bulk mesh correspond to each
+other; in particular it is not checked if surface and bulk nodes coincide and if
+surface elements coincide with the faces of bulk elements.

--- a/MeshLib/IO/VtkIO/VtuInterface.cpp
+++ b/MeshLib/IO/VtkIO/VtuInterface.cpp
@@ -61,7 +61,10 @@ MeshLib::Mesh* VtuInterface::readVTUFile(std::string const &file_name)
 
     vtkUnstructuredGrid* vtkGrid = reader->GetOutput();
     if (vtkGrid->GetNumberOfPoints() == 0)
+    {
+        ERR("Mesh \"%s\" contains zero points.", file_name.c_str());
         return nullptr;
+    }
 
     std::string const mesh_name (BaseLib::extractBaseNameWithoutExtension(file_name));
     return MeshLib::VtkMeshConverter::convertUnstructuredGrid(vtkGrid, mesh_name);

--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -133,11 +133,6 @@ public:
     bool isAxiallySymmetric() const { return _is_axially_symmetric; }
     void setAxiallySymmetric(bool is_axial_symmetric) {
         _is_axially_symmetric = is_axial_symmetric;
-        if (_is_axially_symmetric && getDimension() != 2) {
-            OGS_FATAL(
-                "Axial symmetry is implemented only for two-dimensional "
-                "meshes.");
-        }
     }
 
 protected:

--- a/ProcessLib/BoundaryCondition/BoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/BoundaryCondition.cpp
@@ -8,13 +8,14 @@
  */
 
 #include "BoundaryCondition.h"
-#include "MeshGeoToolsLib/BoundaryElementsSearcher.h"
-#include "MeshGeoToolsLib/MeshNodeSearcher.h"
-#include "MeshGeoToolsLib/SearchLength.h"
-#include "MeshGeoToolsLib/CreateSearchLength.h"
 #include "BoundaryConditionConfig.h"
 #include "DirichletBoundaryCondition.h"
+#include "MeshGeoToolsLib/BoundaryElementsSearcher.h"
+#include "MeshGeoToolsLib/CreateSearchLength.h"
+#include "MeshGeoToolsLib/MeshNodeSearcher.h"
+#include "MeshGeoToolsLib/SearchLength.h"
 #include "NeumannBoundaryCondition.h"
+#include "NonuniformNeumannBoundaryCondition.h"
 #include "RobinBoundaryCondition.h"
 
 namespace ProcessLib
@@ -47,6 +48,12 @@ BoundaryConditionBuilder::createBoundaryCondition(
         return createRobinBoundaryCondition(
                     config, dof_table, mesh, variable_id,
                     integration_order, shapefunction_order, parameters);
+    }
+    if (type == "NonuniformNeumann")
+    {
+        return createNonuniformNeumannBoundaryCondition(
+            config, dof_table, mesh, variable_id, integration_order,
+            shapefunction_order, parameters);
     }
 
     OGS_FATAL("Unknown boundary condition type: `%s'.", type.c_str());
@@ -155,6 +162,32 @@ BoundaryConditionBuilder::createRobinBoundaryCondition(
         getClonedElements(boundary_element_searcher, config.geometry),
         dof_table, variable_id, config.component_id,
         mesh.isAxiallySymmetric(), integration_order, shapefunction_order, mesh.getDimension(),
+        parameters);
+}
+
+std::unique_ptr<BoundaryCondition>
+BoundaryConditionBuilder::createNonuniformNeumannBoundaryCondition(
+    const BoundaryConditionConfig& config,
+    const NumLib::LocalToGlobalIndexMap& dof_table, const MeshLib::Mesh& mesh,
+    const int variable_id, const unsigned integration_order,
+    const unsigned shapefunction_order,
+    const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters)
+{
+    std::unique_ptr<MeshGeoToolsLib::SearchLength> search_length_algorithm =
+        MeshGeoToolsLib::createSearchLengthAlgorithm(config.config, mesh);
+
+    MeshGeoToolsLib::MeshNodeSearcher const& mesh_node_searcher =
+        MeshGeoToolsLib::MeshNodeSearcher::getMeshNodeSearcher(
+            mesh, std::move(search_length_algorithm));
+
+    MeshGeoToolsLib::BoundaryElementsSearcher boundary_element_searcher(
+        mesh, mesh_node_searcher);
+
+    return ProcessLib::createNonuniformNeumannBoundaryCondition(
+        config.config,
+        getClonedElements(boundary_element_searcher, config.geometry),
+        dof_table, variable_id, config.component_id, mesh.isAxiallySymmetric(),
+        integration_order, shapefunction_order, mesh.getDimension(),
         parameters);
 }
 

--- a/ProcessLib/BoundaryCondition/BoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/BoundaryCondition.cpp
@@ -53,7 +53,7 @@ BoundaryConditionBuilder::createBoundaryCondition(
     {
         return createNonuniformNeumannBoundaryCondition(
             config, dof_table, mesh, variable_id, integration_order,
-            shapefunction_order, parameters);
+            shapefunction_order);
     }
 
     OGS_FATAL("Unknown boundary condition type: `%s'.", type.c_str());
@@ -170,25 +170,11 @@ BoundaryConditionBuilder::createNonuniformNeumannBoundaryCondition(
     const BoundaryConditionConfig& config,
     const NumLib::LocalToGlobalIndexMap& dof_table, const MeshLib::Mesh& mesh,
     const int variable_id, const unsigned integration_order,
-    const unsigned shapefunction_order,
-    const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters)
+    const unsigned shapefunction_order)
 {
-    std::unique_ptr<MeshGeoToolsLib::SearchLength> search_length_algorithm =
-        MeshGeoToolsLib::createSearchLengthAlgorithm(config.config, mesh);
-
-    MeshGeoToolsLib::MeshNodeSearcher const& mesh_node_searcher =
-        MeshGeoToolsLib::MeshNodeSearcher::getMeshNodeSearcher(
-            mesh, std::move(search_length_algorithm));
-
-    MeshGeoToolsLib::BoundaryElementsSearcher boundary_element_searcher(
-        mesh, mesh_node_searcher);
-
     return ProcessLib::createNonuniformNeumannBoundaryCondition(
-        config.config,
-        getClonedElements(boundary_element_searcher, config.geometry),
-        dof_table, variable_id, config.component_id, mesh.isAxiallySymmetric(),
-        integration_order, shapefunction_order, mesh.getDimension(),
-        parameters);
+        config.config, dof_table, variable_id, config.component_id,
+        integration_order, shapefunction_order, mesh);
 }
 
 std::vector<MeshLib::Element*> BoundaryConditionBuilder::getClonedElements(

--- a/ProcessLib/BoundaryCondition/BoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/BoundaryCondition.h
@@ -107,6 +107,15 @@ protected:
         const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>&
             parameters);
 
+    virtual std::unique_ptr<BoundaryCondition>
+    createNonuniformNeumannBoundaryCondition(
+        const BoundaryConditionConfig& config,
+        const NumLib::LocalToGlobalIndexMap& dof_table,
+        const MeshLib::Mesh& mesh, const int variable_id,
+        const unsigned integration_order, const unsigned shapefunction_order,
+        const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>&
+            parameters);
+
     static std::vector<MeshLib::Element*> getClonedElements(
         MeshGeoToolsLib::BoundaryElementsSearcher& boundary_element_searcher,
         GeoLib::GeoObject const& geometry);

--- a/ProcessLib/BoundaryCondition/BoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/BoundaryCondition.h
@@ -112,9 +112,7 @@ protected:
         const BoundaryConditionConfig& config,
         const NumLib::LocalToGlobalIndexMap& dof_table,
         const MeshLib::Mesh& mesh, const int variable_id,
-        const unsigned integration_order, const unsigned shapefunction_order,
-        const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>&
-            parameters);
+        const unsigned integration_order, const unsigned shapefunction_order);
 
     static std::vector<MeshLib::Element*> getClonedElements(
         MeshGeoToolsLib::BoundaryElementsSearcher& boundary_element_searcher,

--- a/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.h
@@ -36,6 +36,17 @@ public:
           _variable_id(variable_id),
           _component_id(component_id)
     {
+        if (variable_id >= static_cast<int>(dof_table.getNumberOfVariables()) ||
+            component_id >=
+                dof_table.getNumberOfVariableComponents(variable_id))
+        {
+            OGS_FATAL(
+                "Variable id or component id too high. Actual values: (%d, "
+                "%d), "
+                "maximum values: (%d, %d).",
+                variable_id, component_id, dof_table.getNumberOfVariables(),
+                dof_table.getNumberOfVariableComponents(variable_id));
+        }
     }
 
     void preTimestep(const double t) override;

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
@@ -35,8 +35,18 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
       _elements(std::move(elements)),
       _integration_order(integration_order)
 {
-    assert(component_id <
-           static_cast<int>(dof_table_bulk.getNumberOfComponents()));
+    // check basic data consistency
+    if (variable_id >=
+            static_cast<int>(dof_table_bulk.getNumberOfVariables()) ||
+        component_id >=
+            dof_table_bulk.getNumberOfVariableComponents(variable_id))
+    {
+        OGS_FATAL(
+            "Variable id or component id too high. Actual values: (%d, %d), "
+            "maximum values: (%d, %d).",
+            variable_id, component_id, dof_table_bulk.getNumberOfVariables(),
+            dof_table_bulk.getNumberOfVariableComponents(variable_id));
+    }
 
     std::vector<MeshLib::Node*> nodes = MeshLib::getUniqueNodes(_elements);
     DBUG("Found %d nodes for Natural BCs for the variable %d and component %d",

--- a/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition-impl.h
@@ -30,14 +30,21 @@ GenericNonuniformNaturalBoundaryCondition<BoundaryConditionData,
                                typename std::decay<Data>::type>::value,
                   "Type mismatch between declared and passed BC data.");
 
-#if 0
-    // TODO fix/improve check!
-    if (component_id >=
-           static_cast<int>(dof_table_bulk.getNumberOfComponents()))
+    // check basic data consistency
+    if (_data.variable_id_bulk >=
+            static_cast<int>(_data.dof_table_bulk.getNumberOfVariables()) ||
+        _data.component_id_bulk >=
+            _data.dof_table_bulk.getNumberOfVariableComponents(
+                _data.variable_id_bulk))
     {
-        OGS_FATAL("");  // TODO better error message.
+        OGS_FATAL(
+            "Variable id or component id too high. Actual values: (%d, %d), "
+            "maximum values: (%d, %d).",
+            _data.variable_id_bulk, _data.component_id_bulk,
+            _data.dof_table_bulk.getNumberOfVariables(),
+            _data.dof_table_bulk.getNumberOfVariableComponents(
+                _data.variable_id_bulk));
     }
-#endif
 
     if (_boundary_mesh->getDimension() + 1 != global_dim)
     {

--- a/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition-impl.h
@@ -21,8 +21,8 @@ template <typename Data>
 GenericNonuniformNaturalBoundaryCondition<BoundaryConditionData,
                                           LocalAssemblerImplementation>::
     GenericNonuniformNaturalBoundaryCondition(
-        bool is_axially_symmetric, unsigned const integration_order,
-        unsigned const shapefunction_order, unsigned const global_dim,
+        unsigned const integration_order, unsigned const shapefunction_order,
+        unsigned const global_dim,
         std::unique_ptr<MeshLib::Mesh>&& boundary_mesh, Data&& data)
     : _data(std::forward<Data>(data)), _boundary_mesh(std::move(boundary_mesh))
 {
@@ -51,8 +51,8 @@ GenericNonuniformNaturalBoundaryCondition<BoundaryConditionData,
 
     createLocalAssemblers<LocalAssemblerImplementation>(
         global_dim, _boundary_mesh->getElements(), *_dof_table_boundary,
-        shapefunction_order, _local_assemblers, is_axially_symmetric,
-        integration_order, _data);
+        shapefunction_order, _local_assemblers,
+        _boundary_mesh->isAxiallySymmetric(), integration_order, _data);
 }
 
 template <typename BoundaryConditionData,

--- a/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition-impl.h
@@ -68,7 +68,7 @@ template <typename BoundaryConditionData,
 void GenericNonuniformNaturalBoundaryCondition<
     BoundaryConditionData, LocalAssemblerImplementation>::constructDofTable()
 {
-    // construct one-component dof table for the surface mesh
+    // construct one-component DOF-table for the surface mesh
     _mesh_subset_all_nodes.reset(
         new MeshLib::MeshSubset(*_boundary_mesh, &_boundary_mesh->getNodes()));
 

--- a/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition-impl.h
@@ -1,0 +1,90 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "GenericNonuniformNaturalBoundaryCondition.h"
+#include "GenericNonuniformNaturalBoundaryConditionLocalAssembler.h"
+#include "MeshLib/MeshSearch/NodeSearch.h"
+#include "ProcessLib/Utils/CreateLocalAssemblers.h"
+
+namespace ProcessLib
+{
+template <typename BoundaryConditionData,
+          template <typename, typename, unsigned>
+          class LocalAssemblerImplementation>
+template <typename Data>
+GenericNonuniformNaturalBoundaryCondition<BoundaryConditionData,
+                                          LocalAssemblerImplementation>::
+    GenericNonuniformNaturalBoundaryCondition(
+        typename std::enable_if<
+            std::is_same<typename std::decay<BoundaryConditionData>::type,
+                         typename std::decay<Data>::type>::value,
+            bool>::type is_axially_symmetric,
+        unsigned const integration_order, unsigned const shapefunction_order,
+        NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
+        int const variable_id, int const component_id,
+        unsigned const global_dim, std::vector<MeshLib::Element*>&& elements,
+        Data&& data)
+    : _data(std::forward<Data>(data)),
+      _elements(std::move(elements)),
+      _integration_order(integration_order)
+{
+    assert(component_id <
+           static_cast<int>(dof_table_bulk.getNumberOfComponents()));
+
+    std::vector<MeshLib::Node*> nodes = MeshLib::getUniqueNodes(_elements);
+    DBUG("Found %d nodes for Natural BCs for the variable %d and component %d",
+         nodes.size(), variable_id, component_id);
+
+    auto const& mesh_subsets =
+        dof_table_bulk.getMeshSubsets(variable_id, component_id);
+
+    // TODO extend the node intersection to all parts of mesh_subsets, i.e.
+    // to each of the MeshSubset in the mesh_subsets.
+    _mesh_subset_all_nodes.reset(
+        mesh_subsets.getMeshSubset(0).getIntersectionByNodes(nodes));
+    MeshLib::MeshSubsets all_mesh_subsets{_mesh_subset_all_nodes.get()};
+
+    // Create local DOF table from intersected mesh subsets for the given
+    // variable and component ids.
+    _dof_table_boundary.reset(dof_table_bulk.deriveBoundaryConstrainedMap(
+        variable_id, {component_id}, std::move(all_mesh_subsets), _elements));
+
+    createLocalAssemblers<LocalAssemblerImplementation>(
+        global_dim, _elements, *_dof_table_boundary, shapefunction_order,
+        _local_assemblers, is_axially_symmetric, _integration_order, _data);
+}
+
+template <typename BoundaryConditionData,
+          template <typename, typename, unsigned>
+          class LocalAssemblerImplementation>
+GenericNonuniformNaturalBoundaryCondition<
+    BoundaryConditionData,
+    LocalAssemblerImplementation>::~GenericNonuniformNaturalBoundaryCondition()
+{
+    for (auto e : _elements)
+        delete e;
+}
+
+template <typename BoundaryConditionData,
+          template <typename, typename, unsigned>
+          class LocalAssemblerImplementation>
+void GenericNonuniformNaturalBoundaryCondition<
+    BoundaryConditionData,
+    LocalAssemblerImplementation>::applyNaturalBC(const double t,
+                                                  const GlobalVector& x,
+                                                  GlobalMatrix& K,
+                                                  GlobalVector& b)
+{
+    GlobalExecutor::executeMemberOnDereferenced(
+        &GenericNonuniformNaturalBoundaryConditionLocalAssemblerInterface::
+            assemble,
+        _local_assemblers, *_dof_table_boundary, t, x, K, b);
+}
+
+}  // ProcessLib

--- a/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition.h
@@ -48,11 +48,10 @@ private:
 
     std::unique_ptr<MeshLib::MeshSubset const> _mesh_subset_all_nodes;
 
-    /// Local dof table, a subset of the global one restricted to the
-    /// participating #_elements of the boundary condition.
+    /// DOF table (one single-component variable) of the boundary mesh.
     std::unique_ptr<NumLib::LocalToGlobalIndexMap> _dof_table_boundary;
 
-    /// Local assemblers for each element of #_elements.
+    /// Local assemblers for each element of the boundary mesh.
     std::vector<std::unique_ptr<
         GenericNonuniformNaturalBoundaryConditionLocalAssemblerInterface>>
         _local_assemblers;

--- a/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition.h
@@ -27,8 +27,8 @@ public:
     /// A local DOF-table, a subset of the given one, is constructed.
     template <typename Data>
     GenericNonuniformNaturalBoundaryCondition(
-        bool is_axially_symmetric, unsigned const integration_order,
-        unsigned const shapefunction_order, unsigned const global_dim,
+        unsigned const integration_order, unsigned const shapefunction_order,
+        unsigned const global_dim,
         std::unique_ptr<MeshLib::Mesh>&& boundary_mesh, Data&& data);
 
     /// Calls local assemblers which calculate their contributions to the global

--- a/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition.h
@@ -27,17 +27,9 @@ public:
     /// A local DOF-table, a subset of the given one, is constructed.
     template <typename Data>
     GenericNonuniformNaturalBoundaryCondition(
-        typename std::enable_if<
-            std::is_same<typename std::decay<BoundaryConditionData>::type,
-                         typename std::decay<Data>::type>::value,
-            bool>::type is_axially_symmetric,
-        unsigned const integration_order, unsigned const shapefunction_order,
-        NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
-        int const variable_id, int const component_id,
-        unsigned const global_dim, std::vector<MeshLib::Element*>&& elements,
-        Data&& data);
-
-    ~GenericNonuniformNaturalBoundaryCondition() override;
+        bool is_axially_symmetric, unsigned const integration_order,
+        unsigned const shapefunction_order, unsigned const global_dim,
+        std::unique_ptr<MeshLib::Mesh>&& boundary_mesh, Data&& data);
 
     /// Calls local assemblers which calculate their contributions to the global
     /// matrix and the right-hand-side.
@@ -47,21 +39,18 @@ public:
                         GlobalVector& b) override;
 
 private:
+    void constructDofTable();
+
     /// Data used in the assembly of the specific boundary condition.
     BoundaryConditionData _data;
 
-    /// Vector of lower-dimensional elements on which the boundary condition is
-    /// defined.
-    std::vector<MeshLib::Element*> _elements;
+    std::unique_ptr<MeshLib::Mesh> _boundary_mesh;
 
     std::unique_ptr<MeshLib::MeshSubset const> _mesh_subset_all_nodes;
 
     /// Local dof table, a subset of the global one restricted to the
     /// participating #_elements of the boundary condition.
     std::unique_ptr<NumLib::LocalToGlobalIndexMap> _dof_table_boundary;
-
-    /// Integration order for integration over the lower-dimensional elements
-    unsigned const _integration_order;
 
     /// Local assemblers for each element of #_elements.
     std::vector<std::unique_ptr<

--- a/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition.h
@@ -1,0 +1,74 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include "BoundaryCondition.h"
+#include "MeshLib/MeshSubset.h"
+
+namespace ProcessLib
+{
+class GenericNonuniformNaturalBoundaryConditionLocalAssemblerInterface;
+
+template <typename BoundaryConditionData,
+          template <typename, typename, unsigned>
+          class LocalAssemblerImplementation>
+class GenericNonuniformNaturalBoundaryCondition final : public BoundaryCondition
+{
+public:
+    /// Create a boundary condition process from given config,
+    /// DOF-table, and a mesh subset for a given variable and its component.
+    /// A local DOF-table, a subset of the given one, is constructed.
+    template <typename Data>
+    GenericNonuniformNaturalBoundaryCondition(
+        typename std::enable_if<
+            std::is_same<typename std::decay<BoundaryConditionData>::type,
+                         typename std::decay<Data>::type>::value,
+            bool>::type is_axially_symmetric,
+        unsigned const integration_order, unsigned const shapefunction_order,
+        NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
+        int const variable_id, int const component_id,
+        unsigned const global_dim, std::vector<MeshLib::Element*>&& elements,
+        Data&& data);
+
+    ~GenericNonuniformNaturalBoundaryCondition() override;
+
+    /// Calls local assemblers which calculate their contributions to the global
+    /// matrix and the right-hand-side.
+    void applyNaturalBC(const double t,
+                        GlobalVector const& x,
+                        GlobalMatrix& K,
+                        GlobalVector& b) override;
+
+private:
+    /// Data used in the assembly of the specific boundary condition.
+    BoundaryConditionData _data;
+
+    /// Vector of lower-dimensional elements on which the boundary condition is
+    /// defined.
+    std::vector<MeshLib::Element*> _elements;
+
+    std::unique_ptr<MeshLib::MeshSubset const> _mesh_subset_all_nodes;
+
+    /// Local dof table, a subset of the global one restricted to the
+    /// participating #_elements of the boundary condition.
+    std::unique_ptr<NumLib::LocalToGlobalIndexMap> _dof_table_boundary;
+
+    /// Integration order for integration over the lower-dimensional elements
+    unsigned const _integration_order;
+
+    /// Local assemblers for each element of #_elements.
+    std::vector<std::unique_ptr<
+        GenericNonuniformNaturalBoundaryConditionLocalAssemblerInterface>>
+        _local_assemblers;
+};
+
+}  // ProcessLib
+
+#include "GenericNonuniformNaturalBoundaryCondition-impl.h"

--- a/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryCondition.h
@@ -48,7 +48,7 @@ private:
 
     std::unique_ptr<MeshLib::MeshSubset const> _mesh_subset_all_nodes;
 
-    /// DOF table (one single-component variable) of the boundary mesh.
+    /// DOF-table (one single-component variable) of the boundary mesh.
     std::unique_ptr<NumLib::LocalToGlobalIndexMap> _dof_table_boundary;
 
     /// Local assemblers for each element of the boundary mesh.

--- a/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryConditionLocalAssembler.h
@@ -1,0 +1,58 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include "NumLib/Fem/ShapeMatrixPolicy.h"
+#include "ProcessLib/Utils/InitShapeMatrices.h"
+
+namespace ProcessLib
+{
+class GenericNonuniformNaturalBoundaryConditionLocalAssemblerInterface
+{
+public:
+    virtual ~GenericNonuniformNaturalBoundaryConditionLocalAssemblerInterface() =
+        default;
+
+    virtual void assemble(
+        std::size_t const id,
+        NumLib::LocalToGlobalIndexMap const& dof_table_boundary, double const t,
+        const GlobalVector& x, GlobalMatrix& K, GlobalVector& b) = 0;
+};
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          unsigned GlobalDim>
+class GenericNonuniformNaturalBoundaryConditionLocalAssembler
+    : public GenericNonuniformNaturalBoundaryConditionLocalAssemblerInterface
+{
+protected:
+    using ShapeMatricesType = ShapeMatrixPolicyType<ShapeFunction, GlobalDim>;
+    using NodalMatrixType = typename ShapeMatricesType::NodalMatrixType;
+    using NodalVectorType = typename ShapeMatricesType::NodalVectorType;
+
+public:
+    GenericNonuniformNaturalBoundaryConditionLocalAssembler(
+        MeshLib::Element const& e, bool is_axially_symmetric,
+        unsigned const integration_order)
+        : _integration_method(integration_order),
+          _shape_matrices(initShapeMatrices<ShapeFunction, ShapeMatricesType,
+                                            IntegrationMethod, GlobalDim>(
+              e, is_axially_symmetric, _integration_method))
+    {
+    }
+
+protected:
+    IntegrationMethod const _integration_method;
+    std::vector<typename ShapeMatricesType::ShapeMatrices,
+                Eigen::aligned_allocator<
+                    typename ShapeMatricesType::ShapeMatrices>> const
+        _shape_matrices;
+};
+
+}  // ProcessLib

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
@@ -31,6 +31,11 @@ createNonuniformNeumannBoundaryCondition(
     std::unique_ptr<MeshLib::Mesh> boundary_mesh(
         MeshLib::IO::readMeshFromFile(mesh_file));
 
+    if (!boundary_mesh)
+    {
+        OGS_FATAL("Error reading mesh `%s'", mesh_file.c_str());
+    }
+
     // Surface mesh and bulk mesh must have equal axial symmetry flags!
     boundary_mesh->setAxiallySymmetric(bulk_mesh.isAxiallySymmetric());
 
@@ -61,7 +66,7 @@ createNonuniformNeumannBoundaryCondition(
     }
 
     auto const* const mapping_to_bulk_nodes =
-        boundary_mesh->getProperties().getPropertyVector<long>(
+        boundary_mesh->getProperties().getPropertyVector<unsigned long>(
             "bulk_mesh_node_ids");
 
     if (!(mapping_to_bulk_nodes &&

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
@@ -55,7 +55,7 @@ createNonuniformNeumannBoundaryCondition(
     if (property->getMeshItemType() != MeshLib::MeshItemType::Node)
     {
         OGS_FATAL(
-            "Only nodal fields are supported fur non-uniform fields. Field "
+            "Only nodal fields are supported for non-uniform fields. Field "
             "`%s' is not nodal.",
             field_name.c_str());
     }
@@ -65,16 +65,18 @@ createNonuniformNeumannBoundaryCondition(
         OGS_FATAL("`%s' is not a one-component field.", field_name.c_str());
     }
 
+    std::string mapping_to_bulk_nodes_property = "OriginalSubsurfaceNodeIDs";
     auto const* const mapping_to_bulk_nodes =
         boundary_mesh->getProperties().getPropertyVector<unsigned long>(
-            "bulk_mesh_node_ids");
+            mapping_to_bulk_nodes_property);
 
     if (!(mapping_to_bulk_nodes &&
           mapping_to_bulk_nodes->getMeshItemType() ==
               MeshLib::MeshItemType::Node) &&
         mapping_to_bulk_nodes->getNumberOfComponents() == 1)
     {
-        OGS_FATAL("Field `bulk_mesh_node_ids' is not set up properly.");
+        OGS_FATAL("Field `%s' is not set up properly.",
+                  mapping_to_bulk_nodes_property.c_str());
     }
 
     return std::make_unique<NonuniformNeumannBoundaryCondition>(

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
@@ -67,7 +67,7 @@ createNonuniformNeumannBoundaryCondition(
 
     std::string mapping_to_bulk_nodes_property = "OriginalSubsurfaceNodeIDs";
     auto const* const mapping_to_bulk_nodes =
-        boundary_mesh->getProperties().getPropertyVector<unsigned long>(
+        boundary_mesh->getProperties().getPropertyVector<std::size_t>(
             mapping_to_bulk_nodes_property);
 
     if (!(mapping_to_bulk_nodes &&

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
@@ -34,7 +34,7 @@ createNonuniformNeumannBoundaryCondition(
     // Surface mesh and bulk mesh must have equal axial symmetry flags!
     boundary_mesh->setAxiallySymmetric(bulk_mesh.isAxiallySymmetric());
 
-    // TODO add field type?
+    // TODO finally use ProcessLib::Parameter here
     auto const field_name =
         config.getConfigParameter<std::string>("field_name");
 

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
@@ -1,0 +1,40 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "NonuniformNeumannBoundaryCondition.h"
+#include "ProcessLib/Utils/ProcessUtils.h"
+
+namespace ProcessLib
+{
+std::unique_ptr<NonuniformNeumannBoundaryCondition>
+createNonuniformNeumannBoundaryCondition(
+    BaseLib::ConfigTree const& config,
+    std::vector<MeshLib::Element*>&& elements,
+    NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
+    int const component_id, bool is_axially_symmetric,
+    unsigned const integration_order, unsigned const shapefunction_order,
+    unsigned const global_dim,
+    std::vector<std::unique_ptr<ParameterBase>> const& parameters)
+{
+    DBUG("Constructing NonuniformNeumann BC from config.");
+    //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition__type}
+    config.checkConfigParameter("type", "NonuniformNeumann");
+
+    //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition__NonuniformNeumann__parameter}
+    auto const param_name = config.getConfigParameter<std::string>("parameter");
+    DBUG("Using parameter %s", param_name.c_str());
+
+    auto const& param = findParameter<double>(param_name, parameters, 1);
+
+    return std::make_unique<NonuniformNeumannBoundaryCondition>(
+        is_axially_symmetric, integration_order, shapefunction_order, dof_table,
+        variable_id, component_id, global_dim, std::move(elements), param);
+}
+
+}  // ProcessLib

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
@@ -28,18 +28,18 @@ createNonuniformNeumannBoundaryCondition(
     // TODO handle paths correctly
     auto const mesh_file = config.getConfigParameter<std::string>("mesh");
 
-    std::unique_ptr<MeshLib::Mesh> surface_mesh(
+    std::unique_ptr<MeshLib::Mesh> boundary_mesh(
         MeshLib::IO::readMeshFromFile(mesh_file));
 
     // Surface mesh and bulk mesh must have equal axial symmetry flags!
-    surface_mesh->setAxiallySymmetric(bulk_mesh.isAxiallySymmetric());
+    boundary_mesh->setAxiallySymmetric(bulk_mesh.isAxiallySymmetric());
 
     // TODO add field type?
     auto const field_name =
         config.getConfigParameter<std::string>("field_name");
 
     auto const* const property =
-        surface_mesh->getProperties().getPropertyVector<double>(field_name);
+        boundary_mesh->getProperties().getPropertyVector<double>(field_name);
 
     if (!property)
     {
@@ -61,7 +61,7 @@ createNonuniformNeumannBoundaryCondition(
     }
 
     auto const* const mapping_to_bulk_nodes =
-        surface_mesh->getProperties().getPropertyVector<long>(
+        boundary_mesh->getProperties().getPropertyVector<long>(
             "bulk_mesh_node_ids");
 
     if (!(mapping_to_bulk_nodes &&
@@ -73,8 +73,8 @@ createNonuniformNeumannBoundaryCondition(
     }
 
     return std::make_unique<NonuniformNeumannBoundaryCondition>(
-        bulk_mesh.isAxiallySymmetric(), integration_order, shapefunction_order,
-        bulk_mesh.getDimension(), std::move(surface_mesh),
+        integration_order, shapefunction_order, bulk_mesh.getDimension(),
+        std::move(boundary_mesh),
         NonuniformNeumannBoundaryConditionData{
             *property, bulk_mesh.getID(), *mapping_to_bulk_nodes, dof_table,
             variable_id, component_id});

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
@@ -26,6 +26,7 @@ createNonuniformNeumannBoundaryCondition(
     config.checkConfigParameter("type", "NonuniformNeumann");
 
     // TODO handle paths correctly
+    //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition__NonuniformNeumann__mesh}
     auto const mesh_file = config.getConfigParameter<std::string>("mesh");
 
     std::unique_ptr<MeshLib::Mesh> boundary_mesh(
@@ -41,6 +42,7 @@ createNonuniformNeumannBoundaryCondition(
 
     // TODO finally use ProcessLib::Parameter here
     auto const field_name =
+        //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition__NonuniformNeumann__field_name}
         config.getConfigParameter<std::string>("field_name");
 
     auto const* const property =

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.cpp
@@ -8,6 +8,8 @@
  */
 
 #include "NonuniformNeumannBoundaryCondition.h"
+
+#include "MeshLib/IO/readMeshFromFile.h"
 #include "ProcessLib/Utils/ProcessUtils.h"
 
 namespace ProcessLib
@@ -15,26 +17,67 @@ namespace ProcessLib
 std::unique_ptr<NonuniformNeumannBoundaryCondition>
 createNonuniformNeumannBoundaryCondition(
     BaseLib::ConfigTree const& config,
-    std::vector<MeshLib::Element*>&& elements,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
-    int const component_id, bool is_axially_symmetric,
-    unsigned const integration_order, unsigned const shapefunction_order,
-    unsigned const global_dim,
-    std::vector<std::unique_ptr<ParameterBase>> const& parameters)
+    int const component_id, unsigned const integration_order,
+    unsigned const shapefunction_order, MeshLib::Mesh const& bulk_mesh)
 {
     DBUG("Constructing NonuniformNeumann BC from config.");
     //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition__type}
     config.checkConfigParameter("type", "NonuniformNeumann");
 
-    //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition__NonuniformNeumann__parameter}
-    auto const param_name = config.getConfigParameter<std::string>("parameter");
-    DBUG("Using parameter %s", param_name.c_str());
+    // TODO handle paths correctly
+    auto const mesh_file = config.getConfigParameter<std::string>("mesh");
 
-    auto const& param = findParameter<double>(param_name, parameters, 1);
+    std::unique_ptr<MeshLib::Mesh> surface_mesh(
+        MeshLib::IO::readMeshFromFile(mesh_file));
+
+    // Surface mesh and bulk mesh must have equal axial symmetry flags!
+    surface_mesh->setAxiallySymmetric(bulk_mesh.isAxiallySymmetric());
+
+    // TODO add field type?
+    auto const field_name =
+        config.getConfigParameter<std::string>("field_name");
+
+    auto const* const property =
+        surface_mesh->getProperties().getPropertyVector<double>(field_name);
+
+    if (!property)
+    {
+        OGS_FATAL("A property with name `%s' does not exist in `%s'.",
+                  field_name.c_str(), mesh_file.c_str());
+    }
+
+    if (property->getMeshItemType() != MeshLib::MeshItemType::Node)
+    {
+        OGS_FATAL(
+            "Only nodal fields are supported fur non-uniform fields. Field "
+            "`%s' is not nodal.",
+            field_name.c_str());
+    }
+
+    if (property->getNumberOfComponents() != 1)
+    {
+        OGS_FATAL("`%s' is not a one-component field.", field_name.c_str());
+    }
+
+    auto const* const mapping_to_bulk_nodes =
+        surface_mesh->getProperties().getPropertyVector<long>(
+            "bulk_mesh_node_ids");
+
+    if (!(mapping_to_bulk_nodes &&
+          mapping_to_bulk_nodes->getMeshItemType() ==
+              MeshLib::MeshItemType::Node) &&
+        mapping_to_bulk_nodes->getNumberOfComponents() == 1)
+    {
+        OGS_FATAL("Field `bulk_mesh_node_ids' is not set up properly.");
+    }
 
     return std::make_unique<NonuniformNeumannBoundaryCondition>(
-        is_axially_symmetric, integration_order, shapefunction_order, dof_table,
-        variable_id, component_id, global_dim, std::move(elements), param);
+        bulk_mesh.isAxiallySymmetric(), integration_order, shapefunction_order,
+        bulk_mesh.getDimension(), std::move(surface_mesh),
+        NonuniformNeumannBoundaryConditionData{
+            *property, bulk_mesh.getID(), *mapping_to_bulk_nodes, dof_table,
+            variable_id, component_id});
 }
 
 }  // ProcessLib

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.h
@@ -10,24 +10,21 @@
 #pragma once
 
 #include "GenericNonuniformNaturalBoundaryCondition.h"
+#include "MeshLib/PropertyVector.h"
 #include "NonuniformNeumannBoundaryConditionLocalAssembler.h"
-#include "ProcessLib/Parameter/Parameter.h"
 
 namespace ProcessLib
 {
 using NonuniformNeumannBoundaryCondition =
     GenericNonuniformNaturalBoundaryCondition<
-        Parameter<double> const&,
+        NonuniformNeumannBoundaryConditionData,
         NonuniformNeumannBoundaryConditionLocalAssembler>;
 
 std::unique_ptr<NonuniformNeumannBoundaryCondition>
 createNonuniformNeumannBoundaryCondition(
     BaseLib::ConfigTree const& config,
-    std::vector<MeshLib::Element*>&& elements,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
-    int const component_id, bool is_axially_symmetric,
-    unsigned const integration_order, unsigned const shapefunction_order,
-    unsigned const global_dim,
-    std::vector<std::unique_ptr<ParameterBase>> const& parameters);
+    int const component_id, unsigned const integration_order,
+    unsigned const shapefunction_order, const MeshLib::Mesh& bulk_mesh);
 
 }  // ProcessLib

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryCondition.h
@@ -1,0 +1,33 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include "GenericNonuniformNaturalBoundaryCondition.h"
+#include "NonuniformNeumannBoundaryConditionLocalAssembler.h"
+#include "ProcessLib/Parameter/Parameter.h"
+
+namespace ProcessLib
+{
+using NonuniformNeumannBoundaryCondition =
+    GenericNonuniformNaturalBoundaryCondition<
+        Parameter<double> const&,
+        NonuniformNeumannBoundaryConditionLocalAssembler>;
+
+std::unique_ptr<NonuniformNeumannBoundaryCondition>
+createNonuniformNeumannBoundaryCondition(
+    BaseLib::ConfigTree const& config,
+    std::vector<MeshLib::Element*>&& elements,
+    NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
+    int const component_id, bool is_axially_symmetric,
+    unsigned const integration_order, unsigned const shapefunction_order,
+    unsigned const global_dim,
+    std::vector<std::unique_ptr<ParameterBase>> const& parameters);
+
+}  // ProcessLib

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryConditionLocalAssembler.h
@@ -24,7 +24,7 @@ struct NonuniformNeumannBoundaryConditionData
 
     // Used for mapping boundary nodes to bulk nodes.
     std::size_t bulk_mesh_id;
-    MeshLib::PropertyVector<long> const& mapping_to_bulk_nodes;
+    MeshLib::PropertyVector<unsigned long> const& mapping_to_bulk_nodes;
     NumLib::LocalToGlobalIndexMap const& dof_table_bulk;
     int const variable_id_bulk;
     int const component_id_bulk;

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryConditionLocalAssembler.h
@@ -1,0 +1,77 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include "GenericNonuniformNaturalBoundaryConditionLocalAssembler.h"
+#include "NumLib/DOF/DOFTableUtil.h"
+#include "ProcessLib/Parameter/Parameter.h"
+
+namespace ProcessLib
+{
+template <typename ShapeFunction, typename IntegrationMethod,
+          unsigned GlobalDim>
+class NonuniformNeumannBoundaryConditionLocalAssembler final
+    : public GenericNonuniformNaturalBoundaryConditionLocalAssembler<
+          ShapeFunction, IntegrationMethod, GlobalDim>
+{
+    using Base = GenericNonuniformNaturalBoundaryConditionLocalAssembler<
+        ShapeFunction, IntegrationMethod, GlobalDim>;
+
+public:
+    /// The neumann_bc_value factor is directly integrated into the local
+    /// element matrix.
+    NonuniformNeumannBoundaryConditionLocalAssembler(
+        MeshLib::Element const& e,
+        std::size_t const local_matrix_size,
+        bool is_axially_symmetric,
+        unsigned const integration_order,
+        Parameter<double> const& neumann_bc_parameter)
+        : Base(e, is_axially_symmetric, integration_order),
+          _neumann_bc_parameter(neumann_bc_parameter),
+          _local_rhs(local_matrix_size)
+    {
+    }
+
+    void assemble(std::size_t const id,
+                  NumLib::LocalToGlobalIndexMap const& dof_table_boundary,
+                  double const t, const GlobalVector& /*x*/,
+                  GlobalMatrix& /*K*/, GlobalVector& b) override
+    {
+        _local_rhs.setZero();
+
+        unsigned const n_integration_points =
+            Base::_integration_method.getNumberOfPoints();
+
+        SpatialPosition pos;
+        pos.setElementID(id);
+
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            pos.setIntegrationPoint(ip);
+            auto const& sm = Base::_shape_matrices[ip];
+            auto const& wp = Base::_integration_method.getWeightedPoint(ip);
+            _local_rhs.noalias() += sm.N * _neumann_bc_parameter(t, pos)[0] *
+                                    sm.detJ * wp.getWeight() *
+                                    sm.integralMeasure;
+        }
+
+        auto const indices = NumLib::getIndices(id, dof_table_boundary);
+        b.add(indices, _local_rhs);
+    }
+
+private:
+    Parameter<double> const& _neumann_bc_parameter;
+    typename Base::NodalVectorType _local_rhs;
+
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+};
+
+}  // namespace ProcessLib

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryConditionLocalAssembler.h
@@ -61,9 +61,6 @@ public:
     {
         _local_rhs.setZero();
 
-        unsigned const n_integration_points =
-            Base::_integration_method.getNumberOfPoints();
-
         auto indices = NumLib::getIndices(id, dof_table_boundary);
 
         // TODO lots of heap allocations.
@@ -75,16 +72,15 @@ public:
                 _data.values.getComponent(i, 0));
         }
 
+        auto const n_integration_points = Base::_ns_and_weights.size();
         for (unsigned ip = 0; ip < n_integration_points; ip++)
         {
-            auto const& sm = Base::_shape_matrices[ip];
+            auto const& n_and_weight = Base::_ns_and_weights[ip];
             double flux;
             NumLib::shapeFunctionInterpolate(neumann_param_nodal_values_local,
-                                             sm.N, flux);
-
-            auto const& wp = Base::_integration_method.getWeightedPoint(ip);
+                                             n_and_weight.N, flux);
             _local_rhs.noalias() +=
-                sm.N * flux * sm.detJ * wp.getWeight() * sm.integralMeasure;
+                n_and_weight.N * (n_and_weight.weight * flux);
         }
 
         // map boundary dof indices to bulk dof indices

--- a/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/NonuniformNeumannBoundaryConditionLocalAssembler.h
@@ -24,7 +24,7 @@ struct NonuniformNeumannBoundaryConditionData
 
     // Used for mapping boundary nodes to bulk nodes.
     std::size_t bulk_mesh_id;
-    MeshLib::PropertyVector<unsigned long> const& mapping_to_bulk_nodes;
+    MeshLib::PropertyVector<std::size_t> const& mapping_to_bulk_nodes;
     NumLib::LocalToGlobalIndexMap const& dof_table_bulk;
     int const variable_id_bulk;
     int const component_id_bulk;
@@ -93,9 +93,8 @@ public:
             auto const bulk_node_id =
                 _data.mapping_to_bulk_nodes.getComponent(i, 0);
 
-            MeshLib::Location const l{_data.bulk_mesh_id,
-                                      MeshLib::MeshItemType::Node,
-                                      static_cast<std::size_t>(bulk_node_id)};
+            MeshLib::Location const l{
+                _data.bulk_mesh_id, MeshLib::MeshItemType::Node, bulk_node_id};
 
             i = _data.dof_table_bulk.getGlobalIndex(l, _data.variable_id_bulk,
                                                     _data.component_id_bulk);

--- a/ProcessLib/GroundwaterFlow/Tests.cmake
+++ b/ProcessLib/GroundwaterFlow/Tests.cmake
@@ -573,3 +573,15 @@ foreach(mesh_size 1e1)
         line_1_line_${mesh_size}.vtu line_${mesh_size}_neumann_pcs_0_ts_1_t_1_000000_0.vtu D1_left_N1_right pressure
     )
 endforeach()
+
+AddTest(
+    NAME GroundWaterFlowProcess_Neumann_nonuniform
+    PATH Elliptic/nonuniform_bc_Groundwaterflow
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS neumann_nonuniform.prj
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    ABSTOL 1e-15 RELTOL 1e-15
+    DIFF_DATA
+    a b c d
+)

--- a/ProcessLib/GroundwaterFlow/Tests.cmake
+++ b/ProcessLib/GroundwaterFlow/Tests.cmake
@@ -581,7 +581,7 @@ AddTest(
     EXECUTABLE_ARGS neumann_nonuniform.prj
     TESTER vtkdiff
     REQUIREMENTS NOT OGS_USE_MPI
-    ABSTOL 1e-15 RELTOL 1e-15
+    ABSTOL 4e-2 RELTOL 1e-16
     DIFF_DATA
-    a b c d
+    inhomogeneous_permeability.vtu neumann_nonuniform_pcs_0_ts_1_t_1.000000.vtu mass_flux_ref mass_flux
 )


### PR DESCRIPTION
The structure is to a large extent copied from the current uniform natural BC implementation.

Todo:
* [x] some cleanup
* Not this PR: test with multi-component process, LIE, partitioned nonuniform BCs (PETSc)

In order to see what changed from the previous implementation:
https://github.com/chleh/ogs6/compare/f47cb8f4a0a5847929aa67a2c3d7462139af6ae9...chleh:nonuniform-neumann-bc