### PR TITLE
[Jenkins] Added [ci skip] functionality.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('jenkins-pipeline@1.0.18') _
+@Library('jenkins-pipeline@1.0.19') _
 
 def stage_required = [build: false, data: false, full: false, docker: false]
 
@@ -19,6 +19,7 @@ pipeline {
         sh "git config core.whitespace -blank-at-eof"
         sh "git diff --check `git merge-base origin/master HEAD` HEAD -- . ':!*.md' ':!*.pandoc'"
         dir('scripts/jenkins') { stash(name: 'known_hosts', includes: 'known_hosts') }
+        ciSkip action: 'check' // Check for [ci skip] commit message.
 
         // ********* Check changesets for conditional stage execution **********
         script {
@@ -64,6 +65,8 @@ pipeline {
           }
         }
       }
+      // Mark build as NOT_BUILT when [ci skip] commit message was found
+      post { always { ciSkip action: 'postProcess' } }
     }
     stage('Build') {
       parallel {

--- a/web/content/docs/devguide/testing/jenkins.pandoc
+++ b/web/content/docs/devguide/testing/jenkins.pandoc
@@ -56,6 +56,14 @@ The master-branch of the the UFZ repository as well as all pull requests on that
 
 ![](../Jenkins-PR-Overview.png)
 
+### Skip automatic testing
+
+If you want to skip the Jenkins automatic testing for a specific commit add `[ci skip]` to the commit message. This marks the Jenkins build as not built (shown as a grey icon). Example:
+
+```
+git commit -m "Added feature X [ci skip]"
+```
+
 ### Automatic testing for own repository
 
 This assumes you have your own clone/fork of OGS on GitHub.


### PR DESCRIPTION
When a commit message contains `[ci skip]` the Jenkins build will be skipped. Can be useful to not overload our CI system when testing is not necessary.