### PR TITLE
MeshLib point vertex VTK conversion

### DIFF
--- a/MeshLib/MeshGenerators/VtkMeshConverter.cpp
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.cpp
@@ -19,40 +19,40 @@
 #include "MeshLib/Node.h"
 
 // Conversion from Image to QuadMesh
-#include <vtkImageData.h>
-#include <vtkPointData.h>
-#include <vtkSmartPointer.h>
 #include <vtkBitArray.h>
 #include <vtkCharArray.h>
+#include <vtkDoubleArray.h>
+#include <vtkImageData.h>
+#include <vtkIntArray.h>
+#include <vtkPointData.h>
+#include <vtkSmartPointer.h>
 #include <vtkUnsignedCharArray.h>
 #include <vtkUnsignedLongArray.h>
 #include <vtkUnsignedLongLongArray.h>
-#include <vtkDoubleArray.h>
-#include <vtkIntArray.h>
 
 // Conversion from vtkUnstructuredGrid
 #include <vtkCell.h>
 #include <vtkCellData.h>
-#include <vtkUnstructuredGrid.h>
 #include <vtkUnsignedIntArray.h>
+#include <vtkUnstructuredGrid.h>
 
 namespace MeshLib
 {
-
 namespace detail
 {
 template <class T_ELEMENT>
-MeshLib::Element* createElementWithSameNodeOrder(const std::vector<MeshLib::Node*> &nodes,
-        vtkIdList* const node_ids)
+MeshLib::Element* createElementWithSameNodeOrder(
+    const std::vector<MeshLib::Node*>& nodes, vtkIdList* const node_ids)
 {
     auto** ele_nodes = new MeshLib::Node*[T_ELEMENT::n_all_nodes];
-    for (unsigned k(0); k<T_ELEMENT::n_all_nodes; k++)
+    for (unsigned k(0); k < T_ELEMENT::n_all_nodes; k++)
         ele_nodes[k] = nodes[node_ids->GetId(k)];
     return new T_ELEMENT(ele_nodes);
 }
-}
+}  // namespace detail
 
-MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(vtkUnstructuredGrid* grid, std::string const& mesh_name)
+MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(
+    vtkUnstructuredGrid* grid, std::string const& mesh_name)
 {
     if (!grid)
         return nullptr;
@@ -85,110 +85,143 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(vtkUnstructuredGrid* gr
                     nodes, node_ids);
                 break;
             }
