### PR TITLE
Set coupling term as a member of class Process

### DIFF
--- a/NumLib/ODESolver/NonlinearSolver.cpp
+++ b/NumLib/ODESolver/NonlinearSolver.cpp
@@ -21,14 +21,13 @@
 namespace NumLib
 {
 void NonlinearSolver<NonlinearSolverTag::Picard>::assemble(
-    GlobalVector const& x,
-    ProcessLib::StaggeredCouplingTerm const& coupling_term) const
+    GlobalVector const& x) const
 {
-    _equation_system->assemble(x, coupling_term);
+    _equation_system->assemble(x);
 }
 
 bool NonlinearSolver<NonlinearSolverTag::Picard>::solve(
-    GlobalVector& x, ProcessLib::StaggeredCouplingTerm const& coupling_term,
+    GlobalVector& x,
     std::function<void(unsigned, GlobalVector const&)> const& postIterationCallback)
 {
     namespace LinAlg = MathLib::LinAlg;
@@ -59,7 +58,7 @@ bool NonlinearSolver<NonlinearSolverTag::Picard>::solve(
 
         BaseLib::RunTime time_assembly;
         time_assembly.start();
-        sys.assemble(x, coupling_term);
+        sys.assemble(x);
         sys.getA(A);
         sys.getRhs(rhs);
         INFO("[time] Assembly took %g s.", time_assembly.elapsed());
@@ -159,17 +158,16 @@ bool NonlinearSolver<NonlinearSolverTag::Picard>::solve(
 }
 
 void NonlinearSolver<NonlinearSolverTag::Newton>::assemble(
-    GlobalVector const& x,
-    ProcessLib::StaggeredCouplingTerm const& coupling_term) const
+    GlobalVector const& x) const
 {
-    _equation_system->assemble(x, coupling_term);
+    _equation_system->assemble(x);
     // TODO if the equation system would be reset to nullptr after each
     //      assemble() or solve() call, the user would be forced to set the
     //      equation every time and could not forget it.
 }
 
 bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
-    GlobalVector& x, ProcessLib::StaggeredCouplingTerm const& coupling_term,
+    GlobalVector& x,
     std::function<void(unsigned, GlobalVector const&)> const& postIterationCallback)
 {
     namespace LinAlg = MathLib::LinAlg;
@@ -202,7 +200,7 @@ bool NonlinearSolver<NonlinearSolverTag::Newton>::solve(
 
         BaseLib::RunTime time_assembly;
         time_assembly.start();
-        sys.assemble(x, coupling_term);
+        sys.assemble(x);
         sys.getResidual(x, res);
         sys.getJacobian(J);
         INFO("[time] Assembly took %g s.", time_assembly.elapsed());

--- a/NumLib/ODESolver/NonlinearSolver.h
+++ b/NumLib/ODESolver/NonlinearSolver.h
@@ -22,11 +22,6 @@ namespace BaseLib
 class ConfigTree;
 }
 
-namespace ProcessLib
-{
-    struct StaggeredCouplingTerm;
-}
-
 // TODO Document in the ODE solver lib, which matrices and vectors that are
 // passed around as method arguments are guaranteed to be of the right size
 // (and zeroed out) and which are not.
@@ -47,27 +42,18 @@ public:
      *
      * \param x             the state at which the equation system will be
      *                      assembled.
-     * \param coupling_term  the coupled term including the reference of the
-     *                      coupled processes and solutions of the equations of
-     *                      the coupled processes.
      */
-    virtual void assemble(GlobalVector const& x,
-                          ProcessLib::StaggeredCouplingTerm const& coupling_term
-                         ) const = 0;
+    virtual void assemble(GlobalVector const& x) const = 0;
 
     /*! Assemble and solve the equation system.
      *
      * \param x   in: the initial guess, out: the solution.
-     * \param coupling_term  the coupled term including the reference of the
-     *                      coupled processes and solutions of the equations of
-     *                      the coupled processes.
      * \param postIterationCallback called after each iteration if set.
      *
      * \retval true if the equation system could be solved
      * \retval false otherwise
      */
     virtual bool solve(GlobalVector& x,
-                       ProcessLib::StaggeredCouplingTerm const& coupling_term,
                        std::function<void(unsigned, GlobalVector const&)> const&
                            postIterationCallback) = 0;
 
@@ -117,12 +103,9 @@ public:
         _convergence_criterion = &conv_crit;
     }
 
-    void assemble(GlobalVector const& x,
-                  ProcessLib::StaggeredCouplingTerm const& coupling_term
-                 ) const override;
+    void assemble(GlobalVector const& x) const override;
 
     bool solve(GlobalVector& x,
-               ProcessLib::StaggeredCouplingTerm const& coupling_term,
                std::function<void(unsigned, GlobalVector const&)> const&
                    postIterationCallback) override;
 
@@ -176,12 +159,9 @@ public:
         _convergence_criterion = &conv_crit;
     }
 
-    void assemble(GlobalVector const& x,
-                  ProcessLib::StaggeredCouplingTerm const& coupling_term
-                 ) const override;
+    void assemble(GlobalVector const& x) const override;
 
     bool solve(GlobalVector& x,
-               ProcessLib::StaggeredCouplingTerm const& coupling_term,
                std::function<void(unsigned, GlobalVector const&)> const&
                    postIterationCallback) override;
 

--- a/NumLib/ODESolver/NonlinearSystem.h
+++ b/NumLib/ODESolver/NonlinearSystem.h
@@ -12,11 +12,6 @@
 #include "EquationSystem.h"
 #include "Types.h"
 
