### PR TITLE
Output only explicitly given meshes

### DIFF
--- a/Documentation/ProjectFile/prj/time_loop/output/meshes/i_meshes.md
+++ b/Documentation/ProjectFile/prj/time_loop/output/meshes/i_meshes.md
@@ -1,3 +1,4 @@
 Opens a sequence of mesh tags. Each mesh tag specifies a mesh that have to be
 contained in the global mesh list. Output will be generated for each of the
-specified meshes.
+specified meshes. If this list is empty or not present, only the bulk mesh will
+be written.

--- a/ProcessLib/Output/Output.cpp
+++ b/ProcessLib/Output/Output.cpp
@@ -92,7 +92,7 @@ bool Output::shallDoOutput(unsigned timestep, double const t)
     return make_output;
 }
 
-Output::Output(std::string output_directory, std::string prefix,
+Output::Output(std::string output_directory, std::string output_file_prefix,
                bool const compress_output, std::string const& data_mode,
                bool const output_nonlinear_iteration_results,
                std::vector<PairRepeatEachSteps> repeats_each_steps,
@@ -101,7 +101,7 @@ Output::Output(std::string output_directory, std::string prefix,
                std::vector<std::string>&& mesh_names_for_output,
                std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes)
     : _output_directory(std::move(output_directory)),
-      _output_file_prefix(std::move(prefix)),
+      _output_file_prefix(std::move(output_file_prefix)),
       _output_file_compression(compress_output),
       _output_file_data_mode(convertVtkDataMode(data_mode)),
       _output_nonlinear_iteration_results(output_nonlinear_iteration_results),

--- a/ProcessLib/Output/Output.cpp
+++ b/ProcessLib/Output/Output.cpp
@@ -150,6 +150,43 @@ Output::ProcessData* Output::findProcessData(Process const& process,
     return process_data;
 }
 
+struct Output::OutputFile
+{
+    OutputFile(std::string const& directory, std::string const& prefix,
+               int const process_id, int const timestep, double const t,
+               int const data_mode_, bool const compression_)
+        : name(constructFileName(prefix, process_id, timestep, t) + ".vtu"),
+          path(BaseLib::joinPaths(directory, name)),
+          data_mode(data_mode_),
+          compression(compression_)
+    {
+    }
+
+    std::string const name;
+    std::string const path;
+    //! Chooses vtk's data mode for output following the enumeration given
+    /// in the vtkXMLWriter: {Ascii, Binary, Appended}.  See vtkXMLWriter
+    /// documentation
+    /// http://www.vtk.org/doc/nightly/html/classvtkXMLWriter.html
+    int const data_mode;
+
+    //! Enables or disables zlib-compression of the output files.
+    bool const compression;
+};
+
+void Output::outputBulkMesh(OutputFile const& output_file,
+                            ProcessData* const process_data,
+                            MeshLib::Mesh const& mesh,
+                            double const t) const
+{
+    DBUG("output to %s", output_file.path.c_str());
+
+    process_data->pvd_file.addVTUFile(output_file.name, t);
+
+    makeOutput(output_file.path, mesh, output_file.compression,
+               output_file.data_mode);
+}
+
 void Output::doOutputAlways(Process const& process,
                             const int process_id,
                             unsigned timestep,
@@ -176,24 +213,25 @@ void Output::doOutputAlways(Process const& process,
         return;
     }
 
-    std::string const output_file_name =
-        constructFileName(_output_file_prefix, process_id, timestep, t) +
-        ".vtu";
-    std::string const output_file_path =
-        BaseLib::joinPaths(_output_directory, output_file_name);
-
-    DBUG("output to %s", output_file_path.c_str());
-
-    ProcessData* process_data = findProcessData(process, process_id);
-    process_data->pvd_file.addVTUFile(output_file_name, t);
-
-    makeOutput(output_file_path, process.getMesh(), _output_file_compression,
-               _output_file_data_mode);
+    auto output_bulk_mesh = [&]() {
+        outputBulkMesh(
+            OutputFile(_output_directory, _output_file_prefix, process_id,
+                       timestep, t, _output_file_data_mode,
+                       _output_file_compression),
+            findProcessData(process, process_id), process.getMesh(), t);
+    };
+    // Write the bulk mesh only if there are no other meshes specified for
+    // output, otherwise only the specified meshes are written.
+    if (_mesh_names_for_output.empty())
+    {
+        output_bulk_mesh();
+    }
 
     for (auto const& mesh_output_name : _mesh_names_for_output)
     {
         if (process.getMesh().getName() == mesh_output_name)
         {
+            output_bulk_mesh();
             continue;
         }
         auto& mesh = *BaseLib::findElementOrError(
@@ -220,19 +258,22 @@ void Output::doOutputAlways(Process const& process,
                           output_secondary_variable,
                           process.getIntegrationPointWriter(), _process_output);
 
-        std::string const mesh_output_file_name =
-            constructFileName(mesh.getName(), process_id, timestep, t) + ".vtu";
-        std::string const mesh_output_file_path =
-            BaseLib::joinPaths(_output_directory, mesh_output_file_name);
-
-        DBUG("output to %s", mesh_output_file_path.c_str());
-
         // TODO (TomFischer): add pvd support here. This can be done if the
         // output is mesh related instead of process related. This would also
         // allow for merging bulk mesh output and arbitrary mesh output.
 
-        makeOutput(mesh_output_file_path, mesh, _output_file_compression,
-                   _output_file_data_mode);
+        OutputFile const output_file{_output_directory,
+                                     mesh.getName(),
+                                     process_id,
+                                     timestep,
+                                     t,
+                                     _output_file_data_mode,
+                                     _output_file_compression};
+
+        DBUG("output to %s", output_file.path.c_str());
+
+        makeOutput(output_file.path, mesh, output_file.compression,
+                   output_file.data_mode);
     }
     INFO("[time] Output of timestep %d took %g s.", timestep,
          time_output.elapsed());

--- a/ProcessLib/Output/Output.cpp
+++ b/ProcessLib/Output/Output.cpp
@@ -46,7 +46,7 @@ int convertVtkDataMode(std::string const& data_mode)
 
 std::string constructFileName(std::string const& prefix,
                               int const process_id,
-                              unsigned const timestep,
+                              int const timestep,
                               double const t)
 {
     return prefix + "_pcs_" + std::to_string(process_id) + "_ts_" +
@@ -56,9 +56,9 @@ std::string constructFileName(std::string const& prefix,
 
 namespace ProcessLib
 {
-bool Output::shallDoOutput(unsigned timestep, double const t)
+bool Output::shallDoOutput(int timestep, double const t)
 {
-    unsigned each_steps = 1;
+    int each_steps = 1;
 
     for (auto const& pair : _repeats_each_steps)
     {
@@ -189,7 +189,7 @@ void Output::outputBulkMesh(OutputFile const& output_file,
 
 void Output::doOutputAlways(Process const& process,
                             const int process_id,
-                            unsigned timestep,
+                            const int timestep,
                             const double t,
                             GlobalVector const& x)
 {
@@ -281,7 +281,7 @@ void Output::doOutputAlways(Process const& process,
 
 void Output::doOutput(Process const& process,
                       const int process_id,
-                      unsigned timestep,
+                      const int timestep,
                       const double t,
                       GlobalVector const& x)
 {
@@ -298,7 +298,7 @@ void Output::doOutput(Process const& process,
 
 void Output::doOutputLastTimestep(Process const& process,
                                   const int process_id,
-                                  unsigned timestep,
+                                  const int timestep,
                                   const double t,
                                   GlobalVector const& x)
 {
@@ -313,9 +313,9 @@ void Output::doOutputLastTimestep(Process const& process,
 
 void Output::doOutputNonlinearIteration(Process const& process,
                                         const int process_id,
-                                        const unsigned timestep, const double t,
+                                        const int timestep, const double t,
                                         GlobalVector const& x,
-                                        const unsigned iteration)
+                                        const int iteration)
 {
     if (!_output_nonlinear_iteration_results)
     {

--- a/ProcessLib/Output/Output.h
+++ b/ProcessLib/Output/Output.h
@@ -90,6 +90,13 @@ private:
         MeshLib::IO::PVDFile pvd_file;
     };
 
+    struct OutputFile;
+    void outputBulkMesh(OutputFile const& output_file,
+                        ProcessData* const process_data,
+                        MeshLib::Mesh const& mesh,
+                        double const t) const;
+
+private:
     std::string const _output_directory;
     std::string const _output_file_prefix;
 

--- a/ProcessLib/Output/Output.h
+++ b/ProcessLib/Output/Output.h
@@ -29,13 +29,10 @@ class Output
 public:
     struct PairRepeatEachSteps
     {
-        explicit PairRepeatEachSteps(unsigned c, unsigned e)
-            : repeat(c), each_steps(e)
-        {
-        }
+        explicit PairRepeatEachSteps(int c, int e) : repeat(c), each_steps(e) {}
 
-        const unsigned repeat;      //!< Apply \c each_steps \c repeat times.
-        const unsigned each_steps;  //!< Do output every \c each_steps timestep.
+        const int repeat;      //!< Apply \c each_steps \c repeat times.
+        const int each_steps;  //!< Do output every \c each_steps timestep.
     };
 
 public:
@@ -54,29 +51,28 @@ public:
     //! Writes output for the given \c process if it should be written in the
     //! given \c timestep.
     void doOutput(Process const& process, const int process_id,
-                  unsigned timestep, const double t, GlobalVector const& x);
+                  const int timestep, const double t, GlobalVector const& x);
 
     //! Writes output for the given \c process if it has not been written yet.
     //! This method is intended for doing output after the last timestep in
     //! order to make sure that its results are written.
     void doOutputLastTimestep(Process const& process, const int process_id,
-                              unsigned timestep, const double t,
+                              const int timestep, const double t,
                               GlobalVector const& x);
 
     //! Writes output for the given \c process.
     //! This method will always write.
     //! It is intended to write output in error handling routines.
     void doOutputAlways(Process const& process, const int process_id,
-                        unsigned timestep, const double t,
+                        const int timestep, const double t,
                         GlobalVector const& x);
 
     //! Writes output for the given \c process.
     //! To be used for debug output after an iteration of the nonlinear solver.
     void doOutputNonlinearIteration(Process const& process,
-                                    const int process_id,
-                                    const unsigned timestep, const double t,
-                                    GlobalVector const& x,
-                                    const unsigned iteration);
+                                    const int process_id, const int timestep,
+                                    const double t, GlobalVector const& x,
+                                    const int iteration);
 
     std::vector<double> getFixedOutputTimes() {return _fixed_output_times;}
 
@@ -126,7 +122,7 @@ private:
     ProcessData* findProcessData(Process const& process, const int process_id);
 
     //! Determines if there should be output at the given \c timestep or \c t.
-    bool shallDoOutput(unsigned timestep, double const t);
+    bool shallDoOutput(int timestep, double const t);
 
     ProcessOutput const _process_output;
     std::vector<std::string> const _mesh_names_for_output;

--- a/ProcessLib/Output/ProcessOutput.cpp
+++ b/ProcessLib/Output/ProcessOutput.cpp
@@ -239,7 +239,7 @@ void processOutputData(
     addIntegrationPointWriter(mesh, integration_point_writer);
 }
 
-void makeOutput(std::string const& file_name, MeshLib::Mesh& mesh,
+void makeOutput(std::string const& file_name, MeshLib::Mesh const& mesh,
                 bool const compress_output, int const data_mode)
 {
     // Write output file

--- a/ProcessLib/Output/ProcessOutput.h
+++ b/ProcessLib/Output/ProcessOutput.h
@@ -45,7 +45,7 @@ void processOutputData(
 ///
 /// See Output::_output_file_data_mode documentation for the data_mode
 /// parameter.
-void makeOutput(std::string const& file_name, MeshLib::Mesh& mesh,
+void makeOutput(std::string const& file_name, MeshLib::Mesh const& mesh,
                 bool const compress_output, int const data_mode);
 
 }  // namespace ProcessLib

--- a/ProcessLib/Output/SecondaryVariable.h
+++ b/ProcessLib/Output/SecondaryVariable.h
@@ -40,8 +40,6 @@ struct SecondaryVariableFunctions final
         NumLib::LocalToGlobalIndexMap const& dof_table,
         std::unique_ptr<GlobalVector>& result_cache)>;
 
-    SecondaryVariableFunctions() = default;
-
     template <typename F1, typename F2>
     SecondaryVariableFunctions(const unsigned num_components_, F1&& eval_field_,
                                F2&& eval_residuals_)


### PR DESCRIPTION
Replacing the previous attempt https://github.com/ufz/ogs/pull/2471.

Only if the output meshes list is empty, write it.
As requested by @ErikNixdorf

Some refactorings included avoiding code duplication.

The bulk mesh output and the observation meshes outputs are identical now but for the pvd files. The pvd files need some refactorings before => another PR.