### PR TITLE
Name change and new argument for a member function of process classes

### DIFF
--- a/ProcessLib/AbstractJacobianAssembler.h
+++ b/ProcessLib/AbstractJacobianAssembler.h
@@ -40,7 +40,7 @@ public:
         std::vector<double>& /*local_K_data*/,
         std::vector<double>& /*local_b_data*/,
         std::vector<double>& /*local_Jac_data*/,
-        LocalCoupledSolutions const& /*coupling_term*/)
+        LocalCoupledSolutions const& /*coupled_solutions*/)
     {
     }
 

--- a/ProcessLib/AbstractJacobianAssembler.h
+++ b/ProcessLib/AbstractJacobianAssembler.h
@@ -14,7 +14,7 @@
 namespace ProcessLib
 {
 class LocalAssemblerInterface;
-struct LocalCouplingTerm;
+struct LocalCoupledSolutions;
 
 //! Base class for Jacobian assemblers.
 class AbstractJacobianAssembler
@@ -40,7 +40,7 @@ public:
         std::vector<double>& /*local_K_data*/,
         std::vector<double>& /*local_b_data*/,
         std::vector<double>& /*local_Jac_data*/,
-        LocalCouplingTerm const& /*coupling_term*/)
+        LocalCoupledSolutions const& /*coupling_term*/)
     {
     }
 

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
@@ -63,7 +63,7 @@ void ComponentTransportProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 void ComponentTransportProcess::assembleWithJacobianConcreteProcess(
@@ -77,7 +77,7 @@ void ComponentTransportProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 }  // namespace ComponentTransport

--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.cpp
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.cpp
@@ -5,19 +5,19 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   StaggeredCouplingTerm.cpp
+ * \file   CoupledSolutionsForStaggeredScheme.cpp
  *
  * Created on November 7, 2016, 12:14 PM
  */
 