-        case VTK_LINE: {
-            elem = detail::createElementWithSameNodeOrder<MeshLib::Line>(nodes, node_ids);
-            break;
-        }
-        case VTK_TRIANGLE: {
-            elem = detail::createElementWithSameNodeOrder<MeshLib::Tri>(nodes, node_ids);
-            break;
-        }
-        case VTK_QUAD: {
-            elem = detail::createElementWithSameNodeOrder<MeshLib::Quad>(nodes, node_ids);
-            break;
-        }
-        case VTK_PIXEL: {
-            auto** quad_nodes = new MeshLib::Node*[4];
-            quad_nodes[0] = nodes[node_ids->GetId(0)];
-            quad_nodes[1] = nodes[node_ids->GetId(1)];
-            quad_nodes[2] = nodes[node_ids->GetId(3)];
-            quad_nodes[3] = nodes[node_ids->GetId(2)];
-            elem = new MeshLib::Quad(quad_nodes);
-            break;
-        }
-        case VTK_TETRA: {
-            elem = detail::createElementWithSameNodeOrder<MeshLib::Tet>(nodes, node_ids);
-            break;
-        }
-        case VTK_HEXAHEDRON: {
-            elem = detail::createElementWithSameNodeOrder<MeshLib::Hex>(nodes, node_ids);
-            break;
-        }
-        case VTK_VOXEL: {
-            auto** voxel_nodes = new MeshLib::Node*[8];
-            voxel_nodes[0] = nodes[node_ids->GetId(0)];
-            voxel_nodes[1] = nodes[node_ids->GetId(1)];
-            voxel_nodes[2] = nodes[node_ids->GetId(3)];
-            voxel_nodes[3] = nodes[node_ids->GetId(2)];
-            voxel_nodes[4] = nodes[node_ids->GetId(4)];
-            voxel_nodes[5] = nodes[node_ids->GetId(5)];
-            voxel_nodes[6] = nodes[node_ids->GetId(7)];
-            voxel_nodes[7] = nodes[node_ids->GetId(6)];
-            elem = new MeshLib::Hex(voxel_nodes);
-            break;
-        }
-        case VTK_PYRAMID: {
-            elem = detail::createElementWithSameNodeOrder<MeshLib::Pyramid>(nodes, node_ids);
-            break;
-        }
-        case VTK_WEDGE: {
-            auto** prism_nodes = new MeshLib::Node*[6];
-            for (unsigned i=0; i<3; ++i)
+            case VTK_LINE:
             {
-                prism_nodes[i] = nodes[node_ids->GetId(i+3)];
-                prism_nodes[i+3] = nodes[node_ids->GetId(i)];
+                elem = detail::createElementWithSameNodeOrder<MeshLib::Line>(
+                    nodes, node_ids);
+                break;
             }
-            elem = new MeshLib::Prism(prism_nodes);
-            break;
-        }
-        case VTK_QUADRATIC_EDGE: {
-            elem = detail::createElementWithSameNodeOrder<MeshLib::Line3>(nodes, node_ids);
-            break;
-        }
-        case VTK_QUADRATIC_TRIANGLE: {
-            elem = detail::createElementWithSameNodeOrder<MeshLib::Tri6>(nodes, node_ids);
-            break;
-        }
-        case VTK_QUADRATIC_QUAD: {
-            elem = detail::createElementWithSameNodeOrder<MeshLib::Quad8>(nodes, node_ids);
-            break;
-        }
-        case VTK_BIQUADRATIC_QUAD: {
-            elem = detail::createElementWithSameNodeOrder<MeshLib::Quad9>(nodes, node_ids);
-            break;
-        }
-        case VTK_QUADRATIC_TETRA: {
-            elem = detail::createElementWithSameNodeOrder<MeshLib::Tet10>(nodes, node_ids);
-            break;
-        }
-        case VTK_QUADRATIC_HEXAHEDRON: {
-            elem = detail::createElementWithSameNodeOrder<MeshLib::Hex20>(nodes, node_ids);
-            break;
-        }
-        case VTK_QUADRATIC_PYRAMID: {
-            elem = detail::createElementWithSameNodeOrder<MeshLib::Pyramid13>(nodes, node_ids);
-            break;
-        }
-        case VTK_QUADRATIC_WEDGE: {
-            auto** prism_nodes = new MeshLib::Node*[15];
-            for (unsigned i=0; i<3; ++i)
+            case VTK_TRIANGLE:
             {
-                prism_nodes[i] = nodes[node_ids->GetId(i+3)];
-                prism_nodes[i+3] = nodes[node_ids->GetId(i)];
+                elem = detail::createElementWithSameNodeOrder<MeshLib::Tri>(
+                    nodes, node_ids);
+                break;
             }
-            for (unsigned i=0; i<3; ++i)
-                prism_nodes[6+i] = nodes[node_ids->GetId(8-i)];
-            prism_nodes[9] = nodes[node_ids->GetId(12)];
-            prism_nodes[10] = nodes[node_ids->GetId(14)];
-            prism_nodes[11] = nodes[node_ids->GetId(13)];
-            for (unsigned i=0; i<3; ++i)
-                prism_nodes[12+i] = nodes[node_ids->GetId(11-i)];
-            elem = new MeshLib::Prism15(prism_nodes);
-            break;
-        }
-        default:
-            ERR("VtkMeshConverter::convertUnstructuredGrid(): Unknown mesh element type \"%d\".", cell_type);
-            return nullptr;
+            case VTK_QUAD:
+            {
+                elem = detail::createElementWithSameNodeOrder<MeshLib::Quad>(
+                    nodes, node_ids);
+                break;
+            }
+            case VTK_PIXEL:
+            {
+                auto** quad_nodes = new MeshLib::Node*[4];
+                quad_nodes[0] = nodes[node_ids->GetId(0)];
+                quad_nodes[1] = nodes[node_ids->GetId(1)];
+                quad_nodes[2] = nodes[node_ids->GetId(3)];
+                quad_nodes[3] = nodes[node_ids->GetId(2)];
+                elem = new MeshLib::Quad(quad_nodes);
+                break;
+            }
+            case VTK_TETRA:
+            {
+                elem = detail::createElementWithSameNodeOrder<MeshLib::Tet>(
+                    nodes, node_ids);
+                break;
+            }
+            case VTK_HEXAHEDRON:
+            {
+                elem = detail::createElementWithSameNodeOrder<MeshLib::Hex>(
+                    nodes, node_ids);
+                break;
+            }
+            case VTK_VOXEL:
+            {
+                auto** voxel_nodes = new MeshLib::Node*[8];
+                voxel_nodes[0] = nodes[node_ids->GetId(0)];
+                voxel_nodes[1] = nodes[node_ids->GetId(1)];
+                voxel_nodes[2] = nodes[node_ids->GetId(3)];
+                voxel_nodes[3] = nodes[node_ids->GetId(2)];
+                voxel_nodes[4] = nodes[node_ids->GetId(4)];
+                voxel_nodes[5] = nodes[node_ids->GetId(5)];
+                voxel_nodes[6] = nodes[node_ids->GetId(7)];
+                voxel_nodes[7] = nodes[node_ids->GetId(6)];
+                elem = new MeshLib::Hex(voxel_nodes);
+                break;
+            }
+            case VTK_PYRAMID:
+            {
+                elem = detail::createElementWithSameNodeOrder<MeshLib::Pyramid>(
+                    nodes, node_ids);
+                break;
+            }
+            case VTK_WEDGE:
+            {
+                auto** prism_nodes = new MeshLib::Node*[6];
+                for (unsigned i = 0; i < 3; ++i)
+                {
+                    prism_nodes[i] = nodes[node_ids->GetId(i + 3)];
+                    prism_nodes[i + 3] = nodes[node_ids->GetId(i)];
+                }
+                elem = new MeshLib::Prism(prism_nodes);
+                break;
+            }
+            case VTK_QUADRATIC_EDGE:
+            {
+                elem = detail::createElementWithSameNodeOrder<MeshLib::Line3>(
+                    nodes, node_ids);
+                break;
+            }
+            case VTK_QUADRATIC_TRIANGLE:
+            {
+                elem = detail::createElementWithSameNodeOrder<MeshLib::Tri6>(
+                    nodes, node_ids);
+                break;
+            }
+            case VTK_QUADRATIC_QUAD:
+            {
+                elem = detail::createElementWithSameNodeOrder<MeshLib::Quad8>(
+                    nodes, node_ids);
+                break;
+            }
+            case VTK_BIQUADRATIC_QUAD:
+            {
+                elem = detail::createElementWithSameNodeOrder<MeshLib::Quad9>(
+                    nodes, node_ids);
+                break;
+            }
+            case VTK_QUADRATIC_TETRA:
+            {
+                elem = detail::createElementWithSameNodeOrder<MeshLib::Tet10>(
+                    nodes, node_ids);
+                break;
+            }
+            case VTK_QUADRATIC_HEXAHEDRON:
+            {
+                elem = detail::createElementWithSameNodeOrder<MeshLib::Hex20>(
+                    nodes, node_ids);
+                break;
+            }
+            case VTK_QUADRATIC_PYRAMID:
+            {
+                elem =
+                    detail::createElementWithSameNodeOrder<MeshLib::Pyramid13>(
+                        nodes, node_ids);
+                break;
+            }
+            case VTK_QUADRATIC_WEDGE:
+            {
+                auto** prism_nodes = new MeshLib::Node*[15];
+                for (unsigned i = 0; i < 3; ++i)
+                {
+                    prism_nodes[i] = nodes[node_ids->GetId(i + 3)];
+                    prism_nodes[i + 3] = nodes[node_ids->GetId(i)];
+                }
+                for (unsigned i = 0; i < 3; ++i)
+                    prism_nodes[6 + i] = nodes[node_ids->GetId(8 - i)];
+                prism_nodes[9] = nodes[node_ids->GetId(12)];
+                prism_nodes[10] = nodes[node_ids->GetId(14)];
+                prism_nodes[11] = nodes[node_ids->GetId(13)];
+                for (unsigned i = 0; i < 3; ++i)
+                    prism_nodes[12 + i] = nodes[node_ids->GetId(11 - i)];
+                elem = new MeshLib::Prism15(prism_nodes);
+                break;
+            }
+            default:
+                ERR("VtkMeshConverter::convertUnstructuredGrid(): Unknown mesh "
+                    "element type \"%d\".",
+                    cell_type);
+                return nullptr;
         }
 
         elements[i] = elem;
