### PR TITLE
[Test] Changed the linear solver type in Parabolic/TwoPhaseFlowPrho/MoMaS/Twophase_MoMaS_quad.prj

### DIFF
--- a/Tests/Data/Parabolic/TwoPhaseFlowPrho/MoMaS/Twophase_MoMaS_quad.prj
+++ b/Tests/Data/Parabolic/TwoPhaseFlowPrho/MoMaS/Twophase_MoMaS_quad.prj
@@ -259,7 +259,7 @@
             <name>general_linear_solver</name>
             <lis>-i bicgstab -p ilu -tol 1e-18 -maxiter 10000</lis>
             <eigen>
-                <solver_type>BiCGSTAB</solver_type>
+                <solver_type>SparseLU</solver_type>
                 <precon_type>ILUT</precon_type>
                 <max_iteration_step>10000</max_iteration_step>
                 <error_tolerance>1e-18</error_tolerance>


### PR DESCRIPTION
To fix the test of LARGE_2D_TwoPhase_Prho_MoMa (see PR #2056).