-#include "StaggeredCouplingTerm.h"
+#include "CoupledSolutionsForStaggeredScheme.h"
 
 #include "MathLib/LinAlg/LinAlg.h"
 #include "Process.h"
 
 namespace ProcessLib
 {
-StaggeredCouplingTerm::StaggeredCouplingTerm(
+CoupledSolutionsForStaggeredScheme::CoupledSolutionsForStaggeredScheme(
     std::unordered_map<std::type_index, Process const&> const&
         coupled_processes_,
     std::unordered_map<std::type_index, GlobalVector const&> const& coupled_xs_,

--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.h
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   StaggeredCouplingTerm.h
+ * \file   CoupledSolutionsForStaggeredScheme.h
  *
  * Created on November 7, 2016, 12:14 PM
  */
@@ -29,9 +29,9 @@ class Process;
  *  and passed through interfaces to global and local assemblers for each
  *  process.
  */
-struct StaggeredCouplingTerm
+struct CoupledSolutionsForStaggeredScheme
 {
-    StaggeredCouplingTerm(
+    CoupledSolutionsForStaggeredScheme(
         std::unordered_map<std::type_index, Process const&> const&
             coupled_processes_,
         std::unordered_map<std::type_index, GlobalVector const&> const&
@@ -58,9 +58,9 @@ struct StaggeredCouplingTerm
  *  During the global assembly loop, an instance of this struct is created for
  *  each element and it is then passed to local assemblers.
  */
-struct LocalCouplingTerm
+struct LocalCoupledSolutions
 {
-    LocalCouplingTerm(
+    LocalCoupledSolutions(
         const double dt_,
         std::unordered_map<std::type_index, Process const&> const&
             coupled_processes_,

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -68,7 +68,7 @@ void GroundwaterFlowProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(
@@ -82,7 +82,7 @@ void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 }   // namespace GroundwaterFlow

--- a/ProcessLib/HT/CreateHTProcess.cpp
+++ b/ProcessLib/HT/CreateHTProcess.cpp
@@ -43,15 +43,14 @@ std::unique_ptr<Process> createHTProcess(
 
     auto process_variables = findProcessVariables(
         variables, pv_config,
-        {
-        //! \ogs_file_param_special{prj__processes__process__HT__process_variables__temperature}
-        "temperature",
-        //! \ogs_file_param_special{prj__processes__process__HT__process_variables__pressure}
-        "pressure"});
+        {//! \ogs_file_param_special{prj__processes__process__HT__process_variables__temperature}
+         "temperature",
+         //! \ogs_file_param_special{prj__processes__process__HT__process_variables__pressure}
+         "pressure"});
 
     MaterialLib::PorousMedium::PorousMediaProperties porous_media_properties{
-        MaterialLib::PorousMedium::createPorousMediaProperties(
-            mesh, config, parameters)};
+        MaterialLib::PorousMedium::createPorousMediaProperties(mesh, config,
+                                                               parameters)};
 
     //! \ogs_file_param{prj__processes__process__HT__fluid}
     auto const& fluid_config = config.getConfigSubtree("fluid");
@@ -59,7 +58,7 @@ std::unique_ptr<Process> createHTProcess(
         MaterialLib::Fluid::createFluidProperties(fluid_config);
 
     // Parameter for the density of the fluid.
-    auto& fluid_reference_density= findParameter<double>(
+    auto& fluid_reference_density = findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HT__fluid_reference_density}
         "fluid_reference_density", parameters, 1);
@@ -134,17 +133,19 @@ std::unique_ptr<Process> createHTProcess(
         std::copy_n(b.data(), b.size(), specific_body_force.data());
     }
 
-    HTMaterialProperties process_data{std::move(porous_media_properties),
-                               density_solid,
-                               fluid_reference_density,
-                               std::move(fluid_properties),
-                               thermal_dispersivity_longitudinal,
-                               thermal_dispersivity_transversal,
-                               specific_heat_capacity_solid,
-                               thermal_conductivity_solid,
-                               thermal_conductivity_fluid,
-                               specific_body_force,
-                               has_gravity};
+    std::unique_ptr<HTMaterialProperties> material_properties =
+        std::make_unique<HTMaterialProperties>(
+            std::move(porous_media_properties),
+            density_solid,
+            fluid_reference_density,
+            std::move(fluid_properties),
+            thermal_dispersivity_longitudinal,
+            thermal_dispersivity_transversal,
+            specific_heat_capacity_solid,
+            thermal_conductivity_solid,
+            thermal_conductivity_fluid,
+            specific_body_force,
+            has_gravity);
 
     SecondaryVariableCollection secondary_variables;
 
@@ -156,7 +157,7 @@ std::unique_ptr<Process> createHTProcess(
 
     return std::make_unique<HTProcess>(
         mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
+        std::move(process_variables), std::move(material_properties),
         std::move(secondary_variables), std::move(named_function_caller));
 }
 

--- a/ProcessLib/HT/CreateHTProcess.cpp
+++ b/ProcessLib/HT/CreateHTProcess.cpp
@@ -17,7 +17,7 @@
 #include "ProcessLib/Utils/ProcessUtils.h"
 
 #include "HTProcess.h"
-#include "HTProcessData.h"
+#include "HTMaterialProperties.h"
 
 namespace ProcessLib
 {
@@ -134,7 +134,7 @@ std::unique_ptr<Process> createHTProcess(
         std::copy_n(b.data(), b.size(), specific_body_force.data());
     }
 
-    HTProcessData process_data{std::move(porous_media_properties),
+    HTMaterialProperties process_data{std::move(porous_media_properties),
                                density_solid,
                                fluid_reference_density,
                                std::move(fluid_properties),

--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -13,7 +13,7 @@
 #include <vector>
 
 
-#include "HTProcessData.h"
+#include "HTMaterialProperties.h"
 #include "MathLib/LinAlg/Eigen/EigenMapTools.h"
 #include "NumLib/DOF/DOFTableUtil.h"
 #include "NumLib/Extrapolation/ExtrapolatableElement.h"
@@ -87,7 +87,7 @@ public:
                        std::size_t const local_matrix_size,
                        bool is_axially_symmetric,
                        unsigned const integration_order,
-                       HTProcessData const& process_data)
+                       HTMaterialProperties const& process_data)
         : _element(element),
           _process_data(process_data),
           _integration_method(integration_order)
@@ -342,7 +342,7 @@ public:
 
 private:
     MeshLib::Element const& _element;
-    HTProcessData const& _process_data;
+    HTMaterialProperties const& _process_data;
 
     IntegrationMethod const _integration_method;
     std::vector<

--- a/ProcessLib/HT/HTMaterialProperties.h
+++ b/ProcessLib/HT/HTMaterialProperties.h
@@ -22,9 +22,9 @@ struct Parameter;
 
 namespace HT
 {
-struct HTProcessData
+struct HTMaterialProperties
 {
-    HTProcessData(
+    HTMaterialProperties(
         MaterialLib::PorousMedium::PorousMediaProperties&&
             porous_media_properties_,
         ProcessLib::Parameter<double> const& density_solid_,
@@ -52,7 +52,7 @@ struct HTProcessData
     {
     }
 
-    HTProcessData(HTProcessData&& other)
+    HTMaterialProperties(HTMaterialProperties&& other)
         : porous_media_properties(std::move(other.porous_media_properties)),
           density_solid(other.density_solid),
           fluid_reference_density(other.fluid_reference_density),
@@ -70,13 +70,13 @@ struct HTProcessData
     }
 
     //! Copies are forbidden.
-    HTProcessData(HTProcessData const&) = delete;
+    HTMaterialProperties(HTMaterialProperties const&) = delete;
 
     //! Assignments are not needed.
-    void operator=(HTProcessData const&) = delete;
+    void operator=(HTMaterialProperties const&) = delete;
 
     //! Assignments are not needed.
-    void operator=(HTProcessData&&) = delete;
+    void operator=(HTMaterialProperties&&) = delete;
 
     MaterialLib::PorousMedium::PorousMediaProperties porous_media_properties;
     Parameter<double> const& density_solid;

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -23,13 +23,13 @@ HTProcess::HTProcess(
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
     unsigned const integration_order,
     std::vector<std::reference_wrapper<ProcessVariable>>&& process_variables,
-    HTMaterialProperties&& process_data,
+    std::unique_ptr<HTMaterialProperties>&& material_properties,
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller)
     : Process(mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller)),
-      _process_data(std::move(process_data))
+      _material_properties(std::move(material_properties))
 {
 }
 
@@ -42,7 +42,7 @@ void HTProcess::initializeConcreteProcess(
     ProcessLib::createLocalAssemblers<LocalAssemblerData>(
         mesh.getDimension(), mesh.getElements(), dof_table,
         pv.getShapeFunctionOrder(), _local_assemblers,
-        mesh.isAxiallySymmetric(), integration_order, _process_data);
+        mesh.isAxiallySymmetric(), integration_order, *_material_properties);
 
     _secondary_variables.addSecondaryVariable(
         "darcy_velocity",

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -23,7 +23,7 @@ HTProcess::HTProcess(
     std::vector<std::unique_ptr<ParameterBase>> const& parameters,
     unsigned const integration_order,
     std::vector<std::reference_wrapper<ProcessVariable>>&& process_variables,
-    HTProcessData&& process_data,
+    HTMaterialProperties&& process_data,
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller)
     : Process(mesh, std::move(jacobian_assembler), parameters,

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -62,7 +62,7 @@ void HTProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 void HTProcess::assembleWithJacobianConcreteProcess(
@@ -76,7 +76,7 @@ void HTProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 }  // namespace HT

--- a/ProcessLib/HT/HTProcess.h
+++ b/ProcessLib/HT/HTProcess.h
@@ -47,7 +47,7 @@ public:
               unsigned const integration_order,
               std::vector<std::reference_wrapper<ProcessVariable>>&&
                   process_variables,
-              HTMaterialProperties&& process_data,
+              std::unique_ptr<HTMaterialProperties>&& material_properties,
               SecondaryVariableCollection&& secondary_variables,
               NumLib::NamedFunctionCaller&& named_function_caller);
 
@@ -72,7 +72,7 @@ private:
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
         GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
-    HTMaterialProperties _process_data;
+    const std::unique_ptr<HTMaterialProperties> _material_properties;
 
     std::vector<std::unique_ptr<HTLocalAssemblerInterface>> _local_assemblers;
 };

--- a/ProcessLib/HT/HTProcess.h
+++ b/ProcessLib/HT/HTProcess.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "HTFEM.h"
-#include "HTProcessData.h"
+#include "HTMaterialProperties.h"
 #include "NumLib/Extrapolation/LocalLinearLeastSquaresExtrapolator.h"
 #include "ProcessLib/Process.h"
 
@@ -47,7 +47,7 @@ public:
               unsigned const integration_order,
               std::vector<std::reference_wrapper<ProcessVariable>>&&
                   process_variables,
-              HTProcessData&& process_data,
+              HTMaterialProperties&& process_data,
               SecondaryVariableCollection&& secondary_variables,
               NumLib::NamedFunctionCaller&& named_function_caller);
 
@@ -72,7 +72,7 @@ private:
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
         GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
-    HTProcessData _process_data;
+    HTMaterialProperties _process_data;
 
     std::vector<std::unique_ptr<HTLocalAssemblerInterface>> _local_assemblers;
 };

--- a/ProcessLib/HeatConduction/HeatConductionFEM-impl.h
+++ b/ProcessLib/HeatConduction/HeatConductionFEM-impl.h
@@ -110,7 +110,7 @@ void LocalAssemblerData<ShapeFunction, IntegrationMethod, GlobalDim>::
                             std::vector<double>& local_M_data,
                             std::vector<double>& local_K_data,
                             std::vector<double>& /*local_b_data*/,
-                            LocalCouplingTerm const& coupled_term)
+                            LocalCoupledSolutions const& coupled_term)
 {
     for (auto const& coupled_process_pair : coupled_term.coupled_processes)
     {

--- a/ProcessLib/HeatConduction/HeatConductionFEM.h
+++ b/ProcessLib/HeatConduction/HeatConductionFEM.h
@@ -135,7 +135,7 @@ public:
         double const t, std::vector<double> const& local_x,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& /*local_b_data*/,
-        LocalCouplingTerm const& coupled_term) override;
+        LocalCoupledSolutions const& coupled_term) override;
 
     void computeSecondaryVariableConcrete(
         const double t, std::vector<double> const& local_x) override

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -95,7 +95,7 @@ void HeatConductionProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 void HeatConductionProcess::assembleWithJacobianConcreteProcess(
@@ -109,7 +109,7 @@ void HeatConductionProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 void HeatConductionProcess::computeSecondaryVariableConcrete(
@@ -119,7 +119,7 @@ void HeatConductionProcess::computeSecondaryVariableConcrete(
     GlobalExecutor::executeMemberOnDereferenced(
             &HeatConductionLocalAssemblerInterface::computeSecondaryVariable,
             _local_assemblers, *_local_to_global_index_map, t, x,
-            _coupling_term);
+            _coupled_solutions);
 }
 
 }  // namespace HeatConduction

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -35,7 +35,8 @@ HeatConductionProcess::HeatConductionProcess(
 
 void HeatConductionProcess::preTimestepConcreteProcess(GlobalVector const& x,
                                             const double /*t*/,
-                                            const double /*delta_t*/)
+                                            const double /*delta_t*/,
+                                            const int /*process_id*/)
 {
     if (!_x_previous_timestep)
     {

--- a/ProcessLib/HeatConduction/HeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.h
@@ -42,7 +42,8 @@ public:
         double const t, GlobalVector const& x) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, const double t,
-                                    const double delta_t) override;
+                                    const double delta_t,
+                                    const int process_id) override;
 
     // Get the solution of the previous time step.
     GlobalVector* getPreviousTimeStepSolution() const override

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess-impl.h
@@ -200,7 +200,8 @@ void HydroMechanicsProcess<DisplacementDim>::
 }
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt)
+    GlobalVector const& x, double const t, double const dt,
+    const int /*process_id*/)
 {
     DBUG("PreTimestep HydroMechanicsProcess.");
 

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess-impl.h
@@ -180,7 +180,7 @@ void HydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 template <int DisplacementDim>
@@ -196,7 +196,7 @@ void HydroMechanicsProcess<DisplacementDim>::
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -64,8 +64,9 @@ private:
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
         GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt) override;
+    void preTimestepConcreteProcess(
+        GlobalVector const& x, double const t, double const dt,
+        const int process_id) override;
 
     void postTimestepConcreteProcess(GlobalVector const& x) override;
 

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -408,7 +408,7 @@ void HydroMechanicsProcess<GlobalDim>::computeSecondaryVariableConcrete(
     GlobalExecutor::executeMemberOnDereferenced(
         &HydroMechanicsLocalAssemblerInterface::computeSecondaryVariable,
         _local_assemblers, *_local_to_global_index_map, t, x,
-        _coupling_term);
+        _coupled_solutions);
 
     // Copy displacement jumps in a solution vector to mesh property
     // Remark: the copy is required because mesh properties for primary

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
@@ -92,8 +92,9 @@ private:
             dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
     }
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt) override
+    void preTimestepConcreteProcess(
+        GlobalVector const& x, double const t, double const dt,
+        const int /*process_id*/) override
     {
         DBUG("PreTimestep HydroMechanicsProcess.");
 

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
@@ -75,7 +75,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assemble,
             _local_assemblers, *_local_to_global_index_map, t, x, M, K, b,
-            _coupling_term);
+            _coupled_solutions);
     }
 
     void assembleWithJacobianConcreteProcess(
@@ -89,7 +89,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
             _local_assemblers, *_local_to_global_index_map, t, x, xdot,
-            dxdot_dx, dx_dx, M, K, b, Jac, _coupling_term);
+            dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
     }
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
@@ -90,8 +90,9 @@ private:
             dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
     }
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                     double const dt) override
+    void preTimestepConcreteProcess(
+        GlobalVector const& x, double const t, double const dt,
+        const int /*process_id*/) override
     {
         DBUG("PreTimestep SmallDeformationProcess.");
 

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
@@ -73,7 +73,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assemble,
             _local_assemblers, *_local_to_global_index_map, t, x, M, K, b,
-            _coupling_term);
+            _coupled_solutions);
     }
 
     void assembleWithJacobianConcreteProcess(
@@ -87,7 +87,7 @@ private:
         GlobalExecutor::executeMemberDereferenced(
             _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
             _local_assemblers, *_local_to_global_index_map, t, x, xdot,
-            dxdot_dx, dx_dx, M, K, b, Jac, _coupling_term);
+            dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
     }
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
@@ -16,7 +16,7 @@
 
 #include "NumLib/Function/Interpolation.h"
 
