### PR TITLE
[DE] Re-implementing strict double validation

### DIFF
--- a/Applications/DataExplorer/Base/StrictDoubleValidator.h
+++ b/Applications/DataExplorer/Base/StrictDoubleValidator.h
@@ -17,7 +17,7 @@
 
 /**
  * \brief A validator for an input field which only accepts decimals.
- * Source code adapted from [Qt developer fac](http://developer.qt.nokia.com/faq/answer/i_can_still_insert_numbers_outside_the_range_specified_with_a_qdoublevalida)
+ * Source code adapted from [StackOverflow](https://stackoverflow.com/questions/19571033/allow-entry-in-qlineedit-only-within-range-of-qdoublevalidator)
  */
 class StrictDoubleValidator : public QDoubleValidator
 {
@@ -34,8 +34,20 @@ public:
     {
         if (input.isEmpty() || input == "." || input == "-") return Intermediate;
 
-        if (QDoubleValidator::validate(input, pos) != Acceptable)
-            return Invalid;
-        return Acceptable;
+        QChar const decimalPoint('.');
+        if (input.indexOf(decimalPoint) != -1)
+        {
+            int const charsAfterPoint = input.length() - input.indexOf(decimalPoint) - 1;
+            if (charsAfterPoint > decimals())
+                return QValidator::Invalid;
+        }
+
+        bool ok;
+        double const d = input.toDouble(&ok);
+
+        if (ok && d >= bottom() && d <= top())
+            return QValidator::Acceptable;
+        else
+            return QValidator::Invalid;
     }
 };

--- a/Applications/DataExplorer/DataView/GMSHPrefs.ui
+++ b/Applications/DataExplorer/DataView/GMSHPrefs.ui
@@ -391,6 +391,9 @@
             <property name="text">
              <string/>
             </property>
+            <property name="maxLength">
+             <number>10</number>
+            </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
@@ -400,6 +403,9 @@
            <widget class="QLineEdit" name="param2">
             <property name="text">
              <string/>
+            </property>
+            <property name="maxLength">
+             <number>10</number>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/Applications/DataExplorer/DataView/GMSHPrefsDialog.cpp
+++ b/Applications/DataExplorer/DataView/GMSHPrefsDialog.cpp
@@ -43,11 +43,11 @@ GMSHPrefsDialog::GMSHPrefsDialog(GeoLib::GEOObjects const& geoObjects, QDialog* 
     param1->setValidator (max_number_of_points_in_quadtree_leaf_validator);
     // object will be deleted by Qt
     auto* mesh_density_scaling_pnts_validator(
-        new StrictDoubleValidator(1e-10, 1.0, 5, this->param2));
+        new StrictDoubleValidator(0, 1, 5, this->param2));
     param2->setValidator (mesh_density_scaling_pnts_validator);
     // object will be deleted by Qt#
     auto* mesh_density_scaling_stations_validator(
-        new StrictDoubleValidator(1e-10, 1.0, 5, this->param3));
+        new StrictDoubleValidator(0, 1, 5, this->param3));
     param3->setValidator (mesh_density_scaling_stations_validator);
 
     std::vector<std::string> geoNames;
@@ -147,16 +147,17 @@ void GMSHPrefsDialog::accept()
 
     if (this->radioAdaptive->isChecked())
     {
+        double const min_scaling_factor (1e-10);
         max_number_of_points_in_quadtree_leaf = BaseLib::str2number<unsigned> (
                 param1->text().toStdString().c_str());
         if (max_number_of_points_in_quadtree_leaf == 0)
             max_number_of_points_in_quadtree_leaf = 10;
         mesh_density_scaling_pnts = fabs (param2->text().toDouble());
-        if (mesh_density_scaling_pnts < sqrt(std::numeric_limits<double>::epsilon()))
-            mesh_density_scaling_pnts = 0.5;
+        if (mesh_density_scaling_pnts < min_scaling_factor)
+            mesh_density_scaling_pnts = min_scaling_factor;
         mesh_density_scaling_stations = param3->text().toDouble();
-        if (mesh_density_scaling_stations < sqrt(std::numeric_limits<double>::epsilon()))
-            mesh_density_scaling_stations = 0.05;
+        if (mesh_density_scaling_stations < min_scaling_factor)
+            mesh_density_scaling_stations = min_scaling_factor;
     }
     else
         val4 = param4->text().toDouble();


### PR DESCRIPTION
Previous implementation didn't work with small value ranges for some reason (such as GMSH preferences where some params need to be in [0;1]).

This fixes an issue with unchangable parameter values in the GMSH dialog.
Also adjusts the minimum default value for parameters to something more reasonable.

(No entry to the changelog because this was supposed to work anyway. I *think* it *did* work in the past, possibly something was changed in QDoubleValidator?)