### PR TITLE
[PL] Fix source term integrate() call.

### DIFF
--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -220,6 +220,9 @@ void Process::assembleWithJacobian(const double t, GlobalVector const& x,
     const auto pcs_id =
         (_coupled_solutions) != nullptr ? _coupled_solutions->process_id : 0;
     _boundary_conditions[pcs_id].applyNaturalBC(t, x, K, b, &Jac);
+
+    // the last argument is for the jacobian, nullptr is for a unused jacobian
+    _source_term_collections[pcs_id].integrate(t, x, b, &Jac);
 }
 
 void Process::constructDofTable()


### PR DESCRIPTION
The call was simply missing in the assembleWithJacobian().

Fixes #2317 