### PR TITLE
TecPlot utility

### DIFF
--- a/Applications/Utils/FileConverter/CMakeLists.txt
+++ b/Applications/Utils/FileConverter/CMakeLists.txt
@@ -39,6 +39,11 @@ add_executable(TIN2VTK TIN2VTK.cpp)
 set_target_properties(TIN2VTK PROPERTIES FOLDER Utilities)
 target_link_libraries(TIN2VTK MeshLib)
 
+add_executable(TecPlotTools TecPlotTools.cpp)
+set_target_properties(TecPlotTools PROPERTIES FOLDER Utilities)
+target_link_libraries(TecPlotTools GeoLib MeshLib)
+
+
 ####################
 ### Installation ###
 ####################

--- a/Applications/Utils/FileConverter/TecPlotTools.cpp
+++ b/Applications/Utils/FileConverter/TecPlotTools.cpp
@@ -19,12 +19,14 @@
 #include "BaseLib/BuildInfo.h"
 #include "BaseLib/StringTools.h"
 
+#include "MeshLib/IO/VtkIO/VtuInterface.h"
 #include "MeshLib/Mesh.h"
 #include "MeshLib/MeshGenerators/RasterToMesh.h"
-#include "MeshLib/IO/VtkIO/VtuInterface.h"
 
 /// Returns the value for the given parameter name (i.e. for "x = 3" it returns "3")
-std::string getValue(std::string const& line, std::string const& val_name, bool is_string)
+std::string getValue(std::string const& line,
+                     std::string const& val_name,
+                     bool is_string)
 {
     std::string value;
     std::size_t start(line.find(val_name));
@@ -82,9 +84,9 @@ std::string trimVariable(std::string& var)
 /// Returns an vector of variable names from the "Variables"-description
 std::vector<std::string> getVariables(std::string const& line)
 {
-    std::string const var_str ("VARIABLES");
+    std::string const var_str("VARIABLES");
     std::size_t start(line.find(var_str));
-    std::string all_vars = line.substr(start+var_str.length(), std::string::npos);
+    std::string all_vars = line.substr(start + var_str.length(), std::string::npos);
     start = all_vars.find("=");
     all_vars = all_vars.substr(start + 1, std::string::npos);
     BaseLib::trim(all_vars);
@@ -96,7 +98,7 @@ std::vector<std::string> getVariables(std::string const& line)
         end = all_vars.find_first_of(" ");
         std::string var = all_vars.substr(0, end);
         variables.push_back(trimVariable(var));
-        all_vars = all_vars.substr(end+1, std::string::npos);
+        all_vars = all_vars.substr(end + 1, std::string::npos);
         BaseLib::trim(all_vars);
     }
 
@@ -104,7 +106,9 @@ std::vector<std::string> getVariables(std::string const& line)
 }
 
 /// Tests if the number of read values equals the number of expected values
