### PR TITLE
Extend ExtractSurface tool

### DIFF
--- a/Applications/Utils/Tests.cmake
+++ b/Applications/Utils/Tests.cmake
@@ -204,3 +204,44 @@ AddTest(
     TESTER diff
     DIFF_DATA 00-raster.asc
 )
+
+AddTest(
+    NAME ExtractSurfaceLeft
+    PATH MeshLib/
+    EXECUTABLE ExtractSurface
+    EXECUTABLE_ARGS -i cube_1x1x1_hex_1e3_layers_10.vtu -o ${Data_BINARY_DIR}/MeshLib/Left.vtu -x 1 -y 0 -z 0 -a 25
+    REQUIREMENTS NOT OGS_USE_MPI
+    TESTER diff
+    DIFF_DATA Left.vtu
+)
+
+AddTest(
+    NAME ExtractSurfaceRight
+    PATH MeshLib/
+    EXECUTABLE ExtractSurface
+    EXECUTABLE_ARGS -i cube_1x1x1_hex_1e3_layers_10.vtu -o ${Data_BINARY_DIR}/MeshLib/Right.vtu -x -1 -y 0 -z 0 -a 25
+    REQUIREMENTS NOT OGS_USE_MPI
+    TESTER diff
+    DIFF_DATA Right.vtu
+)
+
+AddTest(
+    NAME ExtractSurfaceFront
+    PATH MeshLib/
+    EXECUTABLE ExtractSurface
+    EXECUTABLE_ARGS -i cube_1x1x1_hex_1e3_layers_10.vtu -o ${Data_BINARY_DIR}/MeshLib/Front.vtu -x 0 -y 1 -z 0 -a 25
+    REQUIREMENTS NOT OGS_USE_MPI
+    TESTER diff
+    DIFF_DATA Front.vtu
+)
+
+AddTest(
+    NAME ExtractSurfaceBack
+    PATH MeshLib/
+    EXECUTABLE ExtractSurface
+    EXECUTABLE_ARGS -i cube_1x1x1_hex_1e3_layers_10.vtu -o ${Data_BINARY_DIR}/MeshLib/Back.vtu -x 0 -y -1 -z 0 -a 25
+    REQUIREMENTS NOT OGS_USE_MPI
+    TESTER diff
+    TESTER diff
+    DIFF_DATA Back.vtu
+)

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -143,7 +143,8 @@ MeshLib::Mesh* MeshSurfaceExtraction::getMeshSurface(
     }
 
     // transmit the original subsurface element ids as a property
-    if (!subsfc_element_id_prop_name.empty()) {
+    if (!subsfc_element_id_prop_name.empty())
+    {
         MeshLib::addPropertyToMesh(*result, subsfc_element_id_prop_name,
                                    MeshLib::MeshItemType::Cell, 1,
                                    element_ids_map);
@@ -156,6 +157,19 @@ MeshLib::Mesh* MeshSurfaceExtraction::getMeshSurface(
                                    face_ids_map);
     }
 
+    auto const* subsurface_material_ids(MeshLib::materialIDs(subsfc_mesh));
+    if (subsurface_material_ids)
+    {
+        std::vector<int> material_ids;
+        material_ids.reserve(sfc_elements.size());
+        for (auto bulk_id : element_ids_map)
+        {
+            material_ids.push_back((*subsurface_material_ids)[bulk_id]);
+        }
+        MeshLib::addPropertyToMesh(*result, "MaterialIDs",
+                                   MeshLib::MeshItemType::Cell, 1,
+                                   material_ids);
+    }
     return result;
 }
 

--- a/Tests/Data/MeshLib/Back.vtu
+++ b/Tests/Data/MeshLib/Back.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a269d7b490071f842ae8f95efccccd62a46ae799804d55606c75599be2145da
+size 14767

--- a/Tests/Data/MeshLib/Front.vtu
+++ b/Tests/Data/MeshLib/Front.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6552aa6358af7be5982c64c0ce9b95186e560b2ff063f5b6b5c03287f24b2133
+size 14764

--- a/Tests/Data/MeshLib/Left.vtu
+++ b/Tests/Data/MeshLib/Left.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e736ca07e17d322817487a9c56195d0c897285acf1c4cc8b96383d8077f13f4
+size 14764

--- a/Tests/Data/MeshLib/Right.vtu
+++ b/Tests/Data/MeshLib/Right.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc62e9826904cc6a5e58108447cde919e2169e2fb7c676b3ed6beafb3e2d3b70
+size 14765

--- a/Tests/Data/MeshLib/cube_1x1x1_hex_1e3_layers_10.vtu
+++ b/Tests/Data/MeshLib/cube_1x1x1_hex_1e3_layers_10.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fc6549510bdd96a6ca802bb7fb72bfeb96a086678c1a02b8d6d702655e952a0
+size 110815

--- a/web/content/docs/tools/meshing/extract-surface/CubeFrontRightBackLeft.png
+++ b/web/content/docs/tools/meshing/extract-surface/CubeFrontRightBackLeft.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a4c061079f837aae8ccc58fe743b2ee1f1cb96069961b473297b1e1c1a42e0
+size 173061

--- a/web/content/docs/tools/meshing/extract-surface/index.pandoc
+++ b/web/content/docs/tools/meshing/extract-surface/index.pandoc
@@ -33,3 +33,10 @@ Extracted top, bottom and side surfaces:
 - top `ExtractSurface -i Input.vtu -o TopSurface.vtu`
 - bottom `ExtractSurface -i Input.vtu -o BottomSurface.vtu -x 0 -y 0 -z 1`
 - side `ExtractSurface -i Input.vtu -o SideSurface.vtu -x 1 -y 1 -z 0 -a 45`
+
+![](CubeFrontRightBackLeft.png)
+
+The figure shows the extracted front, right, back, and left surfaces from the
+cube that are colored by the corresponding subsurface material id. The material
+ids transformed to the surfaces can be used for further boundary condition
+preparations for instance employing paraviews threshold filter.


### PR DESCRIPTION
Add the subsurface MaterialIDs to the extracted surface. This information can be further be used for setting the boundary conditions.