### PR TITLE
Move bc meshes

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -265,16 +265,7 @@ void ProjectData::parseProcessVariables(
     BaseLib::ConfigTree const& process_variables_config)
 {
     DBUG("Parse process variables:")
-    if (_geoObjects == nullptr)
-    {
-        ERR("Geometric objects are required to define process variables.");
-        ERR("No geometric objects present.");
-        return;
-    }
 
-    // TODO at the moment we have only one mesh, later there
-    // can be several meshes. Then we have to check for correct mesh here and
-    // assign the referenced mesh below.
     if (_mesh_vec.empty() || _mesh_vec[0] == nullptr)
     {
         ERR("A mesh is required to define process variables.");
@@ -287,9 +278,8 @@ void ProjectData::parseProcessVariables(
          //! \ogs_file_param{prj__process_variables__process_variable}
          : process_variables_config.getConfigSubtreeList("process_variable"))
     {
-        // TODO Extend to referenced meshes.
-        auto pv = ProcessLib::ProcessVariable{var_config, *_mesh_vec[0],
-                                              *_geoObjects, _parameters};
+        auto pv =
+            ProcessLib::ProcessVariable{var_config, _mesh_vec, _parameters};
         if (!names.insert(pv.getName()).second)
             OGS_FATAL("A process variable with name `%s' already exists.",
                       pv.getName().c_str());

--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -23,6 +23,7 @@
 
 #include "MathLib/Curve/CreatePiecewiseLinearCurve.h"
 #include "MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h"
+#include "MeshGeoToolsLib/ConstructMeshesFromGeometries.h"
 #include "MeshLib/Mesh.h"
 
 #include "NumLib/ODESolver/ConvergenceCriterion.h"
@@ -132,6 +133,15 @@ ProjectData::ProjectData(BaseLib::ConfigTree const& project_config,
         }
         _mesh_vec.push_back(mesh);
     }
+
+    auto additional_meshes =
+        MeshGeoToolsLib::constructAdditionalMeshesFromGeoObjects(*_geoObjects,
+                                                                 *_mesh_vec[0]);
+    // release the unique_ptr's while copying to the raw pointers storage.
+    // TODO (naumov) Store unique_ptr's in _mesh_vec.
+    std::transform(begin(additional_meshes), end(additional_meshes),
+                   std::back_inserter(_mesh_vec),
+                   [](auto&& mesh) { return mesh.release(); });
 
     //! \ogs_file_param{prj__curves}
     parseCurves(project_config.getConfigSubtreeOptional("curves"));

--- a/MeshGeoToolsLib/ConstructMeshesFromGeometries.cpp
+++ b/MeshGeoToolsLib/ConstructMeshesFromGeometries.cpp
@@ -1,0 +1,113 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ */
+
+#include "ConstructMeshesFromGeometries.h"
+
+#include <logog/include/logog.hpp>
+
+#include "MeshLib/Elements/Element.h"
+#include "MeshLib/MeshEditing/DuplicateMeshComponents.h"
+#include "MeshLib/Node.h"
+
+#include "BoundaryElementsSearcher.h"
+#include "MeshNodeSearcher.h"
+
+namespace MeshGeoToolsLib
+{
+template <typename GeometryVec>
+std::vector<std::unique_ptr<MeshLib::Mesh>>
+constructAdditionalMeshesFromGeometries(
+    std::vector<GeometryVec*> const& geometries,
+    MeshGeoToolsLib::BoundaryElementsSearcher& boundary_element_searcher)
+{
+    std::vector<std::unique_ptr<MeshLib::Mesh>> additional_meshes;
+
+    for (GeometryVec* const geometry_vec : geometries)
+    {
+        // Each geometry_vec has a name, this is the first part of the full
+        // name.
+        auto const& vec_name = geometry_vec->getName();
+
+        auto const& vec_data = *geometry_vec->getVector();
+
+        auto const vec_size = geometry_vec->size();
+        for (std::size_t i = 0; i < vec_size; ++i)
+        {
+            // Each geometry has a name, this is the second part of the full
+            // name.
+            std::string geometry_name;
+            bool const is_geometry_named =
+                geometry_vec->getNameOfElementByID(i, geometry_name);
+            if (!is_geometry_named)
+            {
+                continue;
+            }
+
+            auto const& geometry = *vec_data[i];
+
+            DBUG("Creating mesh from geometry %s %s.", vec_name.c_str(),
+                 geometry_name.c_str());
+
+            additional_meshes.emplace_back(createMeshFromElementSelection(
+                vec_name + "_" + geometry_name,
+                MeshLib::cloneElements(
+                    boundary_element_searcher.getBoundaryElements(geometry))));
+        }
+    }
+    return additional_meshes;
+}
+
+std::vector<std::unique_ptr<MeshLib::Mesh>>
+constructAdditionalMeshesFromGeoObjects(GeoLib::GEOObjects const& geo_objects,
+                                        MeshLib::Mesh const& mesh)
+{
+    std::vector<std::unique_ptr<MeshLib::Mesh>> additional_meshes;
+
+    // TODO (naumov) add config for search length algorithms.
+    auto search_length_algorithm =
+        std::make_unique<MeshGeoToolsLib::SearchLength>();
+
+    auto const& mesh_node_searcher =
+        MeshGeoToolsLib::MeshNodeSearcher::getMeshNodeSearcher(
+            mesh, std::move(search_length_algorithm));
+
+    MeshGeoToolsLib::BoundaryElementsSearcher boundary_element_searcher(
+        mesh, mesh_node_searcher);
+
+    //
+    // Points
+    //
+    {
+        auto point_meshes = constructAdditionalMeshesFromGeometries(
+            geo_objects.getPoints(), boundary_element_searcher);
+        std::move(begin(point_meshes), end(point_meshes),
+                  std::back_inserter(additional_meshes));
+    }
+
+    //
+    // Polylines
+    //
+    {
+        auto polyline_meshes = constructAdditionalMeshesFromGeometries(
+            geo_objects.getPolylines(), boundary_element_searcher);
+        std::move(begin(polyline_meshes), end(polyline_meshes),
+                  std::back_inserter(additional_meshes));
+    }
+
+    // Surfaces
+    {
+        auto surface_meshes = constructAdditionalMeshesFromGeometries(
+            geo_objects.getSurfaces(), boundary_element_searcher);
+        std::move(begin(surface_meshes), end(surface_meshes),
+                  std::back_inserter(additional_meshes));
+    }
+
+    return additional_meshes;
+}
+}  // namespace MeshGeoToolsLib

--- a/MeshGeoToolsLib/ConstructMeshesFromGeometries.h
+++ b/MeshGeoToolsLib/ConstructMeshesFromGeometries.h
@@ -1,0 +1,29 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ */
+
+#include <memory>
+#include <vector>
+
+#include "MeshLib/Mesh.h"
+
+namespace GeoLib
+{
+class GEOObjects;
+}
+
+namespace MeshGeoToolsLib
+{
+/// For each named geometry in the give geo_objects (defined on the given \c
+/// mesh) constructs a mesh corresponding to the geometry with mappings to the
+/// bulk mesh elements and nodes.
+std::vector<std::unique_ptr<MeshLib::Mesh>>
+constructAdditionalMeshesFromGeoObjects(GeoLib::GEOObjects const& geo_objects,
+                                        MeshLib::Mesh const& mesh);
+
+}  // namespace MeshGeoToolsLib

--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -284,5 +285,12 @@ PropertyVector<T>* getOrCreateMeshProperty(Mesh& mesh,
     result->resize(numberOfMeshItems() * number_of_components);
     return result;
 }
+
+/// Creates a new mesh from a vector of elements.
+///
+/// \note The elements are owned by the returned mesh object as well as the
+/// nodes and will be destructed together with the mesh.
+std::unique_ptr<MeshLib::Mesh> createMeshFromElementSelection(
+    std::string mesh_name, std::vector<MeshLib::Element*> const& elements);
 
 } /* namespace */

--- a/MeshLib/MeshSubset.h
+++ b/MeshLib/MeshSubset.h
@@ -22,28 +22,6 @@
 
 namespace MeshLib
 {
-inline std::vector<Node*> nodesNodesIntersection(
-    std::vector<Node*> const& nodes_a, std::vector<Node*> const& nodes_b)
-{
-    if (nodes_a.empty() || nodes_b.empty())
-    {
-        return {};
-    }
-
-    std::vector<Node*> active_nodes;
-
-    for (auto const& n_a : nodes_a)
-    {
-        auto it = std::find(begin(nodes_b), end(nodes_b), n_a);
-        if (it != end(nodes_b))
-        {
-            active_nodes.push_back(n_a);
-        }
-    }
-
-    return active_nodes;
-}
-
 /// A subset of nodes on a single mesh.
 class MeshSubset
 {

--- a/NumLib/DOF/LocalToGlobalIndexMap.h
+++ b/NumLib/DOF/LocalToGlobalIndexMap.h
@@ -82,16 +82,13 @@ public:
             vec_var_elements,
         NumLib::ComponentOrder const order);
 
-    /// Derive a LocalToGlobalIndexMap constrained to a set of mesh subsets and
-    /// elements. A new mesh component map will be constructed using the passed
-    /// mesh_subsets for the given variable and component ids.
-    ///
-    /// \note The elements are not necessarily those used in the mesh_subsets.
+    /// Derive a LocalToGlobalIndexMap constrained to the mesh subset and mesh
+    /// subset's elements. A new mesh component map will be constructed using
+    /// the passed mesh_subset for the given variable and component ids.
     LocalToGlobalIndexMap* deriveBoundaryConstrainedMap(
         int const variable_id,
         std::vector<int> const& component_ids,
-        MeshLib::MeshSubset&& mesh_subset,
-        std::vector<MeshLib::Element*> const& elements) const;
+        MeshLib::MeshSubset&& mesh_subset) const;
 
     /// Returns total number of degrees of freedom including those located in
     /// the ghost nodes.

--- a/NumLib/DOF/MeshComponentMap.cpp
+++ b/NumLib/DOF/MeshComponentMap.cpp
@@ -171,8 +171,10 @@ MeshComponentMap MeshComponentMap::getSubset(
 
         for (auto component_id : new_global_component_ids)
         {
-            subset_dict.insert({new_location, component_id,
-                                getGlobalIndex(bulk_location, component_id)});
+            auto const global_index =
+                getGlobalIndex(bulk_location, component_id);
+            assert (global_index != nop);
+            subset_dict.insert({new_location, component_id, global_index});
         }
     }
 

--- a/NumLib/DOF/MeshComponentMap.h
+++ b/NumLib/DOF/MeshComponentMap.h
@@ -44,12 +44,18 @@ public:
     /// The order (BY_LOCATION/BY_COMPONENT) of components is the same as of the
     /// current map.
     ///
-    /// \note For each component the same mesh_subset will be used.
+    /// \attention For each component the same new_mesh_subset will be used.
     ///
-    /// \param component_ids  The vector of global components id.
-    /// \param components components that should remain in the created subset
-    MeshComponentMap getSubset(std::vector<int> const& component_ids,
-                               MeshLib::MeshSubset const& mesh_subset) const;
+    /// \param bulk_mesh_subsets components that should remain in the created
+    /// subset, one for each global component.
+    /// \param new_mesh_subset The constraining mesh subset with a mapping of
+    /// node ids to the bulk mesh nodes.
+    /// \param new_global_component_ids The components for which the
+    /// bulk_mesh_subsets should be intersected with the new_mesh_subset.
+    MeshComponentMap getSubset(
+        std::vector<MeshLib::MeshSubset> const& bulk_mesh_subsets,
+        MeshLib::MeshSubset const& new_mesh_subset,
+        std::vector<int> const& new_global_component_ids) const;
 
     /// The number of dofs including the those located in the ghost nodes.
     std::size_t dofSizeWithGhosts() const

--- a/ProcessLib/BoundaryCondition/BoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/BoundaryCondition.h
@@ -11,22 +11,9 @@
 
 #include "NumLib/NumericsConfig.h"
 
-namespace GeoLib
-{
-class GeoObject;
-}
-
 namespace MeshLib
 {
-class Element;
 class Mesh;
-}
-
-namespace MeshGeoToolsLib
-{
-class SearchLength;
-class MeshNodeSearcher;
-class BoundaryElementsSearcher;
 }
 
 namespace NumLib

--- a/ProcessLib/BoundaryCondition/BoundaryConditionConfig.h
+++ b/ProcessLib/BoundaryCondition/BoundaryConditionConfig.h
@@ -17,7 +17,7 @@ namespace ProcessLib
 struct BoundaryConditionConfig final
 {
     BoundaryConditionConfig(BaseLib::ConfigTree&& config_,
-                            MeshLib::Mesh& mesh_,
+                            MeshLib::Mesh const& mesh_,
                             boost::optional<int> const component_id_)
         : config(std::move(config_)), mesh(mesh_), component_id(component_id_)
     {
@@ -31,7 +31,7 @@ struct BoundaryConditionConfig final
     }
 
     BaseLib::ConfigTree config;
-    MeshLib::Mesh& mesh;
+    MeshLib::Mesh const& mesh;
     boost::optional<int> const component_id;
 };
 

--- a/ProcessLib/BoundaryCondition/BoundaryConditionConfig.h
+++ b/ProcessLib/BoundaryCondition/BoundaryConditionConfig.h
@@ -10,31 +10,28 @@
 #pragma once
 
 #include "BaseLib/ConfigTree.h"
-#include "GeoLib/GEOObjects.h"
+#include "MeshLib/Mesh.h"
 
 namespace ProcessLib
 {
-
 struct BoundaryConditionConfig final
 {
     BoundaryConditionConfig(BaseLib::ConfigTree&& config_,
-                            GeoLib::GeoObject const& geometry_,
+                            MeshLib::Mesh& mesh_,
                             boost::optional<int> const component_id_)
-        : config(std::move(config_)),
-          geometry(geometry_),
-          component_id(component_id_)
+        : config(std::move(config_)), mesh(mesh_), component_id(component_id_)
     {
     }
 
     BoundaryConditionConfig(BoundaryConditionConfig&& other)
         : config(std::move(other.config)),
-          geometry(other.geometry),
+          mesh(other.mesh),
           component_id(other.component_id)
     {
     }
 
     BaseLib::ConfigTree config;
-    GeoLib::GeoObject const& geometry;
+    MeshLib::Mesh& mesh;
     boost::optional<int> const component_id;
 };
 

--- a/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.cpp
@@ -56,7 +56,7 @@ void DirichletBoundaryCondition::getEssentialBCValues(
 }
 
 std::unique_ptr<DirichletBoundaryCondition> createDirichletBoundaryCondition(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table,
     std::size_t const bulk_mesh_id, int const variable_id,
     int const component_id,

--- a/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.cpp
@@ -21,16 +21,22 @@ void DirichletBoundaryCondition::getEssentialBCValues(
 {
     SpatialPosition pos;
 
+    auto const& bulk_node_ids_map =
+        *_bc_mesh.getProperties().getPropertyVector<std::size_t>(
+            "bulk_node_ids");
+
     bc_values.ids.clear();
     bc_values.values.clear();
 
     // convert mesh node ids to global index for the given component
-    bc_values.ids.reserve(bc_values.ids.size() + _mesh_node_ids.size());
-    bc_values.values.reserve(bc_values.values.size() + _mesh_node_ids.size());
-    for (auto const id : _mesh_node_ids)
+    bc_values.ids.reserve(bc_values.ids.size() + _bc_mesh.getNumberOfNodes());
+    bc_values.values.reserve(bc_values.values.size() +
+                             _bc_mesh.getNumberOfNodes());
+    for (auto const* const node : _bc_mesh.getNodes())
     {
+        auto const id = bulk_node_ids_map[node->getID()];
         pos.setNodeID(id);
-        MeshLib::Location l(_mesh_id, MeshLib::MeshItemType::Node, id);
+        MeshLib::Location l(_bulk_mesh_id, MeshLib::MeshItemType::Node, id);
         // TODO: that might be slow, but only done once
         const auto g_idx =
             _dof_table.getGlobalIndex(l, _variable_id, _component_id);
@@ -50,9 +56,10 @@ void DirichletBoundaryCondition::getEssentialBCValues(
 }
 
 std::unique_ptr<DirichletBoundaryCondition> createDirichletBoundaryCondition(
-    BaseLib::ConfigTree const& config, std::vector<std::size_t>&& mesh_node_ids,
-    NumLib::LocalToGlobalIndexMap const& dof_table, std::size_t const mesh_id,
-    int const variable_id, int const component_id,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
+    NumLib::LocalToGlobalIndexMap const& dof_table,
+    std::size_t const bulk_mesh_id, int const variable_id,
+    int const component_id,
     const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters)
 {
     DBUG("Constructing DirichletBoundaryCondition from config.");
@@ -66,8 +73,7 @@ std::unique_ptr<DirichletBoundaryCondition> createDirichletBoundaryCondition(
     auto& param = findParameter<double>(param_name, parameters, 1);
 
     return std::make_unique<DirichletBoundaryCondition>(
-        param, std::move(mesh_node_ids), dof_table, mesh_id, variable_id,
-        component_id);
+        param, bc_mesh, dof_table, bulk_mesh_id, variable_id, component_id);
 }
 
 }  // namespace ProcessLib

--- a/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.h
@@ -25,7 +25,7 @@ class DirichletBoundaryCondition final : public BoundaryCondition
 {
 public:
     DirichletBoundaryCondition(Parameter<double> const& parameter,
-                               MeshLib::Mesh& bc_mesh,
+                               MeshLib::Mesh const& bc_mesh,
                                NumLib::LocalToGlobalIndexMap const& dof_table,
                                std::size_t const bulk_mesh_id,
                                int const variable_id, int const component_id)
@@ -64,7 +64,7 @@ public:
 private:
     Parameter<double> const& _parameter;
 
-    MeshLib::Mesh& _bc_mesh;
+    MeshLib::Mesh const& _bc_mesh;
     NumLib::LocalToGlobalIndexMap const& _dof_table;
     std::size_t const _bulk_mesh_id;
     int const _variable_id;
@@ -72,7 +72,7 @@ private:
 };
 
 std::unique_ptr<DirichletBoundaryCondition> createDirichletBoundaryCondition(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, std::size_t const mesh_id,
     int const variable_id, int const component_id,
     const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters);

--- a/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.h
@@ -25,14 +25,14 @@ class DirichletBoundaryCondition final : public BoundaryCondition
 {
 public:
     DirichletBoundaryCondition(Parameter<double> const& parameter,
-                               std::vector<std::size_t>&& mesh_node_ids,
+                               MeshLib::Mesh& bc_mesh,
                                NumLib::LocalToGlobalIndexMap const& dof_table,
-                               std::size_t const mesh_id, int const variable_id,
-                               int const component_id)
+                               std::size_t const bulk_mesh_id,
+                               int const variable_id, int const component_id)
         : _parameter(parameter),
-          _mesh_node_ids(std::move(mesh_node_ids)),
+          _bc_mesh(bc_mesh),
           _dof_table(dof_table),
-          _mesh_id(mesh_id),
+          _bulk_mesh_id(bulk_mesh_id),
           _variable_id(variable_id),
           _component_id(component_id)
     {
@@ -47,6 +47,14 @@ public:
                 variable_id, component_id, dof_table.getNumberOfVariables(),
                 dof_table.getNumberOfVariableComponents(variable_id));
         }
+
+        if (!_bc_mesh.getProperties().existsPropertyVector<std::size_t>(
+                "bulk_node_ids"))
+        {
+            OGS_FATAL(
+                "The required bulk node ids map does not exist in the boundary "
+                "mesh.");
+        }
     }
 
     void getEssentialBCValues(
@@ -56,15 +64,15 @@ public:
 private:
     Parameter<double> const& _parameter;
 
-    std::vector<std::size_t> _mesh_node_ids;
+    MeshLib::Mesh& _bc_mesh;
     NumLib::LocalToGlobalIndexMap const& _dof_table;
-    std::size_t const _mesh_id;
+    std::size_t const _bulk_mesh_id;
     int const _variable_id;
     int const _component_id;
 };
 
 std::unique_ptr<DirichletBoundaryCondition> createDirichletBoundaryCondition(
-    BaseLib::ConfigTree const& config, std::vector<std::size_t>&& mesh_node_ids,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, std::size_t const mesh_id,
     int const variable_id, int const component_id,
     const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters);

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
@@ -9,7 +9,6 @@
 
 #include "GenericNaturalBoundaryCondition.h"
 #include "ProcessLib/Utils/CreateLocalAssemblers.h"
-#include "MeshLib/MeshSearch/NodeSearch.h"
 #include "GenericNaturalBoundaryConditionLocalAssembler.h"
 
 namespace ProcessLib
@@ -25,14 +24,12 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
             std::is_same<typename std::decay<BoundaryConditionData>::type,
                          typename std::decay<Data>::type>::value,
             bool>::type is_axially_symmetric,
-        unsigned const integration_order,
-        unsigned const shapefunction_order,
+        unsigned const integration_order, unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
-        unsigned const global_dim, std::vector<MeshLib::Element*>&& elements,
-        Data&& data)
+        unsigned const global_dim, MeshLib::Mesh& bc_mesh, Data&& data)
     : _data(std::forward<Data>(data)),
-      _elements(std::move(elements)),
+      _bc_mesh(bc_mesh),
       _integration_order(integration_order)
 {
     // check basic data consistency
@@ -48,35 +45,21 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
             dof_table_bulk.getNumberOfVariableComponents(variable_id));
     }
 
