### PR TITLE
Fixed a bug in time stepper when non-linear solver diverges

### DIFF
--- a/ProcessLib/LiquidFlow/Tests.cmake
+++ b/ProcessLib/LiquidFlow/Tests.cmake
@@ -117,7 +117,7 @@ AddTest(
     EXECUTABLE_ARGS quad_5500x5500_adaptive_dt.prj
     WRAPPER time
     TESTER vtkdiff
-    REQUIREMENTS NOT (OGS_USE_LIS OR OGS_USE_MPI)
+    REQUIREMENTS NOT OGS_USE_MPI
     ABSTOL 1.e-16 RELTOL 1e-16
     DIFF_DATA
     ThermalConvection_pcs_1_ts_232_t_50000000000.000000_non_const_mu.vtu  ThermalConvection_pcs_1_ts_232_t_50000000000.000000.vtu  pressure pressure
@@ -131,8 +131,8 @@ AddTest(
     EXECUTABLE_ARGS quad_5500x5500_adaptive_dt_constant_viscosity.prj
     WRAPPER time
     TESTER vtkdiff
-    REQUIREMENTS NOT (OGS_USE_LIS OR OGS_USE_MPI)
-    ABSTOL 1.e-16 RELTOL 1e-16
+    REQUIREMENTS NOT OGS_USE_MPI
+    ABSTOL 1.e-16 RELTOL 1e-9 ### increased RETOL for the case of lis solver
     DIFF_DATA
     ConstViscosityThermalConvection_pcs_1_ts_137_t_50000000000.000000.vtu  ConstViscosityThermalConvection_pcs_1_ts_137_t_50000000000.000000.vtu  pressure pressure
     ConstViscosityThermalConvection_pcs_1_ts_137_t_50000000000.000000.vtu  ConstViscosityThermalConvection_pcs_1_ts_137_t_50000000000.000000.vtu  temperature temperature

--- a/ProcessLib/RichardsFlow/Tests.cmake
+++ b/ProcessLib/RichardsFlow/Tests.cmake
@@ -41,12 +41,12 @@ AddTest(
     ABSTOL 1e-8 RELTOL 1e-3
     DIFF_DATA
     ref_t_1600.000000.vtu richards_pcs_0_ts_803_t_1600.000000.vtu pressure pressure
-    REQUIREMENTS NOT (OGS_USE_MPI OR OGS_USE_LIS)
+    REQUIREMENTS NOT OGS_USE_MPI
 )
 
 #PETSc/MPI
 AddTest(
-    NAME 2D_RichardsFlow_h_us_quad_small_Adpative_dt
+    NAME 2D_RichardsFlow_h_us_quad_small_Adaptive_dt
     PATH Parabolic/Richards
     EXECUTABLE_ARGS RichardsFlow_2d_small_adaptive_dt.prj
     WRAPPER mpirun

--- a/ProcessLib/RichardsFlow/Tests.cmake
+++ b/ProcessLib/RichardsFlow/Tests.cmake
@@ -40,7 +40,7 @@ AddTest(
     TESTER vtkdiff
     ABSTOL 1e-8 RELTOL 1e-3
     DIFF_DATA
-    ref_t_1600.000000.vtu richards_pcs_0_ts_805_t_1600.000000.vtu pressure pressure
+    ref_t_1600.000000.vtu richards_pcs_0_ts_803_t_1600.000000.vtu pressure pressure
     REQUIREMENTS NOT (OGS_USE_MPI OR OGS_USE_LIS)
 )
 
@@ -55,5 +55,5 @@ AddTest(
     REQUIREMENTS OGS_USE_MPI
     ABSTOL 1e-8 RELTOL 1e-3
     DIFF_DATA
-    ref_t_1600.000000.vtu richards_pcs_0_ts_805_t_1600_000000_0.vtu pressure pressure
+    ref_t_1600.000000.vtu richards_pcs_0_ts_803_t_1600_000000_0.vtu pressure pressure
 )


### PR DESCRIPTION
The  step size estimation after a diverged non-linear solver is now integrated into the time stepping function. This resolves 
1) the problem that time stepping goes endless rejected steps after non-linear solver fails,
2) the rejected time step after a diverged non-linear solver restarts with the solution of the previous non-linear step but not with the solution of the previous time step.

With the changes, the time step size after a diverged nonlinear solver is computed in time stepper with the in-converged solution of the non-linear solver.
 