### PR TITLE
Cleanup MaterialStateVariables in solid models

### DIFF
--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -221,15 +221,6 @@ template <int DisplacementDim>
 struct StateVariables
     : public MechanicsBase<DisplacementDim>::MaterialStateVariables
 {
-    StateVariables& operator=(StateVariables const&) = default;
-    typename MechanicsBase<DisplacementDim>::MaterialStateVariables& operator=(
-        typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
-            state) noexcept override
-    {
-        assert(dynamic_cast<StateVariables const*>(&state) != nullptr);
-        return operator=(static_cast<StateVariables const&>(state));
-    }
-
     void setInitialConditions()
     {
         eps_p = eps_p_prev;

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.cpp
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.cpp
@@ -15,16 +15,16 @@ namespace Solids
 {
 template <int DisplacementDim>
 boost::optional<
-    std::tuple<typename LinearElasticIsotropic<DisplacementDim>::KelvinVector,
+    std::tuple<typename MechanicsBase<DisplacementDim>::KelvinVector,
                std::unique_ptr<typename MechanicsBase<
                    DisplacementDim>::MaterialStateVariables>,
-               typename LinearElasticIsotropic<DisplacementDim>::KelvinMatrix>>
+               typename MechanicsBase<DisplacementDim>::KelvinMatrix>>
 LinearElasticIsotropic<DisplacementDim>::integrateStress(
     double const t, ParameterLib::SpatialPosition const& x, double const /*dt*/,
     KelvinVector const& eps_prev, KelvinVector const& eps,
     KelvinVector const& sigma_prev,
-    typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
-        material_state_variables,
+    typename MechanicsBase<DisplacementDim>::
+        MaterialStateVariables const& /*material_state_variables*/,
     double const T) const
 {
     KelvinMatrix C = getElasticTensor(t, x, T);
@@ -33,11 +33,8 @@ LinearElasticIsotropic<DisplacementDim>::integrateStress(
 
     return {std::make_tuple(
         sigma,
-        std::unique_ptr<
-            typename MechanicsBase<DisplacementDim>::MaterialStateVariables>{
-            new MaterialStateVariables{
-                static_cast<MaterialStateVariables const&>(
-                    material_state_variables)}},
+        std::make_unique<
+            typename MechanicsBase<DisplacementDim>::MaterialStateVariables>(),
         C)};
 }
 

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.h
@@ -63,14 +63,6 @@ public:
         : public MechanicsBase<DisplacementDim>::MaterialStateVariables
     {
         void pushBackState() override {}
-        MaterialStateVariables& operator=(MaterialStateVariables const&) =
-            default;
-        typename MechanicsBase<DisplacementDim>::MaterialStateVariables&
-        operator=(typename MechanicsBase<DisplacementDim>::
-                      MaterialStateVariables const& state) noexcept override
-        {
-            return operator=(static_cast<MaterialStateVariables const&>(state));
-        }
     };
 
     std::unique_ptr<

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.h
@@ -64,15 +64,6 @@ public:
     {
     };
 
-    std::unique_ptr<
-        typename MechanicsBase<DisplacementDim>::MaterialStateVariables>
-    createMaterialStateVariables() const override
-    {
-        return std::unique_ptr<
-            typename MechanicsBase<DisplacementDim>::MaterialStateVariables>{
-            new MaterialStateVariables};
-    }
-
 public:
     static int const KelvinVectorSize =
         MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.h
@@ -62,7 +62,6 @@ public:
     struct MaterialStateVariables
         : public MechanicsBase<DisplacementDim>::MaterialStateVariables
     {
-        void pushBackState() override {}
     };
 
     std::unique_ptr<

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.h
@@ -59,11 +59,6 @@ public:
         P const& _poissons_ratio;
     };
 
-    struct MaterialStateVariables
-        : public MechanicsBase<DisplacementDim>::MaterialStateVariables
-    {
-    };
-
 public:
     static int const KelvinVectorSize =
         MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
@@ -90,10 +85,11 @@ public:
         return eps.dot(sigma) / 2;
     }
 
-    boost::optional<std::tuple<KelvinVector,
-                               std::unique_ptr<typename MechanicsBase<
-                                   DisplacementDim>::MaterialStateVariables>,
-                               KelvinMatrix>>
+    boost::optional<
+        std::tuple<typename MechanicsBase<DisplacementDim>::KelvinVector,
+                   std::unique_ptr<typename MechanicsBase<
+                       DisplacementDim>::MaterialStateVariables>,
+                   typename MechanicsBase<DisplacementDim>::KelvinMatrix>>
     integrateStress(
         double const t, ParameterLib::SpatialPosition const& x,
         double const /*dt*/, KelvinVector const& eps_prev,

--- a/MaterialLib/SolidModels/LinearElasticOrthotropic.cpp
+++ b/MaterialLib/SolidModels/LinearElasticOrthotropic.cpp
@@ -17,17 +17,17 @@ namespace MaterialLib
 namespace Solids
 {
 template <int DisplacementDim>
-boost::optional<std::tuple<
-    typename LinearElasticOrthotropic<DisplacementDim>::KelvinVector,
-    std::unique_ptr<
-        typename MechanicsBase<DisplacementDim>::MaterialStateVariables>,
-    typename LinearElasticOrthotropic<DisplacementDim>::KelvinMatrix>>
+boost::optional<
+    std::tuple<typename MechanicsBase<DisplacementDim>::KelvinVector,
+               std::unique_ptr<typename MechanicsBase<
+                   DisplacementDim>::MaterialStateVariables>,
+               typename MechanicsBase<DisplacementDim>::KelvinMatrix>>
 LinearElasticOrthotropic<DisplacementDim>::integrateStress(
     double const t, ParameterLib::SpatialPosition const& x, double const /*dt*/,
     KelvinVector const& eps_prev, KelvinVector const& eps,
     KelvinVector const& sigma_prev,
-    typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
-        material_state_variables,
+    typename MechanicsBase<DisplacementDim>::
+        MaterialStateVariables const& /* material_state_variables */,
     double const T) const
 {
     KelvinMatrix C = getElasticTensor(t, x, T);
@@ -36,11 +36,8 @@ LinearElasticOrthotropic<DisplacementDim>::integrateStress(
 
     return {std::make_tuple(
         sigma,
-        std::unique_ptr<
-            typename MechanicsBase<DisplacementDim>::MaterialStateVariables>{
-            new MaterialStateVariables{
-                static_cast<MaterialStateVariables const&>(
-                    material_state_variables)}},
+        std::make_unique<
+            typename MechanicsBase<DisplacementDim>::MaterialStateVariables>(),
         C)};
 }
 

--- a/MaterialLib/SolidModels/LinearElasticOrthotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticOrthotropic.h
@@ -127,14 +127,6 @@ public:
         : public MechanicsBase<DisplacementDim>::MaterialStateVariables
     {
         void pushBackState() override {}
-        MaterialStateVariables& operator=(MaterialStateVariables const&) =
-            default;
-        typename MechanicsBase<DisplacementDim>::MaterialStateVariables&
-        operator=(typename MechanicsBase<DisplacementDim>::
-                      MaterialStateVariables const& state) noexcept override
-        {
-            return operator=(static_cast<MaterialStateVariables const&>(state));
-        }
     };
 
     std::unique_ptr<

--- a/MaterialLib/SolidModels/LinearElasticOrthotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticOrthotropic.h
@@ -126,7 +126,6 @@ public:
     struct MaterialStateVariables
         : public MechanicsBase<DisplacementDim>::MaterialStateVariables
     {
-        void pushBackState() override {}
     };
 
     std::unique_ptr<

--- a/MaterialLib/SolidModels/LinearElasticOrthotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticOrthotropic.h
@@ -128,15 +128,6 @@ public:
     {
     };
 
-    std::unique_ptr<
-        typename MechanicsBase<DisplacementDim>::MaterialStateVariables>
-    createMaterialStateVariables() const override
-    {
-        return std::unique_ptr<
-            typename MechanicsBase<DisplacementDim>::MaterialStateVariables>{
-            new MaterialStateVariables};
-    }
-
 public:
     static int const KelvinVectorSize =
         MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;

--- a/MaterialLib/SolidModels/LinearElasticOrthotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticOrthotropic.h
@@ -123,11 +123,6 @@ public:
         P const& poissons_ratios;  // Stored as nu_12, nu_23, nu_13
     };
 
-    struct MaterialStateVariables
-        : public MechanicsBase<DisplacementDim>::MaterialStateVariables
-    {
-    };
-
 public:
     static int const KelvinVectorSize =
         MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
@@ -158,10 +153,11 @@ public:
         return eps.dot(sigma) / 2;
     }
 
-    boost::optional<std::tuple<KelvinVector,
-                               std::unique_ptr<typename MechanicsBase<
-                                   DisplacementDim>::MaterialStateVariables>,
-                               KelvinMatrix>>
+    boost::optional<
+        std::tuple<typename MechanicsBase<DisplacementDim>::KelvinVector,
+                   std::unique_ptr<typename MechanicsBase<
+                       DisplacementDim>::MaterialStateVariables>,
+                   typename MechanicsBase<DisplacementDim>::KelvinMatrix>>
     integrateStress(
         double const t, ParameterLib::SpatialPosition const& x,
         double const /*dt*/, KelvinVector const& eps_prev,

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -118,15 +118,6 @@ public:
             eps_M_j.setZero(KelvinVectorSize);
         }
 
-        MaterialStateVariables& operator=(MaterialStateVariables const&) =
-            default;
-        MaterialStateVariables& operator=(
-            typename MechanicsBase<DisplacementDim>::
-                MaterialStateVariables const& state) noexcept override
-        {
-            return operator=(static_cast<MaterialStateVariables const&>(state));
-        }
-
         void setInitialConditions()
         {
             eps_K_j = eps_K_t;

--- a/MaterialLib/SolidModels/MechanicsBase.h
+++ b/MaterialLib/SolidModels/MechanicsBase.h
@@ -57,9 +57,6 @@ struct MechanicsBase
     struct MaterialStateVariables
     {
         virtual ~MaterialStateVariables() = default;
-        virtual MaterialStateVariables& operator=(
-            MaterialStateVariables const&) = default;
-
         virtual void pushBackState() = 0;
     };
 

--- a/MaterialLib/SolidModels/MechanicsBase.h
+++ b/MaterialLib/SolidModels/MechanicsBase.h
@@ -63,7 +63,10 @@ struct MechanicsBase
     /// Polymorphic creator for MaterialStateVariables objects specific for a
     /// material model.
     virtual std::unique_ptr<MaterialStateVariables>
-    createMaterialStateVariables() const = 0;
+    createMaterialStateVariables() const
+    {
+        return std::make_unique<MaterialStateVariables>();
+    }
 
     using KelvinVector =
         MathLib::KelvinVector::KelvinVectorType<DisplacementDim>;

--- a/MaterialLib/SolidModels/MechanicsBase.h
+++ b/MaterialLib/SolidModels/MechanicsBase.h
@@ -57,7 +57,7 @@ struct MechanicsBase
     struct MaterialStateVariables
     {
         virtual ~MaterialStateVariables() = default;
-        virtual void pushBackState() = 0;
+        virtual void pushBackState(){};
     };
 
     /// Polymorphic creator for MaterialStateVariables objects specific for a


### PR DESCRIPTION
Originally pointed out by cppcheck about some assignment operator not being marked with 'override', but resulted in the following refactoring.