### PR TITLE
[BL] Use implementation specific [[noreturn]].

### DIFF
--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -526,7 +526,12 @@ private:
      *
      * This method only acts as a helper method and throws std::runtime_error.
      */
-    [[noreturn]] void error(std::string const& message) const;
+#if defined(_MSC_VER) && _MSC_VER < 1500
+    __declspec(noreturn)
+#else
+    [[noreturn]]
+#endif
+        void error(std::string const& message) const;
 
     //! Called for printing warning messages. Will call the warning callback.
     //! This method only acts as a helper method.

--- a/BaseLib/Error.h
+++ b/BaseLib/Error.h
@@ -19,7 +19,12 @@ namespace BaseLib
 namespace detail
 {
 template <typename Msg>
-[[noreturn]] bool error_impl(Msg&& msg)
+#if defined(_MSC_VER) && _MSC_VER < 1500
+__declspec(noreturn)
+#else
+[[noreturn]]
+#endif
+    bool error_impl(Msg&& msg)
 {
     ERR("%s", msg.data());
     std::abort();
@@ -38,7 +43,12 @@ namespace BaseLib
 namespace detail
 {
 template <typename Msg>
-[[noreturn]] bool error_impl(Msg&& msg)
+#if defined(_MSC_VER) && _MSC_VER < 1500
+__declspec(noreturn)
+#else
+[[noreturn]]
+#endif
+    bool error_impl(Msg&& msg)
 {
     throw std::runtime_error(std::forward<Msg>(msg));
 }


### PR DESCRIPTION
Unfortunately the Visual Studio 2015 does not support
the platform independent style for the function attributes.
Although it is a c++11 standard.

Closes https://github.com/ufz/ogs/issues/2024