### PR TITLE
Update doxygen for LIE fracture models.

### DIFF
--- a/Documentation/ProjectFile/material/fracture_model/LinearElasticIsotropic/c_LinearElasticIsotropic.md
+++ b/Documentation/ProjectFile/material/fracture_model/LinearElasticIsotropic/c_LinearElasticIsotropic.md
@@ -1,0 +1,1 @@
+Isotropic linear elastic fracture model.

--- a/Documentation/ProjectFile/material/fracture_model/LinearElasticIsotropic/t_normal_stiffness.md
+++ b/Documentation/ProjectFile/material/fracture_model/LinearElasticIsotropic/t_normal_stiffness.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::Fracture::LinearElasticIsotropic::MaterialProperties::normal_stiffness

--- a/Documentation/ProjectFile/material/fracture_model/LinearElasticIsotropic/t_penalty_aperture_cutoff.md
+++ b/Documentation/ProjectFile/material/fracture_model/LinearElasticIsotropic/t_penalty_aperture_cutoff.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::Fracture::LinearElasticIsotropic::_penalty_aperture_cutoff

--- a/Documentation/ProjectFile/material/fracture_model/LinearElasticIsotropic/t_shear_stiffness.md
+++ b/Documentation/ProjectFile/material/fracture_model/LinearElasticIsotropic/t_shear_stiffness.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::Fracture::LinearElasticIsotropic::MaterialProperties::shear_stiffness

--- a/Documentation/ProjectFile/material/fracture_model/LinearElasticIsotropic/t_tension_cutoff.md
+++ b/Documentation/ProjectFile/material/fracture_model/LinearElasticIsotropic/t_tension_cutoff.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::Fracture::LinearElasticIsotropic::_tension_cutoff

--- a/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/c_MohrCoulomb.md
+++ b/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/c_MohrCoulomb.md
@@ -1,0 +1,1 @@
+An elasto-plastic fracture model.

--- a/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_cohesion.md
+++ b/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_cohesion.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::Fracture::MohrCoulomb::MaterialProperties::cohesion

--- a/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_dilatancy_angle.md
+++ b/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_dilatancy_angle.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::Fracture::MohrCoulomb::MaterialProperties::dilatancy_angle

--- a/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_friction_angle.md
+++ b/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_friction_angle.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::Fracture::MohrCoulomb::MaterialProperties::friction_angle

--- a/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_normal_stiffness.md
+++ b/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_normal_stiffness.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::Fracture::MohrCoulomb::MaterialProperties::normal_stiffness

--- a/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_penalty_aperture_cutoff.md
+++ b/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_penalty_aperture_cutoff.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::Fracture::MohrCoulomb::_penalty_aperture_cutoff

--- a/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_shear_stiffness.md
+++ b/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_shear_stiffness.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::Fracture::MohrCoulomb::MaterialProperties::shear_stiffness

--- a/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_tension_cutoff.md
+++ b/Documentation/ProjectFile/material/fracture_model/MohrCoulomb/t_tension_cutoff.md
@@ -1,0 +1,1 @@
+\copydoc MaterialLib::Fracture::MohrCoulomb::_tension_cutoff

--- a/Documentation/ProjectFile/material/fracture_model/i_fracture_model.md
+++ b/Documentation/ProjectFile/material/fracture_model/i_fracture_model.md
@@ -1,0 +1,1 @@
+Fracture models used in LIE/XFEM solvers.

--- a/Documentation/ProjectFile/material/fracture_model/t_type.md
+++ b/Documentation/ProjectFile/material/fracture_model/t_type.md
@@ -1,0 +1,1 @@
+The fracture model type describing the fracture's opening and closing behaviour.

