### PR TITLE
bad_alloc catch in time loop creation

### DIFF
--- a/NumLib/TimeStepping/Algorithms/CreateFixedTimeStepping.cpp
+++ b/NumLib/TimeStepping/Algorithms/CreateFixedTimeStepping.cpp
@@ -63,7 +63,32 @@ std::unique_ptr<TimeStepAlgorithm> createFixedTimeStepping(
 
         if (t_curr <= t_end)
         {
-            timesteps.resize(timesteps.size() + repeat, delta_t);
+            auto const new_size = timesteps.size() + repeat;
+            try
+            {
+                timesteps.resize(new_size, delta_t);
+            }
+            catch (std::length_error const& e)
+            {
+                OGS_FATAL(
+                    "Resize of the time steps vector failed for the requested "
+                    "new size %u. Probably there is not enough memory (%g GiB "
+                    "requested).\n"
+                    "Thrown exception: %s",
+                    new_size,
+                    new_size * sizeof(double) / 1024. / 1024. / 1024.,
+                    e.what());
+            }
+            catch (std::bad_alloc const& e)
+            {
+                OGS_FATAL(
+                    "Resize of the time steps vector failed for the requested "
+                    "new size %u. Probably there is not enough memory (%g GiB "
+                    "requested).\n"
+                    "Thrown exception: %s",
+                    new_size, new_size * sizeof(double) / 1024. / 1024. / 1024.,
+                    e.what());
+            }
 
             t_curr += repeat * delta_t;
         }
@@ -74,7 +99,32 @@ std::unique_ptr<TimeStepAlgorithm> createFixedTimeStepping(
     {
         auto const repeat =
             static_cast<std::size_t>(std::ceil((t_end - t_curr) / delta_t));
-        timesteps.resize(timesteps.size() + repeat, delta_t);
+        auto const new_size = timesteps.size() + repeat;
+        try
+        {
+            timesteps.resize(new_size, delta_t);
+        }
+        catch (std::length_error const& e)
+        {
+            OGS_FATAL(
+                "Resize of the time steps vector failed for the requested new "
+                "size %u. Probably there is not enough memory (%g GiB "
+                "requested).\n"
+                "Thrown exception: %s",
+                new_size,
+                new_size * sizeof(double) / 1024. / 1024. / 1024.,
+                e.what());
+        }
+        catch (std::bad_alloc const& e)
+        {
+            OGS_FATAL(
+                "Resize of the time steps vector failed for the requested new "
+                "size %u. Probably there is not enough memory (%g GiB "
+                "requested).\n"
+                "Thrown exception: %s",
+                new_size, new_size * sizeof(double) / 1024. / 1024. / 1024.,
+                e.what());
+        }
     }
 
     return std::make_unique<FixedTimeStepping>(t_initial, t_end, timesteps);

--- a/NumLib/TimeStepping/Algorithms/TimeStepAlgorithm.h
+++ b/NumLib/TimeStepping/Algorithms/TimeStepAlgorithm.h
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <vector>
 
+#include "BaseLib/Error.h"
 #include "NumLib/TimeStepping/TimeStep.h"
 
 namespace NumLib
@@ -31,12 +32,23 @@ public:
     }
 
     TimeStepAlgorithm(const double t0, const double t_end, const double dt)
-        : _t_initial(t0),
-          _t_end(t_end),
-          _ts_prev(t0),
-          _ts_current(t0),
-          _dt_vector(static_cast<std::size_t>(std::ceil((t_end - t0) / dt)), dt)
+        : _t_initial(t0), _t_end(t_end), _ts_prev(t0), _ts_current(t0)
     {
+        try
+        {
+            _dt_vector = std::vector<double>(
+                static_cast<std::size_t>(std::ceil((t_end - t0) / dt)), dt);
+        }
+        catch (std::bad_alloc const& e)
+        {
+            OGS_FATAL(
+                "Allocation of the time steps vector failed for the requested "
+                "size %d. Probably there is not enough memory (%d GiB "
+                "requested)",
+                static_cast<std::size_t>(std::ceil((t_end - t0) / dt)),
+                static_cast<std::size_t>(std::ceil((t_end - t0) / dt)) *
+                    sizeof(double) / 1024 / 1024 / 1024);
+        }
     }
 
     TimeStepAlgorithm(const double t0, const double t_end,

--- a/NumLib/TimeStepping/Algorithms/TimeStepAlgorithm.h
+++ b/NumLib/TimeStepping/Algorithms/TimeStepAlgorithm.h
@@ -34,20 +34,32 @@ public:
     TimeStepAlgorithm(const double t0, const double t_end, const double dt)
         : _t_initial(t0), _t_end(t_end), _ts_prev(t0), _ts_current(t0)
     {
+        auto const new_size =
+            static_cast<std::size_t>(std::ceil((t_end - t0) / dt));
         try
         {
-            _dt_vector = std::vector<double>(
-                static_cast<std::size_t>(std::ceil((t_end - t0) / dt)), dt);
+            _dt_vector = std::vector<double>(new_size, dt);
+        }
+        catch (std::length_error const& e)
+        {
+            OGS_FATAL(
+                "Resize of the time steps vector failed for the requested new "
+                "size %u. Probably there is not enough memory (%g GiB "
+                "requested).\n"
+                "Thrown exception: %s",
+                new_size, new_size * sizeof(double) / 1024. / 1024. / 1024.,
+                e.what());
         }
         catch (std::bad_alloc const& e)
         {
             OGS_FATAL(
                 "Allocation of the time steps vector failed for the requested "
-                "size %d. Probably there is not enough memory (%d GiB "
-                "requested)",
-                static_cast<std::size_t>(std::ceil((t_end - t0) / dt)),
-                static_cast<std::size_t>(std::ceil((t_end - t0) / dt)) *
-                    sizeof(double) / 1024 / 1024 / 1024);
+                "size %u. Probably there is not enough memory (%d GiB "
+                "requested).\n"
+                "Thrown exception: %s",
+                new_size,
+                new_size * sizeof(double) / 1024. / 1024. / 1024.,
+                e.what());
         }
     }
 


### PR DESCRIPTION
Improves error finding.

Removing the vector allocation would be better, but needs more time.