### PR TITLE
Doxygen material lib references

### DIFF
--- a/Documentation/ProjectFile/material/fluid/i_fluid.md
+++ b/Documentation/ProjectFile/material/fluid/i_fluid.md
@@ -1,1 +1,1 @@
-\ogs_missing_documentation
+Description of the fluid properties using constitutive relations.

--- a/Documentation/ProjectFile/material/solid/constitutive_relation/i_constitutive_relation.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/i_constitutive_relation.md
@@ -1,1 +1,1 @@
-\ogs_missing_documentation
+Description of the solid properties using constitutive relations.

--- a/Documentation/ProjectFile/material/solid/constitutive_relation/t_type.md
+++ b/Documentation/ProjectFile/material/solid/constitutive_relation/t_type.md
@@ -1,1 +1,4 @@
-\ogs_missing_documentation
+The constitutive relation type.
+See constitutive relation \ref
+ogs_file_param__material__solid__constitutive_relation "cases" for available
+options.

--- a/Documentation/ProjectFile/prj/processes/process/ComponentTransport/fluid
+++ b/Documentation/ProjectFile/prj/processes/process/ComponentTransport/fluid
@@ -1,0 +1,1 @@
+../../../../material/fluid

--- a/Documentation/ProjectFile/prj/processes/process/ComponentTransport/fluid/i_fluid.md
+++ b/Documentation/ProjectFile/prj/processes/process/ComponentTransport/fluid/i_fluid.md
@@ -1,1 +1,0 @@
-Description of the fluid properties using constitutive relations.

--- a/Documentation/ProjectFile/prj/processes/process/HT/fluid
+++ b/Documentation/ProjectFile/prj/processes/process/HT/fluid
@@ -1,0 +1,1 @@
+../../../../material/fluid

--- a/Documentation/ProjectFile/prj/processes/process/HT/fluid/i_fluid.md
+++ b/Documentation/ProjectFile/prj/processes/process/HT/fluid/i_fluid.md
@@ -1,1 +1,0 @@
-Defines fluid properties.

--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/constitutive_relation
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/constitutive_relation
@@ -1,0 +1,1 @@
+../../../../material/solid/constitutive_relation

--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/constitutive_relation/i_constitutive_relation.md
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/constitutive_relation/i_constitutive_relation.md
@@ -1,1 +1,0 @@
-\copydoc ProcessLib::HydroMechanics::HydroMechanicsProcessData::material

--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/constitutive_relation/t_type.md
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/constitutive_relation/t_type.md
@@ -1,3 +1,0 @@
-The type of constitutive relation. See
-ProcessLib::HydroMechanics::createHydroMechanicsProcess()
-for available implementations.

--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/constitutive_relation
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/constitutive_relation
@@ -1,0 +1,1 @@
+../../../../material/solid/constitutive_relation

--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/constitutive_relation/i_constitutive_relation.md
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/constitutive_relation/i_constitutive_relation.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/constitutive_relation/t_type.md
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/constitutive_relation/t_type.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/fracture_model
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/fracture_model
@@ -1,0 +1,1 @@
+../../../../material/fracture_model

--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/fracture_model/i_fracture_model.md
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/fracture_model/i_fracture_model.md
@@ -1,1 +1,0 @@
-Fracture models used in LIE/XFEM solvers.

--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/fracture_model/t_type.md
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/fracture_model/t_type.md
@@ -1,1 +1,0 @@
-The fracture model type describing the fracture's opening and closing behaviour.

--- a/Documentation/ProjectFile/prj/processes/process/LIQUID_FLOW/material_property/fluid
+++ b/Documentation/ProjectFile/prj/processes/process/LIQUID_FLOW/material_property/fluid
@@ -1,0 +1,1 @@
+../../../../../material/fluid

--- a/Documentation/ProjectFile/prj/processes/process/LIQUID_FLOW/material_property/fluid/i_fluid.md
+++ b/Documentation/ProjectFile/prj/processes/process/LIQUID_FLOW/material_property/fluid/i_fluid.md
@@ -1,1 +1,0 @@
-Defines fluid properties of liquid phase.

--- a/Documentation/ProjectFile/prj/processes/process/PHASE_FIELD/constitutive_relation
+++ b/Documentation/ProjectFile/prj/processes/process/PHASE_FIELD/constitutive_relation
@@ -1,0 +1,1 @@
+../../../../material/solid/constitutive_relation

--- a/Documentation/ProjectFile/prj/processes/process/PHASE_FIELD/constitutive_relation/i_constitutive_relation.md
+++ b/Documentation/ProjectFile/prj/processes/process/PHASE_FIELD/constitutive_relation/i_constitutive_relation.md
@@ -1,1 +1,0 @@
-The constitutive relation for the brittle fracture.