--- a/Documentation/ProjectFile/material/solid/constitutive_relation/LinearElasticIsotropic/t_normal_stiffness.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/LinearElasticIsotropic/t_normal_stiffness.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/material/solid/constitutive_relation/LinearElasticIsotropic/t_shear_stiffness.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/LinearElasticIsotropic/t_shear_stiffness.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/material/solid/constitutive_relation/MohrCoulomb/c_MohrCoulomb.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/MohrCoulomb/c_MohrCoulomb.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/material/solid/constitutive_relation/MohrCoulomb/t_cohesion.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/MohrCoulomb/t_cohesion.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/material/solid/constitutive_relation/MohrCoulomb/t_dilatancy_angle.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/MohrCoulomb/t_dilatancy_angle.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/material/solid/constitutive_relation/MohrCoulomb/t_friction_angle.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/MohrCoulomb/t_friction_angle.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/material/solid/constitutive_relation/MohrCoulomb/t_normal_stiffness.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/MohrCoulomb/t_normal_stiffness.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/material/solid/constitutive_relation/MohrCoulomb/t_shear_stiffness.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/MohrCoulomb/t_shear_stiffness.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/MaterialLib/FractureModels/CreateLinearElasticIsotropic.cpp
+++ b/MaterialLib/FractureModels/CreateLinearElasticIsotropic.cpp
@@ -23,24 +23,24 @@ createLinearElasticIsotropic(
     std::vector<std::unique_ptr<ProcessLib::ParameterBase>> const& parameters,
     BaseLib::ConfigTree const& config)
 {
-    //! \ogs_file_param{material__solid__constitutive_relation__type}
+    //! \ogs_file_param{material__fracture_model__type}
     config.checkConfigParameter("type", "LinearElasticIsotropic");
     DBUG("Create LinearElasticIsotropic material");
 
     auto& Kn = ProcessLib::findParameter<double>(
-        //! \ogs_file_param_special{material__solid__constitutive_relation__LinearElasticIsotropic__normal_stiffness}
+        //! \ogs_file_param_special{material__fracture_model__LinearElasticIsotropic__normal_stiffness}
         config, "normal_stiffness", parameters, 1);
 
     auto& Ks = ProcessLib::findParameter<double>(
-        //! \ogs_file_param_special{material__solid__constitutive_relation__LinearElasticIsotropic__shear_stiffness}
+        //! \ogs_file_param_special{material__fracture_model__LinearElasticIsotropic__shear_stiffness}
         config, "shear_stiffness", parameters, 1);
 
     auto const penalty_aperture_cutoff =
-        //! \ogs_file_param_special{material__solid__constitutive_relation__LinearElasticIsotropic__penalty_aperture_cutoff}
+        //! \ogs_file_param{material__fracture_model__LinearElasticIsotropic__penalty_aperture_cutoff}
         config.getConfigParameter<double>("penalty_aperture_cutoff");
 
     auto const tension_cutoff =
-        //! \ogs_file_param_special{material__solid__constitutive_relation__LinearElasticIsotropic__tension_cutoff}
+        //! \ogs_file_param{material__fracture_model__LinearElasticIsotropic__tension_cutoff}
         config.getConfigParameter<bool>("tension_cutoff");
 
     typename LinearElasticIsotropic<DisplacementDim>::MaterialProperties mp{

--- a/MaterialLib/FractureModels/CreateMohrCoulomb.cpp
+++ b/MaterialLib/FractureModels/CreateMohrCoulomb.cpp
@@ -23,36 +23,36 @@ createMohrCoulomb(
     std::vector<std::unique_ptr<ProcessLib::ParameterBase>> const& parameters,
     BaseLib::ConfigTree const& config)
 {
-    //! \ogs_file_param{material__solid__constitutive_relation__type}
+    //! \ogs_file_param{material__fracture_model__type}
     config.checkConfigParameter("type", "MohrCoulomb");
     DBUG("Create MohrCoulomb material");
 
     auto& Kn = ProcessLib::findParameter<double>(
-        //! \ogs_file_param_special{material__solid__constitutive_relation__MohrCoulomb__normal_stiffness}
+        //! \ogs_file_param_special{material__fracture_model__MohrCoulomb__normal_stiffness}
         config, "normal_stiffness", parameters, 1);
 
     auto& Ks = ProcessLib::findParameter<double>(
-        //! \ogs_file_param_special{material__solid__constitutive_relation__MohrCoulomb__shear_stiffness}
+        //! \ogs_file_param_special{material__fracture_model__MohrCoulomb__shear_stiffness}
         config, "shear_stiffness", parameters, 1);
 
     auto& friction_angle = ProcessLib::findParameter<double>(
-        //! \ogs_file_param_special{material__solid__constitutive_relation__MohrCoulomb__friction_angle}
+        //! \ogs_file_param_special{material__fracture_model__MohrCoulomb__friction_angle}
         config, "friction_angle", parameters, 1);
 
     auto& dilatancy_angle = ProcessLib::findParameter<double>(
-        //! \ogs_file_param_special{material__solid__constitutive_relation__MohrCoulomb__dilatancy_angle}
+        //! \ogs_file_param_special{material__fracture_model__MohrCoulomb__dilatancy_angle}
         config, "dilatancy_angle", parameters, 1);
 
     auto& cohesion = ProcessLib::findParameter<double>(
-        //! \ogs_file_param_special{material__solid__constitutive_relation__MohrCoulomb__cohesion}
+        //! \ogs_file_param_special{material__fracture_model__MohrCoulomb__cohesion}
         config, "cohesion", parameters, 1);
 
     auto const penalty_aperture_cutoff =
-        //! \ogs_file_param_special{material__solid__constitutive_relation__LinearElasticIsotropic__penalty_aperture_cutoff}
+        //! \ogs_file_param{material__fracture_model__MohrCoulomb__penalty_aperture_cutoff}
         config.getConfigParameter<double>("penalty_aperture_cutoff");
 
     auto const tension_cutoff =
-        //! \ogs_file_param_special{material__solid__constitutive_relation__MohrCoulomb__tension_cutoff}
+        //! \ogs_file_param{material__fracture_model__MohrCoulomb__tension_cutoff}
         config.getConfigParameter<bool>("tension_cutoff");
 
     typename MohrCoulomb<DisplacementDim>::MaterialProperties mp{

--- a/MaterialLib/FractureModels/LinearElasticIsotropic.h
+++ b/MaterialLib/FractureModels/LinearElasticIsotropic.h
@@ -123,5 +123,5 @@ namespace Fracture
 {
 extern template class LinearElasticIsotropic<2>;
 extern template class LinearElasticIsotropic<3>;
-}  // namespace Fractrue
+}  // namespace Fracture
 }  // namespace MaterialLib

--- a/MaterialLib/FractureModels/LinearElasticIsotropic.h
+++ b/MaterialLib/FractureModels/LinearElasticIsotropic.h
@@ -36,7 +36,9 @@ public:
         {
         }
 
+        /// Normal stiffness given in units of stress.
         P const& normal_stiffness;
+        /// Shear stiffness given in units of stress.
         P const& shear_stiffness;
     };
 

--- a/MaterialLib/FractureModels/MohrCoulomb.h
+++ b/MaterialLib/FractureModels/MohrCoulomb.h
@@ -41,10 +41,18 @@ public:
         {
         }
 
+        /// Normal stiffness given in units of stress.
         P const& normal_stiffness;
+        /// Shear stiffness given in units of stress.
         P const& shear_stiffness;
+        /// Governs the normal stress dependence of the shear strength.
+        /// \note Given in degrees (not radian).
         P const& friction_angle;
+        /// Governs the dilatancy behaviour during the plastic deformation of
+        /// the fault.
+        /// \note Given in degrees (not radian).
         P const& dilatancy_angle;
+        /// Fracture cohesion in units of stress.
         P const& cohesion;
     };
 
