### PR TITLE
Fixed issue with limiting the date range on time series data

### DIFF
--- a/Applications/DataExplorer/DataView/DiagramView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/DiagramView/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
 
 set(HEADERS
     DiagramList.h
+    getDateTime.h
     QArrow.h
     QGraphicsGrid.h
     DiagramScene.h

--- a/Applications/DataExplorer/DataView/DiagramView/CMakeLists.txt
+++ b/Applications/DataExplorer/DataView/DiagramView/CMakeLists.txt
@@ -10,7 +10,7 @@ set(SOURCES
 
 set(HEADERS
     DiagramList.h
-    getDateTime.h
+    GetDateTime.h
     QArrow.h
     QGraphicsGrid.h
     DiagramScene.h

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
@@ -13,7 +13,7 @@
  */
 
 #include "DiagramList.h"
-#include "getDateTime.h"
+#include "GetDateTime.h"
 
 #include <logog/include/logog.hpp>
 

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
@@ -304,8 +304,11 @@ void DiagramList::truncateToRange(QDateTime const& start, QDateTime const& end)
     update();
 }
 
-void DiagramList::setList(std::vector< std::pair<QDateTime, float> > coords)
+void DiagramList::setList(std::vector<std::pair<QDateTime, float>> const& coords)
 {
+    if (coords.empty())
+        return;
+
     this->_startDate = coords[0].first;
     _coords.emplace_back(0.0f, coords[0].second);
 
@@ -320,8 +323,11 @@ void DiagramList::setList(std::vector< std::pair<QDateTime, float> > coords)
     update();
 }
 
-void DiagramList::setList(std::vector< std::pair<float, float> > coords)
+void DiagramList::setList(std::vector< std::pair<float, float> > const& coords)
 {
+    if (coords.empty())
+        return;
+
     this->_startDate = QDateTime();
     std::size_t nCoords = coords.size();
     for (std::size_t i = 0; i < nCoords; i++)

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
@@ -13,6 +13,7 @@
  */
 
 #include "DiagramList.h"
+#include "getDateTime.h"
 
 #include <logog/include/logog.hpp>
 
@@ -260,12 +261,12 @@ int DiagramList::readList(const SensorData* data, std::vector<DiagramList*> &lis
         if (is_date)
         {
             l->setXUnit("day");
-            QDateTime startDate(getDateTime(QString::fromStdString(BaseLib::int2date(time_steps[0]))));
+            QDateTime const startDate(getDateTime(BaseLib::int2date(time_steps[0])));
             lists[i]->setStartDate(startDate);
             for (std::size_t j = 0; j < nValues; j++)
             {
-                QString const data_str = QString::fromStdString(BaseLib::int2date(time_steps[j]));
-                float numberOfSecs = static_cast<float>(startDate.secsTo(getDateTime(data_str)));
+                QDateTime const currentDate(getDateTime(BaseLib::int2date(time_steps[j])));
+                float numberOfSecs = static_cast<float>(startDate.secsTo(currentDate));
                 lists[i]->addNextPoint(numberOfSecs, (*time_series)[j]);
             }
         }
@@ -352,13 +353,4 @@ void DiagramList::update()
     _maxY = calcMaxYValue();
 }
 
-QDateTime DiagramList::getDateTime(QString stringDate)
-{
-    if (stringDate.length() == 10)
-        return QDateTime::fromString(stringDate, "dd.MM.yyyy");
 
-    if (stringDate.length() == 19)
-        return QDateTime::fromString(stringDate, "dd.MM.yyyy.HH.mm.ss");
-
-    return QDateTime();
-}

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramList.h
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramList.h
@@ -107,6 +107,10 @@ public:
 
     /// Adds a point at (x,y) to the list
     void addNextPoint(float x, float y) { _coords.emplace_back(x, y); }
+
+    /// cut list entries not within the given range
+    void truncateToRange(QDateTime const& start, QDateTime const& end);
+
     /// Sets the start date (i.e. the min-value of the x-axis).
     void setStartDate(QDateTime date) { _startDate = date; }
 
@@ -142,6 +146,9 @@ public:
     /// Returns the width of the bounding box of all data points within the list.
     double width() const { return _maxX - _minX; }
 
+    /// Converts string into QDateTime-format
+    static QDateTime getDateTime(QString s);
+
 private:
     /// Returns the minimum x-value of all the data points.
     float calcMinXValue();
@@ -154,9 +161,7 @@ private:
 
     /// Returns the maximum y-value of all the data points.
     float calcMaxYValue();
-
-    static QDateTime getDateTime(QString s);
-
+    
     /**
      * Reads an ASCII file containing the coordinates in the following format:
      *        date (tab) value

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramList.h
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramList.h
@@ -124,7 +124,7 @@ public:
      * Sets the list of x/y-coordinates.
      * \param coords List of coordinates.
      */
-    void setList(std::vector< std::pair<float, float> > coords);
+    void setList(std::vector< std::pair<float, float> > const& coords);
 
     /**
      * Sets the list of x/y-coordinates.
@@ -132,7 +132,7 @@ public:
      * days from the first date (which is set as day 0)
      * \param coords List of coordinates.
      */
-    void setList(std::vector< std::pair<QDateTime, float> > coords);
+    void setList(std::vector< std::pair<QDateTime, float> > const& coords);
 
     /// Specifies the unit of the x Axis.
     void setXUnit(QString unit) { _xUnit = unit; }

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramList.h
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramList.h
@@ -146,9 +146,6 @@ public:
     /// Returns the width of the bounding box of all data points within the list.
     double width() const { return _maxX - _minX; }
 
-    /// Converts string into QDateTime-format
-    static QDateTime getDateTime(QString s);
-
 private:
     /// Returns the minimum x-value of all the data points.
     float calcMinXValue();
@@ -161,7 +158,7 @@ private:
 
     /// Returns the maximum y-value of all the data points.
     float calcMaxYValue();
-    
+
     /**
      * Reads an ASCII file containing the coordinates in the following format:
      *        date (tab) value

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramPrefs.ui
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramPrefs.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>267</width>
-    <height>236</height>
+    <width>317</width>
+    <height>244</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -45,7 +45,16 @@
    </item>
    <item>
     <layout class="QGridLayout" name="DateBoundsLayout">
-     <property name="margin">
+     <property name="leftMargin">
+      <number>10</number>
+     </property>
+     <property name="topMargin">
+      <number>10</number>
+     </property>
+     <property name="rightMargin">
+      <number>10</number>
+     </property>
+     <property name="bottomMargin">
       <number>10</number>
      </property>
      <property name="spacing">

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramPrefsDialog.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramPrefsDialog.cpp
@@ -15,7 +15,7 @@
 #include "DiagramPrefsDialog.h"
 #include "DetailWindow.h"
 #include "DiagramList.h"
-#include "getDateTime.h"
+#include "GetDateTime.h"
 #include "OGSError.h"
 #include "Station.h"
 

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramPrefsDialog.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramPrefsDialog.cpp
@@ -77,7 +77,8 @@ void DiagramPrefsDialog::accept()
         return;
     }
 
-    // data has been loaded
+    // Data has been loaded.
+    // If loading the other lists fails at least nothing terrible will happen.
     if (_list[0]->size() > 0)
     {
         bool window_is_empty(false);

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramScene.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramScene.cpp
@@ -68,7 +68,7 @@ DiagramScene::~DiagramScene()
 }
 
 /// Adds an arrow object to the diagram which might be used as a coordinate axis, etc.
-QArrow* DiagramScene::addArrow(float length, float angle, QPen &pen)
+QArrow* DiagramScene::addArrow(qreal length, qreal angle, QPen &pen)
 {
     auto* arrow = new QArrow(length, angle, 8, 5, pen);
     addItem(arrow);
@@ -130,7 +130,7 @@ QNonScalableGraphicsTextItem* DiagramScene::addNonScalableText(const QString &te
 }
 
 /// Resizes a given axis to "nice" dimensions and calculates an adequate number of ticks to be placed on it
-void DiagramScene::adjustAxis(float &min, float &max, int &numberOfTicks)
+void DiagramScene::adjustAxis(qreal& min, qreal& max, int& numberOfTicks)
 {
     const int MinTicks = 4;
     double grossStep = (max - min) / MinTicks;
@@ -142,8 +142,8 @@ void DiagramScene::adjustAxis(float &min, float &max, int &numberOfTicks)
     numberOfTicks = int(ceil(max / step) - std::floor(min / step));
     if (numberOfTicks < MinTicks)
         numberOfTicks = MinTicks;
-    min = std::floor(min / step) * step;
-    max = ceil(max / step) * step;
+    min = (std::floor(min / step) * step);
+    max = (ceil(max / step) * step);
 }
 
 ///Calculates scaling factors to set coordinate system and graphs to default window size
@@ -151,8 +151,8 @@ void DiagramScene::adjustScaling()
 {
     if ( (_unscaledBounds.width() > 0) && (_unscaledBounds.height() > 0))
     {
-        _scaleX = DEFAULTX / (_unscaledBounds.width());
-        _scaleY = DEFAULTY / (_unscaledBounds.height());
+        _scaleX = DEFAULTX / static_cast<float>(_unscaledBounds.width());
+        _scaleY = DEFAULTY / static_cast<float>(_unscaledBounds.height());
     }
 }
 
@@ -184,10 +184,10 @@ void DiagramScene::constructGrid()
 {
     // be very careful with scaling parameters here!
     int numXTicks, numYTicks;
-    float xMin = _unscaledBounds.left();
-    float yMin = _unscaledBounds.top();
-    float xMax = _unscaledBounds.right();
-    float yMax = _unscaledBounds.bottom();
+    qreal xMin = _unscaledBounds.left();
+    qreal yMin = _unscaledBounds.top();
+    qreal xMax = _unscaledBounds.right();
+    qreal yMax = _unscaledBounds.bottom();
 
     adjustAxis(xMin, xMax, numXTicks);
     adjustAxis(yMin, yMax, numYTicks);
@@ -229,9 +229,9 @@ void DiagramScene::constructGrid()
 
     for (int j = 0; j <= numYTicks; ++j)
     {
-        float y     = _bounds.bottom() / _scaleY -
+        qreal y     = _bounds.bottom() / _scaleY -
                       (j * (_bounds.height() / _scaleY) / numYTicks);
-        float label = _bounds.top()   / _scaleY +
+        qreal label = _bounds.top()   / _scaleY +
                       (j * (_bounds.height() / _scaleY) / numYTicks);
         _yTicksText.push_back(addNonScalableText(QString::number(label)));
         _yTicksText.last()->setPos(_bounds.left() - MARGIN / 2, y * _scaleY);
@@ -284,7 +284,7 @@ int DiagramScene::getYAxisOffset()
 /// calculates axes-lengths, offsets, etc.
 void DiagramScene::initialize()
 {
-    QPen pen(Qt::black, 2, Qt::SolidLine, Qt::SquareCap, Qt::RoundJoin);
+    QPen pen(Qt::black, 1, Qt::SolidLine, Qt::SquareCap, Qt::RoundJoin);
     pen.setCosmetic(true);
 
     setXAxis(addArrow(_bounds.width(),  0, pen));

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramScene.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramScene.cpp
@@ -142,8 +142,8 @@ void DiagramScene::adjustAxis(qreal& min, qreal& max, int& numberOfTicks)
     numberOfTicks = int(ceil(max / step) - std::floor(min / step));
     if (numberOfTicks < MinTicks)
         numberOfTicks = MinTicks;
-    min = (std::floor(min / step) * step);
-    max = (ceil(max / step) * step);
+    min = std::floor(min / step) * step;
+    max = ceil(max / step) * step;
 }
 
 ///Calculates scaling factors to set coordinate system and graphs to default window size

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramScene.h
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramScene.h
@@ -32,7 +32,7 @@ public:
     DiagramScene(DiagramList* list, QObject* parent = nullptr);
     ~DiagramScene() override;
 
-    QArrow* addArrow(float length, float angle, QPen &pen);
+    QArrow* addArrow(qreal length, qreal angle, QPen &pen);
     void addGraph(DiagramList* list);
     QGraphicsGrid* addGrid(const QRectF &rect, int xTicks, int yTicks, const QPen &pen);
 
@@ -42,7 +42,7 @@ private:
     void addCaption(const QString &name, QPen &pen);
     QNonScalableGraphicsTextItem* addNonScalableText(const QString &text,
                                                      const QFont &font = QFont());
-    void adjustAxis(float &min, float &max, int &numberOfTicks);
+    void adjustAxis(qreal& min, qreal& max, int& numberOfTicks);
     void adjustScaling();
     void clearGrid();
     void constructGrid();

--- a/Applications/DataExplorer/DataView/DiagramView/GetDateTime.h
+++ b/Applications/DataExplorer/DataView/DiagramView/GetDateTime.h
@@ -1,0 +1,31 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include <QDateTime>
+#include <QString>
+#include <string>
+
+/// Converts string into QDateTime-format
+inline QDateTime getDateTime(QString const& stringDate)
+{
+    if (stringDate.length() == 10)
+        return QDateTime::fromString(stringDate, "dd.MM.yyyy");
+
+    if (stringDate.length() == 19)
+        return QDateTime::fromString(stringDate, "dd.MM.yyyy.HH.mm.ss");
+
+    return QDateTime();
+}
+
+/// Converts string into QDateTime-format
+inline QDateTime getDateTime(std::string const& stringDate)
+{
+    return getDateTime(QString::fromStdString(stringDate));
+}

--- a/Applications/DataExplorer/DataView/DiagramView/QArrow.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/QArrow.cpp
@@ -25,7 +25,7 @@
  * \param pen The pen for drawing the arrow
  * \param parent The parent QGraphicsItem.
  */
-QArrow::QArrow(float l, float a, float hl, float hw, QPen &pen,
+QArrow::QArrow(qreal l, qreal a, qreal hl, qreal hw, QPen& pen,
                QGraphicsItem* parent) : QGraphicsItem(parent)
 {
     _arrowLength = l;
@@ -42,7 +42,8 @@ QArrow::QArrow(float l, float a, float hl, float hw, QPen &pen,
  * \param pen The pen for drawing the arrow
  * \param parent The parent QGraphicsItem.
  */
-QArrow::QArrow(float l, float a, QPen &pen, QGraphicsItem* parent) : QGraphicsItem(parent)
+QArrow::QArrow(qreal l, qreal a, QPen& pen, QGraphicsItem* parent)
+    : QGraphicsItem(parent)
 {
     _arrowLength = l;
     _arrowAngle  = a;
@@ -116,13 +117,13 @@ void QArrow::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QW
 }
 
 /// Changes orientation of the arrow.
-void QArrow::setAngle(double a)
+void QArrow::setAngle(float a)
 {
     _arrowAngle = a;
 }
 
 /// Changes the length of the arrow.
-void QArrow::setLength(double l)
+void QArrow::setLength(qreal l)
 {
     _arrowLength = l;
 }

--- a/Applications/DataExplorer/DataView/DiagramView/QArrow.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/QArrow.cpp
@@ -117,7 +117,7 @@ void QArrow::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QW
 }
 
 /// Changes orientation of the arrow.
-void QArrow::setAngle(float a)
+void QArrow::setAngle(qreal a)
 {
     _arrowAngle = a;
 }

--- a/Applications/DataExplorer/DataView/DiagramView/QArrow.h
+++ b/Applications/DataExplorer/DataView/DiagramView/QArrow.h
@@ -35,7 +35,7 @@ public:
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
                QWidget* widget) override;
     QRectF boundingRect() const override;
-    void setAngle(float a);
+    void setAngle(qreal a);
     void setLength(qreal l);
 
 private:

--- a/Applications/DataExplorer/DataView/DiagramView/QArrow.h
+++ b/Applications/DataExplorer/DataView/DiagramView/QArrow.h
@@ -25,9 +25,9 @@ const double PI = 3.14159265;
 class QArrow : public QGraphicsItem
 {
 public:
-    QArrow(float l, float a, float hl, float hw, QPen& pen,
+    QArrow(qreal l, qreal a, qreal hl, qreal hw, QPen& pen,
            QGraphicsItem* parent = nullptr);
-    QArrow(float l, float a, QPen& pen, QGraphicsItem* parent = nullptr);
+    QArrow(qreal l, qreal a, QPen& pen, QGraphicsItem* parent = nullptr);
     ~QArrow() override;
 
     double getLength();
@@ -35,16 +35,16 @@ public:
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
                QWidget* widget) override;
     QRectF boundingRect() const override;
-    void setAngle(double a);
-    void setLength(double l);
+    void setAngle(float a);
+    void setLength(qreal l);
 
 private:
     double calcCos(double angle);
     double calcSin(double angle);
 
-    float _arrowLength;
-    float _arrowAngle;
-    float _headLength;
-    float _headWidth;
+    qreal _arrowLength;
+    qreal _arrowAngle;
+    qreal _headLength;
+    qreal _headWidth;
     QPen _arrowPen;
 };


### PR DESCRIPTION
When visualising a time series as a diagram, limiting the time range works as intended now.

Also fixed a number of implicit data type conversion warnings.