### PR TITLE
[App] Add project dir to python module path.

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -200,6 +200,11 @@ ProjectData::ProjectData(BaseLib::ConfigTree const& project_config,
     {
 #ifdef OGS_USE_PYTHON
         namespace py = pybind11;
+
+        // Append project's directory to python's module search path.
+        py::module::import("sys").attr("path").attr("append")(
+            project_directory);
+
         auto const script_path =
             BaseLib::copyPathToFileName(*python_script, project_directory);
 


### PR DESCRIPTION
When the python modules are not in the current working directory but
in the projects directory, the user modules would not be found.
Adding project's directory to the python's module path allows to run ogs
from a different directory than the project file.

The error occurs, for example, if running the python piston  benchmark from the build directory like
```sh
bin/ogs ../ogs_source_dir/Tests/Data/Mechanics/Linear/PythonPiston/piston.prj
```
It would fail to load the `chamber` module from the [project directory](https://github.com/ufz/ogs/tree/master/Tests/Data/Mechanics/Linear/PythonPiston).