--- a/Documentation/ProjectFile/prj/processes/process/PHASE_FIELD/constitutive_relation/t_type.md
+++ b/Documentation/ProjectFile/prj/processes/process/PHASE_FIELD/constitutive_relation/t_type.md
@@ -1,2 +1,0 @@
-The type of constitutive relation available.
-1. Linear elastic

--- a/Documentation/ProjectFile/prj/processes/process/RICHARDS_FLOW/material_property/fluid
+++ b/Documentation/ProjectFile/prj/processes/process/RICHARDS_FLOW/material_property/fluid
@@ -1,0 +1,1 @@
+../../../../../material/fluid

--- a/Documentation/ProjectFile/prj/processes/process/RICHARDS_FLOW/material_property/fluid/i_fluid.md
+++ b/Documentation/ProjectFile/prj/processes/process/RICHARDS_FLOW/material_property/fluid/i_fluid.md
@@ -1,1 +1,0 @@
-Defines fluid properties.

--- a/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION/constitutive_relation
+++ b/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION/constitutive_relation
@@ -1,0 +1,1 @@
+../../../../material/solid/constitutive_relation

--- a/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION/constitutive_relation/i_constitutive_relation.md
+++ b/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION/constitutive_relation/i_constitutive_relation.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION/constitutive_relation/t_type.md
+++ b/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION/constitutive_relation/t_type.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION_WITH_LIE/constitutive_relation
+++ b/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION_WITH_LIE/constitutive_relation
@@ -1,0 +1,1 @@
+../../../../material/solid/constitutive_relation

--- a/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION_WITH_LIE/constitutive_relation/i_constitutive_relation.md
+++ b/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION_WITH_LIE/constitutive_relation/i_constitutive_relation.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION_WITH_LIE/constitutive_relation/t_type.md
+++ b/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION_WITH_LIE/constitutive_relation/t_type.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION_WITH_LIE/fracture_model
+++ b/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION_WITH_LIE/fracture_model
@@ -1,0 +1,1 @@
+../../../../material/fracture_model

--- a/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION_WITH_LIE/fracture_model/i_fracture_model.md
+++ b/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION_WITH_LIE/fracture_model/i_fracture_model.md
@@ -1,1 +1,0 @@
-Fracture models used in LIE/XFEM solvers.

--- a/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION_WITH_LIE/fracture_model/t_type.md
+++ b/Documentation/ProjectFile/prj/processes/process/SMALL_DEFORMATION_WITH_LIE/fracture_model/t_type.md
@@ -1,1 +1,0 @@
-The fracture model type describing the fracture's opening and closing behaviour.

--- a/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/fluid
+++ b/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/fluid
@@ -1,0 +1,1 @@
+../../../../../material/fluid

--- a/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/fluid/i_fluid.md
+++ b/Documentation/ProjectFile/prj/processes/process/TWOPHASE_FLOW_PP/material_property/fluid/i_fluid.md
@@ -1,1 +1,0 @@
-Defines fluid properties of gas and liquid phases.

--- a/scripts/cmake/DocumentationProjectFile.cmake
+++ b/scripts/cmake/DocumentationProjectFile.cmake
@@ -131,7 +131,8 @@ if (IS_DIRECTORY ${DocumentationProjectFileBuildDir})
 endif()
 
 # traverse input file hierarchy
-file(GLOB_RECURSE input_paths ${DocumentationProjectFileInputDir}/c_* ${DocumentationProjectFileInputDir}/i_*)
+file(GLOB_RECURSE input_paths FOLLOW_SYMLINKS
+    ${DocumentationProjectFileInputDir}/c_* ${DocumentationProjectFileInputDir}/i_*)
 
 foreach(p ${input_paths})
     message("directory index file ${p}")

--- a/scripts/doc/linked-xml-file.py
+++ b/scripts/doc/linked-xml-file.py
@@ -38,8 +38,6 @@ outdir = os.path.join(docauxdir, "dox", "CTestProjectFiles")
 # "prj__processes__process": "process",
 # See the expansion table in the append-xml-tags.py too.
 tag_path_expansion_table = {
-        "prj__processes__process__constitutive_relation" : "material__solid__constitutive_relation",
-        "prj__processes__process__material_property" : "material",
         "material__porous_medium__porous_medium" : "material__porous_medium",
         }
 


### PR DESCRIPTION
for fluid, solid/constitutive_relation, and fracture_model.
Now these tags are expanded in each process yielding better documentation, have a look [here](
https://jenkins.opengeosys.org/job/User/job/endJunction/job/ogs/job/DoxygenMaterialLibReferences_j/Doxygen/ogs_file_param__prj__processes__process__HYDRO_MECHANICS__constitutive_relation__Lubby2.html)
Didn't touch the porous_media because the docu is different in some processes.