### PR TITLE
Extract surface with scalar arrays

### DIFF
--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -156,8 +156,8 @@ MeshLib::Mesh* MeshSurfaceExtraction::getMeshSurface(
                                    face_ids_map);
     }
 
-    if (!createSfcMeshProperties(*result, subsfc_mesh.getProperties(),
-                                 id_map, element_ids_map))
+    if (!createSfcMeshProperties(*result, subsfc_mesh.getProperties(), id_map,
+                                 element_ids_map))
     {
         ERR("Transferring subsurface properties failed.");
     }
@@ -355,7 +355,8 @@ std::vector<MeshLib::Element*> MeshSurfaceExtraction::createSfcElementVector(
         auto** new_nodes = new MeshLib::Node*[n_elem_nodes];
         for (unsigned k(0); k < n_elem_nodes; k++)
         {
-            new_nodes[k] = sfc_nodes[node_id_map[sfc_element->getNode(k)->getID()]];
+            new_nodes[k] =
+                sfc_nodes[node_id_map[sfc_element->getNode(k)->getID()]];
         }
         if (sfc_element->getGeomType() == MeshElemType::TRIANGLE)
         {
@@ -382,8 +383,10 @@ bool MeshSurfaceExtraction::createSfcMeshProperties(
     if (node_ids_map.size() != n_nodes)
     {
         ERR("MeshSurfaceExtraction::createSfcMeshProperties() - Incorrect "
-            "number of node IDs (%d) compared to actual number of surface nodes "
-            "(%d).", node_ids_map.size(), n_nodes);
+            "number of node IDs (%d) compared to actual number of surface "
+            "nodes "
+            "(%d).",
+            node_ids_map.size(), n_nodes);
         return false;
     }
 
@@ -391,28 +394,42 @@ bool MeshSurfaceExtraction::createSfcMeshProperties(
     {
         ERR("MeshSurfaceExtraction::createSfcMeshProperties() - Incorrect "
             "number of element IDs (%d) compared to actual number of surface "
-            "elements (%d).", element_ids_map.size(), n_elems);
+            "elements (%d).",
+            element_ids_map.size(), n_elems);
         return false;
     }
 
-    std::size_t vectors_copied (0), vectors_skipped (0);
-    std::vector<std::string> const& array_names = properties.getPropertyVectorNames();
+    std::size_t vectors_copied(0), vectors_skipped(0);
+    std::vector<std::string> const& array_names =
+        properties.getPropertyVectorNames();
     for (std::string const& name : array_names)
     {
-        if (processPropertyVector<double>(name, MeshLib::MeshItemType::Cell, properties, n_elems, element_ids_map, sfc_mesh) ||
-            processPropertyVector<int>(name, MeshLib::MeshItemType::Cell, properties, n_elems, element_ids_map, sfc_mesh) ||
-            processPropertyVector<double>(name, MeshLib::MeshItemType::Node, properties, n_nodes, node_ids_map, sfc_mesh) ||
-            processPropertyVector<int>(name, MeshLib::MeshItemType::Node, properties, n_nodes, node_ids_map, sfc_mesh))
+        if (processPropertyVector<double>(name, MeshLib::MeshItemType::Cell,
+                                          properties, n_elems, element_ids_map,
+                                          sfc_mesh) ||
+            processPropertyVector<int>(name, MeshLib::MeshItemType::Cell,
+                                       properties, n_elems, element_ids_map,
+                                       sfc_mesh) ||
+            processPropertyVector<double>(name, MeshLib::MeshItemType::Node,
+                                          properties, n_nodes, node_ids_map,
+                                          sfc_mesh) ||
+            processPropertyVector<int>(name, MeshLib::MeshItemType::Node,
+                                       properties, n_nodes, node_ids_map,
+                                       sfc_mesh))
         {
             vectors_copied++;
         }
         else
         {
-            WARN("Skipping property vector \"%s\" - no matching data type found.", name.c_str());
+            WARN(
+                "Skipping property vector \"%s\" - no matching data type "
+                "found.",
+                name.c_str());
             vectors_skipped++;
         }
     }
-    INFO("%d property vectors copied, %d vectors skipped.", vectors_copied, vectors_skipped);
+    INFO("%d property vectors copied, %d vectors skipped.", vectors_copied,
+         vectors_skipped);
     return true;
 }
 

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -358,15 +358,16 @@ std::vector<MeshLib::Element*> MeshSurfaceExtraction::createSfcElementVector(
             new_nodes[k] =
                 sfc_nodes[node_id_map[sfc_element->getNode(k)->getID()]];
         }
-        if (sfc_element->getGeomType() == MeshElemType::TRIANGLE)
+        switch (sfc_element->getGeomType())
         {
-            new_elements.push_back(new MeshLib::Tri(new_nodes));
-        }
-        else
-        {
-            if (sfc_element->getGeomType() != MeshElemType::QUAD)
+            case MeshElemType::TRIANGLE:
+                new_elements.push_back(new MeshLib::Tri(new_nodes));
+                break;
+            case MeshElemType::QUAD:
+                new_elements.push_back(new MeshLib::Quad(new_nodes));
+                break;
+            default:
                 OGS_FATAL("MeshSurfaceExtraction: Unknown element type.");
-            new_elements.push_back(new MeshLib::Quad(new_nodes));
         }
     }
     return new_elements;

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -421,10 +421,8 @@ bool MeshSurfaceExtraction::createSfcMeshProperties(
         }
         else
         {
-            WARN(
-                "Skipping property vector \"%s\" - no matching data type "
-                "found.",
-                name.c_str());
+            WARN("Skipping property vector '%s' - no matching data type found.",
+                 name.c_str());
             vectors_skipped++;
         }
     }

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -126,10 +126,9 @@ MeshLib::Mesh* MeshSurfaceExtraction::getMeshSurface(
 
     std::vector<std::size_t> id_map;
     id_map.reserve(sfc_nodes.size());
-    for (auto const* node : sfc_nodes)
-    {
-        id_map.push_back(node->getID());
-    }
+    std::transform(begin(sfc_nodes), end(sfc_nodes), std::back_inserter(id_map),
+                   [](MeshLib::Node* const n) { return n->getID(); });
+
     MeshLib::Mesh* result(
         new Mesh(subsfc_mesh.getName() + "-Surface", sfc_nodes, new_elements));
 

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -366,7 +366,10 @@ std::vector<MeshLib::Element*> MeshSurfaceExtraction::createSfcElementVector(
                 new_elements.push_back(new MeshLib::Quad(new_nodes));
                 break;
             default:
-                OGS_FATAL("MeshSurfaceExtraction: Unknown element type.");
+                OGS_FATAL(
+                    "MeshSurfaceExtraction::createSfcElementVector Unknown "
+                    "element type '%s'.",
+                    MeshElemType2String(sfc_element->getGeomType()).c_str());
         }
     }
     return new_elements;

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -91,6 +91,12 @@ private:
         std::size_t n_all_nodes,
         const std::vector<MeshLib::Element*>& sfc_elements,
         std::vector<std::size_t>& node_id_map);
