### PR TITLE
Don't reset node element ids always.

### DIFF
--- a/Applications/FileIO/FEFLOW/FEFLOWMeshInterface.cpp
+++ b/Applications/FileIO/FEFLOW/FEFLOWMeshInterface.cpp
@@ -691,7 +691,7 @@ void FEFLOWMeshInterface::setMaterialIDs(
         for (std::size_t i = 0; i < vec_elements.size(); i++)
         {
             MeshLib::Element* e = vec_elements[i];
-            unsigned e_min_nodeID = std::numeric_limits<unsigned>::max();
+            std::size_t e_min_nodeID = std::numeric_limits<std::size_t>::max();
             for (std::size_t j = 0; j < e->getNumberOfBaseNodes(); j++)
                 e_min_nodeID = std::min(e_min_nodeID, e->getNodeIndex(j));
             std::size_t layer_id = e_min_nodeID / no_nodes_per_layer;

--- a/MeshLib/Elements/Element.cpp
+++ b/MeshLib/Elements/Element.cpp
@@ -161,7 +161,7 @@ void Element::setNode(unsigned idx, Node* node)
         _nodes[idx] = node;
 }
 
-unsigned Element::getNodeIndex(unsigned i) const
+std::size_t Element::getNodeIndex(unsigned i) const
 {
 #ifndef NDEBUG
     if (i<getNumberOfNodes())
@@ -169,7 +169,7 @@ unsigned Element::getNodeIndex(unsigned i) const
         return _nodes[i]->getID();
 #ifndef NDEBUG
     ERR("Error in MeshLib::Element::getNodeIndex() - Index does not exist.");
-    return std::numeric_limits<unsigned>::max();
+    return std::numeric_limits<std::size_t>::max();
 #endif
 }
 

--- a/MeshLib/Elements/Element.h
+++ b/MeshLib/Elements/Element.h
@@ -120,7 +120,7 @@ public:
      * @return the global index or std::numeric_limits<unsigned>::max()
      * @sa Element::getNode()
      */
-    unsigned getNodeIndex(unsigned i) const;
+    std::size_t getNodeIndex(unsigned i) const;
 
     /**
      * Get the type of the mesh element in geometric context (as a MeshElemType-enum).

--- a/MeshLib/Mesh.cpp
+++ b/MeshLib/Mesh.cpp
@@ -50,6 +50,10 @@ Mesh::Mesh(std::string name,
     assert(_n_base_nodes <= _nodes.size());
     this->resetNodeIDs();
     this->resetElementIDs();
+    if (_n_base_nodes == 0)
+    {
+        recalculateMaxBaseNodeId();
+    }
     if ((_n_base_nodes == 0 && hasNonlinearElement()) || isNonlinear())
         this->checkNonlinearNodeIDs();
     this->setDimension();
@@ -119,18 +123,24 @@ void Mesh::addElement(Element* elem)
 
 void Mesh::resetNodeIDs()
 {
-    const std::size_t nNodes (this->_nodes.size());
-    for (unsigned i=0; i<nNodes; ++i)
-        _nodes[i]->setID(i);
-
-    if (_n_base_nodes==0)
+    const std::size_t nNodes(_nodes.size());
+    for (std::size_t i = 0; i < nNodes; ++i)
     {
-        unsigned max_basenode_ID = 0;
-        for (Element const* e : _elements)
-            for (unsigned i=0; i<e->getNumberOfBaseNodes(); i++)
-                max_basenode_ID = std::max(max_basenode_ID, e->getNodeIndex(i));
-        _n_base_nodes = max_basenode_ID + 1;
+        _nodes[i]->setID(i);
     }
+}
+
+void Mesh::recalculateMaxBaseNodeId()
+{
+    std::size_t max_basenode_ID = 0;
+    for (Element const* e : _elements)
+    {
+        for (std::size_t i = 0; i < e->getNumberOfBaseNodes(); i++)
+        {
+            max_basenode_ID = std::max(max_basenode_ID, e->getNodeIndex(i));
+        }
+    }
+    _n_base_nodes = max_basenode_ID + 1;
 }
 
 void Mesh::resetElementIDs()

--- a/MeshLib/Mesh.h
+++ b/MeshLib/Mesh.h
@@ -113,6 +113,9 @@ public:
     /// Resets the IDs of all mesh-nodes to their position in the node vector
     void resetNodeIDs();
 
+    /// Finds the maximum id among all of the base nodes.
+    void recalculateMaxBaseNodeId();
+
     /// Changes the name of the mesh.
     void setName(const std::string &name) { this->_name = name; }
 

--- a/MeshLib/MeshGenerators/VtkMeshConverter.cpp
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.cpp
@@ -43,12 +43,13 @@ namespace detail
 {
 template <class T_ELEMENT>
 MeshLib::Element* createElementWithSameNodeOrder(
-    const std::vector<MeshLib::Node*>& nodes, vtkIdList* const node_ids)
+    const std::vector<MeshLib::Node*>& nodes, vtkIdList* const node_ids,
+    std::size_t const element_id)
 {
     auto** ele_nodes = new MeshLib::Node*[T_ELEMENT::n_all_nodes];
     for (unsigned k(0); k < T_ELEMENT::n_all_nodes; k++)
         ele_nodes[k] = nodes[node_ids->GetId(k)];
-    return new T_ELEMENT(ele_nodes);
+    return new T_ELEMENT(ele_nodes, element_id);
 }
 }  // namespace detail
 
@@ -65,7 +66,7 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(
     for (std::size_t i = 0; i < nNodes; i++)
     {
         coords = grid->GetPoints()->GetPoint(i);
-        nodes[i] = new MeshLib::Node(coords[0], coords[1], coords[2]);
+        nodes[i] = new MeshLib::Node(coords[0], coords[1], coords[2], i);
     }
 
     // set mesh elements
@@ -83,25 +84,25 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(
             case VTK_VERTEX:
             {
                 elem = detail::createElementWithSameNodeOrder<MeshLib::Point>(
-                    nodes, node_ids);
+                    nodes, node_ids, i);
                 break;
             }
             case VTK_LINE:
             {
                 elem = detail::createElementWithSameNodeOrder<MeshLib::Line>(
-                    nodes, node_ids);
+                    nodes, node_ids, i);
                 break;
             }
             case VTK_TRIANGLE:
             {
                 elem = detail::createElementWithSameNodeOrder<MeshLib::Tri>(
-                    nodes, node_ids);
+                    nodes, node_ids, i);
                 break;
             }
             case VTK_QUAD:
             {
                 elem = detail::createElementWithSameNodeOrder<MeshLib::Quad>(
-                    nodes, node_ids);
+                    nodes, node_ids, i);
                 break;
             }
             case VTK_PIXEL:
@@ -111,19 +112,19 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(
                 quad_nodes[1] = nodes[node_ids->GetId(1)];
                 quad_nodes[2] = nodes[node_ids->GetId(3)];
                 quad_nodes[3] = nodes[node_ids->GetId(2)];
-                elem = new MeshLib::Quad(quad_nodes);
+                elem = new MeshLib::Quad(quad_nodes, i);
                 break;
             }
             case VTK_TETRA:
             {
                 elem = detail::createElementWithSameNodeOrder<MeshLib::Tet>(
-                    nodes, node_ids);
+                    nodes, node_ids, i);
                 break;
             }
             case VTK_HEXAHEDRON:
             {
                 elem = detail::createElementWithSameNodeOrder<MeshLib::Hex>(
-                    nodes, node_ids);
+                    nodes, node_ids, i);
                 break;
             }
             case VTK_VOXEL:
@@ -137,13 +138,13 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(
                 voxel_nodes[5] = nodes[node_ids->GetId(5)];
                 voxel_nodes[6] = nodes[node_ids->GetId(7)];
                 voxel_nodes[7] = nodes[node_ids->GetId(6)];
-                elem = new MeshLib::Hex(voxel_nodes);
+                elem = new MeshLib::Hex(voxel_nodes, i);
                 break;
             }
             case VTK_PYRAMID:
             {
                 elem = detail::createElementWithSameNodeOrder<MeshLib::Pyramid>(
-                    nodes, node_ids);
+                    nodes, node_ids, i);
                 break;
             }
             case VTK_WEDGE:
@@ -154,50 +155,50 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(
                     prism_nodes[i] = nodes[node_ids->GetId(i + 3)];
                     prism_nodes[i + 3] = nodes[node_ids->GetId(i)];
                 }
-                elem = new MeshLib::Prism(prism_nodes);
+                elem = new MeshLib::Prism(prism_nodes, i);
                 break;
             }
             case VTK_QUADRATIC_EDGE:
             {
                 elem = detail::createElementWithSameNodeOrder<MeshLib::Line3>(
-                    nodes, node_ids);
+                    nodes, node_ids, i);
                 break;
             }
             case VTK_QUADRATIC_TRIANGLE:
             {
                 elem = detail::createElementWithSameNodeOrder<MeshLib::Tri6>(
-                    nodes, node_ids);
+                    nodes, node_ids, i);
                 break;
             }
             case VTK_QUADRATIC_QUAD:
             {
                 elem = detail::createElementWithSameNodeOrder<MeshLib::Quad8>(
-                    nodes, node_ids);
+                    nodes, node_ids, i);
                 break;
             }
             case VTK_BIQUADRATIC_QUAD:
             {
                 elem = detail::createElementWithSameNodeOrder<MeshLib::Quad9>(
-                    nodes, node_ids);
+                    nodes, node_ids, i);
                 break;
             }
             case VTK_QUADRATIC_TETRA:
             {
                 elem = detail::createElementWithSameNodeOrder<MeshLib::Tet10>(
-                    nodes, node_ids);
+                    nodes, node_ids, i);
                 break;
             }
             case VTK_QUADRATIC_HEXAHEDRON:
             {
                 elem = detail::createElementWithSameNodeOrder<MeshLib::Hex20>(
-                    nodes, node_ids);
+                    nodes, node_ids, i);
                 break;
             }
             case VTK_QUADRATIC_PYRAMID:
             {
                 elem =
                     detail::createElementWithSameNodeOrder<MeshLib::Pyramid13>(
-                        nodes, node_ids);
+                        nodes, node_ids, i);
                 break;
             }
             case VTK_QUADRATIC_WEDGE:
@@ -215,7 +216,7 @@ MeshLib::Mesh* VtkMeshConverter::convertUnstructuredGrid(
                 prism_nodes[11] = nodes[node_ids->GetId(13)];
                 for (unsigned i = 0; i < 3; ++i)
                     prism_nodes[12 + i] = nodes[node_ids->GetId(11 - i)];
-                elem = new MeshLib::Prism15(prism_nodes);
+                elem = new MeshLib::Prism15(prism_nodes, i);
                 break;
             }
             default:


### PR DESCRIPTION
For the vtk meshes, where the node and element ids are already set (starting from 0, no gaps, etc) it is better to keep the original numbering. This comes in handy for pre- and post-processing, and sparse matrix bandwidth reduction.