### PR TITLE
[DE] Fixed 3D update on item removal

### DIFF
--- a/Applications/DataExplorer/VtkVis/VisualizationWidget.cpp
+++ b/Applications/DataExplorer/VtkVis/VisualizationWidget.cpp
@@ -85,6 +85,9 @@ VisualizationWidget::VisualizationWidget(QWidget* parent /*= 0*/)
     // Set alternate cursor shapes
     connect(_interactorStyle, SIGNAL(cursorChanged(Qt::CursorShape)),
             this, SLOT(setCursorShape(Qt::CursorShape)));
+
+    connect((QObject*)_interactorStyle, SIGNAL(requestViewUpdate()),
+            this, SLOT(updateView()));
 }
 
 VisualizationWidget::~VisualizationWidget()

--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -257,9 +257,6 @@ MainWindow::MainWindow(QWidget* parent /* = 0*/)
             SIGNAL(actorSelected(vtkProp3D*)),
             (QObject*) (visualizationWidget->interactorStyle()),
             SLOT(highlightActor(vtkProp3D*)));
-    connect((QObject*) (visualizationWidget->interactorStyle()),
-            SIGNAL(requestViewUpdate()),
-            visualizationWidget, SLOT(updateView()));
 
     // Propagates selected vtk object in the pipeline to the pick interactor
     connect(vtkVisTabWidget->vtkVisPipelineView,

--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -257,6 +257,8 @@ MainWindow::MainWindow(QWidget* parent /* = 0*/)
             SIGNAL(actorSelected(vtkProp3D*)),
             (QObject*) (visualizationWidget->interactorStyle()),
             SLOT(highlightActor(vtkProp3D*)));
+    connect(_vtkVisPipeline.get(), SIGNAL(vtkVisPipelineChanged()),
+            visualizationWidget, SLOT(updateView()));
 
     // Propagates selected vtk object in the pipeline to the pick interactor
     connect(vtkVisTabWidget->vtkVisPipelineView,


### PR DESCRIPTION
Probably since switching to the new QVTKWidget (#2432) the 3D view was not updated automatically upon item removal (e.g. mesh removal). I added a new signal/slot connect to fix this. I have not investigated why it worked before...