### PR TITLE
Deformation picard

### DIFF
--- a/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.cpp
@@ -74,6 +74,7 @@ createSmallDeformationProcess(
 
     std::unique_ptr<MaterialLib::Solids::MechanicsBase<DisplacementDim>>
         material = nullptr;
+    bool linear_elastic (0);
     if (type == "Ehlers")
     {
         material = MaterialLib::Solids::Ehlers::createEhlers<DisplacementDim>(
@@ -84,6 +85,7 @@ createSmallDeformationProcess(
         material =
             MaterialLib::Solids::createLinearElasticIsotropic<DisplacementDim>(
                 parameters, constitutive_relation_config);
+        linear_elastic = true;
     }
     else if (type == "Lubby2")
     {
@@ -122,7 +124,7 @@ createSmallDeformationProcess(
     }
 
     SmallDeformationProcessData<DisplacementDim> process_data{
-        std::move(material), solid_density, specific_body_force};
+        std::move(material), solid_density, specific_body_force, linear_elastic};
 
     SecondaryVariableCollection secondary_variables;
 

--- a/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.cpp
@@ -74,7 +74,7 @@ createSmallDeformationProcess(
 
     std::unique_ptr<MaterialLib::Solids::MechanicsBase<DisplacementDim>>
         material = nullptr;
-    bool linear_elastic (0);
+    bool linear_elastic = false;
     if (type == "Ehlers")
     {
         material = MaterialLib::Solids::Ehlers::createEhlers<DisplacementDim>(

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -155,9 +155,6 @@ public:
             OGS_FATAL("SmallDeformationLocalAssembler: assembly without jacobian "
                     "requires linear elastic material behaviour.");
         }
-        //        M=0;
-        //        K = B.transpose() * C B * w //vormals Jac
-        //        b = N_u_op.transpose() * rho * b * w;
         auto const local_matrix_size = local_x.size();
 
         auto local_K = MathLib::createZeroedMatrix<StiffnessMatrixType>(

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -150,11 +150,14 @@ public:
             std::vector<double>& local_K_data,
             std::vector<double>& local_b_data) override
     {
-        //fatal::only for linear elastic
+        if (!_process_data.is_linear_elastic_isotropic)
+        {
+            OGS_FATAL("SmallDeformationLocalAssembler: assembly without jacobian "
+                    "requires linear elastic material behaviour.");
+        }
         //        M=0;
         //        K = B.transpose() * C B * w //vormals Jac
         //        b = N_u_op.transpose() * rho * b * w;
-
         auto const local_matrix_size = local_x.size();
 
         auto local_K = MathLib::createZeroedMatrix<StiffnessMatrixType>(

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -146,13 +146,18 @@ public:
     }
 
     void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
-                  std::vector<double>& /*local_M_data*/,
-                  std::vector<double>& /*local_K_data*/,
-                  std::vector<double>& /*local_b_data*/) override
+                  std::vector<double>& local_M_data,
+                  std::vector<double>& local_K_data,
+                  std::vector<double>& local_b_data) override
     {
-        OGS_FATAL(
-            "SmallDeformationLocalAssembler: assembly without jacobian is not "
-            "implemented.");
+//        OGS_FATAL(
+//            "SmallDeformationLocalAssembler: assembly without jacobian is not "
+//            "implemented.");
+        //only for linear elastic
+//        M=0;
+//        K = B.transpose() * C B * w //vormals Jac
+//        b = N_u_op.transpose() * rho * b * w;
+
     }
 
     void assembleWithJacobian(double const t,

--- a/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
@@ -30,11 +30,11 @@ struct SmallDeformationProcessData
         Parameter<double> const& solid_density_,
         Eigen::Matrix<double, DisplacementDim, 1>
             specific_body_force_,
-        bool is_linear_elastic_isotropic)
+        bool const is_linear_elastic_isotropic_)
         : material{std::move(material)},
           solid_density(solid_density_),
           specific_body_force(std::move(specific_body_force_)),
-          is_linear_elastic_isotropic (is_linear_elastic_isotropic)
+          is_linear_elastic_isotropic (is_linear_elastic_isotropic_)
     {
     }
 
@@ -65,7 +65,7 @@ struct SmallDeformationProcessData
     /// It is usually used to apply gravitational forces.
     /// A vector of displacement dimension's length.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
-    bool is_linear_elastic_isotropic;
+    bool const is_linear_elastic_isotropic;
     double dt = 0;
     double t = 0;
 };

--- a/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
@@ -29,10 +29,12 @@ struct SmallDeformationProcessData
             material,
         Parameter<double> const& solid_density_,
         Eigen::Matrix<double, DisplacementDim, 1>
-            specific_body_force_)
+            specific_body_force_,
+        bool is_linear_elastic_isotropic)
         : material{std::move(material)},
           solid_density(solid_density_),
-          specific_body_force(std::move(specific_body_force_))
+          specific_body_force(std::move(specific_body_force_)),
+          is_linear_elastic_isotropic (is_linear_elastic_isotropic)
     {
     }
 
@@ -40,6 +42,7 @@ struct SmallDeformationProcessData
         : material{std::move(other.material)},
           solid_density(other.solid_density),
           specific_body_force(other.specific_body_force),
+          is_linear_elastic_isotropic (other.is_linear_elastic_isotropic),
           dt{other.dt},
           t{other.t}
     {
@@ -62,6 +65,7 @@ struct SmallDeformationProcessData
     /// It is usually used to apply gravitational forces.
     /// A vector of displacement dimension's length.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
+    bool is_linear_elastic_isotropic;
     double dt = 0;
     double t = 0;
 };


### PR DESCRIPTION
Picard method is now implemented for small deformation processes, restricted to linear elasticity. The 'assemble' method is basically the same as the 'assembleWithJacobian', only one or two lines are different. However, I decided to keep the two methods appart rather then combing them, since it is more convenient and easier to read this way.

In order to assure that inelastic or non-linear elastic models are used, I came up with a flag in SmallDeformationProcessData which is set to true for linear elastic materials in the process creation routine. This is not the best way (maybe its the worst) to check for the constitutive relation. I think, this flag (or some kind of a type-specifier) is needed in the material object itself, since it belongs to the material and not to the process (BTW: the same counts imo for the solid density). But, this would require much more changes; tell me what you think about it..