### PR TITLE
[CMake] Copy CXX to C flags.

### DIFF
--- a/scripts/cmake/CompilerSetup.cmake
+++ b/scripts/cmake/CompilerSetup.cmake
@@ -148,3 +148,6 @@ endif()
 # preceding cxx flags definition in order to override earlier flags, e.g. for
 # optimization.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OGS_CXX_FLAGS}")
+
+# Copy CXX to C flags. To have these flags in C libraries (e.g. metis) too.
+set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
This adds the flags setup in `CompilerSetup.cmake` for C libraries such `metis` too. Tom needed this to add cpu arch flags when compiling on cluster systems.