+
+    static std::vector<MeshLib::Element*> createSfcElementVector(
+        std::vector<MeshLib::Element*> const& sfc_elems,
+        std::vector<MeshLib::Node*> const& sfc_nodes,
+        std::vector<std::size_t> const& node_id_map);
+
 };
 
 } // end namespace MeshLib

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "MathLib/Vector3.h"
+#include "MeshLib/Mesh.h"
 #include "MeshLib/Properties.h"
 
 namespace MeshLib
@@ -107,7 +108,7 @@ private:
     static bool processPropertyVector(std::string const& name,
                                       MeshLib::MeshItemType const type,
                                       MeshLib::Properties const& properties,
-                                      std::size_t const vec_size,
+                                      std::size_t const /*vec_size*/,
                                       std::vector<std::size_t> const& id_map,
                                       MeshLib::Mesh& sfc_mesh)
     {
@@ -115,15 +116,15 @@ private:
         {
             return false;
         }
-        std::vector<T> const& org_vec =
-            *properties.getPropertyVector<T>(name, type, 1);
-        std::vector<T> sfc_prop;
-        sfc_prop.reserve(vec_size);
-        for (auto bulk_id : id_map)
-        {
-            sfc_prop.push_back(org_vec[bulk_id]);
-        }
-        MeshLib::addPropertyToMesh<T>(sfc_mesh, name, type, 1, sfc_prop);
+        auto sfc_prop = getOrCreateMeshProperty<T>(sfc_mesh, name, type, 1);
+        sfc_prop->clear();
+        sfc_prop->reserve(id_map.size());
+
+        auto const& org_vec = *properties.getPropertyVector<T>(name, type, 1);
+        std::transform(
+            begin(id_map), end(id_map), std::back_inserter(*sfc_prop),
+            [&org_vec](std::size_t const bulk_id) { return org_vec[bulk_id]; });
+
         return true;
     }
 

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -97,11 +97,13 @@ private:
         const std::vector<MeshLib::Element*>& sfc_elements,
         std::vector<std::size_t>& node_id_map);
 
+    /// Creates the element vector for the 2d surface mesh
     static std::vector<MeshLib::Element*> createSfcElementVector(
         std::vector<MeshLib::Element*> const& sfc_elems,
         std::vector<MeshLib::Node*> const& sfc_nodes,
         std::vector<std::size_t> const& node_id_map);
 
