### PR TITLE
Improve TM process

### DIFF
--- a/Documentation/ProjectFile/prj/processes/process/THERMO_MECHANICS/t_reference_temperature.md
+++ b/Documentation/ProjectFile/prj/processes/process/THERMO_MECHANICS/t_reference_temperature.md
@@ -1,1 +1,0 @@
-Reference temperature for the thermo-mechanical process.

--- a/ProcessLib/ThermoMechanics/CreateThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/CreateThermoMechanicsProcess.cpp
@@ -134,10 +134,6 @@ std::unique_ptr<Process> createThermoMechanicsProcess(
         "thermal_conductivity", parameters, 1);
     DBUG("Use \'%s\' as thermal conductivity parameter.",
          thermal_conductivity.name.c_str());
-    // Reference temperature
-    const double reference_temperature =
-        //! \ogs_file_param{prj__processes__process__THERMO_MECHANICS__reference_temperature}
-        config.getConfigParameter<double>("reference_temperature");
 
     // Specific body force
     Eigen::Matrix<double, DisplacementDim, 1> specific_body_force;
@@ -162,7 +158,6 @@ std::unique_ptr<Process> createThermoMechanicsProcess(
         linear_thermal_expansion_coefficient,
         specific_heat_capacity,
         thermal_conductivity,
-        reference_temperature,
         specific_body_force};
 
     SecondaryVariableCollection secondary_variables;

--- a/ProcessLib/ThermoMechanics/Tests.cmake
+++ b/ProcessLib/ThermoMechanics/Tests.cmake
@@ -7,9 +7,9 @@ AddTest(
     TESTER vtkdiff
     REQUIREMENTS NOT (OGS_USE_LIS OR OGS_USE_MPI)
     DIFF_DATA
-    stress_analytical.vtu cube_1e3_tm_pcs_0_ts_17_t_72000.000000.vtu sigma_xx sigma_xx 1e-10 1e-12
-    stress_analytical.vtu cube_1e3_tm_pcs_0_ts_17_t_72000.000000.vtu sigma_yy sigma_yy 1e-10 1e-12
-    stress_analytical.vtu cube_1e3_tm_pcs_0_ts_17_t_72000.000000.vtu sigma_zz sigma_zz 1e-10 1e-12
+    stress_analytical.vtu cube_1e3_tm_pcs_0_ts_17_t_72000.000000.vtu sigma_xx sigma_xx 1e-10 1e-11
+    stress_analytical.vtu cube_1e3_tm_pcs_0_ts_17_t_72000.000000.vtu sigma_yy sigma_yy 1e-10 1e-11
+    stress_analytical.vtu cube_1e3_tm_pcs_0_ts_17_t_72000.000000.vtu sigma_zz sigma_zz 1e-10 1e-11
     expected_cube_1e3_tm_pcs_0_ts_17_t_72000.000000.vtu cube_1e3_tm_pcs_0_ts_17_t_72000.000000.vtu displacement displacement 1e-10 1e-12
     expected_cube_1e3_tm_pcs_0_ts_17_t_72000.000000.vtu cube_1e3_tm_pcs_0_ts_17_t_72000.000000.vtu temperature temperature 1e-10 1e-12
 )
