### PR TITLE
Remove unneeded Base ns specifier

### DIFF
--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -24,8 +24,6 @@ namespace GroundwaterFlow
 {
 class GroundwaterFlowProcess final : public Process
 {
-    using Base = Process;
-
 public:
     GroundwaterFlowProcess(
         MeshLib::Mesh& mesh,

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
@@ -174,60 +174,60 @@ void HydroMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
         _local_assemblers, mesh.isAxiallySymmetric(), integration_order,
         _process_data);
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma_xx",
         makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtSigmaXX));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma_yy",
         makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtSigmaYY));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma_zz",
         makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtSigmaZZ));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma_xy",
         makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtSigmaXY));
 
     if (DisplacementDim == 3)
     {
-        Base::_secondary_variables.addSecondaryVariable(
+        _secondary_variables.addSecondaryVariable(
             "sigma_xz",
             makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                              &LocalAssemblerInterface::getIntPtSigmaXZ));
 
-        Base::_secondary_variables.addSecondaryVariable(
+        _secondary_variables.addSecondaryVariable(
             "sigma_yz",
             makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                              &LocalAssemblerInterface::getIntPtSigmaYZ));
     }
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon_xx",
         makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtEpsilonXX));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon_yy",
         makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtEpsilonYY));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon_zz",
         makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtEpsilonZZ));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon_xy",
         makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtEpsilonXY));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "velocity",
         makeExtrapolator(mesh.getDimension(), getExtrapolator(),
                          _local_assemblers,

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -26,8 +26,6 @@ struct LocalAssemblerInterface;
 template <int DisplacementDim>
 class HydroMechanicsProcess final : public Process
 {
-    using Base = Process;
-
 public:
     HydroMechanicsProcess(
         MeshLib::Mesh& mesh,

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
@@ -25,8 +25,6 @@ class HydroMechanicsLocalAssemblerInterface;
 template <int GlobalDim>
 class HydroMechanicsProcess final : public Process
 {
-    using Base = Process;
-
     static_assert(GlobalDim == 2 || GlobalDim == 3,
                   "Currently LIE::HydroMechanicsProcess "
                   "supports only 2D or 3D.");

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -192,25 +192,25 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
             // by location order is needed for output
             NumLib::ComponentOrder::BY_LOCATION);
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma_xx",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtSigmaXX));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma_yy",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtSigmaYY));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma_zz",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtSigmaZZ));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma_xy",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
@@ -218,38 +218,38 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
 
     if (DisplacementDim == 3)
     {
-        Base::_secondary_variables.addSecondaryVariable(
+        _secondary_variables.addSecondaryVariable(
             "sigma_xz",
             makeExtrapolator(
                 1, getExtrapolator(), _local_assemblers,
                 &SmallDeformationLocalAssemblerInterface::getIntPtSigmaXZ));
 
-        Base::_secondary_variables.addSecondaryVariable(
+        _secondary_variables.addSecondaryVariable(
             "sigma_yz",
             makeExtrapolator(
                 1, getExtrapolator(), _local_assemblers,
                 &SmallDeformationLocalAssemblerInterface::getIntPtSigmaYZ));
     }
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon_xx",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonXX));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon_yy",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonYY));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon_zz",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
             &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonZZ));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon_xy",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
