### PR TITLE
[A/U] Add CLI to construct meshes from geometries.

### DIFF
--- a/Applications/Utils/MeshGeoTools/CMakeLists.txt
+++ b/Applications/Utils/MeshGeoTools/CMakeLists.txt
@@ -8,3 +8,10 @@ target_link_libraries( ComputeSurfaceNodeIDsInPolygonalRegion
     ${OGS_VTK_REQUIRED_LIBS}
 )
 
+add_executable(constructMeshesFromGeometry ConstructMeshesFromGeometry.cpp )
+set_target_properties(constructMeshesFromGeometry PROPERTIES FOLDER Utilities)
+target_link_libraries(constructMeshesFromGeometry
+    MeshGeoToolsLib
+    ApplicationsFileIO
+    ${OGS_VTK_REQUIRED_LIBS}
+)

--- a/Applications/Utils/MeshGeoTools/CMakeLists.txt
+++ b/Applications/Utils/MeshGeoTools/CMakeLists.txt
@@ -1,6 +1,6 @@
-ADD_EXECUTABLE( ComputeSurfaceNodeIDsInPolygonalRegion ComputeSurfaceNodeIDsInPolygonalRegion.cpp )
-SET_TARGET_PROPERTIES( ComputeSurfaceNodeIDsInPolygonalRegion PROPERTIES FOLDER Utilities)
-TARGET_LINK_LIBRARIES( ComputeSurfaceNodeIDsInPolygonalRegion
+add_executable( ComputeSurfaceNodeIDsInPolygonalRegion ComputeSurfaceNodeIDsInPolygonalRegion.cpp )
+set_target_properties( ComputeSurfaceNodeIDsInPolygonalRegion PROPERTIES FOLDER Utilities)
+target_link_libraries( ComputeSurfaceNodeIDsInPolygonalRegion
     MeshLib
     GeoLib
     MathLib

--- a/Applications/Utils/MeshGeoTools/ConstructMeshesFromGeometry.cpp
+++ b/Applications/Utils/MeshGeoTools/ConstructMeshesFromGeometry.cpp
@@ -1,0 +1,72 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include <tclap/CmdLine.h>
+
+#include "Applications/ApplicationsLib/LogogSetup.h"
+#include "GeoLib/GEOObjects.h"
+#include "GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.h"
+#include "MeshGeoToolsLib/ConstructMeshesFromGeometries.h"
+#include "MeshGeoToolsLib/SearchLength.h"
+#include "MeshLib/IO/readMeshFromFile.h"
+#include "MeshLib/IO/writeMeshToFile.h"
+#include "MeshLib/Mesh.h"
+
+std::unique_ptr<GeoLib::GEOObjects> readGeometry(std::string const& filename)
+{
+    auto geo_objects = std::make_unique<GeoLib::GEOObjects>();
+    GeoLib::IO::BoostXmlGmlInterface gml_reader(*geo_objects);
+
+    DBUG("Reading geometry file \'%s\'.", filename.c_str());
+    gml_reader.readFile(filename);
+    return geo_objects;
+}
+
+int main(int argc, char* argv[])
+{
+    ApplicationsLib::LogogSetup logo_setup;
+
+    TCLAP::CmdLine cmd(
+        "Converts a geometry defined on a given mesh to distinct meshes.",
+        ' ',
+        "0.1");
+
+    TCLAP::ValueArg<std::string> geometry_arg("g",
+                                              "geometry",
+                                              "the file name the geometry",
+                                              true,
+                                              "",
+                                              "geometry file name");
+    cmd.add(geometry_arg);
+
+    TCLAP::ValueArg<std::string> mesh_arg(
+        "m",
+        "mesh",
+        "the file name of the mesh where the geometry is defined",
+        true,
+        "",
+        "mesh file name");
+    cmd.add(mesh_arg);
+    cmd.parse(argc, argv);
+
+    std::unique_ptr<MeshLib::Mesh> mesh{
+        MeshLib::IO::readMeshFromFile(mesh_arg.getValue())};
+
+    auto const geo_objects = readGeometry(geometry_arg.getValue());
+
+    auto const extracted_meshes = constructAdditionalMeshesFromGeoObjects(
+        *geo_objects, *mesh, std::make_unique<MeshGeoToolsLib::SearchLength>());
+
+    for (auto const& m_ptr : extracted_meshes)
+    {
+        MeshLib::IO::writeMeshToFile(*m_ptr, m_ptr->getName() + ".vtu");
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,9 +2,13 @@
 [build]
   base    = "web"
   publish = "web/public"
-  command = "git lfs fetch && yarn --ignore-engines --ignore-optional --non-interactive && yarn prod"
+  command = """
+    git lfs fetch
+    yarn --ignore-engines --ignore-optional --non-interactive &&
+    node_modules/.bin/webpack -p --mode=production &&
+    hugo -b $DEPLOY_PRIME_URL"""
 
 [context.production.environment]
-  HUGO_VERSION = "0.41"
+  HUGO_VERSION = "0.42.1"
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.41"
+  HUGO_VERSION = "0.42.1"

--- a/web/config.toml
+++ b/web/config.toml
@@ -3,6 +3,7 @@ title = "OpenGeoSys"
 theme = "ogs"
 baseURL = "https://www.opengeosys.org"
 buildDrafts = false
+buildFuture = true
 pygmentsstyle = 'friendly'
 enableGitInfo = true
 canonifyURLs = true

--- a/web/content/docs/tools/model-preparation/constructMeshesFromGeometry/index.pandoc
+++ b/web/content/docs/tools/model-preparation/constructMeshesFromGeometry/index.pandoc
@@ -1,0 +1,55 @@
++++
+date = "2018-06-19T15:56:57+01:00"
+title = "Construct meshes from bulk mesh and geometries"
+author = "Dmitri Naumov"
+
+[menu]
+  [menu.tools]
+    parent = "model-preparation"
++++
+
+## General
+
+`constructMeshesFromGeometry` is a conversion tool for the `gml` files.  Given a
+"bulk" mesh and the `gml` geometry file the tool generates meshes for all named
+geometries.
+
+The meshes are used for the boundary conditions and provide node ids and element
+ids mappings to the bulk mesh.
+
+## Example
+
+For example a conversion of a mesh from `Tests/Data/LIE/Hydromechanics` single
+fracture 3D project:
+```
+constructMeshesFromGeometry -m single_fracture_3D.vtu -g single_fracture_3D.gml
+
+debug: Reading geometry file '../s/Tests/Data/LIE/HydroMechanics/single_fracture_3D.gml'.
+debug: Project configuration from file '../s/Tests/Data/LIE/HydroMechanics/single_fracture_3D.gml' read.
+debug: The search length for mesh "single_fracture_3D" is 1.000000e-09.
+debug: Creating mesh from geometry single_fracture_3D inlet.
+debug: Found 3 elements in the mesh
+debug: Creating mesh from geometry single_fracture_3D outlet.
+debug: Found 3 elements in the mesh
+debug: Creating mesh from geometry single_fracture_3D left.
+debug: Found 46 elements in the mesh
+debug: Creating mesh from geometry single_fracture_3D right.
+debug: Found 46 elements in the mesh
+debug: Creating mesh from geometry single_fracture_3D front.
+debug: Found 1150 elements in the mesh
+debug: Creating mesh from geometry single_fracture_3D back.
+debug: Found 1150 elements in the mesh
+debug: Creating mesh from geometry single_fracture_3D bottom.
+debug: Found 25 elements in the mesh
+debug: Creating mesh from geometry single_fracture_3D top.
+debug: Found 25 elements in the mesh
+```
+yields new meshes for each named geometry: `single_fracture_3D_inlet.vtu`,
+`single_fracture_3D_right.vtu`, `single_fracture_3D_outlet.vtu`,
+`single_fracture_3D_left.vtu`, `single_fracture_3D_front.vtu`,
+`single_fracture_3D_top.vtu`, `single_fracture_3D_bottom.vtu`, and
+`single_fracture_3D_back.vtu`.
+
+![](single_fracture_3D_geometries.png)
+The figure shows the front part of the mesh with the extracted geometries. Note,
+the lower dimensional inlet boundary, shown as a line.

--- a/web/content/docs/tools/model-preparation/constructMeshesFromGeometry/single_fracture_3D_geometries.png
+++ b/web/content/docs/tools/model-preparation/constructMeshesFromGeometry/single_fracture_3D_geometries.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15f1428e0682e465e9cc2754a3feed5d2b6dc857160cadb03b00b8552a170c9d
+size 145253


### PR DESCRIPTION
Command line interface to the MeshGeoToolsLib's construct meshes from geometries function.

Needed for automated conversion when multiple meshes will be supported by the project files.
Also good for checking your geometrical input!