-#include "ProcessLib/StaggeredCouplingTerm.h"
+#include "ProcessLib/CoupledSolutionsForStaggeredScheme.h"
 
 #include "ProcessLib/HeatConduction/HeatConductionProcess.h"
 
@@ -60,7 +60,7 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
                             std::vector<double>& local_M_data,
                             std::vector<double>& local_K_data,
                             std::vector<double>& local_b_data,
-                            LocalCouplingTerm const& coupled_term)
+                            LocalCoupledSolutions const& coupled_term)
 {
     SpatialPosition pos;
     pos.setElementID(_element.getID());

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
@@ -268,7 +268,7 @@ LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
     //  the assert must be changed to perm.rows() == _element->getDimension()
     assert(permeability.rows() == GlobalDim || permeability.rows() == 1);
 
-    if (!_coupling_term)
+    if (!_coupled_solutions)
     {
         computeDarcyVelocity(permeability, local_x, veloctiy_cache_vectors);
     }
@@ -276,7 +276,7 @@ LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
     {
         auto const local_coupled_xs =
             getCurrentLocalSolutionsOfCoupledProcesses(
-                _coupling_term->coupled_xs, indices);
+                _coupled_solutions->coupled_xs, indices);
         if (local_coupled_xs.empty())
             computeDarcyVelocity(permeability, local_x, veloctiy_cache_vectors);
         else

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -43,15 +43,16 @@ class LiquidFlowLocalAssemblerInterface
 {
 public:
     LiquidFlowLocalAssemblerInterface(
-        CoupledSolutionsForStaggeredScheme* const coupling_term)
-        : _coupling_term(coupling_term)
+        CoupledSolutionsForStaggeredScheme* const coupled_solutions)
+        : _coupled_solutions(coupled_solutions)
     {
     }
 
-    void setCoupledSolutionsForStaggeredScheme(std::size_t const /*mesh_item_id*/,
-                                  CoupledSolutionsForStaggeredScheme* const coupling_term)
+    void setCoupledSolutionsForStaggeredScheme(
+        std::size_t const /*mesh_item_id*/,
+        CoupledSolutionsForStaggeredScheme* const coupled_solutions)
     {
-        _coupling_term = coupling_term;
+        _coupled_solutions = coupled_solutions;
     }
 
     virtual std::vector<double> const& getIntPtDarcyVelocity(
@@ -61,11 +62,8 @@ public:
         std::vector<double>& /*cache*/) const = 0;
 
 protected:
-    // TODO: remove _coupling_term or move integration point data from local
-    // assembler class to a new class to make local assembler unique for each
-    //process.
     /// Pointer that is set from a Process class.
-    CoupledSolutionsForStaggeredScheme* _coupling_term;
+    CoupledSolutionsForStaggeredScheme* _coupled_solutions;
 };
 
 template <typename ShapeFunction, typename IntegrationMethod,
@@ -95,8 +93,8 @@ public:
         double const gravitational_acceleration,
         double const reference_temperature,
         LiquidFlowMaterialProperties const& material_propertries,
-        CoupledSolutionsForStaggeredScheme* coupling_term)
-        : LiquidFlowLocalAssemblerInterface(coupling_term),
+        CoupledSolutionsForStaggeredScheme* coupled_solutions)
+        : LiquidFlowLocalAssemblerInterface(coupled_solutions),
           _element(element),
           _integration_method(integration_order),
           _shape_matrices(initShapeMatrices<ShapeFunction, ShapeMatricesType,

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -31,7 +31,7 @@
 
 namespace ProcessLib
 {
-struct StaggeredCouplingTerm;
+struct CoupledSolutionsForStaggeredScheme;
 
 namespace LiquidFlow
 {
@@ -43,13 +43,13 @@ class LiquidFlowLocalAssemblerInterface
 {
 public:
     LiquidFlowLocalAssemblerInterface(
-        StaggeredCouplingTerm* const coupling_term)
+        CoupledSolutionsForStaggeredScheme* const coupling_term)
         : _coupling_term(coupling_term)
     {
     }
 
-    void setStaggeredCouplingTerm(std::size_t const /*mesh_item_id*/,
-                                  StaggeredCouplingTerm* const coupling_term)
+    void setCoupledSolutionsForStaggeredScheme(std::size_t const /*mesh_item_id*/,
+                                  CoupledSolutionsForStaggeredScheme* const coupling_term)
     {
         _coupling_term = coupling_term;
     }
@@ -65,7 +65,7 @@ protected:
     // assembler class to a new class to make local assembler unique for each
     //process.
     /// Pointer that is set from a Process class.
-    StaggeredCouplingTerm* _coupling_term;
+    CoupledSolutionsForStaggeredScheme* _coupling_term;
 };
 
 template <typename ShapeFunction, typename IntegrationMethod,
@@ -95,7 +95,7 @@ public:
         double const gravitational_acceleration,
         double const reference_temperature,
         LiquidFlowMaterialProperties const& material_propertries,
-        StaggeredCouplingTerm* coupling_term)
+        CoupledSolutionsForStaggeredScheme* coupling_term)
         : LiquidFlowLocalAssemblerInterface(coupling_term),
           _element(element),
           _integration_method(integration_order),
@@ -118,7 +118,7 @@ public:
         double const t, std::vector<double> const& local_x,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data,
-        LocalCouplingTerm const& coupled_term) override;
+        LocalCoupledSolutions const& coupled_term) override;
 
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         const unsigned integration_point) const override

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -66,7 +66,7 @@ void LiquidFlowProcess::initializeConcreteProcess(
         pv.getShapeFunctionOrder(), _local_assemblers,
         mesh.isAxiallySymmetric(), integration_order, _gravitational_axis_id,
         _gravitational_acceleration, _reference_temperature,
-        *_material_properties, _coupling_term);
+        *_material_properties, _coupled_solutions);
 
     _secondary_variables.addSecondaryVariable(
         "darcy_velocity",
@@ -85,7 +85,7 @@ void LiquidFlowProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 void LiquidFlowProcess::assembleWithJacobianConcreteProcess(
@@ -99,7 +99,7 @@ void LiquidFlowProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 void LiquidFlowProcess::computeSecondaryVariableConcrete(const double t,
@@ -108,15 +108,16 @@ void LiquidFlowProcess::computeSecondaryVariableConcrete(const double t,
     DBUG("Compute the velocity for LiquidFlowProcess.");
     GlobalExecutor::executeMemberOnDereferenced(
         &LiquidFlowLocalAssemblerInterface::computeSecondaryVariable,
-        _local_assemblers, *_local_to_global_index_map, t, x, _coupling_term);
+        _local_assemblers, *_local_to_global_index_map, t, x, _coupled_solutions);
 }
 
 void LiquidFlowProcess::setCoupledSolutionsForStaggeredSchemeToLocalAssemblers()
 {
     DBUG("Compute the velocity for LiquidFlowProcess.");
     GlobalExecutor::executeMemberOnDereferenced(
-        &LiquidFlowLocalAssemblerInterface::setCoupledSolutionsForStaggeredScheme,
-        _local_assemblers, _coupling_term);
+        &LiquidFlowLocalAssemblerInterface::
+            setCoupledSolutionsForStaggeredScheme,
+        _local_assemblers, _coupled_solutions);
 }
 
 }  // end of namespace

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -111,11 +111,11 @@ void LiquidFlowProcess::computeSecondaryVariableConcrete(const double t,
         _local_assemblers, *_local_to_global_index_map, t, x, _coupling_term);
 }
 
