### PR TITLE
Conan PETSc

### DIFF
--- a/BaseLib/LogogCustomCout.h
+++ b/BaseLib/LogogCustomCout.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <ostream>
+#include <iostream>
 
 #include <logog/include/logog.hpp>
 

--- a/scripts/cmake/ConanSetup.cmake
+++ b/scripts/cmake/ConanSetup.cmake
@@ -36,6 +36,10 @@ if(OGS_USE_MPI)
     set(CONAN_OPTIONS ${CONAN_OPTIONS} VTK:mpi=True)
 endif()
 
+if(OGS_USE_PETSC)
+    set(CONAN_REQUIRES ${CONAN_REQUIRES} petsc/3.8.3@bilke/testing)
+endif()
+
 if(OGS_BUILD_GUI)
     set(CONAN_REQUIRES ${CONAN_REQUIRES}
         Shapelib/1.3.0@bilke/stable


### PR DESCRIPTION
As requested by Keita. Not officially supported but works on macOS:

```bash
brew install open-mpi # (MPI installed via Homebrew is required)
...
CC=mpicc CXX=mpic++ cmake ../ogs -DCMAKE_BUILD_TYPE=Release -DOGS_USE_PETSC=ON -DOGS_USE_CONAN=ON
[builds VTK Conan package with MPI support locally]
[builds Petsc Conan package locally]
make ctest
```