### PR TITLE
BHE_1U flow properties update and bugfixes.

### DIFF
--- a/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/borehole_heat_exchangers/borehole_heat_exchanger/pipes/inlet/t_diameter.md
+++ b/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/borehole_heat_exchangers/borehole_heat_exchanger/pipes/inlet/t_diameter.md
@@ -1,0 +1,1 @@
+The diameter of the inlet pipe.

--- a/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/borehole_heat_exchangers/borehole_heat_exchanger/pipes/inlet/t_radius.md
+++ b/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/borehole_heat_exchangers/borehole_heat_exchanger/pipes/inlet/t_radius.md
@@ -1,1 +1,0 @@
-The radius of the inlet pipe.

--- a/ProcessLib/HeatTransportBHE/BHE/BHE_1U.h
+++ b/ProcessLib/HeatTransportBHE/BHE/BHE_1U.h
@@ -140,8 +140,8 @@ private:
 
 public:
     std::array<double, number_of_unknowns> const cross_section_areas = {
-        {_pipes.inlet.area(), _pipes.inlet.area(),
-         borehole_geometry.area() / 2 - _pipes.outlet.area(),
+        {_pipes.inlet.area(), _pipes.outlet.area(),
+         borehole_geometry.area() / 2 - _pipes.inlet.area(),
          borehole_geometry.area() / 2 - _pipes.outlet.area()}};
 
 private:

--- a/ProcessLib/HeatTransportBHE/BHE/Physics.h
+++ b/ProcessLib/HeatTransportBHE/BHE/Physics.h
@@ -59,6 +59,43 @@ inline double nusseltNumber(double const reynolds_number,
                       (std::pow(prandtl_number, 2.0 / 3.0) - 1.0)) *
            (1.0 + std::pow(pipe_diameter / pipe_length, 2.0 / 3.0));
 }
+
+// Pipe aspect ratio is the pipe's diameter equivalent over pipe's length.
+inline double nusseltNumberAnnulus(double const reynolds_number,
+                                   double const prandtl_number,
+                                   double const diameter_ratio,
+                                   double const pipe_aspect_ratio)
+{
+    if (reynolds_number < 2300.0)
+    {
+        return 3.66 + (4.0 - 0.102 / (diameter_ratio + 0.02)) *
+                          std::pow(diameter_ratio, 0.04);
+    }
+    if (reynolds_number < 10000.0)
+    {
+        double const gamma = (reynolds_number - 2300) / (10000 - 2300);
+
+        return (1.0 - gamma) *
+                   (3.66 + (4.0 - 0.102 / (diameter_ratio + 0.02))) *
+                   std::pow(diameter_ratio, 0.04) +
+               gamma *
+                   ((0.0308 / 8.0 * 1.0e4 * prandtl_number) /
+                    (1.0 + 12.7 * std::sqrt(0.0308 / 8.0) *
+                               (std::pow(prandtl_number, 2.0 / 3.0) - 1.0)) *
+                    (1.0 + std::pow(pipe_aspect_ratio, 2.0 / 3.0)) *
+                    ((0.86 * std::pow(diameter_ratio, 0.84) + 1.0 -
+                      0.14 * std::pow(diameter_ratio, 0.6)) /
+                     (1.0 + diameter_ratio)));
+    }
+    double const xi = std::pow(1.8 * std::log10(reynolds_number) - 1.5, -2.0);
+    return (xi / 8.0 * reynolds_number * prandtl_number) /
+           (1.0 + 12.7 * std::sqrt(xi / 8.0) *
+                      (std::pow(prandtl_number, 2.0 / 3.0) - 1.0)) *
+           (1.0 + std::pow(pipe_aspect_ratio, 2.0 / 3.0)) *
+           ((0.86 * std::pow(diameter_ratio, 0.84) + 1.0 -
+             0.14 * std::pow(diameter_ratio, 0.6)) /
+            (1.0 + diameter_ratio));
+}
 }  // end of namespace BHE
 }  // end of namespace HeatTransportBHE
 }  // end of namespace ProcessLib