-    std::vector<MeshLib::Node*> nodes = MeshLib::getUniqueNodes(_elements);
+    std::vector<MeshLib::Node*> const& bc_nodes = _bc_mesh.getNodes();
     DBUG("Found %d nodes for Natural BCs for the variable %d and component %d",
-         nodes.size(), variable_id, component_id);
+         bc_nodes.size(), variable_id, component_id);
 
-    auto const& mesh_subset =
-        dof_table_bulk.getMeshSubset(variable_id, component_id);
+    MeshLib::MeshSubset bc_mesh_subset(_bc_mesh, bc_nodes);
 
-    _nodes_subset = nodesNodesIntersection(mesh_subset.getNodes(), nodes);
-    MeshLib::MeshSubset bc_mesh_subset(mesh_subset.getMesh(), _nodes_subset);
-
-    // Create local DOF table from intersected mesh subsets for the given
-    // variable and component ids.
+    // Create local DOF table from the bc mesh subset for the given variable and
+    // component id.
     _dof_table_boundary.reset(dof_table_bulk.deriveBoundaryConstrainedMap(
-        variable_id, {component_id}, std::move(bc_mesh_subset), _elements));
+        variable_id, {component_id}, std::move(bc_mesh_subset)));
 
     createLocalAssemblers<LocalAssemblerImplementation>(
-        global_dim, _elements, *_dof_table_boundary, shapefunction_order,
-        _local_assemblers, is_axially_symmetric, _integration_order, _data);
-}
-
-template <typename BoundaryConditionData,
-          template <typename, typename, unsigned>
-          class LocalAssemblerImplementation>
-GenericNaturalBoundaryCondition<
-    BoundaryConditionData,
-    LocalAssemblerImplementation>::~GenericNaturalBoundaryCondition()
-{
-    for (auto e : _elements)
-        delete e;
+        global_dim, _bc_mesh.getElements(), *_dof_table_boundary,
+        shapefunction_order, _local_assemblers, is_axially_symmetric,
+        _integration_order, _data);
 }
 
 template <typename BoundaryConditionData,

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
@@ -27,7 +27,7 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
         unsigned const integration_order, unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
