### PR TITLE
Check BC parameters domains

### DIFF
--- a/ParameterLib/Parameter.cpp
+++ b/ParameterLib/Parameter.cpp
@@ -84,4 +84,23 @@ std::unique_ptr<ParameterBase> createParameter(
     OGS_FATAL("Cannot construct a parameter of given type '%s'.", type.c_str());
 }
 
+boost::optional<std::string> isDefinedOnSameMesh(ParameterBase const& parameter,
+                                                 MeshLib::Mesh const& mesh)
+{
+    // Arbitrary domain of definition.
+    if (parameter.mesh() == nullptr)
+    {
+        return {};
+    }
+
+    // Equal meshes.
+    if (*parameter.mesh() == mesh)
+    {
+        return {};
+    }
+
+    return "The parameter's domain of definition mesh '" +
+           parameter.mesh()->getName() + "' differs from the used mesh '" +
+           mesh.getName() + "'. Both meshes must be equal.";
+}
 }  // namespace ParameterLib

--- a/ParameterLib/Parameter.h
+++ b/ParameterLib/Parameter.h
@@ -197,4 +197,13 @@ std::unique_ptr<ParameterBase> createParameter(
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
         curves);
 
+//! Checks whether the parameter can be used on the given mesh. The parameter's
+//! domain of definition can be arbitrary (like for constant parameters), or the
+//! parameter is defined on a mesh. In the latter case that mesh must be equal
+//! to the given mesh.
+//! \returns nothing if the parameter can be used on the given mesh, or an error
+//! string otherwise.
+boost::optional<std::string> isDefinedOnSameMesh(ParameterBase const& parameter,
+                                                 MeshLib::Mesh const& mesh);
+
 }  // namespace ParameterLib

