### PR TITLE
Raster to Point Cloud Filters

### DIFF
--- a/Applications/DataExplorer/VtkVis/CMakeLists.txt
+++ b/Applications/DataExplorer/VtkVis/CMakeLists.txt
@@ -19,15 +19,19 @@ set(SOURCES
     VtkCompositeElementSelectionFilter.cpp
     VtkCompositeGeoObjectFilter.cpp
     VtkCompositeImageToCylindersFilter.cpp
+    VtkCompositeImageToPointCloudFilter.cpp
     VtkCompositeLineToTubeFilter.cpp
     VtkCompositeNodeSelectionFilter.cpp
     VtkCompositePointToGlyphFilter.cpp
     VtkCompositeTextureOnSurfaceFilter.cpp
     VtkCompositeThresholdFilter.cpp
     VtkConsoleOutputWindow.cpp
+    VtkCustomInteractorStyle.cpp
     VtkFilterFactory.cpp
     VtkGeoImageSource.cpp
     VtkImageDataToLinePolyDataFilter.cpp
+    VtkImageDataToPointCloudFilter.cpp
+    VtkPickCallback.cpp
     VtkPolylinesSource.cpp
     VtkPointsSource.cpp
     VtkRaster.cpp
@@ -41,11 +45,18 @@ set(SOURCES
     VtkVisPipelineView.cpp
     VtkVisPointSetItem.cpp
     VtkVisTabWidget.cpp
-    VtkPickCallback.cpp
-    VtkCustomInteractorStyle.cpp
 )
 
 set(HEADERS
+    MeshFromRasterDialog.h
+    QVtkDataSetMapper.h
+    VisPrefsDialog.h
+    VisualizationWidget.h
+    VtkAddFilterDialog.h
+    VtkAlgorithmProperties.h
+    VtkAlgorithmPropertyLineEdit.h
+    VtkAlgorithmPropertyCheckbox.h
+    VtkAlgorithmPropertyVectorEdit.h
     VtkAppendArrayFilter.h
     VtkBGImageSource.h
     VtkColorByHeightFilter.h
@@ -57,14 +68,19 @@ set(HEADERS
     VtkCompositeElementSelectionFilter.h
     VtkCompositeGeoObjectFilter.h
     VtkCompositeImageToCylindersFilter.h
+    VtkCompositeImageToPointCloudFilter.h
     VtkCompositeLineToTubeFilter.h
     VtkCompositeNodeSelectionFilter.h
     VtkCompositePointToGlyphFilter.h
     VtkCompositeTextureOnSurfaceFilter.h
     VtkCompositeThresholdFilter.h
+    VtkConsoleOutputWindow.h
+    VtkCustomInteractorStyle.h
     VtkFilterFactory.h
     VtkGeoImageSource.h
     VtkImageDataToLinePolyDataFilter.h
+    VtkImageDataToPointCloudFilter.h
+    VtkPickCallback.h
     VtkPolylinesSource.h
     VtkPointsSource.h
     VtkRaster.h
@@ -73,23 +89,11 @@ set(HEADERS
     VtkTextureOnSurfaceFilter.h
     VtkVisHelper.h
     VtkVisImageItem.h
-    VtkVisPipelineItem.h
-    VtkVisPointSetItem.h
-    MeshFromRasterDialog.h
-    QVtkDataSetMapper.h
-    VisPrefsDialog.h
-    VisualizationWidget.h
-    VtkAddFilterDialog.h
-    VtkAlgorithmProperties.h
-    VtkAlgorithmPropertyLineEdit.h
-    VtkAlgorithmPropertyCheckbox.h
-    VtkAlgorithmPropertyVectorEdit.h
     VtkVisPipeline.h
+    VtkVisPipelineItem.h
     VtkVisPipelineView.h
+    VtkVisPointSetItem.h
     VtkVisTabWidget.h
-    VtkConsoleOutputWindow.h
-    VtkPickCallback.h
-    VtkCustomInteractorStyle.h
 )
 
 # Visual Studio folder

--- a/Applications/DataExplorer/VtkVis/CMakeLists.txt
+++ b/Applications/DataExplorer/VtkVis/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
     VtkCompositeGeoObjectFilter.cpp
     VtkCompositeImageToCylindersFilter.cpp
     VtkCompositeImageToPointCloudFilter.cpp
+    VtkCompositeImageToSurfacePointsFilter.cpp
     VtkCompositeLineToTubeFilter.cpp
     VtkCompositeNodeSelectionFilter.cpp
     VtkCompositePointToGlyphFilter.cpp
@@ -31,6 +32,7 @@ set(SOURCES
     VtkGeoImageSource.cpp
     VtkImageDataToLinePolyDataFilter.cpp
     VtkImageDataToPointCloudFilter.cpp
+    VtkImageDataToSurfacePointsFilter.cpp
     VtkPickCallback.cpp
     VtkPolylinesSource.cpp
     VtkPointsSource.cpp
@@ -69,6 +71,7 @@ set(HEADERS
     VtkCompositeGeoObjectFilter.h
     VtkCompositeImageToCylindersFilter.h
     VtkCompositeImageToPointCloudFilter.h
+    VtkCompositeImageToSurfacePointsFilter.h
     VtkCompositeLineToTubeFilter.h
     VtkCompositeNodeSelectionFilter.h
     VtkCompositePointToGlyphFilter.h
@@ -80,6 +83,7 @@ set(HEADERS
     VtkGeoImageSource.h
     VtkImageDataToLinePolyDataFilter.h
     VtkImageDataToPointCloudFilter.h
+    VtkImageDataToSurfacePointsFilter.h
     VtkPickCallback.h
     VtkPolylinesSource.h
     VtkPointsSource.h

--- a/Applications/DataExplorer/VtkVis/VtkCompositeImageToPointCloudFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeImageToPointCloudFilter.cpp
@@ -24,8 +24,6 @@ VtkCompositeImageToPointCloudFilter::VtkCompositeImageToPointCloudFilter(vtkAlgo
     init();
 }
 
-VtkCompositeImageToPointCloudFilter::~VtkCompositeImageToPointCloudFilter() = default;
-
 void VtkCompositeImageToPointCloudFilter::init()
 {
     _inputDataObjectType = VTK_IMAGE_DATA;

--- a/Applications/DataExplorer/VtkVis/VtkCompositeImageToPointCloudFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeImageToPointCloudFilter.cpp
@@ -1,0 +1,96 @@
+/**
+* \copyright
+* Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+*            Distributed under a Modified BSD License.
+*              See accompanying file LICENSE.txt or
+*              http://www.opengeosys.org/project/license
+*
+*/
+
+#include "VtkCompositeImageToPointCloudFilter.h"
+
+#include <vtkPointData.h>
+#include <vtkSmartPointer.h>
+
+#include <QMap>
+#include <QString>
+#include <QVariant>
+
+#include "VtkImageDataToPointCloudFilter.h"
+
+VtkCompositeImageToPointCloudFilter::VtkCompositeImageToPointCloudFilter(vtkAlgorithm* inputAlgorithm)
+: VtkCompositeFilter(inputAlgorithm)
+{
+    init();
+}
+
+VtkCompositeImageToPointCloudFilter::~VtkCompositeImageToPointCloudFilter() = default;
+
+void VtkCompositeImageToPointCloudFilter::init()
+{
+    _inputDataObjectType = VTK_IMAGE_DATA;
+    _outputDataObjectType = VTK_POLY_DATA;
+
+    VtkImageDataToPointCloudFilter* point_cloud_filter = VtkImageDataToPointCloudFilter::New();
+    point_cloud_filter->SetInputConnection(_inputAlgorithm->GetOutputPort());
+    _inputAlgorithm->Update();
+
+    QList<QVariant> n_points_range_list;
+    n_points_range_list.push_back(point_cloud_filter->GetMinNumberOfPointsPerCell());
+    n_points_range_list.push_back(point_cloud_filter->GetMaxNumberOfPointsPerCell());
+    (*_algorithmUserVectorProperties)["Number of points range"] = n_points_range_list;
+    QList<QVariant> vertical_extent_list;
+    vertical_extent_list.push_back(point_cloud_filter->GetMinHeight());
+    vertical_extent_list.push_back(point_cloud_filter->GetMaxHeight());
+    (*_algorithmUserVectorProperties)["Vertical extent"] = vertical_extent_list;
+    (*_algorithmUserProperties)["Logarithmic interpolation"] = !point_cloud_filter->GetIsLinear();
+    (*_algorithmUserProperties)["Gamma value"] = point_cloud_filter->GetGamma();
+
+    point_cloud_filter->Update();
+    _outputAlgorithm = point_cloud_filter;
+}
+
+void VtkCompositeImageToPointCloudFilter::SetUserProperty(QString name, QVariant value)
+{
+    VtkAlgorithmProperties::SetUserProperty(name, value);
+
+    if ((name == "Gamma value") && (value.toDouble() > 0))
+    {
+        static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)->SetGamma(value.toDouble());
+    }
+    if (name == "Logarithmic interpolation")
+    {
+        if (value.toBool() == true)
+        {
+            double const gamma = VtkAlgorithmProperties::GetUserProperty("Gamma value").toDouble();
+            if (gamma > 0)
+                static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)->useLogarithmicInterpolation(gamma);
+        }
+        else
+            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)->useLinearInterpolation();
+    }
+}
+
+void VtkCompositeImageToPointCloudFilter::SetUserVectorProperty(
+    QString name, QList<QVariant> values)
+{
+    VtkAlgorithmProperties::SetUserVectorProperty(name, values);
+
+    if (name == "Number of points range")
+    {
+        if (values[0].toInt() >= 0 && values[1].toInt() >=0 && values[0].toInt() <= values[1].toInt())
+        {
+            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)->SetMinNumberOfPointsPerCell(values[0].toInt());
+            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)->SetMaxNumberOfPointsPerCell(values[1].toInt());
+        }
+    }
+    else if (name == "Vertical extent")
+    {
+        if (values[0].toDouble() <= values[1].toDouble())
+        {
+            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)->SetMinHeight(values[0].toDouble());
+            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)->SetMaxHeight(values[1].toDouble());
+        }
+    }
+}
+