-        unsigned const global_dim, MeshLib::Mesh& bc_mesh, Data&& data)
+        unsigned const global_dim, MeshLib::Mesh const& bc_mesh, Data&& data)
     : _data(std::forward<Data>(data)),
       _bc_mesh(bc_mesh),
       _integration_order(integration_order)

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition.h
@@ -31,14 +31,10 @@ public:
             std::is_same<typename std::decay<BoundaryConditionData>::type,
                          typename std::decay<Data>::type>::value,
             bool>::type is_axially_symmetric,
-        unsigned const integration_order,
-        unsigned const shapefunction_order,
+        unsigned const integration_order, unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
-        unsigned const global_dim, std::vector<MeshLib::Element*>&& elements,
-        Data&& data);
-
-    ~GenericNaturalBoundaryCondition() override;
+        unsigned const global_dim, MeshLib::Mesh& bc_mesh, Data&& data);
 
     /// Calls local assemblers which calculate their contributions to the global
     /// matrix and the right-hand-side.
@@ -51,13 +47,8 @@ private:
     /// Data used in the assembly of the specific boundary condition.
     BoundaryConditionData _data;
 
-    /// Vector of lower-dimensional elements on which the boundary condition is
-    /// defined.
-    std::vector<MeshLib::Element*> _elements;
-
-    /// Intersection of boundary nodes and bulk mesh subset for the
-    /// variable_id/component_id pair.
-    std::vector<MeshLib::Node*> _nodes_subset;
+    /// A lower-dimensional mesh on which the boundary condition is defined.
+    MeshLib::Mesh& _bc_mesh;
 
     /// Local dof table, a subset of the global one restricted to the
     /// participating #_elements of the boundary condition.

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition.h
@@ -51,13 +51,13 @@ private:
     MeshLib::Mesh const& _bc_mesh;
 
     /// Local dof table, a subset of the global one restricted to the