@@ -108,12 +116,14 @@ public:
             material_state_variables) override;
 
 private:
-    /// \copydoc
-    /// MaterialLib::Fracture::LinearElasticIsotropic::_penalty_aperture_cutoff
+    /// Compressive normal displacements above this value will not enter the
+    /// computation of the normal stiffness modulus of the fracture.
+    /// \note Setting this to the initial aperture value allows negative
+    /// apertures.
     double const _penalty_aperture_cutoff;
 
-    /// \copydoc
-    /// MaterialLib::Fracture::LinearElasticIsotropic::_tension_cutoff
+    /// If set no resistance to open the fracture over the initial aperture is
+    /// opposed.
     bool const _tension_cutoff;
 
     MaterialProperties _mp;

--- a/MaterialLib/FractureModels/MohrCoulomb.h
+++ b/MaterialLib/FractureModels/MohrCoulomb.h
@@ -138,5 +138,5 @@ namespace Fracture
 {
 extern template class MohrCoulomb<2>;
 extern template class MohrCoulomb<3>;
-}  // namespace Fractrue
+}  // namespace Fracture
 }  // namespace MaterialLib

--- a/NumLib/DOF/LocalToGlobalIndexMap.h
+++ b/NumLib/DOF/LocalToGlobalIndexMap.h
@@ -110,7 +110,7 @@ public:
 
     int getNumberOfVariableComponents(int variable_id) const
     {
-        assert(static_cast<unsigned>(variable_id) < getNumberOfVariables());
+        assert(variable_id < getNumberOfVariables());
         return _variable_component_offsets[variable_id+1] - _variable_component_offsets[variable_id];
     }
 