--- a/ProcessLib/BoundaryCondition/ConstraintDirichletBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/ConstraintDirichletBoundaryCondition.cpp
@@ -298,8 +298,8 @@ createConstraintDirichletBoundaryCondition(
     auto const param_name = config.getConfigParameter<std::string>("parameter");
     DBUG("Using parameter %s", param_name.c_str());
 
-    auto& param =
-        ParameterLib::findParameter<double>(param_name, parameters, 1);
+    auto& param = ParameterLib::findParameter<double>(param_name, parameters, 1,
+                                                      &bc_mesh);
 
     // In case of partitioned mesh the boundary could be empty, i.e. there is no
     // boundary condition.

--- a/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/DirichletBoundaryCondition.cpp
@@ -68,17 +68,8 @@ std::unique_ptr<DirichletBoundaryCondition> createDirichletBoundaryCondition(
     auto const param_name = config.getConfigParameter<std::string>("parameter");
     DBUG("Using parameter %s", param_name.c_str());
 
-    auto& parameter =
-        ParameterLib::findParameter<double>(param_name, parameters, 1);
-
-    if (parameter.mesh() && *parameter.mesh() != bc_mesh)
-    {
-        OGS_FATAL(
-            "The boundary condition is defined on a different domain than the "
-            "parameter: boundary condition is defined on mesh '%s', parameter "
-            "is defined on mesh '%s'.",
-            bc_mesh.getName().c_str(), parameter.mesh()->getName().c_str());
-    }
+    auto& parameter = ParameterLib::findParameter<double>(
+        param_name, parameters, 1, &bc_mesh);
 
 // In case of partitioned mesh the boundary could be empty, i.e. there is no
 // boundary condition.

--- a/ProcessLib/BoundaryCondition/DirichletBoundaryConditionWithinTimeInterval.cpp
+++ b/ProcessLib/BoundaryCondition/DirichletBoundaryConditionWithinTimeInterval.cpp
@@ -110,8 +110,8 @@ createDirichletBoundaryConditionWithinTimeInterval(
     auto const param_name = config.getConfigParameter<std::string>("parameter");
     DBUG("Using parameter %s", param_name.c_str());
 
-    auto& param =
-        ParameterLib::findParameter<double>(param_name, parameters, 1);
+    auto& param = ParameterLib::findParameter<double>(param_name, parameters, 1,
+                                                      &bc_mesh);
 
 // In case of partitioned mesh the boundary could be empty, i.e. there is no
 // boundary condition.

--- a/ProcessLib/BoundaryCondition/HCNonAdvectiveFreeComponentFlowBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/HCNonAdvectiveFreeComponentFlowBoundaryCondition.cpp
@@ -33,7 +33,7 @@ createHCNonAdvectiveFreeComponentFlowBoundaryCondition(
         //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition__HCNonAdvectiveFreeComponentFlowBoundary__parameter}
         config.getConfigParameter<std::string>("parameter");
     auto const& boundary_permeability = ParameterLib::findParameter<double>(
-        boundary_permeability_name, parameters, 1);
+        boundary_permeability_name, parameters, 1, &bc_mesh);
 
     if (global_dim != 3)
     {

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryCondition.cpp
@@ -27,8 +27,8 @@ std::unique_ptr<NeumannBoundaryCondition> createNeumannBoundaryCondition(
     auto const param_name = config.getConfigParameter<std::string>("parameter");
     DBUG("Using parameter %s", param_name.c_str());
 
-    auto const& param =
-        ParameterLib::findParameter<double>(param_name, parameters, 1);
+    auto const& param = ParameterLib::findParameter<double>(
+        param_name, parameters, 1, &bc_mesh);
 
     // In case of partitioned mesh the boundary could be empty, i.e. there is no
     // boundary condition.

--- a/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition-impl.h
@@ -91,8 +91,8 @@ createNormalTractionBoundaryCondition(
         config.getConfigParameter<std::string>("parameter");
     DBUG("Using parameter %s", parameter_name.c_str());
 
-    auto const& pressure =
-        ParameterLib::findParameter<double>(parameter_name, parameters, 1);
+    auto const& pressure = ParameterLib::findParameter<double>(
+        parameter_name, parameters, 1, &bc_mesh);
     return std::make_unique<NormalTractionBoundaryCondition<
         NormalTractionBoundaryConditionLocalAssembler>>(
         integration_order, shapefunction_order, dof_table, variable_id,

--- a/ProcessLib/BoundaryCondition/RobinBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryCondition.cpp
@@ -28,10 +28,11 @@ std::unique_ptr<RobinBoundaryCondition> createRobinBoundaryCondition(
     //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition__Robin__u_0}
     auto const u_0_name = config.getConfigParameter<std::string>("u_0");
 
-    auto const& alpha =
-        ParameterLib::findParameter<double>(alpha_name, parameters, 1);
+    auto const& alpha = ParameterLib::findParameter<double>(
+        alpha_name, parameters, 1, &bc_mesh);
+
     auto const& u_0 =
-        ParameterLib::findParameter<double>(u_0_name, parameters, 1);
+        ParameterLib::findParameter<double>(u_0_name, parameters, 1, &bc_mesh);
 
     // In case of partitioned mesh the boundary could be empty, i.e. there is no
     // boundary condition.

--- a/ProcessLib/BoundaryCondition/VariableDependentNeumannBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/VariableDependentNeumannBoundaryCondition.cpp
@@ -35,8 +35,8 @@ createVariableDependentNeumannBoundaryCondition(
     auto const constant_name =
         //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition__VariableDependentNeumann__constant_name}
         config.getConfigParameter<std::string>("constant_name");
-    auto const& constant =
-        ParameterLib::findParameter<double>(constant_name, parameters, 1);
+    auto const& constant = ParameterLib::findParameter<double>(
+        constant_name, parameters, 1, &bc_mesh);
 
     auto const coefficient_current_variable_name =
         //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition__VariableDependentNeumann__coefficient_current_variable_name}
@@ -44,7 +44,7 @@ createVariableDependentNeumannBoundaryCondition(
             "coefficient_current_variable_name");
     auto const& coefficient_current_variable =
         ParameterLib::findParameter<double>(coefficient_current_variable_name,
-                                            parameters, 1);
+                                            parameters, 1, &bc_mesh);
 
     auto const coefficient_other_variable_name =
         //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition__VariableDependentNeumann__coefficient_other_variable_name}
@@ -52,7 +52,7 @@ createVariableDependentNeumannBoundaryCondition(
             "coefficient_other_variable_name");
     auto const& coefficient_other_variable =
         ParameterLib::findParameter<double>(coefficient_other_variable_name,
-                                            parameters, 1);
+                                            parameters, 1, &bc_mesh);
 
     auto const coefficient_mixed_variables_name =
         //! \ogs_file_param{prj__process_variables__process_variable__boundary_conditions__boundary_condition__VariableDependentNeumann__coefficient_mixed_variables_name}
@@ -60,7 +60,7 @@ createVariableDependentNeumannBoundaryCondition(
             "coefficient_mixed_variables_name");
     auto const& coefficient_mixed_variables =
         ParameterLib::findParameter<double>(coefficient_mixed_variables_name,
-                                            parameters, 1);
+                                            parameters, 1, &bc_mesh);
 
     std::vector<MeshLib::Node*> const& bc_nodes = bc_mesh.getNodes();
     MeshLib::MeshSubset bc_mesh_subset(bc_mesh, bc_nodes);

--- a/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
@@ -114,19 +114,19 @@ std::unique_ptr<Process> createComponentTransportProcess(
         //! \ogs_file_param_special{prj__processes__process__ComponentTransport__fluid_reference_density}
         "fluid_reference_density", parameters, 1);
     DBUG("Use '%s' as fluid_reference_density parameter.",
-         fluid_reference_density.name.c_str());
+         fluid_reference_density.name.c_str(), &mesh);
 
     // Parameter for the retardation factor.
     auto const& retardation_factor = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__ComponentTransport__retardation_factor}
-        "retardation_factor", parameters, 1);
+        "retardation_factor", parameters, 1, &mesh);
 
     // Parameter for the decay rate.
     auto const& decay_rate = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__ComponentTransport__decay_rate}
-        "decay_rate", parameters, 1);
+        "decay_rate", parameters, 1, &mesh);
 
     // Specific body force parameter.
     Eigen::VectorXd specific_body_force;

--- a/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
@@ -53,7 +53,8 @@ std::unique_ptr<Process> createGroundwaterFlowProcess(
     auto& hydraulic_conductivity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__GROUNDWATER_FLOW__hydraulic_conductivity}
-        "hydraulic_conductivity", parameters, 0 /*arbitrary many components*/);
+        "hydraulic_conductivity", parameters, 0 /*arbitrary many components*/,
+        &mesh);
 
     DBUG("Use '%s' as hydraulic conductivity parameter.",
          hydraulic_conductivity.name.c_str());

--- a/ProcessLib/HT/CreateHTProcess.cpp
+++ b/ProcessLib/HT/CreateHTProcess.cpp
@@ -115,12 +115,12 @@ std::unique_ptr<Process> createHTProcess(
     {
         solid_thermal_expansion = &ParameterLib::findParameter<double>(
             //! \ogs_file_param_special{prj__processes__process__HT__solid_thermal_expansion__thermal_expansion}
-            *solid_config, "thermal_expansion", parameters, 1);
+            *solid_config, "thermal_expansion", parameters, 1, &mesh);
         DBUG("Use '%s' as solid thermal expansion.",
              solid_thermal_expansion->name.c_str());
         biot_constant = &ParameterLib::findParameter<double>(
             //! \ogs_file_param_special{prj__processes__process__HT__solid_thermal_expansion__biot_constant}
-            *solid_config, "biot_constant", parameters, 1);
+            *solid_config, "biot_constant", parameters, 1, &mesh);
         DBUG("Use '%s' as Biot's constant.", biot_constant->name.c_str());
     }
 

