### PR TITLE
Changed the type of paramter members of  CreepBGRa

### DIFF
--- a/MaterialLib/SolidModels/CreateCreepBGRa.cpp
+++ b/MaterialLib/SolidModels/CreateCreepBGRa.cpp
@@ -22,6 +22,7 @@
 #include "BaseLib/Error.h"
 
 #include "ProcessLib/Parameter/Parameter.h"
+#include "ProcessLib/Utils/ProcessUtils.h"  // required for findParameter
 
 namespace MaterialLib
 {
@@ -39,27 +40,27 @@ createCreepBGRa(
     config.checkConfigParameter("type", "CreepBGRa");
     DBUG("Create CreepBGRa material");
 
-    // Read elastic data frist.
+    // Read elastic data first.
     const bool skip_type_checking = true;
     auto elastic_data =
         MaterialLib::Solids::createLinearElasticIsotropic<DisplacementDim>(
             parameters, config, skip_type_checking);
 
-    //! \ogs_file_param_special{material__solid__constitutive_relation__CreepBGRa__a}
-    const auto A = config.getConfigParameter<double>("a");
-    DBUG("CreepBGRa parameter A=%g", A);
+    auto& A = ProcessLib::findParameter<double>(
+        //! \ogs_file_param_special{material__solid__constitutive_relation__CreepBGRa__a}
+        config, "a", parameters, 1);
 
-    //! \ogs_file_param_special{material__solid__constitutive_relation__CreepBGRa__n}
-    const auto n = config.getConfigParameter<double>("n");
-    DBUG("CreepBGRa parameter n=%g", n);
+    auto& n = ProcessLib::findParameter<double>(
+        //! \ogs_file_param_special{material__solid__constitutive_relation__CreepBGRa__n}
+        config, "n", parameters, 1);
 
-    //! \ogs_file_param_special{material__solid__constitutive_relation__CreepBGRa__sigma0}
-    const auto sigma0 = config.getConfigParameter<double>("sigma0");
-    DBUG("CreepBGRa parameter sigma0=%g", sigma0);
+    auto& sigma0 = ProcessLib::findParameter<double>(
+        //! \ogs_file_param_special{material__solid__constitutive_relation__CreepBGRa__sigma0}
+        config, "sigma0", parameters, 1);
 
-    //! \ogs_file_param_special{material__solid__constitutive_relation__CreepBGRa__q}
-    const auto Q = config.getConfigParameter<double>("q");
-    DBUG("CreepBGRa parameter Q=%g", Q);
+    auto& Q = ProcessLib::findParameter<double>(
+        //! \ogs_file_param_special{material__solid__constitutive_relation__CreepBGRa__q}
+        config, "q", parameters, 1);
 
     auto const nonlinear_solver_parameters =
         createNewtonRaphsonSolverParameters(config);

--- a/MaterialLib/SolidModels/CreepBGRa.cpp
+++ b/MaterialLib/SolidModels/CreepBGRa.cpp
@@ -20,6 +20,12 @@ namespace Solids
 {
 namespace Creep
 {
+double getCreepConstantCoefficient(const double A, const double n,
+                                   const double sigma0)
+{
+    return A * std::pow(1.5, 0.5 * (1 + n)) / std::pow(sigma0, n);
+}
+
 template <int DisplacementDim>
 boost::optional<std::tuple<typename CreepBGRa<DisplacementDim>::KelvinVector,
                            std::unique_ptr<typename MechanicsBase<
@@ -48,10 +54,11 @@ CreepBGRa<DisplacementDim>::integrateStress(
     const double sigma0 = _sigma_f(t, x)[0];
     const double Q = _q(t, x)[0];
 
-    const double coef = A * std::pow(1.5, 0.5 * (1 + n)) / std::pow(sigma0, n);
+    const double constant_coefficient =
+        getCreepConstantCoefficient(A, n, sigma0);
 
     const double b =
-        dt * coef *
+        dt * constant_coefficient *
         std::exp(-Q / (MaterialLib::PhysicalConstant::IdealGasConstant * T));
     auto const& deviatoric_matrix = Invariants::deviatoric_projection;
 
@@ -122,8 +129,10 @@ double CreepBGRa<DisplacementDim>::getTemperatureRelatedCoefficient(
     const double sigma0 = _sigma_f(t, x)[0];
     const double Q = _q(t, x)[0];
 
-    const double coef = A * std::pow(1.5, 0.5 * (1 + n)) / std::pow(sigma0, n);
-    return 2.0 * coef *
+    const double constant_coefficient =
+        getCreepConstantCoefficient(A, n, sigma0);
+
+    return 2.0 * constant_coefficient *
            std::exp(-Q /
                     (MaterialLib::PhysicalConstant::IdealGasConstant * T)) *
            this->_mp.mu(t, x) * std::pow(deviatoric_stress_norm, n - 1) * dt *

--- a/Tests/Data/ThermoMechanics/CreepBGRa/CreepAfterExcavation/CreepAfterExcavation.prj
+++ b/Tests/Data/ThermoMechanics/CreepBGRa/CreepAfterExcavation/CreepAfterExcavation.prj
@@ -15,10 +15,10 @@
                 <type>CreepBGRa</type>
                 <youngs_modulus>E</youngs_modulus>
                 <poissons_ratio>nu</poissons_ratio>
-                <a>2.0833333333333334e-06</a>
-                <n>4.9</n>
-                <sigma0>1e6</sigma0>
-                <q>54000</q>
+                <a>A</a>
+                <n>n</n>
+                <sigma0>sigma_f</sigma0>
+                <q>Q</q>
                 <nonlinear_solver>
                     <maximum_iterations>1000</maximum_iterations>
                     <error_tolerance>2e-8</error_tolerance>
@@ -109,6 +109,27 @@
     </time_loop>
 
     <parameters>
+        <parameter>
+            <name>A</name>
+            <type>Constant</type>
+            <value>2.0833333333333334e-06</value>
+        </parameter>
+        <parameter>
+            <name>n</name>
+            <type>Constant</type>
+            <value>4.9</value>
+        </parameter>
+        <parameter>
+            <name>sigma_f</name>
+            <type>Constant</type>
+            <value>1.0e+6</value>
+        </parameter>
+        <parameter>
+            <name>Q</name>
+            <type>Constant</type>
+            <value>54000</value>
+        </parameter>
+
         <parameter>
             <name>E</name>
             <type>MeshElement</type>

--- a/Tests/Data/ThermoMechanics/CreepBGRa/CreepAfterExcavation/CreepAfterExcavation.prj
+++ b/Tests/Data/ThermoMechanics/CreepBGRa/CreepAfterExcavation/CreepAfterExcavation.prj
@@ -111,8 +111,8 @@
     <parameters>
         <parameter>
             <name>A</name>
-            <type>Constant</type>
-            <value>2.0833333333333334e-06</value>
+            <type>MeshElement</type>
+            <field_name>A</field_name>
         </parameter>
         <parameter>
             <name>n</name>

--- a/Tests/Data/ThermoMechanics/CreepBGRa/CreepAfterExcavation/ExpectedCreepAfterExcavation_pcs_0_ts_61_t_4320000.000000.vtu
+++ b/Tests/Data/ThermoMechanics/CreepBGRa/CreepAfterExcavation/ExpectedCreepAfterExcavation_pcs_0_ts_61_t_4320000.000000.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e5c6736ac05a9b66ca8bc4f9d771453bbfabe1530b2465353019e64d4fadae3
-size 185031
+oid sha256:f7ff2e11894119a96e8b7110d7a51b7d117378cc9ddbac4da8ad93cafe9ac8ee
+size 185317

--- a/Tests/Data/ThermoMechanics/CreepBGRa/CreepAfterExcavation/mesh.vtu
+++ b/Tests/Data/ThermoMechanics/CreepBGRa/CreepAfterExcavation/mesh.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e6693047520f77b89ff0f43e63229fe54efaed674290d93c1ad38bf05022196
-size 176019
+oid sha256:63351c97e8fea8910c6c59faec743b084b1950557086c58eaee19e66b533d8ad
+size 255945

--- a/Tests/Data/ThermoMechanics/CreepBGRa/SimpleAxisymmetricCreep/SimpleAxisymmetricCreep.prj
+++ b/Tests/Data/ThermoMechanics/CreepBGRa/SimpleAxisymmetricCreep/SimpleAxisymmetricCreep.prj
@@ -11,10 +11,10 @@
                 <type>CreepBGRa</type>
                 <youngs_modulus>E</youngs_modulus>
                 <poissons_ratio>nu</poissons_ratio>
-                <a>0.18</a>
-                <n>5.0</n>
-                <sigma0>1</sigma0>
-                <q>54000</q>
+                <a>A</a>
+                <n>n</n>
+                <sigma0>sigma_f</sigma0>
+                <q>Q</q>
                 <nonlinear_solver>
                     <maximum_iterations>1000</maximum_iterations>
                     <error_tolerance>1e-8</error_tolerance>
@@ -105,6 +105,27 @@
     </time_loop>
 
     <parameters>
+        <parameter>
+            <name>A</name>
+            <type>Constant</type>
+            <value>0.18</value>
+        </parameter>
+        <parameter>
+            <name>n</name>
+            <type>Constant</type>
+            <value>5.0</value>
+        </parameter>
+        <parameter>
+            <name>sigma_f</name>
+            <type>Constant</type>
+            <value>1</value>
+        </parameter>
+        <parameter>
+            <name>Q</name>
+            <type>Constant</type>
+            <value>54000</value>
+        </parameter>
+
         <parameter>
             <name>E</name>
             <type>Constant</type>

--- a/Tests/Data/ThermoMechanics/CreepBGRa/SimpleAxisymmetricCreep/SimpleAxisymmetricCreepWithAnalyticSolution.prj
+++ b/Tests/Data/ThermoMechanics/CreepBGRa/SimpleAxisymmetricCreep/SimpleAxisymmetricCreepWithAnalyticSolution.prj
@@ -11,10 +11,10 @@
                 <type>CreepBGRa</type>
                 <youngs_modulus>E</youngs_modulus>
                 <poissons_ratio>nu</poissons_ratio>
-                <a>0.18</a>
-                <n>5.0</n>
-                <sigma0>1</sigma0>
-                <q>54000</q>
+                <a>A</a>
+                <n>n</n>
+                <sigma0>sigma_f</sigma0>
+                <q>Q</q>
                 <nonlinear_solver>
                     <maximum_iterations>1000</maximum_iterations>
                     <error_tolerance>1e-8</error_tolerance>
@@ -93,6 +93,27 @@
     </time_loop>
 
     <parameters>
+        <parameter>
+            <name>A</name>
+            <type>Constant</type>
+            <value>0.18</value>
+        </parameter>
+        <parameter>
+            <name>n</name>
+            <type>Constant</type>
+            <value>5.0</value>
+        </parameter>
+        <parameter>
+            <name>sigma_f</name>
+            <type>Constant</type>
+            <value>1</value>
+        </parameter>
+        <parameter>
+            <name>Q</name>
+            <type>Constant</type>
+            <value>54000</value>
+        </parameter>
+
         <parameter>
             <name>E</name>
             <type>Constant</type>

--- a/web/content/docs/benchmarks/creep-after-excavation-bgra/CreepAfterExcavation.md
+++ b/web/content/docs/benchmarks/creep-after-excavation-bgra/CreepAfterExcavation.md
@@ -40,7 +40,7 @@ material group is for rock salt. The material properties of the rocks are given 
 ---------------------- ---------- ----------- ------------
 
 The parameters of the BGRa creep model are $A=0.18\, \mbox{d}^{-1}$,
-$m=5$, $Q=54 \mbox{ kJ/mol}$.
+$m=5$, $Q=54 \mbox{ kJ/mol}$ for the rock salt. For the cap rock, $A$ is set to zero.
 
 
 The width
@@ -53,7 +53,7 @@ assume a steady state of stress and temperature of excavation at the
 beginning of the current simulation. For this assumption, the boundary
 conditions are given as:
 
--   top boundary: $\tau_x = \sigma_x=0$, $\tau_y=\sigma_y=70$ MPa,
+-   top boundary: $\tau_x =$$\sigma_x$$_y=0$, $\tau_y=\sigma_y=-10$ MPa,
     $T=310$ K.
 
 -   two lateral boundaries: normal displacement is fixed, and no heat

--- a/web/content/docs/benchmarks/creep-after-excavation-bgra/strain.png
+++ b/web/content/docs/benchmarks/creep-after-excavation-bgra/strain.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff2fb210d6f7d543082f490c55ab265e27095efef30fe60f6dd596df0d87ce67
-size 153593
+oid sha256:153483e1d0c8ebd67dea26d500696b4158cb311c3094964790e890662f73ae79
+size 158967

--- a/web/content/docs/benchmarks/creep-after-excavation-bgra/stress_xx_yy_110.png
+++ b/web/content/docs/benchmarks/creep-after-excavation-bgra/stress_xx_yy_110.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:abde5d089d6edc8847dc425c8feec31515832449415bc6bb5f8a414d05dd632a
-size 870467
+oid sha256:fec1098395053e7b7a81da36b99d24bc12f8f63885e908d148087e2ea2608921
+size 876055

--- a/web/content/docs/benchmarks/creep-after-excavation-bgra/stress_xx_yy_20.png
+++ b/web/content/docs/benchmarks/creep-after-excavation-bgra/stress_xx_yy_20.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ea312ed37bd6c593ca4b4a7f4a7b1d7d064c83af53bc70c675eadd2517adef2
-size 847877
+oid sha256:8ed1ed72abd6cf61f22f28816ca83f79d524485e73aa0ef58b2495c81b2dc935
+size 850159

--- a/web/content/docs/benchmarks/creep-after-excavation-bgra/stress_xx_yy_50.png
+++ b/web/content/docs/benchmarks/creep-after-excavation-bgra/stress_xx_yy_50.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f50ecaaeaaf49a8e6ac371571f55ab0278df5b27a15b43c015ebdf7827b93c32
-size 858276
+oid sha256:8d9bbef7cbe055d4820030bd13cf31282f9cc6cde7b87086e62729abc12f2949
+size 864108

--- a/web/content/docs/benchmarks/creepbgra/CreepBRGa.md
+++ b/web/content/docs/benchmarks/creepbgra/CreepBRGa.md
@@ -15,9 +15,9 @@ author = "Wenqing Wang"
 
 The BGRa stationary creep model defines the uniaxial creep strain
 increment as
-$$\Delta{ \epsilon}^c=Ae^{-Q/R_uT}\left(\dfrac{{ \sigma}}{{ \sigma}_f}\right)^m \Delta t
+$$\Delta{ \epsilon}^c=Ae^{-Q/R_uT}\left(\dfrac{{ \sigma_1}}{{ \sigma}_f}\right)^m \Delta t
 $$
- where $A$, $m$ and $Q$ are parameters determined
+ where $\sigma_1$ is the stress, $A$, $m$ and $Q$ are parameters determined
 by experiments, $Q$ is called activation energy,
 $R_u=8.314472 \mbox{J/(Kmol)}$ is the universal gas constant, and
 ${ \sigma}_f$ is a stress scaling factor.
@@ -27,24 +27,30 @@ Creep potential and creep strain
 
 Assume there is a creep potential $g^c$ and the creep induced strain
 rate is given by the flow rule
-$$\dot { \mathbf \epsilon}^c ({ \sigma})= \frac{2}{3}{\dfrac{\partial g^c}{\partial { \mathbf \sigma}}}
-$$ where ${ \sigma}$ is the equivalence stress
-defined by
-${ \sigma}={\sqrt{{\frac{3}{2}}}}{\left\Vert{\mathbf s}\right\Vert}$
-with ${\mathbf s}= { \mathbf \sigma}-\frac{1}{3}{ \sigma}{\mathbf I}$,
-the deviatoric stress. The creep strain rate is then expressed as
+$$\dot { \mathbf \epsilon}^c ({ \mathbf \sigma})= {\dfrac{\partial g^c}{\partial { \mathbf \sigma}}}
+$$ where ${ \mathbf\sigma}$ is the stress tensor.
+To establish equivalence between the three-dimensional and the uniaxial formulation given above,
+ we use the effective stress defined by
+${ \bar\sigma}={\sqrt{{\frac{3}{2}}}}{\left\Vert{\mathbf s}\right\Vert}$
+with ${\mathbf s}= { \mathbf \sigma}-\frac{1}{3}{ \mathrm{tr}(\mathbf\sigma}){\mathbf I}$,
+the deviatoric stress. 
+The creep strain rate is then expressed as
 $$\begin{gathered}
-\dot { \mathbf \epsilon}^c ({ \sigma})= \frac{2}{3} {\dfrac{\partial g^c}{\partial { \sigma}}}{\dfrac{\partial { \sigma}}{\partial { \mathbf \sigma}}}=\sqrt{{\frac{2}{3}}}{\dfrac{\partial g^c}{\partial { \sigma}}}\dfrac{{\mathbf s}}{{\left\Vert{\mathbf s}\right\Vert}}={\dfrac{\partial g^c}{\partial { \sigma}}}\dfrac{{\mathbf s}}{\sigma}
+\dot { \mathbf \epsilon}^c ({ \sigma})=  {\dfrac{\partial g^c}{\partial {\bar\sigma}}}
+{\dfrac{\partial { \bar\sigma}}{\partial { \mathbf \sigma}}}
+=\sqrt{{\frac{2}{3}}}{\dfrac{\partial g^c}{\partial {\bar \sigma}}}\dfrac{{\mathbf s}}{{\left\Vert{\mathbf s}\right\Vert}}
 \end{gathered}$$
  The above creep strain rate expression
-must be valid for the problems with different dimension. Applying
-the creep rate equation to one dimensional leads to
+must be valid for problems independent from the Euclidean dimension. Applying
+the creep rate equation to a uniaxial stress state ${\mathbf \sigma} = \mathrm{diag}[\sigma_1, 0, 0]$,
+ which gives ${\mathbf s} = \mathrm{diag}[\frac{2}{3}\sigma_1, -\frac{2}{3}\sigma_1, -\frac{2}{3}\sigma_1]$,
+ we have
  $$\begin{gathered}
-\dot { \epsilon}^c = {\dfrac{\partial g^c}{\partial { \sigma}}}{\color{red} {\frac{2}{3}}}=Ae^{-Q/R_uT}\left(\dfrac{{ \sigma}}{{ \sigma}_f}\right)^m
-\end{gathered}$$ which says 
-
+\dot { \epsilon_1}^c = {\dfrac{\partial g^c}{\partial { \bar\sigma}}}=Ae^{-Q/R_uT}\left(\dfrac{{ \sigma_1}}{{ \sigma}_f}\right)^m
+\end{gathered}$$
+which says 
 $$\begin{gathered}
- {\dfrac{\partial g^c}{\partial { \sigma}}}={\color{red}{\frac{3}{2}}}Ae^{-Q/R_u T}\left(\dfrac{{ \sigma}}{{ \sigma}_f}\right)^m
+ {\dfrac{\partial g^c}{\partial { \bar\sigma}}}=Ae^{-Q/R_u T}\left(\dfrac{{ \sigma_1}}{{ \sigma}_f}\right)^m
 \end{gathered}$$
 
 Therefore, the creep strain rate for multi-dimensional problems can be


### PR DESCRIPTION
The member type is changed from double to Parameter. One test of BGRa is changed to use different parameters of BGRa creep model with the new source code change.