### PR TITLE
Eigen alignment

### DIFF
--- a/MaterialLib/SolidModels/Ehlers-impl.h
+++ b/MaterialLib/SolidModels/Ehlers-impl.h
@@ -135,6 +135,8 @@ struct PhysicalStressWithInvariants final
     double I_1;
     double J_2;
     double J_3;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 /// Holds powers of 1 + gamma_p*theta to base 0, m_p, and m_p-1.

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -149,6 +149,8 @@ public:
         /// iteration
         KelvinVector eps_M_t;
         KelvinVector eps_M_j;
+
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
     };
 
     std::unique_ptr<

--- a/NumLib/Fem/CoordinatesMapping/ShapeMatrices.h
+++ b/NumLib/Fem/CoordinatesMapping/ShapeMatrices.h
@@ -14,6 +14,8 @@
 
 #include <ostream>
 
+#include <Eigen/Core>
+
 namespace NumLib
 {
 
@@ -103,6 +105,7 @@ struct ShapeMatrices
      */
     void write (std::ostream& out) const;
 
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 }; // ShapeMatrices
 
 

--- a/ProcessLib/ComponentTransport/ComponentTransportFEM.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportFEM.h
@@ -40,6 +40,8 @@ struct IntegrationPointData final
     NodalRowVectorType const N;
     GlobalDimNodalMatrixType const dNdx;
     double const integration_weight;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 const unsigned NUM_NODAL_DOF = 2;

--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -42,6 +42,8 @@ struct IntegrationPointData final
     NodalRowVectorType const N;
     GlobalDimNodalMatrixType const dNdx;
     double const integration_weight;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 const unsigned NUM_NODAL_DOF = 2;

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
@@ -99,6 +99,8 @@ struct HydroMechanicsProcessData
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
     double dt = 0.0;
     double t = 0.0;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 }  // namespace HydroMechanics

--- a/ProcessLib/LIE/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/LIE/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
@@ -83,6 +83,8 @@ public:
         b.add(indices, _local_rhs);
     }
 
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+
 private:
     Parameter<double> const& _neumann_bc_parameter;
     typename Base::NodalVectorType _local_rhs;

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcessData.h
@@ -150,6 +150,8 @@ struct HydroMechanicsProcessData
     MeshLib::PropertyVector<double>* mesh_prop_fracture_shear_failure = nullptr;
     MeshLib::PropertyVector<double>* mesh_prop_nodal_w = nullptr;
     MeshLib::PropertyVector<double>* mesh_prop_nodal_b = nullptr;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 }  // namespace HydroMechanics

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/IntegrationPointDataFracture.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/IntegrationPointDataFracture.h
@@ -74,6 +74,8 @@ struct IntegrationPointDataFracture final
         w_prev = w;
         sigma_eff_prev = sigma_eff;
     }
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 }  // namespace HydroMechanics

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/IntegrationPointDataMatrix.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/IntegrationPointDataMatrix.h
@@ -79,6 +79,8 @@ struct IntegrationPointDataMatrix final
         sigma_eff_prev = sigma_eff;
         material_state_variables->pushBackState();
     }
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 }  // namespace HydroMechanics

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/IntegrationPointDataFracture.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/IntegrationPointDataFracture.h
@@ -72,6 +72,8 @@ struct IntegrationPointDataFracture final
         _sigma_prev = _sigma;
         _aperture_prev = _aperture;
     }
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 }  // namespace SmallDeformation

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/IntegrationPointDataMatrix.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/IntegrationPointDataMatrix.h
@@ -53,6 +53,8 @@ struct IntegrationPointDataMatrix final
         _sigma_prev = _sigma;
         _material_state_variables->pushBackState();
     }
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 }  // namespace SmallDeformation

--- a/ProcessLib/RichardsFlow/RichardsFlowFEM.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowFEM.h
@@ -47,6 +47,8 @@ struct IntegrationPointData final
     GlobalDimNodalMatrixType const dNdx;
     double const integration_weight;
     NodalMatrixType const mass_operator;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 const unsigned NUM_NODAL_DOF = 1;
 

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -61,6 +61,8 @@ struct IntegrationPointData final
         sigma_prev = sigma;
         material_state_variables->pushBackState();
     }
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 /// Used by for extrapolation of the integration point values. It is ordered

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPLocalAssembler.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPLocalAssembler.h
@@ -50,6 +50,8 @@ struct IntegrationPointData final
     double const integration_weight;
     NodalMatrixType const mass_operator;
     NodalMatrixType const diffusion_operator;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 const unsigned NUM_NODAL_DOF = 3;
 

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
@@ -87,6 +87,8 @@ struct IntegrationPointData final
 
         return C;
     }
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 /// Used by for extrapolation of the integration point values. It is ordered

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
@@ -75,6 +75,8 @@ struct ThermoMechanicsProcessData
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
     double dt;
     double t;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 
 }  // namespace ThermoMechanics

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler.h
@@ -52,6 +52,8 @@ struct IntegrationPointData final
     double integration_weight;
     NodalMatrixType massOperator;
     NodalMatrixType diffusionOperator;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 const unsigned NUM_NODAL_DOF = 2;
 

--- a/Tests/NumLib/SteadyDiffusion2DExample1.h
+++ b/Tests/NumLib/SteadyDiffusion2DExample1.h
@@ -147,4 +147,6 @@ template<typename IndexType>struct SteadyDiffusion2DExample1
 
     LocalMatrixType _localA;
     LocalVectorType _localRhs;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };


### PR DESCRIPTION
Adding Eigen's operator new to classes using any (fixed size) Eigen::Matrix as members.

Continuation of #1897.
Relates to  #1881 #1323
clang's matcher:
```
recordDecl(
    hasDescendant(fieldDecl(hasType(cxxRecordDecl(hasName("Eigen::Matrix"))))),
    unless(hasDescendant(typedefDecl(hasName("eigen_aligned_operator_new_marker_type")))),
    unless(isExpansionInSystemHeader()))
```
This can be refined not to match dynamic matrices...