### PR TITLE
[HT] Use MPL for solid phase properties.

### DIFF
--- a/ProcessLib/HT/CreateHTProcess.cpp
+++ b/ProcessLib/HT/CreateHTProcess.cpp
@@ -79,30 +79,6 @@ std::unique_ptr<Process> createHTProcess(
     const int _heat_transport_process_id = 0;
     const int _hydraulic_process_id = 1;
 
-    // Parameter for the density of the solid.
-    auto& density_solid = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HT__density_solid}
-        "density_solid", parameters, 1);
-    DBUG("Use '%s' as density_solid parameter.", density_solid.name.c_str());
-
-    // Parameter for the specific heat capacity of the solid.
-    auto& specific_heat_capacity_solid = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HT__specific_heat_capacity_solid}
-        "specific_heat_capacity_solid", parameters, 1);
-    DBUG("Use '%s' as specific_heat_capacity_solid parameter.",
-         specific_heat_capacity_solid.name.c_str());
-
-    // Parameter for the thermal conductivity of the solid (only one scalar per
-    // element, i.e., the isotropic case is handled at the moment)
-    auto& thermal_conductivity_solid = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HT__thermal_conductivity_solid}
-        "thermal_conductivity_solid", parameters, 1);
-    DBUG("Use '%s' as thermal_conductivity_solid parameter.",
-         thermal_conductivity_solid.name.c_str());
-
     // Specific body force parameter.
     Eigen::VectorXd specific_body_force;
     std::vector<double> const b =
