### PR TITLE
Partition boundary meshes

### DIFF
--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -195,12 +195,15 @@ findNonGhostNodesInPartition(
     return {base_nodes, extra_nodes};
 }
 
-int numberOfRegularNodes(MeshLib::Element const& e, std::size_t const part_id,
-                         std::vector<std::size_t> const& partition_ids)
+int numberOfRegularNodes(
+    MeshLib::Element const& e, std::size_t const part_id,
+    std::vector<std::size_t> const& partition_ids,
+    std::vector<std::size_t> const* node_id_mapping = nullptr)
 {
     return std::count_if(e.getNodes(), e.getNodes() + e.getNumberOfNodes(),
                          [&](MeshLib::Node* const n) {
-                             return partition_ids[n->getID()] == part_id;
+                             return partitionLookup(*n, partition_ids,
+                                                    node_id_mapping) == part_id;
                          });
 }
 
@@ -210,9 +213,11 @@ int numberOfRegularNodes(MeshLib::Element const& e, std::size_t const part_id,
 /// fills vector partition.ghost_elements
 std::tuple<std::vector<MeshLib::Element const*>,
            std::vector<MeshLib::Element const*>>
-findElementsInPartition(std::size_t const part_id,
-                        std::vector<MeshLib::Element*> const& elements,
-                        std::vector<std::size_t> const& partition_ids)
+findElementsInPartition(
+    std::size_t const part_id,
+    std::vector<MeshLib::Element*> const& elements,
+    std::vector<std::size_t> const& partition_ids,
+    std::vector<std::size_t> const* node_id_mapping = nullptr)
 {
     std::vector<MeshLib::Element const*> regular_elements;
     std::vector<MeshLib::Element const*> ghost_elements;

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -108,6 +108,23 @@ std::ostream& Partition::writeConfigBinary(std::ostream& os) const
                     sizeof(data));
 }
 
+void splitOffHigherOrderNode(std::vector<MeshLib::Node*> const& nodes,
+                             bool const is_mixed_high_order_linear_elems,
+                             unsigned const node_id,
+                             unsigned const n_base_nodes,
+                             std::vector<MeshLib::Node*>& base_nodes,
+                             std::vector<MeshLib::Node*>& extra_nodes)
+{
+    if (!is_mixed_high_order_linear_elems || node_id > n_base_nodes)
+    {
+        base_nodes.push_back(nodes[node_id]);
+    }
+    else
+    {
+        extra_nodes.push_back(nodes[node_id]);
+    }
+}
+
 void NodeWiseMeshPartitioner::findNonGhostNodesInPartition(
     std::size_t const part_id,
     const bool is_mixed_high_order_linear_elems,
@@ -121,6 +138,7 @@ void NodeWiseMeshPartitioner::findNonGhostNodesInPartition(
         if (_nodes_partition_ids[i] == part_id)
         {
             splitOffHigherOrderNode(nodes, is_mixed_high_order_linear_elems, i,
+                                    _mesh->getNumberOfBaseNodes(),
                                     partition.nodes, extra_nodes);
         }
     }
@@ -190,28 +208,11 @@ void NodeWiseMeshPartitioner::findGhostNodesInPartition(
             if (_nodes_partition_ids[node_id] != part_id)
             {
                 splitOffHigherOrderNode(nodes, is_mixed_high_order_linear_elems,
-                                        node_id, partition.nodes, extra_nodes);
+                                        node_id, _mesh->getNumberOfBaseNodes(),
+                                        partition.nodes, extra_nodes);
                 nodes_reserved[node_id] = true;
             }
         }
-    }
-}
-
-void NodeWiseMeshPartitioner::splitOffHigherOrderNode(
-    std::vector<MeshLib::Node*> const& nodes,
-    bool const is_mixed_high_order_linear_elems,
-    unsigned const node_id,
-    std::vector<MeshLib::Node*>& base_nodes,
-    std::vector<MeshLib::Node*>& extra_nodes)
-{
-    auto const n_base_nodes = _mesh->getNumberOfBaseNodes();
-    if (!is_mixed_high_order_linear_elems || node_id > n_base_nodes)
-    {
-        base_nodes.push_back(nodes[node_id]);
-    }
-    else
-    {
-        extra_nodes.push_back(nodes[node_id]);
     }
 }
 

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -109,23 +109,6 @@ std::ostream& Partition::writeConfigBinary(std::ostream& os) const
                     sizeof(data));
 }
 
