### PR TITLE
Package non python

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -346,12 +346,10 @@ pipeline {
               def num_threads = env.NUM_THREADS
               bat 'git submodule sync'
               bat 'conan remove --locks'
-              // CLI + GUI
-              configure {
+              configure { // CLI + GUI
                 cmakeOptions =
                   "-DBUILD_SHARED_LIBS=OFF " +
                   '-DOGS_DOWNLOAD_ADDITIONAL_CONTENT=ON ' +
-                  '-DOGS_USE_PYTHON=ON ' +
                   '-DOGS_BUILD_GUI=ON ' +
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_BUILD_SWMM=ON '
@@ -361,6 +359,11 @@ pipeline {
                 log="build.log"
                 cmd_args="-l ${num_threads}"
               }
+              configure { // CLI + GUI + Python
+                cmakeOptions = '-DOGS_USE_PYTHON=ON '
+                keepDir = true
+              }
+              build { target="package" }
               build { target="tests" }
               build { target="ctest" }
             }

--- a/scripts/cmake/packaging/Pack.cmake
+++ b/scripts/cmake/packaging/Pack.cmake
@@ -16,8 +16,11 @@ set(CPACK_RESOURCE_FILE_README "${PROJECT_SOURCE_DIR}/README.md")
 # set(CPACK_RESOURCE_FILE_WELCOME "${PROJECT_SOURCE_DIR}/README.md")
 
 # Package file name
+if(OGS_USE_PYTHON)
+    set(SUFFIX "${SUFFIX}-python-${Python_VERSION}")
+endif()
 if(OGS_BUILD_GUI)
-    set(SUFFIX "-de")
+    set(SUFFIX "${SUFFIX}-de")
 endif()
 if(OGS_BUILD_UTILS)
     set(SUFFIX "${SUFFIX}-utils")


### PR DESCRIPTION
Packaged OGS build with `OGS_USE_PYTHON=ON` has a dependency on the Python distribution (Python system modules) it was built with.

This PR adds the used Python version as a string to the package name and adds Windows packages without Python for easy distribution.