@@ -164,10 +140,7 @@ std::unique_ptr<Process> createHTProcess(
 
     std::unique_ptr<HTMaterialProperties> material_properties =
         std::make_unique<HTMaterialProperties>(
-            density_solid,
             std::move(media_map),
-            specific_heat_capacity_solid,
-            thermal_conductivity_solid,
             has_fluid_thermal_expansion,
             *solid_thermal_expansion,
             *biot_constant,

--- a/ProcessLib/HT/HTMaterialProperties.h
+++ b/ProcessLib/HT/HTMaterialProperties.h
@@ -24,20 +24,14 @@ namespace HT
 struct HTMaterialProperties final
 {
     HTMaterialProperties(
-        ParameterLib::Parameter<double> const& density_solid_,
         std::unique_ptr<MaterialPropertyLib::MaterialSpatialDistributionMap>&&
             media_map_,
-        ParameterLib::Parameter<double> const& specific_heat_capacity_solid_,
-        ParameterLib::Parameter<double> const& thermal_conductivity_solid_,
         bool const has_fluid_thermal_expansion_,
         ParameterLib::Parameter<double> const& solid_thermal_expansion_,
         ParameterLib::Parameter<double> const& biot_constant_,
         Eigen::VectorXd specific_body_force_,
         bool const has_gravity_)
-        : density_solid(density_solid_),
-          media_map(std::move(media_map_)),
-          specific_heat_capacity_solid(specific_heat_capacity_solid_),
-          thermal_conductivity_solid(thermal_conductivity_solid_),
+        : media_map(std::move(media_map_)),
           has_fluid_thermal_expansion(has_fluid_thermal_expansion_),
           solid_thermal_expansion(solid_thermal_expansion_),
           biot_constant(biot_constant_),
@@ -51,11 +45,8 @@ struct HTMaterialProperties final
     void operator=(HTMaterialProperties&&) = delete;
     void operator=(HTMaterialProperties const&) = delete;
 
-    ParameterLib::Parameter<double> const& density_solid;
     std::unique_ptr<MaterialPropertyLib::MaterialSpatialDistributionMap>
         media_map;
-    ParameterLib::Parameter<double> const& specific_heat_capacity_solid;
-    ParameterLib::Parameter<double> const& thermal_conductivity_solid;
 
     bool const has_fluid_thermal_expansion;
     ParameterLib::Parameter<double> const& solid_thermal_expansion;

--- a/ProcessLib/HT/MonolithicHTFEM.h
+++ b/ProcessLib/HT/MonolithicHTFEM.h
@@ -176,8 +176,8 @@ public:
             // matrix assembly
             GlobalDimMatrixType const thermal_conductivity_dispersivity =
                 this->getThermalConductivityDispersivity(
-                    t, pos, porosity, fluid_density,
-                    specific_heat_capacity_fluid, velocity, I);
+                    vars, porosity, fluid_density, specific_heat_capacity_fluid,
+                    velocity, I);
             Ktt.noalias() +=
                 (dNdx.transpose() * thermal_conductivity_dispersivity * dNdx +
                  N.transpose() * velocity.transpose() * dNdx * fluid_density *
@@ -186,7 +186,7 @@ public:
             Kpp.noalias() += w * dNdx.transpose() * K_over_mu * dNdx;
             Mtt.noalias() +=
                 w *
-                this->getHeatEnergyCoefficient(t, pos, porosity, fluid_density,
+                this->getHeatEnergyCoefficient(vars, porosity, fluid_density,
                                                specific_heat_capacity_fluid) *
                 N.transpose() * N;
             Mpp.noalias() += w * N.transpose() * specific_storage * N;

--- a/ProcessLib/HT/StaggeredHTFEM-impl.h
+++ b/ProcessLib/HT/StaggeredHTFEM-impl.h
@@ -252,7 +252,7 @@ void StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
         // Assemble mass matrix
         local_M.noalias() +=
             w *
-            this->getHeatEnergyCoefficient(t, pos, porosity, fluid_density,
+            this->getHeatEnergyCoefficient(vars, porosity, fluid_density,
                                            specific_heat_capacity_fluid) *
             N.transpose() * N;
 
@@ -276,7 +276,7 @@ void StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
 
         GlobalDimMatrixType const thermal_conductivity_dispersivity =
             this->getThermalConductivityDispersivity(
-                t, pos, porosity, fluid_density, specific_heat_capacity_fluid,
+                vars, porosity, fluid_density, specific_heat_capacity_fluid,
                 velocity, I);
 
         local_K.noalias() +=

--- a/ProcessLib/HT/Tests.cmake
+++ b/ProcessLib/HT/Tests.cmake
@@ -209,19 +209,20 @@ AddTest(
     VIS ConstViscosityThermalConvectionStaggeredAdaptive_dt_pcs_1_ts_141_t_50000000000.000000.vtu
 )
 
-AddTest(
-    NAME HT_a_DECOVALEX_THMC_based_Example
-    PATH Parabolic/HT/StaggeredCoupling/ADecovalexTHMCBasedHTExample
-    EXECUTABLE ogs
-    EXECUTABLE_ARGS th_decovalex.prj
-    WRAPPER time
-    TESTER vtkdiff
-    REQUIREMENTS NOT (OGS_USE_LIS OR OGS_USE_MPI)
-    DIFF_DATA
-    th_decovalex.vtu th_decovalex_pcs_1_ts_40_t_18.000000.vtu T_ref T 6e-12 1.e-14
-    th_decovalex.vtu th_decovalex_pcs_1_ts_40_t_18.000000.vtu p_ref p 1e-7 1.e-14
-    VIS th_decovalex_pcs_1_ts_78_t_1000.000000.vtu
-)
+# 2019-05-09 TF disable the test until the MPL can deal with parameters as properties
+#AddTest(
+#    NAME HT_a_DECOVALEX_THMC_based_Example
+#    PATH Parabolic/HT/StaggeredCoupling/ADecovalexTHMCBasedHTExample
+#    EXECUTABLE ogs
+#    EXECUTABLE_ARGS th_decovalex.prj
+#    WRAPPER time
+#    TESTER vtkdiff
+#    REQUIREMENTS NOT (OGS_USE_LIS OR OGS_USE_MPI)
+#    DIFF_DATA
+#    th_decovalex.vtu th_decovalex_pcs_1_ts_40_t_18.000000.vtu T_ref T 6e-12 1.e-14
+#    th_decovalex.vtu th_decovalex_pcs_1_ts_40_t_18.000000.vtu p_ref p 1e-7 1.e-14
+#    VIS th_decovalex_pcs_1_ts_78_t_1000.000000.vtu
+#)
 
 AddTest(
     NAME HT_SimpleSynthetics_IsothermalFluidFlowStaggered
@@ -412,20 +413,21 @@ AddTest(
     VIS ConstViscosityThermalConvectionStaggeredAdaptive_dt_pcs_1_ts_141_t_50000000000_000000_0.vtu
 )
 
-AddTest(
-    NAME HT_a_DECOVALEX_THMC_based_Example
-    PATH Parabolic/HT/StaggeredCoupling/ADecovalexTHMCBasedHTExample
-    EXECUTABLE_ARGS th_decovalex.prj
-    WRAPPER mpirun
-    WRAPPER_ARGS -np 1
-    TESTER vtkdiff
-    REQUIREMENTS OGS_USE_MPI
-    RUNTIME 186
-    DIFF_DATA
-    th_decovalex.vtu th_decovalex_pcs_1_ts_40_t_18_000000_0.vtu T_ref T 1e-10  1.e-10
-    th_decovalex.vtu th_decovalex_pcs_1_ts_40_t_18_000000_0.vtu p_ref p 1e-10  1.e-10
-    VIS th_decovalex_pcs_1_ts_78_t_1000_000000_0.vtu
-)
+# 2019-05-09 TF disable the test until the MPL can deal with parameters as properties
+# AddTest(
+#     NAME HT_a_DECOVALEX_THMC_based_Example
+#     PATH Parabolic/HT/StaggeredCoupling/ADecovalexTHMCBasedHTExample
+#     EXECUTABLE_ARGS th_decovalex.prj
+#     WRAPPER mpirun
+#     WRAPPER_ARGS -np 1
+#     TESTER vtkdiff
+#     REQUIREMENTS OGS_USE_MPI
+#     RUNTIME 186
+#     DIFF_DATA
+#     th_decovalex.vtu th_decovalex_pcs_1_ts_40_t_18_000000_0.vtu T_ref T 1e-10  1.e-10
+#     th_decovalex.vtu th_decovalex_pcs_1_ts_40_t_18_000000_0.vtu p_ref p 1e-10  1.e-10
+#     VIS th_decovalex_pcs_1_ts_78_t_1000_000000_0.vtu
+# )
 
 AddTest(
     NAME HT_FaultedCube_rev0

--- a/Tests/Data/Parabolic/HT/ConstViscosity/square_5500x5500.prj
+++ b/Tests/Data/Parabolic/HT/ConstViscosity/square_5500x5500.prj
@@ -11,9 +11,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 -9.81</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -70,6 +67,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -227,19 +239,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
         </parameter>
         <parameter>
             <name>alpha_l</name>
@@ -250,11 +252,6 @@
             <name>alpha_t</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/FaultedCube/Ra_795_fault_bcgs_jacobi.prj
+++ b/Tests/Data/Parabolic/HT/FaultedCube/Ra_795_fault_bcgs_jacobi.prj
@@ -18,9 +18,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 0 -9.81</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -82,6 +79,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -153,6 +165,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -332,24 +359,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>c_fluid</name>
@@ -396,16 +408,16 @@
             <type>Constant</type>
             <value>20</value>
         </parameter>
-          <parameter>
+        <parameter>
             <name>kappa1</name>
             <type>Constant</type>
             <values>1.0e-18 0 0 0 1.0e-18 0 0 0 1.0e-18</values>
-          </parameter>
-          <parameter>
+        </parameter>
+        <parameter>
             <name>kappa2</name>
             <type>Constant</type>
             <values>1.7e-13 0 0 0 1.7e-13 0 0 0 1.7e-13</values>
-          </parameter>
+        </parameter>
         <parameter>
             <name>constant_porosity_parameter</name>
             <type>Constant</type>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/CoupledPressureParabolicTemperatureParabolic.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/CoupledPressureParabolicTemperatureParabolic.prj
@@ -11,9 +11,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -63,6 +60,21 @@
                         </property>
                         <property>
                             <name>storage</name>
+                            <type>Constant</type>
+                            <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0e-10</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
                             <type>Constant</type>
                             <value>0</value>
                         </property>
@@ -126,19 +138,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1e-5</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0e-10</value>
         </parameter>
         <parameter>
             <name>lambda_fluid</name>
@@ -154,11 +156,6 @@
             <name>alpha_t</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/CoupledPressureParabolicTemperatureParabolicStaggered.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/CoupledPressureParabolicTemperatureParabolicStaggered.prj
@@ -12,9 +12,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -64,6 +61,21 @@
                         </property>
                         <property>
                             <name>storage</name>
+                            <type>Constant</type>
+                            <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0e-10</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
                             <type>Constant</type>
                             <value>0</value>
                         </property>
@@ -166,19 +178,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1e-5</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0e-10</value>
         </parameter>
         <parameter>
             <name>lambda_fluid</name>
@@ -194,11 +196,6 @@
             <name>alpha_t</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlow.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlow.prj
@@ -11,9 +11,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -65,6 +62,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
                         </property>
                     </properties>
                 </phase>
@@ -126,24 +138,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlowStaggered.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlowStaggered.prj
@@ -12,9 +12,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -66,6 +63,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -166,19 +178,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
         </parameter>
         <parameter>
             <name>lambda_fluid</name>
@@ -194,11 +196,6 @@
             <name>alpha_t</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlowWithGravity.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlowWithGravity.prj
@@ -11,9 +11,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 -9.81</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -65,6 +62,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -126,19 +138,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
         </parameter>
         <parameter>
             <name>lambda_fluid</name>
@@ -154,11 +156,6 @@
             <name>alpha_t</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlowWithGravityStaggered.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlowWithGravityStaggered.prj
@@ -12,9 +12,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 -9.81</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -66,6 +63,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -166,19 +178,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
         </parameter>
         <parameter>
             <name>lambda_fluid</name>
@@ -194,11 +196,6 @@
             <name>alpha_t</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureDiffusionTemperatureDiffusion.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureDiffusionTemperatureDiffusion.prj
@@ -11,9 +11,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -65,6 +62,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -126,29 +138,14 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
         </parameter>
         <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
-        </parameter>
-        <parameter>
             <name>lambda_fluid</name>
             <type>Constant</type>
             <value>0.65</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureDiffusionTemperatureDiffusionStaggered.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureDiffusionTemperatureDiffusionStaggered.prj
@@ -12,9 +12,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -66,6 +63,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -166,19 +178,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
         </parameter>
         <parameter>
             <name>lambda_fluid</name>
@@ -194,11 +196,6 @@
             <name>alpha_t</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureParabolicTemperatureParabolic.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureParabolicTemperatureParabolic.prj
@@ -11,9 +11,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -65,6 +62,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>1e-5</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>100.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
                         </property>
                     </properties>
                 </phase>
@@ -126,19 +138,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>100.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
         </parameter>
         <parameter>
             <name>lambda_fluid</name>
@@ -154,11 +156,6 @@
             <name>alpha_t</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>1e-3</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureParabolicTemperatureParabolicStaggered.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureParabolicTemperatureParabolicStaggered.prj
@@ -12,9 +12,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -66,6 +63,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>1e-5</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>100.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
                         </property>
                     </properties>
                 </phase>
@@ -166,19 +178,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>100.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
         </parameter>
         <parameter>
             <name>lambda_fluid</name>
@@ -194,11 +196,6 @@
             <name>alpha_t</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>1e-3</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/calculatesurfaceflux_ht_cube_1e3.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/calculatesurfaceflux_ht_cube_1e3.prj
@@ -15,9 +15,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 0 0</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -74,6 +71,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -155,24 +167,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/calculatesurfaceflux_ht_cube_1e4.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/calculatesurfaceflux_ht_cube_1e4.prj
@@ -15,9 +15,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 0 0</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -79,6 +76,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -160,24 +172,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/constraint_bc_1e3.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/constraint_bc_1e3.prj
@@ -11,9 +11,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 0 0</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -70,6 +67,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -151,19 +163,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
         </parameter>
         <parameter>
             <name>lambda_fluid</name>
@@ -179,11 +181,6 @@
             <name>alpha_t</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/StaggeredCoupling/ConstViscosity/square_5500x5500_staggered_scheme.prj
+++ b/Tests/Data/Parabolic/HT/StaggeredCoupling/ConstViscosity/square_5500x5500_staggered_scheme.prj
@@ -12,9 +12,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 -9.81</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -71,6 +68,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -363,19 +375,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
         </parameter>
         <parameter>
             <name>alpha_l</name>
@@ -386,11 +388,6 @@
             <name>alpha_t</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>

--- a/Tests/Data/Parabolic/HT/StaggeredCoupling/ConstViscosity/square_5500x5500_staggered_scheme_adaptive_dt.prj
+++ b/Tests/Data/Parabolic/HT/StaggeredCoupling/ConstViscosity/square_5500x5500_staggered_scheme_adaptive_dt.prj
@@ -12,9 +12,6 @@
                 <temperature>T</temperature>
                 <pressure>p</pressure>
             </process_variables>
-            <density_solid>rho_solid</density_solid>
-            <specific_heat_capacity_solid>c_solid</specific_heat_capacity_solid>
-            <thermal_conductivity_solid>lambda_solid</thermal_conductivity_solid>
             <specific_body_force>0 -9.81</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -71,6 +68,21 @@
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.0</value>
+                        </property>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -173,19 +185,9 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>rho_solid</name>
-            <type>Constant</type>
-            <value>0.0</value>
-        </parameter>
-        <parameter>
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>lambda_solid</name>
-            <type>Constant</type>
-            <value>3.0</value>
         </parameter>
         <parameter>
             <name>lambda_fluid</name>
@@ -201,11 +203,6 @@
             <name>alpha_t</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>c_solid</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>T0</name>


### PR DESCRIPTION
Using MPL for solid phase properties needs also changes in the project files. For the benchmarks this is done in this PR.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.1)
2. [x] All HT-Tests were changed, except the decovalex test since these tests use mesh parameters that are not implemented yet in the MPL. As soon as we can use a parameter as MPL::Property we can reenable the tests.
