### PR TITLE
Rewrite quadratic mesh generator

### DIFF
--- a/Tests/MeshLib/TestQuadraticMesh.cpp
+++ b/Tests/MeshLib/TestQuadraticMesh.cpp
@@ -82,29 +82,31 @@ TEST(MeshLib, QuadraticOrderMesh_Quad)
             ASSERT_FALSE(mesh->isBaseNode(e->getNodeIndex(i)));
     }
 
-    auto isIn = [](MeshLib::Node const* node, std::initializer_list<std::size_t> list)
-    {
-        return list.end() != std::find(list.begin(), list.end(), node->getID());
-    };
+    auto const& mesh_nodes = mesh->getNodes();
 
-    for (MeshLib::Node const* node : mesh->getNodes())
-    {
-        if (isIn(node, {4}))
-        {
-            ASSERT_EQ(4u, node->getElements().size());
-            ASSERT_EQ(21u, node->getConnectedNodes().size());
-        }
-        else if (isIn(node, {0, 2, 6, 8, 9, 10, 11, 13, 15, 18, 19, 20}))
-        {
-            ASSERT_EQ(1u, node->getElements().size());
-            ASSERT_EQ(8u, node->getConnectedNodes().size());
-        }
-        else
-        {
-            ASSERT_EQ(2u, node->getElements().size());
-            ASSERT_EQ(13u, node->getConnectedNodes().size());
-        }
-    }
+    // Count nodes shared by four elements and also connected to all 21 other
+    // nodes.
+    ASSERT_EQ(1, std::count_if(mesh_nodes.begin(), mesh_nodes.end(),
+                               [](Node* const n) {
+                                   return (n->getElements().size() == 4) &&
+                                          (n->getConnectedNodes().size() == 21);
+                               }));
+
+    // Count nodes belonging to one element and also connected to all 8 other
+    // nodes of that corner element.
+    ASSERT_EQ(12, std::count_if(mesh_nodes.begin(), mesh_nodes.end(),
+                                [](Node* const n) {
+                                    return (n->getElements().size() == 1) &&
+                                           (n->getConnectedNodes().size() == 8);
+                                }));
+
+    // Count nodes shared by two elements and also connected to the 13 other
+    // nodes of the two elements.
+    ASSERT_EQ(8, std::count_if(mesh_nodes.begin(), mesh_nodes.end(),
+                               [](Node* const n) {
+                                   return (n->getElements().size() == 2) &&
+                                          (n->getConnectedNodes().size() == 13);
+                               }));
 }
 
 TEST(MeshLib, QuadraticOrderMesh_LineQuad)
@@ -159,32 +161,37 @@ TEST(MeshLib, QuadraticOrderMesh_LineQuad)
             ASSERT_FALSE(mesh->isBaseNode(e->getNodeIndex(i)));
     }
 
-    auto isIn = [](MeshLib::Node const* node, std::initializer_list<std::size_t> list)
-    {
-        return list.end() != std::find(list.begin(), list.end(), node->getID());
-    };
+    auto const& mesh_nodes = mesh->getNodes();
 
