### PR TITLE
CMake fixes

### DIFF
--- a/scripts/cmake/ConanSetup.cmake
+++ b/scripts/cmake/ConanSetup.cmake
@@ -70,7 +70,7 @@ if(OGS_BUILD_GUI)
     )
 endif()
 
-conan_check(VERSION 1.0.0)
+conan_check(VERSION 1.3.0)
 conan_add_remote(NAME ogs INDEX 0
     URL https://ogs.jfrog.io/ogs/api/conan/conan)
 conan_add_remote(NAME conan-community INDEX 1

--- a/scripts/cmake/packaging/Pack.cmake
+++ b/scripts/cmake/packaging/Pack.cmake
@@ -105,7 +105,7 @@ cpack_add_component(ogs_docs
 if(OGS_USE_CONAN)
     # Install shared libraries, copied to bin-dir
     foreach(PATTERN "*.dll" "*.dylib*")
-        file(GLOB MATCHED_FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PATTERN})
+        file(GLOB LIST_DIRECTORIES false MATCHED_FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PATTERN})
         install(FILES ${MATCHED_FILES} DESTINATION bin)
     endforeach()
 


### PR DESCRIPTION
As reported by @KeitaYoshioka:

- `conan_add_remote()` in `ConanSetup.cmake` requires Conan 1.3.0
- On macOS on Debug build with PETSc there are directories containing `.dylib` which throw an error when trying to install as files