-void LiquidFlowProcess::setStaggeredCouplingTermToLocalAssemblers()
+void LiquidFlowProcess::setCoupledSolutionsForStaggeredSchemeToLocalAssemblers()
 {
     DBUG("Compute the velocity for LiquidFlowProcess.");
     GlobalExecutor::executeMemberOnDereferenced(
-        &LiquidFlowLocalAssemblerInterface::setStaggeredCouplingTerm,
+        &LiquidFlowLocalAssemblerInterface::setCoupledSolutionsForStaggeredScheme,
         _local_assemblers, _coupling_term);
 }
 

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -108,7 +108,8 @@ void LiquidFlowProcess::computeSecondaryVariableConcrete(const double t,
     DBUG("Compute the velocity for LiquidFlowProcess.");
     GlobalExecutor::executeMemberOnDereferenced(
         &LiquidFlowLocalAssemblerInterface::computeSecondaryVariable,
-        _local_assemblers, *_local_to_global_index_map, t, x, _coupled_solutions);
+        _local_assemblers, *_local_to_global_index_map, t, x,
+        _coupled_solutions);
 }
 
 void LiquidFlowProcess::setCoupledSolutionsForStaggeredSchemeToLocalAssemblers()

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -88,7 +88,7 @@ public:
         return _material_properties.get();
     }
 
