### PR TITLE
Explicit constructors

### DIFF
--- a/BaseLib/FileFinder.h
+++ b/BaseLib/FileFinder.h
@@ -26,7 +26,7 @@ namespace BaseLib
  * for a given filename if the corresponding file is found in any of these
  * directories.
  */
-class FileFinder
+class FileFinder final
 {
 public:
     /// Constructor having current directory (.) as the search-space
@@ -37,7 +37,7 @@ public:
      *
      * @param dirs   an initializer list of additional directory paths to the search-space
      */
-    FileFinder(std::initializer_list<std::string> dirs);
+    explicit FileFinder(std::initializer_list<std::string> dirs);
 
     /**
      * \brief Adds another directory to the search-space.

--- a/BaseLib/IO/XmlIO/Qt/XMLQtInterface.h
+++ b/BaseLib/IO/XmlIO/Qt/XMLQtInterface.h
@@ -30,7 +30,7 @@ namespace IO
 class XMLQtInterface
 {
 public:
-    XMLQtInterface(QString schemaFile = "");
+    explicit XMLQtInterface(QString schemaFile = "");
     virtual ~XMLQtInterface() = default;
 
     /// As QXMLStreamWriter seems currently unable to include style-file links into xml-files, this method will workaround this issue and include the stylefile link.

--- a/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.h
+++ b/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.h
@@ -29,13 +29,11 @@ namespace IO
 /**
  * \brief Reads and writes GeoObjects to and from XML files.
  */
-class XmlGmlInterface : public BaseLib::IO::XMLInterface,
-                        public BaseLib::IO::XMLQtInterface
+class XmlGmlInterface final : public BaseLib::IO::XMLInterface,
+                              public BaseLib::IO::XMLQtInterface
 {
 public:
-    XmlGmlInterface(GeoLib::GEOObjects& geo_objs);
-
-    ~XmlGmlInterface() override = default;
+    explicit XmlGmlInterface(GeoLib::GEOObjects& geo_objs);
 
     /// Reads an xml-file containing geometric object definitions into the GEOObjects used in the contructor
     int readFile(const QString& fileName) override;

--- a/GeoLib/IO/XmlIO/Qt/XmlStnInterface.h
+++ b/GeoLib/IO/XmlIO/Qt/XmlStnInterface.h
@@ -32,11 +32,11 @@ namespace IO
 /**
  * \brief Reads and writes Observation Sites to and from XML files.
  */
-class XmlStnInterface : public BaseLib::IO::XMLInterface,
-                        public BaseLib::IO::XMLQtInterface
+class XmlStnInterface final : public BaseLib::IO::XMLInterface,
+                              public BaseLib::IO::XMLQtInterface
 {
 public:
-    XmlStnInterface(GeoLib::GEOObjects& geo_objs);
+    explicit XmlStnInterface(GeoLib::GEOObjects& geo_objs);
 
     /// Reads an xml-file containing station object definitions into the GEOObjects used in the contructor (requires Qt)
     int readFile(const QString& fileName) override;

--- a/MathLib/LinAlg/Lis/LisOption.h
+++ b/MathLib/LinAlg/Lis/LisOption.h
@@ -37,9 +37,9 @@ namespace MathLib
  * currently (version 1.5.57) only sets the number of threads in
  * \c lis_initialize(). Refer to the Lis source code for details.
  */
-struct LisOption
+struct LisOption final
 {
-    LisOption(BaseLib::ConfigTree const* const options)
+    explicit LisOption(BaseLib::ConfigTree const* const options)
     {
         if (options) {
             ignoreOtherLinearSolvers(*options, "lis");

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
@@ -33,11 +33,11 @@ namespace IO
 {
 /// Class for parallel reading of ascii or binary partitioned mesh files into a
 /// NodePartitionedMesh via MPI.
-class NodePartitionedMeshReader
+class NodePartitionedMeshReader final
 {
 public:
     ///  \param comm   MPI communicator.
-    NodePartitionedMeshReader(MPI_Comm comm);
+    explicit NodePartitionedMeshReader(MPI_Comm comm);
 
     ~NodePartitionedMeshReader();
 

--- a/NumLib/NamedFunctionCaller.h
+++ b/NumLib/NamedFunctionCaller.h
@@ -22,7 +22,7 @@ class NamedFunctionCaller final
 {
 public:
     //! Constructs an instance whose unbound arguments have the given names.
-    NamedFunctionCaller(
+    explicit NamedFunctionCaller(
         std::initializer_list<std::string> unbound_argument_names);
 
     //! Adds the given named function

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcessData.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcessData.h
@@ -17,10 +17,9 @@ struct Parameter;
 
 namespace GroundwaterFlow
 {
-
-struct GroundwaterFlowProcessData
+struct GroundwaterFlowProcessData final
 {
-    GroundwaterFlowProcessData(
+    explicit GroundwaterFlowProcessData(
         ParameterLib::Parameter<double> const& hydraulic_conductivity_)
         : hydraulic_conductivity(hydraulic_conductivity_)
     {}


### PR DESCRIPTION
As reported by cppcheck, single argument ctors should be marked explicit.

Additionally add final specifier to the modified classes (where applicable).
Remove one defaulted dtor.