-namespace ProcessLib
-{
-    struct StaggeredCouplingTerm;
-}
-
 namespace NumLib
 {
 //! \addtogroup ODESolver
@@ -41,9 +36,7 @@ public:
     //! Assembles the linearized equation system at the point \c x.
     //! The linearized system is \f$A(x) \cdot x = b(x)\f$. Here the matrix
     //! \f$A(x)\f$ and the vector \f$b(x)\f$ are assembled.
-    virtual void assemble(GlobalVector const& x,
-                          ProcessLib::StaggeredCouplingTerm const& coupling_term
-                          ) = 0;
+    virtual void assemble(GlobalVector const& x) = 0;
 
     /*! Writes the residual at point \c x to \c res.
      *
@@ -82,9 +75,7 @@ public:
     //! Assembles the linearized equation system at the point \c x.
     //! The linearized system is \f$J(x) \cdot \Delta x = (x)\f$. Here the
     //! residual vector \f$r(x)\f$ and its Jacobian \f$J(x)\f$ are assembled.
-    virtual void assemble(GlobalVector const& x,
-                          ProcessLib::StaggeredCouplingTerm const& coupling_term
-                         ) = 0;
+    virtual void assemble(GlobalVector const& x) = 0;
 
     //! Writes the linearized equation system matrix to \c A.
     //! \pre assemble() must have been called before.

--- a/NumLib/ODESolver/ODESystem.h
+++ b/NumLib/ODESolver/ODESystem.h
@@ -15,11 +15,6 @@
 #include "EquationSystem.h"
 #include "Types.h"
 
-namespace ProcessLib
-{
-struct StaggeredCouplingTerm;
-}
-
 namespace NumLib
 {
 //! \addtogroup ODESolver
@@ -52,8 +47,7 @@ public:
     //! Assemble \c M, \c K and \c b at the provided state (\c t, \c x).
     virtual void assemble(
         const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-        GlobalVector& b,
-        ProcessLib::StaggeredCouplingTerm const& coupling_term) = 0;
+        GlobalVector& b) = 0;
 
     using Index = MathLib::MatrixVectorTraits<GlobalMatrix>::Index;
 
@@ -126,8 +120,7 @@ public:
     virtual void assembleWithJacobian(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        ProcessLib::StaggeredCouplingTerm const& coupling_term) = 0;
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) = 0;
 };
 
 //! @}

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
@@ -67,8 +67,7 @@ TimeDiscretizedODESystem<
 
 void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
                               NonlinearSolverTag::Newton>::
-    assemble(const GlobalVector& x_new_timestep,
-             ProcessLib::StaggeredCouplingTerm const& coupling_term)
+    assemble(const GlobalVector& x_new_timestep)
 {
     namespace LinAlg = MathLib::LinAlg;
 
@@ -86,7 +85,7 @@ void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
     _Jac->setZero();
 
     _ode.assembleWithJacobian(t, x_curr, xdot, dxdot_dx, dx_dx, *_M, *_K, *_b,
-                              *_Jac, coupling_term);
+                              *_Jac);
 
     LinAlg::finalizeAssembly(*_M);
     LinAlg::finalizeAssembly(*_K);
@@ -176,8 +175,7 @@ TimeDiscretizedODESystem<
 
 void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
                               NonlinearSolverTag::Picard>::
-    assemble(const GlobalVector& x_new_timestep,
-             ProcessLib::StaggeredCouplingTerm const& coupling_term)
+    assemble(const GlobalVector& x_new_timestep)
 {
     namespace LinAlg = MathLib::LinAlg;
 
@@ -188,7 +186,7 @@ void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
     _K->setZero();
     _b->setZero();
 
-    _ode.assemble(t, x_curr, *_M, *_K, *_b, coupling_term);
+    _ode.assemble(t, x_curr, *_M, *_K, *_b);
 
     LinAlg::finalizeAssembly(*_M);
     LinAlg::finalizeAssembly(*_K);

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.h
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.h
@@ -16,12 +16,6 @@
 #include "ODESystem.h"
 #include "TimeDiscretization.h"
 
-
-namespace ProcessLib
-{
-    struct StaggeredCouplingTerm;
-}
-
 namespace NumLib
 {
 //! \addtogroup ODESolver
@@ -86,8 +80,7 @@ public:
 
     ~TimeDiscretizedODESystem() override;
 
-    void assemble(const GlobalVector& x_new_timestep,
-                  ProcessLib::StaggeredCouplingTerm const& coupling_term)
+    void assemble(const GlobalVector& x_new_timestep)
                   override;
 
     void getResidual(GlobalVector const& x_new_timestep,
@@ -180,8 +173,7 @@ public:
 
     ~TimeDiscretizedODESystem() override;
 
-    void assemble(const GlobalVector& x_new_timestep,
-                  ProcessLib::StaggeredCouplingTerm const& coupling_term)
+    void assemble(const GlobalVector& x_new_timestep)
                   override;
 
     void getA(GlobalMatrix& A) const override

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
@@ -56,22 +56,20 @@ void ComponentTransportProcess::assembleConcreteProcess(
     GlobalVector const& x,
     GlobalMatrix& M,
     GlobalMatrix& K,
-    GlobalVector& b,
-    StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b)
 {
     DBUG("Assemble ComponentTransportProcess.");
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
 }
 
 void ComponentTransportProcess::assembleWithJacobianConcreteProcess(
     const double t, GlobalVector const& x, GlobalVector const& xdot,
     const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac,
-    StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian ComponentTransportProcess.");
 
@@ -79,7 +77,7 @@ void ComponentTransportProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, coupling_term);
+        dx_dx, M, K, b, Jac, *_coupling_term.lock());
 }
 
 }  // namespace ComponentTransport

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
@@ -63,7 +63,7 @@ void ComponentTransportProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
+        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
 }
 
 void ComponentTransportProcess::assembleWithJacobianConcreteProcess(
@@ -77,7 +77,7 @@ void ComponentTransportProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, *_coupling_term.lock());
+        dx_dx, M, K, b, Jac, _coupling_term);
 }
 
 }  // namespace ComponentTransport

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.h
@@ -103,13 +103,12 @@ private:
 
     void assembleConcreteProcess(
         const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-        GlobalVector& b, StaggeredCouplingTerm const& coupling_term) override;
+        GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override;
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     ComponentTransportProcessData _process_data;
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -68,7 +68,7 @@ void GroundwaterFlowProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
+        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
 }
 
 void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(
@@ -82,7 +82,7 @@ void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, *_coupling_term.lock());
+        dx_dx, M, K, b, Jac, _coupling_term);
 }
 
 }   // namespace GroundwaterFlow

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -61,23 +61,20 @@ void GroundwaterFlowProcess::assembleConcreteProcess(const double t,
                                                      GlobalVector const& x,
                                                      GlobalMatrix& M,
                                                      GlobalMatrix& K,
-                                                     GlobalVector& b,
-                                                     StaggeredCouplingTerm
-                                                     const& coupling_term)
+                                                     GlobalVector& b)
 {
     DBUG("Assemble GroundwaterFlowProcess.");
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
 }
 
 void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(
     const double t, GlobalVector const& x, GlobalVector const& xdot,
     const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac,
-    StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian GroundwaterFlowProcess.");
 
@@ -85,7 +82,7 @@ void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, coupling_term);
+        dx_dx, M, K, b, Jac, *_coupling_term.lock());
 }
 
 }   // namespace GroundwaterFlow

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -95,15 +95,12 @@ private:
 
     void assembleConcreteProcess(const double t, GlobalVector const& x,
                                  GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b,
-                                 StaggeredCouplingTerm const& coupling_term
-                                ) override;
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override;
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     GroundwaterFlowProcessData _process_data;
 

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -62,7 +62,7 @@ void HTProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
+        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
 }
 
 void HTProcess::assembleWithJacobianConcreteProcess(
@@ -76,7 +76,7 @@ void HTProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, *_coupling_term.lock());
+        dx_dx, M, K, b, Jac, _coupling_term);
 }
 
 }  // namespace HT

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -55,23 +55,20 @@ void HTProcess::assembleConcreteProcess(const double t,
                                         GlobalVector const& x,
                                         GlobalMatrix& M,
                                         GlobalMatrix& K,
-                                        GlobalVector& b,
-                                        StaggeredCouplingTerm const&
-                                        coupling_term)
+                                        GlobalVector& b)
 {
     DBUG("Assemble HTProcess.");
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
 }
 
 void HTProcess::assembleWithJacobianConcreteProcess(
     const double t, GlobalVector const& x, GlobalVector const& xdot,
     const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac,
-    StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian HTProcess.");
 
@@ -79,7 +76,7 @@ void HTProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, coupling_term);
+        dx_dx, M, K, b, Jac, *_coupling_term.lock());
 }
 
 }  // namespace HT

--- a/ProcessLib/HT/HTProcess.h
+++ b/ProcessLib/HT/HTProcess.h
@@ -65,15 +65,12 @@ private:
 
     void assembleConcreteProcess(const double t, GlobalVector const& x,
                                  GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b,
-                                 StaggeredCouplingTerm const& coupling_term
-                                ) override;
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override;
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     HTProcessData _process_data;
 

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -88,23 +88,20 @@ void HeatConductionProcess::assembleConcreteProcess(const double t,
                                                     GlobalVector const& x,
                                                     GlobalMatrix& M,
                                                     GlobalMatrix& K,
-                                                    GlobalVector& b,
-                                                    StaggeredCouplingTerm
-                                                    const& coupling_term)
+                                                    GlobalVector& b)
 {
     DBUG("Assemble HeatConductionProcess.");
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
 }
 
 void HeatConductionProcess::assembleWithJacobianConcreteProcess(
     const double t, GlobalVector const& x, GlobalVector const& xdot,
     const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac,
-    StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian HeatConductionProcess.");
 
@@ -112,17 +109,17 @@ void HeatConductionProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, coupling_term);
+        dx_dx, M, K, b, Jac, *_coupling_term.lock());
 }
 
 void HeatConductionProcess::computeSecondaryVariableConcrete(
-    const double t, GlobalVector const& x,
-    StaggeredCouplingTerm const& coupled_term)
+    const double t, GlobalVector const& x)
 {
     DBUG("Compute heat flux for HeatConductionProcess.");
     GlobalExecutor::executeMemberOnDereferenced(
             &HeatConductionLocalAssemblerInterface::computeSecondaryVariable,
-            _local_assemblers, *_local_to_global_index_map, t, x, coupled_term);
+            _local_assemblers, *_local_to_global_index_map, t, x,
+            *_coupling_term.lock());
 }
 
 }  // namespace HeatConduction

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -95,7 +95,7 @@ void HeatConductionProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
+        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
 }
 
 void HeatConductionProcess::assembleWithJacobianConcreteProcess(
@@ -109,7 +109,7 @@ void HeatConductionProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, *_coupling_term.lock());
+        dx_dx, M, K, b, Jac, _coupling_term);
 }
 
 void HeatConductionProcess::computeSecondaryVariableConcrete(
@@ -119,7 +119,7 @@ void HeatConductionProcess::computeSecondaryVariableConcrete(
     GlobalExecutor::executeMemberOnDereferenced(
             &HeatConductionLocalAssemblerInterface::computeSecondaryVariable,
             _local_assemblers, *_local_to_global_index_map, t, x,
-            *_coupling_term.lock());
+            _coupling_term);
 }
 
 }  // namespace HeatConduction

--- a/ProcessLib/HeatConduction/HeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.h
@@ -39,8 +39,7 @@ public:
     bool isLinear() const override { return true; }
 
     void computeSecondaryVariableConcrete(
-        double const t, GlobalVector const& x,
-        StaggeredCouplingTerm const& coupled_term) override;
+        double const t, GlobalVector const& x) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, const double t,
                                     const double delta_t) override;
@@ -59,15 +58,12 @@ private:
 
     void assembleConcreteProcess(const double t, GlobalVector const& x,
                                  GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b,
-                                 StaggeredCouplingTerm const& coupling_term
-                                ) override;
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override;
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     HeatConductionProcessData _process_data;
 

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess-impl.h
@@ -185,14 +185,14 @@ void HydroMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b)
 {
     DBUG("Assemble HydroMechanicsProcess.");
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
 }
 
 template <int DisplacementDim>
@@ -200,8 +200,7 @@ void HydroMechanicsProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term)
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleJacobian HydroMechanicsProcess.");
 
@@ -209,7 +208,7 @@ void HydroMechanicsProcess<DisplacementDim>::
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, coupling_term);
+        dx_dx, M, K, b, Jac, *_coupling_term.lock());
 }
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess-impl.h
@@ -192,7 +192,7 @@ void HydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
+        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
 }
 
 template <int DisplacementDim>
@@ -208,7 +208,7 @@ void HydroMechanicsProcess<DisplacementDim>::
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, *_coupling_term.lock());
+        dx_dx, M, K, b, Jac, _coupling_term);
 }
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -57,13 +57,12 @@ private:
 
     void assembleConcreteProcess(
         const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-        GlobalVector& b, StaggeredCouplingTerm const& coupling_term) override;
+        GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override;
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,
                                     double const dt) override;

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -402,13 +402,13 @@ void HydroMechanicsProcess<GlobalDim>::initializeConcreteProcess(
 
 template <unsigned GlobalDim>
 void HydroMechanicsProcess<GlobalDim>::computeSecondaryVariableConcrete(
-    const double t, GlobalVector const& x,
-    StaggeredCouplingTerm const& coupled_term)
+    const double t, GlobalVector const& x)
 {
     DBUG("Compute the secondary variables for HydroMechanicsProcess.");
     GlobalExecutor::executeMemberOnDereferenced(
         &HydroMechanicsLocalAssemblerInterface::computeSecondaryVariable,
-        _local_assemblers, *_local_to_global_index_map, t, x, coupled_term);
+        _local_assemblers, *_local_to_global_index_map, t, x,
+        *_coupling_term.lock());
 
     // Copy displacement jumps in a solution vector to mesh property
     // Remark: the copy is required because mesh properties for primary

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -408,7 +408,7 @@ void HydroMechanicsProcess<GlobalDim>::computeSecondaryVariableConcrete(
     GlobalExecutor::executeMemberOnDereferenced(
         &HydroMechanicsLocalAssemblerInterface::computeSecondaryVariable,
         _local_assemblers, *_local_to_global_index_map, t, x,
-        *_coupling_term.lock());
+        _coupling_term);
 
     // Copy displacement jumps in a solution vector to mesh property
     // Remark: the copy is required because mesh properties for primary

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
@@ -53,9 +53,7 @@ public:
     //! @}
 
     void computeSecondaryVariableConcrete(double const t,
-                                          GlobalVector const& x,
-                                          StaggeredCouplingTerm const&
-                                          coupled_term) override;
+                                          GlobalVector const& x) override;
 
 private:
     using LocalAssemblerInterface = HydroMechanicsLocalAssemblerInterface;
@@ -69,9 +67,7 @@ private:
 
     void assembleConcreteProcess(const double t, GlobalVector const& x,
                                  GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b,
-                                 StaggeredCouplingTerm const&
-                                 coupling_term) override
+                                 GlobalVector& b) override
     {
         DBUG("Assemble HydroMechanicsProcess.");
 
@@ -79,14 +75,13 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assemble,
             _local_assemblers, *_local_to_global_index_map, t, x, M, K, b,
-            coupling_term);
+            *_coupling_term.lock());
     }
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override
     {
         DBUG("AssembleWithJacobian HydroMechanicsProcess.");
 
@@ -94,7 +89,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
             _local_assemblers, *_local_to_global_index_map, t, x, xdot,
-            dxdot_dx, dx_dx, M, K, b, Jac, coupling_term);
+            dxdot_dx, dx_dx, M, K, b, Jac, *_coupling_term.lock());
     }
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
@@ -75,7 +75,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assemble,
             _local_assemblers, *_local_to_global_index_map, t, x, M, K, b,
-            *_coupling_term.lock());
+            _coupling_term);
     }
 
     void assembleWithJacobianConcreteProcess(
@@ -89,7 +89,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
             _local_assemblers, *_local_to_global_index_map, t, x, xdot,
-            dxdot_dx, dx_dx, M, K, b, Jac, *_coupling_term.lock());
+            dxdot_dx, dx_dx, M, K, b, Jac, _coupling_term);
     }
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
@@ -73,7 +73,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assemble,
             _local_assemblers, *_local_to_global_index_map, t, x, M, K, b,
-            *_coupling_term.lock());
+            _coupling_term);
     }
 
     void assembleWithJacobianConcreteProcess(
@@ -87,7 +87,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
             _local_assemblers, *_local_to_global_index_map, t, x, xdot,
-            dxdot_dx, dx_dx, M, K, b, Jac, *_coupling_term.lock());
+            dxdot_dx, dx_dx, M, K, b, Jac, _coupling_term);
     }
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
@@ -65,9 +65,7 @@ private:
 
     void assembleConcreteProcess(const double t, GlobalVector const& x,
                                  GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b,
-                                 StaggeredCouplingTerm const&
-                                 coupling_term) override
+                                 GlobalVector& b) override
     {
         DBUG("Assemble SmallDeformationProcess.");
 
@@ -75,14 +73,13 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assemble,
             _local_assemblers, *_local_to_global_index_map, t, x, M, K, b,
-            coupling_term);
+            *_coupling_term.lock());
     }
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override
     {
         DBUG("AssembleWithJacobian SmallDeformationProcess.");
 
@@ -90,7 +87,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
             _local_assemblers, *_local_to_global_index_map, t, x, xdot,
-            dxdot_dx, dx_dx, M, K, b, Jac, coupling_term);
+            dxdot_dx, dx_dx, M, K, b, Jac, *_coupling_term.lock());
     }
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -94,20 +94,19 @@ void LiquidFlowProcess::initializeConcreteProcess(
 
 void LiquidFlowProcess::assembleConcreteProcess(
     const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b)
 {
     DBUG("Assemble LiquidFlowProcess.");
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
 }
 
 void LiquidFlowProcess::assembleWithJacobianConcreteProcess(
     const double t, GlobalVector const& x, GlobalVector const& xdot,
     const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac,
-    StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian LiquidFlowProcess.");
 
@@ -115,18 +114,18 @@ void LiquidFlowProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, coupling_term);
+        dx_dx, M, K, b, Jac, *_coupling_term.lock());
 }
 
 void LiquidFlowProcess::computeSecondaryVariableConcrete(
     const double t,
-    GlobalVector const& x,
-    StaggeredCouplingTerm const& coupled_term)
+    GlobalVector const& x)
 {
     DBUG("Compute the velocity for LiquidFlowProcess.");
     GlobalExecutor::executeMemberOnDereferenced(
         &LiquidFlowLocalAssemblerInterface::computeSecondaryVariable,
-        _local_assemblers, *_local_to_global_index_map, t, x, coupled_term);
+        _local_assemblers, *_local_to_global_index_map, t, x,
+        *_coupling_term.lock());
 }
 
 }  // end of namespace

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -100,7 +100,7 @@ void LiquidFlowProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
+        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
 }
 
 void LiquidFlowProcess::assembleWithJacobianConcreteProcess(
@@ -114,7 +114,7 @@ void LiquidFlowProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, *_coupling_term.lock());
+        dx_dx, M, K, b, Jac, _coupling_term);
 }
 
 void LiquidFlowProcess::computeSecondaryVariableConcrete(
@@ -125,7 +125,7 @@ void LiquidFlowProcess::computeSecondaryVariableConcrete(
     GlobalExecutor::executeMemberOnDereferenced(
         &LiquidFlowLocalAssemblerInterface::computeSecondaryVariable,
         _local_assemblers, *_local_to_global_index_map, t, x,
-        *_coupling_term.lock());
+        _coupling_term);
 }
 
 }  // end of namespace

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -74,9 +74,7 @@ public:
         BaseLib::ConfigTree const& config);
 
     void computeSecondaryVariableConcrete(
-        double const t,
-        GlobalVector const& x,
-        StaggeredCouplingTerm const& coupled_term) override;
+        double const t, GlobalVector const& x) override;
 
     bool isLinear() const override { return true; }
     int getGravitationalAxisID() const { return _gravitational_axis_id; }
@@ -97,13 +95,12 @@ private:
 
     void assembleConcreteProcess(
         const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-        GlobalVector& b, StaggeredCouplingTerm const& coupling_term) override;
+        GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override;
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     const int _gravitational_axis_id;
     const double _gravitational_acceleration;

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -11,6 +11,8 @@
 #include <cassert>
 #include "NumLib/DOF/DOFTableUtil.h"
 
+#include "StaggeredCouplingTerm.h"
+
 namespace ProcessLib
 {
 void LocalAssemblerInterface::assembleWithCoupledTerm(
@@ -55,19 +57,19 @@ void LocalAssemblerInterface::assembleWithJacobianAndCoupling(
 void LocalAssemblerInterface::computeSecondaryVariable(
     std::size_t const mesh_item_id,
     NumLib::LocalToGlobalIndexMap const& dof_table, double const t,
-    GlobalVector const& x, StaggeredCouplingTerm const& coupled_term)
+    GlobalVector const& x, StaggeredCouplingTerm const* coupled_term)
 {
     auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
     auto const local_x = x.get(indices);
 
-    if (coupled_term.empty)
+    if (!coupled_term)
     {
         computeSecondaryVariableConcrete(t, local_x);
     }
     else
     {
         auto const local_coupled_xs =
-            getCurrentLocalSolutionsOfCoupledProcesses(coupled_term.coupled_xs,
+            getCurrentLocalSolutionsOfCoupledProcesses(coupled_term->coupled_xs,
                                                        indices);
         if (!local_coupled_xs.empty())
             computeSecondaryVariableWithCoupledProcessConcrete(

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -15,7 +15,6 @@
 
 #include "NumLib/NumericsConfig.h"
 #include "MathLib/Point3d.h"
-#include "StaggeredCouplingTerm.h"
 
 namespace NumLib
 {
@@ -24,6 +23,8 @@ class LocalToGlobalIndexMap;
 
 namespace ProcessLib
 {
+struct StaggeredCouplingTerm;
+struct LocalCouplingTerm;
 
 /*! Common interface for local assemblers
  * NumLib::ODESystemTag::FirstOrderImplicitQuasilinear ODE systems.
@@ -67,7 +68,7 @@ public:
     virtual void computeSecondaryVariable(std::size_t const mesh_item_id,
                               NumLib::LocalToGlobalIndexMap const& dof_table,
                               const double t, GlobalVector const& x,
-                              StaggeredCouplingTerm const& coupled_term);
+                              StaggeredCouplingTerm const* coupled_term);
 
     virtual void preTimestep(std::size_t const mesh_item_id,
                              NumLib::LocalToGlobalIndexMap const& dof_table,

--- a/ProcessLib/PhaseField/PhaseFieldProcess.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.h
@@ -191,7 +191,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assemble,
             _local_assemblers, *_local_to_global_index_map, t, x, M, K, b,
-            *_coupling_term.lock());
+            _coupling_term);
     }
 
     void assembleWithJacobianConcreteProcess(
@@ -205,7 +205,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
             _local_assemblers, *_local_to_global_index_map, t, x, xdot,
-            dxdot_dx, dx_dx, M, K, b, Jac, *_coupling_term.lock());
+            dxdot_dx, dx_dx, M, K, b, Jac, _coupling_term);
     }
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/PhaseField/PhaseFieldProcess.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.h
@@ -183,7 +183,7 @@ private:
 
     void assembleConcreteProcess(
         const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-        GlobalVector& b, StaggeredCouplingTerm const& coupling_term) override
+        GlobalVector& b) override
     {
         DBUG("Assemble PhaseFieldProcess.");
 
@@ -191,14 +191,13 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assemble,
             _local_assemblers, *_local_to_global_index_map, t, x, M, K, b,
-            coupling_term);
+            *_coupling_term.lock());
     }
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override
     {
         // DBUG("AssembleJacobian PhaseFieldProcess.");
 
@@ -206,7 +205,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
             _local_assemblers, *_local_to_global_index_map, t, x, xdot,
-            dxdot_dx, dx_dx, M, K, b, Jac, coupling_term);
+            dxdot_dx, dx_dx, M, K, b, Jac, *_coupling_term.lock());
     }
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -15,6 +15,7 @@
 #include "NumLib/ODESolver/ConvergenceCriterionPerComponent.h"
 #include "GlobalVectorFromNamedFunction.h"
 #include "ProcessVariable.h"
+#include "StaggeredCouplingTerm.h"
 
 namespace ProcessLib
 {
@@ -119,12 +120,11 @@ MathLib::MatrixSpecifications Process::getMatrixSpecifications() const
 }
 
 void Process::assemble(const double t, GlobalVector const& x, GlobalMatrix& M,
-                       GlobalMatrix& K, GlobalVector& b,
-                       StaggeredCouplingTerm const& coupling_term)
+                       GlobalMatrix& K, GlobalVector& b)
 {
     MathLib::LinAlg::setLocalAccessibleVector(x);
 
-    assembleConcreteProcess(t, x, M, K, b, coupling_term);
+    assembleConcreteProcess(t, x, M, K, b);
 
     _boundary_conditions.applyNaturalBC(t, x, K, b);
 }
@@ -133,14 +133,13 @@ void Process::assembleWithJacobian(const double t, GlobalVector const& x,
                                    GlobalVector const& xdot,
                                    const double dxdot_dx, const double dx_dx,
                                    GlobalMatrix& M, GlobalMatrix& K,
-                                   GlobalVector& b, GlobalMatrix& Jac,
-                                   StaggeredCouplingTerm const& coupling_term)
+                                   GlobalVector& b, GlobalMatrix& Jac)
 {
     MathLib::LinAlg::setLocalAccessibleVector(x);
     MathLib::LinAlg::setLocalAccessibleVector(xdot);
 
     assembleWithJacobianConcreteProcess(t, x, xdot, dxdot_dx, dx_dx, M, K, b,
-                                        Jac, coupling_term);
+                                       Jac);
 
     // TODO apply BCs to Jacobian.
     _boundary_conditions.applyNaturalBC(t, x, K, b);
@@ -254,13 +253,11 @@ void Process::postTimestep(GlobalVector const& x)
     postTimestepConcreteProcess(x);
 }
 
-void Process::computeSecondaryVariable(const double t, GlobalVector const& x,
-                                       StaggeredCouplingTerm const&
-                                       coupled_term)
+void Process::computeSecondaryVariable(const double t, GlobalVector const& x)
 {
     MathLib::LinAlg::setLocalAccessibleVector(x);
 
-    computeSecondaryVariableConcrete(t, x, coupled_term);
+    computeSecondaryVariableConcrete(t, x);
 }
 
 void Process::preIteration(const unsigned iter, const GlobalVector &x)

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -31,6 +31,7 @@ Process::Process(
       _secondary_variables(std::move(secondary_variables)),
       _named_function_caller(std::move(named_function_caller)),
       _global_assembler(std::move(jacobian_assembler)),
+      _coupling_term(nullptr),
       _integration_order(integration_order),
       _process_variables(std::move(process_variables)),
       _boundary_conditions(parameters)

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -70,8 +70,7 @@ public:
 
     MathLib::MatrixSpecifications getMatrixSpecifications() const final;
 
-    void setStaggeredCouplingTerm(
-        const std::shared_ptr<StaggeredCouplingTerm>& coupling_term)
+    void setStaggeredCouplingTerm(StaggeredCouplingTerm* const coupling_term)
     {
         _coupling_term = coupling_term;
     }
@@ -201,8 +200,10 @@ protected:
 
     VectorMatrixAssembler _global_assembler;
 
-    /// Coupled processes.
-    mutable std::weak_ptr<StaggeredCouplingTerm> _coupling_term;
+    /// Pointer to StaggeredCouplingTerm, which contains the references to the
+    /// coupled processes and the references to the solutions of the coupled
+    /// processes.
+    StaggeredCouplingTerm* _coupling_term;
 
     /// Order of the integration method for element-wise integration.
     /// The Gauss-Legendre integration method and available orders is

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
@@ -83,22 +83,20 @@ void RichardsFlowProcess::assembleConcreteProcess(
     GlobalVector const& x,
     GlobalMatrix& M,
     GlobalMatrix& K,
-    GlobalVector& b,
-    StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b)
 {
     DBUG("Assemble RichardsFlowProcess.");
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
 }
 
 void RichardsFlowProcess::assembleWithJacobianConcreteProcess(
     const double t, GlobalVector const& x, GlobalVector const& xdot,
     const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac,
-    StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian RichardsFlowProcess.");
 
@@ -106,17 +104,17 @@ void RichardsFlowProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, coupling_term);
+        dx_dx, M, K, b, Jac, *_coupling_term.lock());
 }
 
 void RichardsFlowProcess::computeSecondaryVariableConcrete(
-    double const t, GlobalVector const& x,
-    StaggeredCouplingTerm const& coupling_term)
+    double const t, GlobalVector const& x)
 {
     DBUG("Compute the Darcy velocity for RichardsFlowProcess");
     GlobalExecutor::executeMemberOnDereferenced(
         &RichardsFlowLocalAssemblerInterface::computeSecondaryVariable,
-        _local_assemblers, *_local_to_global_index_map, t, x, coupling_term);
+        _local_assemblers, *_local_to_global_index_map, t, x,
+        *_coupling_term.lock());
 }
 
 }  // namespace RichardsFlow

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
@@ -90,7 +90,7 @@ void RichardsFlowProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
+        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
 }
 
 void RichardsFlowProcess::assembleWithJacobianConcreteProcess(
@@ -104,7 +104,7 @@ void RichardsFlowProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, *_coupling_term.lock());
+        dx_dx, M, K, b, Jac, _coupling_term);
 }
 
 void RichardsFlowProcess::computeSecondaryVariableConcrete(
@@ -114,7 +114,7 @@ void RichardsFlowProcess::computeSecondaryVariableConcrete(
     GlobalExecutor::executeMemberOnDereferenced(
         &RichardsFlowLocalAssemblerInterface::computeSecondaryVariable,
         _local_assemblers, *_local_to_global_index_map, t, x,
-        *_coupling_term.lock());
+        _coupling_term);
 }
 
 }  // namespace RichardsFlow

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.h
@@ -47,8 +47,7 @@ public:
     //! @}
 
     void computeSecondaryVariableConcrete(
-        double const t, GlobalVector const& x,
-        StaggeredCouplingTerm const& coupling_term) override;
+        double const t, GlobalVector const& x) override;
 
 private:
     void initializeConcreteProcess(
@@ -58,13 +57,12 @@ private:
 
     void assembleConcreteProcess(
         const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-        GlobalVector& b, StaggeredCouplingTerm const& coupling_term) override;
+        GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override;
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     RichardsFlowProcessData _process_data;
 

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
@@ -204,14 +204,14 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
     const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b)
 {
     DBUG("Assemble SmallDeformationProcess.");
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
 }
 
 template <int DisplacementDim>
@@ -219,8 +219,7 @@ void SmallDeformationProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term)
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian SmallDeformationProcess.");
 
@@ -228,7 +227,7 @@ void SmallDeformationProcess<DisplacementDim>::
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, coupling_term);
+        dx_dx, M, K, b, Jac, *_coupling_term.lock());
 
     b.copyValues(*_nodal_forces);
     std::transform(_nodal_forces->begin(), _nodal_forces->end(),

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
@@ -211,7 +211,7 @@ void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
+        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
 }
 
 template <int DisplacementDim>
@@ -227,7 +227,7 @@ void SmallDeformationProcess<DisplacementDim>::
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, *_coupling_term.lock());
+        dx_dx, M, K, b, Jac, _coupling_term);
 
     b.copyValues(*_nodal_forces);
     std::transform(_nodal_forces->begin(), _nodal_forces->end(),

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -51,13 +51,12 @@ private:
 
     void assembleConcreteProcess(
         const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-        GlobalVector& b, StaggeredCouplingTerm const& coupling_term) override;
+        GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override;
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,
                                     double const dt) override;

--- a/ProcessLib/StaggeredCouplingTerm.cpp
+++ b/ProcessLib/StaggeredCouplingTerm.cpp
@@ -45,14 +45,6 @@ StaggeredCouplingTerm::StaggeredCouplingTerm(
     }
 }
 
-const StaggeredCouplingTerm createVoidStaggeredCouplingTerm()
-{
-    std::unordered_map<std::type_index, Process const&> coupled_processes;
-    std::unordered_map<std::type_index, GlobalVector const&> coupled_xs;
-    const bool empty = true;
-    return StaggeredCouplingTerm(coupled_processes, coupled_xs, 0.0, empty);
-}
-
 std::unordered_map<std::type_index, const std::vector<double>>
 getCurrentLocalSolutionsOfCoupledProcesses(
     const std::unordered_map<std::type_index, GlobalVector const&>&

--- a/ProcessLib/StaggeredCouplingTerm.cpp
+++ b/ProcessLib/StaggeredCouplingTerm.cpp
@@ -17,16 +17,12 @@
 
 namespace ProcessLib
 {
-
 StaggeredCouplingTerm::StaggeredCouplingTerm(
     std::unordered_map<std::type_index, Process const&> const&
         coupled_processes_,
     std::unordered_map<std::type_index, GlobalVector const&> const& coupled_xs_,
-    const double dt_, const bool empty_)
-    : coupled_processes(coupled_processes_),
-      coupled_xs(coupled_xs_),
-      dt(dt_),
-      empty(empty_)
+    const double dt_)
+    : coupled_processes(coupled_processes_), coupled_xs(coupled_xs_), dt(dt_)
 {
     for (auto const& coupled_x_pair : coupled_xs)
     {

--- a/ProcessLib/StaggeredCouplingTerm.h
+++ b/ProcessLib/StaggeredCouplingTerm.h
@@ -36,7 +36,7 @@ struct StaggeredCouplingTerm
             coupled_processes_,
         std::unordered_map<std::type_index, GlobalVector const&> const&
             coupled_xs_,
-        const double dt_, const bool empty_ = false);
+        const double dt_);
 
     /// References to the coupled processes are distinguished by the keys of
     /// process types.
@@ -47,8 +47,7 @@ struct StaggeredCouplingTerm
     /// The coupled solutions are distinguished by the keys of process types.
     std::unordered_map<std::type_index, GlobalVector const&> const& coupled_xs;
 
-    const double dt;   ///< Time step size.
-    const bool empty;  ///< Flag to indicate whether the couping term is empty.
+    const double dt;  ///< Time step size.
 };
 
 /**

--- a/ProcessLib/StaggeredCouplingTerm.h
+++ b/ProcessLib/StaggeredCouplingTerm.h
@@ -91,13 +91,6 @@ struct LocalCouplingTerm
         local_coupled_xs;
 };
 
-/**
- *  A function to create a void instance of StaggeredCouplingTerm. The void
- *  instance is for the StaggeredCouplingTerm reference type of argument
- *  function or class member to indicate no coupling.
- */
-const StaggeredCouplingTerm createVoidStaggeredCouplingTerm();
-
 std::unordered_map<std::type_index, const std::vector<double>>
 getCurrentLocalSolutionsOfCoupledProcesses(
     const std::unordered_map<std::type_index, GlobalVector const&>&

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -225,28 +225,25 @@ void TESProcess::assembleConcreteProcess(const double t,
                                          GlobalVector const& x,
                                          GlobalMatrix& M,
                                          GlobalMatrix& K,
-                                         GlobalVector& b,
-                                         StaggeredCouplingTerm
-                                         const& coupling_term)
+                                         GlobalVector& b)
 {
     DBUG("Assemble TESProcess.");
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
 }
 
 void TESProcess::assembleWithJacobianConcreteProcess(
     const double t, GlobalVector const& x, GlobalVector const& xdot,
     const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac,
-    StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b, GlobalMatrix& Jac)
 {
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, coupling_term);
+        dx_dx, M, K, b, Jac, *_coupling_term.lock());
 }
 
 void TESProcess::preTimestepConcreteProcess(GlobalVector const& x,

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -232,7 +232,7 @@ void TESProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
+        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
 }
 
 void TESProcess::assembleWithJacobianConcreteProcess(
@@ -243,7 +243,7 @@ void TESProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, *_coupling_term.lock());
+        dx_dx, M, K, b, Jac, _coupling_term);
 }
 
 void TESProcess::preTimestepConcreteProcess(GlobalVector const& x,

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -56,17 +56,14 @@ private:
 
     void assembleConcreteProcess(const double t, GlobalVector const& x,
                                  GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b,
-                                 StaggeredCouplingTerm const& coupling_term
-                                ) override;
+                                 GlobalVector& b) override;
 
     void initializeSecondaryVariables();
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override;
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     GlobalVector const& computeVapourPartialPressure(
         const double t,

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
@@ -80,7 +80,7 @@ void ThermalTwoPhaseFlowWithPPProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
+        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
 }
 
 void ThermalTwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
