### PR TITLE
Jacobian tester for local assemblers.

### DIFF
--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CentralDifferences/c_CentralDifferences.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CentralDifferences/c_CentralDifferences.md
@@ -1,0 +1,1 @@
+Assembles the Jacobian using central differences.

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CentralDifferences/t_component_magnitudes.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CentralDifferences/t_component_magnitudes.md
@@ -1,0 +1,5 @@
+Representative magnitudes for the components of the solution vector of the
+process being assembled.
+
+E.g., for the HT process there are two components: pressure and temperature,
+thus two values are expected in this case.

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CentralDifferences/t_relative_epsilons.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CentralDifferences/t_relative_epsilons.md
@@ -1,0 +1,5 @@
+Specifies the magnitudes of the perturbations used to compute the numerical
+Jacobian.
+
+The magnitudes are specified relative to the \c component_magnitudes.
+The number of values given must match the one of the \c component_magnitudes.

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/c_CompareJacobians.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/c_CompareJacobians.md
@@ -4,3 +4,28 @@ script if the provided tolerances are exceeded.
 
 Logging (and optionally program termination) is triggered only if both the
 absolute and the relative tolerance are exceeded.
+
+# Configuration example
+
+Code snippet:
+
+\code{xml}
+<OpenGeoSysProject>
+    <processes>
+        <process>
+            <jacobian_assembler>
+                <type>CompareJacobians</type>
+                <jacobian_assembler>
+                    <type>Analytical</type>
+                </jacobian_assembler>
+                <reference_jacobian_assembler>
+                    <type>CentralDifferences</type>
+                    <component_magnitudes>1 1</component_magnitudes>
+                    <relative_epsilons>1e-6 1e-6</relative_epsilons>
+                </reference_jacobian_assembler>
+                <abs_tol>1e-18</abs_tol>
+                <rel_tol>1e-7</rel_tol>
+                <fail_on_error>true</fail_on_error>
+                <log_file>/tmp/test.log</log_file>
+            </jacobian_assembler>
+\endcode

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/c_CompareJacobians.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/c_CompareJacobians.md
@@ -1,0 +1,6 @@
+A Jacobian assembler that assembles the Jacobian in two different ways, compares
+the resulting local Jacobians and writes extensive logs in the form of a Python
+script if the provided tolerances are exceeded.
+
+Logging (and optionally program termination) is triggered only if both the
+absolute and the relative tolerance are exceeded.

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/t_abs_tol.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/t_abs_tol.md
@@ -1,0 +1,4 @@
+The absolute tolerance (component-wise) for the difference between the two
+assembled local Jacobians.
+
+There is only one absolute tolerance value for all components of the Jacobian.

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/t_fail_on_error.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/t_fail_on_error.md
@@ -1,0 +1,2 @@
+Whether OGS should be aborted if both the absolute and relative tolerance are
+exceeded.

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/t_jacobian_assembler.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/t_jacobian_assembler.md
@@ -1,0 +1,2 @@
+The Jacobian assember whose assembled matrices will be used subsequently in the
+global equation system.

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/t_log_file.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/t_log_file.md
@@ -1,0 +1,8 @@
+The path to the file to which details of differing Jacobians are written.
+
+Finally, the file will contain a Python script that can be used to conveniently
+examine the differences that occured.
+The given path is an absolute path or a path relative to the working directory
+of OGS.
+The log file will be overwritten, even if no differences exceeding the
+tolerances occur.

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/t_reference_jacobian_assembler.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/t_reference_jacobian_assembler.md
@@ -1,0 +1,2 @@
+The Jacobian assembler whose results are used only to check the assembled
+matrices of the other Jacobian assembler.

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/t_rel_tol.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/CompareJacobians/t_rel_tol.md
@@ -1,0 +1,4 @@
+The relative tolerance (component-wise) for the difference between the two
+assembled local Jacobians.
+
+There is only one relative tolerance value for all components of the Jacobian.

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/i_jacobian_assembler.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/i_jacobian_assembler.md
@@ -1,1 +1,2 @@
-\ogs_missing_documentation
+This setting makes it easy to switch between different ways to assemble the
+Jacobian, e.g., analytically or numerically using finite differences.

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/t_component_magnitudes.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/t_component_magnitudes.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/t_relative_epsilons.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/t_relative_epsilons.md
@@ -1,1 +1,0 @@
-\ogs_missing_documentation

--- a/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/t_type.md
+++ b/Documentation/ProjectFile/prj/processes/process/jacobian_assembler/t_type.md
@@ -1,1 +1,1 @@
-\ogs_missing_documentation
+The type of the Jacobian assembler to be used.

--- a/ProcessLib/AbstractJacobianAssembler.h
+++ b/ProcessLib/AbstractJacobianAssembler.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <vector>
+#include "BaseLib/Error.h"
 
 namespace ProcessLib
 {
@@ -41,6 +42,8 @@ public:
         std::vector<double>& /*local_Jac_data*/,
         LocalCoupledSolutions const& /*coupled_solutions*/)
     {
+        // TODO make pure virtual.
+        OGS_FATAL("not implemented.");
     }
 
     virtual ~AbstractJacobianAssembler() = default;

--- a/ProcessLib/CentralDifferencesJacobianAssembler.cpp
+++ b/ProcessLib/CentralDifferencesJacobianAssembler.cpp
@@ -134,10 +134,10 @@ createCentralDifferencesJacobianAssembler(BaseLib::ConfigTree const& config)
     config.checkConfigParameter("type", "CentralDifferences");
 
     // TODO make non-optional.