+    /// Copies relevant parts of scalar arrays to the surface mesh
     static bool createSfcMeshProperties(MeshLib::Mesh& sfc_mesh,
                                         MeshLib::Properties const& properties,
                                         std::vector<std::size_t> const& node_ids_map,

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -111,20 +111,20 @@ private:
                                       std::vector<std::size_t> const& id_map,
                                       MeshLib::Mesh& sfc_mesh)
     {
-        if (properties.existsPropertyVector<T>(name, type, 1))
+        if (!properties.existsPropertyVector<T>(name, type, 1))
         {
-            std::vector<T> const& org_vec =
-                *properties.getPropertyVector<T>(name, type, 1);
-            std::vector<T> sfc_prop;
-            sfc_prop.reserve(vec_size);
-            for (auto bulk_id : id_map)
-            {
-                sfc_prop.push_back(org_vec[bulk_id]);
-            }
-            MeshLib::addPropertyToMesh<T>(sfc_mesh, name, type, 1, sfc_prop);
-            return true;
+            return false;
         }
-        return false;
+        std::vector<T> const& org_vec =
+            *properties.getPropertyVector<T>(name, type, 1);
+        std::vector<T> sfc_prop;
+        sfc_prop.reserve(vec_size);
+        for (auto bulk_id : id_map)
+        {
+            sfc_prop.push_back(org_vec[bulk_id]);
+        }
+        MeshLib::addPropertyToMesh<T>(sfc_mesh, name, type, 1, sfc_prop);
+        return true;
     }
 
     /// Copies relevant parts of scalar arrays to the surface mesh

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -18,21 +18,25 @@
 #include <vector>
 
 #include "MathLib/Vector3.h"
+#include "MeshLib/Properties.h"
 
-namespace MeshLib {
+namespace MeshLib
+{
 // forward declarations
 class Mesh;
 class Element;
 class Node;
 
 /**
- * \brief A set of tools concerned with extracting nodes and elements from a mesh surface
+ * \brief A set of tools concerned with extracting nodes and elements from a
+ * mesh surface
  */
 class MeshSurfaceExtraction
 {
 public:
     /// Returns a vector of the areas assigned to each node on a surface mesh.
-    static std::vector<double> getSurfaceAreaForNodes(const MeshLib::Mesh &mesh);
+    static std::vector<double> getSurfaceAreaForNodes(
+        const MeshLib::Mesh& mesh);
 
     /// Returns the surface nodes of a mesh.
     static std::vector<MeshLib::Node*> getSurfaceNodes(
@@ -66,13 +70,14 @@ public:
         std::string const& face_id_prop_name = "");
 
     /**
-     * Returns the boundary of mesh, i.e. lines for 2D meshes and surfaces for 3D meshes.
-     * Note, that this method also returns inner boundaries and might give unexpected results
-     * when the mesh geometry is not strict (e.g. more than two triangles sharing an edge).
-     * \param mesh The original mesh of dimension d
-     * \return     A mesh of dimension (d-1) representing the boundary of the mesh.
+     * Returns the boundary of mesh, i.e. lines for 2D meshes and surfaces for
+     * 3D meshes. Note, that this method also returns inner boundaries and might
+     * give unexpected results when the mesh geometry is not strict (e.g. more
+     * than two triangles sharing an edge). \param mesh The original mesh of
+     * dimension d \return     A mesh of dimension (d-1) representing the
+     * boundary of the mesh.
      */
-    static MeshLib::Mesh* getMeshBoundary(const MeshLib::Mesh &mesh);
+    static MeshLib::Mesh* getMeshBoundary(const MeshLib::Mesh& mesh);
 
 private:
     /// Functionality needed for getSurfaceNodes() and getMeshSurface()
@@ -97,6 +102,10 @@ private:
         std::vector<MeshLib::Node*> const& sfc_nodes,
         std::vector<std::size_t> const& node_id_map);
 
+    static bool createSfcMeshProperties(MeshLib::Mesh& sfc_mesh,
+                                        MeshLib::Properties const& properties,
+                                        std::vector<std::size_t> const& node_ids_map,
+                                        std::vector<std::size_t> const& element_ids_map);
 };
 
-} // end namespace MeshLib
+}  // end namespace MeshLib

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -105,32 +105,34 @@ private:
 
     template <typename T>
     static bool processPropertyVector(std::string const& name,
-                               MeshLib::MeshItemType const type,
-                               MeshLib::Properties const& properties,
-                               std::size_t const vec_size,
-                               std::vector<std::size_t> const& id_map,
-                               MeshLib::Mesh& sfc_mesh)
+                                      MeshLib::MeshItemType const type,
+                                      MeshLib::Properties const& properties,
+                                      std::size_t const vec_size,
+                                      std::vector<std::size_t> const& id_map,
+                                      MeshLib::Mesh& sfc_mesh)
     {
         if (properties.existsPropertyVector<T>(name, type, 1))
         {
-            std::vector<T> const& org_vec = *properties.getPropertyVector<T>(name, type, 1);
+            std::vector<T> const& org_vec =
+                *properties.getPropertyVector<T>(name, type, 1);
             std::vector<T> sfc_prop;
             sfc_prop.reserve(vec_size);
             for (auto bulk_id : id_map)
             {
                 sfc_prop.push_back(org_vec[bulk_id]);
             }
-            MeshLib::addPropertyToMesh<T>( sfc_mesh, name, type, 1, sfc_prop);
+            MeshLib::addPropertyToMesh<T>(sfc_mesh, name, type, 1, sfc_prop);
             return true;
         }
         return false;
     }
 
     /// Copies relevant parts of scalar arrays to the surface mesh
