### PR TITLE
Liquid flow improvements

### DIFF
--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -36,6 +36,23 @@ namespace ProcessLib
 
 namespace LiquidFlow
 {
+
+template <typename NodalRowVectorType, typename GlobalDimNodalMatrixType>
+struct IntegrationPointData final
+{
+    IntegrationPointData(NodalRowVectorType const& N_,
+                         GlobalDimNodalMatrixType const& dNdx_,
+                         double const& integration_weight_)
+        : N(N_), dNdx(dNdx_), integration_weight(integration_weight_)
+    {}
+
+    NodalRowVectorType const N;
+    GlobalDimNodalMatrixType const dNdx;
+    double const integration_weight;
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
+};
+
 const unsigned NUM_NODAL_DOF = 1;
 
 class LiquidFlowLocalAssemblerInterface
@@ -62,7 +79,9 @@ class LiquidFlowLocalAssembler : public LiquidFlowLocalAssemblerInterface
 
     using NodalMatrixType = typename LocalAssemblerTraits::LocalMatrix;
     using NodalVectorType = typename LocalAssemblerTraits::LocalVector;
-    using GlobalDimVectorType = typename ShapeMatricesType::GlobalDimVectorType;
+    using NodalRowVectorType = typename ShapeMatricesType::NodalRowVectorType;
+    using GlobalDimNodalMatrixType =
+        typename ShapeMatricesType::GlobalDimNodalMatrixType;
 
     using MatrixOfVelocityAtIntegrationPoints = Eigen::Map<
         Eigen::Matrix<double, GlobalDim, Eigen::Dynamic, Eigen::RowMajor>>;
@@ -94,6 +113,7 @@ public:
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;
 
+
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         const unsigned integration_point) const override
     {
@@ -113,6 +133,11 @@ private:
     MeshLib::Element const& _element;
 
     IntegrationMethod const _integration_method;
+    std::vector<
+        IntegrationPointData<NodalRowVectorType, GlobalDimNodalMatrixType>,
+        Eigen::aligned_allocator<
+            IntegrationPointData<NodalRowVectorType, GlobalDimNodalMatrixType>>>
+        _ip_data;
     std::vector<ShapeMatrices, Eigen::aligned_allocator<ShapeMatrices>>
         _shape_matrices;
 

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -40,10 +40,12 @@ namespace LiquidFlow
 template <typename NodalRowVectorType, typename GlobalDimNodalMatrixType>
 struct IntegrationPointData final
 {
-    IntegrationPointData(NodalRowVectorType const& N_,
-                         GlobalDimNodalMatrixType const& dNdx_,
-                         double const& integration_weight_)
-        : N(N_), dNdx(dNdx_), integration_weight(integration_weight_)
+    explicit IntegrationPointData(NodalRowVectorType const& N_,
+                                  GlobalDimNodalMatrixType const& dNdx_,
+                                  double const& integration_weight_)
+        : N(N_),
+          dNdx(dNdx_),
+          integration_weight(integration_weight_)
     {}
 
     NodalRowVectorType const N;
@@ -106,6 +108,25 @@ public:
           _reference_temperature(reference_temperature),
           _material_properties(material_propertries)
     {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+        _ip_data.reserve(n_integration_points);
+
+        /*
+        auto const& shape_matrices =
+            initShapeMatrices<ShapeFunction, ShapeMatricesType,
+                              IntegrationMethod, GlobalDim>(
+                element, is_axially_symmetric, _integration_method);
+        */
+
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            _ip_data.emplace_back(
+                _shape_matrices[ip].N, _shape_matrices[ip].dNdx,
+                _integration_method.getWeightedPoint(ip).getWeight() *
+                    _shape_matrices[ip].integralMeasure *
+                    _shape_matrices[ip].detJ);
+        }
     }
 
     void assemble(double const t, std::vector<double> const& local_x,


### PR DESCRIPTION
Use IntegrationPointData to accelerate the assembly. This saves ~ 3 % of the total run time for the two large benchmark cases.