### PR TITLE
Use new overloaded getPropertyVector

### DIFF
--- a/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
+++ b/Applications/DataExplorer/DataView/DirectConditionGenerator.cpp
@@ -97,22 +97,23 @@ const std::vector< std::pair<std::size_t,double> >& DirectConditionGenerator::di
     const std::size_t nNodes(surface_mesh->getNumberOfNodes());
     const double no_data(raster->getHeader().no_data);
 
-    auto const* const node_id_pv =
-        surface_mesh->getProperties().getPropertyVector<int>(prop_name);
-    if (!node_id_pv)
+    MeshLib::PropertyVector<int> const* node_id_pv = nullptr;
+    try
     {
-        ERR(
-            "Need subsurface node ids, but the property \"%s\" is not "
-            "available.",
-            prop_name.c_str());
+        node_id_pv = surface_mesh->getProperties().getPropertyVector<int>(
+            prop_name, MeshLib::MeshItemType::Node, 1);
+    }
+    catch (std::runtime_error const& e)
+    {
+        WARN("%s", e.what());
         return _direct_values;
     }
 
     _direct_values.reserve(nNodes);
-    for (std::size_t i=0; i<nNodes; ++i)
+    for (std::size_t i = 0; i < nNodes; ++i)
     {
         double val(raster->getValueAtPoint(*surface_nodes[i]));
-        val = (val == no_data) ? 0 : ((val*node_area_vec[i])/scaling);
+        val = (val == no_data) ? 0 : ((val * node_area_vec[i]) / scaling);
         _direct_values.emplace_back((*node_id_pv)[i], val);
     }
 

--- a/Applications/DataExplorer/DataView/ElementTreeModel.cpp
+++ b/Applications/DataExplorer/DataView/ElementTreeModel.cpp
@@ -65,9 +65,11 @@ void ElementTreeModel::setElement(vtkUnstructuredGridAlgorithm const*const grid,
     auto* typeItem = new TreeItem(typeData, elemItem);
     elemItem->appendChild(typeItem);
 
-    MeshLib::PropertyVector<int> const*const mat_ids =
-        mesh->getProperties().existsPropertyVector<int>("MaterialIDs")
-            ? mesh->getProperties().getPropertyVector<int>("MaterialIDs")
+    MeshLib::PropertyVector<int> const* const mat_ids =
+        mesh->getProperties().existsPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1)
+            ? mesh->getProperties().getPropertyVector<int>(
+                  "MaterialIDs", MeshLib::MeshItemType::Cell, 1)
             : nullptr;
     QString matIdString = !mat_ids ? QString("not defined") : QString::number((*mat_ids)[elem->getID()]);
     QList<QVariant> materialData;

--- a/Applications/Utils/MeshEdit/queryMesh.cpp
+++ b/Applications/Utils/MeshEdit/queryMesh.cpp
@@ -68,9 +68,11 @@ int main(int argc, char *argv[])
     }
     selected_node_ids.insert(selected_node_ids.end(), nodeId_arg.getValue().begin(), nodeId_arg.getValue().end());
 
-    MeshLib::PropertyVector<int> const*const materialIds =
-        mesh->getProperties().existsPropertyVector<int>("MaterialIDs")
-            ? mesh->getProperties().getPropertyVector<int>("MaterialIDs")
+    MeshLib::PropertyVector<int> const* const materialIds =
+        mesh->getProperties().existsPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1)
+            ? mesh->getProperties().getPropertyVector<int>(
+                  "MaterialIDs", MeshLib::MeshItemType::Cell, 1)
             : nullptr;
     for (auto ele_id : eleId_arg.getValue())
     {

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -600,7 +600,8 @@ std::vector<Partition> NodeWiseMeshPartitioner::partitionOtherMesh(
     bool const is_mixed_high_order_linear_elems) const
 {
     auto const& bulk_node_ids =
-        mesh.getProperties().getPropertyVector<std::size_t>("bulk_node_ids");
+        mesh.getProperties().getPropertyVector<std::size_t>(
+            "bulk_node_ids", MeshLib::MeshItemType::Node, 1);
 
     std::vector<Partition> partitions(_partitions.size());
     for (std::size_t part_id = 0; part_id < _partitions.size(); part_id++)

--- a/Applications/Utils/ModelPreparation/PartitionMesh/PartitionMesh.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/PartitionMesh.cpp
@@ -187,11 +187,11 @@ int main(int argc, char* argv[])
             partitionProperties(mesh->getProperties(), partitions);
         mesh_partitioner.renumberBulkNodeIdsProperty(
             partitioned_properties.getPropertyVector<std::size_t>(
-                "bulk_node_ids"),
+                "bulk_node_ids", MeshLib::MeshItemType::Node, 1),
             partitions);
         mesh_partitioner.renumberBulkElementIdsProperty(
             partitioned_properties.getPropertyVector<std::size_t>(
-                "bulk_element_ids"),
+                "bulk_element_ids", MeshLib::MeshItemType::Cell, 1),
             partitions);
         mesh_partitioner.writeOtherMesh(output_file_name_wo_extension,
                                         partitions, partitioned_properties);