--- a/Applications/DataExplorer/VtkVis/VtkCompositeImageToPointCloudFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeImageToPointCloudFilter.cpp
@@ -1,11 +1,11 @@
 /**
-* \copyright
-* Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
-*            Distributed under a Modified BSD License.
-*              See accompanying file LICENSE.txt or
-*              http://www.opengeosys.org/project/license
-*
-*/
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
 
 #include "VtkCompositeImageToPointCloudFilter.h"
 
@@ -19,7 +19,7 @@
 #include "VtkImageDataToPointCloudFilter.h"
 
 VtkCompositeImageToPointCloudFilter::VtkCompositeImageToPointCloudFilter(vtkAlgorithm* inputAlgorithm)
-: VtkCompositeFilter(inputAlgorithm)
+    : VtkCompositeFilter(inputAlgorithm)
 {
     init();
 }
@@ -31,7 +31,8 @@ void VtkCompositeImageToPointCloudFilter::init()
     _inputDataObjectType = VTK_IMAGE_DATA;
     _outputDataObjectType = VTK_POLY_DATA;
 
-    VtkImageDataToPointCloudFilter* point_cloud_filter = VtkImageDataToPointCloudFilter::New();
+    VtkImageDataToPointCloudFilter* point_cloud_filter =
+        VtkImageDataToPointCloudFilter::New();
     point_cloud_filter->SetInputConnection(_inputAlgorithm->GetOutputPort());
     _inputAlgorithm->Update();
 
@@ -62,35 +63,41 @@ void VtkCompositeImageToPointCloudFilter::SetUserProperty(QString name, QVariant
     {
         if (value.toBool() == true)
         {
-            double const gamma = VtkAlgorithmProperties::GetUserProperty("Gamma value").toDouble();
+            double const gamma =
+                VtkAlgorithmProperties::GetUserProperty("Gamma value").toDouble();
             if (gamma > 0)
-                static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)->useLogarithmicInterpolation(gamma);
+                static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)
+                    ->useLogarithmicInterpolation(gamma);
         }
         else
-            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)->useLinearInterpolation();
+            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)
+                ->useLinearInterpolation();
     }
 }
 
-void VtkCompositeImageToPointCloudFilter::SetUserVectorProperty(
-    QString name, QList<QVariant> values)
+void VtkCompositeImageToPointCloudFilter::SetUserVectorProperty(QString name, QList<QVariant> values)
 {
     VtkAlgorithmProperties::SetUserVectorProperty(name, values);
 
     if (name == "Number of points range")
     {
-        if (values[0].toInt() >= 0 && values[1].toInt() >=0 && values[0].toInt() <= values[1].toInt())
+        if (values[0].toInt() >= 0 && values[1].toInt() >= 0 &&
+            values[0].toInt() <= values[1].toInt())
         {
-            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)->SetMinNumberOfPointsPerCell(values[0].toInt());
-            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)->SetMaxNumberOfPointsPerCell(values[1].toInt());
+            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)
+                ->SetMinNumberOfPointsPerCell(values[0].toInt());
+            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)
+                ->SetMaxNumberOfPointsPerCell(values[1].toInt());
         }
     }
     else if (name == "Vertical extent")
     {
         if (values[0].toDouble() <= values[1].toDouble())
         {
-            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)->SetMinHeight(values[0].toDouble());
-            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)->SetMaxHeight(values[1].toDouble());
+            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)
+                ->SetMinHeight(values[0].toDouble());
+            static_cast<VtkImageDataToPointCloudFilter*>(_outputAlgorithm)
+                ->SetMaxHeight(values[1].toDouble());
         }
     }
 }
-

--- a/Applications/DataExplorer/VtkVis/VtkCompositeImageToPointCloudFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeImageToPointCloudFilter.h
@@ -24,7 +24,4 @@ public:
     void SetUserProperty(QString name, QVariant value) override;
 
     void SetUserVectorProperty(QString name, QList<QVariant> values) override;
-
-private:
-    //VtkImageDataToPointCloudFilter* _point_cloud_filter;
 };

