### PR TITLE
LIE_HM fix nodal aperture output

### DIFF
--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -421,30 +421,20 @@ void HydroMechanicsProcess<GlobalDim>::computeSecondaryVariableConcrete(
     // variables are set during output and are not ready yet when this function
     // is called.
     int g_variable_id = 0;
-    int g_global_component_offset = 0;
     {
-        int global_component_offset_next = 0;
-        int global_component_offset = 0;
-
         const int monolithic_process_id = 0;
-        for (int variable_id = 0;
-             variable_id <
-             static_cast<int>(this->getProcessVariables(
-                              monolithic_process_id).size());
-             ++variable_id)
+        auto const& pvs = getProcessVariables(monolithic_process_id);
+        auto const it =
+            std::find_if(pvs.begin(), pvs.end(), [](ProcessVariable const& pv) {
+                return pv.getName() == "displacement_jump1";
+            });
+        if (it == pvs.end())
         {
-            ProcessVariable& pv =
-                this->getProcessVariables(monolithic_process_id)[variable_id];
-            int const n_components = pv.getNumberOfComponents();
-            global_component_offset = global_component_offset_next;
-            global_component_offset_next += n_components;
-            if (pv.getName() != "displacement_jump1")
-                continue;
-
-            g_variable_id = variable_id;
-            g_global_component_offset = global_component_offset;
-            break;
+            OGS_FATAL(
+                "Didn't find expected \"displacement_jump1\" process "
+                "variable.");
         }
+        g_variable_id = std::distance(pvs.begin(), it);
     }
 
     MathLib::LinAlg::setLocalAccessibleVector(x);
@@ -466,10 +456,11 @@ void HydroMechanicsProcess<GlobalDim>::computeSecondaryVariableConcrete(
                 MeshLib::Location const l(mesh_id, MeshLib::MeshItemType::Node,
                                           node->getID());
 
-                auto const global_component_id =
-                    g_global_component_offset + component_id;
+                auto const global_index =
+                    _local_to_global_index_map->getGlobalIndex(l, g_variable_id,
+                                                               component_id);
                 mesh_prop_g[node->getID() * num_comp + component_id] =
-                    x[global_component_id];
+                    x[global_index];
             }
         }
     }

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -484,7 +484,7 @@ void HydroMechanicsProcess<GlobalDim>::computeSecondaryVariableConcrete(
 
         ProcessLib::SpatialPosition x;
         x.setNodeID(node_id);
-        vec_b[node_id] = w[GlobalDim == 2 ? 1 : 2] +
+        vec_b[node_id] = w[GlobalDim - 1] +
                          (*_process_data.fracture_property->aperture0)(0, x)[0];
     }
 }

--- a/ProcessLib/LIE/HydroMechanics/Tests.cmake
+++ b/ProcessLib/LIE/HydroMechanics/Tests.cmake
@@ -35,6 +35,8 @@ AddTest(
     expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu pressure_interpolated pressure_interpolated 1e-12 1e-12
     expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu displacement displacement 1e-12 1e-12
     expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu displacement_jump1 displacement_jump1 1e-12 1e-12
+    expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu nodal_w nodal_w 1e-12 1e-12
+    expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu nodal_aperture nodal_aperture 1e-12 1e-12
     expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu strain_xx strain_xx 1e-12 1e-12
     expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu strain_yy strain_yy 1e-12 1e-12
     expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu strain_zz strain_zz 1e-12 1e-12
@@ -60,6 +62,8 @@ AddTest(
     expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu pressure_interpolated pressure_interpolated 1e-12 1e-12
     expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu displacement displacement 1e-12 1e-12
     expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu displacement_jump1 displacement_jump1 1e-12 1e-12
+    expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu nodal_w nodal_w 1e-12 1e-12
+    expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu nodal_aperture nodal_aperture 1e-12 1e-12
     expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu strain_xx strain_xx 1e-12 1e-12
     expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu strain_yy strain_yy 1e-12 1e-12
     expected_TaskB_pcs_0_ts_4_t_18.000000.vtu TaskB_pcs_0_ts_4_t_18.000000.vtu strain_xy strain_xy 1e-12 1e-12

--- a/Tests/Data/LIE/HydroMechanics/expected_TaskB_pcs_0_ts_4_t_18.000000.vtu
+++ b/Tests/Data/LIE/HydroMechanics/expected_TaskB_pcs_0_ts_4_t_18.000000.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b08492f33ca88b4178325b6ceecc7193b2277838b04dddaf499af27a02f2e66e
-size 1060423
+oid sha256:e6ad13887eb3e17097f065dd5e8400ba289c5477ecbe3af8a98bc29d59511390
+size 1067158

--- a/Tests/Data/LIE/HydroMechanics/expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu
+++ b/Tests/Data/LIE/HydroMechanics/expected_single_fracture_3D_pcs_0_ts_10_t_100.000000.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:803b1b2fd32cc67a9e9f2ef55db84da3112fa8af446b156a4b1c50a41cec75aa
-size 443378
+oid sha256:26851af4c2c501a114e581a4e94f3106c04fddfdc6d440ecbd93f16fa7843968
+size 447261

--- a/Tests/Data/LIE/HydroMechanics/expected_single_fracture_pcs_0_ts_10_t_100.000000.vtu
+++ b/Tests/Data/LIE/HydroMechanics/expected_single_fracture_pcs_0_ts_10_t_100.000000.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ea519e43ff58bd60d4236001ee06cfb387e82fc6463894277ccb6a250567f13
-size 221464
+oid sha256:41977c52c492ddd5a2176bfe848a32edcd83bfbda9a98cb5466e4eb435c8d7bd
+size 223115


### PR DESCRIPTION
The first commit contains a bug fix for wrong global index access.

Small improvement in a vector access and updating the expected results.