@@ -94,7 +94,7 @@ void ThermalTwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, *_coupling_term.lock());
+        dx_dx, M, K, b, Jac, _coupling_term);
 }
 void ThermalTwoPhaseFlowWithPPProcess::preTimestepConcreteProcess(
     GlobalVector const& x, double const t, double const delta_t)

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
@@ -74,21 +74,19 @@ void ThermalTwoPhaseFlowWithPPProcess::assembleConcreteProcess(
     GlobalVector const& x,
     GlobalMatrix& M,
     GlobalMatrix& K,
-    GlobalVector& b,
-    StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b)
 {
     DBUG("Assemble ThermalTwoPhaseFlowWithPPProcess.");
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
 }
 
 void ThermalTwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
     const double t, GlobalVector const& x, GlobalVector const& xdot,
     const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac,
-    StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian ThermalTwoPhaseFlowWithPPProcess.");
 
@@ -96,7 +94,7 @@ void ThermalTwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, coupling_term);
+        dx_dx, M, K, b, Jac, *_coupling_term.lock());
 }
 void ThermalTwoPhaseFlowWithPPProcess::preTimestepConcreteProcess(
     GlobalVector const& x, double const t, double const delta_t)

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
@@ -60,13 +60,12 @@ private:
 
     void assembleConcreteProcess(
         const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-        GlobalVector& b, StaggeredCouplingTerm const& coupling_term) override;
