### PR TITLE
Small improvements and bug fix in XML GML part

### DIFF
--- a/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
@@ -344,7 +344,7 @@ void DiagramList::setList(std::vector<std::pair<float, float>> const& coords)
     update();
 }
 
-std::size_t DiagramList::size()
+std::size_t DiagramList::size() const
 {
     if (!(_coords.empty()))
         return _coords.size();

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
@@ -340,10 +340,7 @@ void DiagramList::setList(std::vector<std::pair<float, float>> const& coords)
         return;
 
     this->_startDate = QDateTime();
-    std::size_t nCoords = coords.size();
-    for (std::size_t i = 0; i < nCoords; i++)
-        _coords.push_back(coords[i]);
-
+    std::copy(coords.begin(), coords.end(), std::back_inserter(_coords));
     update();
 }
 

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
@@ -346,10 +346,7 @@ void DiagramList::setList(std::vector<std::pair<float, float>> const& coords)
 
 std::size_t DiagramList::size() const
 {
-    if (!(_coords.empty()))
-        return _coords.size();
-
-    return 0;
+    return _coords.size();
 }
 
 void DiagramList::update()

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramList.h
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramList.h
@@ -141,7 +141,7 @@ public:
     void setYUnit(QString unit) { _yUnit = unit; }
 
     /// Returns the number of data points.
-    std::size_t size();
+    std::size_t size() const;
 
     /// Returns the width of the bounding box of all data points within the list.
     double width() const { return _maxX - _minX; }

--- a/Applications/DataExplorer/DataView/FemConditionModel.h
+++ b/Applications/DataExplorer/DataView/FemConditionModel.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "Applications/DataHolderLib/FemCondition.h"
-#include "TreeModel.h"
+#include "Applications/DataExplorer/Base/TreeModel.h"
 
 /**
  * \brief A model for the display of information from boundary conditions and

--- a/Applications/DataExplorer/DataView/FemConditionModel.h
+++ b/Applications/DataExplorer/DataView/FemConditionModel.h
@@ -24,7 +24,7 @@ class FemConditionModel : public TreeModel
 public:
     FemConditionModel(QObject* parent = nullptr);
 
-    int columnCount() const { return 2; }
+    int columnCount(const QModelIndex& /*parent*/ = QModelIndex()) const { return 2; }
 
 public slots:
     /// Clears the tree.

--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -497,8 +497,18 @@ void MainWindow::loadFile(ImportFileType::type t, const QString &fileName)
         else if (fi.suffix().toLower() == "gml")
         {
             GeoLib::IO::XmlGmlInterface xml(_project.getGEOObjects());
-            if (!xml.readFile(fileName))
-                OGSError::box("Failed to load geometry.\n Please see console for details.");
+            try
+            {
+                if (!xml.readFile(fileName))
+                    OGSError::box(
+                        "Failed to load geometry.\n Please see console for "
+                        "details.");
+            }
+            catch (std::runtime_error const& err)
+            {
+                OGSError::box(err.what(),
+                              "Failed to read file `" + fileName + "'");
+            }
         }
         // OpenGeoSys observation station files (incl. boreholes)
         else if (fi.suffix().toLower() == "stn")