@@ -39,11 +39,11 @@ AddTest(
     TESTER vtkdiff
     REQUIREMENTS NOT (OGS_USE_LIS OR OGS_USE_MPI)
     DIFF_DATA
-    expected_tm_a_pcs_0_ts_20_t_20000.000000.vtu tm_a_pcs_0_ts_20_t_20000.000000.vtu displacement displacement 1e-10 1e-15
-    expected_tm_a_pcs_0_ts_20_t_20000.000000.vtu tm_a_pcs_0_ts_20_t_20000.000000.vtu temperature temperature 1e-10 1e-15
-    expected_tm_a_pcs_0_ts_20_t_20000.000000.vtu tm_a_pcs_0_ts_20_t_20000.000000.vtu sigma_xx sigma_xx 1e-10 1e-15
-    expected_tm_a_pcs_0_ts_20_t_20000.000000.vtu tm_a_pcs_0_ts_20_t_20000.000000.vtu sigma_yy sigma_yy 1e-10 1e-15
-    expected_tm_a_pcs_0_ts_20_t_20000.000000.vtu tm_a_pcs_0_ts_20_t_20000.000000.vtu sigma_zz sigma_zz 1e-10 1e-15
+    expected_tm_a_pcs_0_ts_20_t_20000.000000.vtu tm_a_pcs_0_ts_20_t_20000.000000.vtu displacement displacement 1e-9 1e-15
+    expected_tm_a_pcs_0_ts_20_t_20000.000000.vtu tm_a_pcs_0_ts_20_t_20000.000000.vtu temperature temperature 1e-10 1e-8
+    expected_tm_a_pcs_0_ts_20_t_20000.000000.vtu tm_a_pcs_0_ts_20_t_20000.000000.vtu sigma_xx sigma_xx 1e-10 1e-6
+    expected_tm_a_pcs_0_ts_20_t_20000.000000.vtu tm_a_pcs_0_ts_20_t_20000.000000.vtu sigma_yy sigma_yy 1e-10 1e-6
+    expected_tm_a_pcs_0_ts_20_t_20000.000000.vtu tm_a_pcs_0_ts_20_t_20000.000000.vtu sigma_zz sigma_zz 1e-10 1e-6
 )
 
 AddTest(
@@ -72,10 +72,10 @@ AddTest(
     REQUIREMENTS NOT (OGS_USE_LIS OR OGS_USE_MPI)
     DIFF_DATA
     expected_tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu displacement displacement 5e-10 1e-15
-    expected_tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu temperature temperature 5e-10 1e-15
-    expected_tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu sigma_xx sigma_xx 5e-10 1e-15
-    expected_tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu sigma_yy sigma_yy 5e-10 1e-15
-    expected_tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu sigma_zz sigma_zz 5e-10 1e-15
+    expected_tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu temperature temperature 5e-10 1e-7
+    expected_tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu sigma_xx sigma_xx 5e-10 1e-6
+    expected_tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu sigma_yy sigma_yy 5e-10 1e-8
+    expected_tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu tm_a_quad_pcs_0_ts_20_t_20000.000000.vtu sigma_zz sigma_zz 5e-10 1e-7
 )
 
 AddTest(

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
@@ -50,6 +50,7 @@ struct IntegrationPointData final
     std::unique_ptr<typename MaterialLib::Solids::MechanicsBase<
         DisplacementDim>::MaterialStateVariables>
         material_state_variables;
+    double solid_density_current, solid_density_prev;
 
     double integration_weight;
     typename ShapeMatricesType::NodalRowVectorType N;
@@ -59,6 +60,7 @@ struct IntegrationPointData final
     {
         eps_m_prev = eps_m;
         sigma_prev = sigma;
+        solid_density_prev = solid_density_current;
         material_state_variables->pushBackState();
     }
 
@@ -137,6 +139,12 @@ public:
             ip_data.eps.setZero(kelvin_vector_size);
             ip_data.eps_m.setZero(kelvin_vector_size);
             ip_data.eps_m_prev.setZero(kelvin_vector_size);
+
+            SpatialPosition x_position;
+            x_position.setElementID(_element.getID());
+            ip_data.solid_density_current =
+                _process_data.reference_solid_density(0, x_position)[0];
+            ip_data.solid_density_prev = ip_data.solid_density_current;
 
             ip_data.N = shape_matrices[ip].N;
             ip_data.dNdx = shape_matrices[ip].dNdx;
@@ -227,14 +235,13 @@ public:
             auto& eps_m_prev = _ip_data[ip].eps_m_prev;
             auto& state = _ip_data[ip].material_state_variables;
 
-            double const delta_T =
-                N.dot(T) - _process_data.reference_temperature;
+            double const dT = N.dot(T_dot) * dt;
             // calculate thermally induced strain
             // assume isotropic thermal expansion
             auto const alpha =
                 _process_data.linear_thermal_expansion_coefficient(
                     t, x_position)[0];
-            double const linear_thermal_strain = alpha * delta_T;
+            double const linear_thermal_strain = alpha * dT;
 
             //
             // displacement equation, displacement part
@@ -246,11 +253,12 @@ public:
                     DisplacementDim>::value>;
 
             // assume isotropic thermal expansion
+            const double T_ip = N.dot(T);  // T at integration point
             eps_m.noalias() =
                 eps - linear_thermal_strain * Invariants::identity2;
             auto&& solution = _ip_data[ip].solid_material.integrateStress(
-                t, x_position, dt, eps_m_prev, eps_m, sigma_prev, *state,
-                delta_T + _process_data.reference_temperature);
+                t, x_position, dt, eps_m_prev, eps_m, sigma_prev, *state, T_ip);
+            eps_m.noalias() = eps;
 
             if (!solution)
                 OGS_FATAL("Computation of local constitutive relation failed.");
@@ -276,13 +284,13 @@ public:
                     .noalias() = N;
 
             // calculate real density
-            // rho_s * (V_0 + dV) = rho_sr * V_0
+            // rho_s_{n+1} * (V_{n} + dV) = rho_s_n * V_n
             // dV = 3 * alpha * dT * V_0
-            // rho_s = rho_sr / (1 + 3 * alpha * dT )
+            // rho_s_{n+1} = rho_s_n / (1 + 3 * alpha * dT )
             // see reference solid density description for details.
-            auto const rho_sr =
-                _process_data.reference_solid_density(t, x_position)[0];
-            double const rho_s = rho_sr / (1 + 3 * linear_thermal_strain);
+            double const rho_s = _ip_data[ip].solid_density_prev /
+                                 (1 + 3 * linear_thermal_strain);
+            _ip_data[ip].solid_density_current = rho_s;
 
             auto const& b = _process_data.specific_body_force;
             local_rhs
@@ -302,8 +310,7 @@ public:
                 double const norm_s = Invariants::FrobeniusNorm(s);
                 const double creep_coefficient =
                     _process_data.material->getTemperatureRelatedCoefficient(
-                        t, dt, x_position,
-                        delta_T + _process_data.reference_temperature, norm_s);
+                        t, dt, x_position, T_ip, norm_s);
                 KuT.noalias() += creep_coefficient * B.transpose() * s * N * w;
             }
 

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
@@ -38,7 +38,6 @@ struct ThermoMechanicsProcessData
         Parameter<double> const& linear_thermal_expansion_coefficient_,
         Parameter<double> const& specific_heat_capacity_,
         Parameter<double> const& thermal_conductivity_,