+        GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override;
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, const double t,
                                     const double delta_t) override;

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
@@ -164,7 +164,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assemble,
             _local_assemblers, *_local_to_global_index_map, t, x, M, K, b,
-            *_coupling_term.lock());
+            _coupling_term);
     }
 
     void assembleWithJacobianConcreteProcess(
@@ -178,7 +178,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
             _local_assemblers, *_local_to_global_index_map, t, x, xdot,
-            dxdot_dx, dx_dx, M, K, b, Jac, *_coupling_term.lock());
+            dxdot_dx, dx_dx, M, K, b, Jac, _coupling_term);
     }
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
@@ -156,7 +156,7 @@ private:
 
     void assembleConcreteProcess(
         const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-        GlobalVector& b, StaggeredCouplingTerm const& coupling_term) override
+        GlobalVector& b) override
     {
         DBUG("Assemble ThermoMechanicsProcess.");
 
@@ -164,14 +164,13 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assemble,
             _local_assemblers, *_local_to_global_index_map, t, x, M, K, b,
-            coupling_term);
+            *_coupling_term.lock());
     }
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override
     {
         DBUG("AssembleJacobian ThermoMechanicsProcess.");
 
@@ -179,7 +178,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
             _local_assemblers, *_local_to_global_index_map, t, x, xdot,
-            dxdot_dx, dx_dx, M, K, b, Jac, coupling_term);
+            dxdot_dx, dx_dx, M, K, b, Jac, *_coupling_term.lock());
     }
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
@@ -78,7 +78,7 @@ void TwoPhaseFlowWithPPProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
+        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
 }
 
 void TwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
