### PR TITLE
Fix on IterationNumberBasedTimeStepping

### DIFF
--- a/NumLib/TimeStepping/Algorithms/IterationNumberBasedTimeStepping.cpp
+++ b/NumLib/TimeStepping/Algorithms/IterationNumberBasedTimeStepping.cpp
@@ -124,6 +124,6 @@ double IterationNumberBasedTimeStepping::getNextTimeStepSize() const
 
 bool IterationNumberBasedTimeStepping::accepted() const
 {
-    return _iter_times <= _max_iter;
+    return _accepted;
 }
 }  // namespace NumLib

--- a/NumLib/TimeStepping/Algorithms/IterationNumberBasedTimeStepping.h
+++ b/NumLib/TimeStepping/Algorithms/IterationNumberBasedTimeStepping.h
@@ -95,6 +95,7 @@ public:
     bool next(double solution_error, int number_iterations) override;
 
     bool accepted() const override;
+    void setAcceptedOrNot(bool accepted) override { _accepted = accepted; };
 
     bool isSolutionErrorComputationNeeded() override { return true; }
 
@@ -125,6 +126,8 @@ private:
     int _iter_times = 0;
     /// The number of rejected steps.
     int _n_rejected_steps = 0;
+    /// True, if the timestep is accepted.
+    bool _accepted = true;
 };
 
 }  // namespace NumLib

--- a/ProcessLib/UncoupledProcessesTimeLoop.cpp
+++ b/ProcessLib/UncoupledProcessesTimeLoop.cpp
@@ -349,6 +349,10 @@ double UncoupledProcessesTimeLoop::computeTimeStepping(
         {
             timestepper->setAcceptedOrNot(false);
         }
+        else
+        {
+            timestepper->setAcceptedOrNot(true);
+        }
 
         if (!timestepper->next(solution_error,
                                ppd.nonlinear_solver_status.number_iterations) &&

--- a/Tests/NumLib/TestTimeSteppingFixed.cpp
+++ b/Tests/NumLib/TestTimeSteppingFixed.cpp
@@ -40,7 +40,7 @@ TEST(NumLib, TimeSteppingFixed)
     // dt vector (t_end == t0 + sum(dt))
     {
         const std::vector<double> fixed_dt = {10, 10, 10};
-        NumLib::FixedTimeStepping fixed(1, 31, 10);
+        NumLib::FixedTimeStepping fixed(1, 31, fixed_dt);
         const std::vector<double> expected_vec_t = {1, 11, 21, 31};
 
         std::vector<double> vec_t =

--- a/Tests/NumLib/TestTimeSteppingIterationNumber.cpp
+++ b/Tests/NumLib/TestTimeSteppingIterationNumber.cpp
@@ -68,17 +68,17 @@ TEST(NumLib, TimeSteppingIterationNumberBased1)
 
     ASSERT_TRUE(alg.next(solution_error, 8 /* exceed maximum */));
     ts = alg.getTimeStep();
-    ASSERT_EQ(5u, ts.steps());
-    ASSERT_EQ(7., ts.previous());
-    ASSERT_EQ(8, ts.current());
-    ASSERT_EQ(1., ts.dt());
-    ASSERT_FALSE(alg.accepted());
-
-    ASSERT_TRUE(alg.next(solution_error, 4));
-    ts = alg.getTimeStep();
     ASSERT_EQ(6u, ts.steps());
     ASSERT_EQ(8., ts.previous());
     ASSERT_EQ(9, ts.current());
+    ASSERT_EQ(1., ts.dt());
+    ASSERT_TRUE(alg.accepted());
+
+    ASSERT_TRUE(alg.next(solution_error, 4));
+    ts = alg.getTimeStep();
+    ASSERT_EQ(7u, ts.steps());
+    ASSERT_EQ(9., ts.previous());
+    ASSERT_EQ(10, ts.current());
     ASSERT_EQ(1., ts.dt());
     ASSERT_TRUE(alg.accepted());
 }
@@ -91,13 +91,13 @@ TEST(NumLib, TimeSteppingIterationNumberBased2)
                                                  std::move(iter_times_vector),
                                                  std::move(multiplier_vector));
 
-    std::vector<int> nr_iterations = {0, 2, 2, 2, 4, 6, 8, 4, 4, 2, 2};
+    std::vector<int> nr_iterations = {0, 2, 2, 2, 4, 6, 8, 4, 1};
     const std::vector<double> expected_vec_t = {1,  2,  4,  8,  16,
-                                                24, 28, 28, 30, 31};
+                                                24, 28, 29, 30, 31};
 
     std::vector<double> vec_t = timeStepping(alg, nr_iterations);
 
     ASSERT_EQ(expected_vec_t.size(), vec_t.size());
-    ASSERT_EQ(1u, alg.getNumberOfRepeatedSteps());
+    ASSERT_EQ(0u, alg.getNumberOfRepeatedSteps());
     ASSERT_ARRAY_NEAR(expected_vec_t, vec_t, expected_vec_t.size(), std::numeric_limits<double>::epsilon());
 }


### PR DESCRIPTION
Introduced information flow whether the timestep was accepted or not.

This prevents the times in the timestepper and the external loop to diverge
which causes two issues otherwise:
1.) Endless loop at t --> t_end, if max_iter > largest multiplier
2.) Endless loop at t --> t_end, if nonlinear solver fails during
	execution