--- a/ProcessLib/LIE/HydroMechanics/CreateHydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/CreateHydroMechanicsProcess.cpp
@@ -198,26 +198,28 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
 
     // Fracture constitutive relation.
     std::unique_ptr<MaterialLib::Fracture::FractureModelBase<GlobalDim>> fracture_model = nullptr;
-    auto const opt_fracture_constitutive_relation_config =
-        //! \ogs_file_param{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__fracture_constitutive_relation}
-        config.getConfigSubtreeOptional("fracture_constitutive_relation");
-    if (opt_fracture_constitutive_relation_config)
+    auto const opt_fracture_model_config =
+        //! \ogs_file_param{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__fracture_model}
+        config.getConfigSubtreeOptional("fracture_model");
+    if (opt_fracture_model_config)
     {
-        auto& fracture_constitutive_relation_config = *opt_fracture_constitutive_relation_config;
+        auto& fracture_model_config = *opt_fracture_model_config;
 
         auto const frac_type =
-            //! \ogs_file_param{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__fracture_constitutive_relation__type}
-            fracture_constitutive_relation_config.peekConfigParameter<std::string>("type");
+            //! \ogs_file_param{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__fracture_model_type}
+            fracture_model_config.peekConfigParameter<std::string>("type");
 
         if (frac_type == "LinearElasticIsotropic")
         {
-            fracture_model = MaterialLib::Fracture::createLinearElasticIsotropic<GlobalDim>(
-                parameters, fracture_constitutive_relation_config);
+            fracture_model =
+                MaterialLib::Fracture::createLinearElasticIsotropic<GlobalDim>(
+                    parameters, fracture_model_config);
         }
         else if (frac_type == "MohrCoulomb")
         {
-            fracture_model = MaterialLib::Fracture::createMohrCoulomb<GlobalDim>(
-                parameters, fracture_constitutive_relation_config);
+            fracture_model =
+                MaterialLib::Fracture::createMohrCoulomb<GlobalDim>(
+                    parameters, fracture_model_config);
         }
         else
         {

--- a/ProcessLib/LIE/SmallDeformation/CreateSmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/CreateSmallDeformationProcess.cpp
@@ -119,24 +119,25 @@ createSmallDeformationProcess(
 
     // Fracture constitutive relation.
     // read type;
-    auto const fracture_constitutive_relation_config =
-        //! \ogs_file_param{prj__processes__process__SMALL_DEFORMATION_WITH_LIE__fracture_constitutive_relation}
-        config.getConfigSubtree("fracture_constitutive_relation");
+    auto const fracture_model_config =
+        //! \ogs_file_param{prj__processes__process__SMALL_DEFORMATION_WITH_LIE__fracture_model}
+        config.getConfigSubtree("fracture_model");
 
     auto const frac_type =
-        //! \ogs_file_param{prj__processes__process__SMALL_DEFORMATION_WITH_LIE__fracture_constitutive_relation__type}
-        fracture_constitutive_relation_config.peekConfigParameter<std::string>("type");
+        //! \ogs_file_param{prj__processes__process__SMALL_DEFORMATION_WITH_LIE__fracture_model__type}
+        fracture_model_config.peekConfigParameter<std::string>("type");
 
     std::unique_ptr<MaterialLib::Fracture::FractureModelBase<DisplacementDim>> fracture_model = nullptr;
     if (frac_type == "LinearElasticIsotropic")
     {
-        fracture_model = MaterialLib::Fracture::createLinearElasticIsotropic<DisplacementDim>(
-            parameters, fracture_constitutive_relation_config);
+        fracture_model = MaterialLib::Fracture::createLinearElasticIsotropic<
+            DisplacementDim>(parameters, fracture_model_config);
     }
     else if (frac_type == "MohrCoulomb")
     {
-        fracture_model = MaterialLib::Fracture::createMohrCoulomb<DisplacementDim>(
-            parameters, fracture_constitutive_relation_config);
+        fracture_model =
+            MaterialLib::Fracture::createMohrCoulomb<DisplacementDim>(
+                parameters, fracture_model_config);
     }
     else
     {

--- a/scripts/cmake/SubmoduleSetup.cmake
+++ b/scripts/cmake/SubmoduleSetup.cmake
@@ -42,6 +42,7 @@ foreach(SUBMODULE ${REQUIRED_SUBMODULES})
     string(REGEX MATCH "^\\-" UNINITIALIZED ${SUBMODULE_STATE})
     string(REGEX MATCH "^\\+" MISMATCH ${SUBMODULE_STATE})
 
+    set(RESULT "")
     if(UNINITIALIZED)
         message(STATUS "Initializing submodule ${SUBMODULE}")
         if(${SUBMODULE} STREQUAL "Tests/Data")
@@ -50,6 +51,7 @@ foreach(SUBMODULE ${REQUIRED_SUBMODULES})
         execute_process(
             COMMAND ${GIT_TOOL_PATH} submodule update --init --recursive ${DEPTH} ${SUBMODULE}
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+            RESULT_VARIABLE RESULT
         )
 
     elseif(MISMATCH)
@@ -57,6 +59,11 @@ foreach(SUBMODULE ${REQUIRED_SUBMODULES})
         execute_process(
             COMMAND ${GIT_TOOL_PATH} submodule update --recursive ${SUBMODULE}
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+            RESULT_VARIABLE RESULT
         )
+    endif()
+
+    if((NOT ${RESULT} STREQUAL "") AND (NOT ${RESULT} STREQUAL "0"))
+        message(FATAL_ERROR "Error in submodule setup; return value: ${RESULT}")
     endif()
 endforeach()

--- a/tracer.cpp
+++ b/tracer.cpp
@@ -1,0 +1,52 @@
+#ifdef __cplusplus
+extern "C" {
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+void __cyg_profile_func_enter(void* this_fn, void* call_site)
+    __attribute__((no_instrument_function));
+void __cyg_profile_func_exit(void* this_fn, void* call_site)
+    __attribute__((no_instrument_function));
+}
+
+#endif
+static FILE* fp;
+int call_level = 0;
+void* last_fn;
+void __cyg_profile_func_enter(void* this_fn, void* call_site)
+{
+    Dl_info di;
+
+    if (fp == NULL)
+        fp = fopen("trace.txt", "w");
+    if (fp == NULL)
+        exit(-1);
+
+    if (this_fn != last_fn)
+        ++call_level;
+    for (int i = 0; i <= call_level; i++)
+        fprintf(fp, "\t");
+    fprintf(fp, "entering %p", (int*)this_fn);
+    if (dladdr(this_fn, &di))
+    {
+        fprintf(fp, " %s (%s)", di.dli_sname ? di.dli_sname : "<unknown>",
+                di.dli_fname);
+    }
+    fputs("\n", fp);
+    (void)call_site;
+    last_fn = this_fn;
+}
+
+void __cyg_profile_func_exit(void* this_fn, void* call_site)
+{
+    --call_level;
+    for (int i = 0; i <= call_level; i++)
+        fprintf(fp, "\t");
+    fprintf(fp, "exiting %p\n", (int*)this_fn);
+    (void)call_site;
+}


### PR DESCRIPTION
There was an error in CI (which is already fixed) for parsing the doxygen output and so the missing/incorrect documentation slipped in.

The LIE fracture model are inconsistent; the linear elastic model is (mis)using the solid's linear elastic material, Mohr-Coulomb has its own documentation/folder but also inside the solid material models.

In this PR:
 - Moving all fracture models documentation in own folder corresponding to the `fracture_model` tag.
 - Filling out all of the missing documentation.
 - Updating the project files for the new prj file structure.