-    void setStaggeredCouplingTermToLocalAssemblers() override;
+    void setCoupledSolutionsForStaggeredSchemeToLocalAssemblers() override;
 
 private:
     void initializeConcreteProcess(

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -11,7 +11,7 @@
 #include <cassert>
 #include "NumLib/DOF/DOFTableUtil.h"
 
-#include "StaggeredCouplingTerm.h"
+#include "CoupledSolutionsForStaggeredScheme.h"
 
 namespace ProcessLib
 {
@@ -20,7 +20,7 @@ void LocalAssemblerInterface::assembleWithCoupledTerm(
     std::vector<double>& /*local_M_data*/,
     std::vector<double>& /*local_K_data*/,
     std::vector<double>& /*local_b_data*/,
-    LocalCouplingTerm const& /*coupling_term*/)
+    LocalCoupledSolutions const& /*coupling_term*/)
 {
     OGS_FATAL(
         "The assembleWithCoupledTerm() function is not implemented in the "
@@ -47,7 +47,7 @@ void LocalAssemblerInterface::assembleWithJacobianAndCoupling(
     std::vector<double>& /*local_K_data*/,
     std::vector<double>& /*local_b_data*/,
     std::vector<double>& /*local_Jac_data*/,
-    LocalCouplingTerm const& /*coupling_term*/)
+    LocalCoupledSolutions const& /*coupling_term*/)
 {
     OGS_FATAL(
         "The assembleWithJacobianAndCoupling() function is not implemented in"
@@ -57,7 +57,7 @@ void LocalAssemblerInterface::assembleWithJacobianAndCoupling(
 void LocalAssemblerInterface::computeSecondaryVariable(
     std::size_t const mesh_item_id,
     NumLib::LocalToGlobalIndexMap const& dof_table, double const t,
-    GlobalVector const& x, StaggeredCouplingTerm const* coupled_term)
+    GlobalVector const& x, CoupledSolutionsForStaggeredScheme const* coupled_term)
 {
     auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
     auto const local_x = x.get(indices);

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -57,7 +57,8 @@ void LocalAssemblerInterface::assembleWithJacobianAndCoupling(
 void LocalAssemblerInterface::computeSecondaryVariable(
     std::size_t const mesh_item_id,
     NumLib::LocalToGlobalIndexMap const& dof_table, double const t,
-    GlobalVector const& x, CoupledSolutionsForStaggeredScheme const* coupled_term)
+    GlobalVector const& x,
+    CoupledSolutionsForStaggeredScheme const* coupled_term)
 {
     auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
     auto const local_x = x.get(indices);

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -20,7 +20,7 @@ void LocalAssemblerInterface::assembleWithCoupledTerm(
     std::vector<double>& /*local_M_data*/,
     std::vector<double>& /*local_K_data*/,
     std::vector<double>& /*local_b_data*/,
-    LocalCoupledSolutions const& /*coupling_term*/)
+    LocalCoupledSolutions const& /*coupled_solutions*/)
 {
     OGS_FATAL(
         "The assembleWithCoupledTerm() function is not implemented in the "
@@ -47,7 +47,7 @@ void LocalAssemblerInterface::assembleWithJacobianAndCoupling(
     std::vector<double>& /*local_K_data*/,
     std::vector<double>& /*local_b_data*/,
     std::vector<double>& /*local_Jac_data*/,
-    LocalCoupledSolutions const& /*coupling_term*/)
+    LocalCoupledSolutions const& /*coupled_solutions*/)
 {
     OGS_FATAL(
         "The assembleWithJacobianAndCoupling() function is not implemented in"

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-
 #include <unordered_map>
 #include <typeindex>
 
@@ -36,17 +35,18 @@ class LocalAssemblerInterface
 public:
     virtual ~LocalAssemblerInterface() = default;
 
-    virtual void assemble(
-        double const t, std::vector<double> const& local_x,
-        std::vector<double>& local_M_data, std::vector<double>& local_K_data,
-        std::vector<double>& local_b_data) = 0;
+    virtual void assemble(double const t, std::vector<double> const& local_x,
+                          std::vector<double>& local_M_data,
+                          std::vector<double>& local_K_data,
+                          std::vector<double>& local_b_data) = 0;
 
-    virtual void assembleWithCoupledTerm(double const t,
-                                   std::vector<double> const& local_x,
-                                   std::vector<double>& local_M_data,
-                                   std::vector<double>& local_K_data,
-                                   std::vector<double>& local_b_data,
-                                   LocalCoupledSolutions const& coupled_solutions);
+    virtual void assembleWithCoupledTerm(
+        double const t,
+        std::vector<double> const& local_x,
+        std::vector<double>& local_M_data,
+        std::vector<double>& local_K_data,
+        std::vector<double>& local_b_data,
+        LocalCoupledSolutions const& coupled_solutions);
 
     virtual void assembleWithJacobian(double const t,
                                       std::vector<double> const& local_x,
@@ -65,10 +65,11 @@ public:
         std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& coupled_solutions);
 
-    virtual void computeSecondaryVariable(std::size_t const mesh_item_id,
-                              NumLib::LocalToGlobalIndexMap const& dof_table,
-                              const double t, GlobalVector const& x,
-                              CoupledSolutionsForStaggeredScheme const* coupled_term);
+    virtual void computeSecondaryVariable(
+        std::size_t const mesh_item_id,
+        NumLib::LocalToGlobalIndexMap const& dof_table, const double t,
+        GlobalVector const& x,
+        CoupledSolutionsForStaggeredScheme const* coupled_term);
 
     virtual void preTimestep(std::size_t const mesh_item_id,
                              NumLib::LocalToGlobalIndexMap const& dof_table,
@@ -95,15 +96,17 @@ private:
     }
 
     virtual void postTimestepConcrete(std::vector<double> const& /*local_x*/) {}
+    virtual void computeSecondaryVariableConcrete(
+        double const /*t*/, std::vector<double> const& /*local_x*/)
+    {
+    }
 
-    virtual void computeSecondaryVariableConcrete
-                (double const /*t*/, std::vector<double> const& /*local_x*/) {}
-
-    virtual void computeSecondaryVariableWithCoupledProcessConcrete
-            (double const /*t*/, std::vector<double> const& /*local_x*/,
-             std::unordered_map<std::type_index,
-             const std::vector<double>> const&
-             /*coupled_local_solutions*/) {}
+    virtual void computeSecondaryVariableWithCoupledProcessConcrete(
+        double const /*t*/, std::vector<double> const& /*local_x*/,
+        std::unordered_map<std::type_index, const std::vector<double>> const&
+        /*coupled_local_solutions*/)
+    {
+    }
 };
 
-} // namespace ProcessLib
+}  // namespace ProcessLib

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -46,7 +46,7 @@ public:
                                    std::vector<double>& local_M_data,
                                    std::vector<double>& local_K_data,
                                    std::vector<double>& local_b_data,
-                                   LocalCoupledSolutions const& coupling_term);
+                                   LocalCoupledSolutions const& coupled_solutions);
 
     virtual void assembleWithJacobian(double const t,
                                       std::vector<double> const& local_x,
@@ -63,7 +63,7 @@ public:
         const double dx_dx, std::vector<double>& local_M_data,
         std::vector<double>& local_K_data, std::vector<double>& local_b_data,
         std::vector<double>& local_Jac_data,
-        LocalCoupledSolutions const& coupling_term);
+        LocalCoupledSolutions const& coupled_solutions);
 
     virtual void computeSecondaryVariable(std::size_t const mesh_item_id,
                               NumLib::LocalToGlobalIndexMap const& dof_table,

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -23,8 +23,8 @@ class LocalToGlobalIndexMap;
 
 namespace ProcessLib
 {
-struct StaggeredCouplingTerm;
-struct LocalCouplingTerm;
+struct CoupledSolutionsForStaggeredScheme;
+struct LocalCoupledSolutions;
 
 /*! Common interface for local assemblers
  * NumLib::ODESystemTag::FirstOrderImplicitQuasilinear ODE systems.
@@ -46,7 +46,7 @@ public:
                                    std::vector<double>& local_M_data,
                                    std::vector<double>& local_K_data,
                                    std::vector<double>& local_b_data,
-                                   LocalCouplingTerm const& coupling_term);
+                                   LocalCoupledSolutions const& coupling_term);
 
     virtual void assembleWithJacobian(double const t,
                                       std::vector<double> const& local_x,
@@ -63,12 +63,12 @@ public:
         const double dx_dx, std::vector<double>& local_M_data,
         std::vector<double>& local_K_data, std::vector<double>& local_b_data,
         std::vector<double>& local_Jac_data,
-        LocalCouplingTerm const& coupling_term);
+        LocalCoupledSolutions const& coupling_term);
 
     virtual void computeSecondaryVariable(std::size_t const mesh_item_id,
                               NumLib::LocalToGlobalIndexMap const& dof_table,
                               const double t, GlobalVector const& x,
-                              StaggeredCouplingTerm const* coupled_term);
+                              CoupledSolutionsForStaggeredScheme const* coupled_term);
 
     virtual void preTimestep(std::size_t const mesh_item_id,
                              NumLib::LocalToGlobalIndexMap const& dof_table,

--- a/ProcessLib/PhaseField/PhaseFieldProcess-impl.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess-impl.h
@@ -162,7 +162,8 @@ void PhaseFieldProcess<DisplacementDim>::assembleWithJacobianConcreteProcess(
 
 template <int DisplacementDim>
 void PhaseFieldProcess<DisplacementDim>::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt)
+    GlobalVector const& x, double const t, double const dt,
+    const int /*process_id*/)
 {
     DBUG("PreTimestep PhaseFieldProcess.");
 

--- a/ProcessLib/PhaseField/PhaseFieldProcess-impl.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess-impl.h
@@ -142,7 +142,7 @@ void PhaseFieldProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 template <int DisplacementDim>
@@ -157,7 +157,7 @@ void PhaseFieldProcess<DisplacementDim>::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/PhaseField/PhaseFieldProcess.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.h
@@ -85,8 +85,9 @@ private:
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
         GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt) override;
+    void preTimestepConcreteProcess(
+        GlobalVector const& x, double const t, double const dt,
+        const int process_id) override;
 
     void postTimestepConcreteProcess(GlobalVector const& x) override;
 

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -15,7 +15,7 @@
 #include "NumLib/ODESolver/ConvergenceCriterionPerComponent.h"
 #include "GlobalVectorFromNamedFunction.h"
 #include "ProcessVariable.h"
-#include "StaggeredCouplingTerm.h"
+#include "CoupledSolutionsForStaggeredScheme.h"
 
 namespace ProcessLib
 {

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -254,7 +254,7 @@ void Process::computeSparsityPattern()
 }
 
 void Process::preTimestep(GlobalVector const& x, const double t,
-                          const double delta_t)
+                          const double delta_t, const int process_id)
 {
     for (auto& cached_var : _cached_secondary_variables)
     {
@@ -262,7 +262,7 @@ void Process::preTimestep(GlobalVector const& x, const double t,
     }
 
     MathLib::LinAlg::setLocalAccessibleVector(x);
-    preTimestepConcreteProcess(x, t, delta_t);
+    preTimestepConcreteProcess(x, t, delta_t, process_id);
 }
 
 void Process::postTimestep(GlobalVector const& x)

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -31,7 +31,7 @@ Process::Process(
       _secondary_variables(std::move(secondary_variables)),
       _named_function_caller(std::move(named_function_caller)),
       _global_assembler(std::move(jacobian_assembler)),
-      _coupling_term(nullptr),
+      _coupled_solutions(nullptr),
       _integration_order(integration_order),
       _process_variables(std::move(process_variables)),
       _boundary_conditions(parameters)

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -65,12 +65,10 @@ void Process::initialize()
          ++variable_id)
     {
         ProcessVariable& pv = _process_variables[variable_id];
-        auto sts =
-            pv.createSourceTerms(*_local_to_global_index_map, variable_id,
-                                 _integration_order);
+        auto sts = pv.createSourceTerms(*_local_to_global_index_map,
+                                        variable_id, _integration_order);
 
-        std::move(sts.begin(), sts.end(),
-                  std::back_inserter(_source_terms));
+        std::move(sts.begin(), sts.end(), std::back_inserter(_source_terms));
     }
 }
 
@@ -109,13 +107,14 @@ void Process::setInitialConditions(double const t, GlobalVector& x)
                         std::abs(_local_to_global_index_map->getGlobalIndex(
                             l, variable_id, component_id));
 #ifdef USE_PETSC
-                    // The global indices of the ghost entries of the global matrix
-                    // or the global vectors need to be set as negative values for
-                    // equation assembly, however the global indices start from
-                    // zero. Therefore, any ghost entry with zero index is assigned
-                    // an negative value of the vector size or the matrix dimension.
-                    // To assign the initial value for the ghost entries, the
-                    // negative indices of the ghost entries are restored to zero.
+                    // The global indices of the ghost entries of the global
+                    // matrix or the global vectors need to be set as negative
+                    // values for equation assembly, however the global indices
+                    // start from zero. Therefore, any ghost entry with zero
+                    // index is assigned an negative value of the vector size
+                    // or the matrix dimension. To assign the initial value for
+                    // the ghost entries, the negative indices of the ghost
+                    // entries are restored to zero.
                     if (global_index == x.size())
                         global_index = 0;
 #endif
@@ -158,7 +157,7 @@ void Process::assembleWithJacobian(const double t, GlobalVector const& x,
     MathLib::LinAlg::setLocalAccessibleVector(xdot);
 
     assembleWithJacobianConcreteProcess(t, x, xdot, dxdot_dx, dx_dx, M, K, b,
-                                       Jac);
+                                        Jac);
 
     // TODO apply BCs to Jacobian.
     _boundary_conditions.applyNaturalBC(t, x, K, b);
@@ -233,7 +232,8 @@ void Process::finishNamedFunctionsInitialization()
     _named_function_caller.applyPlugs();
 
     for (auto const& named_function :
-         _named_function_caller.getNamedFunctions()) {
+         _named_function_caller.getNamedFunctions())
+    {
         auto const& name = named_function.getName();
         _secondary_variables.addSecondaryVariable(
             name,
@@ -254,7 +254,7 @@ void Process::computeSparsityPattern()
 }
 
 void Process::preTimestep(GlobalVector const& x, const double t,
-                 const double delta_t)
+                          const double delta_t)
 {
     for (auto& cached_var : _cached_secondary_variables)
     {
@@ -278,10 +278,11 @@ void Process::computeSecondaryVariable(const double t, GlobalVector const& x)
     computeSecondaryVariableConcrete(t, x);
 }
 
-void Process::preIteration(const unsigned iter, const GlobalVector &x)
+void Process::preIteration(const unsigned iter, const GlobalVector& x)
 {
     // In every new iteration cached values of secondary variables are expired.
-    for (auto& cached_var : _cached_secondary_variables) {
+    for (auto& cached_var : _cached_secondary_variables)
+    {
         cached_var->updateCurrentSolution(x, *_local_to_global_index_map);
     }
 
@@ -289,7 +290,7 @@ void Process::preIteration(const unsigned iter, const GlobalVector &x)
     preIterationConcreteProcess(iter, x);
 }
 
-NumLib::IterationResult Process::postIteration(const GlobalVector &x)
+NumLib::IterationResult Process::postIteration(const GlobalVector& x)
 {
     MathLib::LinAlg::setLocalAccessibleVector(x);
     return postIterationConcreteProcess(x);

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -53,7 +53,7 @@ public:
 
     /// Preprocessing before starting assembly for new timestep.
     void preTimestep(GlobalVector const& x, const double t,
-                     const double delta_t);
+                     const double delta_t, const int process_id);
 
     /// Postprocessing after a complete timestep.
     void postTimestep(GlobalVector const& x);
@@ -153,7 +153,8 @@ private:
 
     virtual void preTimestepConcreteProcess(GlobalVector const& /*x*/,
                                             const double /*t*/,
-                                            const double /*delta_t*/)
+                                            const double /*delta_t*/,
+                                            const int /*process_id*/)
     {
     }
 

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -31,7 +31,7 @@ class Mesh;
 
 namespace ProcessLib
 {
-struct StaggeredCouplingTerm;
+struct CoupledSolutionsForStaggeredScheme;
 
 class Process
     : public NumLib::ODESystem<  // TODO: later on use a simpler ODE system
@@ -71,12 +71,12 @@ public:
 
     MathLib::MatrixSpecifications getMatrixSpecifications() const final;
 
-    void setStaggeredCouplingTerm(StaggeredCouplingTerm* const coupling_term)
+    void setCoupledSolutionsForStaggeredScheme(CoupledSolutionsForStaggeredScheme* const coupling_term)
     {
         _coupling_term = coupling_term;
     }
 
-    virtual void setStaggeredCouplingTermToLocalAssemblers() {}
+    virtual void setCoupledSolutionsForStaggeredSchemeToLocalAssemblers() {}
     void assemble(const double t, GlobalVector const& x, GlobalMatrix& M,
                   GlobalMatrix& K, GlobalVector& b) final;
 
@@ -202,10 +202,10 @@ protected:
 
     VectorMatrixAssembler _global_assembler;
 
-    /// Pointer to StaggeredCouplingTerm, which contains the references to the
+    /// Pointer to CoupledSolutionsForStaggeredScheme, which contains the references to the
     /// coupled processes and the references to the solutions of the coupled
     /// processes.
-    StaggeredCouplingTerm* _coupling_term;
+    CoupledSolutionsForStaggeredScheme* _coupling_term;
 
     /// Order of the integration method for element-wise integration.
     /// The Gauss-Legendre integration method and available orders is

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -71,7 +71,8 @@ public:
 
     MathLib::MatrixSpecifications getMatrixSpecifications() const final;
 
-    void setCoupledSolutionsForStaggeredScheme(CoupledSolutionsForStaggeredScheme* const coupled_solutions)
+    void setCoupledSolutionsForStaggeredScheme(
+        CoupledSolutionsForStaggeredScheme* const coupled_solutions)
     {
         _coupled_solutions = coupled_solutions;
     }
@@ -202,7 +203,8 @@ protected:
 
     VectorMatrixAssembler _global_assembler;
 
-    /// Pointer to CoupledSolutionsForStaggeredScheme, which contains the references to the
+    /// Pointer to CoupledSolutionsForStaggeredScheme, which contains the
+    /// references to the
     /// coupled processes and the references to the solutions of the coupled
     /// processes.
     CoupledSolutionsForStaggeredScheme* _coupled_solutions;

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -71,9 +71,9 @@ public:
 
     MathLib::MatrixSpecifications getMatrixSpecifications() const final;
 
-    void setCoupledSolutionsForStaggeredScheme(CoupledSolutionsForStaggeredScheme* const coupling_term)
+    void setCoupledSolutionsForStaggeredScheme(CoupledSolutionsForStaggeredScheme* const coupled_solutions)
     {
-        _coupling_term = coupling_term;
+        _coupled_solutions = coupled_solutions;
     }
 
     virtual void setCoupledSolutionsForStaggeredSchemeToLocalAssemblers() {}
@@ -205,7 +205,7 @@ protected:
     /// Pointer to CoupledSolutionsForStaggeredScheme, which contains the references to the
     /// coupled processes and the references to the solutions of the coupled
     /// processes.
-    CoupledSolutionsForStaggeredScheme* _coupling_term;
+    CoupledSolutionsForStaggeredScheme* _coupled_solutions;
 
     /// Order of the integration method for element-wise integration.
     /// The Gauss-Legendre integration method and available orders is

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
@@ -70,7 +70,7 @@ void RichardsComponentTransportProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 void RichardsComponentTransportProcess::assembleWithJacobianConcreteProcess(
@@ -84,7 +84,7 @@ void RichardsComponentTransportProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 }  // namespace RichardsComponentTransport

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
@@ -73,7 +73,7 @@ void RichardsFlowProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 void RichardsFlowProcess::assembleWithJacobianConcreteProcess(
@@ -87,7 +87,7 @@ void RichardsFlowProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 }  // namespace RichardsFlow

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
@@ -175,7 +175,8 @@ void SmallDeformationProcess<DisplacementDim>::
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt)
+    GlobalVector const& x, double const t, double const dt,
+    const int /*process_id*/)
 {
     DBUG("PreTimestep SmallDeformationProcess.");
 

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess-impl.h
@@ -150,7 +150,7 @@ void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 template <int DisplacementDim>
@@ -166,7 +166,7 @@ void SmallDeformationProcess<DisplacementDim>::
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 
     b.copyValues(*_nodal_forces);
     std::transform(_nodal_forces->begin(), _nodal_forces->end(),

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -58,8 +58,9 @@ private:
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
         GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt) override;
+    void preTimestepConcreteProcess(
+        GlobalVector const& x, double const t, double const dt,
+        const int process_id) override;
 
     void postTimestepConcreteProcess(GlobalVector const& x) override;
 

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -232,7 +232,7 @@ void TESProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 void TESProcess::assembleWithJacobianConcreteProcess(
@@ -243,7 +243,7 @@ void TESProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 void TESProcess::preTimestepConcreteProcess(GlobalVector const& x,

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -248,7 +248,8 @@ void TESProcess::assembleWithJacobianConcreteProcess(
 
 void TESProcess::preTimestepConcreteProcess(GlobalVector const& x,
                                             const double t,
-                                            const double delta_t)
+                                            const double delta_t,
+                                            const int /*process_id*/)
 {
     DBUG("new timestep");
 

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -41,7 +41,8 @@ public:
                BaseLib::ConfigTree const& config);
 
     void preTimestepConcreteProcess(GlobalVector const& x, const double t,
-                                    const double delta_t) override;
+                                    const double delta_t,
+                                    const int process_id) override;
     void preIterationConcreteProcess(const unsigned iter,
                                      GlobalVector const& x) override;
     NumLib::IterationResult postIterationConcreteProcess(

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
@@ -97,7 +97,8 @@ void ThermalTwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
         dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 void ThermalTwoPhaseFlowWithPPProcess::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const delta_t)
+    GlobalVector const& x, double const t, double const delta_t,
+    const int /*process_id*/)
 {
     DBUG("PreTimestep ThermalTwoPhaseFlowWithPPProcess.");
 

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
@@ -80,7 +80,7 @@ void ThermalTwoPhaseFlowWithPPProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 void ThermalTwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
@@ -94,7 +94,7 @@ void ThermalTwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 void ThermalTwoPhaseFlowWithPPProcess::preTimestepConcreteProcess(
     GlobalVector const& x, double const t, double const delta_t)

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
@@ -68,7 +68,8 @@ private:
         GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, const double t,
-                                    const double delta_t) override;
+                                    const double delta_t,
+                                    const int process_id) override;
 
     ThermalTwoPhaseFlowWithPPProcessData _process_data;
 

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess-impl.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess-impl.h
@@ -154,7 +154,7 @@ void ThermoMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 template <int DisplacementDim>
@@ -172,7 +172,7 @@ void ThermoMechanicsProcess<DisplacementDim>::
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess-impl.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess-impl.h
@@ -177,7 +177,8 @@ void ThermoMechanicsProcess<DisplacementDim>::
 
 template <int DisplacementDim>
 void ThermoMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt)
+    GlobalVector const& x, double const t, double const dt,
+    const int /*process_id*/)
 {
     DBUG("PreTimestep ThermoMechanicsProcess.");
 

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
@@ -58,8 +58,9 @@ private:
         const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
         GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt) override;