-void splitOffHigherOrderNode(std::vector<MeshLib::Node*> const& nodes,
-                             bool const is_mixed_high_order_linear_elems,
-                             unsigned const node_id,
-                             unsigned const n_base_nodes,
-                             std::vector<MeshLib::Node*>& base_nodes,
-                             std::vector<MeshLib::Node*>& higher_order_nodes)
-{
-    if (!is_mixed_high_order_linear_elems || node_id > n_base_nodes)
-    {
-        base_nodes.push_back(nodes[node_id]);
-    }
-    else
-    {
-        higher_order_nodes.push_back(nodes[node_id]);
-    }
-}
-
 std::size_t nodeIdBulkMesh(
     MeshLib::Node const& node,
     std::vector<std::size_t> const* node_id_mapping = nullptr)

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -113,7 +113,7 @@ void splitOffHigherOrderNode(std::vector<MeshLib::Node*> const& nodes,
                              unsigned const node_id,
                              unsigned const n_base_nodes,
                              std::vector<MeshLib::Node*>& base_nodes,
-                             std::vector<MeshLib::Node*>& extra_nodes)
+                             std::vector<MeshLib::Node*>& higher_order_nodes)
 {
     if (!is_mixed_high_order_linear_elems || node_id > n_base_nodes)
     {
@@ -121,7 +121,7 @@ void splitOffHigherOrderNode(std::vector<MeshLib::Node*> const& nodes,
     }
     else
     {
-        extra_nodes.push_back(nodes[node_id]);
+        higher_order_nodes.push_back(nodes[node_id]);
     }
 }
 
@@ -177,8 +177,8 @@ findNonGhostNodesInPartition(
     base_nodes.reserve(partition_nodes.size() /
                        2);  // if linear mesh, then one reallocation, no realloc
                             // for higher order elements meshes.
-    std::vector<MeshLib::Node*> extra_nodes;
-    extra_nodes.reserve(
+    std::vector<MeshLib::Node*> higher_order_nodes;
+    higher_order_nodes.reserve(
         partition_nodes.size() /
         2);  // if linear mesh, then wasted space, good estimate for quadratic
              // order mesh, and realloc needed for higher order element meshes.
@@ -186,13 +186,13 @@ findNonGhostNodesInPartition(
     // Split the nodes into base nodes and extra nodes.
     partition_copy(begin(partition_nodes), end(partition_nodes),
                    std::back_inserter(base_nodes),
-                   std::back_inserter(extra_nodes),
+                   std::back_inserter(higher_order_nodes),
                    [&](MeshLib::Node* const n) {
                        return !is_mixed_high_order_linear_elems ||
                               node_id(*n) > n_base_nodes;
                    });
 
-    return {base_nodes, extra_nodes};
+    return {base_nodes, higher_order_nodes};
 }
 
 int numberOfRegularNodes(

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -291,20 +291,19 @@ findGhostNodesInPartition(
 void NodeWiseMeshPartitioner::processPartition(
     std::size_t const part_id, const bool is_mixed_high_order_linear_elems)
 {
-    std::vector<MeshLib::Node*> extra_nodes;
-    std::tie(_partitions[part_id].nodes, extra_nodes) =
+    auto& partition = _partitions[part_id];
+    std::vector<MeshLib::Node*> higher_order_regular_nodes;
+    std::tie(partition.nodes, higher_order_regular_nodes) =
         findNonGhostNodesInPartition(part_id, is_mixed_high_order_linear_elems,
                                      _mesh->getNumberOfBaseNodes(),
                                      _mesh->getNodes(), _nodes_partition_ids);
 
-    _partitions[part_id].number_of_non_ghost_base_nodes =
-        _partitions[part_id].nodes.size();
-    _partitions[part_id].number_of_non_ghost_nodes =
-        _partitions[part_id].number_of_non_ghost_base_nodes +
-        extra_nodes.size();
+    partition.number_of_non_ghost_base_nodes = partition.nodes.size();
+    partition.number_of_non_ghost_nodes =
+        partition.number_of_non_ghost_base_nodes +
+        higher_order_regular_nodes.size();
 
-    std::tie(_partitions[part_id].regular_elements,
-             _partitions[part_id].ghost_elements) =
+    std::tie(partition.regular_elements, partition.ghost_elements) =
         findElementsInPartition(part_id, _mesh->getElements(),
                                 _nodes_partition_ids);
     std::vector<MeshLib::Node*> base_ghost_nodes;
@@ -322,8 +321,9 @@ void NodeWiseMeshPartitioner::processPartition(
 
     if (is_mixed_high_order_linear_elems)
     {
-        partition.nodes.insert(partition.nodes.end(), extra_nodes.begin(),
-                               extra_nodes.end());
+        std::copy(begin(higher_order_regular_nodes),
+                  end(higher_order_regular_nodes),
+                  std::back_inserter(partition.nodes));
         std::copy(begin(higher_order_ghost_nodes),
                   end(higher_order_ghost_nodes),
                   std::back_inserter(partition.nodes));

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -105,8 +105,7 @@ std::ostream& Partition::writeConfigBinary(std::ostream& os) const
             getNumberOfIntegerVariablesOfElements(ghost_elements)),
     };
 
-    return os.write(reinterpret_cast<const char*>(data),
-                    sizeof(data));
+    return os.write(reinterpret_cast<const char*>(data), sizeof(data));
 }
 
 std::size_t nodeIdBulkMesh(
@@ -590,8 +589,7 @@ template <typename T>
 void writePropertyVectorValuesBinary(std::ostream& os,
                                      MeshLib::PropertyVector<T> const& pv)
 {
-    os.write(reinterpret_cast<const char*>(pv.data()),
-            pv.size() * sizeof(T));
+    os.write(reinterpret_cast<const char*>(pv.data()), pv.size() * sizeof(T));
 }
 
 template <typename T>
@@ -651,10 +649,10 @@ void writePropertiesBinary(const std::string& file_name_base,
     BaseLib::writeValueBinary(out, number_of_properties);
 
     applyToPropertyVectors(property_names,
-                         [&](auto type, std::string const& name) {
-                             return writePropertyVectorBinary<decltype(type)>(
-                                 partitioned_properties, name, out_val, out);
-                         });
+                           [&](auto type, std::string const& name) {
+                               return writePropertyVectorBinary<decltype(type)>(
+                                   partitioned_properties, name, out_val, out);
+                           });
 
     unsigned long offset = 0;
     for (const auto& partition : partitions)
@@ -696,8 +694,7 @@ struct PartitionOffsets
     long ghost_elements;
 };
 
-PartitionOffsets
-computePartitionElementOffsets(Partition const& partition)
+PartitionOffsets computePartitionElementOffsets(Partition const& partition)
 {
     return {static_cast<long>(partition.nodes.size()),
             static_cast<long>(partition.regular_elements.size() +
@@ -731,8 +728,7 @@ ConfigOffsets incrementConfigOffsets(ConfigOffsets const& oldConfig,
 ///     partition.
 ///  2. The number of all ghost element integer variables for each partition.
 std::tuple<std::vector<long>, std::vector<long>> writeConfigDataBinary(
-    const std::string& file_name_base,
-    std::vector<Partition> const& partitions)
+    const std::string& file_name_base, std::vector<Partition> const& partitions)
 {
     auto const file_name_cfg = file_name_base + "_partitioned_msh_cfg" +
                                std::to_string(partitions.size()) + ".bin";

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -76,6 +76,10 @@ public:
     /// interpolation
     void partitionByMETIS(const bool is_mixed_high_order_linear_elems);
 
+    std::vector<Partition> partitionOtherMesh(
+        MeshLib::Mesh const& mesh,
+        bool const is_mixed_high_order_linear_elems) const;
+
     /// Write the partitions into ASCII files
     /// \param file_name_base The prefix of the file name.
     void writeASCII(const std::string& file_name_base);
@@ -83,6 +87,9 @@ public:
     /// Write the partitions into binary files
     /// \param file_name_base The prefix of the file name.
     void writeBinary(const std::string& file_name_base);
+
+    void writeOtherMesh(std::string const& output_filename_base,
+                        std::vector<Partition> const& partitions) const;
 
     void resetPartitionIdsForNodes(
         std::vector<std::size_t>&& node_partition_ids)

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -139,12 +139,6 @@ private:
                                    const bool is_mixed_high_order_linear_elems,
                                    std::vector<MeshLib::Node*>& extra_nodes);
 
-    void splitOffHigherOrderNode(std::vector<MeshLib::Node*> const& nodes,
-                                 bool const is_mixed_high_order_linear_elems,
-                                 unsigned const node_id,
-                                 std::vector<MeshLib::Node*>& base_nodes,
-                                 std::vector<MeshLib::Node*>& extra_nodes);
-
     void processPartition(std::size_t const part_id,
                           const bool is_mixed_high_order_linear_elems);
 

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -117,14 +117,6 @@ private:
     /// interpolation
     void renumberNodeIndices(const bool is_mixed_high_order_linear_elems);
 
-    /// 1 copy pointers to nodes belonging to the partition part_id
-    /// 2 collect non-linear element nodes belonging to the partition part_id in
-    /// extra_nodes
-    void findNonGhostNodesInPartition(
-        std::size_t const part_id,
-        const bool is_mixed_high_order_linear_elems,
-        std::vector<MeshLib::Node*>& extra_nodes);
-
     /// 1 find elements belonging to the partition part_id:
     /// fills vector partition.regular_elements
     /// 2 find ghost elements belonging to the partition part_id

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -117,12 +117,6 @@ private:
     /// interpolation
     void renumberNodeIndices(const bool is_mixed_high_order_linear_elems);
 
-    /// 1 find elements belonging to the partition part_id:
-    /// fills vector partition.regular_elements
-    /// 2 find ghost elements belonging to the partition part_id
-    /// fills vector partition.ghost_elements
-    void findElementsInPartition(std::size_t const part_id);
-
     /// Prerequisite: the ghost elements has to be found (using
     /// findElementsInPartition).
     /// Finds ghost nodes and non-linear element ghost nodes by walking over

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -117,14 +117,6 @@ private:
     /// interpolation
     void renumberNodeIndices(const bool is_mixed_high_order_linear_elems);
 
-    /// Prerequisite: the ghost elements has to be found (using
-    /// findElementsInPartition).
-    /// Finds ghost nodes and non-linear element ghost nodes by walking over
-    /// ghost elements.
-    void findGhostNodesInPartition(std::size_t const part_id,
-                                   const bool is_mixed_high_order_linear_elems,
-                                   std::vector<MeshLib::Node*>& extra_nodes);
-
     void processPartition(std::size_t const part_id,
                           const bool is_mixed_high_order_linear_elems);
 

--- a/Applications/Utils/Tests.cmake
+++ b/Applications/Utils/Tests.cmake
@@ -60,7 +60,14 @@ AddTest(
     NAME partmesh_2Dmesh_3partitions_binary
     PATH NodePartitionedMesh/partmesh_2Dmesh_3partitions
     EXECUTABLE partmesh
-    EXECUTABLE_ARGS -m -n 3 -i 2Dmesh.vtu -o ${Data_BINARY_DIR}/NodePartitionedMesh/partmesh_2Dmesh_3partitions
+    EXECUTABLE_ARGS -m -n 3 -i 2Dmesh.vtu
+                    -o ${Data_BINARY_DIR}/NodePartitionedMesh/partmesh_2Dmesh_3partitions --
+                    2Dmesh_PLY_EAST.vtu
+                    2Dmesh_PLY_WEST.vtu
+                    2Dmesh_PLY_NORTH.vtu
+                    2Dmesh_PLY_SOUTH.vtu
+                    2Dmesh_POINT4.vtu
+                    2Dmesh_POINT5.vtu
     REQUIREMENTS NOT (OGS_USE_MPI OR APPLE)
     TESTER diff
     DIFF_DATA 2Dmesh_partitioned_node_properties_val3.bin
@@ -71,4 +78,28 @@ AddTest(
               2Dmesh_partitioned_msh_ele_g3.bin
               2Dmesh_partitioned_msh_ele3.bin
               2Dmesh_partitioned_msh_nod3.bin
+              2Dmesh_PLY_EAST_partitioned_msh_cfg3.bin
+              2Dmesh_PLY_EAST_partitioned_msh_ele3.bin
+              2Dmesh_PLY_EAST_partitioned_msh_ele_g3.bin
+              2Dmesh_PLY_EAST_partitioned_msh_nod3.bin
+              2Dmesh_PLY_NORTH_partitioned_msh_cfg3.bin
+              2Dmesh_PLY_NORTH_partitioned_msh_ele3.bin
+              #2Dmesh_PLY_NORTH_partitioned_msh_ele_g3.bin   empty
+              2Dmesh_PLY_NORTH_partitioned_msh_nod3.bin
+              2Dmesh_PLY_SOUTH_partitioned_msh_cfg3.bin
+              2Dmesh_PLY_SOUTH_partitioned_msh_ele3.bin
+              #2Dmesh_PLY_SOUTH_partitioned_msh_ele_g3.bin   empty
+              2Dmesh_PLY_SOUTH_partitioned_msh_nod3.bin
+              2Dmesh_PLY_WEST_partitioned_msh_cfg3.bin
+              2Dmesh_PLY_WEST_partitioned_msh_ele3.bin
+              2Dmesh_PLY_WEST_partitioned_msh_ele_g3.bin
+              2Dmesh_PLY_WEST_partitioned_msh_nod3.bin
+              2Dmesh_POINT4_partitioned_msh_cfg3.bin
+              2Dmesh_POINT4_partitioned_msh_ele3.bin
+              #2Dmesh_PLY_POINT4_partitioned_msh_ele_g3.bin   empty
+              2Dmesh_POINT4_partitioned_msh_nod3.bin
+              2Dmesh_POINT5_partitioned_msh_cfg3.bin
+              2Dmesh_POINT5_partitioned_msh_ele3.bin
+              #2Dmesh_PLY_POINT5_partitioned_msh_ele_g3.bin   empty
+              2Dmesh_POINT5_partitioned_msh_nod3.bin
 )

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_EAST.vtu
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_EAST.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0714177ddeff00b8b4b6bf4d6fd481f544e0346df1803f7fe72b7caccfa391f
+size 7692

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_EAST_partitioned_msh_cfg3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_EAST_partitioned_msh_cfg3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27736cd5a2050d67f3407e06003b03eaf9aa96a8b5c4038c09175d8147c3429f
+size 336

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_EAST_partitioned_msh_ele3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_EAST_partitioned_msh_ele3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52b85d95359f1f4df4e51997bddbe06f5b29bc4004f2b2167c0d404651da1b49
+size 2464

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_EAST_partitioned_msh_ele_g3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_EAST_partitioned_msh_ele_g3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f32418bbcb593946d221b5d9991317bd798936e535745902282a8c114ea3e93
+size 224

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_EAST_partitioned_msh_nod3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_EAST_partitioned_msh_nod3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f20380c09799a60ed7cec7c54ae8f4d34a17ecd539096e14efb7ab4c202d3bc1
+size 3168

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_NORTH.vtu
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_NORTH.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a932ae403dc0b92ea01d51929ded4e27976ce408d567571180d25d6690df62e
+size 4283

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_NORTH_partitioned_msh_cfg3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_NORTH_partitioned_msh_cfg3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69f767e1247089a09dc6e12f1c3ca198a7f3aae3bc158bd191f08ad0e3a63285
+size 336

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_NORTH_partitioned_msh_ele3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_NORTH_partitioned_msh_ele3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79b3fece7cc931e90003f9edcfadc5b8e5161bca93418959471371dfaa72d7dd
+size 1176

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_NORTH_partitioned_msh_nod3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_NORTH_partitioned_msh_nod3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a40804da2f81fb6794db734a2ba45d5be583e983b204fba019f0eb42504ee1e
+size 1440

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_SOUTH.vtu
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_SOUTH.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35f671274ca334c4a008c934be995c0cd032d79d6f67941100d41294b9fd526c
+size 4270

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_SOUTH_partitioned_msh_cfg3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_SOUTH_partitioned_msh_cfg3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75e34f61ef896fcab52f098da36e7994008b31da20cdd6f24bcc94dc36162d0d
+size 336

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_SOUTH_partitioned_msh_ele3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_SOUTH_partitioned_msh_ele3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4082ab2deb239c910cde38f6c1985fb5105825d070ab5b00d7f81539053ca179
+size 1176

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_SOUTH_partitioned_msh_nod3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_SOUTH_partitioned_msh_nod3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0cdb9bae8aed4189e77e07c0553b7ca6f27973e6eddb2ce942d08162c6c51a5
+size 1440

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_WEST.vtu
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_WEST.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a411450b46ca9370d222f52a12c00d625676f8122085413a5b522b97acd816d
+size 7678

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_WEST_partitioned_msh_cfg3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_WEST_partitioned_msh_cfg3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0b9ccfe221b2166ec07998100e2f7350fe41da2807def9224d52a00a401ed26
+size 336

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_WEST_partitioned_msh_ele3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_WEST_partitioned_msh_ele3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b751e1a6b59a56fa3aad1e3720514f6f61f35b285a4ae73f42e83dcdf510b9ad
+size 2464

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_WEST_partitioned_msh_ele_g3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_WEST_partitioned_msh_ele_g3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a34e5dad348778fd578cc1935690f0b225a1659c52ac61853002bdf074da04
+size 224

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_WEST_partitioned_msh_nod3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_PLY_WEST_partitioned_msh_nod3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f781c5d27b1e850edb2a113abbcb359b49ab049a37a4dc52b7e29fc3fc04505d
+size 3168

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT4.vtu
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT4.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12eb221941d843021f22226434f83c351ef21a2e0d21996b28fadb7e5a7f7d14
+size 1257

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT4_partitioned_msh_cfg3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT4_partitioned_msh_cfg3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73cc909d5075f4e117c6b3772af3cb16f6cf929580e92a4a03819d9560588eb6
+size 336

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT4_partitioned_msh_ele3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT4_partitioned_msh_ele3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2620d5fe2c33bcbe7073b9a8a8c7a862450e01e4ed596f0e86b0e0b81054dde
+size 40

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT4_partitioned_msh_nod3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT4_partitioned_msh_nod3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15e0c5acc13bacbee06fc9cff514c375181621158f303d838975025435f31c52
+size 32

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT5.vtu
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT5.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eee9c7114d10957066eba347297cebb34ad17a05f9ca0177e62cde014bd85561
+size 1275

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT5_partitioned_msh_cfg3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT5_partitioned_msh_cfg3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73cc909d5075f4e117c6b3772af3cb16f6cf929580e92a4a03819d9560588eb6
+size 336

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT5_partitioned_msh_ele3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT5_partitioned_msh_ele3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2620d5fe2c33bcbe7073b9a8a8c7a862450e01e4ed596f0e86b0e0b81054dde
+size 40

--- a/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT5_partitioned_msh_nod3.bin
+++ b/Tests/Data/NodePartitionedMesh/partmesh_2Dmesh_3partitions/2Dmesh_POINT5_partitioned_msh_nod3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b075be03f350bc68a3e3f70afb9e9a88a6e270f16d5235ac16377e9318d66d9f
+size 32


### PR DESCRIPTION
Follow up of #2177 (MeshLib vertex point vtk conversion).

Further refactorings (mainly free-functions) to the NodeWiseMeshPartitioner.
Extension of the partmesh tool to partition boundary meshes (with ctests).