--- a/ProcessLib/HeatConduction/CreateHeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/CreateHeatConductionProcess.cpp
@@ -49,7 +49,7 @@ std::unique_ptr<Process> createHeatConductionProcess(
     auto& thermal_conductivity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HEAT_CONDUCTION__thermal_conductivity}
-        "thermal_conductivity", parameters, 1);
+        "thermal_conductivity", parameters, 1, &mesh);
 
     DBUG("Use '%s' as thermal conductivity parameter.",
          thermal_conductivity.name.c_str());
@@ -58,7 +58,7 @@ std::unique_ptr<Process> createHeatConductionProcess(
     auto& heat_capacity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HEAT_CONDUCTION__heat_capacity}
-        "heat_capacity", parameters, 1);
+        "heat_capacity", parameters, 1, &mesh);
 
     DBUG("Use '%s' as heat capacity parameter.", heat_capacity.name.c_str());
 
@@ -66,7 +66,7 @@ std::unique_ptr<Process> createHeatConductionProcess(
     auto& density = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HEAT_CONDUCTION__density}
-        "density", parameters, 1);
+        "density", parameters, 1, &mesh);
 
     DBUG("Use '%s' as density parameter.", density.name.c_str());
 

--- a/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.cpp
+++ b/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.cpp
@@ -90,7 +90,7 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     auto& thermal_conductivity_solid = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__thermal_conductivity_solid}
-        "thermal_conductivity_solid", parameters, 1);
+        "thermal_conductivity_solid", parameters, 1, &mesh);
 
     DBUG("Use '%s' as solid phase thermal conductivity parameter.",
          thermal_conductivity_solid.name.c_str());
@@ -99,7 +99,7 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     auto& thermal_conductivity_fluid = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__thermal_conductivity_fluid}
-        "thermal_conductivity_fluid", parameters, 1);
+        "thermal_conductivity_fluid", parameters, 1, &mesh);
 
     DBUG("Use '%s' as fluid phase thermal conductivity parameter.",
          thermal_conductivity_fluid.name.c_str());
@@ -108,7 +108,7 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     auto& thermal_conductivity_gas = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__thermal_conductivity_gas}
-        "thermal_conductivity_gas", parameters, 1);
+        "thermal_conductivity_gas", parameters, 1, &mesh);
 
     DBUG("Use '%s' as gas phase thermal conductivity parameter.",
          thermal_conductivity_gas.name.c_str());
@@ -117,7 +117,7 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     auto& heat_capacity_solid = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__heat_capacity_solid}
-        "heat_capacity_solid", parameters, 1);
+        "heat_capacity_solid", parameters, 1, &mesh);
 
     DBUG("Use '%s' as solid phase heat capacity parameter.",
          heat_capacity_solid.name.c_str());
@@ -126,7 +126,7 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     auto& heat_capacity_fluid = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__heat_capacity_fluid}
-        "heat_capacity_fluid", parameters, 1);
+        "heat_capacity_fluid", parameters, 1, &mesh);
 
     DBUG("Use '%s' as fluid phase heat capacity parameter.",
          heat_capacity_fluid.name.c_str());
@@ -135,7 +135,7 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     auto& heat_capacity_gas = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__heat_capacity_gas}
-        "heat_capacity_gas", parameters, 1);
+        "heat_capacity_gas", parameters, 1, &mesh);
 
     DBUG("Use '%s' as gas phase heat capacity parameter.",
          heat_capacity_gas.name.c_str());
@@ -144,7 +144,7 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     auto& density_solid = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__density_solid}
-        "density_solid", parameters, 1);
+        "density_solid", parameters, 1, &mesh);
 
     DBUG("Use '%s' as solid phase density parameter.",
          density_solid.name.c_str());
@@ -153,7 +153,7 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     auto& density_fluid = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__density_fluid}
-        "density_fluid", parameters, 1);
+        "density_fluid", parameters, 1, &mesh);
 
     DBUG("Use '%s' as fluid phase density parameter.",
          density_fluid.name.c_str());
@@ -162,7 +162,7 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     auto& density_gas = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__density_gas}
-        "density_gas", parameters, 1);
+        "density_gas", parameters, 1, &mesh);
 
     DBUG("Use '%s' as gas phase density parameter.", density_gas.name.c_str());
 

--- a/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.cpp
@@ -111,7 +111,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     auto& intrinsic_permeability = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS__intrinsic_permeability}
-        "intrinsic_permeability", parameters, 1);
+        "intrinsic_permeability", parameters, 1, &mesh);
 
     DBUG("Use '%s' as intrinsic conductivity parameter.",
          intrinsic_permeability.name.c_str());
@@ -120,7 +120,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     auto& specific_storage = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS__specific_storage}
-        "specific_storage", parameters, 1);
+        "specific_storage", parameters, 1, &mesh);
 
     DBUG("Use '%s' as storage coefficient parameter.",
          specific_storage.name.c_str());
@@ -129,7 +129,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     auto& fluid_viscosity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS__fluid_viscosity}
-        "fluid_viscosity", parameters, 1);
+        "fluid_viscosity", parameters, 1, &mesh);
     DBUG("Use '%s' as fluid viscosity parameter.",
          fluid_viscosity.name.c_str());
 
@@ -137,14 +137,14 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     auto& fluid_density = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS__fluid_density}
-        "fluid_density", parameters, 1);
+        "fluid_density", parameters, 1, &mesh);
     DBUG("Use '%s' as fluid density parameter.", fluid_density.name.c_str());
 
     // Biot coefficient
     auto& biot_coefficient = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS__biot_coefficient}
-        "biot_coefficient", parameters, 1);
+        "biot_coefficient", parameters, 1, &mesh);
     DBUG("Use '%s' as Biot coefficient parameter.",
          biot_coefficient.name.c_str());
 
