### PR TITLE
Migrate LFS from GitLab to Artifactory

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,2 +1,2 @@
 [lfs]
-    url = https://gitlab.opengeosys.org/ogs/ogs.git/info/lfs
+    url = https://ogs.jfrog.io/ogs/api/lfs/ogs

--- a/web/content/docs/devguide/advanced/gitlab.pandoc
+++ b/web/content/docs/devguide/advanced/gitlab.pandoc
@@ -13,8 +13,6 @@ weight = 1038
 
 [GitLab](https://gitlab.com) is a web-based Git repository manager similar to [GitHub](https://github.com). GitLab can be self-hosted and we do just that with <https://gitlab.opengeosys.org>. For the moment all OGS repositories are still hosted at [github.com/ufz](https://github.com/ufz) but we store benchmark data files on our own GitLab because of storage limits on GitHub.
 
-To submit a PR containing also new benchmark files (or in general: containing files tracked by `git-lfs`) you need an account on our GitLab server.
-
 ## Setup an account
 
 - Creating a GitLab account can be done by simply using your existing GitHub account: click the GitHub logo (octocat) on the [Gitlab sign-in page](https://gitlab.opengeosys.org/users/sign_in)
@@ -22,5 +20,3 @@ To submit a PR containing also new benchmark files (or in general: containing fi
   - You will be redirected to GitHub (please login there) and asked for authorization.
   - Your new user account will be blocked at first, please let us know we will unblock it
 - Once unblocked, on the [ogs group page](https://gitlab.opengeosys.org/ogs) click the button `Request access`. We will then give access to the repo. If the button is not there we already gave you access.
-- Create a [GitLab personal access token](https://gitlab.opengeosys.org/profile/personal_access_tokens), enable the following scopes: `api`, `read_user`. This is the password you have to use when pushing a PR which also contains `git-lfs`-tracked files. Your user name is the same as your GitHub user name.
-- For caching credentials you may want to use a [git credential helper](https://docs.gitlab.com/ee/workflow/lfs/manage_large_binaries_with_git_lfs.html#credentials-are-always-required-when-pushing-an-object).

--- a/web/content/docs/devguide/advanced/working-on-envinf1.pandoc
+++ b/web/content/docs/devguide/advanced/working-on-envinf1.pandoc
@@ -13,6 +13,15 @@ weight = 1036
 
 Members of the Department Environmental Informatics of the Helmholtz Centre for Environmental Research - UFZ can use the `envinf1`-machine which is tightly connected to the Eve cluster system.
 
+::: {.note}
+On envinf1 the installed git module (2.10) is over 2 years old and we recommend using a newer module (especially when you have problems with fetching or checking out of Git LFS files):
+
+```bash
+ml use /global/apps/modulefiles
+ml git/2.20.1
+```
+:::
+
 ## Build OGS-6
 
 Load required modules by sourcing the environment script:


### PR DESCRIPTION
Our Artifactory at https://ogs.jfrog.io/ allows non-authenticated pushes for git lfs files in contrast to GitLab where user always needed to authenticate which was quite uncomfortable especially for new contributors.

We have no size limit on Artifactory so we should be safe for the future.

Related to #2347.

TODO after merge:

- [ ] Switch off git lfs on GitLab to make sure nobody pushes to the old repo