### PR TITLE
[MGTL] Transform OGS_FATAL to DBUG in parallel version.

### DIFF
--- a/MeshGeoToolsLib/BoundaryElementsAtPoint.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsAtPoint.cpp
@@ -26,10 +26,21 @@ BoundaryElementsAtPoint::BoundaryElementsAtPoint(
 {
     auto const node_ids = mshNodeSearcher.getMeshNodeIDs(_point);
     if (node_ids.empty())
+    {
+        #ifndef USE_PETSC
         OGS_FATAL(
             "BoundaryElementsAtPoint: the mesh node searcher was unable to "
             "locate the point (%f, %f, %f) in the mesh.",
             _point[0], _point[1], _point[2]);
+        #else
+        DBUG(
+            "BoundaryElementsAtPoint: the mesh node searcher was unable to "
+            "locate the point (%f, %f, %f) in the current domain of the "
+            "partitioned mesh.",
+            _point[0], _point[1], _point[2]);
+            return;
+        #endif
+    }
     if (node_ids.size() > 1)
         OGS_FATAL(
             "BoundaryElementsAtPoint: the mesh node searcher found %d points "


### PR DESCRIPTION
In parallel execution it must not to be necessarily a fatal error if the BoundaryElementsAtPoint searcher doesn't find a mesh node.

Allows for running the cube_ht benchmark on eve.