### PR TITLE
Cleanup _MSC_VER uses.

### DIFF
--- a/BaseLib/ConfigTree.h
+++ b/BaseLib/ConfigTree.h
@@ -545,12 +545,7 @@ private:
      *
      * This method only acts as a helper method and throws std::runtime_error.
      */
-#if defined(_MSC_VER) && _MSC_VER < 1500
-    __declspec(noreturn)
-#else
-    [[noreturn]]
-#endif
-        void error(std::string const& message) const;
+    [[noreturn]] void error(std::string const& message) const;
 
     //! Called for printing warning messages. Will call the warning callback.
     //! This method only acts as a helper method.

--- a/BaseLib/Error.h
+++ b/BaseLib/Error.h
@@ -19,11 +19,7 @@ namespace BaseLib
 namespace detail
 {
 template <typename Msg>
-#if defined(_MSC_VER) && _MSC_VER < 1500
-__declspec(noreturn)
-#else
 [[noreturn]]
-#endif
     bool error_impl(Msg&& msg)
 {
     ERR("%s", msg.data());
@@ -43,11 +39,7 @@ namespace BaseLib
 namespace detail
 {
 template <typename Msg>
-#if defined(_MSC_VER) && _MSC_VER < 1500
-__declspec(noreturn)
-#else
 [[noreturn]]
-#endif
     bool error_impl(Msg&& msg)
 {
     throw std::runtime_error(std::forward<Msg>(msg));

--- a/BaseLib/RunTime.h
+++ b/BaseLib/RunTime.h
@@ -38,7 +38,7 @@ class RunTime
 #if defined(USE_MPI)
             _start_time = MPI_Wtime();
 #else
-#ifndef _MSC_VER
+#ifndef WIN32
             timeval t;
             gettimeofday(&t, nullptr);
             _start_time = t.tv_sec + t.tv_usec/1000000.0;
@@ -54,7 +54,7 @@ class RunTime
 #if defined(USE_MPI)
             return MPI_Wtime() - _start_time;
 #else
-#ifndef _MSC_VER
+#ifndef WIN32
             timeval t;
             gettimeofday(&t, nullptr);
             return t.tv_sec + t.tv_usec/1000000.0 - _start_time;

--- a/NumLib/Assembler/SerialExecutor.h
+++ b/NumLib/Assembler/SerialExecutor.h
@@ -46,11 +46,7 @@ struct SerialExecutor
     ///
     template <typename F, typename C, typename... Args_>
     static void
-#if defined(_MSC_VER) && (_MSC_VER >= 1700)
-    executeDereferenced(F& f, C const& c, Args_&&... args)
-#else
     executeDereferenced(F const& f, C const& c, Args_&&... args)
-#endif
     {
         for (std::size_t i = 0; i < c.size(); i++)
         {
@@ -191,12 +187,8 @@ struct SerialExecutor
     ///             size().
     /// \param args additional arguments passed to \c f
     template <typename F, typename C, typename Data, typename... Args_>
-    static void
-#if defined(_MSC_VER) && (_MSC_VER >= 1700)
-    transformDereferenced(F& f, C const& c, Data& data, Args_&&... args)
-#else
-    transformDereferenced(F const& f, C const& c, Data& data, Args_&&... args)
-#endif
+    static void transformDereferenced(F const& f, C const& c, Data& data,
+                                      Args_&&... args)
     {
         assert(c.size() == data.size());
 

--- a/Tests/GeoLib/TestLineSegmentIntersect2d.cpp
+++ b/Tests/GeoLib/TestLineSegmentIntersect2d.cpp
@@ -50,13 +50,6 @@ public:
     ac::gtest_reporter gtest_reporter;
 };
 
-#if !defined(_MSC_VER) || (_MSC_VER >= 2000)
-// Compilers of MVS below 2015 do not support unrestricted unions. The
-// unrestricted union is used by autocheck to handle test data. The autocheck
-// workaround for MVS compilers (below version 2015) contains a bug and in the
-// consequence the tests crashes. For this reason the tests are disabled under
-// this environments.
-
 // Test the intersection of intersecting line segments. Line segments are chords
 // of the same circle that both contains the center of the circle. As a
 // consequence the center of the circle is the intersection point.
@@ -139,5 +132,3 @@ TEST_F(LineSegmentIntersect2dTest, ParallelIntersectingSegmentOrientation)
         ac::make_arbitrary(pair_segment_generator2),
         gtest_reporter);
 }
-
-#endif

--- a/Tests/GeoLib/TestSortSegments.cpp
+++ b/Tests/GeoLib/TestSortSegments.cpp
@@ -30,13 +30,6 @@ public:
     ac::gtest_reporter gtest_reporter;
 };
 
-#if !defined(_MSC_VER) || (_MSC_VER >= 2000)
-// Compilers of MVS below 2015 do not support unrestricted unions. The
-// unrestricted union is used by autocheck to handle test data. The autocheck
-// workaround for MVS compilers (below version 2015) contains a bug and in the
-// consequence the tests crashes. For this reason the tests are disabled under
-// this environments.
-
 // Use a chord of the unit circle as the original line segment. The line segment
 // will be partitioned into several sub segments. The set of subsegments are
 // given to the algorithm.
@@ -115,5 +108,3 @@ TEST_F(GeoLibSortLineSegments, SortSubSegments)
         ac::make_arbitrary(segment_generator),
         gtest_reporter);
 }
-
-#endif


### PR DESCRIPTION
Some older VisualStudio compilers are no longer supported anyway.