### PR TITLE
[CMake] Added CVODE_INCLUDE_DIRS to MathLib.

### DIFF
--- a/MathLib/CMakeLists.txt
+++ b/MathLib/CMakeLists.txt
@@ -39,6 +39,7 @@ set_target_properties(MathLib PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(MathLib PUBLIC BaseLib logog ${OpenMP_CXX_LIBRARIES})
 
 if (CVODE_FOUND)
+    target_include_directories(MathLib PRIVATE ${CVODE_INCLUDE_DIRS})
     target_link_libraries(MathLib PUBLIC ${CVODE_LIBRARIES})
 endif()
 


### PR DESCRIPTION
Is required when CVode is installed in a non-standard location.