### PR TITLE
Check header for standalone compilation

### DIFF
--- a/BaseLib/CMakeLists.txt
+++ b/BaseLib/CMakeLists.txt
@@ -41,3 +41,5 @@ endif()
 if(OGS_USE_PCH)
     cotire(BaseLib)
 endif()
+
+check_header_compilation()

--- a/BaseLib/CMakeLists.txt
+++ b/BaseLib/CMakeLists.txt
@@ -41,5 +41,3 @@ endif()
 if(OGS_USE_PCH)
     cotire(BaseLib)
 endif()
-
-check_header_compilation()

--- a/BaseLib/DebugTools.h
+++ b/BaseLib/DebugTools.h
@@ -13,8 +13,9 @@
 
 #pragma once
 
-#include <ostream>
 #include <algorithm>
+#include <iterator>
+#include <ostream>
 #include <vector>
 
 template<typename T>

--- a/BaseLib/reorderVector.h
+++ b/BaseLib/reorderVector.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <vector>
+
 namespace BaseLib
 {
 /**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,8 @@ include_directories( SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/autocheck/inc
 include_directories( SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/tclap/include )
 include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/vtkGUISupportQt)
 
+include(scripts/cmake/CheckHeaderCompilation.cmake)
+
 add_subdirectory( Applications )
 add_subdirectory( BaseLib )
 # TODO This is a hack but we have to make sure that Boost is built first

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,5 +296,7 @@ endif() # OGS_BUILD_TESTS
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/BaseLib/BuildInfo.cpp.in"
     "${CMAKE_CURRENT_BINARY_DIR}/BaseLib/BuildInfo.cpp" @ONLY)
 
+check_header_compilation()
+
 include(scripts/cmake/MarkVariablesAdvanced.cmake)
 unset(PRE_INSTALL_RUN CACHE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,8 @@ option(OGS_ENABLE_ELEMENT_CUBOID  "Build FEM elements for cuboids (quads, hexahe
 option(OGS_ENABLE_ELEMENT_PRISM   "Build FEM elements for prisms." ON)
 option(OGS_ENABLE_ELEMENT_PYRAMID "Build FEM elements for pyramids." ON)
 
+option(OGS_CHECK_HEADER_COMPILATION "Check header for standalone compilation." OFF)
+
 ###################
 ### Definitions ###
 ###################

--- a/GeoLib/CMakeLists.txt
+++ b/GeoLib/CMakeLists.txt
@@ -34,5 +34,3 @@ endif()
 
 include(${PROJECT_SOURCE_DIR}/scripts/cmake/packaging/InstallXmlSchemaFiles.cmake)
 InstallXmlSchemaFiles("IO/XmlIO/*.xsd")
-
-#check_header_compilation(GeoLib)

--- a/GeoLib/CMakeLists.txt
+++ b/GeoLib/CMakeLists.txt
@@ -34,3 +34,5 @@ endif()
 
 include(${PROJECT_SOURCE_DIR}/scripts/cmake/packaging/InstallXmlSchemaFiles.cmake)
 InstallXmlSchemaFiles("IO/XmlIO/*.xsd")
+
+#check_header_compilation(GeoLib)

--- a/GeoLib/QuadTree.h
+++ b/GeoLib/QuadTree.h
@@ -14,10 +14,11 @@
 
 #pragma once
 
+#include <cassert>
 #include <limits>
+#include <utility>
 
 #include <logog/include/logog.hpp>
-#include <utility>
 
 namespace GeoLib
 {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,6 +117,7 @@ pipeline {
                   config = 'Debug'
                 }
               }
+              build { target = 'check-header' }
               build { }
               build { target = 'tests' }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,6 @@ pipeline {
                   config = 'Debug'
                 }
               }
-              build { target = 'check-header' }
               build { }
               build { target = 'tests' }
             }
@@ -308,6 +307,33 @@ pipeline {
     stage('Master') {
       when { environment name: 'JOB_NAME', value: 'ufz/ogs/master' }
       parallel {
+        // ************************ Check-Header *******************************
+        stage('Check-Header') {
+          agent {
+            dockerfile {
+              filename 'Dockerfile.gcc.minimal'
+              dir 'scripts/docker'
+              label 'docker'
+              args '-v ccache:/home/jenkins/cache/ccache -v conan-cache:/home/jenkins/cache/conan'
+              additionalBuildArgs '--pull'
+            }
+          }
+          steps {
+            script {
+              lock(resource: "conanCache-${env.NODE_NAME}") {
+                sh 'find $CONAN_USER_HOME -name "system_reqs.txt" -exec rm {} \\;'
+                configure {
+                  cmakeOptions =
+                    '-DOGS_USE_CONAN=ON ' +
+                    '-DOGS_CONAN_BUILD=never '
+                  config = 'Debug'
+                }
+              }
+              build { target = 'check-header' }
+            }
+          }
+          post { always { dir('build') { deleteDir() } } }
+        }
         // ************************* Deploy Web ********************************
         stage('Deploy Web') {
           agent any

--- a/MaterialLib/Adsorption/ReactionSinusoidal.h
+++ b/MaterialLib/Adsorption/ReactionSinusoidal.h
@@ -13,6 +13,7 @@
 
 #include "Reaction.h"
 #include "BaseLib/ConfigTree.h"
+#include "BaseLib/Error.h"
 #include "BaseLib/StringTools.h"
 
 namespace Adsorption

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturation.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturation.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <limits>
 #include <string>
 
 namespace MaterialLib

--- a/NumLib/Assembler/SerialExecutor.h
+++ b/NumLib/Assembler/SerialExecutor.h
@@ -12,6 +12,9 @@
 
 #pragma once
 
+#include <cstddef>
+#include <utility>
+
 namespace NumLib
 {
 

--- a/NumLib/Fem/Integration/IntegrationGaussPrism.h
+++ b/NumLib/Fem/Integration/IntegrationGaussPrism.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "MathLib/TemplateWeightedPoint.h"
 #include "MathLib/Integration/GaussLegendre.h"
 #include "MathLib/Integration/GaussLegendreTri.h"
 

--- a/NumLib/Fem/Integration/IntegrationGaussPyramid.h
+++ b/NumLib/Fem/Integration/IntegrationGaussPyramid.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "MathLib/TemplateWeightedPoint.h"
 #include "MathLib/Integration/GaussLegendrePyramid.h"
 
 namespace NumLib

--- a/NumLib/Fem/Integration/IntegrationGaussTet.h
+++ b/NumLib/Fem/Integration/IntegrationGaussTet.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "MathLib/TemplateWeightedPoint.h"
 #include "MathLib/Integration/GaussLegendreTet.h"
 
 namespace NumLib

--- a/NumLib/Fem/Integration/IntegrationGaussTri.h
+++ b/NumLib/Fem/Integration/IntegrationGaussTri.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "MathLib/TemplateWeightedPoint.h"
 #include "MathLib/Integration/GaussLegendreTri.h"
 
 namespace NumLib

--- a/NumLib/Fem/Integration/IntegrationPoint.h
+++ b/NumLib/Fem/Integration/IntegrationPoint.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "MathLib/TemplateWeightedPoint.h"
+
 namespace NumLib
 {
 /// Integration rule for point elements.

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryConditionLocalAssembler.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "NumLib/DOF/LocalToGlobalIndexMap.h"
 #include "NumLib/Fem/ShapeMatrixPolicy.h"
 #include "ProcessLib/Utils/InitShapeMatrices.h"
 

--- a/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/GenericNonuniformNaturalBoundaryConditionLocalAssembler.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "NumLib/DOF/LocalToGlobalIndexMap.h"
 #include "NumLib/Fem/ShapeMatrixPolicy.h"
 #include "ProcessLib/Utils/InitShapeMatrices.h"
 

--- a/ProcessLib/BoundaryCondition/NormalTractionBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/NormalTractionBoundaryConditionLocalAssembler.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "MeshLib/Elements/FaceRule.h"
 #include "MathLib/LinAlg/Eigen/EigenMapTools.h"
 #include "NumLib/DOF/DOFTableUtil.h"
 #include "ProcessLib/Parameter/Parameter.h"

--- a/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFluxLocalAssembler.h
+++ b/ProcessLib/CalculateSurfaceFlux/CalculateSurfaceFluxLocalAssembler.h
@@ -12,8 +12,9 @@
 #include "NumLib/Fem/ShapeMatrixPolicy.h"
 
 #include "NumLib/DOF/DOFTableUtil.h"
-#include "ProcessLib/Parameter/Parameter.h"
 
+#include "ProcessLib/Process.h"
+#include "ProcessLib/Parameter/Parameter.h"
 #include "ProcessLib/Utils/InitShapeMatrices.h"
 
 #include "MapBulkElementPoint.h"

--- a/ProcessLib/Deformation/LinearBMatrix.h
+++ b/ProcessLib/Deformation/LinearBMatrix.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "ProcessLib/Deformation/BMatrixPolicy.h"
+
 #include <cmath>
 
 namespace ProcessLib

--- a/ProcessLib/HT/HTLocalAssemblerInterface.h
+++ b/ProcessLib/HT/HTLocalAssemblerInterface.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "NumLib/Extrapolation/ExtrapolatableElement.h"
 #include "NumLib/Function/Interpolation.h"
 #include "ProcessLib/LocalAssemblerInterface.h"
 #include "MathLib/LinAlg/Eigen/EigenMapTools.h"

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
@@ -9,6 +9,11 @@
 
 #pragma once
 
+#include "ProcessLib/Parameter/Parameter.h"
+
+#include <memory>
+#include <utility>
+
 #include <Eigen/Dense>
 
 namespace MaterialLib

--- a/ProcessLib/HydroMechanics/LocalAssemblerInterface.h
+++ b/ProcessLib/HydroMechanics/LocalAssemblerInterface.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "NumLib/Extrapolation/ExtrapolatableElement.h"
 #include "ProcessLib/LocalAssemblerInterface.h"
 
 namespace ProcessLib

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SecondaryData.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SecondaryData.h
@@ -9,6 +9,12 @@
 
 #pragma once
 
+#include <vector>
+
+#include <Eigen/Eigen>
+
+#include "NumLib/Fem/CoordinatesMapping/ShapeMatrices.h"
+
 namespace ProcessLib
 {
 namespace LIE

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -17,6 +17,8 @@
 #include <vector>
 #include <typeindex>
 
+#include "MaterialLib/PorousMedium/Permeability/Permeability.h"
+#include "MaterialLib/PorousMedium/Storage/Storage.h"
 #include "MathLib/LinAlg/Eigen/EigenMapTools.h"
 #include "NumLib/Extrapolation/ExtrapolatableElement.h"
 #include "NumLib/DOF/DOFTableUtil.h"

--- a/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.h
@@ -18,21 +18,9 @@
 
 #include "MaterialLib/Fluid/FluidProperty.h"
 #include "MaterialLib/Fluid/FluidProperties/FluidProperties.h"
-
-namespace MaterialLib
-{
-namespace Fluid
-{
-class FluidProperties;
-}
-
-namespace PorousMedium
-{
-class Permeability;
-class Porosity;
-class Storage;
-}
-}
+#include "MaterialLib/PorousMedium/Permeability/Permeability.h"
+#include "MaterialLib/PorousMedium/Porosity/Porosity.h"
+#include "MaterialLib/PorousMedium/Storage/Storage.h"
 
 namespace BaseLib
 {

--- a/ProcessLib/LocalAssemblerTraits.h
+++ b/ProcessLib/LocalAssemblerTraits.h
@@ -9,6 +9,11 @@
 
 #pragma once
 
+#include "NumLib/Fem/ShapeMatrixPolicy.h"
+
+#include <cassert>
+#include <type_traits>
+
 namespace ProcessLib
 {
 

--- a/ProcessLib/PhaseField/PhaseFieldFEM.h
+++ b/ProcessLib/PhaseField/PhaseFieldFEM.h
@@ -18,6 +18,7 @@
 #include "NumLib/Fem/ShapeMatrixPolicy.h"
 #include "ProcessLib/Deformation/BMatrixPolicy.h"
 #include "ProcessLib/Deformation/LinearBMatrix.h"
+#include "ProcessLib/Parameter/SpatialPosition.h"
 #include "ProcessLib/Utils/InitShapeMatrices.h"
 
 #include "LocalAssemblerInterface.h"

--- a/ProcessLib/PhaseField/PhaseFieldProcessData.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcessData.h
@@ -9,6 +9,9 @@
 
 #pragma once
 
+#include <memory>
+#include <utility>
+
 namespace MaterialLib
 {
 namespace Solids

--- a/ProcessLib/PhaseField/PhaseFieldProcessData.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcessData.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <Eigen/Eigen>
+
 #include <memory>
 #include <utility>
 

--- a/ProcessLib/SecondaryVariableContext.h
+++ b/ProcessLib/SecondaryVariableContext.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "MathLib/LinAlg/GlobalMatrixVectorTypes.h"
+
 namespace ProcessLib
 {
 /*! Provides a "global" context, e.g., for NamedFunction's.

--- a/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
@@ -9,6 +9,9 @@
 
 #pragma once
 
+#include <memory>
+#include <utility>
+
 namespace MaterialLib
 {
 namespace Solids

--- a/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
@@ -12,6 +12,10 @@
 #include <memory>
 #include <utility>
 
+#include <Eigen/Eigen>
+
+#include "ProcessLib/Parameter/Parameter.h"
+
 namespace MaterialLib
 {
 namespace Solids

--- a/ProcessLib/TES/TESLocalAssembler.h
+++ b/ProcessLib/TES/TESLocalAssembler.h
@@ -14,7 +14,7 @@
 
 #include "ProcessLib/LocalAssemblerInterface.h"
 #include "NumLib/Extrapolation/ExtrapolatableElement.h"
-#include "MeshLib/Element.h"
+#include "MeshLib/Elements/Element.h"
 #include "TESAssemblyParams.h"
 #include "TESLocalAssemblerInner-fwd.h"
 

--- a/ProcessLib/TES/TESLocalAssembler.h
+++ b/ProcessLib/TES/TESLocalAssembler.h
@@ -14,6 +14,7 @@
 
 #include "ProcessLib/LocalAssemblerInterface.h"
 #include "NumLib/Extrapolation/ExtrapolatableElement.h"
+#include "MeshLib/Element.h"
 #include "TESAssemblyParams.h"
 #include "TESLocalAssemblerInner-fwd.h"
 

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
@@ -12,6 +12,8 @@
 #include <memory>
 #include <utility>
 
+#include <Eigen/Eigen>
+
 #include "ProcessLib/Parameter/Parameter.h"
 
 namespace MaterialLib

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
@@ -9,6 +9,11 @@
 
 #pragma once
 
+#include <memory>
+#include <utility>
+
+#include "ProcessLib/Parameter/Parameter.h"
+
 namespace MaterialLib
 {
 namespace Solids

--- a/ProcessLib/VariableTransformation.h
+++ b/ProcessLib/VariableTransformation.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <cmath>
+
 namespace ProcessLib
 {
 

--- a/scripts/cmake/CheckHeaderCompilation.cmake
+++ b/scripts/cmake/CheckHeaderCompilation.cmake
@@ -6,6 +6,9 @@ set(CMAKE_REQUIRED_QUIET TRUE)
 
 # Checks header for standalone compilation
 function(check_header_compilation)
+    if(NOT OGS_CHECK_HEADER_COMPILATION)
+        return()
+    endif()
     string(REPLACE "${PROJECT_SOURCE_DIR}/" "" DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     message(STATUS "Checking header compilation for ${DIRECTORY} ...")
     include(CheckCXXSourceCompiles)

--- a/scripts/cmake/CheckHeaderCompilation.cmake
+++ b/scripts/cmake/CheckHeaderCompilation.cmake
@@ -1,6 +1,6 @@
 # Supply include directories and compiler flags
 get_directory_property(INCLUDE_DIRS INCLUDE_DIRECTORIES)
-set(CMAKE_REQUIRED_FLAGS "-std=gnu++14")
+set(CMAKE_REQUIRED_FLAGS "-c -std=gnu++14")
 set(CMAKE_REQUIRED_QUIET TRUE)
 
 # Checks header for standalone compilation

--- a/scripts/cmake/CheckHeaderCompilation.cmake
+++ b/scripts/cmake/CheckHeaderCompilation.cmake
@@ -3,6 +3,16 @@ get_directory_property(INCLUDE_DIRS INCLUDE_DIRECTORIES)
 set(CMAKE_REQUIRED_FLAGS "-c -std=gnu++14")
 set(CMAKE_REQUIRED_QUIET TRUE)
 
+add_custom_target(check-header
+    COMMAND ${CMAKE_COMMAND} -E remove CMakeFiles/CMakeError.log
+    COMMAND ${CMAKE_COMMAND} . -DOGS_CHECK_HEADER_COMPILATION=ON
+    COMMAND ${CMAKE_COMMAND} . -DOGS_CHECK_HEADER_COMPILATION=OFF || true
+    COMMAND if [ -f CMakeFiles/CMakeError.log ]\; then cat CMakeFiles/CMakeError.log\; return 1\; else return 0\; fi\;
+    WORKING_DIRECTOY ${PROJECT_BINARY_DIR}
+    COMMENT "Checking header files"
+    USES_TERMINAL
+)
+
 # Checks header for standalone compilation
 function(_check_header_compilation TARGET)
 
@@ -80,6 +90,6 @@ function(check_header_compilation)
     _check_header_compilation(ProcessLib)
 
     if(HEADER_COMPILE_ERROR)
-        message(STATUS "... header compilation check failed, see CMakeFiles/CMakeError.log for details!")
+        message(FATAL_ERROR "... header compilation check failed, see CMakeFiles/CMakeError.log for details!")
     endif()
 endfunction()

--- a/scripts/cmake/CheckHeaderCompilation.cmake
+++ b/scripts/cmake/CheckHeaderCompilation.cmake
@@ -1,24 +1,51 @@
 # Supply include directories and compiler flags
 get_directory_property(INCLUDE_DIRS INCLUDE_DIRECTORIES)
-set(CMAKE_REQUIRED_INCLUDES ${INCLUDE_DIRS})
 set(CMAKE_REQUIRED_FLAGS "-std=gnu++14")
 set(CMAKE_REQUIRED_QUIET TRUE)
 
 # Checks header for standalone compilation
-function(check_header_compilation)
-    if(NOT OGS_CHECK_HEADER_COMPILATION)
-        return()
-    endif()
-    string(REPLACE "${PROJECT_SOURCE_DIR}/" "" DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-    message(STATUS "Checking header compilation for ${DIRECTORY} ...")
-    include(CheckCXXSourceCompiles)
-    set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-    file(GLOB_RECURSE FILES *.h)
-    foreach(FILE ${FILES})
-        # Ignore *-impl.h files
-        if("${FILE}" MATCHES ".*-impl.h")
+function(_check_header_compilation TARGET)
+
+    get_target_property(SOURCE_FILES ${TARGET} SOURCES)
+    get_target_property(SOURCE_DIR ${TARGET} SOURCE_DIR)
+
+    get_directory_property(DEFS DIRECTORY ${SOURCE_DIR} COMPILE_DEFINITIONS)
+    foreach(DEF ${DEFS})
+        if(${DEF} MATCHES ".*[0-9]\\(.*")
             continue()
         endif()
+        list(APPEND DEFS_CLEANED "-D${DEF}")
+    endforeach()
+
+    get_target_property(INCLUDE_DIRS ${TARGET} INCLUDE_DIRECTORIES)
+    get_target_property(LINK_LIBS ${TARGET} LINK_LIBRARIES)
+    foreach(LIB ${LINK_LIBS})
+        if(NOT TARGET ${LIB}) # Ignore non-existing targets
+            continue()
+        endif()
+        get_target_property(TARGET_INCLUDE_DIRS ${LIB} INCLUDE_DIRECTORIES)
+        if(TARGET_INCLUDE_DIRS)
+            list(APPEND INCLUDE_DIRS ${TARGET_INCLUDE_DIRS})
+        endif()
+    endforeach()
+    list(REMOVE_DUPLICATES INCLUDE_DIRS)
+
+    string(REPLACE "${PROJECT_SOURCE_DIR}/" "" DIRECTORY ${SOURCE_DIR})
+    message(STATUS "Checking header compilation for ${DIRECTORY} ...")
+    include(CheckCXXSourceCompiles)
+
+    set(CMAKE_REQUIRED_INCLUDES ${INCLUDE_DIRS} ${SOURCE_DIR})
+    set(CMAKE_REQUIRED_DEFINITIONS ${DEFS_CLEANED})
+
+    foreach(FILE ${SOURCE_FILES})
+
+        if(NOT "${FILE}" MATCHES ".*\\.h") # Check only header files
+            continue()
+        endif()
+        if("${FILE}" MATCHES ".*-impl\\.h") # Ignore *-impl.h files
+            continue()
+        endif()
+
         check_cxx_source_compiles(
             "
             #include \"${FILE}\"
@@ -26,10 +53,33 @@ function(check_header_compilation)
             "
             COMPILES
         )
+
         if(NOT COMPILES)
+            set(HEADER_COMPILE_ERROR TRUE CACHE INTERNAL "")
             string(REPLACE "${PROJECT_SOURCE_DIR}/" "" FILE_SHORT ${FILE})
             message(STATUS "  Compilation failed for ${FILE_SHORT}")
         endif()
         unset(COMPILES CACHE)
+
     endforeach()
+endfunction()
+
+function(check_header_compilation)
+    if(NOT OGS_CHECK_HEADER_COMPILATION)
+        return()
+    endif()
+    set(HEADER_COMPILE_ERROR FALSE CACHE INTERNAL "")
+
+    _check_header_compilation(BaseLib)
+    _check_header_compilation(GeoLib)
+    _check_header_compilation(MaterialLib)
+    _check_header_compilation(MathLib)
+    _check_header_compilation(MeshGeoToolsLib)
+    _check_header_compilation(MeshLib)
+    _check_header_compilation(NumLib)
+    _check_header_compilation(ProcessLib)
+
+    if(HEADER_COMPILE_ERROR)
+        message(STATUS "... header compilation check failed, see CMakeFiles/CMakeError.log for details!")
+    endif()
 endfunction()

--- a/scripts/cmake/CheckHeaderCompilation.cmake
+++ b/scripts/cmake/CheckHeaderCompilation.cmake
@@ -1,0 +1,32 @@
+# Supply include directories and compiler flags
+get_directory_property(INCLUDE_DIRS INCLUDE_DIRECTORIES)
+set(CMAKE_REQUIRED_INCLUDES ${INCLUDE_DIRS})
+set(CMAKE_REQUIRED_FLAGS "-std=gnu++14")
+set(CMAKE_REQUIRED_QUIET TRUE)
+
+# Checks header for standalone compilation
+function(check_header_compilation)
+    string(REPLACE "${PROJECT_SOURCE_DIR}/" "" DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    message(STATUS "Checking header compilation for ${DIRECTORY} ...")
+    include(CheckCXXSourceCompiles)
+    set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+    file(GLOB_RECURSE FILES *.h)
+    foreach(FILE ${FILES})
+        # Ignore *-impl.h files
+        if("${FILE}" MATCHES ".*-impl.h")
+            continue()
+        endif()
+        check_cxx_source_compiles(
+            "
+            #include \"${FILE}\"
+            int main() { return 0; }
+            "
+            COMPILES
+        )
+        if(NOT COMPILES)
+            string(REPLACE "${PROJECT_SOURCE_DIR}/" "" FILE_SHORT ${FILE})
+            message(STATUS "  Compilation failed for ${FILE_SHORT}")
+        endif()
+        unset(COMPILES CACHE)
+    endforeach()
+endfunction()


### PR DESCRIPTION
Added check functionality to compile all headers standalone to check for correct includes.

## Usage

```
$ rm CMakeFiles/CMakeError.log
$ cmake . -DOGS_CHECK_HEADER_COMPILATION=ON
[see CMake output for failing headers]
$ cat CMakeFiles/CMakeError.log # for details what went wrong
```

**OR**

```
make check-header
```

## Status

Top-level libs are checked; no errors on standard config.
Checks are done on Jenkins when `ufz/master` gets build (`Check-Header`-job).
