### PR TITLE
[PL] Infrastructure for setInitialConditions().

### DIFF
--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -78,6 +78,16 @@ void LocalAssemblerInterface::computeSecondaryVariable(
     computeSecondaryVariableConcrete(t, local_x);
 }
 
+void LocalAssemblerInterface::setInitialConditions(
+    std::size_t const mesh_item_id,
+    NumLib::LocalToGlobalIndexMap const& dof_table, GlobalVector const& x)
+{
+    auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
+    auto const local_x = x.get(indices);
+
+    setInitialConditionsConcrete(local_x);
+}
+
 void LocalAssemblerInterface::preTimestep(
     std::size_t const mesh_item_id,
     NumLib::LocalToGlobalIndexMap const& dof_table, GlobalVector const& x,

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -80,12 +80,13 @@ void LocalAssemblerInterface::computeSecondaryVariable(
 
 void LocalAssemblerInterface::setInitialConditions(
     std::size_t const mesh_item_id,
-    NumLib::LocalToGlobalIndexMap const& dof_table, GlobalVector const& x)
+    NumLib::LocalToGlobalIndexMap const& dof_table, GlobalVector const& x,
+    double const t)
 {
     auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
     auto const local_x = x.get(indices);
 
-    setInitialConditionsConcrete(local_x);
+    setInitialConditionsConcrete(local_x, t);
 }
 
 void LocalAssemblerInterface::preTimestep(

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -34,6 +34,10 @@ class LocalAssemblerInterface
 public:
     virtual ~LocalAssemblerInterface() = default;
 
+    virtual void setInitialConditions(
+        std::size_t const mesh_item_id,
+        NumLib::LocalToGlobalIndexMap const& dof_table, GlobalVector const& x);
+
     virtual void preAssemble(double const /*t*/,
                              std::vector<double> const& /*local_x*/){};
 
@@ -96,6 +100,11 @@ public:
     }
 
 private:
+    virtual void setInitialConditionsConcrete(
+        std::vector<double> const& /*local_x*/)
+    {
+    }
+
     virtual void preTimestepConcrete(std::vector<double> const& /*local_x*/,
                                      double const /*t*/, double const /*dt*/)
     {

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -36,7 +36,8 @@ public:
 
     virtual void setInitialConditions(
         std::size_t const mesh_item_id,
-        NumLib::LocalToGlobalIndexMap const& dof_table, GlobalVector const& x);
+        NumLib::LocalToGlobalIndexMap const& dof_table, GlobalVector const& x,
+        double const t);
 
     virtual void preAssemble(double const /*t*/,
                              std::vector<double> const& /*local_x*/){};
@@ -101,7 +102,7 @@ public:
 
 private:
     virtual void setInitialConditionsConcrete(
-        std::vector<double> const& /*local_x*/)
+        std::vector<double> const& /*local_x*/, double const /*t*/)
     {
     }
 

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -164,7 +164,7 @@ void Process::setInitialConditions(const int process_id, double const t,
             }
         }
     }
-    setInitialConditionsConcreteProcess(x);
+    setInitialConditionsConcreteProcess(x, t);
 }
 
 MathLib::MatrixSpecifications Process::getMatrixSpecifications(

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -121,6 +121,7 @@ void Process::setInitialConditions(const int process_id, double const t,
          variable_id < per_process_variables.size();
          variable_id++)
     {
+        MathLib::LinAlg::setLocalAccessibleVector(x);
         SpatialPosition pos;
 
         auto const& pv = per_process_variables[variable_id];
@@ -163,6 +164,7 @@ void Process::setInitialConditions(const int process_id, double const t,
             }
         }
     }
+    setInitialConditionsConcreteProcess(x);
 }
 
 MathLib::MatrixSpecifications Process::getMatrixSpecifications(

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -176,7 +176,8 @@ private:
     /// processes. It is called by initialize().
     virtual void initializeBoundaryConditions();
 
-    virtual void setInitialConditionsConcreteProcess(GlobalVector const& /*x*/)
+    virtual void setInitialConditionsConcreteProcess(GlobalVector const& /*x*/,
+                                                     double const /*t*/)
     {
     }
 

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -176,6 +176,10 @@ private:
     /// processes. It is called by initialize().
     virtual void initializeBoundaryConditions();
 
+    virtual void setInitialConditionsConcreteProcess(GlobalVector const& /*x*/)
+    {
+    }
+
     virtual void preAssembleConcreteProcess(const double /*t*/,
                                             GlobalVector const& /*x*/)
     {


### PR DESCRIPTION
Some processes might require setup of the initial conditions dependent variables in local assemblers.
The new interface allows such implementations.

See https://github.com/endJunction/ogs/tree/RMSaturation branch changes of RichardsFlow process for usage.