@@ -152,14 +152,14 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     auto& porosity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS__porosity}
-        "porosity", parameters, 1);
+        "porosity", parameters, 1, &mesh);
     DBUG("Use '%s' as porosity parameter.", porosity.name.c_str());
 
     // Solid density
     auto& solid_density = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS__solid_density}
-        "solid_density", parameters, 1);
+        "solid_density", parameters, 1, &mesh);
     DBUG("Use '%s' as solid density parameter.", solid_density.name.c_str());
 
     // Specific body force

--- a/ProcessLib/LIE/HydroMechanics/CreateHydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/CreateHydroMechanicsProcess.cpp
@@ -138,7 +138,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     auto& intrinsic_permeability = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__intrinsic_permeability}
-        "intrinsic_permeability", parameters, 1);
+        "intrinsic_permeability", parameters, 1, &mesh);
 
     DBUG("Use '%s' as intrinsic permeabiltiy parameter.",
          intrinsic_permeability.name.c_str());
@@ -147,7 +147,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     auto& specific_storage = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__specific_storage}
-        "specific_storage", parameters, 1);
+        "specific_storage", parameters, 1, &mesh);
 
     DBUG("Use '%s' as specific storage parameter.",
          specific_storage.name.c_str());
@@ -156,7 +156,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     auto& fluid_viscosity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__fluid_viscosity}
-        "fluid_viscosity", parameters, 1);
+        "fluid_viscosity", parameters, 1, &mesh);
     DBUG("Use '%s' as fluid viscosity parameter.",
          fluid_viscosity.name.c_str());
 
@@ -164,14 +164,14 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     auto& fluid_density = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__fluid_density}
-        "fluid_density", parameters, 1);
+        "fluid_density", parameters, 1, &mesh);
     DBUG("Use '%s' as fluid density parameter.", fluid_density.name.c_str());
 
     // Biot coefficient
     auto& biot_coefficient = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__biot_coefficient}
-        "biot_coefficient", parameters, 1);
+        "biot_coefficient", parameters, 1, &mesh);
     DBUG("Use '%s' as Biot coefficient parameter.",
          biot_coefficient.name.c_str());
 
@@ -179,14 +179,14 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     auto& porosity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__porosity}
-        "porosity", parameters, 1);
+        "porosity", parameters, 1, &mesh);
     DBUG("Use '%s' as porosity parameter.", porosity.name.c_str());
 
     // Solid density
     auto& solid_density = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__solid_density}
-        "solid_density", parameters, 1);
+        "solid_density", parameters, 1, &mesh);
     DBUG("Use '%s' as solid density parameter.", solid_density.name.c_str());
 
     // Specific body force
@@ -264,13 +264,16 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
             fracture_properties_config.getConfigParameter<int>("material_id"),
             ParameterLib::findParameter<double>(
                 //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__fracture_properties__initial_aperture}
-                fracture_properties_config, "initial_aperture", parameters, 1),
+                fracture_properties_config, "initial_aperture", parameters, 1,
+                &mesh),
             ParameterLib::findParameter<double>(
                 //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__fracture_properties__specific_storage}
-                fracture_properties_config, "specific_storage", parameters, 1),
+                fracture_properties_config, "specific_storage", parameters, 1,
+                &mesh),
             ParameterLib::findParameter<double>(
                 //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__fracture_properties__biot_coefficient}
-                fracture_properties_config, "biot_coefficient", parameters, 1));
+                fracture_properties_config, "biot_coefficient", parameters, 1,
+                &mesh));
         if (frac_prop->aperture0.isTimeDependent())
         {
             OGS_FATAL(
@@ -285,7 +288,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__initial_effective_stress}
         "initial_effective_stress", parameters,
-        MathLib::KelvinVector::KelvinVectorDimensions<GlobalDim>::value);
+        MathLib::KelvinVector::KelvinVectorDimensions<GlobalDim>::value, &mesh);
     DBUG("Use '%s' as initial effective stress parameter.",
          initial_effective_stress.name.c_str());
 
@@ -294,7 +297,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
         double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__initial_fracture_effective_stress}
-        "initial_fracture_effective_stress", parameters, GlobalDim);
+        "initial_fracture_effective_stress", parameters, GlobalDim, &mesh);
     DBUG("Use '%s' as initial fracture effective stress parameter.",
          initial_fracture_effective_stress.name.c_str());
 

--- a/ProcessLib/LIE/SmallDeformation/CreateSmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/CreateSmallDeformationProcess.cpp
@@ -161,7 +161,8 @@ std::unique_ptr<Process> createSmallDeformationProcess(
             fracture_properties_config.getConfigParameter<int>("material_id"),
             ParameterLib::findParameter<double>(
                 //! \ogs_file_param_special{prj__processes__process__SMALL_DEFORMATION_WITH_LIE__fracture_properties__initial_aperture}
-                fracture_properties_config, "initial_aperture", parameters, 1));
+                fracture_properties_config, "initial_aperture", parameters, 1,
+                &mesh));
     }
 
     if (n_var_du < fracture_properties.size())

--- a/ProcessLib/ProcessVariable.cpp
+++ b/ProcessLib/ProcessVariable.cpp
@@ -104,7 +104,7 @@ ProcessVariable::ProcessVariable(
       _initial_condition(ParameterLib::findParameter<double>(
           //! \ogs_file_param{prj__process_variables__process_variable__initial_condition}
           config.getConfigParameter<std::string>("initial_condition"),
-          parameters, _n_components))
+          parameters, _n_components, &mesh))
 {
     DBUG("Constructing process variable %s", _name.c_str());
 

--- a/ProcessLib/RichardsComponentTransport/CreateRichardsComponentTransportProcess.cpp
+++ b/ProcessLib/RichardsComponentTransport/CreateRichardsComponentTransportProcess.cpp
@@ -87,7 +87,7 @@ std::unique_ptr<Process> createRichardsComponentTransportProcess(
     auto& fluid_reference_density = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__RichardsComponentTransport__fluid_reference_density}
-        "fluid_reference_density", parameters, 1);
+        "fluid_reference_density", parameters, 1, &mesh);
     DBUG("Use '%s' as fluid_reference_density parameter.",
          fluid_reference_density.name.c_str());
 
