### PR TITLE
[MatL] KelvinVector: Use vector norm in assertion.

### DIFF
--- a/MaterialLib/SolidModels/KelvinVector-impl.h
+++ b/MaterialLib/SolidModels/KelvinVector-impl.h
@@ -15,8 +15,8 @@ template <int KelvinVectorSize>
 double Invariants<KelvinVectorSize>::equivalentStress(
     Eigen::Matrix<double, KelvinVectorSize, 1> const& deviatoric_v)
 {
-    assert(std::abs(trace(deviatoric_v)) <
-           std::numeric_limits<double>::epsilon() * 100);
+    assert(std::abs(trace(deviatoric_v)) <=
+           1e-16 * std::abs(deviatoric_v.squaredNorm()));
     return std::sqrt(3 * J2(deviatoric_v));
 }
 
@@ -24,8 +24,8 @@ template <int KelvinVectorSize>
 double Invariants<KelvinVectorSize>::J2(
     Eigen::Matrix<double, KelvinVectorSize, 1> const& deviatoric_v)
 {
-    assert(std::abs(trace(deviatoric_v)) <
-           std::numeric_limits<double>::epsilon() * 100);
+    assert(std::abs(trace(deviatoric_v)) <=
+           1e-16 * std::abs(deviatoric_v.squaredNorm()));
     return 0.5 * deviatoric_v.transpose() * deviatoric_v;
 }
 
@@ -35,8 +35,8 @@ template <int KelvinVectorSize>
 double Invariants<KelvinVectorSize>::J3(
     Eigen::Matrix<double, KelvinVectorSize, 1> const& deviatoric_v)
 {
-    assert(std::abs(trace(deviatoric_v)) <
-           std::numeric_limits<double>::epsilon() * 100);
+    assert(std::abs(trace(deviatoric_v)) <=
+           1e-16 * std::abs(deviatoric_v.squaredNorm()));
     return determinant(deviatoric_v);
 }
 


### PR DESCRIPTION
The trace of deviatoric tensor must be zero but is
linearly scaling with the tensor's norm.