### PR TITLE
[CMake] Added option OGS_BUILD_PROCESSES.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #####################
 
 # Specify minimum CMake version
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.3)
 
 # Set CMake policies
 cmake_policy(SET CMP0011 NEW)
@@ -109,6 +109,20 @@ set(ProcessesList
 foreach(process ${ProcessesList})
     option(OGS_BUILD_PROCESS_${process} "Build the ${process} process." ON)
 endforeach()
+
+set(OGS_BUILD_PROCESSES "" CACHE STRING "Semicolon-separated list of processes to build")
+if(NOT "${OGS_BUILD_PROCESSES}" STREQUAL "")
+    message(STATUS "Enabled processes:")
+    foreach(process ${ProcessesList})
+        if("${process}" IN_LIST OGS_BUILD_PROCESSES)
+            set(OGS_BUILD_PROCESS_${process} ON CACHE BOOL "" FORCE)
+            message(STATUS "  ${process}")
+        else()
+            set(OGS_BUILD_PROCESS_${process} OFF CACHE BOOL "" FORCE)
+        endif()
+    endforeach()
+
+endif()
 
 if(WIN32)
     option(OGS_BUILD_SWMM "Should the SWMM interface be built?" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,12 @@ endforeach()
 
 set(OGS_BUILD_PROCESSES "" CACHE STRING "Semicolon-separated list of processes to build")
 if(NOT "${OGS_BUILD_PROCESSES}" STREQUAL "")
+    foreach(process ${OGS_BUILD_PROCESSES})
+        if(NOT "${process}" IN_LIST ProcessesList)
+            message(FATAL_ERROR "${process} given in OGS_BUILD_PROCESSES is "
+                "not a valid process name! Valid names are ${ProcessesList}")
+        endif()
+    endforeach()
     message(STATUS "Enabled processes:")
     foreach(process ${ProcessesList})
         if("${process}" IN_LIST OGS_BUILD_PROCESSES)

--- a/web/content/docs/devguide/advanced/configuration-options.pandoc
+++ b/web/content/docs/devguide/advanced/configuration-options.pandoc
@@ -22,8 +22,9 @@ CMake switches to enable / disable parts of OGS.
 - `OGS_BUILD_TESTS` - Builds the test executables. *Defaults* to *ON*.
 - `OGS_BUILD_UTILS` - Builds several utilities.
 - `OGS_NO_EXTERNAL_LIBS` - Disables all external optional dependencies.
-- `OGS_BUILD_PROCESS_X=OFF` - For disabling compilation of process `X`.
+- `OGS_BUILD_PROCESS_X` - For enabling/disabling compilation of process `X`.
   Run the CMake-Gui to see a list of processes.
+- `OGS_BUILD_PROCESSES` - A `;`-separated list specifying processes to build. *Defaults* to an *empty string*. This will alter the `OGS_BUILD_PROCESS_X`-options. For e.g. building just the two processes `HT` and `LIE`: `-DOGS_BUILD_PROCESSES="HT;LIE"`. Setting this variable back to an empty string **does not reset** the `OGS_BUILD_PROCESS_X`-options.
  
 #### Debugging
  


### PR DESCRIPTION
`;`-separated list of processes to build, e.g.:

```
cmake . -DOGS_BUILD_PROCESSES="HT;LIE"
```

As requested by @OlafKolditz.

Bumped CMake version to 3.3 (from 2015-07) because of `if(X IN_LIST Y)`-syntax.