@@ -92,7 +92,7 @@ void TwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, *_coupling_term.lock());
+        dx_dx, M, K, b, Jac, _coupling_term);
 }
 
 }  // end of namespace

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
@@ -72,22 +72,19 @@ void TwoPhaseFlowWithPPProcess::assembleConcreteProcess(const double t,
                                                         GlobalVector const& x,
                                                         GlobalMatrix& M,
                                                         GlobalMatrix& K,
-                                                        GlobalVector& b,
-                                                        StaggeredCouplingTerm
-                                                        const& coupling_term)
+                                                        GlobalVector& b)
 {
     DBUG("Assemble TwoPhaseFlowWithPPProcess.");
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
 }
 
 void TwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
     const double t, GlobalVector const& x, GlobalVector const& xdot,
     const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac,
-    StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian TwoPhaseFlowWithPPProcess.");
 
@@ -95,7 +92,7 @@ void TwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, coupling_term);
+        dx_dx, M, K, b, Jac, *_coupling_term.lock());
 }
 
 }  // end of namespace

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
@@ -59,15 +59,12 @@ private:
 
     void assembleConcreteProcess(const double t, GlobalVector const& x,
                                  GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b,
-                                 StaggeredCouplingTerm const& coupling_term
-                                ) override;
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override;
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     TwoPhaseFlowWithPPProcessData _process_data;
 

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
@@ -78,7 +78,7 @@ void TwoPhaseFlowWithPrhoProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
+        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
 }
 
 void TwoPhaseFlowWithPrhoProcess::assembleWithJacobianConcreteProcess(
@@ -92,7 +92,7 @@ void TwoPhaseFlowWithPrhoProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, *_coupling_term.lock());
+        dx_dx, M, K, b, Jac, _coupling_term);
 }
 void TwoPhaseFlowWithPrhoProcess::preTimestepConcreteProcess(
     GlobalVector const& x, double const t, double const dt)

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
@@ -72,22 +72,19 @@ void TwoPhaseFlowWithPrhoProcess::assembleConcreteProcess(const double t,
                                                           GlobalVector const& x,
                                                           GlobalMatrix& M,
                                                           GlobalMatrix& K,
-                                                          GlobalVector& b,
-                                                          StaggeredCouplingTerm
-                                                          const& coupling_term)
+                                                          GlobalVector& b)
 {
     DBUG("Assemble TwoPhaseFlowWithPrhoProcess.");
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, *_coupling_term.lock());
 }
 
 void TwoPhaseFlowWithPrhoProcess::assembleWithJacobianConcreteProcess(
     const double t, GlobalVector const& x, GlobalVector const& xdot,
     const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac,
-    StaggeredCouplingTerm const& coupling_term)
+    GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian TwoPhaseFlowWithPrhoProcess.");
 