@@ -96,7 +96,7 @@ std::unique_ptr<Process> createRichardsComponentTransportProcess(
         double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__RichardsComponentTransport__molecular_diffusion_coefficient}
-        "molecular_diffusion_coefficient", parameters, 1);
+        "molecular_diffusion_coefficient", parameters, 1, &mesh);
     DBUG("Use '%s' as molecular diffusion coefficient parameter.",
          molecular_diffusion_coefficient.name.c_str());
 
@@ -105,7 +105,7 @@ std::unique_ptr<Process> createRichardsComponentTransportProcess(
         double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__RichardsComponentTransport__solute_dispersivity_longitudinal}
-        "solute_dispersivity_longitudinal", parameters, 1);
+        "solute_dispersivity_longitudinal", parameters, 1, &mesh);
     DBUG("Use '%s' as longitudinal solute dispersivity parameter.",
          solute_dispersivity_longitudinal.name.c_str());
 
@@ -114,7 +114,7 @@ std::unique_ptr<Process> createRichardsComponentTransportProcess(
         double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__RichardsComponentTransport__solute_dispersivity_transverse}
-        "solute_dispersivity_transverse", parameters, 1);
+        "solute_dispersivity_transverse", parameters, 1, &mesh);
     DBUG("Use '%s' as transverse solute dispersivity parameter.",
          solute_dispersivity_transverse.name.c_str());
 
@@ -122,13 +122,13 @@ std::unique_ptr<Process> createRichardsComponentTransportProcess(
     auto const& retardation_factor = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__RichardsComponentTransport__retardation_factor}
-        "retardation_factor", parameters, 1);
+        "retardation_factor", parameters, 1, &mesh);
 
     // Parameter for the decay rate.
     auto const& decay_rate = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__RichardsComponentTransport__decay_rate}
-        "decay_rate", parameters, 1);
+        "decay_rate", parameters, 1, &mesh);
 
     // Specific body force parameter.
     Eigen::VectorXd specific_body_force;

--- a/ProcessLib/RichardsFlow/CreateRichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/CreateRichardsFlowProcess.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<Process> createRichardsFlowProcess(
     auto& temperature = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__RICHARDS_FLOW__temperature}
-        "temperature", parameters, 1);
+        "temperature", parameters, 1, &mesh);
 
     //! \ogs_file_param{prj__processes__process__RICHARDS_FLOW__material_property}
     auto const& mat_config = config.getConfigSubtree("material_property");

--- a/ProcessLib/RichardsMechanics/CreateRichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/CreateRichardsMechanicsProcess.cpp
@@ -112,7 +112,7 @@ std::unique_ptr<Process> createRichardsMechanicsProcess(
     auto& fluid_bulk_modulus = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__RICHARDS_MECHANICS__fluid_bulk_modulus}
-        "fluid_bulk_modulus", parameters, 1);
+        "fluid_bulk_modulus", parameters, 1, &mesh);
     DBUG("Use '%s' as fluid bulk modulus parameter.",
          fluid_bulk_modulus.name.c_str());
 
@@ -120,7 +120,7 @@ std::unique_ptr<Process> createRichardsMechanicsProcess(
     auto& biot_coefficient = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__RICHARDS_MECHANICS__biot_coefficient}
-        "biot_coefficient", parameters, 1);
+        "biot_coefficient", parameters, 1, &mesh);
     DBUG("Use '%s' as Biot coefficient parameter.",
          biot_coefficient.name.c_str());
 
@@ -128,14 +128,14 @@ std::unique_ptr<Process> createRichardsMechanicsProcess(
     auto& solid_density = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__RICHARDS_MECHANICS__solid_density}
-        "solid_density", parameters, 1);
+        "solid_density", parameters, 1, &mesh);
     DBUG("Use '%s' as solid density parameter.", solid_density.name.c_str());
 
     // Solid bulk modulus
     auto& solid_bulk_modulus = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__RICHARDS_MECHANICS__solid_bulk_modulus}
-        "solid_bulk_modulus", parameters, 1);
+        "solid_bulk_modulus", parameters, 1, &mesh);
     DBUG("Use '%s' as solid bulk modulus parameter.",
          solid_bulk_modulus.name.c_str());
 
@@ -161,7 +161,7 @@ std::unique_ptr<Process> createRichardsMechanicsProcess(
     auto& temperature = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__RICHARDS_MECHANICS__temperature}
-        "temperature", parameters, 1);
+        "temperature", parameters, 1, &mesh);
 
     auto const& flow_material_config =
         //! \ogs_file_param{prj__processes__process__RICHARDS_MECHANICS__material_property}

--- a/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.cpp
@@ -73,7 +73,7 @@ std::unique_ptr<Process> createSmallDeformationProcess(
     auto& solid_density = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__SMALL_DEFORMATION__solid_density}
-        "solid_density", parameters, 1);
+        "solid_density", parameters, 1, &mesh);
     DBUG("Use '%s' as solid density parameter.", solid_density.name.c_str());
 
     // Specific body force

--- a/ProcessLib/SmallDeformationNonlocal/CreateSmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/CreateSmallDeformationNonlocalProcess.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<Process> createSmallDeformationNonlocalProcess(
     auto& solid_density = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__SMALL_DEFORMATION_NONLOCAL__solid_density}
-        "solid_density", parameters, 1);
+        "solid_density", parameters, 1, &mesh);
     DBUG("Use '%s' as solid density parameter.", solid_density.name.c_str());
 
     // Specific body force