-    /// participating #_elements of the boundary condition.
+    /// participating number of _elements of the boundary condition.
     std::unique_ptr<NumLib::LocalToGlobalIndexMap> _dof_table_boundary;
 
     /// Integration order for integration over the lower-dimensional elements
     unsigned const _integration_order;
 
-    /// Local assemblers for each element of #_elements.
+    /// Local assemblers for each element of number of _elements.
     std::vector<
         std::unique_ptr<GenericNaturalBoundaryConditionLocalAssemblerInterface>>
         _local_assemblers;

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition.h
@@ -34,7 +34,7 @@ public:
         unsigned const integration_order, unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
-        unsigned const global_dim, MeshLib::Mesh& bc_mesh, Data&& data);
+        unsigned const global_dim, MeshLib::Mesh const& bc_mesh, Data&& data);
 
     /// Calls local assemblers which calculate their contributions to the global
     /// matrix and the right-hand-side.
@@ -48,7 +48,7 @@ private:
     BoundaryConditionData _data;
 
     /// A lower-dimensional mesh on which the boundary condition is defined.
-    MeshLib::Mesh& _bc_mesh;
+    MeshLib::Mesh const& _bc_mesh;
 
     /// Local dof table, a subset of the global one restricted to the
     /// participating #_elements of the boundary condition.

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.cpp
@@ -13,12 +13,10 @@
 namespace ProcessLib
 {
 std::unique_ptr<NeumannBoundaryCondition> createNeumannBoundaryCondition(
-    BaseLib::ConfigTree const& config,
-    std::vector<MeshLib::Element*>&& elements,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
-    unsigned const integration_order,
-    unsigned const shapefunction_order,
+    unsigned const integration_order, unsigned const shapefunction_order,
     unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters)
 {
@@ -34,7 +32,7 @@ std::unique_ptr<NeumannBoundaryCondition> createNeumannBoundaryCondition(
 
     return std::make_unique<NeumannBoundaryCondition>(
         is_axially_symmetric, integration_order, shapefunction_order, dof_table,
-        variable_id, component_id, global_dim, std::move(elements), param);
+        variable_id, component_id, global_dim, bc_mesh, param);
 }
 
 }  // ProcessLib

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.cpp
@@ -13,7 +13,7 @@
 namespace ProcessLib
 {
 std::unique_ptr<NeumannBoundaryCondition> createNeumannBoundaryCondition(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
     unsigned const integration_order, unsigned const shapefunction_order,

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.h
@@ -19,7 +19,7 @@ using NeumannBoundaryCondition = GenericNaturalBoundaryCondition<
     Parameter<double> const&, NeumannBoundaryConditionLocalAssembler>;
 
 std::unique_ptr<NeumannBoundaryCondition> createNeumannBoundaryCondition(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
     unsigned const integration_order, unsigned const shapefunction_order,

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.h
@@ -19,12 +19,10 @@ using NeumannBoundaryCondition = GenericNaturalBoundaryCondition<
     Parameter<double> const&, NeumannBoundaryConditionLocalAssembler>;
 
 std::unique_ptr<NeumannBoundaryCondition> createNeumannBoundaryCondition(
-    BaseLib::ConfigTree const& config,
-    std::vector<MeshLib::Element*>&& elements,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
-    unsigned const integration_order,
-    unsigned const shapefunction_order,
+    unsigned const integration_order, unsigned const shapefunction_order,
     unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters);
 

--- a/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition-impl.h
@@ -30,7 +30,7 @@ NormalTractionBoundaryCondition<LocalAssemblerImplementation>::
         unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, unsigned const global_dim,
-        MeshLib::Mesh& bc_mesh, Parameter<double> const& pressure)
+        MeshLib::Mesh const& bc_mesh, Parameter<double> const& pressure)
     : _bc_mesh(bc_mesh),
       _integration_order(integration_order),
       _pressure(pressure)
@@ -75,7 +75,7 @@ void NormalTractionBoundaryCondition<
 std::unique_ptr<NormalTractionBoundaryCondition<
     NormalTractionBoundaryConditionLocalAssembler>>
 createNormalTractionBoundaryCondition(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     bool is_axially_symmetric, unsigned const integration_order,
     unsigned const shapefunction_order, unsigned const global_dim,

--- a/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition.h
@@ -40,7 +40,7 @@ public:
         unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, unsigned const global_dim,
-        MeshLib::Mesh& bc_mesh, Parameter<double> const& pressure);
+        MeshLib::Mesh const& bc_mesh, Parameter<double> const& pressure);
 
     /// Calls local assemblers which calculate their contributions to the global
     /// matrix and the right-hand-side.
@@ -50,7 +50,7 @@ public:
                         GlobalVector& b) override;
 
 private:
-    MeshLib::Mesh& _bc_mesh;
+    MeshLib::Mesh const& _bc_mesh;
 
     /// Intersection of boundary nodes and bulk mesh subset for the
     /// variable_id/component_id pair.
@@ -76,7 +76,7 @@ private:
 std::unique_ptr<NormalTractionBoundaryCondition<
     NormalTractionBoundaryConditionLocalAssembler>>
 createNormalTractionBoundaryCondition(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     bool is_axially_symmetric, unsigned const integration_order,
     unsigned const shapefunction_order, unsigned const global_dim,

--- a/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition.h
@@ -40,10 +40,7 @@ public:
         unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, unsigned const global_dim,
-        std::vector<MeshLib::Element*>&& elements,
-        Parameter<double> const& pressure);
-
-    ~NormalTractionBoundaryCondition() override;
+        MeshLib::Mesh& bc_mesh, Parameter<double> const& pressure);
 
     /// Calls local assemblers which calculate their contributions to the global
     /// matrix and the right-hand-side.