-        double const reference_temperature_,
         Eigen::Matrix<double, DisplacementDim, 1> const& specific_body_force_)
         : material{std::move(material_)},
           reference_solid_density(reference_solid_density_),
@@ -46,7 +45,6 @@ struct ThermoMechanicsProcessData
               linear_thermal_expansion_coefficient_),
           specific_heat_capacity(specific_heat_capacity_),
           thermal_conductivity(thermal_conductivity_),
-          reference_temperature(reference_temperature_),
           specific_body_force(specific_body_force_)
     {
     }
@@ -58,7 +56,6 @@ struct ThermoMechanicsProcessData
               other.linear_thermal_expansion_coefficient),
           specific_heat_capacity(other.specific_heat_capacity),
           thermal_conductivity(other.thermal_conductivity),
-          reference_temperature(other.reference_temperature),
           specific_body_force(other.specific_body_force),
           dt(other.dt),
           t(other.t)
@@ -81,7 +78,6 @@ struct ThermoMechanicsProcessData
     Parameter<double> const& specific_heat_capacity;
     Parameter<double> const&
         thermal_conductivity;  // TODO To be changed as a matrix type variable.
-    double const reference_temperature;
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
     double dt = 0;
     double t = 0;

--- a/Tests/Data/ThermoMechanics/CreepBGRa/SimpleAxisymmetricCreep/SimpleAxisymmetricCreep.prj
+++ b/Tests/Data/ThermoMechanics/CreepBGRa/SimpleAxisymmetricCreep/SimpleAxisymmetricCreep.prj
@@ -24,7 +24,6 @@
             <linear_thermal_expansion_coefficient>alpha</linear_thermal_expansion_coefficient>
             <specific_heat_capacity>cs</specific_heat_capacity>
             <thermal_conductivity>lambda</thermal_conductivity>
-            <reference_temperature>330.15</reference_temperature>
             <process_variables>
                 <displacement>displacement</displacement>
                 <temperature>temperature</temperature>

--- a/Tests/Data/ThermoMechanics/CreepBGRa/SimpleAxisymmetricCreep/SimpleAxisymmetricCreepWithAnalyticSolution.prj
+++ b/Tests/Data/ThermoMechanics/CreepBGRa/SimpleAxisymmetricCreep/SimpleAxisymmetricCreepWithAnalyticSolution.prj
@@ -24,7 +24,6 @@
             <linear_thermal_expansion_coefficient>alpha</linear_thermal_expansion_coefficient>
             <specific_heat_capacity>cs</specific_heat_capacity>
             <thermal_conductivity>lambda</thermal_conductivity>
-            <reference_temperature>373.15</reference_temperature>
             <process_variables>
                 <displacement>displacement</displacement>
                 <temperature>temperature</temperature>

