### PR TITLE
[CMake] Added option OGS_EIGEN_INITIALIZE_MATRICES_BY_NAN.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ option(OGS_USE_PETSC "Use PETSc routines" OFF)
 # Eigen
 option(OGS_USE_EIGEN "Use Eigen linear solver" ON)
 option(OGS_USE_EIGEN_UNSUPPORTED "Use Eigen unsupported modules" ON)
+option(OGS_EIGEN_INITIALIZE_MATRICES_BY_NAN "" ON)
 option(EIGEN_NO_DEBUG "Disables Eigen's assertions" OFF)
 
 set(OGS_EIGEN_DYNAMIC_SHAPE_MATRICES "Default" CACHE STRING "Use dynamically allocated shape matrices")
@@ -199,6 +200,9 @@ if(OGS_USE_EIGEN)
     add_definitions(-DOGS_USE_EIGEN)
     if(OGS_USE_EIGEN_UNSUPPORTED)
         add_definitions(-DUSE_EIGEN_UNSUPPORTED)
+    endif()
+    if(OGS_EIGEN_INITIALIZE_MATRICES_BY_NAN)
+        add_definitions(-DEIGEN_INITIALIZE_MATRICES_BY_NAN)
     endif()
 endif()
 

--- a/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionPerComponentResidual.cpp
@@ -54,7 +54,9 @@ void ConvergenceCriterionPerComponentResidual::checkDeltaX(
         INFO(
             "Convergence criterion, component %u: |dx|=%.4e, |x|=%.4e, "
             "|dx|/|x|=%.4e",
-            error_dx, global_component, norm_x, error_dx / norm_x);
+            error_dx, global_component, norm_x,
+            (norm_x == 0. ? std::numeric_limits<double>::quiet_NaN()
+                          : (error_dx / norm_x)));
     }
 }
 
@@ -85,7 +87,9 @@ void ConvergenceCriterionPerComponentResidual::checkResidual(
             INFO(
                 "Convergence criterion, component %u: |r|=%.4e, |r0|=%.4e, "
                 "|r|/|r0|=%.4e",
-                global_component, norm_res, norm_res0, norm_res / norm_res0);
+                global_component, norm_res, norm_res0,
+                (norm_res0 == 0. ? std::numeric_limits<double>::quiet_NaN()
+                                 : (norm_res / norm_res0)));
         }
 
         satisfied_abs = satisfied_abs && norm_res < _abstols[global_component];

--- a/NumLib/ODESolver/ConvergenceCriterionResidual.cpp
+++ b/NumLib/ODESolver/ConvergenceCriterionResidual.cpp
@@ -36,7 +36,9 @@ void ConvergenceCriterionResidual::checkDeltaX(
     auto norm_x = MathLib::LinAlg::norm(x, _norm_type);
 
     INFO("Convergence criterion: |dx|=%.4e, |x|=%.4e, |dx|/|x|=%.4e", error_dx,
-         norm_x, error_dx / norm_x);
+         norm_x,
+         (norm_x == 0. ? std::numeric_limits<double>::quiet_NaN()
+                       : (error_dx / norm_x)));
 }
 
 void ConvergenceCriterionResidual::checkResidual(const GlobalVector& residual)
@@ -62,7 +64,10 @@ void ConvergenceCriterionResidual::checkResidual(const GlobalVector& residual)
         else
         {
             INFO("Convergence criterion: |r|=%.4e |r0|=%.4e |r|/|r0|=%.4e",
-                 norm_res, _residual_norm_0, norm_res / _residual_norm_0);
+                 norm_res, _residual_norm_0,
+                 (_residual_norm_0 == 0.
+                      ? std::numeric_limits<double>::quiet_NaN()
+                      : (norm_res / _residual_norm_0)));
         }
     }
 

--- a/ProcessLib/PhaseField/CreatePhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/CreatePhaseFieldProcess.cpp
@@ -159,12 +159,12 @@ std::unique_ptr<Process> createPhaseFieldProcess(
             //! \ogs_file_param{prj__processes__process__PHASE_FIELD__specific_body_force}
             config.getConfigParameter<std::vector<double>>(
                 "specific_body_force");
-        if (specific_body_force.size() != DisplacementDim)
+        if (b.size() != DisplacementDim)
             OGS_FATAL(
                 "The size of the specific body force vector does not match the "
                 "displacement dimension. Vector size is %d, displacement "
                 "dimension is %d",
-                specific_body_force.size(), DisplacementDim);
+                b.size(), DisplacementDim);
 
         std::copy_n(b.data(), b.size(), specific_body_force.data());
     }

--- a/ProcessLib/PhaseField/PhaseFieldProcessData.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcessData.h
@@ -73,9 +73,9 @@ struct PhaseFieldProcessData
     Parameter<double> const& kinetic_coefficient;
     Parameter<double> const& solid_density;
     Parameter<double>& history_field;
-    Eigen::Matrix<double, DisplacementDim, 1> const& specific_body_force;
-    double dt;
-    double t;
+    Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
+    double dt = 0.0;
+    double t = 0.0;
 };
 
 }  // namespace PhaseField


### PR DESCRIPTION
Defaults to ON.

~~Set EIGEN_NO_AUTOMATIC_RESIZING macro as well.~~
See https://eigen.tuxfamily.org/dox/TopicPreprocessorDirectives.html.

Related to #1909.