### PR TITLE
Refactor mesh information value bounds

### DIFF
--- a/Applications/DataExplorer/DataView/ElementTreeModel.cpp
+++ b/Applications/DataExplorer/DataView/ElementTreeModel.cpp
@@ -168,17 +168,26 @@ void ElementTreeModel::setMesh(MeshLib::Mesh const& mesh)
     {
         QList<QVariant> array_info;
         array_info << QString::fromStdString(vec_name) + ": ";
-        auto vec_bounds(
-            MeshLib::MeshInformation::getValueBounds<int>(mesh, vec_name));
-        if (vec_bounds.second != std::numeric_limits<int>::max())
-            array_info << "[" + QString::number(vec_bounds.first) + "," << QString::number(vec_bounds.second) + "]" << "";
+        if (auto const vec_bounds =  // test if boost::optional is empty
+            MeshLib::MeshInformation::getValueBounds<int>(mesh, vec_name))
+        {
+            array_info << "[" + QString::number(vec_bounds->first) + ","
+                       << QString::number(vec_bounds->second) + "]";
+        }
+        else if (auto const vec_bounds =  // test if boost::optional is empty
+                 MeshLib::MeshInformation::getValueBounds<double>(mesh,
+                                                                  vec_name))
+        {
+            array_info << "[" + QString::number(vec_bounds->first) + ","
+                       << QString::number(vec_bounds->second) + "]";
+        }
         else
         {
-            auto vec_bounds(MeshLib::MeshInformation::getValueBounds<double>(
-                mesh, vec_name));
-            if (vec_bounds.second != std::numeric_limits<double>::max())
-                array_info  << "[" + QString::number(vec_bounds.first) + "," << QString::number(vec_bounds.second) + "]" << "";
+            // Makeup the same structure of output as in the valid cases above.
+            array_info << "[error,"
+                       << "error]";
         }
+
         if (array_info.size() == 1)
             array_info << "[ ?" << "? ]" << "";
         auto* vec_item = new TreeItem(array_info, _rootItem);

--- a/Applications/Utils/MeshEdit/checkMesh.cpp
+++ b/Applications/Utils/MeshEdit/checkMesh.cpp
@@ -116,26 +116,25 @@ int main(int argc, char *argv[])
 
     std::vector<std::string> const& vec_names (mesh->getProperties().getPropertyVectorNames());
     INFO("There are %d properties in the mesh:", vec_names.size());
-    for (const auto & vec_name : vec_names)
+    for (const auto& vec_name : vec_names)
     {
-        auto vec_bounds (MeshLib::MeshInformation::getValueBounds<int>(*mesh, vec_name));
-        if (vec_bounds.second != std::numeric_limits<int>::max())
+        if (auto const vec_bounds =
+                MeshLib::MeshInformation::getValueBounds<int>(*mesh, vec_name))
         {
-            INFO("\t%s: [%d, %d]", vec_name.c_str(), vec_bounds.first,
-                 vec_bounds.second);
+            INFO("\t%s: [%d, %d]", vec_name.c_str(), vec_bounds->first,
+                 vec_bounds->second);
+        }
+        else if (auto const vec_bounds =
+                     MeshLib::MeshInformation::getValueBounds<double>(*mesh,
+                                                                      vec_name))
+        {
+            INFO("\t%s: [%g, %g]", vec_name.c_str(), vec_bounds->first,
+                 vec_bounds->second);
         }
         else
         {
-            auto vec_bounds (MeshLib::MeshInformation::getValueBounds<double>(*mesh, vec_name));
-            if (vec_bounds.second != std::numeric_limits<double>::max())
-            {
-                INFO("\t%s: [%g, %g]", vec_name.c_str(), vec_bounds.first,
-                     vec_bounds.second);
-            }
-            else
-            {
-                INFO("\t%s: Unknown properties", vec_name.c_str());
-            }
+            INFO("\t%s: Could not get value bounds for property vector.",
+                 vec_name.c_str());
         }
     }
 

--- a/MeshLib/MeshInformation.cpp
+++ b/MeshLib/MeshInformation.cpp
@@ -17,17 +17,17 @@
 
 namespace MeshLib
 {
-
-const GeoLib::AABB MeshInformation::getBoundingBox(const MeshLib::Mesh &mesh)
+const GeoLib::AABB MeshInformation::getBoundingBox(const MeshLib::Mesh& mesh)
 {
-    const std::vector<MeshLib::Node*> &nodes (mesh.getNodes());
+    const std::vector<MeshLib::Node*>& nodes(mesh.getNodes());
     return GeoLib::AABB(nodes.begin(), nodes.end());
 }
 
-const std::array<unsigned, 7> MeshInformation::getNumberOfElementTypes(const MeshLib::Mesh &mesh)
+const std::array<unsigned, 7> MeshInformation::getNumberOfElementTypes(
+    const MeshLib::Mesh& mesh)
 {
     std::array<unsigned, 7> n_element_types = {{0, 0, 0, 0, 0, 0, 0}};
-    const std::vector<MeshLib::Element*> &elements (mesh.getElements());
+    const std::vector<MeshLib::Element*>& elements(mesh.getElements());
     for (auto element : elements)
     {
         MeshElemType t = element->getGeomType();

--- a/MeshLib/MeshInformation.h
+++ b/MeshLib/MeshInformation.h
@@ -34,24 +34,26 @@ public:
     /// Returns the smallest and largest value of a scalar array with the given
     /// name.
     template <typename T>
-    static std::pair<T, T> const getValueBounds(MeshLib::Mesh const& mesh,
-                                                std::string const& name)
+    static boost::optional<std::pair<T, T>> const getValueBounds(
+        MeshLib::Mesh const& mesh, std::string const& name)
     {
         if (!mesh.getProperties().existsPropertyVector<T>(name))
-            return {std::numeric_limits<T>::max(),
-                    std::numeric_limits<T>::max()};
+        {
+            return {};
+        }
+
         auto const* const data_vec =
             mesh.getProperties().getPropertyVector<T>(name);
         if (data_vec->empty())
         {
             INFO("Mesh does not contain values for the property '%s'.",
                  name.c_str());
-            return {std::numeric_limits<T>::max(),
-                    std::numeric_limits<T>::max()};
+            return {};
         }
-        auto vec_bounds =
-            std::minmax_element(data_vec->cbegin(), data_vec->cend());
-        return {*(vec_bounds.first), *(vec_bounds.second)};
+
+        auto const [min, max] =
+            std::minmax_element(begin(*data_vec), end(*data_vec));
+        return {{*min, *max}};
     }
 
     /// Returns the bounding box of the mesh.

--- a/MeshLib/MeshInformation.h
+++ b/MeshLib/MeshInformation.h
@@ -15,8 +15,8 @@
 #pragma once
 
 #include <array>
-#include <string>
 #include <limits>
+#include <string>
 
 #include "GeoLib/AABB.h"
 #include "MeshLib/Mesh.h"
@@ -25,49 +25,49 @@
 
 namespace MeshLib
 {
-
 /**
  * \brief A set of tools for extracting information from a mesh
  */
 class MeshInformation
 {
 public:
-    /// Returns the smallest and largest value of a scalar array with the given name.
-    template<typename T>
-    static std::pair<T, T> const
-        getValueBounds(MeshLib::Mesh const& mesh, std::string const& name)
+    /// Returns the smallest and largest value of a scalar array with the given
+    /// name.
+    template <typename T>
+    static std::pair<T, T> const getValueBounds(MeshLib::Mesh const& mesh,
+                                                std::string const& name)
     {
         if (!mesh.getProperties().existsPropertyVector<T>(name))
-            return {std::numeric_limits<T>::max(), std::numeric_limits<T>::max()};
+            return {std::numeric_limits<T>::max(),
+                    std::numeric_limits<T>::max()};
         auto const* const data_vec =
             mesh.getProperties().getPropertyVector<T>(name);
-        if (data_vec->empty()) {
+        if (data_vec->empty())
+        {
             INFO("Mesh does not contain values for the property '%s'.",
                  name.c_str());
-            return {std::numeric_limits<T>::max(), std::numeric_limits<T>::max()};
+            return {std::numeric_limits<T>::max(),
+                    std::numeric_limits<T>::max()};
         }
-        auto vec_bounds = std::minmax_element(data_vec->cbegin(), data_vec->cend());
+        auto vec_bounds =
+            std::minmax_element(data_vec->cbegin(), data_vec->cend());
         return {*(vec_bounds.first), *(vec_bounds.second)};
     }
 
     /// Returns the bounding box of the mesh.
-    static const GeoLib::AABB getBoundingBox(const MeshLib::Mesh &mesh);
+    static const GeoLib::AABB getBoundingBox(const MeshLib::Mesh& mesh);
 
     /**
-     * Returns an array with the number of elements of each type in the given mesh.
-     * On completion, n_element_types array contains the number of elements of each of the seven
-     * supported types. The index to element type conversion is this:
-     *        0: \#lines
-     *        1: \#triangles
-     *        2: \#quads
-     *        3: \#tetrahedra
+     * Returns an array with the number of elements of each type in the given
+     * mesh. On completion, n_element_types array contains the number of
+     * elements of each of the seven supported types. The index to element type
+     * conversion is this: 0: \#lines 1: \#triangles 2: \#quads 3: \#tetrahedra
      *        4: \#hexahedra
      *        5: \#pyramids
      *        6: \#prisms
      */
-    static const std::array<unsigned, 7> getNumberOfElementTypes(const MeshLib::Mesh &mesh);
-
-
+    static const std::array<unsigned, 7> getNumberOfElementTypes(
+        const MeshLib::Mesh& mesh);
 };
 
 }  // namespace MeshLib

--- a/MeshLib/convertMeshToGeo.cpp
+++ b/MeshLib/convertMeshToGeo.cpp
@@ -77,10 +77,7 @@ bool convertMeshToGeo(const MeshLib::Mesh& mesh,
     const std::vector<MeshLib::Element*>& elements = mesh.getElements();
     const std::size_t nElems(mesh.getNumberOfElements());
 
-    MeshLib::PropertyVector<int> const* const materialIds =
-        mesh.getProperties().existsPropertyVector<int>("MaterialIDs")
-            ? mesh.getProperties().getPropertyVector<int>("MaterialIDs")
-            : nullptr;
+    auto const materialIds = materialIDs(mesh);
 
     for (unsigned i = 0; i < nElems; ++i)
     {

--- a/MeshLib/convertMeshToGeo.cpp
+++ b/MeshLib/convertMeshToGeo.cpp
@@ -17,22 +17,24 @@
 #include <logog/include/logog.hpp>
 
 #include "GeoLib/GEOObjects.h"
-#include "GeoLib/Triangle.h"
 #include "GeoLib/Surface.h"
+#include "GeoLib/Triangle.h"
 
-#include "Mesh.h"
-#include "Elements/Tri.h"
 #include "Elements/Quad.h"
-#include "MeshInformation.h"
+#include "Elements/Tri.h"
+#include "Mesh.h"
 #include "MeshEditing/MeshRevision.h"
+#include "MeshInformation.h"
 
-namespace MeshLib {
-
-bool convertMeshToGeo(const MeshLib::Mesh &mesh, GeoLib::GEOObjects &geo_objects, double eps)
+namespace MeshLib
+{
+bool convertMeshToGeo(const MeshLib::Mesh& mesh,
+                      GeoLib::GEOObjects& geo_objects,
+                      double eps)
 {
     if (mesh.getDimension() != 2)
     {
-        ERR ("Mesh to geometry conversion is only working for 2D meshes.");
+        ERR("Mesh to geometry conversion is only working for 2D meshes.");
         return false;
     }
 
@@ -49,12 +51,13 @@ bool convertMeshToGeo(const MeshLib::Mesh &mesh, GeoLib::GEOObjects &geo_objects
 
         geo_objects.addPointVec(std::move(points), mesh_name, nullptr, eps);
     }
-    const std::vector<std::size_t> id_map (geo_objects.getPointVecObj(mesh_name)->getIDMap());
+    const std::vector<std::size_t> id_map(
+        geo_objects.getPointVecObj(mesh_name)->getIDMap());
 
     // elements to surface triangles conversion
-    std::string const mat_name ("MaterialIDs");
-    auto bounds (MeshInformation::getValueBounds<int>(mesh, mat_name));
-    const unsigned nMatGroups(bounds.second-bounds.first+1);
+    std::string const mat_name("MaterialIDs");
+    auto bounds(MeshInformation::getValueBounds<int>(mesh, mat_name));
+    const unsigned nMatGroups(bounds.second - bounds.first + 1);
     auto sfcs = std::make_unique<std::vector<GeoLib::Surface*>>();
     sfcs->reserve(nMatGroups);
     auto const& points = *geo_objects.getPointVec(mesh_name);
@@ -63,18 +66,18 @@ bool convertMeshToGeo(const MeshLib::Mesh &mesh, GeoLib::GEOObjects &geo_objects
         sfcs->push_back(new GeoLib::Surface(points));
     }
 
-    const std::vector<MeshLib::Element*> &elements = mesh.getElements();
-    const std::size_t nElems (mesh.getNumberOfElements());
+    const std::vector<MeshLib::Element*>& elements = mesh.getElements();
+    const std::size_t nElems(mesh.getNumberOfElements());
 
-    MeshLib::PropertyVector<int> const*const materialIds =
+    MeshLib::PropertyVector<int> const* const materialIds =
         mesh.getProperties().existsPropertyVector<int>("MaterialIDs")
             ? mesh.getProperties().getPropertyVector<int>("MaterialIDs")
             : nullptr;
 
-    for (unsigned i=0; i<nElems; ++i)
+    for (unsigned i = 0; i < nElems; ++i)
     {
         auto surfaceId = !materialIds ? 0 : ((*materialIds)[i] - bounds.first);
-        MeshLib::Element* e (elements[i]);
+        MeshLib::Element* e(elements[i]);
         if (e->getGeomType() == MeshElemType::TRIANGLE)
         {
             (*sfcs)[surfaceId]->addTriangle(id_map[e->getNodeIndex(0)],
@@ -83,8 +86,12 @@ bool convertMeshToGeo(const MeshLib::Mesh &mesh, GeoLib::GEOObjects &geo_objects
         }
         if (e->getGeomType() == MeshElemType::QUAD)
         {
-            (*sfcs)[surfaceId]->addTriangle(id_map[e->getNodeIndex(0)], id_map[e->getNodeIndex(1)], id_map[e->getNodeIndex(2)]);
-            (*sfcs)[surfaceId]->addTriangle(id_map[e->getNodeIndex(0)], id_map[e->getNodeIndex(2)], id_map[e->getNodeIndex(3)]);
+            (*sfcs)[surfaceId]->addTriangle(id_map[e->getNodeIndex(0)],
+                                            id_map[e->getNodeIndex(1)],
+                                            id_map[e->getNodeIndex(2)]);
+            (*sfcs)[surfaceId]->addTriangle(id_map[e->getNodeIndex(0)],
+                                            id_map[e->getNodeIndex(2)],
+                                            id_map[e->getNodeIndex(3)]);
         }
         // all other element types are ignored (i.e. lines)
     }
@@ -103,13 +110,15 @@ bool convertMeshToGeo(const MeshLib::Mesh &mesh, GeoLib::GEOObjects &geo_objects
     return true;
 }
 
-MeshLib::Mesh* convertSurfaceToMesh(const GeoLib::Surface &sfc, const std::string &mesh_name, double eps)
+MeshLib::Mesh* convertSurfaceToMesh(const GeoLib::Surface& sfc,
+                                    const std::string& mesh_name,
+                                    double eps)
 {
     // convert to a mesh including duplicated nodes
     std::vector<MeshLib::Node*> nodes;
     std::vector<MeshLib::Element*> elements;
     std::size_t nodeId = 0;
-    for (std::size_t i=0; i<sfc.getNumberOfTriangles(); i++)
+    for (std::size_t i = 0; i < sfc.getNumberOfTriangles(); i++)
     {
         auto* tri = sfc[i];
         auto** tri_nodes = new MeshLib::Node*[3];

--- a/MeshLib/convertMeshToGeo.cpp
+++ b/MeshLib/convertMeshToGeo.cpp
@@ -55,9 +55,17 @@ bool convertMeshToGeo(const MeshLib::Mesh& mesh,
         geo_objects.getPointVecObj(mesh_name)->getIDMap());
 
     // elements to surface triangles conversion
-    std::string const mat_name("MaterialIDs");
-    auto bounds(MeshInformation::getValueBounds<int>(mesh, mat_name));
-    const unsigned nMatGroups(bounds.second - bounds.first + 1);
+    auto const bounds =
+        MeshInformation::getValueBounds<int>(mesh, "MaterialIDs");
+    if (!bounds)
+    {
+        OGS_FATAL(
+            "Could not get minimum/maximum ranges values for the MaterialIDs "
+            "property in the mesh '%s'.",
+            mesh.getName().c_str());
+    }
+
+    const unsigned nMatGroups(bounds->second - bounds->first + 1);
     auto sfcs = std::make_unique<std::vector<GeoLib::Surface*>>();
     sfcs->reserve(nMatGroups);
     auto const& points = *geo_objects.getPointVec(mesh_name);
@@ -76,7 +84,7 @@ bool convertMeshToGeo(const MeshLib::Mesh& mesh,
 
     for (unsigned i = 0; i < nElems; ++i)
     {
-        auto surfaceId = !materialIds ? 0 : ((*materialIds)[i] - bounds.first);
+        auto surfaceId = !materialIds ? 0 : ((*materialIds)[i] - bounds->first);
         MeshLib::Element* e(elements[i]);
         if (e->getGeomType() == MeshElemType::TRIANGLE)
         {

--- a/MeshLib/convertMeshToGeo.h
+++ b/MeshLib/convertMeshToGeo.h
@@ -21,29 +21,33 @@ namespace GeoLib
 {
 class GEOObjects;
 class Surface;
-}
+}  // namespace GeoLib
 
 namespace MeshLib
 {
+class Mesh;
 
-    class Mesh;
+/**
+ * Converts a 2D mesh into a geometry.
+ * A new geometry with the name of the mesh will be inserted into geo_objects,
+ * consisting of points identical with mesh nodes and one surface representing
+ * the mesh. Triangles are converted to geometric triangles, quads are split
+ * into two triangles, all other elements are ignored.
+ */
+bool convertMeshToGeo(const MeshLib::Mesh& mesh,
+                      GeoLib::GEOObjects& geo_objects,
+                      double eps = std::numeric_limits<double>::epsilon());
 
-    /**
-     * Converts a 2D mesh into a geometry.
-     * A new geometry with the name of the mesh will be inserted into geo_objects, consisting
-     * of points identical with mesh nodes and one surface representing the mesh. Triangles are
-     * converted to geometric triangles, quads are split into two triangles, all other elements
-     * are ignored.
-     */
-    bool convertMeshToGeo(const MeshLib::Mesh &mesh, GeoLib::GEOObjects &geo_objects, double eps = std::numeric_limits<double>::epsilon());
+/**
+ * Converts a surface into a triangular mesh
+ * @param sfc         Surface object
+ * @param mesh_name   New mesh name
+ * @param eps         Minimum distance for nodes not to be collapsed
+ * @return a pointer to a converted mesh object. nullptr is returned if the
+ * conversion fails.
+ */
+MeshLib::Mesh* convertSurfaceToMesh(
+    const GeoLib::Surface& sfc, const std::string& mesh_name,
+    double eps = std::numeric_limits<double>::epsilon());
 
-    /**
-     * Converts a surface into a triangular mesh
-     * @param sfc         Surface object
-     * @param mesh_name   New mesh name
-     * @param eps         Minimum distance for nodes not to be collapsed
-     * @return a pointer to a converted mesh object. nullptr is returned if the conversion fails.
-     */
-    MeshLib::Mesh* convertSurfaceToMesh(const GeoLib::Surface &sfc, const std::string &mesh_name, double eps = std::numeric_limits<double>::epsilon());
-
-    }  // namespace MeshLib
+}  // namespace MeshLib

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -101,10 +101,18 @@ HydroMechanicsProcess<GlobalDim>::HydroMechanicsProcess(
     }
     else
     {
-        auto range =
+        auto const range =
             MeshLib::MeshInformation::getValueBounds<int>(mesh, "MaterialIDs");
+        if (!range)
+        {
+            OGS_FATAL(
+                "Could not get minimum/maximum ranges values for the "
+                "MaterialIDs property in the mesh '%s'.",
+                mesh.getName().c_str());
+        }
+
         std::vector<int> vec_p_inactive_matIDs;
-        for (int matID = range.first; matID <= range.second; matID++)
+        for (int matID = range->first; matID <= range->second; matID++)
         {
             if (std::find(vec_fracture_mat_IDs.begin(),
                           vec_fracture_mat_IDs.end(),

--- a/Tests/FileIO/TestGmsInterface.cpp
+++ b/Tests/FileIO/TestGmsInterface.cpp
@@ -29,8 +29,10 @@ TEST(FileIO, TestGmsInterface)
     ASSERT_EQ(1456,  types[3]);    // tets
     ASSERT_EQ(1355,  types[5]);    // pyramids
     ASSERT_EQ(17074, types[6]);    // prism
-    std::pair<int, int> bounds (MeshLib::MeshInformation::getValueBounds<int>(*mesh, "MaterialIDs"));
-    ASSERT_EQ(1, bounds.first);
-    ASSERT_EQ(63, bounds.second);
+    auto const& bounds =
+        MeshLib::MeshInformation::getValueBounds<int>(*mesh, "MaterialIDs");
+    ASSERT_TRUE(boost::none != bounds);
+    ASSERT_EQ(1, bounds->first);
+    ASSERT_EQ(63, bounds->second);
 }
 

--- a/Tests/FileIO/TestTetGenInterface.cpp
+++ b/Tests/FileIO/TestTetGenInterface.cpp
@@ -95,9 +95,11 @@ TEST(FileIO, TetGenMeshReaderWithMaterials)
     ASSERT_EQ(1378, mesh->getNumberOfNodes());
     ASSERT_EQ(5114, mesh->getNumberOfElements());
 
-    std::pair<int, int> bounds (MeshLib::MeshInformation::getValueBounds<int>(*mesh, "MaterialIDs"));
-    ASSERT_EQ(-20, bounds.first);
-    ASSERT_EQ(-10, bounds.second);
+    auto const& bounds =
+        MeshLib::MeshInformation::getValueBounds<int>(*mesh, "MaterialIDs");
+    ASSERT_TRUE(boost::none != bounds);
+    ASSERT_EQ(-20, bounds->first);
+    ASSERT_EQ(-10, bounds->second);
 }
 
 // TetGen mesh without additional information
@@ -111,7 +113,7 @@ TEST(FileIO, TetGenMeshReaderWithoutMaterials)
     ASSERT_EQ(202, mesh->getNumberOfNodes());
     ASSERT_EQ(650, mesh->getNumberOfElements());
 
-    std::pair<int, int> bounds (MeshLib::MeshInformation::getValueBounds<int>(*mesh, "MaterialIDs"));
-    ASSERT_EQ(std::numeric_limits<int>::max(), bounds.first);
-    ASSERT_EQ(std::numeric_limits<int>::max(), bounds.second);
+    auto const& bounds =
+        MeshLib::MeshInformation::getValueBounds<int>(*mesh, "MaterialIDs");
+    ASSERT_TRUE(boost::none == bounds);
 }

--- a/Tests/FileIO_SWMM/TestSwmmInterface.cpp
+++ b/Tests/FileIO_SWMM/TestSwmmInterface.cpp
@@ -68,9 +68,11 @@ TEST(FileIO, TestSwmmInterface)
 
     std::array<unsigned, 7> types (MeshLib::MeshInformation::getNumberOfElementTypes(mesh));
     ASSERT_EQ(n_elems, types[0]); // all elems are lines
-    std::pair<int, int> bounds (MeshLib::MeshInformation::getValueBounds<int>(mesh, "MaterialIDs"));
-    ASSERT_EQ(0, bounds.first);
-    ASSERT_EQ(0, bounds.second);
+    auto const bounds =
+        MeshLib::MeshInformation::getValueBounds<int>(mesh, "MaterialIDs");
+    ASSERT_TRUE(boost::none != bounds);
+    ASSERT_EQ(0, bounds->first);
+    ASSERT_EQ(0, bounds->second);
 
     ASSERT_NEAR(186.06,  mesh.getMinEdgeLength(), 0.01);
     ASSERT_NEAR(3171.42, mesh.getMaxEdgeLength(), 0.01);

--- a/Tests/MeshLib/TestRasterToMesh.cpp
+++ b/Tests/MeshLib/TestRasterToMesh.cpp
@@ -124,10 +124,11 @@ TEST_F(RasterToMeshTest, convertRasterToTriMeshValue)
         mesh->getProperties().getPropertyVector<double>("test");
     ASSERT_EQ(2 * _n_pix, prop->size());
 
-    std::pair<double, double> const& bounds =
+    auto const& bounds =
         MeshLib::MeshInformation::getValueBounds<double>(*mesh, "test");
-    ASSERT_NEAR(0, bounds.first, std::numeric_limits<double>::epsilon());
-    ASSERT_NEAR(0.07, bounds.second, std::numeric_limits<double>::epsilon());
+    ASSERT_TRUE(boost::none != bounds);
+    ASSERT_NEAR(0, bounds->first, std::numeric_limits<double>::epsilon());
+    ASSERT_NEAR(0.07, bounds->second, std::numeric_limits<double>::epsilon());
 
     std::vector<MeshLib::Node*> const& nodes = mesh->getNodes();
     for (MeshLib::Node* n : nodes)
@@ -157,10 +158,11 @@ TEST_F(RasterToMeshTest, convertRasterToQuadMeshValue)
         mesh->getProperties().getPropertyVector<double>("test");
     ASSERT_EQ(_n_pix, prop->size());
 
-    std::pair<double, double> const& bounds =
+    auto const& bounds =
         MeshLib::MeshInformation::getValueBounds<double>(*mesh, "test");
-    ASSERT_NEAR(0, bounds.first, std::numeric_limits<double>::epsilon());
-    ASSERT_NEAR(0.07, bounds.second, std::numeric_limits<double>::epsilon());
+    ASSERT_TRUE(boost::none != bounds);
+    ASSERT_NEAR(0, bounds->first, std::numeric_limits<double>::epsilon());
+    ASSERT_NEAR(0.07, bounds->second, std::numeric_limits<double>::epsilon());
 
     std::vector<MeshLib::Node*> const& nodes = mesh->getNodes();
     for (MeshLib::Node* n : nodes)
@@ -190,10 +192,11 @@ TEST_F(RasterToMeshTest, convertRasterToPrismMeshValue)
         mesh->getProperties().getPropertyVector<double>("test");
     ASSERT_EQ(2 * _n_pix, prop->size());
 
-    std::pair<double, double> const& bounds =
+    auto const& bounds =
         MeshLib::MeshInformation::getValueBounds<double>(*mesh, "test");
-    ASSERT_NEAR(0, bounds.first, std::numeric_limits<double>::epsilon());
-    ASSERT_NEAR(0.07, bounds.second, std::numeric_limits<double>::epsilon());
+    ASSERT_TRUE(boost::none != bounds);
+    ASSERT_NEAR(0, bounds->first, std::numeric_limits<double>::epsilon());
+    ASSERT_NEAR(0.07, bounds->second, std::numeric_limits<double>::epsilon());
 
     std::vector<MeshLib::Node*> const& nodes = mesh->getNodes();
     for (MeshLib::Node* n : nodes)
@@ -223,10 +226,11 @@ TEST_F(RasterToMeshTest, convertRasterToHexMeshValue)
         mesh->getProperties().getPropertyVector<int>("MaterialIDs");
     ASSERT_EQ(_n_pix, prop->size());
 
-    std::pair<int, int> const& bounds =
+    auto const& bounds =
         MeshLib::MeshInformation::getValueBounds<int>(*mesh, "MaterialIDs");
-    ASSERT_NEAR(0, bounds.first, std::numeric_limits<double>::epsilon());
-    ASSERT_NEAR(0, bounds.second, std::numeric_limits<double>::epsilon());
+    ASSERT_TRUE(boost::none != bounds);
+    ASSERT_NEAR(0, bounds->first, std::numeric_limits<double>::epsilon());
+    ASSERT_NEAR(0, bounds->second, std::numeric_limits<double>::epsilon());
 
     std::vector<MeshLib::Node*> const& nodes = mesh->getNodes();
     for (MeshLib::Node* n : nodes)
@@ -287,10 +291,11 @@ TEST_F(RasterToMeshTest, vtkImage)
         mesh->getProperties().getPropertyVector<double>("test");
     ASSERT_EQ(2 * _n_pix, prop->size());
 
-    std::pair<double, double> const& bounds =
+    auto const& bounds =
         MeshLib::MeshInformation::getValueBounds<double>(*mesh, "test");
-    ASSERT_NEAR(0, bounds.first, std::numeric_limits<double>::epsilon());
-    ASSERT_NEAR(0.07, bounds.second, std::numeric_limits<float>::epsilon());
+    ASSERT_TRUE(boost::none != bounds);
+    ASSERT_NEAR(0, bounds->first, std::numeric_limits<double>::epsilon());
+    ASSERT_NEAR(0.07, bounds->second, std::numeric_limits<float>::epsilon());
 
     std::vector<MeshLib::Node*> const& nodes = mesh->getNodes();
     for (MeshLib::Node* n : nodes)


### PR DESCRIPTION
Avoids variable shadowing of `vec_bounds` in two cases.
Adds stricter error checking.
Avoids use of sentinel values, which could be part of the input.