### PR TITLE
HC surface flux now calculates mass flux

### DIFF
--- a/ProcessLib/ComponentTransport/ComponentTransportFEM.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportFEM.h
@@ -854,17 +854,15 @@ public:
 
         GlobalDimVectorType q =
             -K_over_mu * shape_matrices.dNdx * p_nodal_values;
-
+        auto const rho_w = _process_data.fluid_properties->getValue(
+            MaterialLib::Fluid::FluidPropertyType::Density, vars);
         if (_process_data.has_gravity)
         {
-            auto const rho_w =
-                _process_data.fluid_properties->getValue(
-                    MaterialLib::Fluid::FluidPropertyType::Density, vars);
             auto const b = _process_data.specific_body_force;
             q += K_over_mu * rho_w * b;
         }
         Eigen::Vector3d flux(0.0, 0.0, 0.0);
-        flux.head<GlobalDim>() = q;
+        flux.head<GlobalDim>() = rho_w * q;
         return flux;
     }
 


### PR DESCRIPTION
Extracted from https://github.com/ufz/ogs/pull/2466, because unrelated to BC changes.

Already reviewed; can be merged when tests pass.