### PR TITLE
[PL] BC; Fix lower order element values access.

### DIFF
--- a/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
@@ -57,7 +57,8 @@ public:
         // Get element nodes for the interpolation from nodes to integration
         // point.
         NodalVectorType parameter_node_values =
-            _neumann_bc_parameter.getNodalValuesOnElement(Base::_element, t);
+            _neumann_bc_parameter.getNodalValuesOnElement(Base::_element, t)
+                .template topRows<ShapeFunction::MeshElement::n_all_nodes>();
 
         for (unsigned ip = 0; ip < n_integration_points; ip++)
         {

--- a/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
@@ -55,9 +55,11 @@ public:
             Base::_integration_method.getNumberOfPoints();
 
         typename Base::NodalVectorType const alpha =
-            _data.alpha.getNodalValuesOnElement(Base::_element, t);
+            _data.alpha.getNodalValuesOnElement(Base::_element, t)
+                .template topRows<ShapeFunction::MeshElement::n_all_nodes>();
         typename Base::NodalVectorType const u_0 =
-            _data.u_0.getNodalValuesOnElement(Base::_element, t);
+            _data.u_0.getNodalValuesOnElement(Base::_element, t)
+                .template topRows<ShapeFunction::MeshElement::n_all_nodes>();
 
         for (unsigned ip = 0; ip < n_integration_points; ++ip)
         {

--- a/ProcessLib/BoundaryCondition/VariableDependentNeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/VariableDependentNeumannBoundaryConditionLocalAssembler.h
@@ -64,16 +64,20 @@ public:
         // Get element nodes for the interpolation from nodes to
         // integration point.
         NodalVectorType const constant_node_values =
-            _data.constant.getNodalValuesOnElement(Base::_element, t);
+            _data.constant.getNodalValuesOnElement(Base::_element, t)
+                .template topRows<ShapeFunction::MeshElement::n_all_nodes>();
         NodalVectorType const coefficient_current_variable_node_values =
-            _data.coefficient_current_variable.getNodalValuesOnElement(
-                Base::_element, t);
+            _data.coefficient_current_variable
+                .getNodalValuesOnElement(Base::_element, t)
+                .template topRows<ShapeFunction::MeshElement::n_all_nodes>();
         NodalVectorType const coefficient_other_variable_node_values =
-            _data.coefficient_other_variable.getNodalValuesOnElement(
-                Base::_element, t);
+            _data.coefficient_other_variable
+                .getNodalValuesOnElement(Base::_element, t)
+                .template topRows<ShapeFunction::MeshElement::n_all_nodes>();
         NodalVectorType const coefficient_mixed_variables_node_values =
-            _data.coefficient_mixed_variables.getNodalValuesOnElement(
-                Base::_element, t);
+            _data.coefficient_mixed_variables
+                .getNodalValuesOnElement(Base::_element, t)
+                .template topRows<ShapeFunction::MeshElement::n_all_nodes>();
         unsigned const n_integration_points =
             Base::_integration_method.getNumberOfPoints();
 


### PR DESCRIPTION
In cases when the underlying element is quadratic but the shape function
is of linear order, there is a dimension mismatch between the
`NodalVectorType` and the return value of the `getNodalValuesOnElement`.

Taking the first rows of the return matrix ensures correct dimensions.

Changing only for BC's which use the `getNodalValuesOnElement` and
are used by processes like HM/RM etc. where one of the process
variables is of lower order.

The error is present already in the master for quite some time and only shows
up when compiling with fixed size matrices in debug mode.