### PR TITLE
[CMake] Do not build partmesh on gcc 5.4.

### DIFF
--- a/Applications/Utils/ModelPreparation/PartitionMesh/CMakeLists.txt
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(COMPILER_IS_GCC AND CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "5.4")
+    message(WARNING "gcc 5.4 segfaults when compiling partmesh!\n"
+        "Disabled partmesh compilation!")
+    return()
+endif()
 add_executable(partmesh PartitionMesh.cpp Metis.cpp NodeWiseMeshPartitioner.cpp)
 
 set_target_properties(partmesh PROPERTIES FOLDER Utilities)


### PR DESCRIPTION
Closes #2239.