@@ -200,19 +233,24 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(vtkUnstructuredGrid* gr
     return mesh;
 }
 
-void VtkMeshConverter::convertScalarArrays(vtkUnstructuredGrid &grid, MeshLib::Mesh &mesh)
+void VtkMeshConverter::convertScalarArrays(vtkUnstructuredGrid& grid,
+                                           MeshLib::Mesh& mesh)
 {
     vtkPointData* point_data = grid.GetPointData();
     auto const n_point_arrays =
         static_cast<unsigned>(point_data->GetNumberOfArrays());
-    for (unsigned i=0; i<n_point_arrays; ++i)
-        convertArray(*point_data->GetArray(i), mesh.getProperties(), MeshLib::MeshItemType::Node);
+    for (unsigned i = 0; i < n_point_arrays; ++i)
+        convertArray(*point_data->GetArray(i),
+                     mesh.getProperties(),
+                     MeshLib::MeshItemType::Node);
 
     vtkCellData* cell_data = grid.GetCellData();
     auto const n_cell_arrays =
         static_cast<unsigned>(cell_data->GetNumberOfArrays());
-    for (unsigned i=0; i<n_cell_arrays; ++i)
-        convertArray(*cell_data->GetArray(i), mesh.getProperties(), MeshLib::MeshItemType::Cell);
+    for (unsigned i = 0; i < n_cell_arrays; ++i)
+        convertArray(*cell_data->GetArray(i),
+                     mesh.getProperties(),
+                     MeshLib::MeshItemType::Cell);
 
     vtkFieldData* field_data = grid.GetFieldData();
     auto const n_field_arrays =
@@ -224,7 +262,9 @@ void VtkMeshConverter::convertScalarArrays(vtkUnstructuredGrid &grid, MeshLib::M
             MeshLib::MeshItemType::IntegrationPoint);
 }
 