-    static bool createSfcMeshProperties(MeshLib::Mesh& sfc_mesh,
-                                        MeshLib::Properties const& properties,
-                                        std::vector<std::size_t> const& node_ids_map,
-                                        std::vector<std::size_t> const& element_ids_map);
+    static bool createSfcMeshProperties(
+        MeshLib::Mesh& sfc_mesh,
+        MeshLib::Properties const& properties,
+        std::vector<std::size_t> const& node_ids_map,
+        std::vector<std::size_t> const& element_ids_map);
 };
 
 }  // end namespace MeshLib

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -103,6 +103,29 @@ private:
         std::vector<MeshLib::Node*> const& sfc_nodes,
         std::vector<std::size_t> const& node_id_map);
 
+    template <typename T>
+    static bool processPropertyVector(std::string const& name,
+                               MeshLib::MeshItemType const type,
+                               MeshLib::Properties const& properties,
+                               std::size_t const vec_size,
+                               std::vector<std::size_t> const& id_map,
+                               MeshLib::Mesh& sfc_mesh)
+    {
+        if (properties.existsPropertyVector<T>(name, type, 1))
+        {
+            std::vector<T> const& org_vec = *properties.getPropertyVector<T>(name, type, 1);
+            std::vector<T> sfc_prop;
+            sfc_prop.reserve(vec_size);
+            for (auto bulk_id : id_map)
+            {
+                sfc_prop.push_back(org_vec[bulk_id]);
+            }
+            MeshLib::addPropertyToMesh<T>( sfc_mesh, name, type, 1, sfc_prop);
+            return true;
+        }
+        return false;
+    }
+
     /// Copies relevant parts of scalar arrays to the surface mesh
     static bool createSfcMeshProperties(MeshLib::Mesh& sfc_mesh,
                                         MeshLib::Properties const& properties,

--- a/Tests/Data/MeshLib/Back.vtu
+++ b/Tests/Data/MeshLib/Back.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9a269d7b490071f842ae8f95efccccd62a46ae799804d55606c75599be2145da
-size 14767
+oid sha256:35f93fafd1b874ea437d5a745b9f4efa419a2b25447fe6db6d5928790590377f
+size 17665

--- a/Tests/Data/MeshLib/Front.vtu
+++ b/Tests/Data/MeshLib/Front.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6552aa6358af7be5982c64c0ce9b95186e560b2ff063f5b6b5c03287f24b2133
-size 14764
+oid sha256:9f976c276382a35d40ae09ebbd72c1f2cbd0882f5d8d89002b7f741e5dbb38a9
+size 17662

--- a/Tests/Data/MeshLib/Left.vtu
+++ b/Tests/Data/MeshLib/Left.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e736ca07e17d322817487a9c56195d0c897285acf1c4cc8b96383d8077f13f4
-size 14764
+oid sha256:377b55f1b568ae968d447995fa202d1f6cf47dadd1acc257e294d14eb5a6b1b0
+size 17637

--- a/Tests/Data/MeshLib/Right.vtu
+++ b/Tests/Data/MeshLib/Right.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc62e9826904cc6a5e58108447cde919e2169e2fb7c676b3ed6beafb3e2d3b70
-size 14765
+oid sha256:456583478be02a5845b6eaac6edb226666f8af7ff4f334bee83a97d27d554f5d
+size 17664

--- a/Tests/Data/MeshLib/cube_1x1x1_hex_1e3_layers_10.vtu
+++ b/Tests/Data/MeshLib/cube_1x1x1_hex_1e3_layers_10.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3fc6549510bdd96a6ca802bb7fb72bfeb96a086678c1a02b8d6d702655e952a0
-size 110815
+oid sha256:2fba1c33b6b233b2d24f8eda56cbd41ac71f229189d739682b8f9bea7dc7a868
+size 132297


### PR DESCRIPTION
Extended mesh surface extraction for both DataExplorer + CL-tool to also copy scalar arrays (both point- and cell-based). Currently only int and double arrays are transferred and tuple sizes > 1 are ignored.

1. [ x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.1)
2. [ x] Tests covering your feature were added?
