### PR TITLE
Improved the time stepper of EvolutionaryPIDcontroller for two phase flow

### DIFF
--- a/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.cpp
+++ b/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.cpp
@@ -34,8 +34,7 @@ bool EvolutionaryPIDcontroller::next(const double solution_error)
         double h_new = (e_n > zero_threshlod) ? _ts_current.dt() * _tol / e_n
                                               : 0.5 * _ts_current.dt();
 
-        h_new =
-            limitStepSize(h_new, _ts_current.dt(), is_previous_step_accepted);
+        h_new = limitStepSize(h_new, is_previous_step_accepted);
         h_new = checkSpecificTimeReached(h_new);
 
         _ts_current = _ts_prev;
@@ -95,7 +94,7 @@ bool EvolutionaryPIDcontroller::next(const double solution_error)
             }
         }
 
-        h_new = limitStepSize(h_new, h_n, is_previous_step_accepted);
+        h_new = limitStepSize(h_new, is_previous_step_accepted);
         h_new = checkSpecificTimeReached(h_new);
         _dt_vector.push_back(h_new);
 
@@ -110,10 +109,13 @@ bool EvolutionaryPIDcontroller::next(const double solution_error)
 }
 
 double EvolutionaryPIDcontroller::limitStepSize(
-    const double h_new, const double h_n,
-    const bool previous_step_accepted) const
+    const double h_new, const bool previous_step_accepted) const
 {
+    const double h_n = _ts_current.dt();
+    // Forced the computed time step size in the given range
+    // (see the formulas in the documentation of the class)
     const double h_in_range = std::max(_h_min, std::min(h_new, _h_max));
+    // Limit the step size change ratio.
     double limited_h =
         std::max(_rel_h_min * h_n, std::min(h_in_range, _rel_h_max * h_n));
 

--- a/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.h
+++ b/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.h
@@ -115,7 +115,18 @@ private:
 
     bool _is_accepted;
 
-    double limitStepSize(const double h_new, const double h_n,
+    /**
+     * Forced the computed time step size in the given range
+     * (see the formulas in the documentation of the class)
+     * or use the half of the previous time step size under some other
+     * constrains.
+     * @param h_new                   The computed time step size.
+     * @param previous_step_accepted  An indicator for whether the previous time
+     *                                step is rejected.
+     * @return                        The new time step after apply
+     *                                the constrains.
+     */
+    double limitStepSize(const double h_new,
                          const bool previous_step_accepted) const;
 
     double checkSpecificTimeReached(const double h_new);

--- a/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.h
+++ b/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.h
@@ -81,10 +81,16 @@ public:
 
     /// return if current time step is accepted
     bool accepted() const override { return _is_accepted; }
+    /// Set the status of the step
+    /// \param accepted A flag for whether the step is accepted or not
+    void setAcceptedOrNot(const bool accepted) override
+    {
+        _is_accepted = accepted;
+    }
+
     /// Get a flag to indicate that this algorithm need to compute
     /// solution error.
     bool isSolutionErrorComputationNeeded() override { return true; }
-
 private:
     const double _kP = 0.075;  ///< Parameter. \see EvolutionaryPIDcontroller
     const double _kI = 0.175;  ///< Parameter. \see EvolutionaryPIDcontroller
@@ -109,12 +115,8 @@ private:
 
     bool _is_accepted;
 
-    double limitStepSize(const double h_new, const double h_n) const
-    {
-        const double h_in_range = std::max(_h_min, std::min(h_new, _h_max));
-        return std::max(_rel_h_min * h_n,
-                        std::min(h_in_range, _rel_h_max * h_n));
-    }
+    double limitStepSize(const double h_new, const double h_n,
+                         const bool previous_step_accepted) const;
 
     double checkSpecificTimeReached(const double h_new);
 };

--- a/NumLib/TimeStepping/Algorithms/TimeStepAlgorithm.h
+++ b/NumLib/TimeStepping/Algorithms/TimeStepAlgorithm.h
@@ -72,6 +72,10 @@ public:
     /// return if current time step is accepted or not
     virtual bool accepted() const = 0;
 
+    /// Set the status of the step. A boolean parameter is needed to indicated
+    /// whether the step is accepted or not.
+    virtual void setAcceptedOrNot(const bool /*accepted*/){};
+
     /// return a history of time step sizes
     const std::vector<double>& getTimeStepSizeHistory() const
     {
@@ -81,7 +85,6 @@ public:
     /// Get a flag to indicate whether this algorithm needs to compute
     /// solution error. The default return value is false.
     virtual bool isSolutionErrorComputationNeeded() { return false; }
-
 protected:
     /// initial time
     const double _t_initial;

--- a/ProcessLib/LiquidFlow/Tests.cmake
+++ b/ProcessLib/LiquidFlow/Tests.cmake
@@ -118,10 +118,10 @@ AddTest(
     WRAPPER time
     TESTER vtkdiff
     REQUIREMENTS NOT OGS_USE_MPI
-    ABSTOL 1.e-16 RELTOL 1e-16
+    ABSTOL 1.e-3 RELTOL 1e-10
     DIFF_DATA
-    ThermalConvection_pcs_1_ts_232_t_50000000000.000000_non_const_mu.vtu  ThermalConvection_pcs_1_ts_232_t_50000000000.000000.vtu  pressure pressure
-    ThermalConvection_pcs_1_ts_232_t_50000000000.000000_non_const_mu.vtu  ThermalConvection_pcs_1_ts_232_t_50000000000.000000.vtu  temperature temperature
+    ThermalConvection_pcs_1_ts_232_t_50000000000.000000_non_const_mu.vtu  ThermalConvection_pcs_1_ts_223_t_50000000000.000000.vtu  pressure pressure
+    ThermalConvection_pcs_1_ts_232_t_50000000000.000000_non_const_mu.vtu  ThermalConvection_pcs_1_ts_223_t_50000000000.000000.vtu  temperature temperature
 )
 
 AddTest(
@@ -261,10 +261,10 @@ AddTest(
     WRAPPER_ARGS -np 1
     TESTER vtkdiff
     REQUIREMENTS OGS_USE_MPI
-    ABSTOL 1.e-9 RELTOL 1e-8
+    ABSTOL 1.e-3 RELTOL 1e-10
     DIFF_DATA
-    ThermalConvection_pcs_1_ts_232_t_50000000000.000000_non_const_mu.vtu  ThermalConvection_pcs_1_ts_232_t_50000000000_000000_0.vtu  pressure pressure
-    ThermalConvection_pcs_1_ts_232_t_50000000000.000000_non_const_mu.vtu  ThermalConvection_pcs_1_ts_232_t_50000000000_000000_0.vtu  temperature temperature
+    ThermalConvection_pcs_1_ts_232_t_50000000000.000000_non_const_mu.vtu  ThermalConvection_pcs_1_ts_223_t_50000000000_000000_0.vtu  pressure pressure
+    ThermalConvection_pcs_1_ts_232_t_50000000000.000000_non_const_mu.vtu  ThermalConvection_pcs_1_ts_223_t_50000000000_000000_0.vtu  temperature temperature
 )
 
 AddTest(

--- a/ProcessLib/TwoPhaseFlowWithPrho/Tests.cmake
+++ b/ProcessLib/TwoPhaseFlowWithPrho/Tests.cmake
@@ -11,6 +11,21 @@ AddTest(
     ref_ts_10_t_10000.000000.vtu twophaseflow_pcs_0_ts_10_t_10000.000000.vtu overall_mass_density overall_mass_density
     ref_ts_10_t_10000.000000.vtu twophaseflow_pcs_0_ts_10_t_10000.000000.vtu saturation saturation
 )
+
+AddTest(
+    NAME LARGE_2D_TwoPhase_Prho_MoMaS_Adaptive_dt
+    PATH Parabolic/TwoPhaseFlowPrho/MoMaS
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS Twophase_MoMaS_quad_adaptive_dt.prj
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    ABSTOL 1e-7 RELTOL 1e-6
+    DIFF_DATA
+    ref_twophaseflow_pcs_0_ts_19_t_100000.000000.vtu twophaseflow_adaptive_dt_pcs_0_ts_19_t_100000.000000.vtu liquid_pressure liquid_pressure
+    ref_twophaseflow_pcs_0_ts_19_t_100000.000000.vtu twophaseflow_adaptive_dt_pcs_0_ts_19_t_100000.000000.vtu overall_mass_density overall_mass_density
+    ref_twophaseflow_pcs_0_ts_19_t_100000.000000.vtu twophaseflow_adaptive_dt_pcs_0_ts_19_t_100000.000000.vtu saturation saturation
+)
+
 AddTest(
     NAME 2D_TwoPhase_Prho_MoMaS
     PATH Parabolic/TwoPhaseFlowPrho/MoMaS

--- a/ProcessLib/UncoupledProcessesTimeLoop.cpp
+++ b/ProcessLib/UncoupledProcessesTimeLoop.cpp
@@ -576,6 +576,9 @@ double UncoupledProcessesTimeLoop::computeTimeStepping(
                              x, norm_type))
                 : 0.;
 
+        if (!ppd.nonlinear_solver_converged)
+            timestepper->setAcceptedOrNot(false);
+
         if (!timestepper->next(solution_error) &&
             // In case of FixedTimeStepping, which makes timestepper->next(...)
             // return false when the ending time is reached.


### PR DESCRIPTION
Improved the time stepper of EvolutionaryPIDcontroller for two phase flow. In case of non-linear solver diverged, the step size change is forced to decrease in the code improvement. A ctest about a two phase flow scheme, which uses  overall mass density as one of two primary variables, is added. In addition, a test that is influenced by the  improvement is updated as well.

