### PR TITLE
[DE] Fixes index-stack-error in TreeModelIterator

### DIFF
--- a/Applications/DataExplorer/Base/TreeModelIterator.cpp
+++ b/Applications/DataExplorer/Base/TreeModelIterator.cpp
@@ -24,9 +24,6 @@ TreeModelIterator::TreeModelIterator(TreeModel* model)
     if (_model->rootItem()->childCount() > 0)
     {
         _current = _model->rootItem();
-        next(_current);
-        //_parentIndex.push(0);
-        //_currentIndex = 0;
     }
 }
 


### PR DESCRIPTION
Fixes issue where first index would be pushed to the stack twice, causing the iterator to traverse the tree again after finishing.