### PR TITLE
Fixing warnings

### DIFF
--- a/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshElementRemovalDialog.cpp
@@ -92,12 +92,20 @@ void MeshElementRemovalDialog::accept()
             min_val = this->insideScalarMinEdit->text().toDouble();
             max_val = this->insideScalarMaxEdit->text().toDouble();
         }
-        std::size_t n_marked_elements =
-            ex.searchByPropertyValueRange<double>(array_name, min_val, max_val, outside);
 
-        if (n_marked_elements == 0)
-            n_marked_elements =
-                ex.searchByPropertyValueRange<int>(array_name, min_val, max_val, outside);
+        std::size_t n_marked_elements(0);
+        if (msh->getProperties().existsPropertyVector<double>(array_name))
+        {
+            n_marked_elements = ex.searchByPropertyValueRange<double>(
+                array_name, min_val, max_val, outside);
+        }
+        if (msh->getProperties().existsPropertyVector<int>(array_name))
+        {
+            int const lbound = static_cast<int>(min_val);
+            int const rbound = static_cast<int>(max_val);
+            n_marked_elements = ex.searchByPropertyValueRange<int>(
+                array_name, lbound, rbound, outside);
+        }
 
         if (n_marked_elements > 0)
             anything_checked = true;

--- a/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.cpp
+++ b/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.cpp
@@ -148,9 +148,9 @@ void NetCdfConfigureDialog::on_comboBoxDim4_currentIndexChanged(int id)
         unsigned size = 0;
         getDimEdges(id,size,firstValue,lastValue);
         // WARNING: Implicit conversion to int in spinBoxDim4->set*()
-        spinBoxDim4->setValue(firstValue);
-        spinBoxDim4->setMinimum(firstValue);
-        spinBoxDim4->setMaximum(lastValue);
+        spinBoxDim4->setValue(static_cast<int>(firstValue));
+        spinBoxDim4->setMinimum(static_cast<int>(firstValue));
+        spinBoxDim4->setMaximum(static_cast<int>(lastValue));
     }
 }
 
