### PR TITLE
[Jenkins] Update docker base image to Ubuntu 18.04

### DIFF
--- a/ProcessLib/HT/MonolithicHTFEM.h
+++ b/ProcessLib/HT/MonolithicHTFEM.h
@@ -64,7 +64,7 @@ public:
     {
     }
 
-    void assemble(double const t, std::vector<double> const& local_x,
+    void assemble(double const /*t*/, std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override

--- a/ProcessLib/HT/StaggeredHTFEM-impl.h
+++ b/ProcessLib/HT/StaggeredHTFEM-impl.h
@@ -176,7 +176,7 @@ void StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
 template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
 void StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
-    assembleHeatTransportEquation(double const t,
+    assembleHeatTransportEquation(double const /*t*/,
                                   std::vector<double>& local_M_data,
                                   std::vector<double>& local_K_data,
                                   std::vector<double>& /*local_b_data*/,

--- a/scripts/docker/Dockerfile.clang.full
+++ b/scripts/docker/Dockerfile.clang.full
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-# Generated with https://github.com/ufz/ogs-container-maker/commit/cb0c25d
+# Generated with ogs-container-maker 1.2.0
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -27,17 +27,11 @@ RUN apt-get update -y && \
 # Python
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        python \
+        python-dev \
         python3 \
-        libpython3-dev && \
+        python3-dev && \
     rm -rf /var/lib/apt/lists/*
-# pip
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        python3-pip \
-        python3-setuptools \
-        python3-wheel && \
-    rm -rf /var/lib/apt/lists/*
-RUN pip3 install --upgrade pip
 # pip
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -54,8 +48,6 @@ RUN apt-get update -y && \
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.13/cmake-3.13.4-Linux-x86_64.sh && \
     /bin/sh /var/tmp/cmake-3.13.4-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
     rm -rf /var/tmp/cmake-3.13.4-Linux-x86_64.sh
-RUN apt-get update && \
-    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common && \
     apt-add-repository ppa:git-core/ppa -y && \
@@ -66,7 +58,11 @@ RUN apt-get update -y && \
         make \
         ninja-build && \
     rm -rf /var/lib/apt/lists/*
-RUN git lfs install && \
+RUN apt-get update && \
+    apt-get install -y dirmngr --install-recommends && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157 && \
+    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    git lfs install && \
     mkdir -p /apps /scratch /lustre /work /projects
 
 # Package manager Conan building block
@@ -82,8 +78,8 @@ RUN mkdir -p /opt/conan && \
     chmod 777 /opt/conan
 ENV CONAN_USER_HOME=/opt/conan
 LABEL org.opengeosys.pm=conan \
-    org.opengeosys.pm.conan.user_home=/opt/conan \
     org.opengeosys.pm.conan.version=1.12.2
+LABEL org.opengeosys.pm.conan.user_home=/opt/conan
 
 # Include-what-you-use for clang version 7
 RUN apt-get update -y && \

--- a/scripts/docker/Dockerfile.gcc.full
+++ b/scripts/docker/Dockerfile.gcc.full
@@ -1,6 +1,6 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
-# Generated with https://github.com/ufz/ogs-container-maker/commit/cb0c25d
+# Generated with ogs-container-maker 1.2.0
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -16,29 +16,21 @@ RUN apt-get update -y && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc-6 \
-        g++-6 \
-        gfortran-6 && \
+        g++-6 && \
     rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --install /usr/bin/gcc gcc $(which gcc-6) 30 && \
     update-alternatives --install /usr/bin/g++ g++ $(which g++-6) 30 && \
-    update-alternatives --install /usr/bin/gfortran gfortran $(which gfortran-6) 30 && \
     update-alternatives --install /usr/bin/gcov gcov $(which gcov-6) 30
 
 # OGS base building block
 # Python
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        python \
+        python-dev \
         python3 \
-        libpython3-dev && \
+        python3-dev && \
     rm -rf /var/lib/apt/lists/*
-# pip
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        python3-pip \
-        python3-setuptools \
-        python3-wheel && \
-    rm -rf /var/lib/apt/lists/*
-RUN pip3 install --upgrade pip
 # pip
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -55,8 +47,6 @@ RUN apt-get update -y && \
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.13/cmake-3.13.4-Linux-x86_64.sh && \
     /bin/sh /var/tmp/cmake-3.13.4-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
     rm -rf /var/tmp/cmake-3.13.4-Linux-x86_64.sh
-RUN apt-get update && \
-    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common && \
     apt-add-repository ppa:git-core/ppa -y && \
@@ -67,7 +57,11 @@ RUN apt-get update -y && \
         make \
         ninja-build && \
     rm -rf /var/lib/apt/lists/*
-RUN git lfs install && \
+RUN apt-get update && \
+    apt-get install -y dirmngr --install-recommends && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157 && \
+    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    git lfs install && \
     mkdir -p /apps /scratch /lustre /work /projects
 
 # Package manager Conan building block
@@ -83,14 +77,14 @@ RUN mkdir -p /opt/conan && \
     chmod 777 /opt/conan
 ENV CONAN_USER_HOME=/opt/conan
 LABEL org.opengeosys.pm=conan \
-    org.opengeosys.pm.conan.user_home=/opt/conan \
     org.opengeosys.pm.conan.version=1.12.2
+LABEL org.opengeosys.pm.conan.user_home=/opt/conan
 
 # cppcheck version 1.87
 
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/danmar/cppcheck/archive/1.87.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/1.87.tar.gz -C /var/tmp -z && \
-    mkdir -p /var/tmp/build && cd /var/tmp/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local/cppcheck -DCMAKE_BUILD_TYPE=RELEASE /var/tmp/cppcheck-1.87 && \
+    mkdir -p /var/tmp/build && cd /var/tmp/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_PREFIX=/usr/local/cppcheck -DCMAKE_BUILD_TYPE=RELEASE /var/tmp/cppcheck-1.87 && \
     cmake --build /var/tmp/build --target install -- -j$(nproc) && \
     rm -rf /var/tmp/1.87.tar.gz /var/tmp/build /var/tmp/cppcheck-1.87
 ENV PATH=/usr/local/cppcheck/bin:$PATH

--- a/scripts/docker/Dockerfile.gcc.gui
+++ b/scripts/docker/Dockerfile.gcc.gui
@@ -1,6 +1,6 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
-# Generated with https://github.com/ufz/ogs-container-maker/commit/cb0c25d
+# Generated with ogs-container-maker 1.2.0
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -16,29 +16,21 @@ RUN apt-get update -y && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc-6 \
-        g++-6 \
-        gfortran-6 && \
+        g++-6 && \
     rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --install /usr/bin/gcc gcc $(which gcc-6) 30 && \
     update-alternatives --install /usr/bin/g++ g++ $(which g++-6) 30 && \
-    update-alternatives --install /usr/bin/gfortran gfortran $(which gfortran-6) 30 && \
     update-alternatives --install /usr/bin/gcov gcov $(which gcov-6) 30
 
 # OGS base building block
 # Python
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        python \
+        python-dev \
         python3 \
-        libpython3-dev && \
+        python3-dev && \
     rm -rf /var/lib/apt/lists/*
-# pip
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        python3-pip \
-        python3-setuptools \
-        python3-wheel && \
-    rm -rf /var/lib/apt/lists/*
-RUN pip3 install --upgrade pip
 # pip
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -55,8 +47,6 @@ RUN apt-get update -y && \
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.13/cmake-3.13.4-Linux-x86_64.sh && \
     /bin/sh /var/tmp/cmake-3.13.4-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
     rm -rf /var/tmp/cmake-3.13.4-Linux-x86_64.sh
-RUN apt-get update && \
-    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common && \
     apt-add-repository ppa:git-core/ppa -y && \
@@ -67,7 +57,11 @@ RUN apt-get update -y && \
         make \
         ninja-build && \
     rm -rf /var/lib/apt/lists/*
-RUN git lfs install && \
+RUN apt-get update && \
+    apt-get install -y dirmngr --install-recommends && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157 && \
+    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    git lfs install && \
     mkdir -p /apps /scratch /lustre /work /projects
 
 RUN apt-get update -y && \
@@ -90,17 +84,26 @@ RUN mkdir -p /opt/conan && \
     chmod 777 /opt/conan
 ENV CONAN_USER_HOME=/opt/conan
 LABEL org.opengeosys.pm=conan \
-    org.opengeosys.pm.conan.user_home=/opt/conan \
     org.opengeosys.pm.conan.version=1.12.2
+LABEL org.opengeosys.pm.conan.user_home=/opt/conan
 
 # cppcheck version 1.87
 
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/danmar/cppcheck/archive/1.87.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/1.87.tar.gz -C /var/tmp -z && \
-    mkdir -p /var/tmp/build && cd /var/tmp/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local/cppcheck -DCMAKE_BUILD_TYPE=RELEASE /var/tmp/cppcheck-1.87 && \
+    mkdir -p /var/tmp/build && cd /var/tmp/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_PREFIX=/usr/local/cppcheck -DCMAKE_BUILD_TYPE=RELEASE /var/tmp/cppcheck-1.87 && \
     cmake --build /var/tmp/build --target install -- -j$(nproc) && \
     rm -rf /var/tmp/1.87.tar.gz /var/tmp/build /var/tmp/cppcheck-1.87
 ENV PATH=/usr/local/cppcheck/bin:$PATH
+
+# pip
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel && \
+    rm -rf /var/lib/apt/lists/*
+RUN pip3 install gcovr
 
 # Package manager Conan building block
 RUN apt-get update -y && \


### PR DESCRIPTION
Update servers for 17.10 were not available anymore.

Fixes Jenkins job errors in Docker-GUI.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.1)
