### PR TITLE
[Docker] Use default gcc (7.3) on Ubuntu.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,8 +172,7 @@ pipeline {
             dockerfile {
               filename 'Dockerfile.gcc.gui'
               dir 'scripts/docker'
-              // Singularity1 has on old kernel (3.10) which is not compatible with Qt > 5.10 (req. 3.15)
-              label 'docker && !singularity1'
+              label 'docker'
               args '-v /home/jenkins/cache/ccache:/opt/ccache -v /home/jenkins/cache/conan/.conan:/opt/conan/.conan'
               additionalBuildArgs '--pull'
             }

--- a/scripts/docker/Dockerfile.gcc.full
+++ b/scripts/docker/Dockerfile.gcc.full
@@ -11,16 +11,10 @@ RUN apt-get update -y && \
 
 # GNU compiler
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common && \
-    apt-add-repository ppa:ubuntu-toolchain-r/test -y && \
-    apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        gcc-6 \
-        g++-6 && \
+        gcc \
+        g++ && \
     rm -rf /var/lib/apt/lists/*
-RUN update-alternatives --install /usr/bin/gcc gcc $(which gcc-6) 30 && \
-    update-alternatives --install /usr/bin/g++ g++ $(which g++-6) 30 && \
-    update-alternatives --install /usr/bin/gcov gcov $(which gcov-6) 30
 
 # OGS base building block
 # Python

--- a/scripts/docker/Dockerfile.gcc.gui
+++ b/scripts/docker/Dockerfile.gcc.gui
@@ -11,16 +11,10 @@ RUN apt-get update -y && \
 
 # GNU compiler
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common && \
-    apt-add-repository ppa:ubuntu-toolchain-r/test -y && \
-    apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        gcc-6 \
-        g++-6 && \
+        gcc \
+        g++ && \
     rm -rf /var/lib/apt/lists/*
-RUN update-alternatives --install /usr/bin/gcc gcc $(which gcc-6) 30 && \
-    update-alternatives --install /usr/bin/g++ g++ $(which g++-6) 30 && \
-    update-alternatives --install /usr/bin/gcov gcov $(which gcov-6) 30
 
 # OGS base building block
 # Python


### PR DESCRIPTION
Corresponding change: https://github.com/ufz/ogs-container-maker/commit/79241adda9744ae4ee12ef88417a249807620599.

Merge when green.