### PR TITLE
[MeL] Change checkNonlinearNodeId msg to warning.

### DIFF
--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -306,9 +306,10 @@ void Mesh::checkNonlinearNodeIDs() const
             if (e->getNodeIndex(i) >= getNumberOfBaseNodes())
                 continue;
 
-            ERR("Found a nonlinear node whose ID (%d) is smaller than the "
-                "number of base node IDs (%d)."
-                "Some functions may not work properly.",
+            WARN(
+                "Found a nonlinear node whose ID (%d) is smaller than the "
+                "number of base node IDs (%d). Some functions may not work "
+                "properly.",
                 e->getNodeIndex(i), getNumberOfBaseNodes());
             return;
         }


### PR DESCRIPTION
Since (most) parts of the Mesh are not dependent on this property, this is merely a warning.

It would be better, though, to run this check only for algorithms relying on this property. Does anybody knows such algorithms? @rinkk , @TomFischer ?
There, the check must be a hard error, not just a warning.

Related to https://github.com/ufz/ogs/pull/1495