### PR TITLE
[App/IO] Check gmsh return value.

### DIFF
--- a/Applications/FileIO/Legacy/createSurface.cpp
+++ b/Applications/FileIO/Legacy/createSurface.cpp
@@ -82,11 +82,12 @@ bool createSurface(GeoLib::Polyline const& ply,
     std::string gmsh_command =
         "gmsh -2 -algo meshadapt \"" + file_base_name + ".geo\"";
     gmsh_command += " -o \"" + file_base_name + ".msh\"";
-    // Temporarilly disable unused result warning
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wunused-result"
-    std::system(gmsh_command.c_str());
-    #pragma GCC diagnostic pop
+    int const gmsh_return_value = std::system(gmsh_command.c_str());
+    if (gmsh_return_value != 0)
+    {
+        WARN("Call to '%s' returned non-zero value %d.", gmsh_command.c_str(),
+             gmsh_return_value);
+    }
     auto surface_mesh =
         FileIO::GMSH::readGMSHMesh("\"" + file_base_name + ".msh\"");
     if (!surface_mesh)


### PR DESCRIPTION
The PR add testing of the return value of gmsh, which was silently omitted before. The check is related to the warnings about a return value of std::system call not being used.

No test case present. Needs checking by hand from data explorer.