### PR TITLE
Lie preparations

### DIFF
--- a/ProcessLib/LIE/Common/FractureProperty.h
+++ b/ProcessLib/LIE/Common/FractureProperty.h
@@ -36,6 +36,12 @@ struct FractureProperty
     Eigen::MatrixXd R;
     /// Initial aperture
     ProcessLib::Parameter<double> const* aperture0 = nullptr;
+
+    virtual ~FractureProperty() = default;
+};
+
+struct FracturePropertyHM : public FractureProperty
+{
     ProcessLib::Parameter<double> const* specific_storage = nullptr;
     ProcessLib::Parameter<double> const* biot_coefficient = nullptr;
 };

--- a/ProcessLib/LIE/Common/PostUtils.h
+++ b/ProcessLib/LIE/Common/PostUtils.h
@@ -26,7 +26,7 @@ namespace LIE
 ///
 /// The tool creates a new mesh containing duplicated fracture nodes
 /// to represent geometric discontinuities in visualization.
-class PostProcessTool
+class PostProcessTool final
 {
 public:
     PostProcessTool(

--- a/ProcessLib/LIE/HydroMechanics/CreateHydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/CreateHydroMechanicsProcess.cpp
@@ -257,7 +257,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     }
 
     // Fracture properties
-    std::unique_ptr<FractureProperty> frac_prop = nullptr;
+    std::unique_ptr<FracturePropertyHM> frac_prop = nullptr;
     auto opt_fracture_properties_config =
         //! \ogs_file_param{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__fracture_properties}
         config.getConfigSubtreeOptional("fracture_properties");
@@ -265,7 +265,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     {
         auto& fracture_properties_config = *opt_fracture_properties_config;
 
-        frac_prop = std::make_unique<ProcessLib::LIE::FractureProperty>();
+        frac_prop = std::make_unique<ProcessLib::LIE::FracturePropertyHM>();
         frac_prop->mat_id =
             //! \ogs_file_param{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__fracture_properties__material_id}
             fracture_properties_config.getConfigParameter<int>("material_id");

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcessData.h
@@ -49,7 +49,7 @@ struct HydroMechanicsProcessData
             specific_body_force_,
         std::unique_ptr<MaterialLib::Fracture::FractureModelBase<GlobalDim>>&&
             fracture_model,
-        std::unique_ptr<FractureProperty>&& fracture_prop,
+        std::unique_ptr<FracturePropertyHM>&& fracture_prop,
         Parameter<double> const& initial_effective_stress_,
         Parameter<double> const& initial_fracture_effective_stress_,
         bool const deactivate_matrix_in_flow_)
@@ -113,8 +113,7 @@ struct HydroMechanicsProcessData
     Eigen::Matrix<double, GlobalDim, 1> const specific_body_force;
     std::unique_ptr<MaterialLib::Fracture::FractureModelBase<GlobalDim>>
         fracture_model;
-    std::unique_ptr<FractureProperty> fracture_property;
-
+    std::unique_ptr<FracturePropertyHM> fracture_property;
     Parameter<double> const& initial_effective_stress;
     Parameter<double> const& initial_fracture_effective_stress;
 

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
@@ -170,7 +170,7 @@ void HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
 
     // the index of a normal (normal to a fracture plane) component
     // in a displacement vector
-    auto const index_normal = GlobalDim - 1;
+    auto constexpr index_normal = GlobalDim - 1;
 
     typename ShapeMatricesTypePressure::NodalMatrixType laplace_p =
         ShapeMatricesTypePressure::NodalMatrixType::Zero(pressure_size,
@@ -329,7 +329,7 @@ void HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
     auto const& R = frac_prop.R;
     // the index of a normal (normal to a fracture plane) component
     // in a displacement vector
-    auto const index_normal = GlobalDim - 1;
+    auto constexpr index_normal = GlobalDim - 1;
 
     SpatialPosition x_position;
     x_position.setElementID(_element.getID());

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
@@ -61,7 +61,7 @@ HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
                           IntegrationMethod, GlobalDim>(e, is_axially_symmetric,
                                                         integration_method);
 
-    auto const& frac_prop = *_process_data.fracture_property.get();
+    auto const& frac_prop = *_process_data.fracture_property;
 
     SpatialPosition x_position;
     x_position.setElementID(e.getID());
@@ -164,7 +164,7 @@ void HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
         Eigen::Ref<Eigen::MatrixXd>
             J_gp)
 {
-    FractureProperty const& frac_prop = *_process_data.fracture_property;
+    auto const& frac_prop = *_process_data.fracture_property;
     auto const& R = frac_prop.R;
     double const& dt = _process_data.dt;
 
@@ -326,7 +326,7 @@ void HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
     auto const nodal_p = local_x.segment(pressure_index, pressure_size);
     auto const nodal_g = local_x.segment(displacement_index, displacement_size);
 
-    FractureProperty const& frac_prop = *_process_data.fracture_property;
+    auto const& frac_prop = *_process_data.fracture_property;
     auto const& R = frac_prop.R;
     // the index of a normal (normal to a fracture plane) component
     // in a displacement vector

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
@@ -384,8 +384,7 @@ void HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
             effective_stress_prev, effective_stress, C, state);
 
         // permeability
-        double const local_k = b_m * b_m / 12;
-        ip_data.permeability = local_k;
+        double const local_k = ip_data.permeability;
         local_k_tensor.diagonal().head(GlobalDim - 1).setConstant(local_k);
         GlobalDimMatrix const k = R.transpose() * local_k_tensor * R;
 

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture-impl.h
@@ -81,7 +81,7 @@ void HydroMechanicsLocalAssemblerMatrixNearFracture<
 
     if (ele_levelset == 0)
     {
-        // no DoF exists for displacement jumps. do the normal assebmly
+        // no DoF exists for displacement jumps. do the normal assembly
         Base::assembleBlockMatricesWithJacobian(t, p, p_dot, u, u_dot, rhs_p,
                                                 rhs_u, J_pp, J_pu, J_uu, J_up);
         return;
@@ -144,7 +144,7 @@ void HydroMechanicsLocalAssemblerMatrixNearFracture<
 
     if (ele_levelset == 0)
     {
-        // no DoF exists for displacement jumps. do the normal assebmly
+        // no DoF exists for displacement jumps. do the normal assembly
         Base::computeSecondaryVariableConcreteWithBlockVectors(t, p, u);
         return;
     }

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/IntegrationPointDataFracture.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/IntegrationPointDataFracture.h
@@ -50,8 +50,6 @@ struct IntegrationPointDataFracture final
     Eigen::MatrixXd C;
     double integration_weight;
 
-    Eigen::Vector3d darcy_velocity;
-
     void pushBackState()
     {
         w_prev = w;

--- a/ProcessLib/LIE/HydroMechanics/Tests.cmake
+++ b/ProcessLib/LIE/HydroMechanics/Tests.cmake
@@ -11,6 +11,14 @@ AddTest(
     expected_single_fracture_pcs_0_ts_10_t_100.000000.vtu single_fracture_pcs_0_ts_10_t_100.000000.vtu pressure pressure 1e-12 1e-12
     expected_single_fracture_pcs_0_ts_10_t_100.000000.vtu single_fracture_pcs_0_ts_10_t_100.000000.vtu displacement displacement 1e-12 1e-12
     expected_single_fracture_pcs_0_ts_10_t_100.000000.vtu single_fracture_pcs_0_ts_10_t_100.000000.vtu displacement_jump1 displacement_jump1 1e-12 1e-12
+    expected_single_fracture_pcs_0_ts_10_t_100.000000.vtu single_fracture_pcs_0_ts_10_t_100.000000.vtu nodal_w nodal_w 1e-12 1e-12
+    expected_single_fracture_pcs_0_ts_10_t_100.000000.vtu single_fracture_pcs_0_ts_10_t_100.000000.vtu nodal_aperture nodal_aperture 1e-12 1e-12
+    expected_single_fracture_pcs_0_ts_10_t_100.000000.vtu single_fracture_pcs_0_ts_10_t_100.000000.vtu strain_xx strain_xx 1e-12 1e-12
+    expected_single_fracture_pcs_0_ts_10_t_100.000000.vtu single_fracture_pcs_0_ts_10_t_100.000000.vtu strain_yy strain_yy 1e-12 1e-12
+    expected_single_fracture_pcs_0_ts_10_t_100.000000.vtu single_fracture_pcs_0_ts_10_t_100.000000.vtu strain_xy strain_xy 1e-12 1e-12
+    expected_single_fracture_pcs_0_ts_10_t_100.000000.vtu single_fracture_pcs_0_ts_10_t_100.000000.vtu stress_xx stress_xx 1e-12 1e-12
+    expected_single_fracture_pcs_0_ts_10_t_100.000000.vtu single_fracture_pcs_0_ts_10_t_100.000000.vtu stress_yy stress_yy 1e-12 1e-12
+    expected_single_fracture_pcs_0_ts_10_t_100.000000.vtu single_fracture_pcs_0_ts_10_t_100.000000.vtu velocity velocity 1e-12 1e-12
 )
 
 AddTest(
@@ -25,6 +33,16 @@ AddTest(
     expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu pressure pressure 1e-12 1e-12
     expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu displacement displacement 1e-12 1e-12
     expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu displacement_jump1 displacement_jump1 1e-12 1e-12
+    expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu strain_xx strain_xx 1e-12 1e-12
+    expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu strain_yy strain_yy 1e-12 1e-12
+    expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu strain_zz strain_zz 1e-12 1e-12
+    expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu strain_xy strain_xy 1e-12 1e-12
+    expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu strain_xz strain_xz 1e-12 1e-12
+    expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu strain_yz strain_yz 1e-12 1e-12
+    expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu stress_xx stress_xx 1e-12 1e-12
+    expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu stress_yy stress_yy 1e-12 1e-12
+    expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu stress_zz stress_zz 1e-12 1e-12
+    expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu velocity velocity 1e-12 1e-12
 )
 
 AddTest(
@@ -39,4 +57,10 @@ AddTest(
     expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu pressure pressure 1e-12 1e-12
     expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu displacement displacement 1e-12 1e-12
     expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu displacement_jump1 displacement_jump1 1e-12 1e-12
+    expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu strain_xx strain_xx 1e-12 1e-12
+    expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu strain_yy strain_yy 1e-12 1e-12
+    expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu strain_xy strain_xy 1e-12 1e-12
+    expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu stress_xx stress_xx 1e-12 1e-12
+    expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu stress_yy stress_yy 1e-12 1e-12
+    expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu velocity velocity 1e-12 1e-12
 )


### PR DESCRIPTION
Few renames and simplifications for the upcoming PRs for fracture permeability models (https://github.com/ufz/ogs/pull/2014) and pressure interpolation (https://github.com/ufz/ogs/pull/2015).
 
One small logic change is the separation of FracturePropertyHM class from FractureProperty. [[PL] LIE/HM: Separate FractureProperty for HM.](https://github.com/ufz/ogs/commit/a36d5f7ea3f1c7b55865b8b58ada3c17d4c106d7)