-    //! \ogs_file_param{prj__processes__process__jacobian_assembler__relative_epsilons}
+    //! \ogs_file_param{prj__processes__process__jacobian_assembler__CentralDifferences__relative_epsilons}
     auto rel_eps = config.getConfigParameterOptional<std::vector<double>>(
         "relative_epsilons");
-    //! \ogs_file_param{prj__processes__process__jacobian_assembler__component_magnitudes}
+    //! \ogs_file_param{prj__processes__process__jacobian_assembler__CentralDifferences__component_magnitudes}
     auto comp_mag = config.getConfigParameterOptional<std::vector<double>>(
         "component_magnitudes");
 

--- a/ProcessLib/CentralDifferencesJacobianAssembler.h
+++ b/ProcessLib/CentralDifferencesJacobianAssembler.h
@@ -20,7 +20,8 @@ class ConfigTree;
 namespace ProcessLib
 {
 //! Assembles the Jacobian matrix using central differences.
-class CentralDifferencesJacobianAssembler : public AbstractJacobianAssembler
+class CentralDifferencesJacobianAssembler final
+    : public AbstractJacobianAssembler
 {
 public:
     //! Constructs a new instance.

--- a/ProcessLib/CompareJacobiansJacobianAssembler.cpp
+++ b/ProcessLib/CompareJacobiansJacobianAssembler.cpp
@@ -176,9 +176,16 @@ void CompareJacobiansJacobianAssembler::assembleWithJacobian(
                         (local_Jac1.cwiseAbs() + local_Jac2.cwiseAbs()).array())
             .eval();
 
-    // the !(... <= ...) construct handles NaN correctly.
-    auto const abs_diff_mask = (!(abs_diff.cwiseAbs() <= _abs_tol)).eval();
-    auto const rel_diff_mask = (!(rel_diff.cwiseAbs() <= _rel_tol)).eval();
+    auto const abs_diff_mask =
+        (abs_diff.abs() <= _abs_tol)
+            .select(decltype(abs_diff)::Zero(abs_diff.rows(), abs_diff.cols()),
+                    decltype(abs_diff)::Ones(abs_diff.rows(), abs_diff.cols()))
+            .eval();
+    auto const rel_diff_mask =
+        (rel_diff.abs() <= _rel_tol)
+            .select(decltype(rel_diff)::Zero(rel_diff.rows(), rel_diff.cols()),
+                    decltype(rel_diff)::Ones(rel_diff.rows(), rel_diff.cols()))
+            .eval();
 
     auto const abs_diff_OK = !abs_diff_mask.any();
     auto const rel_diff_OK = !rel_diff_mask.any();

--- a/ProcessLib/CompareJacobiansJacobianAssembler.cpp
+++ b/ProcessLib/CompareJacobiansJacobianAssembler.cpp
@@ -1,0 +1,374 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "CompareJacobiansJacobianAssembler.h"
+
+#include <sstream>
+
+#include "MathLib/LinAlg/Eigen/EigenMapTools.h"
+
+#include "CreateJacobianAssembler.h"
+
+namespace
+{
+//! Dumps a \c double value as a Python script snippet.
+void dump_py(std::ofstream& fh, std::string const& var, double const val)
+{
+    fh << var << " = " << val << '\n';
+}
+
+//! Dumps a \c std::size_t value as a Python script snippet.
+void dump_py(std::ofstream& fh, std::string const& var, std::size_t const val)
+{
+    fh << var << " = " << val << '\n';
+}
+
+//! Dumps an Eigen vector as a Python script snippet.
+template <typename Vec>
+void dump_py_vec(std::ofstream& fh, std::string const& var, Vec const& val)
+{
+    fh << var << " = np.array([";
+    for (decltype(val.size()) i = 0; i < val.size(); ++i)
+    {
+        if (i != 0)
+        {
+            if (i % 8 == 0)
+            {
+                // Print at most eight entries on one line,
+                // indent with four spaces.
+                fh << ",\n    ";
+            }
+            else
+            {
+                fh << ", ";
+            }
+        }
+        fh << val[i];
+    }
+    fh << "])\n";
+}
+
+//! Dumps a \c std::vector<double> as a Python script snippet.
+void dump_py(std::ofstream& fh, std::string const& var,
+             std::vector<double> const& val)
+{
+    dump_py_vec(fh, var, val);
+}
+
+template <typename Derived>
+void dump_py(std::ofstream& fh, std::string const& var,
+             Eigen::ArrayBase<Derived> const& val,
+             std::integral_constant<int, 1>)
+{
+    dump_py_vec(fh, var, val);
+}
+
+template <typename Derived, int ColsAtCompileTime>
+void dump_py(std::ofstream& fh, std::string const& var,
+             Eigen::ArrayBase<Derived> const& val,
+             std::integral_constant<int, ColsAtCompileTime>)
+{
+    fh << var << " = np.array([\n";
+    for (std::ptrdiff_t r = 0; r < val.rows(); ++r)
+    {
+        if (r != 0)
+        {
+            fh << ",\n";
+        }
+        fh << "    [";
+        for (std::ptrdiff_t c = 0; c < val.cols(); ++c)
+        {
+            if (c != 0)
+            {
+                fh << ", ";
+            }
+            fh << val(r, c);
+        }
+        fh << "]";
+    }
+    fh << "])\n";
+}
+
+//! Dumps an Eigen array as a Python script snippet.
+template <typename Derived>
+void dump_py(std::ofstream& fh, std::string const& var,
+             Eigen::ArrayBase<Derived> const& val)
+{
+    dump_py(fh, var, val,
+            std::integral_constant<int, Derived::ColsAtCompileTime>{});
+}
+
+//! Dumps an Eigen matrix as a Python script snippet.
+template <typename Derived>
+void dump_py(std::ofstream& fh, std::string const& var,
+             Eigen::MatrixBase<Derived> const& val)
+{
+    dump_py(fh, var, val.array());
+}
+
+//! Will be printed if some consistency error is detected.
+static const std::string msg_fatal =
+    "The local matrices M or K or the local vectors b assembled with the two "
+    "different Jacobian assemblers differ.";
+
+}  // anonymous namespace
+
+namespace ProcessLib
+{
+void CompareJacobiansJacobianAssembler::assembleWithJacobian(
+    LocalAssemblerInterface& local_assembler, double const t,
+    std::vector<double> const& local_x, std::vector<double> const& local_xdot,
+    const double dxdot_dx, const double dx_dx,
+    std::vector<double>& local_M_data, std::vector<double>& local_K_data,
+    std::vector<double>& local_b_data, std::vector<double>& local_Jac_data)
+{
+    ++_counter;
+
+    auto const num_dof = local_x.size();
+    auto to_mat = [num_dof](std::vector<double> const& data) {
+        if (data.empty())
+        {
+            return Eigen::Map<Eigen::Matrix<
+                double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> const>(
+                nullptr, 0, 0);
+        }
+
+        return MathLib::toMatrix(data, num_dof, num_dof);
+    };
+
+    // First assembly -- the one whose results will be added to the global
+    // equation system finally.
+    _asm1->assembleWithJacobian(local_assembler, t, local_x, local_xdot,
+                                dxdot_dx, dx_dx, local_M_data, local_K_data,
+                                local_b_data, local_Jac_data);
+
+    auto const local_M1 = to_mat(local_M_data);
+    auto const local_K1 = to_mat(local_K_data);
+    auto const local_b1 = MathLib::toVector(local_b_data);
+
+    std::vector<double> local_M_data2, local_K_data2, local_b_data2,
+        local_Jac_data2;
+
+    // Second assembly -- used for checking only.
+    _asm2->assembleWithJacobian(local_assembler, t, local_x, local_xdot,
+                                dxdot_dx, dx_dx, local_M_data2, local_K_data2,
+                                local_b_data2, local_Jac_data2);
+
+    auto const local_M2 = to_mat(local_M_data2);
+    auto const local_K2 = to_mat(local_K_data2);
+    auto const local_b2 = MathLib::toVector(local_b_data2);
+
+    auto const local_Jac1 = MathLib::toMatrix(local_Jac_data, num_dof, num_dof);
+    auto const local_Jac2 =
+        MathLib::toMatrix(local_Jac_data2, num_dof, num_dof);
+
+    auto const abs_diff = (local_Jac2 - local_Jac1).array().eval();
+    auto const rel_diff =
+        (abs_diff == 0.0)
+            .select(abs_diff,
+                    2. * abs_diff /
+                        (local_Jac1.cwiseAbs() + local_Jac2.cwiseAbs()).array())
+            .eval();
+
+    // the !(... <= ...) construct handles NaN correctly.
+    auto const abs_diff_mask = (!(abs_diff.cwiseAbs() <= _abs_tol)).eval();
+    auto const rel_diff_mask = (!(rel_diff.cwiseAbs() <= _rel_tol)).eval();
+
+    auto const abs_diff_OK = !abs_diff_mask.any();
+    auto const rel_diff_OK = !rel_diff_mask.any();
+
+    std::ostringstream msg_tolerance;
+    bool tol_exceeded = true;
+    bool fatal_error = false;
+
+    if (abs_diff_OK)
+    {
+        tol_exceeded = false;
+    }
+    else
+    {
+        msg_tolerance << "absolute tolerance of " << _abs_tol << " exceeded";
+    }
+
+    if (rel_diff_OK)
+    {
+        tol_exceeded = false;
+    }
+    else
+    {
+        if (!msg_tolerance.str().empty())
+        {
+            msg_tolerance << " and ";
+        }
+
+        msg_tolerance << "relative tolerance of " << _rel_tol << " exceeded";
+    }
+
+    // basic consistency check if something went terribly wrong
+    auto check_equality = [&fatal_error](auto mat_or_vec1, auto mat_or_vec2) {
+        if (mat_or_vec1.rows() != mat_or_vec2.rows() ||
+            mat_or_vec1.cols() != mat_or_vec2.cols())
+        {
+            fatal_error = true;
+        }
+        else if (((mat_or_vec1 - mat_or_vec2).array().cwiseAbs() >
+                  std::numeric_limits<double>::epsilon())
+                     .any())
+        {
+            fatal_error = true;
+        }
+    };
+    check_equality(local_M1, local_M2);
+    check_equality(local_K1, local_K2);
+    check_equality(local_b1, local_b2);
+
+    if (tol_exceeded)
+    {
+        WARN("Compare Jacobians: %s", msg_tolerance.str().c_str());
+    }
+
+    bool const output = tol_exceeded || fatal_error;
+
+    if (output)
+    {
+        _log_file << "\n### counter: " << std::to_string(_counter)
+                  << " (begin)\n";
+    }
+
+    if (fatal_error)
+    {
+        _log_file << '\n'
+                  << "#######################################################\n"
+                  << "# FATAL ERROR: " << msg_fatal << '\n'
+                  << "#              You cannot expect any meaningful insights "
+                     "from the Jacobian data printed below!\n"
+                  << "#              The reason for the mentioned differences "
+                     "might be\n"
+                  << "#              (a) that the assembly routine has side "
+                     "effects or\n"
+                  << "#              (b) that the assembly routines for M, K "
+                     "and b themselves differ.\n"
+                  << "#######################################################\n"
+                  << '\n';
+    }
+
+    if (tol_exceeded)
+    {
+        _log_file << "# " << msg_tolerance.str() << "\n\n";
+    }
+
+    if (output)
+    {
+        dump_py(_log_file, "counter", _counter);
+        dump_py(_log_file, "num_dof", num_dof);
+        dump_py(_log_file, "abs_tol", _abs_tol);
+        dump_py(_log_file, "rel_tol", _rel_tol);
+
+        _log_file << '\n';
+
+        dump_py(_log_file, "local_x", local_x);
+        dump_py(_log_file, "local_x_dot", local_xdot);
+        dump_py(_log_file, "dxdot_dx", dxdot_dx);
+        dump_py(_log_file, "dx_dx", dx_dx);
+
+        _log_file << '\n';
+
+        dump_py(_log_file, "Jacobian_1", local_Jac1);
+        dump_py(_log_file, "Jacobian_2", local_Jac2);
+
+        _log_file << '\n';
+
+        _log_file << "# Jacobian_2 - Jacobian_1\n";
+        dump_py(_log_file, "abs_diff", abs_diff);
+        _log_file << "# componentwise: 2 * abs_diff / (|Jacobian_1| + "
+                     "|Jacobian_2|)\n";
+        dump_py(_log_file, "rel_diff", rel_diff);
+
+        _log_file << '\n';
+
+        _log_file << "# Masks: 0 ... tolerance met, 1 ... tolerance exceeded\n";
+        dump_py(_log_file, "abs_diff_mask", abs_diff_mask);
+        dump_py(_log_file, "rel_diff_mask", rel_diff_mask);
+
+        _log_file << '\n';
+
+        dump_py(_log_file, "M_1", local_M1);
+        dump_py(_log_file, "M_2", local_M2);
+        if (fatal_error)
+        {
+            dump_py(_log_file, "delta_M", local_M2 - local_M1);
+            _log_file << '\n';
+        }
+
+        dump_py(_log_file, "K_1", local_K1);
+        dump_py(_log_file, "K_2", local_K2);
+        if (fatal_error)
+        {
+            dump_py(_log_file, "delta_K", local_K2 - local_K1);
+            _log_file << '\n';
+        }
+
+        dump_py(_log_file, "b_1", local_b_data);
+        dump_py(_log_file, "b_2", local_b_data2);
+        if (fatal_error)
+        {
+            dump_py(_log_file, "delta_b", local_b2 - local_b1);
+        }
+
+        _log_file << '\n';
+
+        _log_file << "### counter: " << std::to_string(_counter) << " (end)\n";
+    }
+
+    if (fatal_error)
+    {
+        OGS_FATAL("%s", msg_fatal.c_str());
+    }
+
+    if (tol_exceeded && _fail_on_error)
+    {
+        OGS_FATAL(
+            "OGS failed, because the two Jacobian implementations returned "
+            "different results.");
+    }
+}
+
+std::unique_ptr<CompareJacobiansJacobianAssembler>
+createCompareJacobiansJacobianAssembler(BaseLib::ConfigTree const& config)
+{
+    // TODO doc script corner case: Parameter could occur at different
+    // locations.
+    //! \ogs_file_param{prj__processes__process__jacobian_assembler__type}
+    config.checkConfigParameter("type", "CompareJacobians");
+
+    //! \ogs_file_param{prj__processes__process__jacobian_assembler__CompareJacobians__jacobian_assembler}
+    auto asm1 =
+        createJacobianAssembler(config.getConfigSubtree("jacobian_assembler"));
+
+    //! \ogs_file_param{prj__processes__process__jacobian_assembler__CompareJacobians__reference_jacobian_assembler}
+    auto asm2 = createJacobianAssembler(
+        config.getConfigSubtree("reference_jacobian_assembler"));
+
+    //! \ogs_file_param{prj__processes__process__jacobian_assembler__CompareJacobians__abs_tol}
+    auto const abs_tol = config.getConfigParameter<double>("abs_tol");
+    //! \ogs_file_param{prj__processes__process__jacobian_assembler__CompareJacobians__rel_tol}
+    auto const rel_tol = config.getConfigParameter<double>("rel_tol");
+
+    //! \ogs_file_param{prj__processes__process__jacobian_assembler__CompareJacobians__fail_on_error}
+    auto const fail_on_error = config.getConfigParameter<bool>("fail_on_error");
+
+    //! \ogs_file_param{prj__processes__process__jacobian_assembler__CompareJacobians__log_file}
+    auto const log_file = config.getConfigParameter<std::string>("log_file");
+
+    return std::make_unique<CompareJacobiansJacobianAssembler>(
+        std::move(asm1), std::move(asm2), abs_tol, rel_tol, fail_on_error,
+        log_file);
+}
+
+}  // namespace ProcessLib

--- a/ProcessLib/CompareJacobiansJacobianAssembler.cpp
+++ b/ProcessLib/CompareJacobiansJacobianAssembler.cpp
@@ -29,7 +29,7 @@ void dump_py(std::ofstream& fh, std::string const& var, std::size_t const val)
     fh << var << " = " << val << '\n';
 }
 
-//! Dumps an Eigen vector as a Python script snippet.
+//! Dumps an arbitrary vector as a Python script snippet.
 template <typename Vec>
 void dump_py_vec(std::ofstream& fh, std::string const& var, Vec const& val)
 {
@@ -61,6 +61,7 @@ void dump_py(std::ofstream& fh, std::string const& var,
     dump_py_vec(fh, var, val);
 }
 
+//! Dumps an Eigen vector (array with 1 column) as a Python script snippet.
 template <typename Derived>
 void dump_py(std::ofstream& fh, std::string const& var,
              Eigen::ArrayBase<Derived> const& val,
@@ -69,6 +70,7 @@ void dump_py(std::ofstream& fh, std::string const& var,
     dump_py_vec(fh, var, val);
 }
 
+//! Dumps an Eigen array as a Python script snippet.
 template <typename Derived, int ColsAtCompileTime>
 void dump_py(std::ofstream& fh, std::string const& var,
              Eigen::ArrayBase<Derived> const& val,

--- a/ProcessLib/CompareJacobiansJacobianAssembler.cpp
+++ b/ProcessLib/CompareJacobiansJacobianAssembler.cpp
@@ -18,20 +18,20 @@
 namespace
 {
 //! Dumps a \c double value as a Python script snippet.
-void dump_py(std::ofstream& fh, std::string const& var, double const val)
+void dump_py(std::ostream& fh, std::string const& var, double const val)
 {
     fh << var << " = " << val << '\n';
 }
 
 //! Dumps a \c std::size_t value as a Python script snippet.
-void dump_py(std::ofstream& fh, std::string const& var, std::size_t const val)
+void dump_py(std::ostream& fh, std::string const& var, std::size_t const val)
 {
     fh << var << " = " << val << '\n';
 }
 
 //! Dumps an arbitrary vector as a Python script snippet.
 template <typename Vec>
-void dump_py_vec(std::ofstream& fh, std::string const& var, Vec const& val)
+void dump_py_vec(std::ostream& fh, std::string const& var, Vec const& val)
 {
     fh << var << " = np.array([";
     for (decltype(val.size()) i = 0; i < val.size(); ++i)
@@ -55,7 +55,7 @@ void dump_py_vec(std::ofstream& fh, std::string const& var, Vec const& val)
 }
 
 //! Dumps a \c std::vector<double> as a Python script snippet.
-void dump_py(std::ofstream& fh, std::string const& var,
+void dump_py(std::ostream& fh, std::string const& var,
              std::vector<double> const& val)
 {
     dump_py_vec(fh, var, val);
@@ -63,7 +63,7 @@ void dump_py(std::ofstream& fh, std::string const& var,
 
 //! Dumps an Eigen vector (array with 1 column) as a Python script snippet.
 template <typename Derived>
-void dump_py(std::ofstream& fh, std::string const& var,
+void dump_py(std::ostream& fh, std::string const& var,
              Eigen::ArrayBase<Derived> const& val,
              std::integral_constant<int, 1>)
 {
@@ -72,7 +72,7 @@ void dump_py(std::ofstream& fh, std::string const& var,
 
 //! Dumps an Eigen array as a Python script snippet.
 template <typename Derived, int ColsAtCompileTime>
-void dump_py(std::ofstream& fh, std::string const& var,
+void dump_py(std::ostream& fh, std::string const& var,
              Eigen::ArrayBase<Derived> const& val,
              std::integral_constant<int, ColsAtCompileTime>)
 {
@@ -99,7 +99,7 @@ void dump_py(std::ofstream& fh, std::string const& var,
 
 //! Dumps an Eigen array as a Python script snippet.
 template <typename Derived>
-void dump_py(std::ofstream& fh, std::string const& var,
+void dump_py(std::ostream& fh, std::string const& var,
              Eigen::ArrayBase<Derived> const& val)
 {
     dump_py(fh, var, val,
@@ -108,7 +108,7 @@ void dump_py(std::ofstream& fh, std::string const& var,
 
 //! Dumps an Eigen matrix as a Python script snippet.
 template <typename Derived>
-void dump_py(std::ofstream& fh, std::string const& var,
+void dump_py(std::ostream& fh, std::string const& var,
              Eigen::MatrixBase<Derived> const& val)
 {
     dump_py(fh, var, val.array());

--- a/ProcessLib/CompareJacobiansJacobianAssembler.cpp
+++ b/ProcessLib/CompareJacobiansJacobianAssembler.cpp
@@ -380,11 +380,13 @@ void CompareJacobiansJacobianAssembler::assembleWithJacobian(
 
     if (fatal_error)
     {
+        _log_file << std::flush;
         OGS_FATAL("%s", msg_fatal.c_str());
     }
 
     if (tol_exceeded && _fail_on_error)
     {
+        _log_file << std::flush;
         OGS_FATAL(
             "OGS failed, because the two Jacobian implementations returned "
             "different results.");

--- a/ProcessLib/CompareJacobiansJacobianAssembler.cpp
+++ b/ProcessLib/CompareJacobiansJacobianAssembler.cpp
@@ -293,7 +293,7 @@ void CompareJacobiansJacobianAssembler::assembleWithJacobian(
 
         _log_file << "# Jacobian_2 - Jacobian_1\n";
         dump_py(_log_file, "abs_diff", abs_diff);
-        _log_file << "# componentwise: 2 * abs_diff / (|Jacobian_1| + "
+        _log_file << "# Componentwise: 2 * abs_diff / (|Jacobian_1| + "
                      "|Jacobian_2|)\n";
         dump_py(_log_file, "rel_diff", rel_diff);
 

--- a/ProcessLib/CompareJacobiansJacobianAssembler.h
+++ b/ProcessLib/CompareJacobiansJacobianAssembler.h
@@ -1,0 +1,87 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include <fstream>
+#include <limits>
+#include <memory>
+#include "AbstractJacobianAssembler.h"
+
+namespace BaseLib
+{
+class ConfigTree;
+}  // namespace BaseLib
+
+namespace ProcessLib
+{
+//! Assembles the Jacobian matrix using two different Jacobian assemblers
+//! and compares the assembled local Jacobian matrices.
+//!
+//! If the provided tolerances are exceeded, debugging information is logged in
+//! the form of a Python script.
+class CompareJacobiansJacobianAssembler final : public AbstractJacobianAssembler
+{
+public:
+    CompareJacobiansJacobianAssembler(
+        std::unique_ptr<AbstractJacobianAssembler>&& asm1,
+        std::unique_ptr<AbstractJacobianAssembler>&& asm2,
+        double abs_tol,
+        double rel_tol,
+        bool fail_on_error,
+        std::string const& log_file_path)
+        : _asm1(std::move(asm1)),
+          _asm2(std::move(asm2)),
+          _abs_tol(abs_tol),
+          _rel_tol(rel_tol),
+          _fail_on_error(fail_on_error),
+          _log_file(log_file_path)
+    {
+        _log_file.precision(std::numeric_limits<double>::digits10);
+        _log_file << "#!/usr/bin/env python\n"
+                     "import numpy as np\n"
+                     "from numpy import nan\n"
+                  << std::endl;
+    }
+
+    void assembleWithJacobian(LocalAssemblerInterface& local_assembler,
+                              double const t,
+                              std::vector<double> const& local_x,
+                              std::vector<double> const& local_xdot,
+                              const double dxdot_dx, const double dx_dx,
+                              std::vector<double>& local_M_data,
+                              std::vector<double>& local_K_data,
+                              std::vector<double>& local_b_data,
+                              std::vector<double>& local_Jac_data) override;
+
+private:
+    std::unique_ptr<AbstractJacobianAssembler> _asm1;
+    std::unique_ptr<AbstractJacobianAssembler> _asm2;
+
+    // TODO change to matrix
+    double const _abs_tol;
+    double const _rel_tol;
+
+    //! Whether to abort if the tolerances are exceeded.
+    bool const _fail_on_error;
+
+    //! Path where a Python script will be placed, which contains information
+    //! about exceeded tolerances and assembled local matrices.
+    std::ofstream _log_file;
+
+    //! Counter used for identifying blocks in the \c _log_file. Is be
+    //! incremented upon each call of the assembly routine, i.e., for each
+    //! element in each iteration etc.
+    std::size_t _counter = 0;
+};
+
+std::unique_ptr<CompareJacobiansJacobianAssembler>
+createCompareJacobiansJacobianAssembler(BaseLib::ConfigTree const& config);
+
+}  // namespace ProcessLib

--- a/ProcessLib/CompareJacobiansJacobianAssembler.h
+++ b/ProcessLib/CompareJacobiansJacobianAssembler.h
@@ -75,7 +75,7 @@ private:
     //! about exceeded tolerances and assembled local matrices.
     std::ofstream _log_file;
 
-    //! Counter used for identifying blocks in the \c _log_file. Is be
+    //! Counter used for identifying blocks in the \c _log_file. It is
     //! incremented upon each call of the assembly routine, i.e., for each
     //! element in each iteration etc.
     std::size_t _counter = 0;

--- a/ProcessLib/CreateJacobianAssembler.cpp
+++ b/ProcessLib/CreateJacobianAssembler.cpp
@@ -12,6 +12,7 @@
 
 #include "AnalyticalJacobianAssembler.h"
 #include "CentralDifferencesJacobianAssembler.h"
+#include "CompareJacobiansJacobianAssembler.h"
 
 namespace ProcessLib
 {
@@ -31,6 +32,10 @@ std::unique_ptr<AbstractJacobianAssembler> createJacobianAssembler(
     if (type == "CentralDifferences")
     {
         return createCentralDifferencesJacobianAssembler(*config);
+    }
+    if (type == "CompareJacobians")
+    {
+        return createCompareJacobiansJacobianAssembler(*config);
     }
 
     OGS_FATAL("Unknown Jacobian assembler type: `%s'.", type.c_str());


### PR DESCRIPTION
As requested, here comes a simple implementation of the Jacobian tester.

Configuration in the `prj` file:
```xml
<OpenGeoSysProject>
    <processes>
        <process>
            <jacobian_assembler>
                <type>CompareJacobians</type>
                <jacobian_assembler>
                    <type>CentralDifferences</type>
                    <component_magnitudes>1 1</component_magnitudes>
                    <relative_epsilons>1e-8 1e-8</relative_epsilons>
                </jacobian_assembler>
                <reference_jacobian_assembler>
                    <type>CentralDifferences</type>
                    <component_magnitudes>1 1</component_magnitudes>
                    <relative_epsilons>1e-6 1e-6</relative_epsilons>
                </reference_jacobian_assembler>
                <abs_tol>1e-18</abs_tol>
                <rel_tol>1e-7</rel_tol>
                <fail_on_error>true</fail_on_error>
                <log_file>/tmp/test.log</log_file>
            </jacobian_assembler>
```

<details>
  <summary>Sample (Python) log file (Click to expand)</summary>

```python
#!/usr/bin/env python
import numpy as np
from numpy import nan


### counter: 1 (begin)
# absolute tolerance of 1e-18 exceeded and relative tolerance of 1e-07 exceeded

counter = 1
num_dof = 8
abs_tol = 1e-18
rel_tol = 1e-07

local_x = np.array([2, 1, 1, 2, 1, 0, 0, 1])
local_x_dot = np.array([10, 0, 0, 10, 10, 0, 0, 10])
dxdot_dx = 10
dx_dx = 1

Jacobian_1 = np.array([
    [1.93984028211111e-10, -2.78579862194445e-11, -8.88539932722222e-11, -5.28579862194445e-11, -1.66666679687575e-11, 1.66666686149923e-11, 8.33333317658516e-12, -8.33333511528972e-12],
    [-6.11913195527778e-11, 2.27317361544444e-10, -3.61913195527778e-11, -1.05520659938889e-10, -1.66666663531703e-11, 1.66666650607006e-11, 8.33333188411546e-12, -8.33333446905487e-12],
    [-1.05520659938889e-10, -3.61913195527778e-11, 2.27317361544444e-10, -6.11913195527778e-11, -8.33333446905487e-12, 8.33333188411546e-12, 1.666666764564e-11, -1.66666650607006e-11],
    [-5.28579862194445e-11, -8.88539932722222e-11, -2.78579862194445e-11, 1.93984028211111e-10, -8.33333511528972e-12, 8.33333285346774e-12, 1.66666669994052e-11, -1.66666679687575e-11],
    [0, 0, 0, 0, 6.66666666666667e-06, -1.66666666666667e-06, -3.33333333333333e-06, -1.66666666666667e-06],
    [0, 0, 0, 0, -1.66666666666667e-06, 6.66666666666667e-06, -1.66666666666667e-06, -3.33333333333333e-06],
    [0, 0, 0, 0, -3.33333333333333e-06, -1.66666666666667e-06, 6.66666666666667e-06, -1.66666666666667e-06],
    [0, 0, 0, 0, -1.66666666666667e-06, -3.33333333333333e-06, -1.66666666666667e-06, 6.66666666666667e-06]])
Jacobian_2 = np.array([
    [1.93984028211111e-10, -2.78579862194445e-11, -8.88539932722222e-11, -5.28579862194445e-11, -1.66666666601319e-11, 1.66666666569007e-11, 8.33333333168153e-12, -8.33333335429975e-12],
    [-6.11913195527778e-11, 2.27317361544444e-10, -3.61913195527778e-11, -1.05520659938889e-10, -1.66666666472072e-11, 1.66666666472072e-11, 8.33333334137505e-12, -8.33333333168153e-12],
    [-1.05520659938889e-10, -3.61913195527778e-11, 2.27317361544444e-10, -6.11913195527778e-11, -8.33333334460623e-12, 8.33333334137505e-12, 1.66666666601319e-11, -1.66666666730566e-11],
    [-5.28579862194445e-11, -8.88539932722222e-11, -2.78579862194445e-11, 1.93984028211111e-10, -8.33333335753092e-12, 8.33333332845035e-12, 1.6666666643976e-11, -1.66666666569007e-11],
    [0, 0, 0, 0, 6.66666666666667e-06, -1.66666666666667e-06, -3.33333333333333e-06, -1.66666666666667e-06],
    [0, 0, 0, 0, -1.66666666666667e-06, 6.66666666666667e-06, -1.66666666666667e-06, -3.33333333333333e-06],
    [0, 0, 0, 0, -3.33333333333333e-06, -1.66666666666667e-06, 6.66666666666667e-06, -1.66666666666667e-06],
    [0, 0, 0, 0, -1.66666666666667e-06, -3.33333333333333e-06, -1.66666666666667e-06, 6.66666666666667e-06]])

# Jacobian_2 - Jacobian_1
abs_diff = np.array([
    [0, 0, 0, 0, 1.30862557845303e-18, -1.95809160627787e-18, 1.55096364853693e-19, 1.76098997594297e-18],
    [0, 0, 0, 0, -2.94036858368459e-19, 1.58650656548256e-18, 1.45725959477115e-18, 1.13737334226041e-18],
    [0, 0, 0, 0, 1.12444864518927e-18, 1.45725959477115e-18, -9.85508151674506e-19, -1.61235595962485e-18],
    [0, 0, 0, 0, 1.75775880167518e-18, 4.74982617364434e-19, -3.55429169456379e-19, 1.31185675272082e-18],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0]])
# componentwise: 2 * abs_diff / (|Jacobian_1| + |Jacobian_2|)
rel_diff = np.array([
    [0, 0, 0, 0, 7.85175316554661e-08, -1.17485489544093e-07, 1.86115639593274e-08, 2.1131877425367e-07],
    [0, 0, 0, 0, -1.76422116783299e-08, 9.5190398570701e-08, 1.74871166493748e-07, 1.36484791784253e-07],
    [0, 0, 0, 0, 1.34933828136612e-07, 1.74871166493748e-07, -5.91304873754473e-08, -9.6741362219846e-08],
    [0, 0, 0, 0, 2.10931033342587e-07, 5.69979157415116e-08, -2.13257499690227e-08, 7.8711402111628e-08],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0]])

# Masks: 0 ... tolerance met, 1 ... tolerance exceeded
abs_diff_mask = np.array([
    [0, 0, 0, 0, 1, 1, 0, 1],
    [0, 0, 0, 0, 0, 1, 1, 1],
    [0, 0, 0, 0, 1, 1, 0, 1],
    [0, 0, 0, 0, 1, 0, 0, 1],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0]])
rel_diff_mask = np.array([
    [0, 0, 0, 0, 0, 1, 0, 1],
    [0, 0, 0, 0, 0, 0, 1, 1],
    [0, 0, 0, 0, 1, 1, 0, 0],
    [0, 0, 0, 0, 1, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0]])

M_1 = np.array([
    [1.08506944444444e-12, 5.42534722222222e-13, 2.71267361111111e-13, 5.42534722222222e-13, 0, 0, 0, 0],
    [5.42534722222222e-13, 1.08506944444444e-12, 5.42534722222222e-13, 2.71267361111111e-13, 0, 0, 0, 0],
    [2.71267361111111e-13, 5.42534722222222e-13, 1.08506944444444e-12, 5.42534722222222e-13, 0, 0, 0, 0],
    [5.42534722222222e-13, 2.71267361111111e-13, 5.42534722222222e-13, 1.08506944444444e-12, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0]])
M_2 = np.array([
    [1.08506944444444e-12, 5.42534722222222e-13, 2.71267361111111e-13, 5.42534722222222e-13, 0, 0, 0, 0],
    [5.42534722222222e-13, 1.08506944444444e-12, 5.42534722222222e-13, 2.71267361111111e-13, 0, 0, 0, 0],
    [2.71267361111111e-13, 5.42534722222222e-13, 1.08506944444444e-12, 5.42534722222222e-13, 0, 0, 0, 0],
    [5.42534722222222e-13, 2.71267361111111e-13, 5.42534722222222e-13, 1.08506944444444e-12, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0],
    [0, 0, 0, 0, 0, 0, 0, 0]])
K_1 = np.array([
    [1.83133333766667e-10, -3.32833334416667e-11, -9.15666668833333e-11, -5.82833334416667e-11, 0, 0, 0, 0],
    [-6.6616666775e-11, 2.164666671e-10, -4.1616666775e-11, -1.0823333355e-10, 0, 0, 0, 0],
    [-1.0823333355e-10, -4.1616666775e-11, 2.164666671e-10, -6.6616666775e-11, 0, 0, 0, 0],
    [-5.82833334416667e-11, -9.15666668833333e-11, -3.32833334416667e-11, 1.83133333766667e-10, 0, 0, 0, 0],
    [0, 0, 0, 0, 6.66666666666667e-06, -1.66666666666667e-06, -3.33333333333333e-06, -1.66666666666667e-06],
    [0, 0, 0, 0, -1.66666666666667e-06, 6.66666666666667e-06, -1.66666666666667e-06, -3.33333333333333e-06],
    [0, 0, 0, 0, -3.33333333333333e-06, -1.66666666666667e-06, 6.66666666666667e-06, -1.66666666666667e-06],
    [0, 0, 0, 0, -1.66666666666667e-06, -3.33333333333333e-06, -1.66666666666667e-06, 6.66666666666667e-06]])
K_2 = np.array([
    [1.83133333766667e-10, -3.32833334416667e-11, -9.15666668833333e-11, -5.82833334416667e-11, 0, 0, 0, 0],
    [-6.6616666775e-11, 2.164666671e-10, -4.1616666775e-11, -1.0823333355e-10, 0, 0, 0, 0],
    [-1.0823333355e-10, -4.1616666775e-11, 2.164666671e-10, -6.6616666775e-11, 0, 0, 0, 0],
    [-5.82833334416667e-11, -9.15666668833333e-11, -3.32833334416667e-11, 1.83133333766667e-10, 0, 0, 0, 0],
    [0, 0, 0, 0, 6.66666666666667e-06, -1.66666666666667e-06, -3.33333333333333e-06, -1.66666666666667e-06],
    [0, 0, 0, 0, -1.66666666666667e-06, 6.66666666666667e-06, -1.66666666666667e-06, -3.33333333333333e-06],
    [0, 0, 0, 0, -3.33333333333333e-06, -1.66666666666667e-06, 6.66666666666667e-06, -1.66666666666667e-06],
    [0, 0, 0, 0, -1.66666666666667e-06, -3.33333333333333e-06, -1.66666666666667e-06, 6.66666666666667e-06]])
b_1 = np.array([0, 0, 0, 0, 0, 0, 0, 0])
b_2 = np.array([0, 0, 0, 0, 0, 0, 0, 0])

### counter: 1 (end)
```
</details>


A convenient visualization of the results is possible, e.g., with Spyder (or any other Python IDE):
![spyder](https://user-images.githubusercontent.com/10530151/46740109-4fc6d880-cca2-11e8-8de4-7940aa9d65ff.png)
