### PR TITLE
[Output] Cleanup of the output logic

### DIFF
--- a/ProcessLib/ProcessOutput.cpp
+++ b/ProcessLib/ProcessOutput.cpp
@@ -40,20 +40,17 @@ ProcessOutput::ProcessOutput(BaseLib::ConfigTree const& output_config)
     }
 }
 
-void doProcessOutput(std::string const& file_name,
-                     bool const make_output,
-                     bool const compress_output,
-                     int const data_mode,
-                     const double t,
-                     GlobalVector const& x,
-                     MeshLib::Mesh& mesh,
-                     NumLib::LocalToGlobalIndexMap const& dof_table,
-                     std::vector<std::reference_wrapper<ProcessVariable>> const&
-                         process_variables,
-                     SecondaryVariableCollection secondary_variables,
-                     ProcessOutput const& process_output)
+void processOutputData(
+    const double t,
+    GlobalVector const& x,
+    MeshLib::Mesh& mesh,
+    NumLib::LocalToGlobalIndexMap const& dof_table,
+    std::vector<std::reference_wrapper<ProcessVariable>> const&
+        process_variables,
+    SecondaryVariableCollection secondary_variables,
+    ProcessOutput const& process_output)
 {
-    DBUG("Process output.");
+    DBUG("Process output data.");
 
     // Copy result
 #ifdef USE_PETSC
@@ -226,11 +223,11 @@ void doProcessOutput(std::string const& file_name,
     (void)t;
 #endif // USE_PETSC
 
-    if (!make_output)
-    {
-        return;
-    }
+}
 
+void makeOutput(std::string const& file_name, MeshLib::Mesh& mesh,
+                bool const compress_output, int const data_mode)
+{
     // Write output file
     DBUG("Writing output to \'%s\'.", file_name.c_str());
     MeshLib::IO::VtuInterface vtu_interface(&mesh, data_mode, compress_output);

--- a/ProcessLib/ProcessOutput.h
+++ b/ProcessLib/ProcessOutput.h
@@ -14,7 +14,6 @@
 
 namespace ProcessLib
 {
-
 //! Holds information about which variables to write to output files.
 struct ProcessOutput final
 {
@@ -28,21 +27,23 @@ struct ProcessOutput final
     bool output_residuals = false;
 };
 
+///
+/// Prepare the output data, i.e. add the solution to vtu data structure.
+void processOutputData(
+    const double t,
+    GlobalVector const& x,
+    MeshLib::Mesh& mesh,
+    NumLib::LocalToGlobalIndexMap const& dof_table,
+    std::vector<std::reference_wrapper<ProcessVariable>> const&
+        process_variables,
+    SecondaryVariableCollection secondary_variables,
+    ProcessOutput const& process_output);
+
 //! Writes output to the given \c file_name using the VTU file format.
 ///
 /// See Output::_output_file_data_mode documentation for the data_mode
 /// parameter.
-void doProcessOutput(std::string const& file_name,
-                     bool const make_output,
-                     bool const compress_output,
-                     int const data_mode,
-                     const double t,
-                     GlobalVector const& x,
-                     MeshLib::Mesh& mesh,
-                     NumLib::LocalToGlobalIndexMap const& dof_table,
-                     std::vector<std::reference_wrapper<ProcessVariable>> const&
-                         process_variables,
-                     SecondaryVariableCollection secondary_variables,
-                     ProcessOutput const& process_output);
+void makeOutput(std::string const& file_name, MeshLib::Mesh& mesh,
+                bool const compress_output, int const data_mode);
 
-} // ProcessLib
+}  // ProcessLib


### PR DESCRIPTION
This PR fixes #2040. It
1. separates the processing of output data and the data output by splitting  function ``doProcessOutput`` (in ProcessOutput.h) into two functions as  ``processOutputData`` and ``makeOutput``, respectively.
2. removes several  if-condtions that distinguish the data processing and the data output from  `Output::doOutputAlways` and `doOutputNonlinearIteration`.