--- a/Applications/DataExplorer/VtkVis/VtkCompositeImageToPointCloudFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeImageToPointCloudFilter.h
@@ -17,7 +17,7 @@ class VtkCompositeImageToPointCloudFilter : public VtkCompositeFilter
 {
 public:
     VtkCompositeImageToPointCloudFilter(vtkAlgorithm* inputAlgorithm);
-    ~VtkCompositeImageToPointCloudFilter() override;
+    ~VtkCompositeImageToPointCloudFilter() = default;
 
     void init() override;
 

--- a/Applications/DataExplorer/VtkVis/VtkCompositeImageToPointCloudFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeImageToPointCloudFilter.h
@@ -1,0 +1,30 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include "VtkCompositeFilter.h"
+
+class VtkImageDataToPointCloudFilter;
+
+class VtkCompositeImageToPointCloudFilter : public VtkCompositeFilter
+{
+public:
+    VtkCompositeImageToPointCloudFilter(vtkAlgorithm* inputAlgorithm);
+    ~VtkCompositeImageToPointCloudFilter() override;
+
+    void init() override;
+
+    void SetUserProperty(QString name, QVariant value) override;
+
+    void SetUserVectorProperty(QString name, QList<QVariant> values) override;
+
+private:
+    //VtkImageDataToPointCloudFilter* _point_cloud_filter;
+};

--- a/Applications/DataExplorer/VtkVis/VtkCompositeImageToSurfacePointsFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeImageToSurfacePointsFilter.cpp
@@ -25,8 +25,6 @@ VtkCompositeImageToSurfacePointsFilter::VtkCompositeImageToSurfacePointsFilter(
     init();
 }
 
-VtkCompositeImageToSurfacePointsFilter::~VtkCompositeImageToSurfacePointsFilter() = default;
-
 void VtkCompositeImageToSurfacePointsFilter::init()
 {
     _inputDataObjectType = VTK_IMAGE_DATA;

--- a/Applications/DataExplorer/VtkVis/VtkCompositeImageToSurfacePointsFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeImageToSurfacePointsFilter.cpp
@@ -1,0 +1,56 @@
+/**
+* \copyright
+* Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+*            Distributed under a Modified BSD License.
+*              See accompanying file LICENSE.txt or
+*              http://www.opengeosys.org/project/license
+*
+*/
+
+#include "VtkCompositeImageToSurfacePointsFilter.h"
+
+#include <vtkPointData.h>
+#include <vtkSmartPointer.h>
+
+#include <QMap>
+#include <QString>
+#include <QVariant>
+
+#include "VtkImageDataToSurfacePointsFilter.h"
+
+VtkCompositeImageToSurfacePointsFilter::VtkCompositeImageToSurfacePointsFilter(vtkAlgorithm* inputAlgorithm)
+: VtkCompositeFilter(inputAlgorithm)//, _point_cloud_filter(nullptr)
+{
+    init();
+}
+
+VtkCompositeImageToSurfacePointsFilter::~VtkCompositeImageToSurfacePointsFilter() = default;
+
+void VtkCompositeImageToSurfacePointsFilter::init()
+{
+    _inputDataObjectType = VTK_IMAGE_DATA;
+    _outputDataObjectType = VTK_POLY_DATA;
+
+    VtkImageDataToSurfacePointsFilter* point_cloud_filter = VtkImageDataToSurfacePointsFilter::New();
+    point_cloud_filter->SetInputConnection(_inputAlgorithm->GetOutputPort());
+    _inputAlgorithm->Update();
+
+    (*_algorithmUserProperties)["Points per pixel"] = static_cast<int>(point_cloud_filter->GetPointsPerPixel());
+    point_cloud_filter->Update();
+    _outputAlgorithm = point_cloud_filter;
+}
+
+void VtkCompositeImageToSurfacePointsFilter::SetUserProperty(QString name, QVariant value)
+{
+    VtkAlgorithmProperties::SetUserProperty(name, value);
+    if ((name == "Points per pixel") && (value.toInt() > 0))
+        static_cast<VtkImageDataToSurfacePointsFilter*>(_outputAlgorithm)->SetPointsPerPixel(static_cast<vtkIdType>(value.toInt()));
+}
+
+void VtkCompositeImageToSurfacePointsFilter::SetUserVectorProperty(
+    QString name, QList<QVariant> values)
+{
+    Q_UNUSED(name);
+	Q_UNUSED(values);
+}
+

--- a/Applications/DataExplorer/VtkVis/VtkCompositeImageToSurfacePointsFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeImageToSurfacePointsFilter.cpp
@@ -1,11 +1,11 @@
 /**
-* \copyright
-* Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
-*            Distributed under a Modified BSD License.
-*              See accompanying file LICENSE.txt or
-*              http://www.opengeosys.org/project/license
-*
-*/
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
 
 #include "VtkCompositeImageToSurfacePointsFilter.h"
 
@@ -18,8 +18,9 @@
 
 #include "VtkImageDataToSurfacePointsFilter.h"
 
-VtkCompositeImageToSurfacePointsFilter::VtkCompositeImageToSurfacePointsFilter(vtkAlgorithm* inputAlgorithm)
-: VtkCompositeFilter(inputAlgorithm)//, _point_cloud_filter(nullptr)
+VtkCompositeImageToSurfacePointsFilter::VtkCompositeImageToSurfacePointsFilter(
+    vtkAlgorithm* inputAlgorithm)
+    : VtkCompositeFilter(inputAlgorithm)
 {
     init();
 }
@@ -31,11 +32,13 @@ void VtkCompositeImageToSurfacePointsFilter::init()
     _inputDataObjectType = VTK_IMAGE_DATA;
     _outputDataObjectType = VTK_POLY_DATA;
 
-    VtkImageDataToSurfacePointsFilter* point_cloud_filter = VtkImageDataToSurfacePointsFilter::New();
+    VtkImageDataToSurfacePointsFilter* point_cloud_filter =
+        VtkImageDataToSurfacePointsFilter::New();
     point_cloud_filter->SetInputConnection(_inputAlgorithm->GetOutputPort());
     _inputAlgorithm->Update();
 
-    (*_algorithmUserProperties)["Points per pixel"] = static_cast<int>(point_cloud_filter->GetPointsPerPixel());
+    (*_algorithmUserProperties)["Points per pixel"] =
+        static_cast<int>(point_cloud_filter->GetPointsPerPixel());
     point_cloud_filter->Update();
     _outputAlgorithm = point_cloud_filter;
 }
@@ -44,13 +47,13 @@ void VtkCompositeImageToSurfacePointsFilter::SetUserProperty(QString name, QVari
 {
     VtkAlgorithmProperties::SetUserProperty(name, value);
     if ((name == "Points per pixel") && (value.toInt() > 0))
-        static_cast<VtkImageDataToSurfacePointsFilter*>(_outputAlgorithm)->SetPointsPerPixel(static_cast<vtkIdType>(value.toInt()));
+        static_cast<VtkImageDataToSurfacePointsFilter*>(_outputAlgorithm)
+            ->SetPointsPerPixel(static_cast<vtkIdType>(value.toInt()));
 }
 
 void VtkCompositeImageToSurfacePointsFilter::SetUserVectorProperty(
     QString name, QList<QVariant> values)
 {
     Q_UNUSED(name);
-	Q_UNUSED(values);
+    Q_UNUSED(values);
 }
-

--- a/Applications/DataExplorer/VtkVis/VtkCompositeImageToSurfacePointsFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeImageToSurfacePointsFilter.h
@@ -1,0 +1,27 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include "VtkCompositeFilter.h"
+
+class VtkImageDataToSurfacePointsFilter;
+
+class VtkCompositeImageToSurfacePointsFilter : public VtkCompositeFilter
+{
+public:
+    VtkCompositeImageToSurfacePointsFilter(vtkAlgorithm* inputAlgorithm);
+    ~VtkCompositeImageToSurfacePointsFilter() override;
+
+    void init() override;
+
+    void SetUserProperty(QString name, QVariant value) override;
+
+    void SetUserVectorProperty(QString name, QList<QVariant> values) override;
+};

--- a/Applications/DataExplorer/VtkVis/VtkCompositeImageToSurfacePointsFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeImageToSurfacePointsFilter.h
@@ -17,7 +17,7 @@ class VtkCompositeImageToSurfacePointsFilter : public VtkCompositeFilter
 {
 public:
     VtkCompositeImageToSurfacePointsFilter(vtkAlgorithm* inputAlgorithm);
-    ~VtkCompositeImageToSurfacePointsFilter() override;
+    ~VtkCompositeImageToSurfacePointsFilter() = default;
 
     void init() override;
 

--- a/Applications/DataExplorer/VtkVis/VtkFilterFactory.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkFilterFactory.cpp
@@ -27,6 +27,7 @@
 #include "VtkCompositeTextureOnSurfaceFilter.h"
 #include "VtkCompositeThresholdFilter.h"
 #include "VtkImageDataToLinePolyDataFilter.h"
+#include "VtkCompositeImageToPointCloudFilter.h"
 
 #include <vtkDataSetSurfaceFilter.h>
 
@@ -83,6 +84,12 @@ const QVector<VtkFilterInfo> VtkFilterFactory::GetFilterList()
                                  "Visualisation of contour-lines/-planes within dense scalar fields.",
                                  VTK_UNSTRUCTURED_GRID, VTK_UNSTRUCTURED_GRID));
 
+    filterList.push_back(VtkFilterInfo(
+                                 "VtkCompositeImageToPointCloudFilter",
+                                 "Image to point cloud",
+                                 "This filter creates point clouds with a density based on the first component of pixel values.",
+                                 VTK_IMAGE_DATA, VTK_POLY_DATA));
+
     // Simple filters
     filterList.push_back(VtkFilterInfo(
                                  "VtkImageDataToLinePolyDataFilter",
@@ -131,6 +138,8 @@ VtkCompositeFilter* VtkFilterFactory::CreateCompositeFilter( QString type,
         return new VtkCompositeContourFilter(inputAlgorithm);
     if (type.compare(QString("VtkCompositeGeoObjectFilter")) == 0)
         return new VtkCompositeGeoObjectFilter(inputAlgorithm);
+    if (type.compare(QString("VtkCompositeImageToPointCloudFilter")) == 0)
+        return new VtkCompositeImageToPointCloudFilter(inputAlgorithm);
 
     return nullptr;
 }

--- a/Applications/DataExplorer/VtkVis/VtkFilterFactory.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkFilterFactory.cpp
@@ -25,9 +25,10 @@
 #include "VtkCompositeNodeSelectionFilter.h"
 #include "VtkCompositePointToGlyphFilter.h"
 #include "VtkCompositeTextureOnSurfaceFilter.h"
+#include "VtkCompositeImageToPointCloudFilter.h"
+#include "VtkCompositeImageToSurfacePointsFilter.h"
 #include "VtkCompositeThresholdFilter.h"
 #include "VtkImageDataToLinePolyDataFilter.h"
-#include "VtkCompositeImageToPointCloudFilter.h"
 
 #include <vtkDataSetSurfaceFilter.h>
 
@@ -87,8 +88,14 @@ const QVector<VtkFilterInfo> VtkFilterFactory::GetFilterList()
     filterList.push_back(VtkFilterInfo(
                                  "VtkCompositeImageToPointCloudFilter",
                                  "Image to point cloud",
-                                 "This filter creates point clouds with a density based on the first component of pixel values.",
+                                 "This filter creates a point cloud with a density based on the first component of pixel values.",
                                  VTK_IMAGE_DATA, VTK_POLY_DATA));
+
+    filterList.push_back(VtkFilterInfo(
+                                "VtkCompositeImageToSurfacePointsFilter",
+                                "Image to surface points",
+                                "This filter creates a point cloud representing a surface based on the first component of pixel values.",
+                                VTK_IMAGE_DATA, VTK_POLY_DATA));
 
     // Simple filters
     filterList.push_back(VtkFilterInfo(
@@ -140,6 +147,8 @@ VtkCompositeFilter* VtkFilterFactory::CreateCompositeFilter( QString type,
         return new VtkCompositeGeoObjectFilter(inputAlgorithm);
     if (type.compare(QString("VtkCompositeImageToPointCloudFilter")) == 0)
         return new VtkCompositeImageToPointCloudFilter(inputAlgorithm);
+    if (type.compare(QString("VtkCompositeImageToSurfacePointsFilter")) == 0)
+        return new VtkCompositeImageToSurfacePointsFilter(inputAlgorithm);
 
     return nullptr;
 }

--- a/Applications/DataExplorer/VtkVis/VtkFilterFactory.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkFilterFactory.cpp
@@ -21,12 +21,12 @@
 #include "VtkCompositeElementSelectionFilter.h"
 #include "VtkCompositeGeoObjectFilter.h"
 #include "VtkCompositeImageToCylindersFilter.h"
+#include "VtkCompositeImageToPointCloudFilter.h"
+#include "VtkCompositeImageToSurfacePointsFilter.h"
 #include "VtkCompositeLineToTubeFilter.h"
 #include "VtkCompositeNodeSelectionFilter.h"
 #include "VtkCompositePointToGlyphFilter.h"
 #include "VtkCompositeTextureOnSurfaceFilter.h"
-#include "VtkCompositeImageToPointCloudFilter.h"
-#include "VtkCompositeImageToSurfacePointsFilter.h"
 #include "VtkCompositeThresholdFilter.h"
 #include "VtkImageDataToLinePolyDataFilter.h"
 
@@ -86,16 +86,16 @@ const QVector<VtkFilterInfo> VtkFilterFactory::GetFilterList()
                                  VTK_UNSTRUCTURED_GRID, VTK_UNSTRUCTURED_GRID));
 
     filterList.push_back(VtkFilterInfo(
-                                 "VtkCompositeImageToPointCloudFilter",
-                                 "Image to point cloud",
-                                 "This filter creates a point cloud with a density based on the first component of pixel values.",
-                                 VTK_IMAGE_DATA, VTK_POLY_DATA));
+        "VtkCompositeImageToPointCloudFilter", "Image to point cloud",
+        "This filter creates a point cloud with a density based on the first "
+        "component of pixel values.",
+        VTK_IMAGE_DATA, VTK_POLY_DATA));
 
     filterList.push_back(VtkFilterInfo(
-                                "VtkCompositeImageToSurfacePointsFilter",
-                                "Image to surface points",
-                                "This filter creates a point cloud representing a surface based on the first component of pixel values.",
-                                VTK_IMAGE_DATA, VTK_POLY_DATA));
+        "VtkCompositeImageToSurfacePointsFilter", "Image to surface points",
+        "This filter creates a point cloud representing a surface based on the "
+        "first component of pixel values.",
+        VTK_IMAGE_DATA, VTK_POLY_DATA));
 
     // Simple filters
     filterList.push_back(VtkFilterInfo(

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.cpp
@@ -27,17 +27,15 @@
 vtkStandardNewMacro(VtkImageDataToPointCloudFilter);
 
 VtkImageDataToPointCloudFilter::VtkImageDataToPointCloudFilter()
-    : IsLinear(true),
-      MinNumberOfPointsPerCell(1),
-      MaxNumberOfPointsPerCell(20),
-      Gamma(1.0),
+    : Gamma(1.0),
       PointScaleFactor(1.0),
       MinHeight(0),
-      MaxHeight(1000)
+      MaxHeight(1000),
+      MinNumberOfPointsPerCell(1),
+      MaxNumberOfPointsPerCell(20),
+      IsLinear(true)
 {
 }
-
-VtkImageDataToPointCloudFilter::~VtkImageDataToPointCloudFilter() = default;
 
 void VtkImageDataToPointCloudFilter::PrintSelf(ostream& os, vtkIndent indent)
 {
@@ -160,7 +158,7 @@ void VtkImageDataToPointCloudFilter::createPoints(
 /// Creates the point objects based on the parameters set by the user
 double VtkImageDataToPointCloudFilter::getRandomNumber(double const& min, double const& max) const
 {
-    return ((double)rand() / RAND_MAX) * (max - min) + min;
+    return ((double)std::rand() / RAND_MAX) * (max - min) + min;
 }
 
 std::size_t VtkImageDataToPointCloudFilter::interpolate(double low,
@@ -171,6 +169,6 @@ std::size_t VtkImageDataToPointCloudFilter::interpolate(double low,
     assert(p >= low && p <= high);
     double const r = (p - low) / (high - low);
     return static_cast<std::size_t>(
-        (MaxNumberOfPointsPerCell - MinNumberOfPointsPerCell) * pow(r, gamma) +
+        (MaxNumberOfPointsPerCell - MinNumberOfPointsPerCell) * std::pow(r, gamma) +
          MinNumberOfPointsPerCell);
 }

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.cpp
@@ -155,7 +155,6 @@ void VtkImageDataToPointCloudFilter::createPoints(
     }
 }
 
-/// Creates the point objects based on the parameters set by the user
 double VtkImageDataToPointCloudFilter::getRandomNumber(double const& min, double const& max) const
 {
     return ((double)std::rand() / RAND_MAX) * (max - min) + min;

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.cpp
@@ -1,0 +1,156 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+// ** INCLUDES **
+#include "VtkImageDataToPointCloudFilter.h"
+
+#include <vector>
+#include <algorithm>
+
+#include <vtkIdList.h>
+#include <vtkImageData.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+#include <vtkLine.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkPolyData.h>
+#include <vtkSmartPointer.h>
+
+vtkStandardNewMacro(VtkImageDataToPointCloudFilter);
+
+VtkImageDataToPointCloudFilter::VtkImageDataToPointCloudFilter()
+: IsLinear(true), MinNumberOfPointsPerCell(1), MaxNumberOfPointsPerCell(20),
+  Gamma(1.0), PointScaleFactor(1.0), MinHeight(0), MaxHeight(1000)
+{
+}
+
+VtkImageDataToPointCloudFilter::~VtkImageDataToPointCloudFilter() = default;
+
+void VtkImageDataToPointCloudFilter::PrintSelf(ostream& os, vtkIndent indent)
+{
+    this->Superclass::PrintSelf(os, indent);
+}
+
+int VtkImageDataToPointCloudFilter::FillInputPortInformation(int, vtkInformation* info)
+{
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkImageData");
+    return 1;
+}
+
+int VtkImageDataToPointCloudFilter::RequestData(vtkInformation*,
+                                                vtkInformationVector** inputVector,
+                                                vtkInformationVector* outputVector)
+{
+    vtkDebugMacro(<< "Executing VtkImageDataToPointCloudFilter");
+
+    vtkInformation* input_info = inputVector[0]->GetInformationObject(0);
+    vtkInformation* output_info = outputVector->GetInformationObject(0);
+    vtkImageData* input = vtkImageData::SafeDownCast(input_info->Get(vtkDataObject::DATA_OBJECT()));
+    vtkPolyData* output = vtkPolyData::SafeDownCast(output_info->Get(vtkDataObject::DATA_OBJECT()));
+
+    void* pixvals = input->GetScalarPointer();
+    int const n_comp = input->GetNumberOfScalarComponents();
+    if (n_comp < 1)
+        vtkDebugMacro("Error reading number of components.");
+    if (n_comp > 2)
+        vtkDebugMacro("RGB colours detected. Using only first channel for computation.");
+
+    vtkIdType const n_points = input->GetNumberOfPoints();
+    if (n_points == 0)
+    {
+        vtkDebugMacro("No data found!");
+        return -1;
+    }
+
+    double spacing[3];
+    input->GetSpacing(spacing);
+    double range[2];
+    vtkPointData* input_data = input->GetPointData();
+    input_data->GetArray(0)->GetRange(range);
+
+    std::vector<std::size_t> density;
+    density.reserve(n_points);
+    for (vtkIdType i=0; i < n_points; ++i)
+    {
+        // Skip transparent pixels
+        if (n_comp == 2 || n_comp == 4)
+        {
+            if (((float*)pixvals)[(i + 1) * n_comp - 1] < 0.00000001f)
+            {
+                density.push_back(0);
+                continue;
+            }
+        }
+        float const val (((float*)pixvals)[i * n_comp]);
+        double const calc_gamma = (IsLinear) ? 1 : Gamma;
+        double const pnts_per_cell = interpolate(range[0], range[1], val, calc_gamma);
+        density.push_back(static_cast<std::size_t>(std::floor(pnts_per_cell * GetPointScaleFactor())));
+    }
+
+    // Allocate the space needed for output objects
+    std::size_t const sum = std::accumulate(density.begin(), density.end(), 0);
+    vtkSmartPointer<vtkPoints> new_points = vtkSmartPointer<vtkPoints>::New();
+    new_points->SetNumberOfPoints(sum);
+    vtkSmartPointer<vtkCellArray> cells = vtkSmartPointer<vtkCellArray>::New();
+    cells->Allocate(sum);
+
+    vtkPointData* output_data = output->GetPointData();
+    double const half_cellsize (spacing[0] / 2.0);
+    std::size_t pnt_idx (0);
+    for (std::size_t i=0; i<static_cast<std::size_t>(n_points); ++i)
+    {
+        if (density[i] == 0)
+            continue;
+        double p[3];
+        input->GetPoint(i, p);
+
+        MathLib::Point3d min_pnt{
+            std::array<double,3>{{p[0]-half_cellsize, p[1]-half_cellsize, MinHeight}} };
+        MathLib::Point3d max_pnt{
+            std::array<double,3>{ {p[0] + half_cellsize, p[1] + half_cellsize, MaxHeight}} };
+        createPoints(new_points, cells, pnt_idx, density[i], min_pnt, max_pnt);
+        pnt_idx += density[i];
+    }
+
+    output->SetPoints(new_points);
+    output->SetVerts(cells);
+    output->Squeeze();
+
+    vtkDebugMacro(<< "Created " << new_points->GetNumberOfPoints() << " points.");
+    return 1;
+}
+
+void VtkImageDataToPointCloudFilter::createPoints(vtkSmartPointer<vtkPoints> &points, vtkSmartPointer<vtkCellArray> &cells, std::size_t pnt_idx, std::size_t n_points, MathLib::Point3d const& min_pnt, MathLib::Point3d const& max_pnt) const
+{
+    for (std::size_t i=0; i<n_points; ++i)
+    {
+        double p[3];
+        p[0] = getRandomNumber(min_pnt[0], max_pnt[0]);
+        p[1] = getRandomNumber(min_pnt[1], max_pnt[1]);
+        p[2] = getRandomNumber(min_pnt[2], max_pnt[2]);
+        points->SetPoint(pnt_idx+i, p);
+        cells->InsertNextCell(1);
+        cells->InsertCellPoint(pnt_idx +i);
+    }
+}
+
+/// Creates the point objects based on the parameters set by the user
+double VtkImageDataToPointCloudFilter::getRandomNumber(double const& min, double const& max) const
+{
+    return ((double)rand() / RAND_MAX) * (max - min) + min;
+}
+
+std::size_t VtkImageDataToPointCloudFilter::interpolate(double low, double high, double p, double gamma) const
+{
+    assert(p >= low && p <= high);
+    double const r = (p-low) / (high-low);
+    return static_cast<std::size_t>((MaxNumberOfPointsPerCell - MinNumberOfPointsPerCell) * pow(r, gamma) + MinNumberOfPointsPerCell);
+}

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.h
@@ -18,7 +18,8 @@
 class vtkInformation;
 class vtkInformationVector;
 
-/// A VTK Filter that will create a point cloud with local densities based on pixel values.
+/// A VTK Filter that will create a point cloud with local densities based on
+/// pixel values.
 class VtkImageDataToPointCloudFilter : public vtkPolyDataAlgorithm
 {
 public:
@@ -31,7 +32,11 @@ public:
     void PrintSelf(ostream& os, vtkIndent indent) override;
 
     void useLinearInterpolation() { SetIsLinear(true); }
-    void useLogarithmicInterpolation(double gamma) { SetIsLinear(false); SetGamma(gamma); }
+    void useLogarithmicInterpolation(double gamma)
+    {
+        SetIsLinear(false);
+        SetGamma(gamma);
+    }
 
     vtkGetMacro(IsLinear, bool);
     vtkSetMacro(IsLinear, bool);
@@ -74,11 +79,14 @@ protected:
     double MaxHeight;
 
 private:
-    VtkImageDataToPointCloudFilter(const VtkImageDataToPointCloudFilter&) = delete; 
+    VtkImageDataToPointCloudFilter(const VtkImageDataToPointCloudFilter&) = delete;
     void operator=(const VtkImageDataToPointCloudFilter&) = delete;
 
     /// Creates the point objects based on the parameters set by the user
-    void createPoints(vtkSmartPointer<vtkPoints> &points, vtkSmartPointer<vtkCellArray> &cells, std::size_t pnt_idx, std::size_t n_points, MathLib::Point3d const& min_pnt, MathLib::Point3d const& max_pnt) const;
+    void createPoints(vtkSmartPointer<vtkPoints>& points,
+                      vtkSmartPointer<vtkCellArray>& cells, std::size_t pnt_idx,
+                      std::size_t n_points, MathLib::Point3d const& min_pnt,
+                      MathLib::Point3d const& max_pnt) const;
 
     /// Returns a random number in [min, max]
     double getRandomNumber(double const& min, double const& max) const;

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.h
@@ -1,0 +1,88 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include <vtkPolyDataAlgorithm.h>
+
+#include "MathLib/Point3d.h"
+#include "VtkAlgorithmProperties.h"
+
+class vtkInformation;
+class vtkInformationVector;
+
+/// A VTK Filter that will create a point cloud with local densities based on pixel values.
+class VtkImageDataToPointCloudFilter : public vtkPolyDataAlgorithm
+{
+public:
+    /// Create a new objects (required because of VTKs reference counting)
+    static VtkImageDataToPointCloudFilter* New();
+
+    vtkTypeMacro(VtkImageDataToPointCloudFilter, vtkPolyDataAlgorithm);
+
+    /// Prints information about the filter
+    void PrintSelf(ostream& os, vtkIndent indent) override;
+
+    void useLinearInterpolation() { SetIsLinear(true); }
+    void useLogarithmicInterpolation(double gamma) { SetIsLinear(false); SetGamma(gamma); }
+
+    vtkGetMacro(IsLinear, bool);
+    vtkSetMacro(IsLinear, bool);
+
+    vtkGetMacro(MinNumberOfPointsPerCell, vtkIdType);
+    vtkSetMacro(MinNumberOfPointsPerCell, vtkIdType);
+
+    vtkGetMacro(MaxNumberOfPointsPerCell, vtkIdType);
+    vtkSetMacro(MaxNumberOfPointsPerCell, vtkIdType);
+
+    vtkGetMacro(Gamma, double);
+    vtkSetMacro(Gamma, double);
+
+    vtkGetMacro(PointScaleFactor, double);
+    vtkSetMacro(PointScaleFactor, double);
+
+    vtkGetMacro(MinHeight, double);
+    vtkSetMacro(MinHeight, double);
+
+    vtkGetMacro(MaxHeight, double);
+    vtkSetMacro(MaxHeight, double);
+
+protected:
+    VtkImageDataToPointCloudFilter();
+    ~VtkImageDataToPointCloudFilter() override;
+
+    /// Sets input port to vtkImageData.
+    int FillInputPortInformation(int port, vtkInformation* info) override;
+
+    /// Updates the graphical object
+    int RequestData(vtkInformation* request, vtkInformationVector** inputVector,
+                    vtkInformationVector* outputVector) override;
+
+    bool IsLinear;
+    vtkIdType MinNumberOfPointsPerCell;
+    vtkIdType MaxNumberOfPointsPerCell;
+    double Gamma;
+    double PointScaleFactor;
+    double MinHeight;
+    double MaxHeight;
+
+private:
+    VtkImageDataToPointCloudFilter(const VtkImageDataToPointCloudFilter&) = delete; 
+    void operator=(const VtkImageDataToPointCloudFilter&) = delete;
+
+    /// Creates the point objects based on the parameters set by the user
+    void createPoints(vtkSmartPointer<vtkPoints> &points, vtkSmartPointer<vtkCellArray> &cells, std::size_t pnt_idx, std::size_t n_points, MathLib::Point3d const& min_pnt, MathLib::Point3d const& max_pnt) const;
+
+    /// Returns a random number in [min, max]
+    double getRandomNumber(double const& min, double const& max) const;
+
+    /// Interpolates the required number of points
+    std::size_t interpolate(double low, double high, double p, double gamma) const;
+};

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.h
@@ -61,7 +61,7 @@ public:
 
 protected:
     VtkImageDataToPointCloudFilter();
-    ~VtkImageDataToPointCloudFilter() override;
+    ~VtkImageDataToPointCloudFilter() = default;
 
     /// Sets input port to vtkImageData.
     int FillInputPortInformation(int port, vtkInformation* info) override;
@@ -70,18 +70,16 @@ protected:
     int RequestData(vtkInformation* request, vtkInformationVector** inputVector,
                     vtkInformationVector* outputVector) override;
 
-    bool IsLinear;
-    vtkIdType MinNumberOfPointsPerCell;
-    vtkIdType MaxNumberOfPointsPerCell;
     double Gamma;
     double PointScaleFactor;
     double MinHeight;
     double MaxHeight;
+    vtkIdType MinNumberOfPointsPerCell;
+    vtkIdType MaxNumberOfPointsPerCell;
+    bool IsLinear;
+
 
 private:
-    VtkImageDataToPointCloudFilter(const VtkImageDataToPointCloudFilter&) = delete;
-    void operator=(const VtkImageDataToPointCloudFilter&) = delete;
-
     /// Creates the point objects based on the parameters set by the user
     void createPoints(vtkSmartPointer<vtkPoints>& points,
                       vtkSmartPointer<vtkCellArray>& cells, std::size_t pnt_idx,
@@ -91,6 +89,9 @@ private:
     /// Returns a random number in [min, max]
     double getRandomNumber(double const& min, double const& max) const;
 
-    /// Interpolates the required number of points
+    /// Interpolates the required number of points. Using gamma = 1 this is a linear
+    /// interpolation, for values smaller/greater than 1 the curve becomes
+    /// logarithmic/exponential, resulting in a smaller/larger difference of point
+    /// densities given the same input values.
     std::size_t interpolate(double low, double high, double p, double gamma) const;
 };

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToSurfacePointsFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToSurfacePointsFilter.cpp
@@ -31,8 +31,6 @@ VtkImageDataToSurfacePointsFilter::VtkImageDataToSurfacePointsFilter()
 {
 }
 
-VtkImageDataToSurfacePointsFilter::~VtkImageDataToSurfacePointsFilter() = default;
-
 void VtkImageDataToSurfacePointsFilter::PrintSelf(ostream& os, vtkIndent indent)
 {
     this->Superclass::PrintSelf(os, indent);
@@ -154,5 +152,5 @@ void VtkImageDataToSurfacePointsFilter::createPointSurface(
 
 double VtkImageDataToSurfacePointsFilter::getRandomNumber(double const& min, double const& max) const
 {
-    return ((double)rand() / RAND_MAX) * (max - min) + min;
+    return ((double)std::rand() / RAND_MAX) * (max - min) + min;
 }

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToSurfacePointsFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToSurfacePointsFilter.cpp
@@ -1,0 +1,145 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+// ** INCLUDES **
+#include "VtkImageDataToSurfacePointsFilter.h"
+
+#include <vector>
+#include <algorithm>
+
+#include <vtkIdList.h>
+#include <vtkImageData.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+#include <vtkLine.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkPolyData.h>
+#include <vtkSmartPointer.h>
+
+vtkStandardNewMacro(VtkImageDataToSurfacePointsFilter);
+
+VtkImageDataToSurfacePointsFilter::VtkImageDataToSurfacePointsFilter()
+: PointsPerPixel(20)
+{
+}
+
+VtkImageDataToSurfacePointsFilter::~VtkImageDataToSurfacePointsFilter() = default;
+
+void VtkImageDataToSurfacePointsFilter::PrintSelf(ostream& os, vtkIndent indent)
+{
+    this->Superclass::PrintSelf(os, indent);
+}
+
+int VtkImageDataToSurfacePointsFilter::FillInputPortInformation(int, vtkInformation* info)
+{
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkImageData");
+    return 1;
+}
+
+int VtkImageDataToSurfacePointsFilter::RequestData(vtkInformation*,
+                                                vtkInformationVector** inputVector,
+                                                vtkInformationVector* outputVector)
+{
+    vtkDebugMacro(<< "Executing VtkImageDataToSurfacePointsFilter");
+
+    vtkInformation* input_info = inputVector[0]->GetInformationObject(0);
+    vtkInformation* output_info = outputVector->GetInformationObject(0);
+    vtkImageData* input = vtkImageData::SafeDownCast(input_info->Get(vtkDataObject::DATA_OBJECT()));
+    vtkPolyData* output = vtkPolyData::SafeDownCast(output_info->Get(vtkDataObject::DATA_OBJECT()));
+
+    void* pixvals = input->GetScalarPointer();
+    int n_comp = input->GetNumberOfScalarComponents();
+    if (n_comp < 1)
+        vtkDebugMacro("Error reading number of components.");
+    if (n_comp > 2)
+        vtkDebugMacro("RGB colours detected. Using only first channel for computation.");
+
+    std::size_t const n_points = static_cast<std::size_t>(input->GetNumberOfPoints());
+    if (n_points == 0)
+    {
+        vtkDebugMacro("No data found!");
+        return -1;
+    }
+
+    double spacing[3];
+    input->GetSpacing(spacing);
+    int dimensions[3];
+    input->GetDimensions(dimensions);
+    double origin[3];
+    input->GetOrigin(origin);
+    MathLib::Point3d const ll(std::array<double, 3>{ {origin[0], origin[1], origin[2]}});
+    GeoLib::RasterHeader const header = { static_cast<std::size_t>(dimensions[0]), static_cast<std::size_t>(dimensions[1]), 1, ll,  spacing[0], -9999 };
+    std::vector<double> pixels;
+    pixels.reserve(n_points);
+    for (std::size_t i = 0; i<n_points; ++i)
+    {
+        if ((n_comp == 2 || n_comp == 4) && (((float*)pixvals)[(i + 1) * n_comp - 1] < 0.00000001f))
+            pixels.push_back(-9999);
+        else
+            pixels.push_back(((float*)pixvals)[i * n_comp]);
+    }
+    GeoLib::Raster const*const raster(new GeoLib::Raster(header, pixels.begin(), pixels.end()));
+
+    vtkSmartPointer<vtkPoints> new_points = vtkSmartPointer<vtkPoints>::New();
+    new_points->SetNumberOfPoints(PointsPerPixel * n_points);
+    vtkSmartPointer<vtkCellArray> cells = vtkSmartPointer<vtkCellArray>::New();
+    cells->Allocate(PointsPerPixel * n_points);
+
+    vtkPointData* output_data = output->GetPointData();
+    double const half_cellsize(spacing[0] / 2.0);
+    std::size_t pnt_idx(0);
+    for (std::size_t i = 0; i<static_cast<std::size_t>(n_points); ++i)
+    {
+        // Skip transparent pixels
+        if (n_comp == 2 || n_comp == 4)
+        {
+            if (((float*)pixvals)[(i + 1) * n_comp - 1] < 0.00000001f)
+                continue;
+        }
+
+        double p[3];
+        input->GetPoint(i, p);
+        MathLib::Point3d min_pnt{
+            std::array<double,3>{ {p[0] - half_cellsize, p[1] - half_cellsize, 0}} };
+        MathLib::Point3d max_pnt{
+            std::array<double,3>{ {p[0] + half_cellsize, p[1] + half_cellsize, 0}} };
+        createPointSurface(new_points, cells, pnt_idx, min_pnt, max_pnt, *raster);
+        pnt_idx += PointsPerPixel;
+    }
+
+    output->SetPoints(new_points);
+    output->SetVerts(cells);
+    output->Squeeze();
+
+    vtkDebugMacro(<< "Created " << new_points->GetNumberOfPoints() << " points.");
+    return 1;
+}
+
+void VtkImageDataToSurfacePointsFilter::createPointSurface(vtkSmartPointer<vtkPoints> &points, vtkSmartPointer<vtkCellArray> &cells, std::size_t pnt_idx,  MathLib::Point3d const& min_pnt, MathLib::Point3d const& max_pnt, GeoLib::Raster const& raster)
+{
+	std::size_t const n_points (static_cast<std::size_t>(this->GetPointsPerPixel()));
+    for (std::size_t i = 0; i<n_points; ++i)
+    {
+        double p[3];
+        p[0] = getRandomNumber(min_pnt[0], max_pnt[0]);
+        p[1] = getRandomNumber(min_pnt[1], max_pnt[1]);
+        p[2] = raster.interpolateValueAtPoint(MathLib::Point3d( {p[0], p[1], 0 }));
+        points->SetPoint(pnt_idx + i, p);
+        cells->InsertNextCell(1);
+        cells->InsertCellPoint(pnt_idx + i);
+    }
+}
+
+double VtkImageDataToSurfacePointsFilter::getRandomNumber(double const& min, double const& max) const
+{
+    return ((double)rand() / RAND_MAX) * (max - min) + min;
+}
+

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToSurfacePointsFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToSurfacePointsFilter.h
@@ -36,7 +36,7 @@ public:
 
 protected:
     VtkImageDataToSurfacePointsFilter();
-    ~VtkImageDataToSurfacePointsFilter() override;
+    ~VtkImageDataToSurfacePointsFilter() = default;
 
     /// Sets input port to vtkImageData.
     int FillInputPortInformation(int port, vtkInformation* info) override;
@@ -46,9 +46,6 @@ protected:
                     vtkInformationVector* outputVector) override;
 
 private:
-    VtkImageDataToSurfacePointsFilter(const VtkImageDataToSurfacePointsFilter&) = delete;
-    void operator=(const VtkImageDataToSurfacePointsFilter&) = delete;
-
     /// Returns a random number in [min, max]
     void createPointSurface(vtkSmartPointer<vtkPoints>& points,
                             vtkSmartPointer<vtkCellArray>& cells,

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToSurfacePointsFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToSurfacePointsFilter.h
@@ -46,7 +46,7 @@ protected:
                     vtkInformationVector* outputVector) override;
 
 private:
-    /// Returns a random number in [min, max]
+    /// Creates the point objects based on the parameters set by the user
     void createPointSurface(vtkSmartPointer<vtkPoints>& points,
                             vtkSmartPointer<vtkCellArray>& cells,
                             std::size_t pnt_idx,

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToSurfacePointsFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToSurfacePointsFilter.h
@@ -18,7 +18,8 @@
 class vtkInformation;
 class vtkInformationVector;
 
-/// A VTK filter that creates a point cloud representing a surface defined by pixel values
+/// A VTK filter that creates a point cloud representing a surface defined by
+/// pixel values
 class VtkImageDataToSurfacePointsFilter : public vtkPolyDataAlgorithm
 {
 public:
@@ -49,10 +50,15 @@ private:
     void operator=(const VtkImageDataToSurfacePointsFilter&) = delete;
 
     /// Returns a random number in [min, max]
-    void createPointSurface(vtkSmartPointer<vtkPoints> &points, vtkSmartPointer<vtkCellArray> &cells, std::size_t pnt_idx, MathLib::Point3d const& min_pnt, MathLib::Point3d const& max_pnt, GeoLib::Raster const& raster);
+    void createPointSurface(vtkSmartPointer<vtkPoints>& points,
+                            vtkSmartPointer<vtkCellArray>& cells,
+                            std::size_t pnt_idx,
+                            MathLib::Point3d const& min_pnt,
+                            MathLib::Point3d const& max_pnt,
+                            GeoLib::Raster const& raster);
 
     /// Returns a random number in [min, max]
     double getRandomNumber(double const& min, double const& max) const;
 
-	vtkIdType PointsPerPixel;
+    vtkIdType PointsPerPixel;
 };

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToSurfacePointsFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToSurfacePointsFilter.h
@@ -1,0 +1,58 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include <vtkPolyDataAlgorithm.h>
+
+#include "GeoLib/Raster.h"
+#include "VtkAlgorithmProperties.h"
+
+class vtkInformation;
+class vtkInformationVector;
+
+/// A VTK filter that creates a point cloud representing a surface defined by pixel values
+class VtkImageDataToSurfacePointsFilter : public vtkPolyDataAlgorithm
+{
+public:
+    /// Create a new objects (required because of VTKs reference counting)
+    static VtkImageDataToSurfacePointsFilter* New();
+
+    vtkTypeMacro(VtkImageDataToSurfacePointsFilter, vtkPolyDataAlgorithm);
+
+    /// @brief Prints information about itself.
+    void PrintSelf(ostream& os, vtkIndent indent) override;
+
+    vtkGetMacro(PointsPerPixel, vtkIdType);
+    vtkSetMacro(PointsPerPixel, vtkIdType);
+
+protected:
+    VtkImageDataToSurfacePointsFilter();
+    ~VtkImageDataToSurfacePointsFilter() override;
+
+    /// Sets input port to vtkImageData.
+    int FillInputPortInformation(int port, vtkInformation* info) override;
+
+    /// Updates the graphical object
+    int RequestData(vtkInformation* request, vtkInformationVector** inputVector,
+                    vtkInformationVector* outputVector) override;
+
+private:
+    VtkImageDataToSurfacePointsFilter(const VtkImageDataToSurfacePointsFilter&) = delete;
+    void operator=(const VtkImageDataToSurfacePointsFilter&) = delete;
+
+    /// Returns a random number in [min, max]
+    void createPointSurface(vtkSmartPointer<vtkPoints> &points, vtkSmartPointer<vtkCellArray> &cells, std::size_t pnt_idx, MathLib::Point3d const& min_pnt, MathLib::Point3d const& max_pnt, GeoLib::Raster const& raster);
+
+    /// Returns a random number in [min, max]
+    double getRandomNumber(double const& min, double const& max) const;
+
+	vtkIdType PointsPerPixel;
+};


### PR DESCRIPTION
Two VTK filters to represent raster data as point clouds + integration into Data Explorer

1. Varying desity based on pixel value
2. Representing pixel values as surface