@@ -95,7 +92,7 @@ void TwoPhaseFlowWithPrhoProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, coupling_term);
+        dx_dx, M, K, b, Jac, *_coupling_term.lock());
 }
 void TwoPhaseFlowWithPrhoProcess::preTimestepConcreteProcess(
     GlobalVector const& x, double const t, double const dt)

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
@@ -56,14 +56,12 @@ private:
 
     void assembleConcreteProcess(const double t, GlobalVector const& x,
                                  GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b,
-                                 StaggeredCouplingTerm const& coupling_term) override;
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, GlobalVector const& x, GlobalVector const& xdot,
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
-        StaggeredCouplingTerm const& coupling_term) override;
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, const double t,
                                     const double delta_t) override;

--- a/ProcessLib/UncoupledProcessesTimeLoop.cpp
+++ b/ProcessLib/UncoupledProcessesTimeLoop.cpp
@@ -940,12 +940,11 @@ bool UncoupledProcessesTimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
                 spd->process.preTimestep(x, t, dt);
             }
 
-            std::shared_ptr<StaggeredCouplingTerm> coupling_term =
-                std::make_shared<StaggeredCouplingTerm>(
-                    spd->coupled_processes,
-                    _solutions_of_coupled_processes[pcs_idx], dt);
+            StaggeredCouplingTerm coupling_term(
+                spd->coupled_processes,
+                _solutions_of_coupled_processes[pcs_idx], dt);
 
