### PR TITLE
[web/BGRa] Recovered the display of the formula of the elastic tensor and a table

### DIFF
--- a/web/content/docs/benchmarks/creep-after-excavation-bgra/CreepAfterExcavation.pandoc
+++ b/web/content/docs/benchmarks/creep-after-excavation-bgra/CreepAfterExcavation.pandoc
@@ -31,6 +31,7 @@ top part of the domain represents a cap rock type, while the other
 material group is for rock salt. The material properties of the rocks are given in the following table:
 
 ---------------------- ---------- ----------- ------------
+
 |         |Cap rock |  Rock salt|   Unit|
 | --- |:---------:| -----:|----:|
 |Density            |    2000   |    2170 |       kg/m$^{3}$|

--- a/web/content/docs/benchmarks/creepbgra/CreepBRGa.pandoc
+++ b/web/content/docs/benchmarks/creepbgra/CreepBRGa.pandoc
@@ -78,7 +78,7 @@ $$\begin{gathered}
  (\dot { \mathbf \epsilon}- \dot { \mathbf \epsilon}^T- \dot { \mathbf \epsilon}^c)
 \end{gathered}$$
 where
-$\mathbf{C}:= \lambda \mathcal{J} + 2G \mathbf I \otimes \mathbf I  $
+$\mathbf{C} = \lambda  \mathcal{J} + 2G \mathbf I \otimes \mathbf I$
 with $\mathcal{J}$ the forth order identity, $\mathbf I$ the second order identity,
 $\lambda$ the Lamé constant,  $G$ the shear modulus, and $\otimes$  the tensor
 product notation.


### PR DESCRIPTION
1. CreepBRGa.pandoc:  $\mathbf{C}: = \lambda  \mathcal{J} + 2G \mathbf I \otimes \mathbf I$ cannot be displayed after recent commits. Change it to $\mathbf{C} = \lambda  \mathcal{J} + 2G \mathbf I \otimes \mathbf I$
2. CreepAfterExcavation.pandoc: the table of material properties.