### PR TITLE
Switch to GitLab for lfs

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[remote "origin"]
+	lfsurl = https://gitlab.opengeosys.org/ogs/ogs.git/info/lfs


### PR DESCRIPTION
GitHub has some serious limitations on git lfs usage (storage and bandwidth). After merging #1982 we hit the quota in a few hours which resulted in GitHub disabling lfs in our account.

As a quickfix I moved our lfs files to our own GitLab instance where we have lots of more storage and bandwidth available. The new `.lfsconfig`-file should be enough to switch to the other lfs location. 

- Cloning and pulling simply works
- For pushing new lfs files you need to have an account on our GitLab instance and need to have write rights to the [ogs repo](https://gitlab.opengeosys.org/ogs/ogs). You also need a [personal access token](https://gitlab.opengeosys.org/profile/personal_access_tokens). On pushing please provide your GitLab username (should be the same as your GitHub user name) and your created personal access token.

Some more tips:

- Creating a GitLab account can be done by clicking on the GitHub logo (octocat) on the [Gitlab sign-in page]
- Please let me know about your created account so I can give you write rights
- On creating the GitLab personal access token, enable the following scopes: `api`, `read_user`
- You may want to use a [git credential helper](https://docs.gitlab.com/ee/workflow/lfs/manage_large_binaries_with_git_lfs.html#credentials-are-always-required-when-pushing-an-object)