-            spd->process.setStaggeredCouplingTerm(coupling_term);
+            spd->process.setStaggeredCouplingTerm(&coupling_term);
 
             const auto nonlinear_solver_succeeded = solveOneTimeStepOneProcess(
                 x, timestep_id, t, dt, *spd, *_output);
@@ -1021,11 +1020,10 @@ bool UncoupledProcessesTimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
         auto& x = *_process_solutions[pcs_idx];
         pcs.postTimestep(x);
 
-        std::shared_ptr<StaggeredCouplingTerm> coupling_term =
-            std::make_shared<StaggeredCouplingTerm>(
-                spd->coupled_processes,
-                _solutions_of_coupled_processes[pcs_idx], dt);
-        spd->process.setStaggeredCouplingTerm(coupling_term);
+        StaggeredCouplingTerm coupling_term(
+            spd->coupled_processes, _solutions_of_coupled_processes[pcs_idx],
+            dt);
+        spd->process.setStaggeredCouplingTerm(&coupling_term);
 
         pcs.computeSecondaryVariable(t, x);
 

--- a/ProcessLib/VectorMatrixAssembler.h
+++ b/ProcessLib/VectorMatrixAssembler.h
@@ -40,7 +40,7 @@ public:
                   NumLib::LocalToGlobalIndexMap const& dof_table,
                   double const t, GlobalVector const& x, GlobalMatrix& M,
                   GlobalMatrix& K, GlobalVector& b,