+    void preTimestepConcreteProcess(
+        GlobalVector const& x, double const t, double const dt,
+        const int process_id) override;
 
     void postTimestepConcreteProcess(GlobalVector const& x) override;
 

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
@@ -78,7 +78,7 @@ void TwoPhaseFlowWithPPProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 void TwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
@@ -92,7 +92,7 @@ void TwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 }  // end of namespace

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
@@ -78,7 +78,7 @@ void TwoPhaseFlowWithPrhoProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        *_local_to_global_index_map, t, x, M, K, b, _coupling_term);
+        *_local_to_global_index_map, t, x, M, K, b, _coupled_solutions);
 }
 
 void TwoPhaseFlowWithPrhoProcess::assembleWithJacobianConcreteProcess(
@@ -92,7 +92,7 @@ void TwoPhaseFlowWithPrhoProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, *_local_to_global_index_map, t, x, xdot, dxdot_dx,
-        dx_dx, M, K, b, Jac, _coupling_term);
+        dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 void TwoPhaseFlowWithPrhoProcess::preTimestepConcreteProcess(
     GlobalVector const& x, double const t, double const dt)

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
@@ -95,7 +95,8 @@ void TwoPhaseFlowWithPrhoProcess::assembleWithJacobianConcreteProcess(
         dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 void TwoPhaseFlowWithPrhoProcess::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt)
+    GlobalVector const& x, double const t, double const dt,
+    const int /*process_id*/)
 {
     DBUG("PreTimestep TwoPhaseFlowWithPrhoProcess.");
 

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
@@ -64,7 +64,8 @@ private:
         GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, const double t,
-                                    const double delta_t) override;
+                                    const double delta_t,
+                                    const int process_id) override;
 
     TwoPhaseFlowWithPrhoProcessData _process_data;
 