@@ -257,13 +257,13 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
 
     if (DisplacementDim == 3)
     {
-        Base::_secondary_variables.addSecondaryVariable(
+        _secondary_variables.addSecondaryVariable(
             "epsilon_xz",
             makeExtrapolator(
                 1, getExtrapolator(), _local_assemblers,
                 &SmallDeformationLocalAssemblerInterface::getIntPtEpsilonXZ));
 
-        Base::_secondary_variables.addSecondaryVariable(
+        _secondary_variables.addSecondaryVariable(
             "epsilon_yz",
             makeExtrapolator(
                 1, getExtrapolator(), _local_assemblers,

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
@@ -23,8 +23,6 @@ namespace SmallDeformation
 template <int DisplacementDim>
 class SmallDeformationProcess final : public Process
 {
-    using Base = Process;
-
     static_assert(DisplacementDim == 2 || DisplacementDim == 3,
                   "Currently LIE::SmallDeformationProcess "
                   "supports only 2D or 3D.");

--- a/ProcessLib/PhaseField/PhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.cpp
@@ -166,14 +166,14 @@ void PhaseFieldProcess<DisplacementDim>::initializeConcreteProcess(
         mesh.getElements(), dof_table, _local_assemblers,
         mesh.isAxiallySymmetric(), integration_order, _process_data);
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma",
         makeExtrapolator(MathLib::KelvinVector::KelvinVectorType<
                              DisplacementDim>::RowsAtCompileTime,
                          getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtSigma));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon",
         makeExtrapolator(MathLib::KelvinVector::KelvinVectorType<
                              DisplacementDim>::RowsAtCompileTime,

--- a/ProcessLib/PhaseField/PhaseFieldProcess.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.h
@@ -47,8 +47,6 @@ namespace PhaseField
 template <int DisplacementDim>
 class PhaseFieldProcess final : public Process
 {
-    using Base = Process;
-
 public:
     PhaseFieldProcess(
         MeshLib::Mesh& mesh,

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.h
@@ -21,8 +21,6 @@ namespace RichardsFlow
 {
 class RichardsFlowProcess final : public Process
 {
-    using Base = Process;
-
 public:
     RichardsFlowProcess(
         MeshLib::Mesh& mesh,

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -94,19 +94,19 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
             // by location order is needed for output
             NumLib::ComponentOrder::BY_LOCATION);
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "free_energy_density",
         makeExtrapolator(1, getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtFreeEnergyDensity));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma",
         makeExtrapolator(MathLib::KelvinVector::KelvinVectorType<
                              DisplacementDim>::RowsAtCompileTime,
                          getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtSigma));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon",
         makeExtrapolator(MathLib::KelvinVector::KelvinVectorType<
                              DisplacementDim>::RowsAtCompileTime,
@@ -156,7 +156,7 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
                 return cache;
             });
 
-        Base::_secondary_variables.addSecondaryVariable(
+        _secondary_variables.addSecondaryVariable(
             name,
             makeExtrapolator(num_components, getExtrapolator(),
                              _local_assemblers, std::move(getIntPtValues)));

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -55,8 +55,6 @@ private:
 template <int DisplacementDim>
 class SmallDeformationProcess final : public Process
 {
-    using Base = Process;
-
 public:
     SmallDeformationProcess(
         MeshLib::Mesh& mesh,

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess-impl.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess-impl.h
@@ -155,7 +155,7 @@ void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
         _mechanics_related_process_id, _phase_field_process_id,
         _heat_conduction_process_id);
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma",
         makeExtrapolator(
             MathLib::KelvinVector::KelvinVectorType<
@@ -163,7 +163,7 @@ void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
             getExtrapolator(), _local_assemblers,
             &ThermoMechanicalPhaseFieldLocalAssemblerInterface::getIntPtSigma));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon",
         makeExtrapolator(MathLib::KelvinVector::KelvinVectorType<
                              DisplacementDim>::RowsAtCompileTime,
@@ -171,7 +171,7 @@ void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
                          &ThermoMechanicalPhaseFieldLocalAssemblerInterface::
                              getIntPtEpsilon));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "heat_flux",
         makeExtrapolator(mesh.getDimension(), getExtrapolator(),
                          _local_assemblers,

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
@@ -52,8 +52,6 @@ struct ThermoMechanicalPhaseFieldLocalAssemblerInterface;
 template <int DisplacementDim>
 class ThermoMechanicalPhaseFieldProcess final : public Process
 {
-    using Base = Process;
-
 public:
     ThermoMechanicalPhaseFieldProcess(
         MeshLib::Mesh& mesh,

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
@@ -68,25 +68,25 @@ void ThermoMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
             // by location order is needed for output
             NumLib::ComponentOrder::BY_LOCATION));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma_xx",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
             &ThermoMechanicsLocalAssemblerInterface::getIntPtSigmaXX));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma_yy",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
             &ThermoMechanicsLocalAssemblerInterface::getIntPtSigmaYY));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma_zz",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
             &ThermoMechanicsLocalAssemblerInterface::getIntPtSigmaZZ));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "sigma_xy",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
@@ -94,50 +94,50 @@ void ThermoMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
 
     if (DisplacementDim == 3)
     {
-        Base::_secondary_variables.addSecondaryVariable(
+        _secondary_variables.addSecondaryVariable(
             "sigma_xz",
             makeExtrapolator(
                 1, getExtrapolator(), _local_assemblers,
                 &ThermoMechanicsLocalAssemblerInterface::getIntPtSigmaXZ));
 
-        Base::_secondary_variables.addSecondaryVariable(
+        _secondary_variables.addSecondaryVariable(
             "sigma_yz",
             makeExtrapolator(
                 1, getExtrapolator(), _local_assemblers,
                 &ThermoMechanicsLocalAssemblerInterface::getIntPtSigmaYZ));
     }
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon_xx",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
             &ThermoMechanicsLocalAssemblerInterface::getIntPtEpsilonXX));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon_yy",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
             &ThermoMechanicsLocalAssemblerInterface::getIntPtEpsilonYY));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon_zz",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
             &ThermoMechanicsLocalAssemblerInterface::getIntPtEpsilonZZ));
 
-    Base::_secondary_variables.addSecondaryVariable(
+    _secondary_variables.addSecondaryVariable(
         "epsilon_xy",
         makeExtrapolator(
             1, getExtrapolator(), _local_assemblers,
             &ThermoMechanicsLocalAssemblerInterface::getIntPtEpsilonXY));
     if (DisplacementDim == 3)
     {
-        Base::_secondary_variables.addSecondaryVariable(
+        _secondary_variables.addSecondaryVariable(
             "epsilon_yz",
             makeExtrapolator(
                 1, getExtrapolator(), _local_assemblers,
                 &ThermoMechanicsLocalAssemblerInterface::getIntPtEpsilonYZ));
 
-        Base::_secondary_variables.addSecondaryVariable(
+        _secondary_variables.addSecondaryVariable(
             "epsilon_xz",
             makeExtrapolator(
                 1, getExtrapolator(), _local_assemblers,

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
@@ -23,8 +23,6 @@ struct ThermoMechanicsLocalAssemblerInterface;
 template <int DisplacementDim>
 class ThermoMechanicsProcess final : public Process
 {
-    using Base = Process;
-
 public:
     ThermoMechanicsProcess(
         MeshLib::Mesh& mesh,


### PR DESCRIPTION
Was probably needed when `Process` was a template. Obsolete now.