### PR TITLE
Make NetCDF optional.

### DIFF
--- a/Applications/DataExplorer/Base/ImportFileTypes.h
+++ b/Applications/DataExplorer/Base/ImportFileTypes.h
@@ -22,8 +22,8 @@
 class ImportFileType
 {
 public:
-
-    enum type {
+    enum type
+    {
         OGS = 0,
         OGS_GEO,
         OGS_STN,
@@ -31,7 +31,9 @@ public:
         FEFLOW,
         GMS,
         GMSH,
+#ifdef OGS_USE_NETCDF
         NETCDF,
+#endif  // OGS_USE_NETCDF
         PETREL,
         POLYRASTER,
         RASTER,
@@ -48,8 +50,10 @@ public:
             return "GMS";
         if (t == ImportFileType::GMSH)
             return "GMSH";
+#ifdef OGS_USE_NETCDF
         if (t == ImportFileType::NETCDF)
             return "NetCDF";
+#endif  // OGS_USE_NETCDF
         if (t == ImportFileType::OGS)
             return "OGS";
         if (t == ImportFileType::OGS_GEO)
@@ -80,8 +84,10 @@ public:
             return "GMS files (*.txt *.3dm)";
         if (t == ImportFileType::GMSH)
             return "GMSH mesh files (*.msh)";
+#ifdef OGS_USE_NETCDF
         if (t == ImportFileType::NETCDF)
             return "NetCDF files (*.nc)";
+#endif  // OGS_USE_NETCDF
         if (t == ImportFileType::OGS)
             return "OpenGeosys files (*.prj *.gml *.vtu *.stn);;GeoSys legacy "
                    "files (*.gli *.msh);;All files (* *.*)";

--- a/Applications/DataExplorer/CMakeLists.txt
+++ b/Applications/DataExplorer/CMakeLists.txt
@@ -24,7 +24,6 @@ add_subdirectory(Base)
 add_subdirectory(DataView/StratView)
 add_subdirectory(DataView)
 add_subdirectory(DataView/DiagramView)
-add_subdirectory(NetCdfDialog)
 add_subdirectory(VtkVis)
 include(DataExplorer.cmake)
 

--- a/Applications/DataExplorer/DataExplorer.cmake
+++ b/Applications/DataExplorer/DataExplorer.cmake
@@ -37,7 +37,6 @@ target_link_libraries(DataExplorer
     MeshLib
     ApplicationsFileIO
     DataHolderLib
-    NetCdfDialogLib
     OGSFileConverterLib
     QtBase
     QtDataView
@@ -52,6 +51,13 @@ target_link_libraries(DataExplorer
     logog
     ${VTK_LIBRARIES}
 )
+
+
+if(OGS_USE_NETCDF)
+    add_definitions(-DOGS_USE_NETCDF)
+    add_subdirectory(NetCdfDialog)
+    target_link_libraries(DataExplorer NetCdfDialogLib)
+endif()
 
 if(NOT APPLE AND OGS_USE_CONAN)
     # HACK for unresolved external

--- a/Applications/DataExplorer/VtkVis/CMakeLists.txt
+++ b/Applications/DataExplorer/VtkVis/CMakeLists.txt
@@ -138,9 +138,14 @@ if(GEOTIFF_FOUND)
 endif() # GEOTIFF_FOUND
 
 target_link_libraries(VtkVis
-    PUBLIC BaseLib GeoLib MeshLib DataHolderLib QtBase vtkIOImage NetCdfDialogLib
+    PUBLIC BaseLib GeoLib MeshLib DataHolderLib QtBase vtkIOImage
     PRIVATE MathLib ApplicationsFileIO Qt5::Gui logog
 )
+
+if (OGS_USE_NETCDF)
+    target_link_libraries(VtkVis PRIVATE NetCdfDialogLib)
+endif()
+
 if(NOT APPLE AND OGS_USE_CONAN)
     # HACK for unresolved external
     target_link_libraries(VtkVis PUBLIC vtkGUISupportQt-8.1)

--- a/Applications/DataExplorer/VtkVis/VtkCompositeTextureOnSurfaceFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeTextureOnSurfaceFilter.cpp
@@ -23,7 +23,9 @@
 #include <vtkUnstructuredGrid.h>
 #include "VtkGeoImageSource.h"
 #include "VtkRaster.h"
+#ifdef OGS_USE_NETCDF
 #include "NetCdfDialog/NetCdfConfigureDialog.h"
+#endif  // OGS_USE_NETCDF
 
 #include <QFileDialog>
 #include <QFileInfo>
@@ -61,9 +63,14 @@ void VtkCompositeTextureOnSurfaceFilter::init()
 
     QWidget* parent = nullptr;
     QSettings settings;
-    QString fileName = QFileDialog::getOpenFileName(parent, "Select raster file to apply as texture",
-                                                    settings.value("lastOpenedTextureFileDirectory").toString(),
-                                                    "Raster files (*.asc *.grd *.bmp *.jpg *.png *.tif);;NetCDF files (*.nc);;");
+    QString fileName = QFileDialog::getOpenFileName(
+        parent, "Select raster file to apply as texture",
+        settings.value("lastOpenedTextureFileDirectory").toString(),
+        "Raster files (*.asc *.grd *.bmp *.jpg *.png *.tif);;"
+#ifdef OGS_USE_NETCDF
+        "NetCDF files (*.nc);;"
+#endif  // OGS_USE_NETCDF
+    );
     QFileInfo fi(fileName);
 
     if ((fi.suffix().toLower() == "asc") || (fi.suffix().toLower() == "tif") ||
@@ -79,6 +86,7 @@ void VtkCompositeTextureOnSurfaceFilter::init()
         QDir dir = QDir(fileName);
         settings.setValue("lastOpenedTextureFileDirectory", dir.absolutePath());
     }
+#ifdef OGS_USE_NETCDF
     else if (fi.suffix().toLower() == "nc")
     {
         NetCdfConfigureDialog dlg(fileName.toStdString().c_str());
@@ -94,6 +102,7 @@ void VtkCompositeTextureOnSurfaceFilter::init()
             surface->Update();
         }
     }
+#endif  // OGS_USE_NETCDF
     else
         ERR("VtkCompositeTextureOnSurfaceFilter::init(): Error reading texture file.");
 

--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -73,7 +73,9 @@
 #include "MeshAnalysisDialog.h"
 #include "MeshElementRemovalDialog.h"
 #include "MeshQualitySelectionDialog.h"
+#ifdef OGS_USE_NETCDF
 #include "NetCdfDialog/NetCdfConfigureDialog.h"
+#endif  // OGS_USE_NETCDF
 #include "SHPImportDialog.h"
 #include "SetNameDialog.h"
 #include "VtkAddFilterDialog.h"
@@ -609,6 +611,7 @@ void MainWindow::loadFile(ImportFileType::type t, const QString &fileName)
         }
         settings.setValue("lastOpenedFileDirectory", dir.absolutePath());
     }
+#ifdef OGS_USE_NETCDF
     else if (t == ImportFileType::NETCDF)    // CH  01.2012
     {
 
@@ -625,6 +628,7 @@ void MainWindow::loadFile(ImportFileType::type t, const QString &fileName)
 
         settings.setValue("lastOpenedRasterFileDirectory", dir.absolutePath());
     }
+#endif  // OGS_USE_NETCDF
     else if (t == ImportFileType::RASTER)
     {
         VtkGeoImageSource* geoImage = VtkGeoImageSource::New();
@@ -748,9 +752,11 @@ QMenu* MainWindow::createImportFilesMenu()
     QAction* gmshFiles = importFiles->addAction("&GMSH Files...");
     connect(gmshFiles, SIGNAL(triggered()), signal_mapper, SLOT(map()));
     signal_mapper->setMapping(gmshFiles, ImportFileType::GMSH);
+#ifdef OGS_USE_NETCDF
     QAction* netcdfFiles = importFiles->addAction("&NetCDF Files...");
     connect(netcdfFiles, SIGNAL(triggered()), signal_mapper, SLOT(map()));
     signal_mapper->setMapping(netcdfFiles, ImportFileType::NETCDF);
+#endif  // OGS_USE_NETCDF
     QAction* petrelFiles = importFiles->addAction("&Petrel Files...");
     connect(petrelFiles, SIGNAL(triggered()), this, SLOT(loadPetrelFiles()));
     QAction* rasterFiles = importFiles->addAction("&Raster Files...");

--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -17,6 +17,7 @@
 #include <logog/include/logog.hpp>
 
 // Qt includes
+#include <QDate>
 #include <QDesktopWidget>
 #include <QFileDialog>
 #include <QMessageBox>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ option(OGS_BUILD_CLI "Should the OGS simulator be built?" ON)
 option(OGS_BUILD_GUI "Should the Data Explorer be built?" OFF)
 if(OGS_BUILD_GUI)
     add_definitions(-DOGS_BUILD_GUI)
+    option(OGS_USE_NETCDF "Add NetCDF support." ON)
 endif()
 option(OGS_BUILD_UTILS "Should the utilities programms be built?" OFF)
 


### PR DESCRIPTION
Adds an `OGS_USE_NETCDF` option with default being ON => no changes to current setup.
The NetCDF related code is wrapped in if conditions.

Background: The NetCDF library interface provided by paraview/vtk is used now, not the actual netcdf-cxx library. On some systems paraview/vtk installation does not provide the header files for the internally used interface. This leads to compilation problems of the DE. On the long run the netcdf-cxx library should be used directly, not the paraview/vtk interface to that library.

Closes https://github.com/ufz/ogs/issues/2379