-void VtkMeshConverter::convertArray(vtkDataArray &array, MeshLib::Properties &properties, MeshLib::MeshItemType type)
+void VtkMeshConverter::convertArray(vtkDataArray& array,
+                                    MeshLib::Properties& properties,
+                                    MeshLib::MeshItemType type)
 {
     if (vtkDoubleArray::SafeDownCast(&array))
     {
@@ -252,7 +292,8 @@ void VtkMeshConverter::convertArray(vtkDataArray &array, MeshLib::Properties &pr
 
     if (vtkUnsignedLongArray::SafeDownCast(&array))
     {
-        VtkMeshConverter::convertTypedArray<unsigned long>(array, properties, type);
+        VtkMeshConverter::convertTypedArray<unsigned long>(
+            array, properties, type);
         return;
     }
 
@@ -266,16 +307,18 @@ void VtkMeshConverter::convertArray(vtkDataArray &array, MeshLib::Properties &pr
     if (vtkUnsignedIntArray::SafeDownCast(&array))
     {
         // MaterialIDs are assumed to be integers
-        if(std::strncmp(array.GetName(), "MaterialIDs", 11) == 0)
+        if (std::strncmp(array.GetName(), "MaterialIDs", 11) == 0)
             VtkMeshConverter::convertTypedArray<int>(array, properties, type);
         else
-            VtkMeshConverter::convertTypedArray<unsigned>(array, properties, type);
+            VtkMeshConverter::convertTypedArray<unsigned>(
+                array, properties, type);
 
         return;
     }
 
-    ERR ("Array \"%s\" in VTU file uses unsupported data type.", array.GetName());
+    ERR("Array \"%s\" in VTU file uses unsupported data type.",
+        array.GetName());
     return;
 }
 
-} // end namespace MeshLib
+}  // end namespace MeshLib

--- a/MeshLib/MeshGenerators/VtkMeshConverter.cpp
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.cpp
@@ -79,6 +79,12 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(vtkUnstructuredGrid* gr
         int cell_type = grid->GetCellType(i);
         switch (cell_type)
         {
+            case VTK_VERTEX:
+            {
+                elem = detail::createElementWithSameNodeOrder<MeshLib::Point>(
+                    nodes, node_ids);
+                break;
+            }
         case VTK_LINE: {
             elem = detail::createElementWithSameNodeOrder<MeshLib::Line>(nodes, node_ids);
             break;

--- a/MeshLib/MeshGenerators/VtkMeshConverter.h
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.h
@@ -21,20 +21,19 @@
 #include <logog/include/logog.hpp>
 
 #include "GeoLib/Raster.h"
-#include "MeshLib/Node.h"
 #include "MeshLib/Location.h"
 #include "MeshLib/MeshEnums.h"
+#include "MeshLib/Node.h"
 #include "MeshLib/Properties.h"
 #include "MeshLib/PropertyVector.h"
 
-class vtkUnstructuredGrid; // For conversion vom vtk to ogs mesh
-class vtkDataArray; // For node/cell properties
+class vtkUnstructuredGrid;  // For conversion vom vtk to ogs mesh
+class vtkDataArray;         // For node/cell properties
 
-namespace MeshLib {
-
+namespace MeshLib
+{
 class Mesh;
 class Properties;
-
 
 /**
  * \brief Converter for VtkUnstructured Grids to OGS meshes
@@ -43,21 +42,23 @@ class VtkMeshConverter
 {
 public:
     /// Converts a vtkUnstructuredGrid object to a Mesh
-    static MeshLib::Mesh* convertUnstructuredGrid(vtkUnstructuredGrid* grid,
-                                                  std::string const& mesh_name = "vtkUnstructuredGrid");
+    static MeshLib::Mesh* convertUnstructuredGrid(
+        vtkUnstructuredGrid* grid,
+        std::string const& mesh_name = "vtkUnstructuredGrid");
 
 private:
-    static void convertScalarArrays(vtkUnstructuredGrid &grid, MeshLib::Mesh &mesh);
+    static void convertScalarArrays(vtkUnstructuredGrid& grid,
+                                    MeshLib::Mesh& mesh);
 
     static std::vector<MeshLib::Node*> createNodeVector(
         std::vector<double> const& elevation,
-        std::vector<int> &node_idx_map,
+        std::vector<int>& node_idx_map,
         GeoLib::RasterHeader const& header,
         bool use_elevation);
 
     /// Creates a mesh element vector based on image data
     static std::vector<MeshLib::Element*> createElementVector(
-        std::vector<double> const&  pix_val,
+        std::vector<double> const& pix_val,
         std::vector<bool> const& pix_vis,
         std::vector<MeshLib::Node*> const& nodes,
         std::vector<int> const& node_idx_map,
@@ -66,21 +67,20 @@ private:
         MeshElemType elem_type);
 
     /// Creates a scalar array/mesh property based on pixel values
-    template<typename T>
-    static void fillPropertyVector(
-        MeshLib::PropertyVector<T> &prop_vec,
-        std::vector<double> const& pix_val,
-        std::vector<bool> const& pix_vis,
-        const std::size_t &imgHeight,
-        const std::size_t &imgWidth,
-        MeshElemType elem_type)
+    template <typename T>
+    static void fillPropertyVector(MeshLib::PropertyVector<T>& prop_vec,
+                                   std::vector<double> const& pix_val,
+                                   std::vector<bool> const& pix_vis,
+                                   const std::size_t& imgHeight,
+                                   const std::size_t& imgWidth,
+                                   MeshElemType elem_type)
     {
         for (std::size_t i = 0; i < imgHeight; i++)
             for (std::size_t j = 0; j < imgWidth; j++)
             {
-                if (!pix_vis[i*imgWidth+j])
+                if (!pix_vis[i * imgWidth + j])
                     continue;
-                T val (static_cast<T>(pix_val[i*(imgWidth+1)+j]));
+                T val(static_cast<T>(pix_val[i * (imgWidth + 1) + j]));
                 if (elem_type == MeshElemType::TRIANGLE)
                 {
                     prop_vec.push_back(val);
@@ -91,30 +91,34 @@ private:
             }
     }
 
-    static void convertArray(vtkDataArray &array,
-                             MeshLib::Properties &properties,
+    static void convertArray(vtkDataArray& array,
+                             MeshLib::Properties& properties,
                              MeshLib::MeshItemType type);
 
-    template<typename T> static void convertTypedArray(vtkDataArray &array,
-                                                       MeshLib::Properties &properties,
-                                                       MeshLib::MeshItemType type)
+    template <typename T>
+    static void convertTypedArray(vtkDataArray& array,
+                                  MeshLib::Properties& properties,
+                                  MeshLib::MeshItemType type)
     {
-        vtkIdType const nTuples (array.GetNumberOfTuples());
-        int const nComponents (array.GetNumberOfComponents());
-        char const*const array_name (array.GetName());
+        vtkIdType const nTuples(array.GetNumberOfTuples());
+        int const nComponents(array.GetNumberOfComponents());
+        char const* const array_name(array.GetName());
 
         auto* const vec = properties.createNewPropertyVector<T>(
             array_name, type, nComponents);
         if (!vec)
         {
-            WARN("Array %s could not be converted to PropertyVector.", array_name);
+            WARN("Array %s could not be converted to PropertyVector.",
+                 array_name);
             return;
         }
-        vec->reserve(nTuples*nComponents);
+        vec->reserve(nTuples * nComponents);
         auto* data_array = static_cast<T*>(array.GetVoidPointer(0));
-        std::copy(&data_array[0], &data_array[nTuples*nComponents], std::back_inserter(*vec));
+        std::copy(&data_array[0],
+                  &data_array[nTuples * nComponents],
+                  std::back_inserter(*vec));
         return;
     }
 };
 
-} // end namespace MeshLib
+}  // end namespace MeshLib

--- a/MeshLib/VtkOGSEnum.cpp
+++ b/MeshLib/VtkOGSEnum.cpp
@@ -9,6 +9,8 @@
 
 #include "VtkOGSEnum.h"
 
+#include "BaseLib/Error.h"
+
 #include <vtkCellType.h>
 
 MeshLib::CellType VtkCellTypeToOGS(int type)
@@ -50,7 +52,10 @@ MeshLib::CellType VtkCellTypeToOGS(int type)
         case VTK_QUADRATIC_PYRAMID:
             return MeshLib::CellType::PYRAMID13;
         default:
-            return MeshLib::CellType::INVALID;
+            OGS_FATAL(
+                "Unknown cell type in conversion from VTK to OGS. Given cell "
+                "type value is %d.",
+                type);
     }
 }
 
@@ -58,6 +63,8 @@ int OGSToVtkCellType(MeshLib::CellType ogs)
 {
     switch (ogs)
     {
+        case MeshLib::CellType::POINT1:
+            return VTK_VERTEX;
         case MeshLib::CellType::LINE2:
             return VTK_LINE;
         case MeshLib::CellType::LINE3:
@@ -95,7 +102,10 @@ int OGSToVtkCellType(MeshLib::CellType ogs)
         case MeshLib::CellType::INVALID:
             return -1;
         default:
-            return -1;
+            OGS_FATAL(
+                "Unknown cell type in conversion from OGS to VTK. Given cell "
+                "type value is %d.",
+                ogs);
     }
 }
 


### PR DESCRIPTION
Add missing conversions and forbid default case in the first commit.
clang-format is necessary, because the rest of the switch-cases is out of alignment otherwise.