--- a/ProcessLib/UncoupledProcessesTimeLoop.cpp
+++ b/ProcessLib/UncoupledProcessesTimeLoop.cpp
@@ -920,7 +920,8 @@ bool UncoupledProcessesTimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
                 spd->coupled_processes,
                 _solutions_of_coupled_processes[pcs_idx], dt);
 
-            spd->process.setCoupledSolutionsForStaggeredScheme(&coupled_solutions);
+            spd->process.setCoupledSolutionsForStaggeredScheme(
+                &coupled_solutions);
 
             const auto nonlinear_solver_succeeded = solveOneTimeStepOneProcess(
                 x, timestep_id, t, dt, *spd, *_output);
@@ -1038,7 +1039,8 @@ void UncoupledProcessesTimeLoop::outputSolutions(
                 spd->coupled_processes,
                 _solutions_of_coupled_processes[pcs_idx], 0.0);
 
-            spd->process.setCoupledSolutionsForStaggeredScheme(&coupled_solutions);
+            spd->process.setCoupledSolutionsForStaggeredScheme(
+                &coupled_solutions);
             spd->process
                 .setCoupledSolutionsForStaggeredSchemeToLocalAssemblers();
             (output_object.*output_class_member)(pcs, spd->process_output,

--- a/ProcessLib/UncoupledProcessesTimeLoop.cpp
+++ b/ProcessLib/UncoupledProcessesTimeLoop.cpp
@@ -839,7 +839,7 @@ bool UncoupledProcessesTimeLoop::solveUncoupledEquationSystems(
 
         auto& x = *_process_solutions[pcs_idx];
         auto& pcs = spd->process;
-        pcs.preTimestep(x, t, dt);
+        pcs.preTimestep(x, t, dt, pcs_idx);
 
         const auto nonlinear_solver_succeeded =
             solveOneTimeStepOneProcess(x, timestep_id, t, dt, *spd, *_output);
@@ -913,7 +913,7 @@ bool UncoupledProcessesTimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
                 // belongs to process. For some problems, both of the current
                 // solution and the solution of the previous time step are
                 // required for the coupling computation.
-                spd->process.preTimestep(x, t, dt);
+                spd->process.preTimestep(x, t, dt, pcs_idx);
             }
 
             CoupledSolutionsForStaggeredScheme coupled_solutions(
@@ -1032,7 +1032,7 @@ void UncoupledProcessesTimeLoop::outputSolutions(
 
         if (output_initial_condition)
             pcs.preTimestep(x, _start_time,
-                            spd->timestepper->getTimeStep().dt());
+                            spd->timestepper->getTimeStep().dt(), pcs_idx);
         if (is_staggered_coupling)
         {
             CoupledSolutionsForStaggeredScheme coupled_solutions(

--- a/ProcessLib/UncoupledProcessesTimeLoop.cpp
+++ b/ProcessLib/UncoupledProcessesTimeLoop.cpp
@@ -916,11 +916,11 @@ bool UncoupledProcessesTimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
                 spd->process.preTimestep(x, t, dt);
             }
 
-            CoupledSolutionsForStaggeredScheme coupling_term(
+            CoupledSolutionsForStaggeredScheme coupled_solutions(
                 spd->coupled_processes,
                 _solutions_of_coupled_processes[pcs_idx], dt);
 
-            spd->process.setCoupledSolutionsForStaggeredScheme(&coupling_term);
+            spd->process.setCoupledSolutionsForStaggeredScheme(&coupled_solutions);
 
             const auto nonlinear_solver_succeeded = solveOneTimeStepOneProcess(
                 x, timestep_id, t, dt, *spd, *_output);
@@ -1034,12 +1034,13 @@ void UncoupledProcessesTimeLoop::outputSolutions(
                             spd->timestepper->getTimeStep().dt());
         if (is_staggered_coupling)
         {
-            CoupledSolutionsForStaggeredScheme coupling_term(
+            CoupledSolutionsForStaggeredScheme coupled_solutions(
                 spd->coupled_processes,
                 _solutions_of_coupled_processes[pcs_idx], 0.0);
 
-            spd->process.setCoupledSolutionsForStaggeredScheme(&coupling_term);
-            spd->process.setCoupledSolutionsForStaggeredSchemeToLocalAssemblers();
+            spd->process.setCoupledSolutionsForStaggeredScheme(&coupled_solutions);
+            spd->process
+                .setCoupledSolutionsForStaggeredSchemeToLocalAssemblers();
             (output_object.*output_class_member)(pcs, spd->process_output,
                                                  timestep, t, x);
         }

--- a/ProcessLib/UncoupledProcessesTimeLoop.cpp
+++ b/ProcessLib/UncoupledProcessesTimeLoop.cpp
@@ -916,11 +916,11 @@ bool UncoupledProcessesTimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
                 spd->process.preTimestep(x, t, dt);
             }
 
-            StaggeredCouplingTerm coupling_term(
+            CoupledSolutionsForStaggeredScheme coupling_term(
                 spd->coupled_processes,
                 _solutions_of_coupled_processes[pcs_idx], dt);
 
-            spd->process.setStaggeredCouplingTerm(&coupling_term);
+            spd->process.setCoupledSolutionsForStaggeredScheme(&coupling_term);
 
             const auto nonlinear_solver_succeeded = solveOneTimeStepOneProcess(
                 x, timestep_id, t, dt, *spd, *_output);
@@ -1034,12 +1034,12 @@ void UncoupledProcessesTimeLoop::outputSolutions(
                             spd->timestepper->getTimeStep().dt());
         if (is_staggered_coupling)
         {
-            StaggeredCouplingTerm coupling_term(
+            CoupledSolutionsForStaggeredScheme coupling_term(
                 spd->coupled_processes,
                 _solutions_of_coupled_processes[pcs_idx], 0.0);
 
-            spd->process.setStaggeredCouplingTerm(&coupling_term);
-            spd->process.setStaggeredCouplingTermToLocalAssemblers();
+            spd->process.setCoupledSolutionsForStaggeredScheme(&coupling_term);
+            spd->process.setCoupledSolutionsForStaggeredSchemeToLocalAssemblers();
             (output_object.*output_class_member)(pcs, spd->process_output,
                                                  timestep, t, x);
         }

--- a/ProcessLib/VectorMatrixAssembler.cpp
+++ b/ProcessLib/VectorMatrixAssembler.cpp
@@ -21,13 +21,13 @@ namespace ProcessLib
 {
 static std::unordered_map<std::type_index, const std::vector<double>>
 getPreviousLocalSolutionsOfCoupledProcesses(
-    const CoupledSolutionsForStaggeredScheme& coupling_term,
+    const CoupledSolutionsForStaggeredScheme& coupled_solutions,
     const std::vector<GlobalIndexType>& indices)
 {
     std::unordered_map<std::type_index, const std::vector<double>>
         local_coupled_xs0;
 
-    for (auto const& coupled_process_pair : coupling_term.coupled_processes)
+    for (auto const& coupled_process_pair : coupled_solutions.coupled_processes)
     {
         auto const& coupled_pcs = coupled_process_pair.second;
         auto const prevous_time_x = coupled_pcs.getPreviousTimeStepSolution();
@@ -59,7 +59,7 @@ void VectorMatrixAssembler::assemble(
     const std::size_t mesh_item_id, LocalAssemblerInterface& local_assembler,
     const NumLib::LocalToGlobalIndexMap& dof_table, const double t,
     const GlobalVector& x, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
-    const CoupledSolutionsForStaggeredScheme* coupling_term)
+    const CoupledSolutionsForStaggeredScheme* coupled_solutions)
 {
     auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
     auto const local_x = x.get(indices);
@@ -68,7 +68,7 @@ void VectorMatrixAssembler::assemble(
     _local_K_data.clear();
     _local_b_data.clear();
 
-    if (!coupling_term)
+    if (!coupled_solutions)
     {
         local_assembler.assemble(t, local_x, _local_M_data, _local_K_data,
                                  _local_b_data);
@@ -76,9 +76,9 @@ void VectorMatrixAssembler::assemble(
     else
     {
         auto local_coupled_xs0 = getPreviousLocalSolutionsOfCoupledProcesses(
-            *coupling_term, indices);
+            *coupled_solutions, indices);
         auto local_coupled_xs = getCurrentLocalSolutionsOfCoupledProcesses(
-            coupling_term->coupled_xs, indices);
+            coupled_solutions->coupled_xs, indices);
 
         if (local_coupled_xs0.empty() || local_coupled_xs.empty())
         {
@@ -87,13 +87,13 @@ void VectorMatrixAssembler::assemble(
         }
         else
         {
-            ProcessLib::LocalCoupledSolutions local_coupling_term(
-                coupling_term->dt, coupling_term->coupled_processes,
+            ProcessLib::LocalCoupledSolutions local_coupled_solutions(
+                coupled_solutions->dt, coupled_solutions->coupled_processes,
                 std::move(local_coupled_xs0), std::move(local_coupled_xs));
 
             local_assembler.assembleWithCoupledTerm(
                 t, local_x, _local_M_data, _local_K_data, _local_b_data,
-                local_coupling_term);
+                local_coupled_solutions);
         }
     }
 
@@ -123,7 +123,7 @@ void VectorMatrixAssembler::assembleWithJacobian(
     NumLib::LocalToGlobalIndexMap const& dof_table, const double t,
     GlobalVector const& x, GlobalVector const& xdot, const double dxdot_dx,
     const double dx_dx, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
-    GlobalMatrix& Jac, const CoupledSolutionsForStaggeredScheme* coupling_term)
+    GlobalMatrix& Jac, const CoupledSolutionsForStaggeredScheme* coupled_solutions)
 {
     auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
     auto const local_x = x.get(indices);
@@ -134,7 +134,7 @@ void VectorMatrixAssembler::assembleWithJacobian(
     _local_b_data.clear();
     _local_Jac_data.clear();
 
-    if (!coupling_term)
+    if (!coupled_solutions)
     {
         _jacobian_assembler->assembleWithJacobian(
             local_assembler, t, local_x, local_xdot, dxdot_dx, dx_dx,
@@ -143,9 +143,9 @@ void VectorMatrixAssembler::assembleWithJacobian(
     else
     {
         auto local_coupled_xs0 = getPreviousLocalSolutionsOfCoupledProcesses(
-            *coupling_term, indices);
+            *coupled_solutions, indices);
         auto local_coupled_xs = getCurrentLocalSolutionsOfCoupledProcesses(
-            coupling_term->coupled_xs, indices);
+            coupled_solutions->coupled_xs, indices);
         if (local_coupled_xs0.empty() || local_coupled_xs.empty())
         {
             _jacobian_assembler->assembleWithJacobian(
@@ -154,14 +154,14 @@ void VectorMatrixAssembler::assembleWithJacobian(
         }
         else
         {
-            ProcessLib::LocalCoupledSolutions local_coupling_term(
-                coupling_term->dt, coupling_term->coupled_processes,
+            ProcessLib::LocalCoupledSolutions local_coupled_solutions(
+                coupled_solutions->dt, coupled_solutions->coupled_processes,
                 std::move(local_coupled_xs0), std::move(local_coupled_xs));
 
             _jacobian_assembler->assembleWithJacobianAndCoupling(
                 local_assembler, t, local_x, local_xdot, dxdot_dx, dx_dx,
                 _local_M_data, _local_K_data, _local_b_data, _local_Jac_data,
-                local_coupling_term);
+                local_coupled_solutions);
         }
     }
 

--- a/ProcessLib/VectorMatrixAssembler.cpp
+++ b/ProcessLib/VectorMatrixAssembler.cpp
@@ -21,7 +21,7 @@ namespace ProcessLib
 {
 static std::unordered_map<std::type_index, const std::vector<double>>
 getPreviousLocalSolutionsOfCoupledProcesses(
-    const StaggeredCouplingTerm& coupling_term,
+    const CoupledSolutionsForStaggeredScheme& coupling_term,
     const std::vector<GlobalIndexType>& indices)
 {
     std::unordered_map<std::type_index, const std::vector<double>>
@@ -59,7 +59,7 @@ void VectorMatrixAssembler::assemble(
     const std::size_t mesh_item_id, LocalAssemblerInterface& local_assembler,
     const NumLib::LocalToGlobalIndexMap& dof_table, const double t,
     const GlobalVector& x, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
-    const StaggeredCouplingTerm* coupling_term)
+    const CoupledSolutionsForStaggeredScheme* coupling_term)
 {
     auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
     auto const local_x = x.get(indices);
@@ -87,7 +87,7 @@ void VectorMatrixAssembler::assemble(
         }
         else
         {
-            ProcessLib::LocalCouplingTerm local_coupling_term(
+            ProcessLib::LocalCoupledSolutions local_coupling_term(
                 coupling_term->dt, coupling_term->coupled_processes,
                 std::move(local_coupled_xs0), std::move(local_coupled_xs));
 
@@ -123,7 +123,7 @@ void VectorMatrixAssembler::assembleWithJacobian(
     NumLib::LocalToGlobalIndexMap const& dof_table, const double t,
     GlobalVector const& x, GlobalVector const& xdot, const double dxdot_dx,
     const double dx_dx, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
-    GlobalMatrix& Jac, const StaggeredCouplingTerm* coupling_term)
+    GlobalMatrix& Jac, const CoupledSolutionsForStaggeredScheme* coupling_term)
 {
     auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
     auto const local_x = x.get(indices);
@@ -154,7 +154,7 @@ void VectorMatrixAssembler::assembleWithJacobian(
         }
         else
         {
-            ProcessLib::LocalCouplingTerm local_coupling_term(
+            ProcessLib::LocalCoupledSolutions local_coupling_term(
                 coupling_term->dt, coupling_term->coupled_processes,
                 std::move(local_coupled_xs0), std::move(local_coupled_xs));
 

--- a/ProcessLib/VectorMatrixAssembler.h
+++ b/ProcessLib/VectorMatrixAssembler.h
@@ -12,7 +12,7 @@
 #include <vector>
 #include "NumLib/NumericsConfig.h"
 #include "AbstractJacobianAssembler.h"
-#include "StaggeredCouplingTerm.h"
+#include "CoupledSolutionsForStaggeredScheme.h"
 
 namespace NumLib
 {
@@ -40,7 +40,7 @@ public:
                   NumLib::LocalToGlobalIndexMap const& dof_table,
                   double const t, GlobalVector const& x, GlobalMatrix& M,
                   GlobalMatrix& K, GlobalVector& b,
-                  const StaggeredCouplingTerm* coupling_term);
+                  const CoupledSolutionsForStaggeredScheme* coupling_term);
 
     //! Assembles \c M, \c K, \c b, and the Jacobian \c Jac of the residual.
     //! \note The Jacobian must be assembled.
@@ -52,7 +52,7 @@ public:
                               const double dx_dx, GlobalMatrix& M,
                               GlobalMatrix& K, GlobalVector& b,
                               GlobalMatrix& Jac,
-                              const StaggeredCouplingTerm* coupling_term);
+                              const CoupledSolutionsForStaggeredScheme* coupling_term);
 
 private:
     // temporary data only stored here in order to avoid frequent memory

--- a/ProcessLib/VectorMatrixAssembler.h
+++ b/ProcessLib/VectorMatrixAssembler.h
@@ -40,7 +40,7 @@ public:
                   NumLib::LocalToGlobalIndexMap const& dof_table,
                   double const t, GlobalVector const& x, GlobalMatrix& M,
                   GlobalMatrix& K, GlobalVector& b,
-                  const CoupledSolutionsForStaggeredScheme* coupling_term);
+                  const CoupledSolutionsForStaggeredScheme* coupled_solutions);
 
     //! Assembles \c M, \c K, \c b, and the Jacobian \c Jac of the residual.
     //! \note The Jacobian must be assembled.
@@ -52,7 +52,7 @@ public:
                               const double dx_dx, GlobalMatrix& M,
                               GlobalMatrix& K, GlobalVector& b,
                               GlobalMatrix& Jac,
-                              const CoupledSolutionsForStaggeredScheme* coupling_term);
+                              const CoupledSolutionsForStaggeredScheme* coupled_solutions);
 
 private:
     // temporary data only stored here in order to avoid frequent memory

--- a/Tests/NumLib/TimeLoopSingleODE.h
+++ b/Tests/NumLib/TimeLoopSingleODE.h
@@ -14,7 +14,7 @@
 #include "NumLib/ODESolver/NonlinearSolver.h"
 #include "MathLib/LinAlg/LinAlg.h"
 
-#include "ProcessLib/StaggeredCouplingTerm.h"
+#include "ProcessLib/CoupledSolutionsForStaggeredScheme.h"
 
 namespace NumLib
 {

--- a/Tests/NumLib/TimeLoopSingleODE.h
+++ b/Tests/NumLib/TimeLoopSingleODE.h
@@ -14,8 +14,6 @@
 #include "NumLib/ODESolver/NonlinearSolver.h"
 #include "MathLib/LinAlg/LinAlg.h"
 
-#include "ProcessLib/CoupledSolutionsForStaggeredScheme.h"
-
 namespace NumLib
 {
 //! \addtogroup ODESolver


### PR DESCRIPTION
1. Changed the names of structs,  variables that are related to the coupled terms.
2. Changed the name and the type of HTProcessData to HTMaterialProperties (std::unique_ptr).
3. Added an argument to a member function of classes of processes.
4. removed an unused include.

This PR is a part of PR #1970.