--- a/ProcessLib/HeatTransportBHE/BHE/Pipe.cpp
+++ b/ProcessLib/HeatTransportBHE/BHE/Pipe.cpp
@@ -20,15 +20,15 @@ namespace BHE
 {
 Pipe createPipe(BaseLib::ConfigTree const& config)
 {
-    //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__pipes__inlet__radius}
-    const double radius = config.getConfigParameter<double>("radius");
+    //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__pipes__inlet__diameter}
+    const double diameter = config.getConfigParameter<double>("diameter");
     const double wall_thickness =
         //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__pipes__inlet__wall_thickness}
         config.getConfigParameter<double>("wall_thickness");
     const double wall_thermal_conductivity =
         //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__pipes__inlet__wall_thermal_conductivity}
         config.getConfigParameter<double>("wall_thermal_conductivity");
-    return {radius, wall_thickness, wall_thermal_conductivity};
+    return {diameter, wall_thickness, wall_thermal_conductivity};
 }
 }  // namespace BHE
 }  // namespace HeatTransportBHE

--- a/ProcessLib/HeatTransportBHE/BHE/Pipe.h
+++ b/ProcessLib/HeatTransportBHE/BHE/Pipe.h
@@ -29,10 +29,19 @@ struct Pipe
     double const wall_thickness;
     double const wall_thermal_conductivity;
 
+    /// Area of the pipe's inside without the wall.
     double area() const
     {
         constexpr double pi = boost::math::constants::pi<double>();
         return pi * diameter * diameter / 4;
+    }
+
+    /// Area of the pipe's outside including the wall thickness.
+    double outsideArea() const
+    {
+        constexpr double pi = boost::math::constants::pi<double>();
+        double const d = diameter + 2 * wall_thickness;
+        return pi * d * d / 4;
     }
 };
 

--- a/ProcessLib/HeatTransportBHE/BHE/ThermoMechanicalFlowProperties.h
+++ b/ProcessLib/HeatTransportBHE/BHE/ThermoMechanicalFlowProperties.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include "Physics.h"
-#include "PipeParameters.h"
+#include "Pipe.h"
 #include "RefrigerantProperties.h"
 
 namespace ProcessLib
@@ -28,19 +28,19 @@ struct ThermoMechanicalFlowProperties
 };
 
 inline ThermoMechanicalFlowProperties