--- a/MaterialLib/PorousMedium/CreatePorousMediaProperties.cpp
+++ b/MaterialLib/PorousMedium/CreatePorousMediaProperties.cpp
@@ -77,10 +77,12 @@ PorousMediaProperties createPorousMediaProperties(
     BaseLib::reorderVector(storage_models, mat_ids);
 
     std::vector<int> material_ids(mesh.getNumberOfElements());
-    if (mesh.getProperties().existsPropertyVector<int>("MaterialIDs"))
+    if (mesh.getProperties().existsPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1))
     {
         auto const& mesh_material_ids =
-            mesh.getProperties().getPropertyVector<int>("MaterialIDs");
+            mesh.getProperties().getPropertyVector<int>(
+                "MaterialIDs", MeshLib::MeshItemType::Cell, 1);
         material_ids.reserve(mesh_material_ids->size());
         std::copy(mesh_material_ids->cbegin(), mesh_material_ids->cend(),
                   material_ids.begin());

--- a/MeshGeoToolsLib/AppendLinesAlongPolyline.cpp
+++ b/MeshGeoToolsLib/AppendLinesAlongPolyline.cpp
@@ -33,14 +33,16 @@ std::unique_ptr<MeshLib::Mesh> appendLinesAlongPolylines(
     std::vector<MeshLib::Element*> vec_new_eles = MeshLib::copyElementVector(mesh.getElements(), vec_new_nodes);
 
     std::vector<int> new_mat_ids;
+    try
     {
-        if (mesh.getProperties().existsPropertyVector<int>("MaterialIDs")) {
-            auto ids =
-                mesh.getProperties().getPropertyVector<int>("MaterialIDs");
-            new_mat_ids.reserve(ids->size());
-            std::copy(ids->cbegin(), ids->cend(),
-                      std::back_inserter(new_mat_ids));
-        }
+        auto ids = mesh.getProperties().getPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1);
+        new_mat_ids.reserve(ids->size());
+        std::copy(ids->cbegin(), ids->cend(), std::back_inserter(new_mat_ids));
+    }
+    catch (std::runtime_error const& e)
+    {
+        WARN("%s", e.what());
     }
     int max_matID(0);
     if (!new_mat_ids.empty())

--- a/MeshGeoToolsLib/IdentifySubdomainMesh.cpp
+++ b/MeshGeoToolsLib/IdentifySubdomainMesh.cpp
@@ -99,8 +99,8 @@ std::vector<std::vector<std::size_t>> identifySubdomainMeshElements(
     MeshLib::Mesh const& subdomain_mesh, MeshLib::Mesh const& bulk_mesh)
 {
     auto& properties = subdomain_mesh.getProperties();
-    auto const& bulk_node_ids =
-        *properties.getPropertyVector<std::size_t>("bulk_node_ids");
+    auto const& bulk_node_ids = *properties.getPropertyVector<std::size_t>(
+        "bulk_node_ids", MeshLib::MeshItemType::Node, 1);
 
     // Allocate space for all elements for random insertion.
     std::vector<std::vector<std::size_t>> bulk_element_ids_map(

--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -342,8 +342,10 @@ void scaleMeshPropertyVector(MeshLib::Mesh & mesh,
 PropertyVector<int> const* materialIDs(Mesh const& mesh)
 {
     auto const& properties = mesh.getProperties();
-    return properties.existsPropertyVector<int>("MaterialIDs")
-               ? properties.getPropertyVector<int>("MaterialIDs")
+    return properties.existsPropertyVector<int>("MaterialIDs",
+                                                MeshLib::MeshItemType::Cell, 1)
+               ? properties.getPropertyVector<int>(
+                     "MaterialIDs", MeshLib::MeshItemType::Cell, 1)
                : nullptr;
 }
 

--- a/MeshLib/MeshEditing/ElementValueModification.cpp
+++ b/MeshLib/MeshEditing/ElementValueModification.cpp
@@ -28,12 +28,17 @@ bool ElementValueModification::replace(MeshLib::Mesh &mesh,
     std::string const& property_name, int const old_value, int const new_value,
     bool replace_if_exists)
 {
-    if (!mesh.getProperties().existsPropertyVector<int>(property_name))
+    MeshLib::PropertyVector<int>* property_value_vec = nullptr;
+    try
     {
+        property_value_vec = mesh.getProperties().getPropertyVector<int>(
+            property_name, MeshLib::MeshItemType::Cell, 1);
+    }
+    catch (std::runtime_error const& e)
+    {
+        ERR("%s", e.what());
         return false;
     }
-    auto* const property_value_vec =
-        mesh.getProperties().getPropertyVector<int>(property_name);
 
     const std::size_t n_property_tuples(
         property_value_vec->getNumberOfTuples());
@@ -71,20 +76,24 @@ bool ElementValueModification::replace(MeshLib::Mesh &mesh,
 
 std::size_t ElementValueModification::condense(MeshLib::Mesh &mesh)
 {
-    auto* property_value_vector =
-        mesh.getProperties().getPropertyVector<int>("MaterialIDs");
-
-    if (!property_value_vector)
+    MeshLib::PropertyVector<int>* property_value_vector = nullptr;
+    try
     {
+        property_value_vector = mesh.getProperties().getPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1);
+    }
+    catch (std::runtime_error const& e)
+    {
+        ERR("%s", e.what());
         return 0;
     }
 
     std::vector<int> value_mapping(
         getSortedPropertyValues(*property_value_vector));
 
-    std::vector<int> reverse_mapping(value_mapping.back()+1, 0);
-    std::size_t const nValues (value_mapping.size());
-    for (std::size_t i=0; i<nValues; ++i)
+    std::vector<int> reverse_mapping(value_mapping.back() + 1, 0);
+    std::size_t const nValues(value_mapping.size());
+    for (std::size_t i = 0; i < nValues; ++i)
         reverse_mapping[value_mapping[i]] = i;
 
     std::size_t const n_property_values(property_value_vector->size());
@@ -97,18 +106,23 @@ std::size_t ElementValueModification::condense(MeshLib::Mesh &mesh)
 
 std::size_t ElementValueModification::setByElementType(MeshLib::Mesh &mesh, MeshElemType ele_type, int const new_value)
 {
-    auto* const property_value_vector =
-        mesh.getProperties().getPropertyVector<int>("MaterialIDs");
-
-    if (!property_value_vector)
+    MeshLib::PropertyVector<int>* property_value_vector = nullptr;
+    try
     {
+        property_value_vector = mesh.getProperties().getPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1);
+    }
+    catch (std::runtime_error const& e)
+    {
+        ERR("%s", e.what());
         return 0;
     }
 
     std::vector<MeshLib::Element*> const& elements(mesh.getElements());
     std::size_t cnt(0);
-    for (std::size_t k(0); k<elements.size(); k++) {
-        if (elements[k]->getGeomType()!=ele_type)
+    for (std::size_t k(0); k < elements.size(); k++)
+    {
+        if (elements[k]->getGeomType() != ele_type)
             continue;
         (*property_value_vector)[k] = new_value;
         cnt++;

--- a/MeshLib/MeshSearch/ElementSearch.h
+++ b/MeshLib/MeshSearch/ElementSearch.h
@@ -72,24 +72,18 @@ public:
         PROPERTY_TYPE const max_property_value,
         bool outside_of)
     {
-        if (!_mesh.getProperties().existsPropertyVector<PROPERTY_TYPE>(property_name))
+        MeshLib::PropertyVector<PROPERTY_TYPE> const* pv = nullptr;
+        try
         {
-            WARN("Property \"%s\" not found in mesh.", property_name.c_str());
-            return 0;
+            pv = _mesh.getProperties().getPropertyVector<PROPERTY_TYPE>(
+                property_name, MeshLib::MeshItemType::Cell, 1);
         }
-        auto const* const pv =
-            _mesh.getProperties().getPropertyVector<PROPERTY_TYPE>(property_name);
-
-        if (pv->getMeshItemType() != MeshLib::MeshItemType::Cell)
+        catch (std::runtime_error const& e)
         {
-            WARN("The property \"%s\" is not assigned to mesh elements.",
-                 property_name.c_str());
-            return 0;
-        }
-
-        if (pv->getNumberOfComponents() != 1)
-        {
-            WARN("Value-based element removal currently only works for scalars.");
+            ERR("%s", e.what());
+            WARN(
+                "Value-based element removal currently only works for "
+                "scalars.");
             return 0;
         }
 
@@ -99,7 +93,8 @@ public:
         {
             for (std::size_t i(0); i < pv->getNumberOfTuples(); ++i)
             {
-                if ((*pv)[i] < min_property_value || (*pv)[i] > max_property_value)
+                if ((*pv)[i] < min_property_value ||
+                    (*pv)[i] > max_property_value)
                     matchedIDs.push_back(i);
             }
         }
@@ -107,7 +102,8 @@ public:
         {
             for (std::size_t i(0); i < pv->getNumberOfTuples(); ++i)
             {
-                if ((*pv)[i] >= min_property_value && (*pv)[i] <= max_property_value)
+                if ((*pv)[i] >= min_property_value &&
+                    (*pv)[i] <= max_property_value)
                     matchedIDs.push_back(i);
             }
         }

--- a/MeshLib/Properties-impl.h
+++ b/MeshLib/Properties-impl.h
@@ -88,6 +88,33 @@ bool Properties::existsPropertyVector(std::string const& name) const
 }
 
 template <typename T>
+bool Properties::existsPropertyVector(std::string const& name,
+                                      MeshItemType const item_type,
+                                      int const number_of_components) const
+{
+    auto const it = _properties.find(name);
+    if (it == _properties.end())
+    {
+        return false;
+    }
+
+    auto property = dynamic_cast<PropertyVector<T>*>(it->second);
+    if (property == nullptr)
+    {
+        return false;
+    }
+    if (property->getMeshItemType() != item_type)
+    {
+        return false;
+    }
+    if (property->getNumberOfComponents() != number_of_components)
+    {
+        return false;
+    }
+    return true;
+}
+
+template <typename T>
 PropertyVector<T> const* Properties::getPropertyVector(
     std::string const& name) const
 {

--- a/MeshLib/Properties-impl.h
+++ b/MeshLib/Properties-impl.h
@@ -136,25 +136,30 @@ PropertyVector<T> const* Properties::getPropertyVector(
     auto const it = _properties.find(name);
     if (it == _properties.end())
     {
-        OGS_FATAL("A property with name '%s' does not exist.", name.c_str());
+        OGS_FATAL("A PropertyVector with name '%s' does not exist in the mesh.",
+                  name.c_str());
     }
 
     auto property = dynamic_cast<PropertyVector<T>*>(it->second);
     if (property == nullptr)
     {
-        OGS_FATAL("Could not cast property '%s' to given type.", name.c_str());
+        OGS_FATAL(
+            "Could not cast the data type of the PropertyVector '%s' to "
+            "requested data type.",
+            name.c_str());
     }
     if (property->getMeshItemType() != item_type)
     {
         OGS_FATAL(
-            "The PropertyVector '%s' has a different type than requested. A "
-            "'%s' field is requested.",
-            name.c_str(), toString(item_type));
+            "The PropertyVector '%s' has type '%s'. A '%s' field is requested.",
+            name.c_str(), toString(property->getMeshItemType()),
+            toString(item_type));
     }
     if (property->getNumberOfComponents() != n_components)
     {
-        OGS_FATAL("'%s' does not have the right number of components.",
-                  name.c_str());
+        OGS_FATAL(
+            "PropertyVector '%s' has %d components, %d components are needed.",
+            name.c_str(), property->getNumberOfComponents(), n_components);
     }
     return property;
 }

--- a/MeshLib/Properties-impl.h
+++ b/MeshLib/Properties-impl.h
@@ -163,3 +163,39 @@ PropertyVector<T> const* Properties::getPropertyVector(
     }
     return property;
 }
+
+template <typename T>
+PropertyVector<T>* Properties::getPropertyVector(std::string const& name,
+                                                 MeshItemType const item_type,
+                                                 int const n_components)
+{
+    auto const it = _properties.find(name);
+    if (it == _properties.end())
+    {
+        OGS_FATAL("A PropertyVector with name '%s' does not exist in the mesh.",
+                  name.c_str());
+    }
+
+    auto property = dynamic_cast<PropertyVector<T>*>(it->second);
+    if (property == nullptr)
+    {
+        OGS_FATAL(
+            "Could not cast the data type of the PropertyVector '%s' to "
+            "requested data type.",
+            name.c_str());
+    }
+    if (property->getMeshItemType() != item_type)
+    {
+        OGS_FATAL(
+            "The PropertyVector '%s' has type '%s'. A '%s' field is requested.",
+            name.c_str(), toString(property->getMeshItemType()),
+            toString(item_type));
+    }
+    if (property->getNumberOfComponents() != n_components)
+    {
+        OGS_FATAL(
+            "PropertyVector '%s' has %d components, %d components are needed.",
+            name.c_str(), property->getNumberOfComponents(), n_components);
+    }
+    return property;
+}

--- a/MeshLib/Properties-impl.h
+++ b/MeshLib/Properties-impl.h
@@ -89,7 +89,7 @@ bool Properties::existsPropertyVector(std::string const& name) const
 
 template <typename T>
 bool Properties::existsPropertyVector(std::string const& name,
-                                      MeshItemType const item_type,
+                                      MeshItemType const mesh_item_type,
                                       int const number_of_components) const
 {
     auto const it = _properties.find(name);
@@ -103,7 +103,7 @@ bool Properties::existsPropertyVector(std::string const& name,
     {
         return false;
     }
-    if (property->getMeshItemType() != item_type)
+    if (property->getMeshItemType() != mesh_item_type)
     {
         return false;
     }

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -103,6 +103,14 @@ public:
                                                MeshItemType const item_type,
                                                int const n_components) const;
 
+    /// Non-const version of getPropertyVector returns a property vector with
+    /// given \c name, \c item_type and \c number_of_components or calls
+    /// OGS_FATAL if no such property vector exists.
+    template <typename T>
+    PropertyVector<T>* getPropertyVector(std::string const& name,
+                                         MeshItemType const item_type,
+                                         int const number_of_components);
+
     void removePropertyVector(std::string const& name);
 
     /// Check if a PropertyVector accessible by the name is already

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -85,6 +85,14 @@ public:
     template <typename T>
     bool existsPropertyVector(std::string const& name) const;
 
+    /// Checks if a property vector with given type \c T, \c name, \c item_type
+    /// and \c number_of_components exists.
+    /// @param name name of the requested property vector
+    template <typename T>
+    bool existsPropertyVector(std::string const& name,
+                              MeshItemType const item_type,
+                              int const number_of_components) const;
+
     /// Returns a property vector with given \c name or aborts calling OGS_FATAL
     /// if no such property vector exists.
     template <typename T>

--- a/MeshLib/Properties.h
+++ b/MeshLib/Properties.h
@@ -85,12 +85,11 @@ public:
     template <typename T>
     bool existsPropertyVector(std::string const& name) const;
 
-    /// Checks if a property vector with given type \c T, \c name, \c item_type
-    /// and \c number_of_components exists.
-    /// @param name name of the requested property vector
+    /// Checks if a property vector with given type \c T, \c name, \c
+    /// mesh_item_type, and \c number_of_components exists.
     template <typename T>
-    bool existsPropertyVector(std::string const& name,
-                              MeshItemType const item_type,
+    bool existsPropertyVector(std::string const& property_name,
+                              MeshItemType const mesh_item_type,
                               int const number_of_components) const;
 
     /// Returns a property vector with given \c name or aborts calling OGS_FATAL

--- a/NumLib/DOF/MeshComponentMap.cpp
+++ b/NumLib/DOF/MeshComponentMap.cpp
@@ -148,7 +148,7 @@ MeshComponentMap MeshComponentMap::getSubset(
     }
     auto const& bulk_node_ids_map =
         *new_mesh_properties.template getPropertyVector<std::size_t>(
-            "bulk_node_ids");
+            "bulk_node_ids", MeshLib::MeshItemType::Node, 1);
 
     // New dictionary for the subset.
     ComponentGlobalIndexDict subset_dict;

--- a/ProcessLib/BoundaryCondition/ConstraintDirichletBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/ConstraintDirichletBoundaryCondition.cpp
@@ -70,24 +70,10 @@ ConstraintDirichletBoundaryCondition::ConstraintDirichletBoundaryCondition(
     // create _bulk_ids vector
     auto const* bulk_element_ids =
         _bc_mesh.getProperties().getPropertyVector<std::size_t>(
-            "bulk_element_ids");
-    if (!bulk_element_ids)
-    {
-        OGS_FATAL(
-            "The boundary mesh '%s' doesn't contain the needed property "
-            "'bulk_element_ids'.",
-            _bc_mesh.getName().c_str());
-    }
+            "bulk_element_ids", MeshLib::MeshItemType::Cell, 1);
     auto const* bulk_node_ids =
         _bc_mesh.getProperties().getPropertyVector<std::size_t>(
-            "bulk_node_ids");
-    if (!bulk_node_ids)
-    {
-        OGS_FATAL(
-            "The boundary mesh '%s' doesn't contain the needed property "
-            "'bulk_node_ids'.",
-            _bc_mesh.getName().c_str());
-    }
+            "bulk_node_ids", MeshLib::MeshItemType::Node, 1);
     auto const& bulk_nodes = bulk_mesh.getNodes();
 
     auto get_bulk_element_face_id =

--- a/ProcessLib/BoundaryCondition/NonuniformDirichletBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NonuniformDirichletBoundaryCondition.cpp
@@ -32,25 +32,13 @@ createNonuniformDirichletBoundaryCondition(
         config.getConfigParameter<std::string>("field_name");
 
     auto const* const property =
-        boundary_mesh.getProperties().getPropertyVector<double>(field_name);
+        boundary_mesh.getProperties().getPropertyVector<double>(
+            field_name, MeshLib::MeshItemType::Node, 1);
 
     if (!property)
     {
         OGS_FATAL("A property with name `%s' does not exist in `%s'.",
                   field_name.c_str(), boundary_mesh.getName().c_str());
-    }
-
-    if (property->getMeshItemType() != MeshLib::MeshItemType::Node)
-    {
-        OGS_FATAL(
-            "Only nodal fields are supported for non-uniform fields. Field "
-            "`%s' is not nodal.",
-            field_name.c_str());
-    }
-
-    if (property->getNumberOfComponents() != 1)
-    {
-        OGS_FATAL("`%s' is not a one-component field.", field_name.c_str());
     }
 
     // In case of partitioned mesh the boundary could be empty, i.e. there is no

--- a/ProcessLib/BoundaryCondition/Python/PythonBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/Python/PythonBoundaryCondition.cpp
@@ -87,7 +87,7 @@ void PythonBoundaryCondition::getEssentialBCValues(
 
     auto const& bulk_node_ids_map =
         *_bc_data.boundary_mesh.getProperties().getPropertyVector<std::size_t>(
-            "bulk_node_ids");
+            "bulk_node_ids", MeshLib::MeshItemType::Node, 1);
 
     bc_values.ids.clear();
     bc_values.values.clear();

--- a/ProcessLib/BoundaryCondition/Python/PythonBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/Python/PythonBoundaryConditionLocalAssembler.h
@@ -68,7 +68,8 @@ public:
 
         auto const& bulk_node_ids_map =
             *_data.boundary_mesh.getProperties()
-                 .template getPropertyVector<std::size_t>("bulk_node_ids");
+                 .template getPropertyVector<std::size_t>(
+                     "bulk_node_ids", MeshLib::MeshItemType::Node, 1);
 
         // gather primary variables
         Eigen::MatrixXd primary_variables_mat(num_nodes, num_comp_total);

--- a/ProcessLib/LIE/Common/MeshUtils.cpp
+++ b/ProcessLib/LIE/Common/MeshUtils.cpp
@@ -84,8 +84,8 @@ void getFractureMatrixDataInMesh(
          vec_matrix_elements.size(), all_fracture_elements.size());
 
     // get fracture material IDs
-    auto opt_material_ids(
-        mesh.getProperties().getPropertyVector<int>("MaterialIDs"));
+    auto opt_material_ids(mesh.getProperties().getPropertyVector<int>(
+        "MaterialIDs", MeshLib::MeshItemType::Cell, 1));
     for (MeshLib::Element* e : all_fracture_elements)
         vec_fracture_mat_IDs.push_back((*opt_material_ids)[e->getID()]);
     BaseLib::makeVectorUnique(vec_fracture_mat_IDs);

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -318,8 +318,8 @@ void HydroMechanicsProcess<GlobalDim>::initializeConcreteProcess(
             const_cast<MeshLib::Mesh&>(mesh), "aperture",
             MeshLib::MeshItemType::Cell, 1);
         mesh_prop_b->resize(mesh.getNumberOfElements());
-        auto mesh_prop_matid =
-            mesh.getProperties().getPropertyVector<int>("MaterialIDs");
+        auto mesh_prop_matid = mesh.getProperties().getPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1);
         auto frac = _process_data.fracture_property.get();
         for (MeshLib::Element const* e : _mesh.getElements())
         {

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.cpp
@@ -91,12 +91,13 @@ std::unique_ptr<Process> createLiquidFlowProcess(
     //! \ogs_file_param{prj__processes__process__LIQUID_FLOW__material_property}
     auto const& mat_config = config.getConfigSubtree("material_property");
 
-    if (mesh.getProperties().existsPropertyVector<int>("MaterialIDs"))
+    if (mesh.getProperties().existsPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1))
     {
         INFO("The liquid flow is in heterogeneous porous media.");
         const bool has_material_ids = true;
-        auto const& mat_ids =
-            mesh.getProperties().getPropertyVector<int>("MaterialIDs");
+        auto const& mat_ids = mesh.getProperties().getPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1);
         return std::unique_ptr<Process>{new LiquidFlowProcess{
             mesh, std::move(jacobian_assembler), parameters, integration_order,
             std::move(process_variables), std::move(secondary_variables),

--- a/ProcessLib/RichardsFlow/CreateRichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/CreateRichardsFlowProcess.cpp
@@ -80,8 +80,12 @@ std::unique_ptr<Process> createRichardsFlowProcess(
     //! \ogs_file_param{prj__processes__process__RICHARDS_FLOW__material_property}
     auto const& mat_config = config.getConfigSubtree("material_property");
 
-    auto const material_ids =
-        mesh.getProperties().getPropertyVector<int>("MaterialIDs");
+    auto const* material_ids =
+        mesh.getProperties().existsPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1)
+            ? mesh.getProperties().getPropertyVector<int>(
+                  "MaterialIDs", MeshLib::MeshItemType::Cell, 1)
+            : nullptr;
     if (material_ids != nullptr)
     {
         INFO("The Richards flow is in heterogeneous porous media.");

--- a/ProcessLib/SurfaceFlux/SurfaceFlux.cpp
+++ b/ProcessLib/SurfaceFlux/SurfaceFlux.cpp
@@ -40,10 +40,10 @@ SurfaceFlux::SurfaceFlux(
 
     auto const bulk_element_ids =
         boundary_mesh.getProperties().template getPropertyVector<std::size_t>(
-            "bulk_element_ids");
+            "bulk_element_ids", MeshLib::MeshItemType::Cell, 1);
     auto const bulk_face_ids =
         boundary_mesh.getProperties().template getPropertyVector<std::size_t>(
-            "bulk_face_ids");
+            "bulk_face_ids", MeshLib::MeshItemType::Cell, 1);
 
     ProcessLib::createLocalAssemblers<SurfaceFluxLocalAssembler>(
         boundary_mesh.getDimension() + 1,  // or bulk_mesh.getDimension()?

--- a/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.cpp
@@ -79,11 +79,12 @@ std::unique_ptr<Process> createTwoPhaseFlowWithPPProcess(
     auto const& mat_config = config.getConfigSubtree("material_property");
 
     boost::optional<MeshLib::PropertyVector<int> const&> material_ids;
-    if (mesh.getProperties().existsPropertyVector<int>("MaterialIDs"))
+    if (mesh.getProperties().existsPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1))
     {
         INFO("The twophase flow is in heterogeneous porous media.");
-        material_ids =
-            *mesh.getProperties().getPropertyVector<int>("MaterialIDs");
+        material_ids = *mesh.getProperties().getPropertyVector<int>(
+            "MaterialIDs", MeshLib::MeshItemType::Cell, 1);
     }
     else
     {


### PR DESCRIPTION
Using the new overloaded `Properties::getPropertyVector()`  the user can specify additionally to the data type and the name also the `MeshItemType` and the number of components.  These features don't need to be tested later in the user code.