@@ -53,9 +50,7 @@ public:
                         GlobalVector& b) override;
 
 private:
-    /// Vector of lower-dimensional elements on which the boundary condition is
-    /// defined.
-    std::vector<MeshLib::Element*> _elements;
+    MeshLib::Mesh& _bc_mesh;
 
     /// Intersection of boundary nodes and bulk mesh subset for the
     /// variable_id/component_id pair.
@@ -81,8 +76,7 @@ private:
 std::unique_ptr<NormalTractionBoundaryCondition<
     NormalTractionBoundaryConditionLocalAssembler>>
 createNormalTractionBoundaryCondition(
-    BaseLib::ConfigTree const& config,
-    std::vector<MeshLib::Element*>&& elements,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     bool is_axially_symmetric, unsigned const integration_order,
     unsigned const shapefunction_order, unsigned const global_dim,

--- a/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition.h
@@ -59,13 +59,13 @@ private:
     std::unique_ptr<MeshLib::MeshSubset const> _mesh_subset_all_nodes;
 
     /// Local dof table, a subset of the global one restricted to the
-    /// participating #_elements of the boundary condition.
+    /// participating number of _elements of the boundary condition.
     std::unique_ptr<NumLib::LocalToGlobalIndexMap> _dof_table_boundary;
 
     /// Integration order for integration over the lower-dimensional elements
     unsigned const _integration_order;
 
-    /// Local assemblers for each element of #_elements.
+    /// Local assemblers for each element of number of _elements.
     std::vector<
         std::unique_ptr<NormalTractionBoundaryConditionLocalAssemblerInterface>>
         _local_assemblers;

--- a/ProcessLib/BoundaryCondition/RobinBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryCondition.cpp
@@ -13,12 +13,10 @@
 namespace ProcessLib
 {
 std::unique_ptr<RobinBoundaryCondition> createRobinBoundaryCondition(
-    BaseLib::ConfigTree const& config,
-    std::vector<MeshLib::Element*>&& elements,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
-    unsigned const integration_order,
-    unsigned const shapefunction_order,
+    unsigned const integration_order, unsigned const shapefunction_order,
     unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters)
 {
@@ -36,7 +34,7 @@ std::unique_ptr<RobinBoundaryCondition> createRobinBoundaryCondition(
 
     return std::make_unique<RobinBoundaryCondition>(
         is_axially_symmetric, integration_order, shapefunction_order, dof_table,
-        variable_id, component_id, global_dim, std::move(elements),
+        variable_id, component_id, global_dim, bc_mesh,
         RobinBoundaryConditionData{alpha, u_0});
 }
 

--- a/ProcessLib/BoundaryCondition/RobinBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryCondition.cpp
@@ -13,7 +13,7 @@
 namespace ProcessLib
 {
 std::unique_ptr<RobinBoundaryCondition> createRobinBoundaryCondition(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
     unsigned const integration_order, unsigned const shapefunction_order,

--- a/ProcessLib/BoundaryCondition/RobinBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryCondition.h
@@ -30,7 +30,7 @@ using RobinBoundaryCondition = GenericNaturalBoundaryCondition<
  * integrand in the boundary integral for the variable \f$ u \f$.
  */
 std::unique_ptr<RobinBoundaryCondition> createRobinBoundaryCondition(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
     unsigned const integration_order, unsigned const shapefunction_order,

--- a/ProcessLib/BoundaryCondition/RobinBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryCondition.h
@@ -12,11 +12,6 @@
 #include "GenericNaturalBoundaryCondition.h"
 #include "RobinBoundaryConditionLocalAssembler.h"
 
-namespace MeshGeoToolsLib
-{
-class BoundaryElementsSearcher;
-}
-
 namespace ProcessLib
 {
 using RobinBoundaryCondition = GenericNaturalBoundaryCondition<
@@ -35,12 +30,10 @@ using RobinBoundaryCondition = GenericNaturalBoundaryCondition<
  * integrand in the boundary integral for the variable \f$ u \f$.
  */
 std::unique_ptr<RobinBoundaryCondition> createRobinBoundaryCondition(
-    BaseLib::ConfigTree const& config,
-    std::vector<MeshLib::Element*>&& elements,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh& bc_mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
-    unsigned const integration_order,
-    unsigned const shapefunction_order,
+    unsigned const integration_order, unsigned const shapefunction_order,
     unsigned const global_dim,
     std::vector<std::unique_ptr<ParameterBase>> const& parameters);
 

--- a/ProcessLib/CMakeLists.txt
+++ b/ProcessLib/CMakeLists.txt
@@ -22,8 +22,7 @@ APPEND_SOURCE_FILES(SOURCES Utils)
 add_library(ProcessLib ${SOURCES})
 
 target_link_libraries(ProcessLib
-    PUBLIC BaseLib GeoLib MaterialLib MathLib MeshLib NumLib logog
-    PRIVATE MeshGeoToolsLib
+    PUBLIC BaseLib MaterialLib MathLib MeshLib NumLib logog
 )
 
 if(TARGET Eigen)

--- a/ProcessLib/LIE/BoundaryCondition/BoundaryConditionBuilder.cpp
+++ b/ProcessLib/LIE/BoundaryCondition/BoundaryConditionBuilder.cpp
@@ -9,11 +9,7 @@
 
 #include "BoundaryConditionBuilder.h"
 
-#include "MeshGeoToolsLib/BoundaryElementsSearcher.h"
-#include "MeshGeoToolsLib/MeshNodeSearcher.h"
-#include "MeshGeoToolsLib/SearchLength.h"
 #include "MeshLib/Mesh.h"
-#include "MeshLib/MeshEditing/DuplicateMeshComponents.h"
 #include "ProcessLib/BoundaryCondition/BoundaryConditionConfig.h"
 
 #include "NeumannBoundaryCondition.h"
@@ -30,22 +26,10 @@ BoundaryConditionBuilder::createNeumannBoundaryCondition(
     const unsigned shapefunction_order,
     const std::vector<std::unique_ptr<ProcessLib::ParameterBase>>& parameters)
 {
-    auto search_length_strategy =
-        std::make_unique<MeshGeoToolsLib::SearchLength>();
-    MeshGeoToolsLib::MeshNodeSearcher const& mesh_node_searcher =
-        MeshGeoToolsLib::MeshNodeSearcher::getMeshNodeSearcher(
-            mesh, std::move(search_length_strategy));
-
-    MeshGeoToolsLib::BoundaryElementsSearcher boundary_element_searcher(
-        mesh, mesh_node_searcher);
-
     return ProcessLib::LIE::createNeumannBoundaryCondition(
-        config.config,
-        MeshLib::cloneElements(
-            boundary_element_searcher.getBoundaryElements(config.geometry)),
-        dof_table, variable_id, *config.component_id, mesh.isAxiallySymmetric(),
-        integration_order, shapefunction_order, mesh.getDimension(), parameters,
-        _fracture_prop);
+        config.config, config.mesh, dof_table, variable_id,
+        *config.component_id, mesh.isAxiallySymmetric(), integration_order,
+        shapefunction_order, mesh.getDimension(), parameters, _fracture_prop);
 }
 
 }  // namespace LIE

--- a/ProcessLib/LIE/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/LIE/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
@@ -9,8 +9,6 @@
 
 #pragma once
 
-#include "MeshLib/MeshSearch/NodeSearch.h"  // for getUniqueNodes
-
 #include "ProcessLib/BoundaryCondition/GenericNaturalBoundaryConditionLocalAssembler.h"
 #include "ProcessLib/Utils/CreateLocalAssemblers.h"
 
@@ -32,41 +30,29 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
         unsigned const integration_order, unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
-        unsigned const global_dim, std::vector<MeshLib::Element*>&& elements,
-        Data&& data, FractureProperty const& fracture_prop)
+        unsigned const global_dim, MeshLib::Mesh& bc_mesh, Data&& data,
+        FractureProperty const& fracture_prop)
     : _data(std::forward<Data>(data)),
-      _elements(std::move(elements)),
+      _bc_mesh(bc_mesh),
       _integration_order(integration_order)
 {
     assert(component_id < dof_table_bulk.getNumberOfComponents());
 
-    std::vector<MeshLib::Node*> nodes = MeshLib::getUniqueNodes(_elements);
+    std::vector<MeshLib::Node*> const& bc_nodes = _bc_mesh.getNodes();
     DBUG("Found %d nodes for Natural BCs for the variable %d and component %d",
-         nodes.size(), variable_id, component_id);
+         bc_nodes.size(), variable_id, component_id);
 
-    MeshLib::MeshSubset mesh_subset =
-        dof_table_bulk.getMeshSubset(variable_id, component_id);
+    MeshLib::MeshSubset bc_mesh_subset(_bc_mesh, bc_nodes);
 
-    // Create local DOF table from intersected mesh subsets for the given
-    // variable and component ids.
+    // Create local DOF table from the bc mesh subset for the given variable and
+    // component id.
     _dof_table_boundary.reset(dof_table_bulk.deriveBoundaryConstrainedMap(
-        variable_id, {component_id}, std::move(mesh_subset), _elements));
+        variable_id, {component_id}, std::move(bc_mesh_subset)));
 
     createLocalAssemblers<LocalAssemblerImplementation>(
-        global_dim, _elements, *_dof_table_boundary, shapefunction_order,
-        _local_assemblers, is_axially_symmetric, _integration_order, _data,
-        fracture_prop, variable_id);
-}
-
-template <typename BoundaryConditionData,
-          template <typename, typename, unsigned>
-          class LocalAssemblerImplementation>
-GenericNaturalBoundaryCondition<
-    BoundaryConditionData,
-    LocalAssemblerImplementation>::~GenericNaturalBoundaryCondition()
-{
-    for (auto e : _elements)
-        delete e;
+        global_dim, _bc_mesh.getElements(), *_dof_table_boundary,
+        shapefunction_order, _local_assemblers, is_axially_symmetric,
+        _integration_order, _data, fracture_prop, variable_id);
 }
 
 template <typename BoundaryConditionData,

