### PR TITLE
Improve constructMeshFromGeometry

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -189,9 +189,11 @@ std::vector<std::unique_ptr<MeshLib::Mesh>> readMeshes(
 
         std::unique_ptr<MeshGeoToolsLib::SearchLength> search_length_algorithm =
             MeshGeoToolsLib::createSearchLengthAlgorithm(config, *meshes[0]);
+        bool const multiple_nodes_allowed = false;
         auto additional_meshes =
             MeshGeoToolsLib::constructAdditionalMeshesFromGeoObjects(
-                geoObjects, *meshes[0], std::move(search_length_algorithm));
+                geoObjects, *meshes[0], std::move(search_length_algorithm),
+                multiple_nodes_allowed);
 
         std::move(begin(additional_meshes), end(additional_meshes),
                   std::back_inserter(meshes));

--- a/Applications/Utils/FileConverter/GocadSGridReaderMain.cpp
+++ b/Applications/Utils/FileConverter/GocadSGridReaderMain.cpp
@@ -30,7 +30,10 @@ int main(int argc, char* argv[])
 
     TCLAP::CmdLine cmd(
         "Reads a Gocad stratigraphic grid file (file ending sg) and writes the "
-        "data in the vtk unstructured grid file format.\n\n OpenGeoSys-6 "
+        "data in the vtk unstructured grid file format. The documentation is "
+        "available at  "
+        "https://www.opengeosys.org/docs/tools/meshing/gocadsgridreader/.\n\n "
+        "OpenGeoSys-6 "
         "software, version " +
             BaseLib::BuildInfo::ogs_version +
             ".\n"

--- a/Applications/Utils/MeshEdit/ExtractSurface.cpp
+++ b/Applications/Utils/MeshEdit/ExtractSurface.cpp
@@ -37,7 +37,8 @@ int main (int argc, char* argv[])
     TCLAP::CmdLine cmd(
         "Tool extracts the surface of the given mesh. The documentation is "
         "available at "
-        "https://docs.opengeosys.org/docs/tools/meshing/extract-surface.\n\n"
+        "https://docs.opengeosys.org/docs/tools/meshing-submeshes/"
+        "extract-surface.\n\n"
         "OpenGeoSys-6 software, version " +
             BaseLib::BuildInfo::ogs_version +
             ".\n"

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -25,7 +25,7 @@
 #include "MeshLib/IO/writeMeshToFile.h"
 #include "MeshLib/Mesh.h"
 
-int main (int argc, char* argv[])
+int main(int argc, char* argv[])
 {
     ApplicationsLib::LogogSetup logog_setup;
 
@@ -41,37 +41,47 @@ int main (int argc, char* argv[])
             "Copyright (c) 2012-2019, OpenGeoSys Community "
             "(http://www.opengeosys.org)",
         ' ', BaseLib::BuildInfo::ogs_version);
-    TCLAP::ValueArg<std::string> mesh_out("o", "mesh-output-file",
+    TCLAP::ValueArg<std::string> mesh_out(
+        "o", "mesh-output-file",
         "the name of the file the mesh will be written to, format depends on "
-        "the given file name extension", true, "", "file name");
+        "the given file name extension",
+        true, "", "file name");
     cmd.add(mesh_out);
-    TCLAP::ValueArg<std::string> polygon_name_arg("p", "polygon-name",
-        "name of polygon in the geometry", true, "", "string");
+    TCLAP::ValueArg<std::string> polygon_name_arg(
+        "p", "polygon-name", "name of polygon in the geometry", true, "",
+        "string");
     cmd.add(polygon_name_arg);
-    TCLAP::ValueArg<std::string> geometry_fname("g", "geometry", "the name of "
-        "the file containing the input geometry (gli or gml format)", true,
-        "", "file name");
+    TCLAP::ValueArg<std::string> geometry_fname(
+        "g", "geometry",
+        "the name of "
+        "the file containing the input geometry (gli or gml format)",
+        true, "", "file name");
     cmd.add(geometry_fname);
-    TCLAP::ValueArg<char> char_property_arg("c", "char-property-value",
-        "new property value (data type char)", false, 'A', "character");
+    TCLAP::ValueArg<char> char_property_arg(
+        "c", "char-property-value", "new property value (data type char)",
+        false, 'A', "character");
     cmd.add(char_property_arg);
     TCLAP::ValueArg<int> int_property_arg("i", "int-property-value",
-        "new property value (data type int)", false, 0, "number");
+                                          "new property value (data type int)",
+                                          false, 0, "number");
     cmd.add(int_property_arg);
-    TCLAP::ValueArg<bool> bool_property_arg("b", "bool-property-value",
-        "new property value (data type bool)", false, false, "boolean value");
+    TCLAP::ValueArg<bool> bool_property_arg(
+        "b", "bool-property-value", "new property value (data type bool)",
+        false, false, "boolean value");
     cmd.add(bool_property_arg);
-    TCLAP::ValueArg<std::string> property_name_arg("n", "property-name",
-        "name of property in the mesh", false, "MaterialIDs", "string");
+    TCLAP::ValueArg<std::string> property_name_arg(
+        "n", "property-name", "name of property in the mesh", false,
+        "MaterialIDs", "string");
     cmd.add(property_name_arg);
     TCLAP::ValueArg<int> restrict_arg(
         "r", "restrict-to-MaterialID",
         "Restrict reseting the property to the material id", false, -1,
         "MaterialID");
     cmd.add(restrict_arg);
-    TCLAP::ValueArg<std::string> mesh_in("m", "mesh-input-file",
-        "the name of the file containing the input mesh", true,
-        "", "file name");
+    TCLAP::ValueArg<std::string> mesh_in(
+        "m", "mesh-input-file",
+        "the name of the file containing the input mesh", true, "",
+        "file name");
     cmd.add(mesh_in);
     TCLAP::ValueArg<std::string> gmsh_path_arg("", "gmsh-path",
                                                "the path to the gmsh binary",
@@ -94,7 +104,8 @@ int main (int argc, char* argv[])
     // *** check if the data is usable
     // *** get vector of polylines
     GeoLib::PolylineVec const* plys(geometries.getPolylineVecObj(geo_name));
-    if (!plys) {
+    if (!plys)
+    {
         ERR("Could not get vector of polylines out of geometry '%s'.",
             geo_name.c_str());
         return EXIT_FAILURE;
@@ -102,19 +113,18 @@ int main (int argc, char* argv[])
 
     // *** get polygon
     GeoLib::Polyline const* ply(
-        plys->getElementByName(polygon_name_arg.getValue())
-    );
-    if (! ply) {
+        plys->getElementByName(polygon_name_arg.getValue()));
+    if (!ply)
+    {
         ERR("Polyline '%s' not found.", polygon_name_arg.getValue().c_str());
         return EXIT_FAILURE;
     }
 
     // *** check if the polyline is closed (i.e. is a polygon)
-    bool closed (ply->isClosed());
+    bool closed(ply->isClosed());
     if (!closed)
     {
-        ERR("Polyline '%s' is not closed, i.e. does not describe a\
-            region.",
+        ERR("Polyline '%s' is not closed, i.e. does not describe a region.",
             polygon_name_arg.getValue().c_str());
         return EXIT_FAILURE;
     }
@@ -131,19 +141,22 @@ int main (int argc, char* argv[])
     }
     std::string const& property_name(property_name_arg.getValue());
 
-    if (char_property_arg.isSet()) {
+    if (char_property_arg.isSet())
+    {
         MeshGeoToolsLib::resetMeshElementProperty(*mesh, polygon, property_name,
                                                   char_property_arg.getValue(),
                                                   restrict_arg.getValue());
     }
 
-    if (int_property_arg.isSet()) {
+    if (int_property_arg.isSet())
+    {
         MeshGeoToolsLib::resetMeshElementProperty(*mesh, polygon, property_name,
                                                   int_property_arg.getValue(),
                                                   restrict_arg.getValue());
     }
 
-    if (bool_property_arg.isSet()) {
+    if (bool_property_arg.isSet())
+    {
         MeshGeoToolsLib::resetMeshElementProperty(*mesh, polygon, property_name,
                                                   bool_property_arg.getValue(),
                                                   restrict_arg.getValue());
@@ -152,7 +165,8 @@ int main (int argc, char* argv[])
     std::vector<std::string> property_names(
         mesh->getProperties().getPropertyVectorNames());
     INFO("Mesh contains %d property vectors:", property_names.size());
-    for (const auto& name : property_names) {
+    for (const auto& name : property_names)
+    {
         INFO("- %s", name.c_str());
     }
 

--- a/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
+++ b/Applications/Utils/MeshEdit/ResetPropertiesInPolygonalRegion.cpp
@@ -73,7 +73,7 @@ int main (int argc, char* argv[])
         "the name of the file containing the input mesh", true,
         "", "file name");
     cmd.add(mesh_in);
-    TCLAP::ValueArg<std::string> gmsh_path_arg("g", "gmsh-path",
+    TCLAP::ValueArg<std::string> gmsh_path_arg("", "gmsh-path",
                                                "the path to the gmsh binary",
                                                false, "", "path as string");
     cmd.add(gmsh_path_arg);
@@ -124,6 +124,11 @@ int main (int argc, char* argv[])
     // *** read mesh
     auto mesh = std::unique_ptr<MeshLib::Mesh>(
         MeshLib::IO::readMeshFromFile(mesh_in.getValue()));
+    if (!mesh)
+    {
+        // error message written already by readMeshFromFile
+        return EXIT_FAILURE;
+    }
     std::string const& property_name(property_name_arg.getValue());
 
     if (char_property_arg.isSet()) {

--- a/Applications/Utils/MeshGeoTools/constructMeshesFromGeometry.cpp
+++ b/Applications/Utils/MeshGeoTools/constructMeshesFromGeometry.cpp
@@ -71,6 +71,17 @@ int main(int argc, char* argv[])
         "",
         "mesh file name");
     cmd.add(mesh_arg);
+
+    TCLAP::ValueArg<bool> multiple_nodes_allowed_arg(
+        "",
+        "multiple-nodes-allowed",
+        "allows that multiple mesh nodes are contained in the eps environment",
+        false, // required argument
+        false, // default value
+        "allows that multiple mesh nodes are contained in the eps environment, "
+        "the nearest node for a point will be returned");
+    cmd.add(multiple_nodes_allowed_arg);
+
     cmd.parse(argc, argv);
 
     std::unique_ptr<MeshLib::Mesh> mesh{
@@ -83,7 +94,8 @@ int main(int argc, char* argv[])
     auto const extracted_meshes = constructAdditionalMeshesFromGeoObjects(
         *geo_objects,
         *mesh,
-        std::make_unique<MeshGeoToolsLib::SearchLength>(search_length));
+        std::make_unique<MeshGeoToolsLib::SearchLength>(search_length),
+        multiple_nodes_allowed_arg.getValue());
 
     for (auto const& m_ptr : extracted_meshes)
     {
@@ -92,7 +104,10 @@ int main(int argc, char* argv[])
             ERR("Could not create a mesh for each given geometry.");
             return EXIT_FAILURE;
         }
-        MeshLib::IO::writeMeshToFile(*m_ptr, m_ptr->getName() + ".vtu");
+        if (!m_ptr->getNodes().empty())
+        {
+            MeshLib::IO::writeMeshToFile(*m_ptr, m_ptr->getName() + ".vtu");
+        }
     }
 
     return EXIT_SUCCESS;

--- a/Applications/Utils/MeshGeoTools/constructMeshesFromGeometry.cpp
+++ b/Applications/Utils/MeshGeoTools/constructMeshesFromGeometry.cpp
@@ -104,10 +104,15 @@ int main(int argc, char* argv[])
             ERR("Could not create a mesh for each given geometry.");
             return EXIT_FAILURE;
         }
-        if (!m_ptr->getNodes().empty())
+        if (m_ptr->getNodes().empty())
         {
-            MeshLib::IO::writeMeshToFile(*m_ptr, m_ptr->getName() + ".vtu");
+            WARN(
+                "The created mesh '%s' hasn't any nodes or elements and thus "
+                "it isn't written to file.",
+                m_ptr->getName().c_str());
+            continue;
         }
+        MeshLib::IO::writeMeshToFile(*m_ptr, m_ptr->getName() + ".vtu");
     }
 
     return EXIT_SUCCESS;

--- a/Applications/Utils/MeshGeoTools/constructMeshesFromGeometry.cpp
+++ b/Applications/Utils/MeshGeoTools/constructMeshesFromGeometry.cpp
@@ -34,7 +34,10 @@ int main(int argc, char* argv[])
     ApplicationsLib::LogogSetup logo_setup;
 
     TCLAP::CmdLine cmd(
-        "Converts a geometry defined on a given mesh to distinct meshes.\n\n"
+        "Converts a geometry defined on a given mesh to distinct meshes. The "
+        "documentation is available at "
+        "https://www.opengeosys.org/docs/tools/meshing-submeshes/"
+        "constructmeshesfromgeometry/.\n\n"
         "OpenGeoSys-6 software, version " +
             BaseLib::BuildInfo::ogs_version +
             ".\n"

--- a/Applications/Utils/MeshGeoTools/constructMeshesFromGeometry.cpp
+++ b/Applications/Utils/MeshGeoTools/constructMeshesFromGeometry.cpp
@@ -84,6 +84,11 @@ int main(int argc, char* argv[])
 
     for (auto const& m_ptr : extracted_meshes)
     {
+        if (!m_ptr)
+        {
+            ERR("Could not create a mesh for each given geometry.");
+            return EXIT_FAILURE;
+        }
         MeshLib::IO::writeMeshToFile(*m_ptr, m_ptr->getName() + ".vtu");
     }
 

--- a/Applications/Utils/MeshGeoTools/identifySubdomains.cpp
+++ b/Applications/Utils/MeshGeoTools/identifySubdomains.cpp
@@ -46,7 +46,10 @@ int main(int argc, char* argv[])
 
     TCLAP::CmdLine cmd(
         "Checks if the subdomain meshes are part of the bulk mesh and writes "
-        "the 'bulk_node_ids' and the 'bulk_element_ids' in each of them.\n\n"
+        "the 'bulk_node_ids' and the 'bulk_element_ids' in each of them. The "
+        "documentation is avaliable at "
+        "https://www.opengeosys.org/docs/tools/meshing-submeshes/"
+        "identifysubdomains/.\n\n"
         "OpenGeoSys-6 software, version " +
             BaseLib::BuildInfo::ogs_version +
             ".\n"

--- a/MeshGeoToolsLib/BoundaryElementsAtPoint.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsAtPoint.cpp
@@ -9,7 +9,7 @@
 #include "BoundaryElementsAtPoint.h"
 
 #include "GeoLib/Point.h"
-#include "MeshLib/Elements/Element.h"
+#include "MathLib/Point3d.h"
 #include "MeshLib/Elements/Point.h"
 #include "MeshLib/Mesh.h"
 #include "MeshLib/MeshSearch/ElementSearch.h"
@@ -32,19 +32,53 @@ BoundaryElementsAtPoint::BoundaryElementsAtPoint(
             "locate the point (%f, %f, %f) in the mesh.",
             _point[0], _point[1], _point[2]);
     }
-    if (node_ids.size() > 1)
+    if (node_ids.size() == 1)
+    {
+        std::array<MeshLib::Node*, 1> const nodes = {
+            {const_cast<MeshLib::Node*>(_mesh.getNode(node_ids[0]))}};
+        _boundary_elements.push_back(new MeshLib::Point{nodes, node_ids[0]});
+        return;
+    }
+
+    auto& mesh_nodes =
+        const_cast<std::vector<MeshLib::Node*>&>(mesh.getNodes());
+    std::size_t const nearest_node_id =
+        *std::min_element(node_ids.begin(), node_ids.end(),
+                          [&mesh_nodes, &point](auto id0, auto id1) {
+                              return MathLib::sqrDist(*mesh_nodes[id0], point) <
+                                     MathLib::sqrDist(*mesh_nodes[id1], point);
+                          });
+
+    const bool multiple_nodes_allowed = false;
+    if (!multiple_nodes_allowed)
     {
         OGS_FATAL(
             "BoundaryElementsAtPoint: the mesh node searcher found %d points "
             "near the requested point (%f, %f, %f) in the mesh, while exactly "
-            "one is expected.",
-            node_ids.size(), _point[0], _point[1], _point[2]);
+            "one is expected. Node  (id=%d) (%f, %f, %f) has distance %f.",
+            node_ids.size(), _point[0], _point[1], _point[2],
+            mesh_nodes[nearest_node_id]->getID(),
+            (*mesh_nodes[nearest_node_id])[0],
+            (*mesh_nodes[nearest_node_id])[1],
+            (*mesh_nodes[nearest_node_id])[2],
+            MathLib::sqrDist(*mesh_nodes[nearest_node_id], point));
     }
+    WARN(
+        "BoundaryElementsAtPoint: the mesh node searcher found %d points "
+        "near the requested point (%f, %f, %f) in the mesh, while exactly "
+        "one is expected. Node  (id=%d) (%f, %f, %f) has distance %f.",
+        node_ids.size(), _point[0], _point[1], _point[2],
+        mesh_nodes[nearest_node_id]->getID(),
+        (*mesh_nodes[nearest_node_id])[0],
+        (*mesh_nodes[nearest_node_id])[1],
+        (*mesh_nodes[nearest_node_id])[2],
+        MathLib::sqrDist(*mesh_nodes[nearest_node_id], point));
 
-    std::array<MeshLib::Node*, 1> const nodes = {{
-        const_cast<MeshLib::Node*>(_mesh.getNode(node_ids[0]))}};
+    std::array<MeshLib::Node*, 1> const nodes = {
+        {const_cast<MeshLib::Node*>(_mesh.getNode(nearest_node_id))}};
 
-    _boundary_elements.push_back(new MeshLib::Point{nodes, node_ids[0]});
+    _boundary_elements.push_back(
+        new MeshLib::Point{nodes, nearest_node_id});
 }
 
 BoundaryElementsAtPoint::~BoundaryElementsAtPoint()

--- a/MeshGeoToolsLib/BoundaryElementsAtPoint.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsAtPoint.cpp
@@ -21,7 +21,7 @@ namespace MeshGeoToolsLib
 {
 BoundaryElementsAtPoint::BoundaryElementsAtPoint(
     MeshLib::Mesh const& mesh, MeshNodeSearcher const& mshNodeSearcher,
-    GeoLib::Point const& point)
+    GeoLib::Point const& point, const bool multiple_nodes_allowed)
     : _mesh(mesh), _point(point)
 {
     auto const node_ids = mshNodeSearcher.getMeshNodeIDs(_point);
@@ -49,7 +49,6 @@ BoundaryElementsAtPoint::BoundaryElementsAtPoint(
                                      MathLib::sqrDist(*mesh_nodes[id1], point);
                           });
 
-    const bool multiple_nodes_allowed = false;
     if (!multiple_nodes_allowed)
     {
         OGS_FATAL(

--- a/MeshGeoToolsLib/BoundaryElementsAtPoint.h
+++ b/MeshGeoToolsLib/BoundaryElementsAtPoint.h
@@ -36,7 +36,8 @@ public:
     /// \param point            a point object where edges are searched
     BoundaryElementsAtPoint(MeshLib::Mesh const& mesh,
                             MeshNodeSearcher const& mshNodeSearcher,
-                            GeoLib::Point const& point);
+                            GeoLib::Point const& point,
+                            const bool multiple_nodes_allowed);
 
     ~BoundaryElementsAtPoint();
 

--- a/MeshGeoToolsLib/BoundaryElementsAtPoint.h
+++ b/MeshGeoToolsLib/BoundaryElementsAtPoint.h
@@ -34,6 +34,10 @@ public:
     /// \param mshNodeSearcher  a MeshNodeSearcher object which is internally
     /// used to search mesh nodes
     /// \param point            a point object where edges are searched
+    /// \param multiple_nodes_allowed Allows to find multiple nodes within the
+    /// search radius, the nearest node is returned (as point element). This
+    /// enables to specify larger search radius to find possible other
+    /// geometries that don't match exactly to the mesh.
     BoundaryElementsAtPoint(MeshLib::Mesh const& mesh,
                             MeshNodeSearcher const& mshNodeSearcher,
                             GeoLib::Point const& point,

--- a/MeshGeoToolsLib/BoundaryElementsSearcher.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsSearcher.cpp
@@ -46,11 +46,15 @@ BoundaryElementsSearcher::~BoundaryElementsSearcher()
     }
 }
 
-std::vector<MeshLib::Element*> const& BoundaryElementsSearcher::getBoundaryElements(GeoLib::GeoObject const& geoObj)
+std::vector<MeshLib::Element*> const&
+BoundaryElementsSearcher::getBoundaryElements(GeoLib::GeoObject const& geoObj,
+                                              bool const multiple_nodes_allowed)
 {
     switch (geoObj.getGeoType()) {
     case GeoLib::GEOTYPE::POINT:
-        return this->getBoundaryElementsAtPoint(*dynamic_cast<const GeoLib::Point*>(&geoObj));
+        return this->getBoundaryElementsAtPoint(
+            *dynamic_cast<const GeoLib::Point*>(&geoObj),
+            multiple_nodes_allowed);
         break;
     case GeoLib::GEOTYPE::POLYLINE:
         return this->getBoundaryElementsAlongPolyline(*dynamic_cast<const GeoLib::Polyline*>(&geoObj));
@@ -65,7 +69,8 @@ std::vector<MeshLib::Element*> const& BoundaryElementsSearcher::getBoundaryEleme
 }
 
 std::vector<MeshLib::Element*> const&
-BoundaryElementsSearcher::getBoundaryElementsAtPoint(GeoLib::Point const& point)
+BoundaryElementsSearcher::getBoundaryElementsAtPoint(
+    GeoLib::Point const& point, bool const multiple_nodes_allowed)
 {
     // look for already saved points and return if found.
     for (auto const& boundaryElements : _boundary_elements_at_point)
@@ -77,8 +82,8 @@ BoundaryElementsSearcher::getBoundaryElementsAtPoint(GeoLib::Point const& point)
     }
 
     // create new boundary elements at points.
-    _boundary_elements_at_point.push_back(
-        new BoundaryElementsAtPoint(_mesh, _mshNodeSearcher, point));
+    _boundary_elements_at_point.push_back(new BoundaryElementsAtPoint(
+        _mesh, _mshNodeSearcher, point, multiple_nodes_allowed));
     return _boundary_elements_at_point.back()->getBoundaryElements();
 }
 

--- a/MeshGeoToolsLib/BoundaryElementsSearcher.cpp
+++ b/MeshGeoToolsLib/BoundaryElementsSearcher.cpp
@@ -82,33 +82,40 @@ BoundaryElementsSearcher::getBoundaryElementsAtPoint(GeoLib::Point const& point)
     return _boundary_elements_at_point.back()->getBoundaryElements();
 }
 
-std::vector<MeshLib::Element*> const& BoundaryElementsSearcher::getBoundaryElementsAlongPolyline(GeoLib::Polyline const& ply)
+std::vector<MeshLib::Element*> const&
+BoundaryElementsSearcher::getBoundaryElementsAlongPolyline(
+    GeoLib::Polyline const& polyline)
 {
-    std::vector<BoundaryElementsAlongPolyline*>::const_iterator it(_boundary_elements_along_polylines.begin());
-    for (; it != _boundary_elements_along_polylines.end(); ++it) {
-        if (&(*it)->getPolyline() == &ply) {
-            // we calculated mesh nodes for this polyline already
-            return (*it)->getBoundaryElements();
+    // look for already saved polylines and return if found.
+    for (auto const& boundary_elements : _boundary_elements_along_polylines)
+    {
+        if (&boundary_elements->getPolyline() == &polyline)
+        {
+            return boundary_elements->getBoundaryElements();
         }
     }
 
+    // create new boundary elements at points.
     _boundary_elements_along_polylines.push_back(
-            new BoundaryElementsAlongPolyline(_mesh, _mshNodeSearcher, ply));
+        new BoundaryElementsAlongPolyline(_mesh, _mshNodeSearcher, polyline));
     return _boundary_elements_along_polylines.back()->getBoundaryElements();
 }
 
-std::vector<MeshLib::Element*> const& BoundaryElementsSearcher::getBoundaryElementsOnSurface(GeoLib::Surface const& sfc)
+std::vector<MeshLib::Element*> const&
+BoundaryElementsSearcher::getBoundaryElementsOnSurface(
+    GeoLib::Surface const& surface)
 {
-    std::vector<BoundaryElementsOnSurface*>::const_iterator it(_boundary_elements_along_surfaces.begin());
-    for (; it != _boundary_elements_along_surfaces.end(); ++it) {
-        if (&(*it)->getSurface() == &sfc) {
-            // we calculated mesh nodes for this surface already
-            return (*it)->getBoundaryElements();
+    // look for already saved surfaces and return if found.
+    for (auto const& boundary_elements : _boundary_elements_along_surfaces)
+    {
+        if (&boundary_elements->getSurface() == &surface)
+        {
+            return boundary_elements->getBoundaryElements();
         }
     }
 
     _boundary_elements_along_surfaces.push_back(
-            new BoundaryElementsOnSurface(_mesh, _mshNodeSearcher, sfc));
+            new BoundaryElementsOnSurface(_mesh, _mshNodeSearcher, surface));
     return _boundary_elements_along_surfaces.back()->getBoundaryElements();
 }
 

--- a/MeshGeoToolsLib/BoundaryElementsSearcher.h
+++ b/MeshGeoToolsLib/BoundaryElementsSearcher.h
@@ -52,17 +52,22 @@ public:
      * generate boundary elements on the given geometric object (point, polyline, surface).
      *
      * @param geoObj a GeoLib::GeoObject where the nearest mesh node is searched for
+     * @param multiple_nodes_allowed allows for finding multiple nodes within
+     * the given search radius for a point
      * @return a vector of boundary element objects
      */
-    std::vector<MeshLib::Element*> const& getBoundaryElements(GeoLib::GeoObject const& geoObj);
+    std::vector<MeshLib::Element*> const& getBoundaryElements(
+        GeoLib::GeoObject const& geoObj, bool const multiple_nodes_allowed);
 
     /**
      * generate boundary elements at the given point.
      * @param point Search the mesh for given point
+     * @param multiple_nodes_allowed allows for finding multiple nodes within
+     * the given search radius
      * @return a vector of boundary elements
      */
     std::vector<MeshLib::Element*> const& getBoundaryElementsAtPoint(
-        GeoLib::Point const& point);
+        GeoLib::Point const& point, bool const multiple_nodes_allowed);
 
     /**
      * generate boundary elements on the given polyline.

--- a/MeshGeoToolsLib/ConstructMeshesFromGeometries.cpp
+++ b/MeshGeoToolsLib/ConstructMeshesFromGeometries.cpp
@@ -30,7 +30,8 @@ template <typename GeometryVec>
 std::vector<std::unique_ptr<MeshLib::Mesh>>
 constructAdditionalMeshesFromGeometries(
     std::vector<GeometryVec*> const& geometries,
-    MeshGeoToolsLib::BoundaryElementsSearcher& boundary_element_searcher)
+    MeshGeoToolsLib::BoundaryElementsSearcher& boundary_element_searcher,
+    bool const multiple_nodes_allowed)
 {
     std::vector<std::unique_ptr<MeshLib::Mesh>> additional_meshes;
 
@@ -63,7 +64,8 @@ constructAdditionalMeshesFromGeometries(
             additional_meshes.emplace_back(createMeshFromElementSelection(
                 meshNameFromGeometry(vec_name, geometry_name),
                 MeshLib::cloneElements(
-                    boundary_element_searcher.getBoundaryElements(geometry))));
+                    boundary_element_searcher.getBoundaryElements(
+                        geometry, multiple_nodes_allowed))));
         }
     }
     return additional_meshes;
@@ -73,7 +75,8 @@ std::vector<std::unique_ptr<MeshLib::Mesh>>
 constructAdditionalMeshesFromGeoObjects(GeoLib::GEOObjects const& geo_objects,
                                         MeshLib::Mesh const& mesh,
                                         std::unique_ptr<SearchLength>
-                                            search_length_algorithm)
+                                            search_length_algorithm,
+                                        bool const multiple_nodes_allowed)
 {
     std::vector<std::unique_ptr<MeshLib::Mesh>> additional_meshes;
 
@@ -89,7 +92,8 @@ constructAdditionalMeshesFromGeoObjects(GeoLib::GEOObjects const& geo_objects,
     //
     {
         auto point_meshes = constructAdditionalMeshesFromGeometries(
-            geo_objects.getPoints(), boundary_element_searcher);
+            geo_objects.getPoints(), boundary_element_searcher,
+            multiple_nodes_allowed);
         std::move(begin(point_meshes), end(point_meshes),
                   std::back_inserter(additional_meshes));
     }
@@ -99,7 +103,8 @@ constructAdditionalMeshesFromGeoObjects(GeoLib::GEOObjects const& geo_objects,
     //
     {
         auto polyline_meshes = constructAdditionalMeshesFromGeometries(
-            geo_objects.getPolylines(), boundary_element_searcher);
+            geo_objects.getPolylines(), boundary_element_searcher,
+            multiple_nodes_allowed);
         std::move(begin(polyline_meshes), end(polyline_meshes),
                   std::back_inserter(additional_meshes));
     }
@@ -107,7 +112,8 @@ constructAdditionalMeshesFromGeoObjects(GeoLib::GEOObjects const& geo_objects,
     // Surfaces
     {
         auto surface_meshes = constructAdditionalMeshesFromGeometries(
-            geo_objects.getSurfaces(), boundary_element_searcher);
+            geo_objects.getSurfaces(), boundary_element_searcher,
+            multiple_nodes_allowed);
         std::move(begin(surface_meshes), end(surface_meshes),
                   std::back_inserter(additional_meshes));
     }

--- a/MeshGeoToolsLib/ConstructMeshesFromGeometries.h
+++ b/MeshGeoToolsLib/ConstructMeshesFromGeometries.h
@@ -30,7 +30,8 @@ std::vector<std::unique_ptr<MeshLib::Mesh>>
 constructAdditionalMeshesFromGeoObjects(GeoLib::GEOObjects const& geo_objects,
                                         MeshLib::Mesh const& mesh,
                                         std::unique_ptr<SearchLength>
-                                            search_length_algorithm);
+                                            search_length_algorithm,
+                                        bool const multiple_nodes_allowed);
 
 std::string meshNameFromGeometry(std::string const& geometrical_set_name,
                                  std::string const& geometry_name);

--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -142,13 +142,11 @@ std::vector<std::size_t> const& MeshNodeSearcher::getMeshNodeIDsAlongSurface(
 MeshNodesOnPoint& MeshNodeSearcher::getMeshNodesOnPoint(
     GeoLib::Point const& pnt) const
 {
-    std::vector<MeshNodesOnPoint*>::const_iterator it(
-        _mesh_nodes_on_points.begin());
-    for (; it != _mesh_nodes_on_points.end(); ++it)
+    for (auto const& mesh_nodes_on_point : _mesh_nodes_on_points)
     {
-        if (&(*it)->getPoint() == &pnt)
+        if (&(mesh_nodes_on_point->getPoint()) == &pnt)
         {
-            return *(*it);
+            return *mesh_nodes_on_point;
         }
     }
 
@@ -164,14 +162,11 @@ MeshNodesOnPoint& MeshNodeSearcher::getMeshNodesOnPoint(
 MeshNodesAlongPolyline& MeshNodeSearcher::getMeshNodesAlongPolyline(
     GeoLib::Polyline const& ply) const
 {
-    std::vector<MeshNodesAlongPolyline*>::const_iterator it(
-        _mesh_nodes_along_polylines.begin());
-    for (; it != _mesh_nodes_along_polylines.end(); ++it)
+    for (auto const& mesh_nodes_along_polyline : _mesh_nodes_along_polylines)
     {
-        if (&(*it)->getPolyline() == &ply)
+        if (&(mesh_nodes_along_polyline->getPolyline()) == &ply)
         {
-            // we calculated mesh nodes for this polyline already
-            return *(*it);
+            return *mesh_nodes_along_polyline;
         }
     }
 
@@ -185,14 +180,11 @@ MeshNodesAlongPolyline& MeshNodeSearcher::getMeshNodesAlongPolyline(
 MeshNodesAlongSurface& MeshNodeSearcher::getMeshNodesAlongSurface(
     GeoLib::Surface const& sfc) const
 {
-    std::vector<MeshNodesAlongSurface*>::const_iterator it(
-        _mesh_nodes_along_surfaces.begin());
-    for (; it != _mesh_nodes_along_surfaces.end(); ++it)
+    for (auto const& mesh_nodes_along_surface : _mesh_nodes_along_surfaces)
     {
-        if (&(*it)->getSurface() == &sfc)
+        if (&(mesh_nodes_along_surface->getSurface()) == &sfc)
         {
-            // we calculated mesh nodes on this surface already
-            return *(*it);
+            return *mesh_nodes_along_surface;
         }
     }
 

--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -28,8 +28,8 @@
 
 namespace MeshGeoToolsLib
 {
-
-std::vector<std::unique_ptr<MeshNodeSearcher>> MeshNodeSearcher::_mesh_node_searchers;
+std::vector<std::unique_ptr<MeshNodeSearcher>>
+    MeshNodeSearcher::_mesh_node_searchers;
 
 MeshNodeSearcher::MeshNodeSearcher(
     MeshLib::Mesh const& mesh,
@@ -64,20 +64,24 @@ std::vector<std::size_t> MeshNodeSearcher::getMeshNodeIDs(
     GeoLib::GeoObject const& geoObj) const
 {
     std::vector<std::size_t> vec_nodes;
-    switch (geoObj.getGeoType()) {
-    case GeoLib::GEOTYPE::POINT:
+    switch (geoObj.getGeoType())
     {
-        vec_nodes = this->getMeshNodeIDsForPoint(*static_cast<const GeoLib::Point*>(&geoObj));
-        break;
-    }
-    case GeoLib::GEOTYPE::POLYLINE:
-        vec_nodes = this->getMeshNodeIDsAlongPolyline(*static_cast<const GeoLib::Polyline*>(&geoObj));
-        break;
-    case GeoLib::GEOTYPE::SURFACE:
-        vec_nodes = this->getMeshNodeIDsAlongSurface(*static_cast<const GeoLib::Surface*>(&geoObj));
-        break;
-    default:
-        break;
+        case GeoLib::GEOTYPE::POINT:
+        {
+            vec_nodes = this->getMeshNodeIDsForPoint(
+                *static_cast<const GeoLib::Point*>(&geoObj));
+            break;
+        }
+        case GeoLib::GEOTYPE::POLYLINE:
+            vec_nodes = this->getMeshNodeIDsAlongPolyline(
+                *static_cast<const GeoLib::Polyline*>(&geoObj));
+            break;
+        case GeoLib::GEOTYPE::SURFACE:
+            vec_nodes = this->getMeshNodeIDsAlongSurface(
+                *static_cast<const GeoLib::Surface*>(&geoObj));
+            break;
+        default:
+            break;
     }
     return vec_nodes;
 }
@@ -138,9 +142,12 @@ std::vector<std::size_t> const& MeshNodeSearcher::getMeshNodeIDsAlongSurface(
 MeshNodesOnPoint& MeshNodeSearcher::getMeshNodesOnPoint(
     GeoLib::Point const& pnt) const
 {
-    std::vector<MeshNodesOnPoint*>::const_iterator it(_mesh_nodes_on_points.begin());
-    for (; it != _mesh_nodes_on_points.end(); ++it) {
-        if (&(*it)->getPoint() == &pnt) {
+    std::vector<MeshNodesOnPoint*>::const_iterator it(
+        _mesh_nodes_on_points.begin());
+    for (; it != _mesh_nodes_on_points.end(); ++it)
+    {
+        if (&(*it)->getPoint() == &pnt)
+        {
             return *(*it);
         }
     }
@@ -157,9 +164,12 @@ MeshNodesOnPoint& MeshNodeSearcher::getMeshNodesOnPoint(
 MeshNodesAlongPolyline& MeshNodeSearcher::getMeshNodesAlongPolyline(
     GeoLib::Polyline const& ply) const
 {
-    std::vector<MeshNodesAlongPolyline*>::const_iterator it(_mesh_nodes_along_polylines.begin());
-    for (; it != _mesh_nodes_along_polylines.end(); ++it) {
-        if (&(*it)->getPolyline() == &ply) {
+    std::vector<MeshNodesAlongPolyline*>::const_iterator it(
+        _mesh_nodes_along_polylines.begin());
+    for (; it != _mesh_nodes_along_polylines.end(); ++it)
+    {
+        if (&(*it)->getPolyline() == &ply)
+        {
             // we calculated mesh nodes for this polyline already
             return *(*it);
         }
@@ -175,9 +185,12 @@ MeshNodesAlongPolyline& MeshNodeSearcher::getMeshNodesAlongPolyline(
 MeshNodesAlongSurface& MeshNodeSearcher::getMeshNodesAlongSurface(
     GeoLib::Surface const& sfc) const
 {
-    std::vector<MeshNodesAlongSurface*>::const_iterator it(_mesh_nodes_along_surfaces.begin());
-    for (; it != _mesh_nodes_along_surfaces.end(); ++it) {
-        if (&(*it)->getSurface() == &sfc) {
+    std::vector<MeshNodesAlongSurface*>::const_iterator it(
+        _mesh_nodes_along_surfaces.begin());
+    for (; it != _mesh_nodes_along_surfaces.end(); ++it)
+    {
+        if (&(*it)->getSurface() == &sfc)
+        {
             // we calculated mesh nodes on this surface already
             return *(*it);
         }
@@ -223,10 +236,9 @@ MeshNodeSearcher const& MeshNodeSearcher::getMeshNodeSearcher(
     return *_mesh_node_searchers[mesh_id];
 }
 
-std::size_t
-MeshNodeSearcher::getMeshId() const
+std::size_t MeshNodeSearcher::getMeshId() const
 {
     return _mesh.getID();
 }
 
-} // end namespace MeshGeoToolsLib
+}  // end namespace MeshGeoToolsLib

--- a/MeshGeoToolsLib/MeshNodesOnPoint.cpp
+++ b/MeshGeoToolsLib/MeshNodesOnPoint.cpp
@@ -12,13 +12,15 @@
 
 namespace MeshGeoToolsLib
 {
-MeshNodesOnPoint::MeshNodesOnPoint(
-    MeshLib::Mesh const& mesh, GeoLib::Grid<MeshLib::Node> const& mesh_grid,
-    GeoLib::Point const& pnt, double epsilon_radius,
-    SearchAllNodes search_all_nodes)
+MeshNodesOnPoint::MeshNodesOnPoint(MeshLib::Mesh const& mesh,
+                                   GeoLib::Grid<MeshLib::Node> const& mesh_grid,
+                                   GeoLib::Point const& pnt,
+                                   double epsilon_radius,
+                                   SearchAllNodes search_all_nodes)
     : _mesh(mesh), _pnt(pnt)
 {
-    std::vector<std::size_t> vec_ids(mesh_grid.getPointsInEpsilonEnvironment(pnt, epsilon_radius));
+    std::vector<std::size_t> vec_ids(
+        mesh_grid.getPointsInEpsilonEnvironment(pnt, epsilon_radius));
     if (search_all_nodes == SearchAllNodes::Yes)
     {
         _msh_node_ids = vec_ids;
@@ -35,5 +37,5 @@ MeshNodesOnPoint::MeshNodesOnPoint(
     }
 }
 
-} // end namespace MeshGeoToolsLib
+}  // end namespace MeshGeoToolsLib
 

--- a/MeshGeoToolsLib/MeshNodesOnPoint.h
+++ b/MeshGeoToolsLib/MeshNodesOnPoint.h
@@ -37,7 +37,8 @@ public:
      * @param mesh_grid Grid object constructed with mesh nodes
      * @param pnt a point
      * @param epsilon_radius Search radius
-     * @param search_all_nodes whether this searches all nodes or only base nodes
+     * @param search_all_nodes whether this searches all nodes or only base
+     * nodes
      */
     MeshNodesOnPoint(MeshLib::Mesh const& mesh,
                      GeoLib::Grid<MeshLib::Node> const& mesh_grid,
@@ -51,18 +52,18 @@ public:
      * Access the vector of mesh node ids.
      * @return The vector of mesh node ids calculated in the constructor
      */
-    std::vector<std::size_t> const& getNodeIDs () const { return _msh_node_ids; }
+    std::vector<std::size_t> const& getNodeIDs() const { return _msh_node_ids; }
 
     /**
      * Deploying this method the user can get access to the underlying
      * GeoLib::Point.
      * @return the underlying GeoLib::Point
      */
-    GeoLib::Point const& getPoint () const { return _pnt; }
+    GeoLib::Point const& getPoint() const { return _pnt; }
 
 private:
     MeshLib::Mesh const& _mesh;
     GeoLib::Point const& _pnt;
     std::vector<std::size_t> _msh_node_ids;
 };
-} // end namespace MeshGeoToolsLib
+}  // end namespace MeshGeoToolsLib

--- a/Tests/GeoLib/CreateTestPoints.cpp
+++ b/Tests/GeoLib/CreateTestPoints.cpp
@@ -1,0 +1,44 @@
+/**
+ * @copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "CreateTestPoints.h"
+
+void createSetOfTestPointsAndAssociatedNames(GeoLib::GEOObjects& geo_objs,
+                                             std::string& name,
+                                             std::size_t const pnts_per_edge,
+                                             GeoLib::Point const& shift)
+{
+    auto pnts = std::make_unique<std::vector<GeoLib::Point*>>();
+    auto pnt_name_map = std::make_unique<std::map<std::string, std::size_t>>();
+
+    for (std::size_t k(0); k < pnts_per_edge; k++)
+    {
+        const std::size_t k_offset(k * pnts_per_edge * pnts_per_edge);
+        for (std::size_t j(0); j < pnts_per_edge; j++)
+        {
+            const std::size_t offset(j * pnts_per_edge + k_offset);
+            for (std::size_t i(0); i < pnts_per_edge; i++)
+            {
+                std::size_t const id(i + offset);
+                pnts->push_back(new GeoLib::Point(
+                    i + shift[0], j + shift[1], k + shift[2], id));
+                std::string pnt_name(name + "-" + std::to_string(i) + "-" +
+                                     std::to_string(j) + "-" +
+                                     std::to_string(k));
+                pnt_name_map->emplace(pnt_name, id);
+            }
+        }
+    }
+
+    geo_objs.addPointVec(std::move(pnts), name, std::move(pnt_name_map));
+}
+

--- a/Tests/GeoLib/CreateTestPoints.h
+++ b/Tests/GeoLib/CreateTestPoints.h
@@ -1,0 +1,18 @@
+/**
+ * @copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#pragma once
+
+#include <string>
+
+#include "GeoLib/GEOObjects.h"
+
+void createSetOfTestPointsAndAssociatedNames(GeoLib::GEOObjects& geo_objs,
+                                             std::string& name,
+                                             std::size_t const pnts_per_edge,
+                                             GeoLib::Point const& shift);

--- a/Tests/MeshGeoToolsLib/TestConstructAdditionalMeshesFromGeoObjects.cpp
+++ b/Tests/MeshGeoToolsLib/TestConstructAdditionalMeshesFromGeoObjects.cpp
@@ -1,0 +1,90 @@
+/**
+ * @copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+#include <gtest/gtest.h>
+#include <ctime>
+#include <memory>
+
+#include "GeoLib/GEOObjects.h"
+#include "GeoLib/Point.h"
+#include "MeshGeoToolsLib/ConstructMeshesFromGeometries.h"
+#include "MeshGeoToolsLib/SearchLength.h"
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshGenerators/MeshGenerator.h"
+#include "Tests/GeoLib/CreateTestPoints.h"
+
+TEST(ConstructAdditionalMeshesFromGeoObjects, PointMesh)
+{
+    // create 10x10x10 mesh using 1000 hexahedra
+    const double length = 10.0;
+    const std::size_t n_subdivisions = 10;
+    std::unique_ptr<MeshLib::Mesh> mesh(
+        MeshLib::MeshGenerator::generateRegularHexMesh(length, n_subdivisions));
+
+    // create geometry: for every mesh node exactly one point
+    GeoLib::GEOObjects geometries;
+    GeoLib::Point shift(0.0, 0.0, 0.0);
+    std::string geometry_name("AllMeshNodes");
+    // all points have a name
+    int const points_per_edge = 10;
+    createSetOfTestPointsAndAssociatedNames(geometries, geometry_name,
+                                            points_per_edge, shift);
+
+    // construct meshes from the points
+    double const search_length = std::numeric_limits<double>::epsilon();
+    bool const multiple_nodes_allowed = false;
+    auto const meshes =
+        MeshGeoToolsLib::constructAdditionalMeshesFromGeoObjects(
+            geometries, *mesh,
+            std::make_unique<MeshGeoToolsLib::SearchLength>(search_length),
+            multiple_nodes_allowed);
+
+    // the number of constructed meshes have to equal the number of points
+    ASSERT_EQ(geometries.getPointVec(geometry_name)->size(), meshes.size());
+}
+
+TEST(ConstructAdditionalMeshesFromGeoObjects, PointMeshLargeSearchRadius)
+{
+    // create 10x10x10 mesh using 1000 hexahedra
+    const double length = 10.0;
+    const std::size_t n_subdivisions = 10;
+    std::unique_ptr<MeshLib::Mesh> mesh(
+        MeshLib::MeshGenerator::generateRegularHexMesh(length, n_subdivisions));
+
+    // create geometry: for every mesh node exactly one point
+    GeoLib::GEOObjects geometries;
+    GeoLib::Point shift(0.0, 0.0, 0.0);
+    std::string geometry_name("AllMeshNodes");
+    // all points have a name
+    int const points_per_edge = 10;
+    createSetOfTestPointsAndAssociatedNames(geometries, geometry_name,
+                                            points_per_edge, shift);
+
+    // construct meshes from the points
+    double const search_length = 1 + std::numeric_limits<double>::epsilon();
+    bool multiple_nodes_allowed = false;
+
+    EXPECT_ANY_THROW(
+        auto const meshes =
+            MeshGeoToolsLib::constructAdditionalMeshesFromGeoObjects(
+                geometries, *mesh,
+                std::make_unique<MeshGeoToolsLib::SearchLength>(search_length),
+                multiple_nodes_allowed));
+
+    multiple_nodes_allowed = true;
+    auto const meshes_from_multiple_nodes =
+        MeshGeoToolsLib::constructAdditionalMeshesFromGeoObjects(
+            geometries, *mesh,
+            std::make_unique<MeshGeoToolsLib::SearchLength>(search_length),
+            multiple_nodes_allowed);
+
+    // the number of constructed meshes have to equal the number of points
+    ASSERT_EQ(geometries.getPointVec(geometry_name)->size(),
+              meshes_from_multiple_nodes.size());
+}
+

--- a/Tests/MeshLib/TestBoundaryElementSearch.cpp
+++ b/Tests/MeshLib/TestBoundaryElementSearch.cpp
@@ -111,7 +111,10 @@ TEST_F(MeshLibBoundaryElementSearchInSimpleQuadMesh, PolylineSearch)
         std::make_unique<MeshGeoToolsLib::HeuristicSearchLength>(*_quad_mesh),
         MeshGeoToolsLib::SearchAllNodes::Yes);
     MeshGeoToolsLib::BoundaryElementsSearcher boundary_element_searcher(*_quad_mesh, mesh_node_searcher);
-    std::vector<MeshLib::Element*> const& found_edges_ply0(boundary_element_searcher.getBoundaryElements(ply0));
+    bool const multiple_nodes_allowed = false;
+    std::vector<MeshLib::Element*> const& found_edges_ply0(
+        boundary_element_searcher.getBoundaryElements(ply0,
+                                                      multiple_nodes_allowed));
 
     // check the total number of found edges
     ASSERT_EQ(n_eles_per_dir*4u, found_edges_ply0.size());
@@ -165,8 +168,10 @@ void MeshLibBoundaryElementSearchInSimpleHexMesh::
     sfc_bottom.addTriangle(0, 1, 2);
     sfc_bottom.addTriangle(0, 2, 3);
 
+    bool const multiple_nodes_allowed = false;
     std::vector<MeshLib::Element*> const& found_faces_sfc_b(
-        boundary_element_searcher.getBoundaryElements(sfc_bottom));
+        boundary_element_searcher.getBoundaryElements(sfc_bottom,
+                                                      multiple_nodes_allowed));
     ASSERT_EQ(n_eles_2d, found_faces_sfc_b.size());
     ASSERT_EQ(_geometric_size * _geometric_size,
               computeAreaOfFaceElements(found_faces_sfc_b.begin(),
@@ -184,7 +189,8 @@ void MeshLibBoundaryElementSearchInSimpleHexMesh::
     sfc_front.addTriangle(0, 4, 5);
 
     std::vector<MeshLib::Element*> const& found_faces_sfc_f(
-        boundary_element_searcher.getBoundaryElements(sfc_front));
+        boundary_element_searcher.getBoundaryElements(sfc_front,
+                                                      multiple_nodes_allowed));
     ASSERT_EQ(n_eles_2d, found_faces_sfc_f.size());
     ASSERT_EQ(_geometric_size * _geometric_size,
               computeAreaOfFaceElements(found_faces_sfc_f.begin(),

--- a/Tests/NumLib/LocalToGlobalIndexMapMultiComponent.cpp
+++ b/Tests/NumLib/LocalToGlobalIndexMapMultiComponent.cpp
@@ -61,10 +61,11 @@ public:
                 *mesh, std::move(search_length));
         MGTL::BoundaryElementsSearcher searcher_elements(*mesh, searcher_nodes);
 
+        bool const multiple_nodes_allowed = false;
         boundary_mesh = createMeshFromElementSelection(
             "boundary_mesh",
-            MeshLib::cloneElements(
-                searcher_elements.getBoundaryElements(*ply)));
+            MeshLib::cloneElements(searcher_elements.getBoundaryElements(
+                *ply, multiple_nodes_allowed)));
 
         mesh_items_boundary = std::make_unique<MeshLib::MeshSubset>(
             *boundary_mesh, boundary_mesh->getNodes());


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Some users (@Thomas-TK , @ErikNixdorf  and Janine) need a more robust constructMeshesFromGeometry tool. This PR allows to give a larger search radius eps to the tool such that several mesh nodes are located in the eps-ball. Then the mesh node with the smallest distance to the given point is choosen.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.1)
2. [x] Tests covering your feature were added?
3. [x] Any new feature or behavior change was documented?
