### PR TITLE
[Jenkins] Added warnings parser

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -229,7 +229,8 @@ pipeline {
             always {
               publishReports { }
               warnings(canResolveRelativePaths: false,
-                  consoleParsers: [[parserName: 'MSBuild']])
+                  consoleParsers: [[parserName: 'MSBuild']],
+                  messagesPattern: '.*\\.conan.*')
             }
             failure {
                 dir('build') { deleteDir() }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,10 @@ pipeline {
           post {
             always {
               publishReports { }
+              script {
+                warnings(canResolveRelativePaths: false,
+                  consoleParsers: [[parserName: 'GNU C Compiler 4 (gcc)']])
+              }
             }
             failure {
                 dir('build') { deleteDir() }
@@ -224,6 +228,8 @@ pipeline {
           post {
             always {
               publishReports { }
+              warnings(canResolveRelativePaths: false,
+                  consoleParsers: [[parserName: 'MSBuild']])
             }
             failure {
                 dir('build') { deleteDir() }
@@ -370,6 +376,8 @@ pipeline {
           post {
             always {
               dir('build') { deleteDir() }
+              warnings(canResolveRelativePaths: false,
+                  consoleParsers: [[parserName: 'Clang (LLVM based)']])
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -399,6 +399,11 @@ pipeline {
           }
         }
       } // end parallel
+      post {
+        always {
+          step([$class: 'AnalysisPublisher', unstableNewAll: '1'])
+        }
+      }
     } // end stage master
   }
 }


### PR DESCRIPTION
Added warnings logger for GCC, MSVC and Clang (only on master). Warnings are shown on the "classic" Jenkins UI only, e.g. [here](https://jenkins.opengeosys.org/job/ufz/job/ogs/job/PR-2006/2/). There are both links on the left navigation list and on the build summary page.

Also it should mark builds as unstable when there are new warnings introduced, but we have to check after merge if this really works.