--- a/ProcessLib/LIE/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/LIE/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
@@ -30,7 +30,7 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
         unsigned const integration_order, unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
-        unsigned const global_dim, MeshLib::Mesh& bc_mesh, Data&& data,
+        unsigned const global_dim, MeshLib::Mesh const& bc_mesh, Data&& data,
         FractureProperty const& fracture_prop)
     : _data(std::forward<Data>(data)),
       _bc_mesh(bc_mesh),

--- a/ProcessLib/LIE/BoundaryCondition/GenericNaturalBoundaryCondition.h
+++ b/ProcessLib/LIE/BoundaryCondition/GenericNaturalBoundaryCondition.h
@@ -44,10 +44,8 @@ public:
         unsigned const integration_order, unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
-        unsigned const global_dim, std::vector<MeshLib::Element*>&& elements,
-        Data&& data, FractureProperty const& fracture_prop);
-
-    ~GenericNaturalBoundaryCondition() override;
+        unsigned const global_dim, MeshLib::Mesh& mesh, Data&& data,
+        FractureProperty const& fracture_prop);
 
     /// Calls local assemblers which calculate their contributions to the global
     /// matrix and the right-hand-side.
@@ -60,11 +58,8 @@ private:
     /// Data used in the assembly of the specific boundary condition.
     BoundaryConditionData _data;
 
-    /// Vector of lower-dimensional elements on which the boundary condition is
-    /// defined.
-    std::vector<MeshLib::Element*> _elements;
-
-    std::unique_ptr<MeshLib::MeshSubset const> _mesh_subset_all_nodes;
+    /// A lower-dimensional mesh on which the boundary condition is defined.
+    MeshLib::Mesh& _bc_mesh;
 
     /// Local dof table, a subset of the global one restricted to the
     /// participating #_elements of the boundary condition.

--- a/ProcessLib/LIE/BoundaryCondition/GenericNaturalBoundaryCondition.h
+++ b/ProcessLib/LIE/BoundaryCondition/GenericNaturalBoundaryCondition.h
@@ -44,7 +44,7 @@ public:
         unsigned const integration_order, unsigned const shapefunction_order,
         NumLib::LocalToGlobalIndexMap const& dof_table_bulk,
         int const variable_id, int const component_id,
-        unsigned const global_dim, MeshLib::Mesh& mesh, Data&& data,
+        unsigned const global_dim, MeshLib::Mesh const& mesh, Data&& data,
         FractureProperty const& fracture_prop);
 
     /// Calls local assemblers which calculate their contributions to the global
@@ -59,7 +59,7 @@ private:
     BoundaryConditionData _data;
 
     /// A lower-dimensional mesh on which the boundary condition is defined.
-    MeshLib::Mesh& _bc_mesh;
+    MeshLib::Mesh const& _bc_mesh;
 
     /// Local dof table, a subset of the global one restricted to the
     /// participating #_elements of the boundary condition.

--- a/ProcessLib/LIE/BoundaryCondition/GenericNaturalBoundaryCondition.h
+++ b/ProcessLib/LIE/BoundaryCondition/GenericNaturalBoundaryCondition.h
@@ -62,13 +62,13 @@ private:
     MeshLib::Mesh const& _bc_mesh;
 
     /// Local dof table, a subset of the global one restricted to the
-    /// participating #_elements of the boundary condition.
+    /// participating number of _elements of the boundary condition.
     std::unique_ptr<NumLib::LocalToGlobalIndexMap> _dof_table_boundary;
 
     /// Integration order for integration over the lower-dimensional elements
     unsigned const _integration_order;
 
-    /// Local assemblers for each element of #_elements.
+    /// Local assemblers for each element of number of _elements.
     std::vector<
         std::unique_ptr<GenericNaturalBoundaryConditionLocalAssemblerInterface>>
         _local_assemblers;

--- a/ProcessLib/LIE/BoundaryCondition/NeumannBoundaryCondition.cpp
+++ b/ProcessLib/LIE/BoundaryCondition/NeumannBoundaryCondition.cpp
@@ -23,8 +23,7 @@ using NeumannBoundaryCondition =
                                     NeumannBoundaryConditionLocalAssembler>;
 
 std::unique_ptr<BoundaryCondition> createNeumannBoundaryCondition(
-    BaseLib::ConfigTree const& config,
-    std::vector<MeshLib::Element*>&& elements,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh& mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
     unsigned const integration_order, unsigned const shapefunction_order,
@@ -44,8 +43,7 @@ std::unique_ptr<BoundaryCondition> createNeumannBoundaryCondition(
 
     return std::make_unique<NeumannBoundaryCondition>(
         is_axially_symmetric, integration_order, shapefunction_order, dof_table,
-        variable_id, component_id, global_dim, std::move(elements), param,
-        fracture_prop);
+        variable_id, component_id, global_dim, mesh, param, fracture_prop);
 }
 
 }  // namespace LIE

