### PR TITLE
Fix NAN bug in the HT process

### DIFF
--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -135,14 +135,21 @@ protected:
             _material_properties.thermal_dispersivity_transversal(t, pos)[0];
 
         double const velocity_magnitude = velocity.norm();
-        GlobalDimMatrixType const thermal_dispersivity =
-            fluid_density * specific_heat_capacity_fluid *
-            (thermal_dispersivity_transversal * velocity_magnitude * I +
-             (thermal_dispersivity_longitudinal -
-              thermal_dispersivity_transversal) /
-                 velocity_magnitude * velocity * velocity.transpose());
 
-        return thermal_conductivity * I + thermal_dispersivity;
+        if (velocity_magnitude < std::numeric_limits<double>::epsilon())
+        {
+            return thermal_conductivity * I;
+        }
+        else
+        {
+            GlobalDimMatrixType const thermal_dispersivity =
+                fluid_density * specific_heat_capacity_fluid *
+                (thermal_dispersivity_transversal * velocity_magnitude * I +
+                 (thermal_dispersivity_longitudinal -
+                  thermal_dispersivity_transversal) /
+                     velocity_magnitude * velocity * velocity.transpose());
+            return thermal_conductivity * I + thermal_dispersivity;
+        }
     }
 
     std::vector<double> const& getIntPtDarcyVelocityLocal(


### PR DESCRIPTION
This issue was recently raised by Boyan when he was testing his Koeln case study using the HT process. 

As can be seen in the following file HTFEM.h, the code is trying to calculate thermal_dispersivity value using the velocity vector and the velocity_magnitude. In case an inexperienced user sets an initial condition with uniform pressure values in the domain (I sometimes do it as well), the uniform pressure will lead to zero velocity values and hence exact zero for the velocity_magnitude. When left un-checked and passed on to the calculation of thermal_dispersivity, the "(thermal_dispersivity_longitudinal -           thermal_dispersivity_transversal) / velocity_magnitude" operation will deliver a "NAN" into the LHS matrix, and the linear solver will crash accordingly. For an inexperienced user, it is actually quite difficult to figure out the reason then. 

My proposal here is to add a safety check on the velocity_magnitude. In case it is zero (less than epsilon), then the thermal diffusion part can be safely ignored. 

@TomFischer @waltherm , would you please have a look at this and give your opinion? 