--- a/ProcessLib/SourceTerms/CreateNodalSourceTerm.cpp
+++ b/ProcessLib/SourceTerms/CreateNodalSourceTerm.cpp
@@ -33,8 +33,8 @@ std::unique_ptr<SourceTerm> createNodalSourceTerm(
     auto const param_name = config.getConfigParameter<std::string>("parameter");
     DBUG("Using parameter %s as nodal source term.", param_name.c_str());
 
-    auto& param =
-        ParameterLib::findParameter<double>(param_name, parameters, 1);
+    auto& param = ParameterLib::findParameter<double>(param_name, parameters, 1,
+                                                      &st_mesh);
 
     return std::make_unique<NodalSourceTerm>(std::move(dof_table),
                                              source_term_mesh_id, st_mesh,

--- a/ProcessLib/SourceTerms/CreateVolumetricSourceTerm.cpp
+++ b/ProcessLib/SourceTerms/CreateVolumetricSourceTerm.cpp
@@ -34,7 +34,8 @@ std::unique_ptr<SourceTerm> createVolumetricSourceTerm(
         //! \ogs_file_param{prj__process_variables__process_variable__source_terms__source_term__Volumetric__parameter}
         config.getConfigParameter<std::string>("parameter");
     auto& volumetric_source_term = ParameterLib::findParameter<double>(
-        volumetric_source_term_parameter_name, parameters, 1);
+        volumetric_source_term_parameter_name, parameters, 1,
+        &source_term_mesh);
 
     DBUG("Using '%s` as volumetric source term parameter.",
          volumetric_source_term.name.c_str());

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/CreateThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/CreateThermalTwoPhaseFlowWithPPProcess.cpp
@@ -81,25 +81,25 @@ std::unique_ptr<Process> createThermalTwoPhaseFlowWithPPProcess(
     auto& diff_coeff_b = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__TWOPHASE_FLOW_THERMAL__diffusion_coeff_component_b}
-        "diffusion_coeff_component_b", parameters, 1);
+        "diffusion_coeff_component_b", parameters, 1, &mesh);
     auto& diff_coeff_a = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__TWOPHASE_FLOW_THERMAL__diffusion_coeff_component_a}
-        "diffusion_coeff_component_a", parameters, 1);
+        "diffusion_coeff_component_a", parameters, 1, &mesh);
 
     // Parameter for the density of the solid.
 
     auto& density_solid = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__TWOPHASE_FLOW_THERMAL__density_solid}
-        "density_solid", parameters, 1);
+        "density_solid", parameters, 1, &mesh);
     DBUG("Use '%s' as density_solid parameter.", density_solid.name.c_str());
 
     // Parameter for the latent heat of evaporation.
     auto& latent_heat_evaporation = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__TWOPHASE_FLOW_THERMAL__latent_heat_evaporation}
-        "latent_heat_evaporation", parameters, 1);
+        "latent_heat_evaporation", parameters, 1, &mesh);
     DBUG("Use '%s' as latent_heat_evaporation parameter.",
          latent_heat_evaporation.name.c_str());
 

--- a/ProcessLib/ThermoHydroMechanics/CreateThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/CreateThermoHydroMechanicsProcess.cpp
@@ -130,7 +130,7 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
     auto& intrinsic_permeability = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__intrinsic_permeability}
-        "intrinsic_permeability", parameters, 1);
+        "intrinsic_permeability", parameters, 1, &mesh);
 
     DBUG("Use '%s' as intrinsic conductivity parameter.",
          intrinsic_permeability.name.c_str());
@@ -139,7 +139,7 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
     auto& specific_storage = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__specific_storage}
-        "specific_storage", parameters, 1);
+        "specific_storage", parameters, 1, &mesh);
 
     DBUG("Use '%s' as storage coefficient parameter.",
          specific_storage.name.c_str());
@@ -148,7 +148,7 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
     auto& fluid_viscosity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__fluid_viscosity}
-        "fluid_viscosity", parameters, 1);
+        "fluid_viscosity", parameters, 1, &mesh);
     DBUG("Use '%s' as fluid viscosity parameter.",
          fluid_viscosity.name.c_str());
 
@@ -156,14 +156,14 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
     auto& fluid_density = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__fluid_density}
-        "fluid_density", parameters, 1);
+        "fluid_density", parameters, 1, &mesh);
     DBUG("Use '%s' as fluid density parameter.", fluid_density.name.c_str());
 
     // Biot coefficient
     auto& biot_coefficient = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__biot_coefficient}
-        "biot_coefficient", parameters, 1);
+        "biot_coefficient", parameters, 1, &mesh);
     DBUG("Use '%s' as Biot coefficient parameter.",
          biot_coefficient.name.c_str());
 
@@ -171,14 +171,14 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
     auto& porosity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__porosity}
-        "porosity", parameters, 1);
+        "porosity", parameters, 1, &mesh);
     DBUG("Use '%s' as porosity parameter.", porosity.name.c_str());
 
     // Solid density
     auto& solid_density = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__solid_density}
-        "solid_density", parameters, 1);
+        "solid_density", parameters, 1, &mesh);
     DBUG("Use '%s' as solid density parameter.", solid_density.name.c_str());
 
     // linear thermal expansion coefficient for solid
@@ -186,7 +186,7 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
         ParameterLib::findParameter<double>(
             config,
             //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__solid_linear_thermal_expansion_coefficient}
-            "solid_linear_thermal_expansion_coefficient", parameters, 1);
+            "solid_linear_thermal_expansion_coefficient", parameters, 1, &mesh);
     DBUG("Use '%s' as solid linear thermal expansion coefficient parameter.",
          solid_linear_thermal_expansion_coefficient.name.c_str());
 
@@ -195,7 +195,8 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
         ParameterLib::findParameter<double>(
             config,
             //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__fluid_volumetric_thermal_expansion_coefficient}
-            "fluid_volumetric_thermal_expansion_coefficient", parameters, 1);
+            "fluid_volumetric_thermal_expansion_coefficient", parameters, 1,
+            &mesh);
     DBUG(
         "Use '%s' as fluid volumetric thermal expansion coefficient "
         "parameter.",
@@ -205,7 +206,7 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
     auto& solid_specific_heat_capacity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__solid_specific_heat_capacity}
