### PR TITLE
Use Conan per default when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ option(OGS_USE_PCH "Should pre-compiled headers be used?" ON)
 if(DEFINED CMAKE_CXX_CLANG_TIDY)
     set(OGS_USE_PCH OFF CACHE INTERNAL "")
 endif()
-option(OGS_USE_CONAN "Should Conan package manager be used?" OFF)
+option(OGS_USE_CONAN "Should Conan package manager be used?" ON)
 set(OGS_CONAN_BUILD "missing" CACHE STRING "Possible values: all, missing, \
     never or list of libs to build" )
 if(OGS_USE_PETSC)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,6 @@ pipeline {
               sh 'conan user'
               configure {
                 cmakeOptions =
-                  '-DOGS_USE_CONAN=ON ' +
                   '-DOGS_CPU_ARCHITECTURE=generic ' +
                   '-DDOCS_GENERATE_LOGFILE=ON ' + // redirects to build/DoxygenWarnings.log
                   '-DOGS_USE_PYTHON=ON '
@@ -98,7 +97,6 @@ pipeline {
                   reportName: 'Doxygen'])
               configure {
                 cmakeOptions =
-                  '-DOGS_USE_CONAN=ON ' +
                   '-DOGS_CPU_ARCHITECTURE=generic ' +
                   '-DOGS_USE_PYTHON=ON ' +
                   '-DOGS_BUILD_CLI=OFF ' +
@@ -149,7 +147,6 @@ pipeline {
               sh 'conan user'
               configure {
                 cmakeOptions =
-                  '-DOGS_USE_CONAN=ON ' +
                   '-DOGS_CPU_ARCHITECTURE=generic '
                 config = 'Debug'
               }
@@ -244,7 +241,6 @@ pipeline {
               bat 'conan remove --locks'
               configure {
                 cmakeOptions =
-                  '-DOGS_USE_CONAN=ON ' +
                   '-DOGS_DOWNLOAD_ADDITIONAL_CONTENT=ON ' +
                   '-DOGS_USE_PYTHON=ON '
               }
@@ -254,7 +250,6 @@ pipeline {
               // GUI
               configure {
                 cmakeOptions =
-                  '-DOGS_USE_CONAN=ON ' +
                   '-DOGS_DOWNLOAD_ADDITIONAL_CONTENT=ON ' +
                   '-DOGS_USE_PYTHON=ON ' +
                   '-DOGS_BUILD_GUI=ON ' +
@@ -289,7 +284,6 @@ pipeline {
             script {
               configure {
                 cmakeOptions =
-                  '-DOGS_USE_CONAN=ON ' +
                   '-DOGS_CPU_ARCHITECTURE=core2 ' +
                   '-DOGS_DOWNLOAD_ADDITIONAL_CONTENT=ON ' +
                   '-DOGS_BUILD_GUI=ON ' +
@@ -362,7 +356,6 @@ pipeline {
                 sh 'find $CONAN_USER_HOME -name "system_reqs.txt" -exec rm {} \\;'
                 configure {
                   cmakeOptions =
-                    '-DOGS_USE_CONAN=ON ' +
                     '"-DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=include-what-you-use;-Xiwyu;--mapping_file=../scripts/jenkins/iwyu-mappings.imp" ' +
                     '-DCMAKE_LINK_WHAT_YOU_USE=ON ' +
                     '"-DCMAKE_CXX_CPPCHECK=cppcheck;--std=c++11;--language=c++;--suppress=syntaxError;--suppress=preprocessorErrorDirective:*/ThirdParty/*;--suppress=preprocessorErrorDirective:*conan*/package/*" ' +
@@ -465,7 +458,6 @@ pipeline {
               sh 'find $CONAN_USER_HOME -name "system_reqs.txt" -exec rm {} \\;'
               configure {
                 cmakeOptions =
-                  '-DOGS_USE_CONAN=ON ' +
                   '-DOGS_ADDRESS_SANITIZER=ON ' +
                   '-DOGS_UNDEFINED_BEHAVIOR_SANITIZER=ON ' +
                   '-DOGS_BUILD_UTILS=ON '

--- a/scripts/cmake/ConanSetup.cmake
+++ b/scripts/cmake/ConanSetup.cmake
@@ -1,6 +1,15 @@
 if(NOT OGS_USE_CONAN)
     return()
 endif()
+find_program(CONAN_CMD conan)
+if(NOT CONAN_CMD)
+    message(WARNING "conan executable not found. Consider installing Conan for "
+        "automatic third-party library handling. https://www.opengeosys.org/doc"
+        "s/devguide/getting-started/prerequisites/#step-install-conan-package-m"
+        "anager OR disable this warning with OGS_USE_CONAN=OFF")
+    return()
+endif()
+
 
 if(CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
     message(FATAL_ERROR "Multi-config generators are not yet supported when "
@@ -61,7 +70,7 @@ if(OGS_BUILD_GUI)
     )
 endif()
 
-conan_check(VERSION 1.0.0 REQUIRED)
+conan_check(VERSION 1.0.0)
 conan_add_remote(NAME ogs INDEX 0
     URL https://ogs.jfrog.io/ogs/api/conan/conan)
 conan_add_remote(NAME conan-community INDEX 1

--- a/web/content/docs/devguide/advanced/conan-package-manager.pandoc
+++ b/web/content/docs/devguide/advanced/conan-package-manager.pandoc
@@ -15,11 +15,11 @@ weight = 1032
 As of OpenGeoSys 6.1.0 Conan version 1.0.0 is required! Please update Conan by running `pip install --upgrade conan` or by downloading the Windows installer.
 :::
 
-The [Conan package manager](https://www.conan.io) helps to install all required libraries in a convenient way on every platform. See [Setup pre-requisites](../../getting-started/prerequisites) for installation instructions. Set the CMake option `OGS_USE_CONAN=ON` to enable Conan.
+The [Conan package manager](https://www.conan.io) helps to install all required libraries in a convenient way on every platform. See [Setup pre-requisites](../../getting-started/prerequisites) for installation instructions. If the Conan executable is found Conan is used for third-party library handling. Set the CMake option `OGS_USE_CONAN=OFF` to disable Conan.
 
 ## Advanced usage
 
-Per default when Conan is enabled (`OGS_USE_CONAN=ON`) it will try to fetch prebuilt binaries from the [OGS Conan repository](https://ogs.jfrog.io/ogs/conan/) at https://ogs.jfrog.io/ogs/api/conan/conan. With the CMake option `OGS_CONAN_BUILD` you define what gets build locally. This option can be set to:
+Per default when Conan is enabled it will try to fetch prebuilt binaries from the [OGS Conan repository](https://ogs.jfrog.io/ogs/conan/) at https://ogs.jfrog.io/ogs/api/conan/conan. With the CMake option `OGS_CONAN_BUILD` you define what gets build locally. This option can be set to:
 
 - `missing` - Default, only builds packages which are not available as a prebuilt binary for the current configuration
 - `all` - Builds all packages locally

--- a/web/content/docs/devguide/getting-started/build-configuration.pandoc
+++ b/web/content/docs/devguide/getting-started/build-configuration.pandoc
@@ -23,13 +23,11 @@ So just go ahead and create a build-directory along your source code directory.
 
 ## Install required libraries with Conan
 
-It is preferred to use Conan package manager to install required third-party libraries. To use Conan add the CMake option `OGS_USE_CONAN=ON` to the CMake run (see below). This will run Conan automatically downloading either prebuilt binaries of required libraries or building them locally if a binary for your setup (operating system, compiler, ..) is not available. [Check this]({{< ref "conan-package-manager.pandoc" >}}) for advanced Conan usage.
+It is preferred to use Conan package manager to install required third-party libraries. If [Conan is installed]({{< ref "prerequisites" >}}#step-install-conan-package-manager) it will automatically download either prebuilt binaries of required libraries or build them locally if a binary for your setup (operating system, compiler, ..) is not available. [Check this]({{< ref "conan-package-manager.pandoc" >}}) for advanced Conan usage.
 
 *Note:* Instead of using Conan you can optionally [install the required libraries manually]({{< ref "third-party-libraries.pandoc" >}}).
 
 ::: {.win}
-Add `-DOGS_USE_CONAN=ON` to the CMake-run (see below).
-
 ::: {.note}
 ### <i class="fas fa-exclamation-triangle"></i> Multi-configuration with Conan and Visual Studio
 
@@ -48,14 +46,6 @@ $ cmake ../../ogs -G "Visual Studio 14 2015 Win64" -DOGS_USE_CONAN=ON -DCMAKE_BU
 
 Please also note that in Visual Studio you have to choose the correct configuration (i.e. when opening the solution-file in the release-folder you have to switch the Visual Studio configuration to **Release**)!
 :::
-:::
-
-::: {.linux}
-Add `-DOGS_USE_CONAN=ON` to the CMake-run (see below).
-:::
-
-::: {.mac}
-Add `-DOGS_USE_CONAN=ON` to the CMake-run (see below).
 :::
 
 

--- a/web/content/docs/devguide/troubleshooting/conan.pandoc
+++ b/web/content/docs/devguide/troubleshooting/conan.pandoc
@@ -14,7 +14,7 @@ weight = 1042
 When CMake is run Conan will download library packages. You can see under `Requirements` in the CMake output from where the packages will be downloaded. Most packages will come `from ogs`:
 
 ```bash
-$ cmake ../ogs -DOGS_USE_CONAN=ON
+$ cmake ../ogs
 ...
 -- Conan executing: conan install . -g cmake -s build_type=Release -s os=Macos -s compiler=apple-clang -s compiler.version=9.0 -s compiler.libcxx=libc++ --build=missing --update
 PROJECT: Installing /Users/bilke/code/ogs6/build-n/conanfile.txt


### PR DESCRIPTION
Use Conan as default when its executable is found. Developer having Conan installed typically also want to use it for third-party library handling. This avoids strange things happening when switching Conan to ON from the CMake GUI.

If you don't want to use Conan:

- Do not have `conan` in your `PATH`, **OR**
- Set `OGS_USE_CONAN=OFF`

@HaibingShao With this merged you can again use the CMake GUI for the initial CMake run if you like...