### PR TITLE
Fix conan (Default) vs System library selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,9 @@ set(OGS_CONAN_BUILD "missing" CACHE STRING "Possible values: all, missing, \
     never or list of libs to build" )
 
 # Third-party libraries, names come from Conan package names
-set(OGS_LIBS VTK Boost Eigen3 Qt Shapelib libgeotiff CACHE INTERNAL "")
+set(OGS_LIBS
+    VTK Boost Eigen3 Qt Shapelib libgeotiff petsc lis cvode
+    CACHE INTERNAL "")
 foreach(LIB ${OGS_LIBS})
     set(OGS_LIB_${LIB} "Default" CACHE STRING "Which ${LIB} library should be used?")
     set_property(CACHE OGS_LIB_${LIB} PROPERTY STRINGS "Default" "System")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,14 @@ endif()
 option(OGS_USE_CONAN "Should Conan package manager be used?" ON)
 set(OGS_CONAN_BUILD "missing" CACHE STRING "Possible values: all, missing, \
     never or list of libs to build" )
+
+# Third-party libraries, names come from Conan package names
+set(OGS_LIBS VTK Boost Eigen3 Qt Shapelib libgeotiff CACHE INTERNAL "")
+foreach(LIB ${OGS_LIBS})
+    set(OGS_LIB_${LIB} "Default" CACHE STRING "Which ${LIB} library should be used?")
+    set_property(CACHE OGS_LIB_${LIB} PROPERTY STRINGS "Default" "System")
+endforeach(LIB)
+
 if(OGS_USE_PETSC)
     set(OGS_USE_MPI ON CACHE BOOL "Use MPI" FORCE)
 endif()
@@ -213,13 +221,6 @@ endif ()
 option(OGS_COVERAGE "Enables code coverage measurements with gcov/lcov." OFF)
 
 option(OGS_SYNC_SUBMODULES "Sync git submodules on CMake run. Overwrites custom URLs!" ON)
-
-# Third-party libraries, names come from Conan package names
-set(OGS_LIBS VTK Boost Eigen3 Qt Shapelib libgeotiff CACHE INTERNAL "")
-foreach(LIB ${OGS_LIBS})
-    set(OGS_LIB_${LIB} "Default" CACHE STRING "Which ${LIB} library should be used?")
-    set_property(CACHE OGS_LIB_${LIB} PROPERTY STRINGS "Default" "System")
-endforeach(LIB)
 
 # Options controlling which FEM elements will be compiled
 set(OGS_MAX_ELEMENT_DIM   3 CACHE STRING "Maximum dimension of FEM elements to be built.")


### PR DESCRIPTION
The list of libraries which are to be included or excluded
from the conan's list of required libraries must preceed
the conan include(ConanSetup) line. Otherwise the selection
does not have any effects.