### PR TITLE
BHE; Move the function body in "CreateFlowAndTemperatureControl.h" to cpp file.

### DIFF
--- a/ProcessLib/HeatTransportBHE/BHE/CreateFlowAndTemperatureControl.cpp
+++ b/ProcessLib/HeatTransportBHE/BHE/CreateFlowAndTemperatureControl.cpp
@@ -10,7 +10,7 @@
  */
 
 #include "BaseLib/ConfigTree.h"
-#include "BaseLib/Error.h"
+#include "MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h"
 #include "BaseLib/Algorithm.h"
 
 #include "CreateFlowAndTemperatureControl.h"

--- a/ProcessLib/HeatTransportBHE/BHE/CreateFlowAndTemperatureControl.cpp
+++ b/ProcessLib/HeatTransportBHE/BHE/CreateFlowAndTemperatureControl.cpp
@@ -9,7 +9,11 @@
  *
  */
 
+#include "BaseLib/ConfigTree.h"
+#include "BaseLib/Error.h"
+
 #include "CreateFlowAndTemperatureControl.h"
+#include "RefrigerantProperties.h"
 
 namespace ProcessLib
 {

--- a/ProcessLib/HeatTransportBHE/BHE/CreateFlowAndTemperatureControl.cpp
+++ b/ProcessLib/HeatTransportBHE/BHE/CreateFlowAndTemperatureControl.cpp
@@ -1,0 +1,86 @@
+/**
+ * \file
+ *
+ * \copyright
+ * Copyright (c) 2012-2018, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "CreateFlowAndTemperatureControl.h"
+
+namespace ProcessLib
+{
+namespace HeatTransportBHE
+{
+namespace BHE
+{
+FlowAndTemperatureControl createFlowAndTemperatureControl(
+    BaseLib::ConfigTree const& config,
+    std::map<std::string,
+             std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
+        curves,
+    RefrigerantProperties const& refrigerant)
+{
+    auto find_curve_or_error = [&](std::string const& name,
+                                   std::string const& error_message)
+        -> MathLib::PiecewiseLinearInterpolation const& {
+        auto const it = curves.find(name);
+        if (it == curves.end())
+        {
+            ERR(error_message.c_str());
+            OGS_FATAL(
+                "Curve with name '%s' could not be found in the curves list.",
+                name.c_str());
+        }
+        return *it->second;
+    };
+
+    //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__type}
+    auto const type = config.getConfigParameter<std::string>("type");
+    if (type == "TemperatureCurveConstantFlow")
+    {
+        //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__TemperatureCurveConstantFlow__flow_rate}
+        double const flow_rate = config.getConfigParameter<double>("flow_rate");
+
+        auto const& temperature_curve = find_curve_or_error(
+            //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__TemperatureCurveConstantFlow__temperature_curve}
+            config.getConfigParameter<std::string>("temperature_curve"),
+            "Required temperature curve not found.");
+
+        return TemperatureCurveConstantFlow{flow_rate, temperature_curve};
+    }
+    if (type == "FixedPowerConstantFlow")
+    {
+        //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__FixedPowerConstantFlow__power}
+        double const power = config.getConfigParameter<double>("power");
+
+        //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__FixedPowerConstantFlow__flow_rate}
+        double const flow_rate = config.getConfigParameter<double>("flow_rate");
+        return FixedPowerConstantFlow{flow_rate, power,
+                                      refrigerant.specific_heat_capacity,
+                                      refrigerant.density};
+    }
+
+    if (type == "FixedPowerFlowCurve")
+    {
+        auto const& flow_rate_curve = find_curve_or_error(
+            //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__FixedPowerFlowCurve__flow_rate_curve}
+            config.getConfigParameter<std::string>("flow_rate_curve"),
+            "Required flow rate curve not found.");
+
+        //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__FixedPowerFlowCurve__power}
+        double const power = config.getConfigParameter<double>("power");
+
+        return FixedPowerFlowCurve{flow_rate_curve, power,
+                                   refrigerant.specific_heat_capacity,
+                                   refrigerant.density};
+    }
+    OGS_FATAL("FlowAndTemperatureControl type '%s' is not implemented.",
+              type.c_str());
+}
+}  // namespace BHE
+}  // namespace HeatTransportBHE
+}  // namespace ProcessLib

--- a/ProcessLib/HeatTransportBHE/BHE/CreateFlowAndTemperatureControl.h
+++ b/ProcessLib/HeatTransportBHE/BHE/CreateFlowAndTemperatureControl.h
@@ -33,7 +33,7 @@ namespace HeatTransportBHE
 {
 namespace BHE
 {
-class RefrigerantProperties;
+struct RefrigerantProperties;
 
 FlowAndTemperatureControl createFlowAndTemperatureControl(
     BaseLib::ConfigTree const& config,

--- a/ProcessLib/HeatTransportBHE/BHE/CreateFlowAndTemperatureControl.h
+++ b/ProcessLib/HeatTransportBHE/BHE/CreateFlowAndTemperatureControl.h
@@ -11,10 +11,21 @@
 
 #pragma once
 
-#include "BaseLib/ConfigTree.h"
-#include "BaseLib/Error.h"
+#include <map>
+#include <memory>
+#include <string>
+
 #include "FlowAndTemperatureControl.h"
-#include "RefrigerantProperties.h"
+
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace MathLib
+{
+class PiecewiseLinearInterpolation;
+}
 
 namespace ProcessLib
 {
@@ -22,6 +33,8 @@ namespace HeatTransportBHE
 {
 namespace BHE
 {
+class RefrigerantProperties;
+
 FlowAndTemperatureControl createFlowAndTemperatureControl(
     BaseLib::ConfigTree const& config,
     std::map<std::string,

--- a/ProcessLib/HeatTransportBHE/BHE/CreateFlowAndTemperatureControl.h
+++ b/ProcessLib/HeatTransportBHE/BHE/CreateFlowAndTemperatureControl.h
@@ -11,6 +11,9 @@
 
 #pragma once
 
+#include "BaseLib/ConfigTree.h"
+#include "BaseLib/Error.h"
+#include "FlowAndTemperatureControl.h"
 #include "RefrigerantProperties.h"
 
 namespace ProcessLib
@@ -24,65 +27,7 @@ FlowAndTemperatureControl createFlowAndTemperatureControl(
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
         curves,
-    RefrigerantProperties const& refrigerant)
-{
-    auto find_curve_or_error = [&](std::string const& name,
-                                   std::string const& error_message)
-        -> MathLib::PiecewiseLinearInterpolation const& {
-        auto const it = curves.find(name);
-        if (it == curves.end())
-        {
-            ERR(error_message.c_str());
-            OGS_FATAL(
-                "Curve with name '%s' could not be found in the curves list.",
-                name.c_str());
-        }
-        return *it->second;
-    };
-
-    //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__type}
-    auto const type = config.getConfigParameter<std::string>("type");
-    if (type == "TemperatureCurveConstantFlow")
-    {
-        //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__TemperatureCurveConstantFlow__flow_rate}
-        double const flow_rate = config.getConfigParameter<double>("flow_rate");
-
-        auto const& temperature_curve = find_curve_or_error(
-            //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__TemperatureCurveConstantFlow__temperature_curve}
-            config.getConfigParameter<std::string>("temperature_curve"),
-            "Required temperature curve not found.");
-
-        return TemperatureCurveConstantFlow{flow_rate, temperature_curve};
-    }
-    if (type == "FixedPowerConstantFlow")
-    {
-        //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__FixedPowerConstantFlow__power}
-        double const power = config.getConfigParameter<double>("power");
-
-        //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__FixedPowerConstantFlow__flow_rate}
-        double const flow_rate = config.getConfigParameter<double>("flow_rate");
-        return FixedPowerConstantFlow{flow_rate, power,
-                                      refrigerant.specific_heat_capacity,
-                                      refrigerant.density};
-    }
-
-    if (type == "FixedPowerFlowCurve")
-    {
-        auto const& flow_rate_curve = find_curve_or_error(
-            //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__FixedPowerFlowCurve__flow_rate_curve}
-            config.getConfigParameter<std::string>("flow_rate_curve"),
-            "Required flow rate curve not found.");
-
-        //! \ogs_file_param{prj__processes__process__HEAT_TRANSPORT_BHE__borehole_heat_exchangers__borehole_heat_exchanger__flow_and_temperature_control__FixedPowerFlowCurve__power}
-        double const power = config.getConfigParameter<double>("power");
-
-        return FixedPowerFlowCurve{flow_rate_curve, power,
-                                   refrigerant.specific_heat_capacity,
-                                   refrigerant.density};
-    }
-    OGS_FATAL("FlowAndTemperatureControl type '%s' is not implemented.",
-              type.c_str());
-}
+    RefrigerantProperties const& refrigerant);
 }  // namespace BHE
 }  // namespace HeatTransportBHE
 }  // namespace ProcessLib


### PR DESCRIPTION
When adding cases of the CXA/CXC or 2U BHE, we also need to call the function named "createFlowAndTemperatureControl", and this will cause an error that multiple inclusion of the same definition in header file when compiling. Besides, we also need to enrich flow and temperature boundary conditions including the BHE coupled with heat pump.