--- a/Tests/Data/ThermoMechanics/cube_1e3.prj
+++ b/Tests/Data/ThermoMechanics/cube_1e3.prj
@@ -16,7 +16,6 @@
             <linear_thermal_expansion_coefficient>alpha</linear_thermal_expansion_coefficient>
             <specific_heat_capacity>cs</specific_heat_capacity>
             <thermal_conductivity>lambda</thermal_conductivity>
-            <reference_temperature>298</reference_temperature>
             <process_variables>
                 <displacement>displacement</displacement>
                 <temperature>temperature</temperature>

--- a/Tests/Data/ThermoMechanics/iglu_axisymmetric_plane_strain.prj
+++ b/Tests/Data/ThermoMechanics/iglu_axisymmetric_plane_strain.prj
@@ -16,7 +16,6 @@
             <linear_thermal_expansion_coefficient>alpha</linear_thermal_expansion_coefficient>
             <specific_heat_capacity>cs</specific_heat_capacity>
             <thermal_conductivity>lambda</thermal_conductivity>
-            <reference_temperature>283.15</reference_temperature>
             <process_variables>
                 <displacement>displacement</displacement>
                 <temperature>temperature</temperature>

--- a/Tests/Data/ThermoMechanics/iglu_axisymmetric_plane_strain_quad.prj
+++ b/Tests/Data/ThermoMechanics/iglu_axisymmetric_plane_strain_quad.prj
@@ -237,9 +237,9 @@
             <lis>-i bicgstab -p jacobi -tol 1e-11 -maxiter 10000</lis>
             <eigen>
                 <solver_type>BiCGSTAB</solver_type>
-                <precon_type>DIAGONAL</precon_type>
+                <precon_type>ILUT</precon_type>
                 <max_iteration_step>10000</max_iteration_step>
-                <error_tolerance>1e-11</error_tolerance>
+                <error_tolerance>1e-10</error_tolerance>
             </eigen>
         </linear_solver>
     </linear_solvers>

--- a/Tests/Data/ThermoMechanics/iglu_axisymmetric_plane_strain_quad.prj
+++ b/Tests/Data/ThermoMechanics/iglu_axisymmetric_plane_strain_quad.prj
@@ -16,7 +16,6 @@
             <linear_thermal_expansion_coefficient>alpha</linear_thermal_expansion_coefficient>
             <specific_heat_capacity>cs</specific_heat_capacity>
             <thermal_conductivity>lambda</thermal_conductivity>
-            <reference_temperature>283.15</reference_temperature>
             <process_variables>
                 <displacement>displacement</displacement>
                 <temperature>temperature</temperature>

--- a/Tests/Data/ThermoMechanics/iglu_quarter_plane_strain.prj
+++ b/Tests/Data/ThermoMechanics/iglu_quarter_plane_strain.prj
@@ -20,7 +20,6 @@
             <linear_thermal_expansion_coefficient>alpha</linear_thermal_expansion_coefficient>
             <specific_heat_capacity>cs</specific_heat_capacity>
             <thermal_conductivity>lambda</thermal_conductivity>
-            <reference_temperature>283.15</reference_temperature>
             <process_variables>
                 <displacement>displacement</displacement>
                 <temperature>temperature</temperature>

--- a/Tests/Data/ThermoMechanics/iglu_quarter_plane_strain_quad.prj
+++ b/Tests/Data/ThermoMechanics/iglu_quarter_plane_strain_quad.prj
@@ -20,7 +20,6 @@
             <linear_thermal_expansion_coefficient>alpha</linear_thermal_expansion_coefficient>
             <specific_heat_capacity>cs</specific_heat_capacity>
             <thermal_conductivity>lambda</thermal_conductivity>
-            <reference_temperature>283.15</reference_temperature>
             <process_variables>
                 <displacement>displacement</displacement>
                 <temperature>temperature</temperature>


### PR DESCRIPTION
Use the temperature increment dT instead of the global temperature change T-T_0 in the thermal strain calculation. Also this PR corrects the thermal strain calculation with initial temperature.

In the current master, the thermal strain increment is calculated by 
![dt0](https://user-images.githubusercontent.com/1343839/43521322-0bf4eaa4-9596-11e8-86e5-a7a70285a31f.gif)
Such calculation is simplified in  this PR as
![dt1](https://user-images.githubusercontent.com/1343839/43521330-134c1052-9596-11e8-9d48-af74f34ba4b8.gif)
and the parameter of reference_temperature is dropped.
  
Note: In the current repository, the calculation of total strain increment takes the same calculation approach as that for thermal strain increment, which uses extra more memory by storing vectors of eps_prev and eps_m at each Gauss point. This will be improved later for all mechanics related processes. 