-        "solid_specific_heat_capacity", parameters, 1);
+        "solid_specific_heat_capacity", parameters, 1, &mesh);
     DBUG("Use '%s' as solid specific heat capacity parameter.",
          solid_specific_heat_capacity.name.c_str());
 
@@ -213,7 +214,7 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
     auto& fluid_specific_heat_capacity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__fluid_specific_heat_capacity}
-        "fluid_specific_heat_capacity", parameters, 1);
+        "fluid_specific_heat_capacity", parameters, 1, &mesh);
     DBUG("Use '%s' as fluid specific heat capacity parameter.",
          fluid_specific_heat_capacity.name.c_str());
 
@@ -221,7 +222,7 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
     auto& solid_thermal_conductivity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__solid_thermal_conductivity}
-        "solid_thermal_conductivity", parameters, 1);
+        "solid_thermal_conductivity", parameters, 1, &mesh);
     DBUG("Use '%s' as solid thermal conductivity parameter.",
          solid_thermal_conductivity.name.c_str());
 
@@ -229,7 +230,7 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
     auto& fluid_thermal_conductivity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__fluid_thermal_conductivity}
-        "fluid_thermal_conductivity", parameters, 1);
+        "fluid_thermal_conductivity", parameters, 1, &mesh);
     DBUG("Use '%s' as fluid thermal conductivity parameter.",
          fluid_thermal_conductivity.name.c_str());
 
@@ -237,7 +238,7 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
     auto& reference_temperature = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_HYDRO_MECHANICS__reference_temperature}
-        "reference_temperature", parameters, 1);
+        "reference_temperature", parameters, 1, &mesh);
     DBUG("Use '%s' as reference temperature parameter.",
          reference_temperature.name.c_str());
 

--- a/ProcessLib/ThermoMechanicalPhaseField/CreateThermoMechanicalPhaseFieldProcess.cpp
+++ b/ProcessLib/ThermoMechanicalPhaseField/CreateThermoMechanicalPhaseFieldProcess.cpp
@@ -128,35 +128,35 @@ std::unique_ptr<Process> createThermoMechanicalPhaseFieldProcess(
     auto& residual_stiffness = ParameterLib::findParameter<double>(
         phasefield_parameters_config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_MECHANICAL_PHASE_FIELD__phasefield_parameters__residual_stiffness}
-        "residual_stiffness", parameters, 1);
+        "residual_stiffness", parameters, 1, &mesh);
     DBUG("Use '%s' as residual stiffness.", residual_stiffness.name.c_str());
 
     // Crack resistance
     auto& crack_resistance = ParameterLib::findParameter<double>(
         phasefield_parameters_config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_MECHANICAL_PHASE_FIELD__phasefield_parameters__crack_resistance}
-        "crack_resistance", parameters, 1);
+        "crack_resistance", parameters, 1, &mesh);
     DBUG("Use '%s' as crack resistance.", crack_resistance.name.c_str());
 
     // Crack length scale
     auto& crack_length_scale = ParameterLib::findParameter<double>(
         phasefield_parameters_config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_MECHANICAL_PHASE_FIELD__phasefield_parameters__crack_length_scale}
-        "crack_length_scale", parameters, 1);
+        "crack_length_scale", parameters, 1, &mesh);
     DBUG("Use '%s' as crack length scale.", crack_length_scale.name.c_str());
 
     // Kinetic coefficient
     auto& kinetic_coefficient = ParameterLib::findParameter<double>(
         phasefield_parameters_config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_MECHANICAL_PHASE_FIELD__phasefield_parameters__kinetic_coefficient}
-        "kinetic_coefficient", parameters, 1);
+        "kinetic_coefficient", parameters, 1, &mesh);
     DBUG("Use '%s' as kinetic coefficient.", kinetic_coefficient.name.c_str());
 
     // Solid density
     auto& solid_density = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_MECHANICAL_PHASE_FIELD__reference_solid_density}
-        "solid_density", parameters, 1);
+        "solid_density", parameters, 1, &mesh);
     DBUG("Use '%s' as solid density parameter.", solid_density.name.c_str());
 
     // Linear thermal expansion coefficient
@@ -164,7 +164,7 @@ std::unique_ptr<Process> createThermoMechanicalPhaseFieldProcess(
         double>(
         thermal_parameters_config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_MECHANICAL_PHASE_FIELD__thermal_parameters__linear_thermal_expansion_coefficient}
-        "linear_thermal_expansion_coefficient", parameters, 1);
+        "linear_thermal_expansion_coefficient", parameters, 1, &mesh);
     DBUG("Use '%s' as linear thermal expansion coefficient.",
          linear_thermal_expansion_coefficient.name.c_str());
 
@@ -172,7 +172,7 @@ std::unique_ptr<Process> createThermoMechanicalPhaseFieldProcess(
     auto& specific_heat_capacity = ParameterLib::findParameter<double>(
         thermal_parameters_config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_MECHANICAL_PHASE_FIELD__thermal_parameters__specific_heat_capacity}
-        "specific_heat_capacity", parameters, 1);
+        "specific_heat_capacity", parameters, 1, &mesh);
     DBUG("Use '%s' as specific heat capacity.",
          specific_heat_capacity.name.c_str());
 
@@ -180,14 +180,14 @@ std::unique_ptr<Process> createThermoMechanicalPhaseFieldProcess(
     auto& thermal_conductivity = ParameterLib::findParameter<double>(
         thermal_parameters_config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_MECHANICAL_PHASE_FIELD__thermal_parameters__thermal_conductivity}
-        "thermal_conductivity", parameters, 1);
+        "thermal_conductivity", parameters, 1, &mesh);
     DBUG("Use '%s' as thermal conductivity parameter.",
          thermal_conductivity.name.c_str());
     // Residual thermal conductivity
     auto& residual_thermal_conductivity = ParameterLib::findParameter<double>(
         thermal_parameters_config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_MECHANICAL_PHASE_FIELD__thermal_parameters__residual_thermal_conductivity}