-    for (MeshLib::Node const* node : mesh->getNodes())
-    {
-        if (isIn(node, {4}))
-        {
-            ASSERT_EQ(6u, node->getElements().size());
-            ASSERT_EQ(21u, node->getConnectedNodes().size());
-        }
-        else if (isIn(node, {0, 2, 6, 8, 9, 10, 11, 13, 15, 18, 19, 20}))
-        {
-            ASSERT_EQ(1u, node->getElements().size());
-            ASSERT_EQ(8u, node->getConnectedNodes().size());
-        }
-        else if (isIn(node, {3, 5, 14, 16}))
-        {
-            ASSERT_EQ(3u, node->getElements().size());
-            ASSERT_EQ(13u, node->getConnectedNodes().size());
-        }
-        else
-        {
-            ASSERT_EQ(2u, node->getElements().size());
-            ASSERT_EQ(13u, node->getConnectedNodes().size());
-        }
-    }
+    // Count nodes shared by six elements and also connected to all 21 other
+    // nodes.
+    ASSERT_EQ(1, std::count_if(mesh_nodes.begin(), mesh_nodes.end(),
+                               [](Node* const n) {
+                                   return (n->getElements().size() == 6) &&
+                                          (n->getConnectedNodes().size() == 21);
+                               }));
+
+    // Count nodes belonging to one element and also connected to all 8 other
+    // nodes of that corner element.
+    ASSERT_EQ(12, std::count_if(mesh_nodes.begin(), mesh_nodes.end(),
+                                [](Node* const n) {
+                                    return (n->getElements().size() == 1) &&
+                                           (n->getConnectedNodes().size() == 8);
+                                }));
+
+    // Count nodes shared by three elements (quads and the line) and also
+    // connected to the 13 other nodes of the two elements.
+    ASSERT_EQ(4, std::count_if(mesh_nodes.begin(), mesh_nodes.end(),
+                               [](Node* const n) {
+                                   return (n->getElements().size() == 3) &&
+                                          (n->getConnectedNodes().size() == 13);
+                               }));
+
+    // Count nodes shared by two elements (quads) and also connected to the 13
+    // other nodes of the two elements.
+    ASSERT_EQ(4, std::count_if(mesh_nodes.begin(), mesh_nodes.end(),
+                               [](Node* const n) {
+                                   return (n->getElements().size() == 2) &&
+                                          (n->getConnectedNodes().size() == 13);
+                               }));
 }


### PR DESCRIPTION
For the review I suggest to look on the new version of the [QuadraticMeshGenerator.cpp](https://github.com/endJunction/ogs/blob/5cc974165f3447ca3b4793a3b0a25ad767529ebb/MeshLib/MeshGenerators/QuadraticMeshGenerator.cpp)---it's a complete rewrite---and compare the tests.

The only unfortunate thing about the new code are the scattered `new`/`delete` operations on nodes---I don't have a good idea on how to replace them.

The runtime for conversion of a 1e6 linear quad elements mesh in the original version is more than 15 minutes (aborted then).
```
➜  ogs/r time bin/createQuadraticMesh -i quad1e6.vtu -o o.vtu
info: Create a quadratic order mesh
info: Found 2002000 edges in the mesh
^C
bin/createQuadraticMesh -i quad1e6.vtu -o o.vtu  944.93s user 0.27s system 100% cpu 15:45.19 total
```
The new version finishes the conversion in 8 seconds:
```
➜  ogs/r time bin/createQuadraticMesh -i quad1e6.vtu -o o.vtu                                      
info: Create a quadratic order mesh
info: Save the new mesh into a file
bin/createQuadraticMesh -i quad1e6.vtu -o o.vtu  7.74s user 0.51s system 99% cpu 8.311 total
```

The mesh used for testing is
```
➜  ogs/r bin/checkMesh quad1e6.vtu                                                          
info: Memory size: 381 MB
info: Time for reading: 1.53399 s
info: Node coordinates:
info: 	x [0, 1] (extent 1)
info: 	y [0, 1] (extent 1)
info: 	z [0, 4.94066e-324] (extent 4.94066e-324)
info: Edge length: [0.001, 0.001]
info: Element types:
info: 	1000000 quads
info: There are 0 properties in the mesh:
```
and the result is
```
➜  ogs/r bin/checkMesh o.vtu      
info: Memory size: 969 MB
info: Time for reading: 3.74699 s
info: Node coordinates:
info: 	x [0, 1] (extent 1)
info: 	y [0, 1] (extent 1)
info: 	z [0, 4.94066e-324] (extent 4.94066e-324)
info: Edge length: [0.001, 0.001]
info: Element types:
info: 	1000000 quads
info: There are 0 properties in the mesh:
```

Assuming that writing a vtu takes same time as to read it, the conversion needs only  8.311 s - 1.53399 s - 3.74699 s = 3.03 s.