--- a/Applications/FileIO/FEFLOW/FEFLOWMeshInterface.cpp
+++ b/Applications/FileIO/FEFLOW/FEFLOWMeshInterface.cpp
@@ -454,7 +454,7 @@ MeshLib::Element* FEFLOWMeshInterface::readElement(
     ss >> ele_type;
 
     MeshLib::MeshElemType elem_type;
-    int n_nodes_of_element;
+    std::size_t n_nodes_of_element;
     switch (ele_type)
     {
         case 6:

--- a/Applications/FileIO/XmlIO/Qt/XmlPrjInterface.cpp
+++ b/Applications/FileIO/XmlIO/Qt/XmlPrjInterface.cpp
@@ -18,12 +18,13 @@
 #include <QtXml/QDomDocument>
 #include <logog/include/logog.hpp>
 
+#include "Applications/DataExplorer/Base/OGSError.h"
+#include "Applications/DataHolderLib/FemCondition.h"
+
 #include "BaseLib/BuildInfo.h"
 #include "BaseLib/FileFinder.h"
 #include "BaseLib/FileTools.h"
 #include "BaseLib/IO/Writer.h"
-
-#include "Applications/DataHolderLib/FemCondition.h"
 
 #include "GeoLib/GEOObjects.h"
 
@@ -75,7 +76,15 @@ int XmlPrjInterface::readFile(const QString& fileName)
         if (node_name == "geometry")
         {
             GeoLib::IO::XmlGmlInterface gml(_project.getGEOObjects());
-            gml.readFile(QString(path + file_name));
+            try
+            {
+                gml.readFile(QString(path + file_name));
+            }
+            catch (std::runtime_error const& err)
+            {
+                OGSError::box(err.what(),
+                              "Failed to read file `" + fileName + "'");
+            }
         }
         else if (node_name == "stations")
         {

--- a/Applications/Utils/GeoTools/MoveGeometry.cpp
+++ b/Applications/Utils/GeoTools/MoveGeometry.cpp
@@ -50,8 +50,17 @@ int main(int argc, char *argv[])
 
     GeoLib::GEOObjects geo_objects;
     GeoLib::IO::XmlGmlInterface xml(geo_objects);
-    if (!xml.readFile(geo_input_arg.getValue()))
+    try
     {
+        if (!xml.readFile(geo_input_arg.getValue()))
+        {
+            return EXIT_FAILURE;
+        }
+    }
+    catch (std::runtime_error const& err)
+    {
+        ERR("Failed to read file `%s'.", geo_input_arg.getValue().c_str());
+        ERR("%s", err.what());
         return EXIT_FAILURE;
     }
 

--- a/Applications/Utils/GeoTools/TriangulatePolyline.cpp
+++ b/Applications/Utils/GeoTools/TriangulatePolyline.cpp
@@ -56,9 +56,18 @@ int main(int argc, char *argv[])
 
     GeoLib::GEOObjects geo_objects;
     GeoLib::IO::XmlGmlInterface xml(geo_objects);
-    if (!xml.readFile(file_name))
+    try
     {
-        ERR ("Failed to load geometry file.");
+        if (!xml.readFile(file_name))
+        {
+            ERR("Failed to load geometry file.");
+            return EXIT_FAILURE;
+        }
+    }
+    catch (std::runtime_error const& err)
+    {
+        ERR("Failed to read file `%s'.", file_name.c_str());
+        ERR("%s", err.what());
         return EXIT_FAILURE;
     }
 

--- a/Applications/Utils/OGSFileConverter/OGSFileConverter.cpp
+++ b/Applications/Utils/OGSFileConverter/OGSFileConverter.cpp
@@ -53,11 +53,21 @@ void OGSFileConverter::convertGML2GLI(const QStringList &input, const QString &o
         if (fileExists(output_str))
             continue;
 
-        if (!xml.readFile(input_string))
+        try
         {
-            OGSError::box("Error reading geometry " + fi.fileName());
+            if (!xml.readFile(input_string))
+            {
+                OGSError::box("Error reading geometry " + fi.fileName());
+                continue;
+            }
+        }
+        catch (std::runtime_error const& err)
+        {
+            OGSError::box(err.what(),
+                          "Failed to read file `" + input_string + "'");
             continue;
         }
+
         std::vector<std::string> geo_names;
         geo_objects.getGeometryNames(geo_names);
         FileIO::Legacy::writeGLIFileV4(output_str, geo_names[0], geo_objects);

--- a/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
@@ -113,10 +113,19 @@ int XmlGmlInterface::readFile(const QString &fileName)
         }
         else if (nodeName.compare("polylines") == 0)
         {
-            readPolylines(
-                type_node, polylines.get(), *_geo_objs.getPointVec(gliName),
-                _geo_objs.getPointVecObj(gliName)->getIDMap(), ply_names.get());
-
+            try
+            {
+                readPolylines(type_node, polylines.get(),
+                              *_geo_objs.getPointVec(gliName),
+                              _geo_objs.getPointVecObj(gliName)->getIDMap(),
+                              ply_names.get());
+            }
+            catch (std::runtime_error const& err)
+            {
+                // further reading is aborted and it is necessary to clean up
+                _geo_objs.removePointVec(gliName);
+                throw;
+            }
             // if names-map is empty, set it to nullptr because it is not needed
             if (ply_names->empty())
             {
@@ -125,9 +134,20 @@ int XmlGmlInterface::readFile(const QString &fileName)
         }
         else if (nodeName.compare("surfaces") == 0)
         {
-            readSurfaces(
-                type_node, surfaces.get(), *_geo_objs.getPointVec(gliName),
-                _geo_objs.getPointVecObj(gliName)->getIDMap(), sfc_names.get());
+            try
+            {
+                readSurfaces(type_node, surfaces.get(),
+                             *_geo_objs.getPointVec(gliName),
+                             _geo_objs.getPointVecObj(gliName)->getIDMap(),
+                             sfc_names.get());
+            }
+            catch (std::runtime_error const& err)
+            {
+                // further reading is aborted and it is necessary to clean up
+                _geo_objs.removePointVec(gliName);
+                _geo_objs.removePolylineVec(gliName);
+                throw;
+            }
 
             // if names-map is empty, set it to nullptr because it is not needed
             if (sfc_names->empty())

--- a/scripts/cmake/CompilerSetup.cmake
+++ b/scripts/cmake/CompilerSetup.cmake
@@ -47,9 +47,13 @@ if(COMPILER_IS_GCC OR COMPILER_IS_CLANG OR COMPILER_IS_INTEL)
     add_compile_options(
         -Wall
         -Wextra
-        -Wno-c++98-compat-pedantic
         -DOPENMP_LOOP_TYPE=unsigned
     )
+    if(NOT COMPILER_IS_INTEL)
+        add_compile_options(
+            -Wno-c++98-compat-pedantic
+        )
+    endif()
 
     # Profiling
     if(OGS_PROFILE)


### PR DESCRIPTION
As titled. If the DataExplorer reads an erroneous file an exception is thrown within the XML GML Qt interface. ~~For a robust DataExplorer the exception shall be caught, but isn't yet. @rinkk This is for discussion.~~

Fixes the issue #2182 .

Update: Catched exceptions.