### PR TITLE
pre-commit hook for checking git lfs

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Activate via the following setting in .git/config
+# [core]
+#    hooksPath = .hooks
+#
+# **Or** by copying this file to .git/hooks/pre-commit
+
+echo "Running pre-commit hook.."
+
+set -e
+
+RETURN_CODE=0
+
+### git-lfs check ###
+BINARY_FILES=""
+CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+LFS_FILES=$(echo $CHANGED_FILES | xargs git check-attr filter | grep 'filter: lfs$' | sed -e 's/: filter: lfs//')
+
+for FILE in $LFS_FILES; do
+    SOFT_SHA=$(git hash-object -w $FILE)
+    RAW_SHA=$(git hash-object -w --no-filters $FILE)
+
+    if [ $SOFT_SHA == $RAW_SHA ]; then
+        BINARY_FILES="$FILE\n$BINARY_FILES"
+    fi
+done
+
+if [[ -n "$BINARY_FILES" ]]; then
+    echo "Attention!"
+    echo "----------"
+    echo "You tried to commit files tracked by git-lfs as standard git objects:"
+    echo -e "\x1B[31m$BINARY_FILES\x1B[0m"
+    echo "Revert your changes and commit those files with git-lfs!"
+    echo "See https://docs.opengeosys.org/docs/devguide/getting-started/prerequisites"
+    echo "----------"
+    RETURN_CODE=1
+fi
+
+exit $RETURN_CODE


### PR DESCRIPTION
Added git pre-commit hook in .hooks-subdirectory.
Hook checks for correctly committing files tracked by git lfs.

Activate via the following setting in `.git/config`

```
[core]
  hooksPath = .hooks
```

**Or** by copying this file to `.git/hooks/pre-commit`

Closes #1924.