-bool dataCountError(std::string const& name, ::size_t const& current, std::size_t const& total)
+bool dataCountError(std::string const& name,
+                    std::size_t const& current,
+                    std::size_t const& total)
 {
     if (current != total)
     {
@@ -114,7 +118,8 @@ bool dataCountError(std::string const& name, ::size_t const& current, std::size_
     return false;
 }
 
-/// Tests if the number of read values equals the number of expected values and closes the stream
+/// Tests if the number of read values equals the number of expected values and
+/// closes the stream
 bool dataCountError(std::ofstream& out,
                     std::string const& name,
                     std::size_t const& current,
@@ -130,12 +135,12 @@ bool dataCountError(std::ofstream& out,
 
 /// Resets all data structures after a new "Variables"-description is found
 void resetDataStructures(std::size_t const& n_scalars,
-                         std::vector< std::vector<double> >& scalars,
+                         std::vector<std::vector<double>>& scalars,
                          std::size_t& val_count)
 {
     scalars.clear();
     scalars.reserve(n_scalars);
-    for (std::size_t i = 0; i<n_scalars; ++i)
+    for (std::size_t i = 0; i < n_scalars; ++i)
         scalars.push_back(std::vector<double>(0));
     val_count = 0;
 }
@@ -150,7 +155,7 @@ void writeTecPlotSection(std::ofstream& out,
     if (write_count == 0 || val_total != 0)
     {
         std::size_t const delim_pos(file_name.find_last_of("."));
-        std::string const base_name(file_name.substr(0, delim_pos+1));
+        std::string const base_name(file_name.substr(0, delim_pos + 1));
         std::string const extension(file_name.substr(delim_pos, std::string::npos));
 
         val_count = 0;
@@ -165,11 +170,11 @@ void writeTecPlotSection(std::ofstream& out,
 int writeDataToMesh(std::string const& file_name,
                     std::size_t& write_count,
                     std::vector<std::string> const& vec_names,
-                    std::vector< std::vector<double> > const& scalars,
+                    std::vector<std::vector<double>> const& scalars,
                     std::pair<std::size_t, std::size_t> const& dims)
 {
     double cellsize = 0;
-    for (std::size_t i=0; i<vec_names.size(); ++i)
+    for (std::size_t i = 0; i < vec_names.size(); ++i)
     {
         if (vec_names[i] == "x" || vec_names[i] == "X")
         {
@@ -180,21 +185,21 @@ int writeDataToMesh(std::string const& file_name,
 
     if (cellsize == 0)
     {
-        ERR ("Cell size not found. Aborting...");
+        ERR("Cell size not found. Aborting...");
         return -4;
     }
 
-    GeoLib::Point origin (0, 0, 0);
-    GeoLib::RasterHeader header { dims.first, dims.second, 1, origin, cellsize, -9999 };
+    GeoLib::Point origin(0, 0, 0);
+    GeoLib::RasterHeader header{dims.first, dims.second, 1, origin,     cellsize,    -9999};
 
-    std::unique_ptr<MeshLib::Mesh> mesh (MeshLib::RasterToMesh::convert(
-        scalars[0].data(),
-        header,
-        MeshLib::MeshElemType::QUAD,
-        MeshLib::UseIntensityAs::DATAVECTOR,
-        vec_names[0]));
+    std::unique_ptr<MeshLib::Mesh> mesh(
+        MeshLib::RasterToMesh::convert(scalars[0].data(),
+                                       header,
+                                       MeshLib::MeshElemType::QUAD,
+                                       MeshLib::UseIntensityAs::DATAVECTOR,
+                                       vec_names[0]));
     MeshLib::Properties& properties = mesh->getProperties();
-    for (std::size_t i=1; i<vec_names.size(); ++i)
+    for (std::size_t i = 1; i < vec_names.size(); ++i)
     {
         auto* const prop = properties.createNewPropertyVector<double>(
             vec_names[i], MeshLib::MeshItemType::Cell, 1);
@@ -240,21 +245,24 @@ int splitFile(std::ifstream& in, std::string file_name)
     {
         if (line.find("TITLE") != std::string::npos)
         {
-            if (dataCountError(out, name, val_count, val_total)) return -3;
+            if (dataCountError(out, name, val_count, val_total))
+                return -3;
             writeTecPlotSection(out, file_name, write_count, val_count, val_total);
             out << line << "\n";
             continue;
         }
         else if (line.find("VARIABLES") != std::string::npos)
         {
-            if (dataCountError(out, name, val_count, val_total)) return -3;
+            if (dataCountError(out, name, val_count, val_total))
+                return -3;
             writeTecPlotSection(out, file_name, write_count, val_count, val_total);
             out << line << "\n";
             continue;
         }
         else if (line.find("ZONE") != std::string::npos)
         {
-            if (dataCountError(out, name, val_count, val_total)) return -3;
+            if (dataCountError(out, name, val_count, val_total))
+                return -3;
             writeTecPlotSection(out, file_name, write_count, val_count, val_total);
             out << line << "\n";
             name = getName(line);
@@ -279,9 +287,9 @@ int splitFile(std::ifstream& in, std::string file_name)
 int convertFile(std::ifstream& in, std::string file_name)
 {
     std::string line, name;
-    std::pair<std::size_t, std::size_t> dims(0,0);
+    std::pair<std::size_t, std::size_t> dims(0, 0);
     std::vector<std::string> var_names;
-    std::vector< std::vector<double> > scalars;
+    std::vector<std::vector<double>> scalars;
     std::size_t val_count(0), val_total(0);
     std::size_t write_count(0);
     while (std::getline(in, line))
@@ -293,7 +301,8 @@ int convertFile(std::ifstream& in, std::string file_name)
             continue;
         else if (line.find("TITLE") != std::string::npos)
         {
-            if (dataCountError(name, val_count, val_total)) return -3;
+            if (dataCountError(name, val_count, val_total))
+                return -3;
             if (val_count != 0)
             {
                 writeDataToMesh(file_name, write_count, var_names, scalars, dims);
@@ -305,7 +314,8 @@ int convertFile(std::ifstream& in, std::string file_name)
         {
             if (val_count != 0)
             {
-                if (dataCountError(name, val_count, val_total)) return -3;
+                if (dataCountError(name, val_count, val_total))
+                    return -3;
                 writeDataToMesh(file_name, write_count, var_names, scalars, dims);
             }
             var_names.clear();
@@ -317,7 +327,8 @@ int convertFile(std::ifstream& in, std::string file_name)
         {
             if (val_count != 0)
             {
-                if (dataCountError(name, val_count, val_total)) return -3;
+                if (dataCountError(name, val_count, val_total))
+                    return -3;
                 writeDataToMesh(file_name, write_count, var_names, scalars, dims);
                 resetDataStructures(var_names.size(), scalars, val_count);
             }
@@ -331,10 +342,10 @@ int convertFile(std::ifstream& in, std::string file_name)
         double x;
         std::stringstream iss(line);
         std::size_t i(0);
-        std::size_t const n_scalars (scalars.size());
+        std::size_t const n_scalars(scalars.size());
         while (iss >> x)
         {
-            if (i > n_scalars-1)
+            if (i > n_scalars - 1)
             {
                 ERR("Too much data for existing scalar arrays");
                 return -3;
@@ -355,20 +366,31 @@ int convertFile(std::ifstream& in, std::string file_name)
     return 0;
 }
 
-int main(int argc, char *argv[])
+/**
+ * Small collection of scripts to handle TecPlot files.
+ *
+ * Return codes:
+ *      0 : no errors
+ *     -1 : missing arguments
+ *     -2 : file I/O error
+ *     -3 : index error
+ *     -4 : error interpreting data
+ *     -5 : error creating data structures
+ */
+int main(int argc, char* argv[])
 {
     ApplicationsLib::LogogSetup logog_setup;
 
     TCLAP::CmdLine cmd("TecPlot Parser", ' ', BaseLib::BuildInfo::git_describe);
-    TCLAP::ValueArg<std::string> input_arg("i", "input-file","TecPlot input file",true,"","string");
-    cmd.add( input_arg );
-    TCLAP::ValueArg<std::string> output_arg("o", "output-file","output mesh file",false,"","string");
-    cmd.add( output_arg );
-    TCLAP::SwitchArg split_arg("s","split","split time steps into seperate files");
+    TCLAP::ValueArg<std::string> input_arg("i", "input-file", "TecPlot input file", true, "", "string");
+    cmd.add(input_arg);
+    TCLAP::ValueArg<std::string> output_arg("o", "output-file", "output mesh file", false, "", "string");
+    cmd.add(output_arg);
+    TCLAP::SwitchArg split_arg("s", "split", "split time steps into seperate files");
     cmd.add(split_arg);
-    TCLAP::SwitchArg convert_arg("c", "convert","convert TecPlot data into OGS meshes");
+    TCLAP::SwitchArg convert_arg("c", "convert", "convert TecPlot data into OGS meshes");
     cmd.add(convert_arg);
-    cmd.parse( argc, argv );
+    cmd.parse(argc, argv);
 
     if (!input_arg.isSet())
     {
@@ -395,8 +417,9 @@ int main(int argc, char *argv[])
         return 0;
     }
 
-    std::string const filename = (output_arg.isSet()) ? output_arg.getValue() : input_arg.getValue();
-    int return_val (0);
+    std::string const filename = (output_arg.isSet()) ?
+        output_arg.getValue() : input_arg.getValue();
+    int return_val(0);
     if (split_arg.getValue())
         return_val = splitFile(in, filename);
     else if (convert_arg.getValue())

--- a/Applications/Utils/FileConverter/TecPlotTools.cpp
+++ b/Applications/Utils/FileConverter/TecPlotTools.cpp
@@ -1,0 +1,398 @@
+/**
+ * @copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ *
+ */
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <tclap/CmdLine.h>
+
+#include <Applications/ApplicationsLib/LogogSetup.h>
+
+#include "BaseLib/BuildInfo.h"
+#include "BaseLib/StringTools.h"
+
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshGenerators/RasterToMesh.h"
+#include "MeshLib/IO/VtkIO/VtuInterface.h"
+
+
+std::string getValue(std::string const& line, std::string const& val_name, bool is_string)
+{
+    std::string value;
+    std::size_t start(line.find(val_name));
+    std::size_t end(std::string::npos);
+    if (start == end)
+    {
+        ERR("Value not found.");
+        return "";
+    }
+    value = line.substr(start + 1, std::string::npos);
+    if (is_string)
+    {
+        start = value.find("\"");
+        value = value.substr(start + 1, std::string::npos);
+        end = value.find("\"");
+    }
+    else
+    {
+        start = value.find_first_not_of(" ");
+        value = value.substr(start + 1, std::string::npos);
+        BaseLib::trim(value);
+        end = value.find_first_of(" ");
+    }
+    value = value.substr(0, end);
+    BaseLib::trim(value);
+    return value;
+}
+
+std::string getName(std::string const& line)
+{
+    return getValue(line, "T=", true);
+}
+
+std::pair<std::size_t, std::size_t> getDimensions(std::string const& line)
+{
+    std::pair<std::size_t, std::size_t> dims;
+    std::stringstream start(getValue(line, "I=", false));
+    start >> dims.first;
+    std::stringstream end(getValue(line, "J=", false));
+    end >> dims.second;
+    return dims;
+}
+
+std::string trimVariable(std::string& var)
+{
+    std::size_t const start = var.find_first_not_of("\"");
+    var = var.substr(start, std::string::npos);
+    std::size_t const end = var.find_first_of("\"");
+    return var.substr(0, end);
+}
+
+std::vector<std::string> getVariables(std::string const& line)
+{
+    std::string const var_str ("VARIABLES");
+    std::size_t start(line.find(var_str));
+    std::string all_vars = line.substr(start+var_str.length(), std::string::npos);
+    start = all_vars.find("=");
+    all_vars = all_vars.substr(start + 1, std::string::npos);
+    BaseLib::trim(all_vars);
+
+    std::vector<std::string> variables;
+    std::size_t end = 0;
+    while (end != std::string::npos)
+    {
+        end = all_vars.find_first_of(" ");
+        std::string var = all_vars.substr(0, end);
+        variables.push_back(trimVariable(var));
+        all_vars = all_vars.substr(end+1, std::string::npos);
+        BaseLib::trim(all_vars);
+    }
+
+    return variables;
+}
+
+bool dataCountError(std::string const& name, ::size_t const& current, std::size_t const& total)
+{
+    if (current != total)
+    {
+        ERR("Data rows found do not fit specified dimensions for section \"%s\".", name.c_str());
+        return true;
+    }
+    return false;
+}
+
+bool dataCountError(std::ofstream& out,
+                    std::string const& name,
+                    std::size_t const& current,
+                    std::size_t const& total)
+{
+    if (dataCountError(name, current, total))
+    {
+        out.close();
+        return true;
+    }
+    return false;
+}
+
+void resetDataStructures(std::size_t const& n_scalars,
+                         std::vector< std::vector<double> >& scalars,
+                         std::size_t& val_count)
+{
+    scalars.clear();
+    scalars.reserve(n_scalars);
+    for (std::size_t i = 0; i<n_scalars; ++i)
+        scalars.push_back(std::vector<double>(0));
+    val_count = 0;
+}
+
+void writeTecPlotSection(std::ofstream& out,
+                         std::string const& file_name,
+                         std::size_t& write_count,
+                         std::size_t& val_count,
+                         std::size_t& val_total)
+{
+    if (write_count == 0 || val_total != 0)
+    {
+        std::size_t const delim_pos(file_name.find_last_of("."));
+        std::string const base_name(file_name.substr(0, delim_pos+1));
+        std::string const extension(file_name.substr(delim_pos, std::string::npos));
+
+        val_count = 0;
+        val_total = 0;
+        INFO("Writing section #%i", write_count);
+        out.close();
+        out = std::ofstream(base_name + std::to_string(write_count++) + extension);
+    }
+}
+
+int writeDataToMesh(std::string const& file_name,
+                    std::size_t& write_count,
+                    std::vector<std::string> const& vec_names,
+                    std::vector< std::vector<double> > const& scalars,
+                    std::pair<std::size_t, std::size_t> const& dims)
+{
+    double cellsize = 0;
+    for (std::size_t i=0; i<vec_names.size(); ++i)
+    {
+        if (vec_names[i] == "x" || vec_names[i] == "X")
+        {
+            cellsize = scalars[i][1] - scalars[i][0];
+            break;
+        }
+    }
+
+    if (cellsize == 0)
+    {
+        ERR ("Cell size not found. Aborting...");
+        return -4;
+    }
+
+    GeoLib::Point origin (0, 0, 0);
+    GeoLib::RasterHeader header { dims.first, dims.second, 1, origin, cellsize, -9999 };
+
+    std::unique_ptr<MeshLib::Mesh> mesh (MeshLib::RasterToMesh::convert(
+        scalars[0].data(),
+        header,
+        MeshLib::MeshElemType::QUAD,
+        MeshLib::UseIntensityAs::DATAVECTOR,
+        vec_names[0]));
+    MeshLib::Properties& properties = mesh->getProperties();
+    for (std::size_t i=1; i<vec_names.size(); ++i)
+    {
+        auto* const prop = properties.createNewPropertyVector<double>(
+            vec_names[i], MeshLib::MeshItemType::Cell, 1);
+        if (!prop)
+        {
+            ERR("Error creating array \"%s\".", vec_names[i].c_str());
+            return -5;
+        }
+        prop->reserve(scalars[i].size());
+        std::copy(scalars[i].cbegin(), scalars[i].cend(), std::back_inserter(*prop));
+    }
+
+    std::size_t const delim_pos(file_name.find_last_of("."));
+    std::string const base_name(file_name.substr(0, delim_pos + 1));
+    std::string const extension(file_name.substr(delim_pos, std::string::npos));
+
+    INFO("Writing section #%i", write_count);
+    MeshLib::IO::VtuInterface vtu(mesh.get());
+    vtu.writeToFile(base_name + std::to_string(write_count++) + extension);
+    return 0;
+}
+
+void skipGeometrySection(std::ifstream& in, std::string& line)
+{
+    while (getline(in, line))
+    {
+        if ((line.find("TITLE") != std::string::npos) ||
+            (line.find("VARIABLES") != std::string::npos) ||
+            (line.find("ZONE") != std::string::npos))
+            return;
+    }
+}
+
+int splitFile(std::ifstream& in, std::string file_name)
+{
+    std::ofstream out;
+    std::string line("");
+    std::string name;
+    std::pair<std::size_t, std::size_t> dims(0,0);
+    std::size_t val_count(0), val_total(0);
+    std::size_t write_count(0);
+    while (getline(in, line))
+    {
+        if (line.find("TITLE") != std::string::npos)
+        {
+            if (dataCountError(out, name, val_count, val_total)) return -3;
+            writeTecPlotSection(out, file_name, write_count, val_count, val_total);
+            out << line << "\n";
+            continue;
+        }
+        else if (line.find("VARIABLES") != std::string::npos)
+        {
+            if (dataCountError(out, name, val_count, val_total)) return -3;
+            writeTecPlotSection(out, file_name, write_count, val_count, val_total);
+            out << line << "\n";
+            continue;
+        }
+        else if (line.find("ZONE") != std::string::npos)
+        {
+            if (dataCountError(out, name, val_count, val_total)) return -3;
+            writeTecPlotSection(out, file_name, write_count, val_count, val_total);
+            out << line << "\n";
+            name = getName(line);
+            dims = getDimensions(line);
+            val_total = dims.first * dims.second;
+            val_count = 0;
+            continue;
+        }
+
+        out << line << "\n";
+        val_count++;
+    }
+    if (dataCountError(out, name, val_count, val_total))
+        return -3;
+    INFO("Writing time step #%i", write_count);
+    out.close();
+    INFO("Finished split.");
+    return 0;
+}
+
+int convertFile(std::ifstream& in, std::string file_name)
+{
+    std::string line(""), name("");
+    std::pair<std::size_t, std::size_t> dims(0,0);
+    std::vector<std::string> var_names;
+    std::vector< std::vector<double> > scalars;
+    std::size_t val_count(0), val_total(0);
+    std::size_t write_count(0);
+    while (getline(in, line))
+    {
+        if (line.find("GEOMETRY") != std::string::npos)
+            skipGeometrySection(in, line);
+
+        if (line.empty())
+            continue;
+        else if (line.find("TITLE") != std::string::npos)
+        {
+            if (dataCountError(name, val_count, val_total)) return -3;
+            if (val_count != 0)
+            {
+                writeDataToMesh(file_name, write_count, var_names, scalars, dims);
+                resetDataStructures(var_names.size(), scalars, val_count);
+            }
+            continue;
+        }
+        if (line.find("VARIABLES") != std::string::npos)
+        {
+            if (val_count != 0)
+            {
+                if (dataCountError(name, val_count, val_total)) return -3;
+                writeDataToMesh(file_name, write_count, var_names, scalars, dims);
+            }
+            var_names.clear();
+            var_names = getVariables(line);
+            resetDataStructures(var_names.size(), scalars, val_count);
+            continue;
+        }
+        if (line.find("ZONE") != std::string::npos)
+        {
+            if (val_count != 0)
+            {
+                if (dataCountError(name, val_count, val_total)) return -3;
+                writeDataToMesh(file_name, write_count, var_names, scalars, dims);
+                resetDataStructures(var_names.size(), scalars, val_count);
+            }
+            name = getName(line);
+            dims = getDimensions(line);
+            val_total = dims.first * dims.second;
+            val_count = 0;
+            continue;
+        }
+
+        double x;
+        std::stringstream iss(line);
+        std::size_t i(0);
+        std::size_t const n_scalars (scalars.size());
+        while (iss >> x)
+        {
+            if (i > n_scalars-1)
+            {
+                ERR("Too much data for existing scalar arrays");
+                return -3;
+            }
+            scalars[i++].push_back(x);
+        }
+        if (i < n_scalars)
+        {
+            ERR("Not enough data for existing scalar arrays");
+            return -3;
+        }
+        val_count++;
+    }
+    if (dataCountError(name, val_count, val_total))
+        return -3;
+    writeDataToMesh(file_name, write_count, var_names, scalars, dims);
+    INFO("Finished conversion.");
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    ApplicationsLib::LogogSetup logog_setup;
+
+    TCLAP::CmdLine cmd("TecPlot Parser", ' ', BaseLib::BuildInfo::git_describe);
+    TCLAP::ValueArg<std::string> input_arg("i", "input-file","TecPlot input file",true,"","string");
+    cmd.add( input_arg );
+    TCLAP::ValueArg<std::string> output_arg("o", "output-file","output mesh file",false,"","string");
+    cmd.add( output_arg );
+    TCLAP::SwitchArg split_arg("s","split","split time steps into seperate files");
+    cmd.add(split_arg);
+    TCLAP::SwitchArg convert_arg("c", "convert","convert TecPlot data into OGS meshes");
+    cmd.add(convert_arg);
+    cmd.parse( argc, argv );
+
+    if (!input_arg.isSet())
+    {
+        ERR("No input file given. Please specify TecPlot (*.plt) file");
+        return -1;
+    }
+
+    if (convert_arg.getValue() && !output_arg.isSet())
+    {
+        ERR("No output file given. Please specify OGS mesh (*.vtu) file");
+        return -1;
+    }
+
+    std::ifstream in(input_arg.getValue().c_str());
+    if (!in.is_open())
+    {
+        ERR("Could not open file %s.", input_arg.getValue().c_str());
+        return -2;
+    }
+
+    if (!convert_arg.isSet() && !split_arg.isSet())
+    {
+        INFO("Nothing to do. Use -s to split or -c to convert.");
+        return 0;
+    }
+
+    std::string const filename = (output_arg.isSet()) ? output_arg.getValue() : input_arg.getValue();
+    bool const convert (convert_arg.getValue());
+    int return_val (0);
+    if (split_arg.getValue())
+        return_val = splitFile(in, filename);
+    else if (convert_arg.getValue())
+        return_val = convertFile(in, filename);
+
+    in.close();
+    return return_val;
+}

--- a/Applications/Utils/FileConverter/TecPlotTools.cpp
+++ b/Applications/Utils/FileConverter/TecPlotTools.cpp
@@ -23,7 +23,7 @@
 #include "MeshLib/MeshGenerators/RasterToMesh.h"
 #include "MeshLib/IO/VtkIO/VtuInterface.h"
 
-
+/// Returns the value for the given parameter name (i.e. for "x = 3" it returns "3")
 std::string getValue(std::string const& line, std::string const& val_name, bool is_string)
 {
     std::string value;
@@ -53,11 +53,13 @@ std::string getValue(std::string const& line, std::string const& val_name, bool 
     return value;
 }
 
+/// Returns the name/title from the "Zone"-description
 std::string getName(std::string const& line)
 {
     return getValue(line, "T=", true);
 }
 
+/// Returns raster dimensions from the "Zone"-description
 std::pair<std::size_t, std::size_t> getDimensions(std::string const& line)
 {
     std::pair<std::size_t, std::size_t> dims;
@@ -68,6 +70,7 @@ std::pair<std::size_t, std::size_t> getDimensions(std::string const& line)
     return dims;
 }
 
+/// Trims a substring containing a variable-name
 std::string trimVariable(std::string& var)
 {
     std::size_t const start = var.find_first_not_of("\"");
@@ -76,6 +79,7 @@ std::string trimVariable(std::string& var)
     return var.substr(0, end);
 }
 
+/// Returns an vector of variable names from the "Variables"-description
 std::vector<std::string> getVariables(std::string const& line)
 {
     std::string const var_str ("VARIABLES");
@@ -99,6 +103,7 @@ std::vector<std::string> getVariables(std::string const& line)
     return variables;
 }
 
+/// Tests if the number of read values equals the number of expected values
 bool dataCountError(std::string const& name, ::size_t const& current, std::size_t const& total)
 {
     if (current != total)
@@ -109,6 +114,7 @@ bool dataCountError(std::string const& name, ::size_t const& current, std::size_
     return false;
 }
 
+/// Tests if the number of read values equals the number of expected values and closes the stream
 bool dataCountError(std::ofstream& out,
                     std::string const& name,
                     std::size_t const& current,
@@ -122,6 +128,7 @@ bool dataCountError(std::ofstream& out,
     return false;
 }
 
+/// Resets all data structures after a new "Variables"-description is found
 void resetDataStructures(std::size_t const& n_scalars,
                          std::vector< std::vector<double> >& scalars,
                          std::size_t& val_count)
@@ -133,6 +140,7 @@ void resetDataStructures(std::size_t const& n_scalars,
     val_count = 0;
 }
 
+/// Writes one section/zone into a seperate TecPlot file
 void writeTecPlotSection(std::ofstream& out,
                          std::string const& file_name,
                          std::size_t& write_count,
@@ -153,6 +161,7 @@ void writeTecPlotSection(std::ofstream& out,
     }
 }
 
+/// Writes one section/zone into a seperate OGS-mesh
 int writeDataToMesh(std::string const& file_name,
                     std::size_t& write_count,
                     std::vector<std::string> const& vec_names,
@@ -208,6 +217,7 @@ int writeDataToMesh(std::string const& file_name,
     return 0;
 }
 
+/// If a geometry-section is encountered, it is currently ignored
 void skipGeometrySection(std::ifstream& in, std::string& line)
 {
     while (getline(in, line))
@@ -219,6 +229,7 @@ void skipGeometrySection(std::ifstream& in, std::string& line)
     }
 }
 
+/// Splits a TecPlot file containing multiple sections/zones into seperate files
 int splitFile(std::ifstream& in, std::string file_name)
 {
     std::ofstream out;
@@ -266,6 +277,7 @@ int splitFile(std::ifstream& in, std::string file_name)
     return 0;
 }
 
+/// Converts a TecPlot file into one or more OGS-meshes (one mesh per section/zone)
 int convertFile(std::ifstream& in, std::string file_name)
 {
     std::string line(""), name("");

--- a/Applications/Utils/FileConverter/TecPlotTools.cpp
+++ b/Applications/Utils/FileConverter/TecPlotTools.cpp
@@ -157,7 +157,7 @@ void writeTecPlotSection(std::ofstream& out,
         val_total = 0;
         INFO("Writing section #%i", write_count);
         out.close();
-        out = std::ofstream(base_name + std::to_string(write_count++) + extension);
+        out.open(base_name + std::to_string(write_count++) + extension);
     }
 }
 
@@ -220,7 +220,7 @@ int writeDataToMesh(std::string const& file_name,
 /// If a geometry-section is encountered, it is currently ignored
 void skipGeometrySection(std::ifstream& in, std::string& line)
 {
-    while (getline(in, line))
+    while (std::getline(in, line))
     {
         if ((line.find("TITLE") != std::string::npos) ||
             (line.find("VARIABLES") != std::string::npos) ||
@@ -233,12 +233,10 @@ void skipGeometrySection(std::ifstream& in, std::string& line)
 int splitFile(std::ifstream& in, std::string file_name)
 {
     std::ofstream out;
-    std::string line("");
-    std::string name;
-    std::pair<std::size_t, std::size_t> dims(0,0);
+    std::string line, name;
     std::size_t val_count(0), val_total(0);
     std::size_t write_count(0);
-    while (getline(in, line))
+    while (std::getline(in, line))
     {
         if (line.find("TITLE") != std::string::npos)
         {
@@ -260,7 +258,7 @@ int splitFile(std::ifstream& in, std::string file_name)
             writeTecPlotSection(out, file_name, write_count, val_count, val_total);
             out << line << "\n";
             name = getName(line);
-            dims = getDimensions(line);
+            std::pair<std::size_t, std::size_t> dims = getDimensions(line);
             val_total = dims.first * dims.second;
             val_count = 0;
             continue;
@@ -280,13 +278,13 @@ int splitFile(std::ifstream& in, std::string file_name)
 /// Converts a TecPlot file into one or more OGS-meshes (one mesh per section/zone)
 int convertFile(std::ifstream& in, std::string file_name)
 {
-    std::string line(""), name("");
+    std::string line, name;
     std::pair<std::size_t, std::size_t> dims(0,0);
     std::vector<std::string> var_names;
     std::vector< std::vector<double> > scalars;
     std::size_t val_count(0), val_total(0);
     std::size_t write_count(0);
-    while (getline(in, line))
+    while (std::getline(in, line))
     {
         if (line.find("GEOMETRY") != std::string::npos)
             skipGeometrySection(in, line);
@@ -398,7 +396,6 @@ int main(int argc, char *argv[])
     }
 
     std::string const filename = (output_arg.isSet()) ? output_arg.getValue() : input_arg.getValue();
-    bool const convert (convert_arg.getValue());
     int return_val (0);
     if (split_arg.getValue())
         return_val = splitFile(in, filename);


### PR DESCRIPTION
Currently can

* split TecPlot files containing multiple "zones" (i.e. timesteps, subdomains, etc.) into seperate tecplot files
* convert TecPlot files representing raster data into ogs-meshes (one file per zone, containing all variables as scalar arrays)