--- a/ProcessLib/LIE/BoundaryCondition/NeumannBoundaryCondition.cpp
+++ b/ProcessLib/LIE/BoundaryCondition/NeumannBoundaryCondition.cpp
@@ -23,7 +23,7 @@ using NeumannBoundaryCondition =
                                     NeumannBoundaryConditionLocalAssembler>;
 
 std::unique_ptr<BoundaryCondition> createNeumannBoundaryCondition(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh& mesh,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
     unsigned const integration_order, unsigned const shapefunction_order,

--- a/ProcessLib/LIE/BoundaryCondition/NeumannBoundaryCondition.h
+++ b/ProcessLib/LIE/BoundaryCondition/NeumannBoundaryCondition.h
@@ -29,8 +29,7 @@ namespace ProcessLib
 namespace LIE
 {
 std::unique_ptr<BoundaryCondition> createNeumannBoundaryCondition(
-    BaseLib::ConfigTree const& config,
-    std::vector<MeshLib::Element*>&& elements,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh& mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
     unsigned const integration_order, unsigned const shapefunction_order,

--- a/ProcessLib/LIE/BoundaryCondition/NeumannBoundaryCondition.h
+++ b/ProcessLib/LIE/BoundaryCondition/NeumannBoundaryCondition.h
@@ -29,7 +29,7 @@ namespace ProcessLib
 namespace LIE
 {
 std::unique_ptr<BoundaryCondition> createNeumannBoundaryCondition(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh& mesh,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh,
     NumLib::LocalToGlobalIndexMap const& dof_table, int const variable_id,
     int const component_id, bool is_axially_symmetric,
     unsigned const integration_order, unsigned const shapefunction_order,

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -69,7 +69,7 @@ ProcessVariable::ProcessVariable(
                 OGS_FATAL("Required mesh with name '%s' not found.",
                           full_geometry_name.c_str());
             }
-            MeshLib::Mesh& bc_mesh = **mesh_it;
+            MeshLib::Mesh const& bc_mesh = **mesh_it;
 
             DBUG("Found mesh '%s' with id %d.", bc_mesh.getName().c_str(),
                  bc_mesh.getID());
@@ -118,7 +118,7 @@ ProcessVariable::ProcessVariable(
                 OGS_FATAL("Required mesh with name '%s' not found.",
                           full_geometry_name.c_str());
             }
-            MeshLib::Mesh& bc_mesh = **mesh_it;
+            MeshLib::Mesh const& bc_mesh = **mesh_it;
 
             DBUG("Found mesh '%s' with id %d.", bc_mesh.getName().c_str(),
                  bc_mesh.getID());

--- a/ProcessLib/ProcessVariable.h
+++ b/ProcessLib/ProcessVariable.h
@@ -31,8 +31,8 @@ class ProcessVariable
 {
 public:
     ProcessVariable(
-        BaseLib::ConfigTree const& config, MeshLib::Mesh& mesh,
-        GeoLib::GEOObjects const& geometries,
+        BaseLib::ConfigTree const& config,
+        std::vector<MeshLib::Mesh*> const& meshes,
         std::vector<std::unique_ptr<ParameterBase>> const& parameters);
 
     ProcessVariable(ProcessVariable&&);

--- a/ProcessLib/SourceTerms/CreateNodalSourceTerm.cpp
+++ b/ProcessLib/SourceTerms/CreateNodalSourceTerm.cpp
@@ -16,7 +16,7 @@
 namespace ProcessLib
 {
 std::unique_ptr<NodalSourceTerm> createNodalSourceTerm(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh& st_mesh,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& st_mesh,
     const NumLib::LocalToGlobalIndexMap& dof_table,
     std::size_t const bulk_mesh_id, const int variable_id,
     const int component_id,

--- a/ProcessLib/SourceTerms/CreateNodalSourceTerm.cpp
+++ b/ProcessLib/SourceTerms/CreateNodalSourceTerm.cpp
@@ -16,9 +16,10 @@
 namespace ProcessLib
 {
 std::unique_ptr<NodalSourceTerm> createNodalSourceTerm(
-    BaseLib::ConfigTree const& config,
-    const NumLib::LocalToGlobalIndexMap& dof_table, std::size_t const mesh_id,
-    std::size_t const node_id, const int variable_id, const int component_id,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh& st_mesh,
+    const NumLib::LocalToGlobalIndexMap& dof_table,
+    std::size_t const bulk_mesh_id, const int variable_id,
+    const int component_id,
     std::vector<std::unique_ptr<ProcessLib::ParameterBase>> const& parameters)
 {
     DBUG("Constructing NodalSourceTerm from config.");
@@ -31,8 +32,8 @@ std::unique_ptr<NodalSourceTerm> createNodalSourceTerm(
 
     auto& param = findParameter<double>(param_name, parameters, 1);
 
-    return std::make_unique<NodalSourceTerm>(
-        dof_table, mesh_id, node_id, variable_id, component_id, param);
+    return std::make_unique<NodalSourceTerm>(dof_table, bulk_mesh_id, st_mesh,
+                                             variable_id, component_id, param);
 }
 
 }  // namespace ProcessLib

--- a/ProcessLib/SourceTerms/CreateNodalSourceTerm.h
+++ b/ProcessLib/SourceTerms/CreateNodalSourceTerm.h
@@ -15,9 +15,9 @@
 namespace ProcessLib
 {
 std::unique_ptr<NodalSourceTerm> createNodalSourceTerm(
-    BaseLib::ConfigTree const& config,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh& st_mesh,
     const NumLib::LocalToGlobalIndexMap& dof_table, std::size_t mesh_id,
-    std::size_t const node_id, const int variable_id, const int component_id,
+    const int variable_id, const int component_id,
     std::vector<std::unique_ptr<ProcessLib::ParameterBase>> const& parameters);
 
 }   // namespace ProcessLib

--- a/ProcessLib/SourceTerms/CreateNodalSourceTerm.h
+++ b/ProcessLib/SourceTerms/CreateNodalSourceTerm.h
@@ -15,7 +15,7 @@
 namespace ProcessLib
 {
 std::unique_ptr<NodalSourceTerm> createNodalSourceTerm(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh& st_mesh,
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& st_mesh,
     const NumLib::LocalToGlobalIndexMap& dof_table, std::size_t mesh_id,
     const int variable_id, const int component_id,
     std::vector<std::unique_ptr<ProcessLib::ParameterBase>> const& parameters);

--- a/ProcessLib/SourceTerms/NodalSourceTerm.cpp
+++ b/ProcessLib/SourceTerms/NodalSourceTerm.cpp
@@ -14,18 +14,26 @@
 namespace ProcessLib
 {
 NodalSourceTerm::NodalSourceTerm(const NumLib::LocalToGlobalIndexMap& dof_table,
-                                 std::size_t const mesh_id,
-                                 std::size_t const node_id,
-                                 const int variable_id, const int component_id,
+                                 std::size_t const bulk_mesh_id,
+                                 MeshLib::Mesh& st_mesh,
+                                 const int variable_id,
+                                 const int component_id,
                                  Parameter<double> const& parameter)
     : _dof_table(dof_table),
-      _mesh_id(mesh_id),
-      _node_id(node_id),
+      _bulk_mesh_id(bulk_mesh_id),
+      _st_mesh(st_mesh),
       _variable_id(variable_id),
       _component_id(component_id),
       _parameter(parameter)
 {
     DBUG("Create NodalSourceTerm.");
+    if (!_st_mesh.getProperties().template existsPropertyVector<std::size_t>(
+            "bulk_node_ids"))
+    {
+        OGS_FATAL(
+            "Required mesh property \"bulk_node_ids\" does not exists on the "
+            "source term mesh.");
+    }
 }
 
 void NodalSourceTerm::integrateNodalSourceTerm(const double t,
@@ -33,14 +41,22 @@ void NodalSourceTerm::integrateNodalSourceTerm(const double t,
 {
     DBUG("Assemble NodalSourceTerm.");
 
-    MeshLib::Location const l{_mesh_id, MeshLib::MeshItemType::Node, _node_id};
-    auto const index =
-        _dof_table.getGlobalIndex(l, _variable_id, _component_id);
+    auto const& bulk_node_ids_map =
+        *_st_mesh.getProperties().template getPropertyVector<std::size_t>(
+            "bulk_node_ids");
+    for (MeshLib::Node const* const node : _st_mesh.getNodes())
+    {
+        auto const node_id = node->getID();
+        MeshLib::Location const l{_bulk_mesh_id, MeshLib::MeshItemType::Node,
+                                  bulk_node_ids_map[node_id]};
+        auto const index =
+            _dof_table.getGlobalIndex(l, _variable_id, _component_id);
 
-    SpatialPosition pos;
-    pos.setNodeID(_node_id);
+        SpatialPosition pos;
+        pos.setNodeID(node_id);
 
-    b.add(index, _parameter(t, pos).front());
+        b.add(index, _parameter(t, pos).front());
+    }
 }
 
 }  // namespace ProcessLib

--- a/ProcessLib/SourceTerms/NodalSourceTerm.cpp
+++ b/ProcessLib/SourceTerms/NodalSourceTerm.cpp
@@ -15,7 +15,7 @@ namespace ProcessLib
 {
 NodalSourceTerm::NodalSourceTerm(const NumLib::LocalToGlobalIndexMap& dof_table,
                                  std::size_t const bulk_mesh_id,
-                                 MeshLib::Mesh& st_mesh,
+                                 MeshLib::Mesh const& st_mesh,
                                  const int variable_id,
                                  const int component_id,
                                  Parameter<double> const& parameter)

--- a/ProcessLib/SourceTerms/NodalSourceTerm.h
+++ b/ProcessLib/SourceTerms/NodalSourceTerm.h
@@ -18,21 +18,19 @@ class NodalSourceTerm final
 {
 public:
     NodalSourceTerm(const NumLib::LocalToGlobalIndexMap& dof_table,
-                    std::size_t const mesh_id, std::size_t const node_id,
+                    std::size_t const bulk_mesh_id, MeshLib::Mesh& st_mesh,
                     const int variable_id, const int component_id,
                     Parameter<double> const& parameter);
 
-    void integrateNodalSourceTerm(
-        const double t,
-        GlobalVector& b) const;
+    void integrateNodalSourceTerm(const double t, GlobalVector& b) const;
 
 private:
     NumLib::LocalToGlobalIndexMap const& _dof_table;
-    std::size_t const _mesh_id;
-    std::size_t const _node_id;
+    std::size_t const _bulk_mesh_id;
+    MeshLib::Mesh& _st_mesh;
     int const _variable_id;
     int const _component_id;
     Parameter<double> const& _parameter;
 };
 
-}   // namespace ProcessLib
+}  // namespace ProcessLib

--- a/ProcessLib/SourceTerms/NodalSourceTerm.h
+++ b/ProcessLib/SourceTerms/NodalSourceTerm.h
@@ -18,16 +18,16 @@ class NodalSourceTerm final
 {
 public:
     NodalSourceTerm(const NumLib::LocalToGlobalIndexMap& dof_table,
-                    std::size_t const bulk_mesh_id, MeshLib::Mesh& st_mesh,
-                    const int variable_id, const int component_id,
-                    Parameter<double> const& parameter);
+                    std::size_t const bulk_mesh_id,
+                    MeshLib::Mesh const& st_mesh, const int variable_id,
+                    const int component_id, Parameter<double> const& parameter);
 
     void integrateNodalSourceTerm(const double t, GlobalVector& b) const;
 
 private:
     NumLib::LocalToGlobalIndexMap const& _dof_table;
     std::size_t const _bulk_mesh_id;
-    MeshLib::Mesh& _st_mesh;
+    MeshLib::Mesh const& _st_mesh;
     int const _variable_id;
     int const _component_id;
     Parameter<double> const& _parameter;

--- a/ProcessLib/SourceTerms/SourceTermBuilder.h
+++ b/ProcessLib/SourceTerms/SourceTermBuilder.h
@@ -12,20 +12,9 @@
 #include "NodalSourceTerm.h"
 #include "ProcessLib/Parameter/Parameter.h"
 
-namespace GeoLib
-{
-class GeoObject;
-}
-
 namespace MeshLib
 {
-class Element;
 class Mesh;
-}
-
-namespace MeshGeoToolsLib
-{
-class BoundaryElementsSearcher;
 }
 
 namespace NumLib

--- a/ProcessLib/SourceTerms/SourceTermConfig.h
+++ b/ProcessLib/SourceTerms/SourceTermConfig.h
@@ -10,30 +10,28 @@
 #pragma once
 
 #include "BaseLib/ConfigTree.h"
-#include "GeoLib/GEOObjects.h"
+#include "MeshLib/Mesh.h"
 
 namespace ProcessLib
 {
 struct SourceTermConfig final
 {
     SourceTermConfig(BaseLib::ConfigTree&& config_,
-                     GeoLib::GeoObject const& geometry_,
+                     MeshLib::Mesh& mesh_,
                      boost::optional<int> const component_id_)
-        : config(std::move(config_)),
-          geometry(geometry_),
-          component_id(component_id_)
+        : config(std::move(config_)), mesh(mesh_), component_id(component_id_)
     {
     }
 
     SourceTermConfig(SourceTermConfig&& other)
         : config(std::move(other.config)),
-          geometry(other.geometry),
+          mesh(other.mesh),
           component_id(other.component_id)
     {
     }
 
     BaseLib::ConfigTree config;
-    GeoLib::GeoObject const& geometry;
+    MeshLib::Mesh& mesh;
     boost::optional<int> const component_id;
 };
 

--- a/ProcessLib/SourceTerms/SourceTermConfig.h
+++ b/ProcessLib/SourceTerms/SourceTermConfig.h
@@ -17,7 +17,7 @@ namespace ProcessLib
 struct SourceTermConfig final
 {
     SourceTermConfig(BaseLib::ConfigTree&& config_,
-                     MeshLib::Mesh& mesh_,
+                     MeshLib::Mesh const& mesh_,
                      boost::optional<int> const component_id_)
         : config(std::move(config_)), mesh(mesh_), component_id(component_id_)
     {
@@ -31,7 +31,7 @@ struct SourceTermConfig final
     }
 
     BaseLib::ConfigTree config;
-    MeshLib::Mesh& mesh;
+    MeshLib::Mesh const& mesh;
     boost::optional<int> const component_id;
 };
 

--- a/Tests/Data/Elliptic/square_1x1_GroundWaterFlow/square_1e6_with_nodal_sources.prj
+++ b/Tests/Data/Elliptic/square_1x1_GroundWaterFlow/square_1e6_with_nodal_sources.prj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <OpenGeoSysProject>
     <mesh>square_1x1_quad_1e6.vtu</mesh>
-    <geometry>square_1x1.gml</geometry>
+    <geometry>square_1x1_midpoint.gml</geometry>
     <processes>
         <process>
             <name>GW23</name>

--- a/Tests/Data/Elliptic/square_1x1_GroundWaterFlow/square_1x1.gml
+++ b/Tests/Data/Elliptic/square_1x1_GroundWaterFlow/square_1x1.gml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3f52cd5a8058d967f8ead873e1afa323af39266e538bcd2c35af08683a81dad
-size 1083
+oid sha256:9a6e7b692b55d4f0b5e29b055a4945bc3e57a822ba3df69ee94a23e83ace6172
+size 1017

--- a/Tests/Data/Elliptic/square_1x1_GroundWaterFlow/square_1x1_midpoint.gml
+++ b/Tests/Data/Elliptic/square_1x1_GroundWaterFlow/square_1x1_midpoint.gml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3f52cd5a8058d967f8ead873e1afa323af39266e538bcd2c35af08683a81dad
+size 1083


### PR DESCRIPTION
Succeeding the "Move BC meshes; preparations #2140" PR.

Three major parts:
 - Introduction of construct mesh from geometry function (which is mainly a copy from the Neumann BCs mesh creation with some generalizations).
 - Passing the meshes to the BCs and STs in ProcessVariable construction and choosing the meshes based on the geometry name from the config tree.
 - Updating creation of derived DOF table using the bulk and the boundary meshes.