-        "residual_thermal_conductivity", parameters, 1);
+        "residual_thermal_conductivity", parameters, 1, &mesh);
     DBUG("Use '%s' as residual thermal conductivity parameter.",
          residual_thermal_conductivity.name.c_str());
     // Reference temperature

--- a/ProcessLib/ThermoMechanics/CreateThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/CreateThermoMechanicsProcess.cpp
@@ -113,7 +113,7 @@ std::unique_ptr<Process> createThermoMechanicsProcess(
     auto& reference_solid_density = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_MECHANICS__reference_solid_density}
-        "reference_solid_density", parameters, 1);
+        "reference_solid_density", parameters, 1, &mesh);
     DBUG("Use '%s' as solid density parameter.",
          reference_solid_density.name.c_str());
 
@@ -122,21 +122,21 @@ std::unique_ptr<Process> createThermoMechanicsProcess(
         double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_MECHANICS__linear_thermal_expansion_coefficient}
-        "linear_thermal_expansion_coefficient", parameters, 1);
+        "linear_thermal_expansion_coefficient", parameters, 1, &mesh);
     DBUG("Use '%s' as linear thermal expansion coefficient.",
          linear_thermal_expansion_coefficient.name.c_str());
     // Specific heat capacity
     auto& specific_heat_capacity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_MECHANICS__specific_heat_capacity}
-        "specific_heat_capacity", parameters, 1);
+        "specific_heat_capacity", parameters, 1, &mesh);
     DBUG("Use '%s' as specific heat capacity parameter.",
          specific_heat_capacity.name.c_str());
     // Thermal conductivity // TODO To be changed as tensor input.
     auto& thermal_conductivity = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__THERMO_MECHANICS__thermal_conductivity}
-        "thermal_conductivity", parameters, 1);
+        "thermal_conductivity", parameters, 1, &mesh);
     DBUG("Use '%s' as thermal conductivity parameter.",
          thermal_conductivity.name.c_str());
 

--- a/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.cpp
@@ -76,7 +76,7 @@ std::unique_ptr<Process> createTwoPhaseFlowWithPPProcess(
     auto& temperature = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__TWOPHASE_FLOW_PP__temperature}
-        "temperature", parameters, 1);
+        "temperature", parameters, 1, &mesh);
 
     //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PP__material_property}
     auto const& mat_config = config.getConfigSubtree("material_property");

--- a/ProcessLib/TwoPhaseFlowWithPrho/CreateTwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/CreateTwoPhaseFlowWithPrhoProcess.cpp
@@ -76,15 +76,15 @@ std::unique_ptr<Process> createTwoPhaseFlowWithPrhoProcess(
     auto& diff_coeff_b = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__TWOPHASE_FLOW_PRHO__diffusion_coeff_component_b}
-        "diffusion_coeff_component_b", parameters, 1);
+        "diffusion_coeff_component_b", parameters, 1, &mesh);
     auto& diff_coeff_a = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__TWOPHASE_FLOW_PRHO__diffusion_coeff_component_a}
-        "diffusion_coeff_component_a", parameters, 1);
+        "diffusion_coeff_component_a", parameters, 1, &mesh);
     auto& temperature = ParameterLib::findParameter<double>(
         config,
         //! \ogs_file_param_special{prj__processes__process__TWOPHASE_FLOW_PRHO__temperature}
-        "temperature", parameters, 1);
+        "temperature", parameters, 1, &mesh);
 
     //! \ogs_file_param{prj__processes__process__TWOPHASE_FLOW_PRHO__material_property}
     auto const& mat_config = config.getConfigSubtree("material_property");

--- a/Tests/Data/Elliptic/square_1x1_GroundWaterFlow/square_1e3_volumetricsourcetermdataarray.prj
+++ b/Tests/Data/Elliptic/square_1x1_GroundWaterFlow/square_1e3_volumetricsourcetermdataarray.prj
@@ -90,6 +90,7 @@
         </parameter>
         <parameter>
             <name>volumetric_source_term_parameter</name>
+            <mesh>square_1x1_quad_1e3_volumetricsourcetermdataarray_volumetric_source_term</mesh>
             <type>MeshElement</type>
             <field_name>non-constant-source_term</field_name>
         </parameter>

--- a/Tests/Data/Elliptic/square_1x1_GroundWaterFlow/square_1x1_quad_1e3_volumetricsourcetermdataarray.vtu
+++ b/Tests/Data/Elliptic/square_1x1_GroundWaterFlow/square_1x1_quad_1e3_volumetricsourcetermdataarray.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c99a4a2bc725f97088f4c5395d7f5ef058f333eebda2d04318fc62cd402ccfce
-size 156742
+oid sha256:e545488fe8afeef4467ae115f9b6ee08d5d63ee3d79be5fcca862b352ce89f8b
+size 83294

--- a/Tests/Data/Elliptic/square_1x1_GroundWaterFlow/square_1x1_quad_1e3_volumetricsourcetermdataarray_volumetric_source_term.vtu
+++ b/Tests/Data/Elliptic/square_1x1_GroundWaterFlow/square_1x1_quad_1e3_volumetricsourcetermdataarray_volumetric_source_term.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b06d86b4b608361e25a5858542e1ad9aec75f34b1d242abf30dba2e28d647e0
-size 178400
+oid sha256:a99f262dbf38b3a941039d663dfa5e0ed2fd175f3fbf45153070dec981478a97
+size 100048


### PR DESCRIPTION
Sometimes it happens, that a used parameter is defined on a different mesh, then the mesh node/element ids do not point to the right entities. This is difficult to detect at runtime (you have to look into the results) and leads to difficult to find errors.

This implements an additional function to check the domains of definition, and adds an optional call to the test when the parameter is found.