### PR TITLE
Enforced git hooks

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,4 @@
+[core]
+    hooksPath = .hooks
+[submodule]
+	fetchJobs = 4

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+echo "Running pre-commit hook.."
+
+set -e
+
+RETURN_CODE=0
+
+### git-lfs check ###
+BINARY_FILES=""
+CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+LFS_FILES=$(echo $CHANGED_FILES | xargs git check-attr filter | grep 'filter: lfs$' | sed -e 's/: filter: lfs//')
+
+for FILE in $LFS_FILES; do
+    SOFT_SHA=$(git hash-object -w $FILE)
+    RAW_SHA=$(git hash-object -w --no-filters $FILE)
+
+    if [ $SOFT_SHA == $RAW_SHA ]; then
+        BINARY_FILES="$FILE\n$BINARY_FILES"
+    fi
+done
+
+if [[ -n "$BINARY_FILES" ]]; then
+    echo "Attention!"
+    echo "----------"
+    echo "You tried to commit files tracked by git-lfs as standard git objects:"
+    echo -e "\x1B[31m$BINARY_FILES\x1B[0m"
+    echo "Revert your changes and commit those files with git-lfs!"
+    echo "See https://docs.opengeosys.org/docs/devguide/getting-started/prerequisites"
+    echo "----------"
+    RETURN_CODE=1
+fi
+
+exit $RETURN_CODE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(OGS_USE_PCH "Should pre-compiled headers be used?" ON)
 
 ### CMake includes ###
 include(scripts/cmake/PreFind.cmake)
+include(scripts/cmake/GitSetup.cmake)
 include(scripts/cmake/ConanSetup.cmake)
 include(scripts/cmake/CheckTypeSizes.cmake)
 include(scripts/cmake/Functions.cmake)

--- a/scripts/cmake/GitSetup.cmake
+++ b/scripts/cmake/GitSetup.cmake
@@ -1,0 +1,5 @@
+# Setting (local) git include path to .gitconfig
+execute_process(
+    COMMAND ${GIT_TOOL_PATH} config --local include.path ../.gitconfig
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)


### PR DESCRIPTION
### PR is for discussion

This enables enforced (after running CMake) git hooks. I added a pre-commit hook which checks for correctly committing files with git-lfs. Can be extended to more checks (e.g. whitespace, styling, commit message style, ...). Remember that you can always disable checks by committing with `--no-verify` or `-n`. Haven't tested if this works on Windows too (as the hooks are bash scripts).