### PR TITLE
[MGTL] BoundaryElems; Change assertion to error.

### DIFF
--- a/MeshGeoToolsLib/BoundaryElementsAtPoint.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsAtPoint.cpp
@@ -25,7 +25,18 @@ BoundaryElementsAtPoint::BoundaryElementsAtPoint(
     : _mesh(mesh), _point(point)
 {
     auto const node_ids = mshNodeSearcher.getMeshNodeIDs(_point);
-    assert(node_ids.size() == 1);
+    if (node_ids.empty())
+        OGS_FATAL(
+            "BoundaryElementsAtPoint: the mesh node searcher was unable to "
+            "locate the point (%f, %f, %f) in the mesh.",
+            _point[0], _point[1], _point[2]);
+    if (node_ids.size() > 1)
+        OGS_FATAL(
+            "BoundaryElementsAtPoint: the mesh node searcher found %d points "
+            "near the requested point (%f, %f, %f) in the mesh, while exactly "
+            "one is expected.",
+            node_ids.size(), _point[0], _point[1], _point[2]);
+
     std::array<MeshLib::Node*, 1> const nodes = {{
         const_cast<MeshLib::Node*>(_mesh.getNode(node_ids[0]))}};
 


### PR DESCRIPTION
The BoundaryElementsAtPoint algorithm expects the given
point to be found in the mesh. If this fails the preconditions
for the algorithm are not fulfilled.

Closes https://github.com/ufz/ogs/issues/1926