@@ -256,7 +256,7 @@ void NetCdfConfigureDialog::getDaysTime(double minSince, QTime &time, int &days)
 
 long NetCdfConfigureDialog::convertDateToMinutes(QDateTime initialDateTime, QDate selectedDate, QTime selectedTime)
 {
-    int tmpInitialToSelectedDate = (selectedDate.daysTo(initialDateTime.date()));
+    long tmpInitialToSelectedDate = static_cast<long>(selectedDate.daysTo(initialDateTime.date()));
     long selectedDays = - tmpInitialToSelectedDate * 24 * 60;
     long selectedMinutes = (selectedTime.hour() * 60) + selectedTime.minute() + selectedDays;
     return selectedMinutes;
@@ -266,10 +266,10 @@ int NetCdfConfigureDialog::getTimeStep()
 {
     NcVar* timeVar = _currentFile->get_var(comboBoxDim2->currentIndex());
 
-    const double datesToMinutes = convertDateToMinutes(_currentInitialDateTime,dateTimeEditDim3->date(),dateTimeEditDim3->time());
+    int const datesToMinutes = convertDateToMinutes(_currentInitialDateTime,dateTimeEditDim3->date(),dateTimeEditDim3->time());
 
-    double timeArray[1] = {datesToMinutes};
-    double currentTime = timeVar->get_index(timeArray);
+    int timeArray[1] = {datesToMinutes};
+    int currentTime = timeVar->get_index(timeArray);
     if (currentTime < 0) currentTime=0; //if the value isn't found in the array, set it to 0 as default...
     return currentTime;
 }
@@ -277,8 +277,8 @@ int NetCdfConfigureDialog::getTimeStep()
 int NetCdfConfigureDialog::getDim4() const
 {
     NcVar* dim3Var = _currentFile->get_var(comboBoxDim4->currentIndex());
-    double timeArray[1] = {static_cast<double>(spinBoxDim4->value())};
-    double currentValueDim3 = dim3Var->get_index(timeArray);
+    int timeArray[1] = {spinBoxDim4->value()};
+    int currentValueDim3 = dim3Var->get_index(timeArray);
     if (currentValueDim3 < 0) currentValueDim3=0; //if the value isn't found in the array, set it to 0 as default...
     return currentValueDim3;
 }

--- a/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.cpp
+++ b/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.cpp
@@ -266,12 +266,12 @@ int NetCdfConfigureDialog::getTimeStep()
 {
     NcVar* timeVar = _currentFile->get_var(comboBoxDim2->currentIndex());
 
-    int const datesToMinutes = convertDateToMinutes(_currentInitialDateTime,dateTimeEditDim3->date(),dateTimeEditDim3->time());
+    double const datesToMinutes = convertDateToMinutes(_currentInitialDateTime,dateTimeEditDim3->date(),dateTimeEditDim3->time());
 
-    int timeArray[1] = {datesToMinutes};
-    int currentTime = timeVar->get_index(timeArray);
+    double timeArray[1] = {datesToMinutes};
+    double currentTime = timeVar->get_index(timeArray);
     if (currentTime < 0) currentTime=0; //if the value isn't found in the array, set it to 0 as default...
-    return currentTime;
+    return static_cast<int>(currentTime);
 }
 
 int NetCdfConfigureDialog::getDim4() const

--- a/Applications/DataExplorer/VtkVis/VtkColorByHeightFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkColorByHeightFilter.cpp
@@ -20,7 +20,7 @@
 #include "VtkColorLookupTable.h"
 
 #include <vtkCellData.h>
-#include <vtkFloatArray.h>
+#include <vtkDoubleArray.h>
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
 #include <vtkLookupTable.h>
@@ -52,14 +52,11 @@ void VtkColorByHeightFilter::PrintSelf( ostream& os, vtkIndent indent )
 
 vtkMTimeType VtkColorByHeightFilter::GetMTime()
 {
-    unsigned long t1, t2;
-
-    t1 = this->Superclass::GetMTime();
+    vtkMTimeType t1 = this->Superclass::GetMTime();
     if (this->ColorLookupTable)
     {
-        t2 = this->ColorLookupTable->GetMTime();
-        if (t2 > t1)
-            t1 = t2;
+        vtkMTimeType const t2 = this->ColorLookupTable->GetMTime();
+        return std::max(t1, t2);
     }
     return t1;
 }
@@ -70,7 +67,7 @@ int VtkColorByHeightFilter::RequestData( vtkInformation*,
     vtkInformation* inInfo = inputVector[0]->GetInformationObject(0);
     vtkPolyData* input = vtkPolyData::SafeDownCast(inInfo->Get(vtkDataObject::DATA_OBJECT()));
 
-    vtkSmartPointer<vtkFloatArray> colors = vtkSmartPointer<vtkFloatArray>::New();
+    vtkSmartPointer<vtkDoubleArray> colors = vtkSmartPointer<vtkDoubleArray>::New();
     colors->SetNumberOfComponents(1);
     std::size_t nPoints = input->GetNumberOfPoints();
     colors->SetNumberOfValues(nPoints);

--- a/Applications/DataExplorer/VtkVis/VtkColorLookupTable.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkColorLookupTable.cpp
@@ -53,7 +53,7 @@ void VtkColorLookupTable::Build()
     double range[2];
     this->GetTableRange(range);
     const double interval = range[1]-range[0];
-    this->SetNumberOfTableValues(ceil(interval)+1);
+    this->SetNumberOfTableValues(static_cast<vtkIdType>(ceil(interval))+1);
 //    const vtkIdType nColours = this->GetNumberOfTableValues();
     if (!_dict.empty())
     {

--- a/Applications/DataExplorer/VtkVis/VtkColorLookupTable.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkColorLookupTable.cpp
@@ -148,7 +148,7 @@ void VtkColorLookupTable::GetTableValue(vtkIdType idx, unsigned char rgba[4])
     vtkLookupTable::GetTableValue(idx, value);
 
     for (unsigned i=0; i<4; ++i)
-        rgba[i] = value[i]*255.0;
+        rgba[i] = static_cast<unsigned char>(value[i]*255.0);
 }
 
 void VtkColorLookupTable::setColor(double pos, DataHolderLib::Color const& color)

--- a/Applications/DataExplorer/VtkVis/VtkCompositeFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeFilter.cpp
@@ -33,8 +33,7 @@ VtkCompositeFilter::~VtkCompositeFilter()
     _outputAlgorithm->Delete();
 }
 
-
-float VtkCompositeFilter::GetInitialRadius() const
+double VtkCompositeFilter::GetInitialRadius() const
 {
     double bounding_box[6];
     static_cast<vtkPolyData*>(this->_inputAlgorithm->GetOutputDataObject(0))->GetBounds(bounding_box);

--- a/Applications/DataExplorer/VtkVis/VtkCompositeFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeFilter.h
@@ -67,7 +67,7 @@ public:
 
 protected:
     /// Calculates a 1/200th of the largest extension of the bounding box (this is used as default radius for various filters)
-    float GetInitialRadius() const;
+    double GetInitialRadius() const;
 
     /// See [vtkSetGet.h](https://github.com/Kitware/VTK/blob/master/Common/Core/vtkSetGet.h)
     /// for the defines

--- a/Applications/DataExplorer/VtkVis/VtkCompositeGeoObjectFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeGeoObjectFilter.cpp
@@ -88,7 +88,8 @@ void VtkCompositeGeoObjectFilter::init()
 
 void VtkCompositeGeoObjectFilter::SetIndex(std::size_t idx)
 {
-    _threshold->ThresholdBetween(idx, idx);
+    double const d_idx = static_cast<double>(idx);
+    _threshold->ThresholdBetween(d_idx, d_idx);
 }
 
 

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToLinePolyDataFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToLinePolyDataFilter.cpp
@@ -90,8 +90,9 @@ int VtkImageDataToLinePolyDataFilter::RequestData(vtkInformation*,
     // Compute scaling factor that max height is 0.1 * longest image dimension
     double range[2];
     inPD->GetArray(0)->GetRange(range);
-    float scalingFactor = (std::max(dimensions[0], dimensions[1]) * spacing[0] * 0.1)
-                          / std::max(range[0], range[1]);
+    double const scalingFactor =
+        (std::max(dimensions[0], dimensions[1]) * spacing[0] * 0.1) /
+        std::max(range[0], range[1]);
 
     double dir[3] = {0, 0, 1};
 
@@ -104,9 +105,9 @@ int VtkImageDataToLinePolyDataFilter::RequestData(vtkInformation*,
             continue;
 
         // Compute length of the new line (scalar * LengthScaleFactor)
-        float length = ((float*)inScalarPtr)[ptId * numScalarComponents]
-                       * scalingFactor * this->LengthScaleFactor;
-        //float length = (((unsigned char*)inScalarPtr)[ptId * numScalarComponents]* this->LengthScaleFactor > 50000) ? 50000 : ((unsigned char*)inScalarPtr)[ptId * numScalarComponents]* this->LengthScaleFactor;
+        double const length =
+            ((float*)inScalarPtr)[ptId * numScalarComponents] * scalingFactor *
+            this->LengthScaleFactor;
 
         // Skip this line if length is zero
         if (length < 0.00000001f)

--- a/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkImageDataToPointCloudFilter.cpp
@@ -93,7 +93,7 @@ int VtkImageDataToPointCloudFilter::RequestData(
         }
         float const val(((float*)pixvals)[i * n_comp]);
         double const calc_gamma = (IsLinear) ? 1 : Gamma;
-        double const pnts_per_cell = interpolate(range[0], range[1], val, calc_gamma);
+        std::size_t const pnts_per_cell = interpolate(range[0], range[1], val, calc_gamma);
         density.push_back(static_cast<std::size_t>(
             std::floor(pnts_per_cell * GetPointScaleFactor())));
     }

--- a/Applications/DataExplorer/VtkVis/VtkRaster.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkRaster.cpp
@@ -72,7 +72,7 @@ vtkImageImport* VtkRaster::loadImageFromArray(double const*const data_array, Geo
 {
     const unsigned length = header.n_rows * header.n_cols * header.n_depth;
     auto* data = new float[length * 2];
-    float max_val = *std::max_element(data_array, data_array+length);
+    float max_val = static_cast<float>(*std::max_element(data_array, data_array+length));
     for (unsigned j=0; j<length; ++j)
     {
         data[j*2] = static_cast<float>(data_array[j]);

--- a/Applications/DataExplorer/VtkVis/VtkRaster.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkRaster.cpp
@@ -180,9 +180,9 @@ vtkImageImport* VtkRaster::loadImageFromTIFF(const std::string &fileName,
                     if (photometric==1 && colormap_used==1)
                     {
                         int idx = TIFFGetR(pixVal[pxl_idx]);
-                        data[pos]   = cmap_red[idx] >> 8;
-                        data[pos+1] = cmap_green[idx] >> 8;
-                        data[pos+2] = cmap_blue[idx] >> 8;
+                        data[pos]   = static_cast<float>(cmap_red[idx] >> 8);
+                        data[pos+1] = static_cast<float>(cmap_green[idx] >> 8);
+                        data[pos+2] = static_cast<float>(cmap_blue[idx] >> 8);
                         data[pos+3] = 1;
                     }
                     else

--- a/Applications/DataExplorer/VtkVis/VtkSurfacesSource.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkSurfacesSource.cpp
@@ -90,7 +90,7 @@ int VtkSurfacesSource::RequestData( vtkInformation* request,
         newPoints->SetPoint(i, coords);
     }
 
-    vtkIdType count(0);
+    int count(0);
     for (auto surface : *_surfaces)
     {
         const std::size_t nTriangles = surface->getNumberOfTriangles();

--- a/Applications/FileIO/XmlIO/Qt/XmlNumInterface.cpp
+++ b/Applications/FileIO/XmlIO/Qt/XmlNumInterface.cpp
@@ -95,7 +95,7 @@ void XmlNumInterface::readIterationScheme(QDomElement const& iteration_root)
         if (iteration_node.nodeName().compare("MaxIterations") == 0)
             max_iterations = iteration_node.toElement().text().toInt();
         if (iteration_node.nodeName().compare("FixedStepSize") == 0)
-            fixed_step_size = iteration_node.toElement().text().toDouble();
+            fixed_step_size = iteration_node.toElement().text().toInt();
 
         iteration_node = iteration_node.nextSiblingElement();
     }

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -178,7 +178,7 @@ findNonGhostNodesInPartition(
     return {base_nodes, higher_order_nodes};
 }
 
-int numberOfRegularNodes(
+std::ptrdiff_t numberOfRegularNodes(
     MeshLib::Element const& e, std::size_t const part_id,
     std::vector<std::size_t> const& partition_ids,
     std::vector<std::size_t> const* node_id_mapping = nullptr)
@@ -217,7 +217,8 @@ findElementsInPartition(
             continue;
         }
 
-        if (regular_nodes == static_cast<int>(elem->getNumberOfNodes()))
+        if (regular_nodes ==
+            static_cast<std::ptrdiff_t>(elem->getNumberOfNodes()))
         {
             regular_elements.push_back(elem);
         }

--- a/MeshLib/MeshGenerators/RasterToMesh.cpp
+++ b/MeshLib/MeshGenerators/RasterToMesh.cpp
@@ -228,7 +228,7 @@ MeshLib::Mesh* RasterToMesh::convert(
             auto* const prop_vec = properties.createNewPropertyVector<int>(
                 array_name, MeshLib::MeshItemType::Cell, 1);
             fillPropertyVector<int>(*prop_vec, img, header, elem_type);
-            ex.searchByPropertyValue<int>(array_name, header.no_data);
+            ex.searchByPropertyValue<int>(array_name, static_cast<int>(header.no_data));
         }
         else
         {

--- a/scripts/cmake/CompilerSetup.cmake
+++ b/scripts/cmake/CompilerSetup.cmake
@@ -128,6 +128,9 @@ if(MSVC)
         # std::numeric_limits<T>::min() / max()
         -DNOMINMAX
         -DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE # when VC is newer than Boost
+        # Disables all warnings coming from include with <>-syntax
+        # https://devblogs.microsoft.com/cppblog/broken-warnings-theory/
+        /experimental:external /external:anglebrackets /external:W0
     )
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ignore:4099")
 endif()


### PR DESCRIPTION
The CMake change supresses the display of lots of warnings from external libraries (Qt/VTK) when using Visual Studio.

Also fixing a few conversion warnings in our code.