-calculateThermoMechanicalFlowPropertiesPipe(PipeParameters const& pipe,
+calculateThermoMechanicalFlowPropertiesPipe(Pipe const& pipe,
                                             double const length,
                                             RefrigerantProperties const& fluid,
                                             double const flow_rate)
 {
     double const Pr =
-        prandtlNumber(fluid.mu_r, fluid.specific_heat_capacity, fluid.lambda_r);
+        prandtlNumber(fluid.dynamic_viscosity, fluid.specific_heat_capacity,
+                      fluid.thermal_conductivity);
 
-    double const velocity = pipeFlowVelocity(flow_rate, pipe.r_inner);
-    double const Re =
-        reynoldsNumber(velocity, 2.0 * pipe.r_inner, fluid.mu_r, fluid.density);
-    double const nusselt_number =
-        nusseltNumber(Re, Pr, 2 * pipe.r_inner, length);
+    double const velocity = flow_rate / pipe.area();
+    double const Re = reynoldsNumber(velocity, pipe.diameter,
+                                     fluid.dynamic_viscosity, fluid.density);
+    double const nusselt_number = nusseltNumber(Re, Pr, pipe.diameter, length);
     return {velocity, nusselt_number};
 }
 

--- a/ProcessLib/HeatTransportBHE/BHE/ThermoMechanicalFlowProperties.h
+++ b/ProcessLib/HeatTransportBHE/BHE/ThermoMechanicalFlowProperties.h
@@ -46,22 +46,28 @@ calculateThermoMechanicalFlowPropertiesPipe(Pipe const& pipe,
 
 inline ThermoMechanicalFlowProperties
 calculateThermoMechanicalFlowPropertiesAnnulus(
-    PipeParameters const& pipe, double const length,
+    Pipe const& inner_pipe, Pipe const& outer_pipe, double const length,
     RefrigerantProperties const& fluid, double const flow_rate)
 {
     double const Pr =
-        prandtlNumber(fluid.mu_r, fluid.specific_heat_capacity, fluid.lambda_r);
+        prandtlNumber(fluid.dynamic_viscosity, fluid.specific_heat_capacity,
+                      fluid.thermal_conductivity);
 
+    double const inner_pipe_outside_diameter =
+        inner_pipe.diameter + 2. * inner_pipe.wall_thickness;
+
+    // Velocity between the outer pipe and inner pipe.
     double const velocity =
-        annulusFlowVelocity(flow_rate, pipe.r_outer, pipe.r_inner + pipe.b_in);
+        flow_rate / (outer_pipe.area() - inner_pipe.outsideArea());
 
     double const Re = reynoldsNumber(
-        velocity, 2.0 * (pipe.r_outer - (pipe.r_inner + pipe.b_in)), fluid.mu_r,
-        fluid.density);
+        velocity, outer_pipe.diameter - inner_pipe_outside_diameter,
+        fluid.dynamic_viscosity, fluid.density);
 
-    double const diameter_ratio = (pipe.r_inner + pipe.b_in) / pipe.r_outer;
+    double const diameter_ratio =
+        inner_pipe_outside_diameter / outer_pipe.diameter;
     double const pipe_aspect_ratio =
-        (2 * pipe.r_outer - 2 * (pipe.r_inner + pipe.b_in)) / length;
+        (outer_pipe.diameter - inner_pipe_outside_diameter) / length;
     double const nusselt_number =
         nusseltNumberAnnulus(Re, Pr, diameter_ratio, pipe_aspect_ratio);
     return {velocity, nusselt_number};

--- a/Tests/Data/Parabolic/T/3D_Beier_sandbox/beier_sandbox.prj
+++ b/Tests/Data/Parabolic/T/3D_Beier_sandbox/beier_sandbox.prj
@@ -45,12 +45,12 @@
                     </grout>
                     <pipes>
                         <inlet>
-                            <radius> 0.013665</radius>
+                            <diameter> 0.013665</diameter>
                             <wall_thickness>0.003035</wall_thickness>
                             <wall_thermal_conductivity>0.39</wall_thermal_conductivity>
                         </inlet>
                         <outlet>
-                            <radius>0.013665</radius>
+                            <diameter>0.013665</diameter>
                             <wall_thickness>0.003035</wall_thickness>
                             <wall_thermal_conductivity>0.39</wall_thermal_conductivity>
                         </outlet>

--- a/Tests/Data/Parabolic/T/3D_Beier_sandbox/fixed_power_constant_flow.prj
+++ b/Tests/Data/Parabolic/T/3D_Beier_sandbox/fixed_power_constant_flow.prj
@@ -45,12 +45,12 @@
                     </grout>
                     <pipes>
                         <inlet>
-                            <radius> 0.013665</radius>
+                            <diameter> 0.013665</diameter>
                             <wall_thickness>0.003035</wall_thickness>
                             <wall_thermal_conductivity>0.39</wall_thermal_conductivity>
                         </inlet>
                         <outlet>
-                            <radius>0.013665</radius>
+                            <diameter>0.013665</diameter>
                             <wall_thickness>0.003035</wall_thickness>
                             <wall_thermal_conductivity>0.39</wall_thermal_conductivity>
                         </outlet>


### PR DESCRIPTION
Use already extracted code. This prevents code duplication for 2U and the CXA/CXC implementations.

@ChaofanChen Could you please review this?