-                  const StaggeredCouplingTerm& coupling_term);
+                  const StaggeredCouplingTerm* coupling_term);
 
     //! Assembles \c M, \c K, \c b, and the Jacobian \c Jac of the residual.
     //! \note The Jacobian must be assembled.
@@ -52,7 +52,7 @@ public:
                               const double dx_dx, GlobalMatrix& M,
                               GlobalMatrix& K, GlobalVector& b,
                               GlobalMatrix& Jac,
-                              const StaggeredCouplingTerm& coupling_term);
+                              const StaggeredCouplingTerm* coupling_term);
 
 private:
     // temporary data only stored here in order to avoid frequent memory

--- a/Tests/NumLib/ODEs.h
+++ b/Tests/NumLib/ODEs.h
@@ -13,7 +13,6 @@
 #include "MathLib/LinAlg/LinAlg.h"
 #include "MathLib/LinAlg/UnifiedMatrixSetters.h"
 #include "NumLib/ODESolver/ODESystem.h"
-#include "ProcessLib/StaggeredCouplingTerm.h"
 
 // debug
 //#include <iostream>
@@ -28,9 +27,7 @@ class ODE1 final : public NumLib::ODESystem<
 {
 public:
     void assemble(const double /*t*/, GlobalVector const& /*x*/,
-                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
-                  ProcessLib::StaggeredCouplingTerm const& /*coupling_term*/
-                 ) override
+                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) override
     {
         MathLib::setMatrix(M, { 1.0, 0.0,  0.0, 1.0 });
         MathLib::setMatrix(K, { 0.0, 1.0, -1.0, 0.0 });
@@ -42,13 +39,11 @@ public:
                               GlobalVector const& /*xdot*/, const double dxdot_dx,
                               const double dx_dx, GlobalMatrix& M,
                               GlobalMatrix& K, GlobalVector& b,
-                              GlobalMatrix& Jac,
-                              ProcessLib::StaggeredCouplingTerm
-                              const& coupling_term) override
+                              GlobalMatrix& Jac) override
     {
         namespace LinAlg = MathLib::LinAlg;
 
-        assemble(t, x_curr, M, K, b, coupling_term);
+        assemble(t, x_curr, M, K, b);
 
         // compute Jac = M*dxdot_dx + dx_dx*K
         LinAlg::finalizeAssembly(M);
@@ -108,9 +103,7 @@ class ODE2 final : public NumLib::ODESystem<
 {
 public:
     void assemble(const double /*t*/, GlobalVector const& x, GlobalMatrix& M,
-                  GlobalMatrix& K, GlobalVector& b,
-                  ProcessLib::StaggeredCouplingTerm const& /*coupling_term*/
-                 ) override
+                  GlobalMatrix& K, GlobalVector& b) override
     {
         MathLib::setMatrix(M, {1.0});
         MathLib::LinAlg::setLocalAccessibleVector(x);
@@ -122,11 +115,9 @@ public:
                               GlobalVector const& /*xdot*/,
                               const double dxdot_dx, const double dx_dx,
                               GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
-                              GlobalMatrix& Jac,
-                              ProcessLib::StaggeredCouplingTerm const&
-                              coupling_term) override
+                              GlobalMatrix& Jac) override
     {
-        assemble(t, x, M, K, b, coupling_term);
+        assemble(t, x, M, K, b);
 
         namespace LinAlg = MathLib::LinAlg;
 
@@ -197,9 +188,7 @@ class ODE3 final : public NumLib::ODESystem<
 {
 public:
     void assemble(const double /*t*/, GlobalVector const& x_curr, GlobalMatrix& M,
-                  GlobalMatrix& K, GlobalVector& b,
-                  ProcessLib::StaggeredCouplingTerm const& /*coupling_term*/
-                 ) override
+                  GlobalMatrix& K, GlobalVector& b) override
     {
         MathLib::LinAlg::setLocalAccessibleVector(x_curr);
         auto const u = x_curr[0];
@@ -215,13 +204,11 @@ public:
                               GlobalVector const& xdot, const double dxdot_dx,
                               const double dx_dx, GlobalMatrix& M,
                               GlobalMatrix& K, GlobalVector& b,
-                              GlobalMatrix& Jac,
-                              ProcessLib::StaggeredCouplingTerm const&
-                              coupling_term) override
+                              GlobalMatrix& Jac) override
     {
         MathLib::LinAlg::setLocalAccessibleVector(x_curr);
         MathLib::LinAlg::setLocalAccessibleVector(xdot);
-        assemble(t, x_curr, M, K, b, coupling_term);
+        assemble(t, x_curr, M, K, b);
 
         auto const u = x_curr[0];
         auto const v = x_curr[1];

--- a/Tests/NumLib/TimeLoopSingleODE.h
+++ b/Tests/NumLib/TimeLoopSingleODE.h
@@ -99,8 +99,7 @@ bool TimeLoopSingleODE<NLTag>::loop(const double t0, GlobalVector const& x0,
     if (time_disc.needsPreload())
     {
         MathLib::LinAlg::setLocalAccessibleVector(x);
-        _nonlinear_solver->assemble(x,
-                                 ProcessLib::createVoidStaggeredCouplingTerm());
+        _nonlinear_solver->assemble(x);
         time_disc.pushState(t0, x0,
                             _ode_sys);  // TODO: that might do duplicate work
     }
@@ -116,9 +115,7 @@ bool TimeLoopSingleODE<NLTag>::loop(const double t0, GlobalVector const& x0,
         // INFO("time: %e, delta_t: %e", t, delta_t);
         time_disc.nextTimestep(t, delta_t);
 
-        nl_slv_succeeded = _nonlinear_solver->solve(x,
-                                ProcessLib::createVoidStaggeredCouplingTerm(),
-                                nullptr);
+        nl_slv_succeeded = _nonlinear_solver->solve(x, nullptr);
         if (!nl_slv_succeeded)
             break;
 


### PR DESCRIPTION
For the new change of velocity calculation (PR #1874), the coupling term is not considered. As discussed with Christoph, the coupling term could be set as one member of class Process in order not to change the interface  of velocity calculation.

In this PR,
1) a pointer ~weak_ptr~ to StaggeredCouplingTerm, which only contains reference type members, is added as a member of  class Process
2) a pointer to an instance of StaggeredCouplingTerm, which is created  on fly before global assembly, is passed to process class.
~2) a shared_ptr to StaggeredCouplingTerm is created  on fly before global assembly and passed to instance of process class.~
3) StaggeredCouplingTerm type argument is removed from all member functions that have it.
~4) Avoided if-condition about coupling inside element-wise loop during global assembly by adding two members in VectorMatrixAssembler.~

~Note: The first two commits are only related to code format, and they are put in another PR.~

