### PR TITLE
Store process' name in Process

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -506,7 +506,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
             // several meshes. Then we have to assign the referenced mesh
             // here.
             process = ProcessLib::GroundwaterFlow::createGroundwaterFlowProcess(
-                *_mesh_vec[0], std::move(jacobian_assembler),
+                name, *_mesh_vec[0], std::move(jacobian_assembler),
                 _process_variables, _parameters, integration_order,
                 process_config, _mesh_vec, output_directory);
         }
@@ -516,7 +516,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
             if (type == "LIQUID_FLOW")
         {
             process = ProcessLib::LiquidFlow::createLiquidFlowProcess(
-                *_mesh_vec[0], std::move(jacobian_assembler),
+                name, *_mesh_vec[0], std::move(jacobian_assembler),
                 _process_variables, _parameters, integration_order,
                 process_config);
         }
@@ -526,7 +526,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
             if (type == "TES")
         {
             process = ProcessLib::TES::createTESProcess(
-                *_mesh_vec[0], std::move(jacobian_assembler),
+                name, *_mesh_vec[0], std::move(jacobian_assembler),
                 _process_variables, _parameters, integration_order,
                 process_config);
         }
@@ -536,7 +536,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
             if (type == "HEAT_CONDUCTION")
         {
             process = ProcessLib::HeatConduction::createHeatConductionProcess(
-                *_mesh_vec[0], std::move(jacobian_assembler),
+                name, *_mesh_vec[0], std::move(jacobian_assembler),
                 _process_variables, _parameters, integration_order,
                 process_config);
         }
@@ -554,7 +554,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
 
             process =
                 ProcessLib::HeatTransportBHE::createHeatTransportBHEProcess(
-                    *_mesh_vec[0], std::move(jacobian_assembler),
+                    name, *_mesh_vec[0], std::move(jacobian_assembler),
                     _process_variables, _parameters, integration_order,
                     process_config, _curves);
         }
@@ -569,7 +569,8 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 2:
                     process =
                         ProcessLib::HydroMechanics::createHydroMechanicsProcess<
-                            2>(*_mesh_vec[0], std::move(jacobian_assembler),
+                            2>(name, *_mesh_vec[0],
+                               std::move(jacobian_assembler),
                                _process_variables, _parameters,
                                _local_coordinate_system, integration_order,
                                process_config);
@@ -577,7 +578,8 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 3:
                     process =
                         ProcessLib::HydroMechanics::createHydroMechanicsProcess<
-                            3>(*_mesh_vec[0], std::move(jacobian_assembler),
+                            3>(name, *_mesh_vec[0],
+                               std::move(jacobian_assembler),
                                _process_variables, _parameters,
                                _local_coordinate_system, integration_order,
                                process_config);
@@ -599,7 +601,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 2:
                     process = ProcessLib::LIE::HydroMechanics::
                         createHydroMechanicsProcess<2>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -607,7 +609,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 3:
                     process = ProcessLib::LIE::HydroMechanics::
                         createHydroMechanicsProcess<3>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -624,7 +626,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
             if (type == "HT")
         {
             process = ProcessLib::HT::createHTProcess(
-                *_mesh_vec[0], std::move(jacobian_assembler),
+                name, *_mesh_vec[0], std::move(jacobian_assembler),
                 _process_variables, _parameters, integration_order,
                 process_config, _mesh_vec, output_directory, _media);
         }
@@ -635,7 +637,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
         {
             process =
                 ProcessLib::ComponentTransport::createComponentTransportProcess(
-                    *_mesh_vec[0], std::move(jacobian_assembler),
+                    name, *_mesh_vec[0], std::move(jacobian_assembler),
                     _process_variables, _parameters, integration_order,
                     process_config, _mesh_vec, output_directory, _media);
         }
@@ -649,7 +651,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 2:
                     process =
                         ProcessLib::PhaseField::createPhaseFieldProcess<2>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -657,7 +659,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 3:
                     process =
                         ProcessLib::PhaseField::createPhaseFieldProcess<3>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -671,7 +673,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
         {
             process = ProcessLib::RichardsComponentTransport::
                 createRichardsComponentTransportProcess(
-                    *_mesh_vec[0], std::move(jacobian_assembler),
+                    name, *_mesh_vec[0], std::move(jacobian_assembler),
                     _process_variables, _parameters, integration_order,
                     process_config);
         }
@@ -685,7 +687,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 2:
                     process = ProcessLib::SmallDeformation::
                         createSmallDeformationProcess<2>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -693,7 +695,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 3:
                     process = ProcessLib::SmallDeformation::
                         createSmallDeformationProcess<3>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -714,7 +716,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 2:
                     process = ProcessLib::SmallDeformationNonlocal::
                         createSmallDeformationNonlocalProcess<2>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -722,7 +724,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 3:
                     process = ProcessLib::SmallDeformationNonlocal::
                         createSmallDeformationNonlocalProcess<3>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -745,7 +747,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 2:
                     process = ProcessLib::LIE::SmallDeformation::
                         createSmallDeformationProcess<2>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -753,7 +755,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 3:
                     process = ProcessLib::LIE::SmallDeformation::
                         createSmallDeformationProcess<3>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -775,7 +777,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 2:
                     process = ProcessLib::ThermoHydroMechanics::
                         createThermoHydroMechanicsProcess<2>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -783,7 +785,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 3:
                     process = ProcessLib::ThermoHydroMechanics::
                         createThermoHydroMechanicsProcess<3>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -804,7 +806,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 2:
                     process = ProcessLib::ThermoMechanicalPhaseField::
                         createThermoMechanicalPhaseFieldProcess<2>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -812,7 +814,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 3:
                     process = ProcessLib::ThermoMechanicalPhaseField::
                         createThermoMechanicalPhaseFieldProcess<3>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -829,7 +831,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 2:
                     process = ProcessLib::ThermoMechanics::
                         createThermoMechanicsProcess<2>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -837,7 +839,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 3:
                     process = ProcessLib::ThermoMechanics::
                         createThermoMechanicsProcess<3>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -850,7 +852,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
             if (type == "RICHARDS_FLOW")
         {
             process = ProcessLib::RichardsFlow::createRichardsFlowProcess(
-                *_mesh_vec[0], std::move(jacobian_assembler),
+                name, *_mesh_vec[0], std::move(jacobian_assembler),
                 _process_variables, _parameters, integration_order,
                 process_config, _curves);
         }
@@ -865,7 +867,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 2:
                     process = ProcessLib::RichardsMechanics::
                         createRichardsMechanicsProcess<2>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -873,7 +875,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 case 3:
                     process = ProcessLib::RichardsMechanics::
                         createRichardsMechanicsProcess<3>(
-                            *_mesh_vec[0], std::move(jacobian_assembler),
+                            name, *_mesh_vec[0], std::move(jacobian_assembler),
                             _process_variables, _parameters,
                             _local_coordinate_system, integration_order,
                             process_config);
@@ -887,7 +889,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
         {
             process =
                 ProcessLib::TwoPhaseFlowWithPP::createTwoPhaseFlowWithPPProcess(
-                    *_mesh_vec[0], std::move(jacobian_assembler),
+                    name, *_mesh_vec[0], std::move(jacobian_assembler),
                     _process_variables, _parameters, integration_order,
                     process_config, _curves);
         }
@@ -898,7 +900,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
         {
             process = ProcessLib::TwoPhaseFlowWithPrho::
                 createTwoPhaseFlowWithPrhoProcess(
-                    *_mesh_vec[0], std::move(jacobian_assembler),
+                    name, *_mesh_vec[0], std::move(jacobian_assembler),
                     _process_variables, _parameters, integration_order,
                     process_config, _curves);
         }
@@ -909,7 +911,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
         {
             process = ProcessLib::ThermalTwoPhaseFlowWithPP::
                 createThermalTwoPhaseFlowWithPPProcess(
-                    *_mesh_vec[0], std::move(jacobian_assembler),
+                    name, *_mesh_vec[0], std::move(jacobian_assembler),
                     _process_variables, _parameters, integration_order,
                     process_config, _curves);
         }

--- a/Applications/ApplicationsLib/ProjectData.h
+++ b/Applications/ApplicationsLib/ProjectData.h
@@ -72,8 +72,8 @@ public:
     //
 
     /// Provides read access to the process container.
-    std::map<std::string, std::unique_ptr<ProcessLib::Process>> const&
-    getProcesses() const
+    std::vector<std::unique_ptr<ProcessLib::Process>> const& getProcesses()
+        const
     {
         return _processes;
     }
@@ -118,7 +118,7 @@ private:
 
     std::unique_ptr<MaterialPropertyLib::Medium> _medium;
     std::vector<std::unique_ptr<MeshLib::Mesh>> _mesh_vec;
-    std::map<std::string, std::unique_ptr<ProcessLib::Process>> _processes;
+    std::vector<std::unique_ptr<ProcessLib::Process>> _processes;
     std::vector<ProcessLib::ProcessVariable> _process_variables;
 
     /// Buffer for each parameter config passed to the process.

--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -220,7 +220,7 @@ int main(int argc, char* argv[])
             INFO("Initialize processes.");
             for (auto& p : project.getProcesses())
             {
-                p.second->initialize();
+                p->initialize();
             }
 
             // Check intermediately that config parsing went fine.

--- a/BaseLib/Algorithm.h
+++ b/BaseLib/Algorithm.h
@@ -171,6 +171,24 @@ typename Map::mapped_type const& getOrError(Map const& map, Key const& key,
     return it->second;
 }
 
+//! Returns the value of from the given \c container if such an entry fulfilling
+//! the \c predicate exists;
+//! otherwise an \c error_message is printed and the program is aborted.
+template <typename Container, typename Predicate>
+typename Container::value_type const& getIfOrError(
+    Container const& container,
+    Predicate&& predicate,
+    std::string const& error_message)
+{
+    auto it = std::find_if(begin(container), end(container), predicate);
+    if (it == end(container))
+    {
+        OGS_FATAL("Could not find element matching the predicate: %s",
+                  error_message.c_str());
+    }
+    return *it;
+}
+
 /// Make the entries of the std::vector \c v unique. The remaining entries will
 /// be sorted.
 template <typename T>

--- a/BaseLib/Algorithm.h
+++ b/BaseLib/Algorithm.h
@@ -228,6 +228,13 @@ bool contains(Container const& container,
            container.end();
 }
 
+template <typename Container, typename Predicate>
+bool containsIf(Container const& container, Predicate&& predicate)
+{
+    return std::find_if(container.begin(), container.end(), predicate) !=
+           container.end();
+}
+
 template <typename Container>
 boost::optional<typename Container::value_type> findFirstNotEqualElement(
     Container const& container, typename Container::value_type const& element)

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
@@ -20,6 +20,7 @@ namespace ProcessLib
 namespace ComponentTransport
 {
 ComponentTransportProcess::ComponentTransportProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -32,7 +33,7 @@ ComponentTransportProcess::ComponentTransportProcess(
     bool const use_monolithic_scheme,
     std::unique_ptr<ProcessLib::SurfaceFluxData>&& surfaceflux,
     std::vector<std::pair<int, std::string>>&& process_id_to_component_name_map)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller),
               use_monolithic_scheme),

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.h
@@ -89,6 +89,7 @@ class ComponentTransportProcess final : public Process
 {
 public:
     ComponentTransportProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
@@ -26,6 +26,7 @@ namespace ProcessLib
 namespace ComponentTransport
 {
 std::unique_ptr<Process> createComponentTransportProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -196,11 +197,11 @@ std::unique_ptr<Process> createComponentTransportProcess(
     }
 
     return std::make_unique<ComponentTransportProcess>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        use_monolithic_scheme, std::move(surfaceflux),
-        std::move(process_id_to_component_name_map));
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), use_monolithic_scheme,
+        std::move(surfaceflux), std::move(process_id_to_component_name_map));
 }
 
 }  // namespace ComponentTransport

--- a/ProcessLib/ComponentTransport/CreateComponentTransportProcess.h
+++ b/ProcessLib/ComponentTransport/CreateComponentTransportProcess.h
@@ -22,6 +22,7 @@ namespace ProcessLib
 namespace ComponentTransport
 {
 std::unique_ptr<Process> createComponentTransportProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/CreateProcessData.cpp
+++ b/ProcessLib/CreateProcessData.cpp
@@ -47,7 +47,7 @@ static std::unique_ptr<ProcessData> makeProcessData(
 
 std::vector<std::unique_ptr<ProcessData>> createPerProcessData(
     BaseLib::ConfigTree const& config,
-    const std::map<std::string, std::unique_ptr<Process>>& processes,
+    std::vector<std::unique_ptr<Process>> const& processes,
     std::map<std::string, std::unique_ptr<NumLib::NonlinearSolverBase>> const&
         nonlinear_solvers)
 {
@@ -58,8 +58,11 @@ std::vector<std::unique_ptr<ProcessData>> createPerProcessData(
     {
         //! \ogs_file_attr{prj__time_loop__processes__process__ref}
         auto const pcs_name = pcs_config.getConfigAttribute<std::string>("ref");
-        auto& pcs = *BaseLib::getOrError(
-            processes, pcs_name,
+        auto& pcs = *BaseLib::getIfOrError(
+            processes,
+            [&pcs_name](std::unique_ptr<Process> const& p) {
+                return p->name == pcs_name;
+            },
             "A process with the given name has not been defined.");
 
         auto const nl_slv_name =

--- a/ProcessLib/CreateProcessData.h
+++ b/ProcessLib/CreateProcessData.h
@@ -15,7 +15,7 @@ namespace ProcessLib
 {
 std::vector<std::unique_ptr<ProcessData>> createPerProcessData(
     BaseLib::ConfigTree const& config,
-    const std::map<std::string, std::unique_ptr<Process>>& processes,
+    std::vector<std::unique_ptr<Process>> const& processes,
     std::map<std::string, std::unique_ptr<NumLib::NonlinearSolverBase>> const&
         nonlinear_solvers);
 

--- a/ProcessLib/CreateTimeLoop.cpp
+++ b/ProcessLib/CreateTimeLoop.cpp
@@ -22,7 +22,7 @@ namespace ProcessLib
 {
 std::unique_ptr<TimeLoop> createTimeLoop(
     BaseLib::ConfigTree const& config, std::string const& output_directory,
-    const std::map<std::string, std::unique_ptr<Process>>& processes,
+    const std::vector<std::unique_ptr<Process>>& processes,
     const std::map<std::string, std::unique_ptr<NumLib::NonlinearSolverBase>>&
         nonlinear_solvers,
     std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,

--- a/ProcessLib/CreateTimeLoop.h
+++ b/ProcessLib/CreateTimeLoop.h
@@ -47,7 +47,7 @@ namespace ProcessLib
 //! Builds a TimeLoop from the given configuration.
 std::unique_ptr<TimeLoop> createTimeLoop(
     BaseLib::ConfigTree const& config, std::string const& output_directory,
-    std::map<std::string, std::unique_ptr<Process>> const& processes,
+    std::vector<std::unique_ptr<Process>> const& processes,
     std::map<std::string, std::unique_ptr<NumLib::NonlinearSolverBase>> const&
         nonlinear_solvers,
     std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,

--- a/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
@@ -22,6 +22,7 @@ namespace ProcessLib
 namespace GroundwaterFlow
 {
 std::unique_ptr<Process> createGroundwaterFlowProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -79,10 +80,10 @@ std::unique_ptr<Process> createGroundwaterFlowProcess(
     }
 
     return std::make_unique<GroundwaterFlowProcess>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        std::move(surfaceflux));
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), std::move(surfaceflux));
 }
 
 }  // namespace GroundwaterFlow

--- a/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.h
@@ -18,6 +18,7 @@ namespace ProcessLib
 namespace GroundwaterFlow
 {
 std::unique_ptr<Process> createGroundwaterFlowProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -18,6 +18,7 @@ namespace ProcessLib
 namespace GroundwaterFlow
 {
 GroundwaterFlowProcess::GroundwaterFlowProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -28,7 +29,7 @@ GroundwaterFlowProcess::GroundwaterFlowProcess(
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller,
     std::unique_ptr<ProcessLib::SurfaceFluxData>&& surfaceflux)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller)),
       _process_data(std::move(process_data)),

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -26,6 +26,7 @@ class GroundwaterFlowProcess final : public Process
 {
 public:
     GroundwaterFlowProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/HT/CreateHTProcess.cpp
+++ b/ProcessLib/HT/CreateHTProcess.cpp
@@ -26,6 +26,7 @@ namespace ProcessLib
 namespace HT
 {
 std::unique_ptr<Process> createHTProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -156,11 +157,12 @@ std::unique_ptr<Process> createHTProcess(
                                          named_function_caller);
 
     return std::make_unique<HTProcess>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(material_properties),
-        std::move(secondary_variables), std::move(named_function_caller),
-        use_monolithic_scheme, std::move(surfaceflux),
-        _heat_transport_process_id, _hydraulic_process_id);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(material_properties), std::move(secondary_variables),
+        std::move(named_function_caller), use_monolithic_scheme,
+        std::move(surfaceflux), _heat_transport_process_id,
+        _hydraulic_process_id);
 }
 
 }  // namespace HT

--- a/ProcessLib/HT/CreateHTProcess.h
+++ b/ProcessLib/HT/CreateHTProcess.h
@@ -23,6 +23,7 @@ namespace ProcessLib
 namespace HT
 {
 std::unique_ptr<Process> createHTProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -25,6 +25,7 @@ namespace ProcessLib
 namespace HT
 {
 HTProcess::HTProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -38,7 +39,7 @@ HTProcess::HTProcess(
     std::unique_ptr<ProcessLib::SurfaceFluxData>&& surfaceflux,
     const int heat_transport_process_id,
     const int hydraulic_process_id)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller),
               use_monolithic_scheme),

--- a/ProcessLib/HT/HTProcess.h
+++ b/ProcessLib/HT/HTProcess.h
@@ -50,6 +50,7 @@ class HTProcess final : public Process
 {
 public:
     HTProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/HeatConduction/CreateHeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/CreateHeatConductionProcess.cpp
@@ -20,6 +20,7 @@ namespace ProcessLib
 namespace HeatConduction
 {
 std::unique_ptr<Process> createHeatConductionProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -82,9 +83,10 @@ std::unique_ptr<Process> createHeatConductionProcess(
                                          named_function_caller);
 
     return std::make_unique<HeatConductionProcess>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller));
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller));
 }
 
 }  // namespace HeatConduction

--- a/ProcessLib/HeatConduction/CreateHeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/CreateHeatConductionProcess.h
@@ -17,6 +17,7 @@ namespace ProcessLib
 namespace HeatConduction
 {
 std::unique_ptr<Process> createHeatConductionProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -18,6 +18,7 @@ namespace ProcessLib
 namespace HeatConduction
 {
 HeatConductionProcess::HeatConductionProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -27,7 +28,7 @@ HeatConductionProcess::HeatConductionProcess(
     HeatConductionProcessData&& process_data,
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller)),
       _process_data(std::move(process_data))

--- a/ProcessLib/HeatConduction/HeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.h
@@ -22,6 +22,7 @@ class HeatConductionProcess final : public Process
 
 public:
     HeatConductionProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.cpp
+++ b/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.cpp
@@ -25,6 +25,7 @@ namespace ProcessLib
 namespace HeatTransportBHE
 {
 std::unique_ptr<Process> createHeatTransportBHEProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -225,9 +226,10 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
                                          named_function_caller);
 
     return std::make_unique<HeatTransportBHEProcess>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller));
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller));
 }
 }  // namespace HeatTransportBHE
 }  // namespace ProcessLib

--- a/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.h
+++ b/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.h
@@ -17,6 +17,7 @@ namespace ProcessLib
 namespace HeatTransportBHE
 {
 std::unique_ptr<Process> createHeatTransportBHEProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
@@ -24,6 +24,7 @@ namespace ProcessLib
 namespace HeatTransportBHE
 {
 HeatTransportBHEProcess::HeatTransportBHEProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -33,7 +34,7 @@ HeatTransportBHEProcess::HeatTransportBHEProcess(
     HeatTransportBHEProcessData&& process_data,
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller)),
       _process_data(std::move(process_data)),

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
@@ -24,6 +24,7 @@ class HeatTransportBHEProcess final : public Process
 {
 public:
     HeatTransportBHEProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.cpp
@@ -26,6 +26,7 @@ namespace HydroMechanics
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createHydroMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -204,13 +205,14 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
                                          named_function_caller);
 
     return std::make_unique<HydroMechanicsProcess<DisplacementDim>>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        use_monolithic_scheme);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), use_monolithic_scheme);
 }
 
 template std::unique_ptr<Process> createHydroMechanicsProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -221,6 +223,7 @@ template std::unique_ptr<Process> createHydroMechanicsProcess<2>(
     BaseLib::ConfigTree const& config);
 
 template std::unique_ptr<Process> createHydroMechanicsProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.h
@@ -39,6 +39,7 @@ namespace HydroMechanics
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createHydroMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -49,6 +50,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     BaseLib::ConfigTree const& config);
 
 extern template std::unique_ptr<Process> createHydroMechanicsProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -59,6 +61,7 @@ extern template std::unique_ptr<Process> createHydroMechanicsProcess<2>(
     BaseLib::ConfigTree const& config);
 
 extern template std::unique_ptr<Process> createHydroMechanicsProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
@@ -25,6 +25,7 @@ namespace HydroMechanics
 {
 template <int DisplacementDim>
 HydroMechanicsProcess<DisplacementDim>::HydroMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -35,7 +36,7 @@ HydroMechanicsProcess<DisplacementDim>::HydroMechanicsProcess(
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller,
     bool const use_monolithic_scheme)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller),
               use_monolithic_scheme),

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -17,8 +17,6 @@ namespace ProcessLib
 {
 namespace HydroMechanics
 {
-struct LocalAssemblerInterface;
-
 /// Linear kinematics poro-mechanical/biphasic (fluid-solid mixture) model.
 ///
 /// The mixture momentum balance and the mixture mass balance are solved under

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -28,6 +28,7 @@ class HydroMechanicsProcess final : public Process
 {
 public:
     HydroMechanicsProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/LIE/HydroMechanics/CreateHydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/CreateHydroMechanicsProcess.cpp
@@ -29,6 +29,7 @@ namespace HydroMechanics
 {
 template <unsigned GlobalDim>
 std::unique_ptr<Process> createHydroMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -344,13 +345,14 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
                                          named_function_caller);
 
     return std::make_unique<HydroMechanicsProcess<GlobalDim>>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        use_monolithic_scheme);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), use_monolithic_scheme);
 }
 
 template std::unique_ptr<Process> createHydroMechanicsProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -360,6 +362,7 @@ template std::unique_ptr<Process> createHydroMechanicsProcess<2>(
     unsigned const integration_order,
     BaseLib::ConfigTree const& config);
 template std::unique_ptr<Process> createHydroMechanicsProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/LIE/HydroMechanics/CreateHydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/CreateHydroMechanicsProcess.h
@@ -41,6 +41,7 @@ namespace HydroMechanics
 {
 template <unsigned GlobalDim>
 std::unique_ptr<Process> createHydroMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -37,6 +37,7 @@ namespace HydroMechanics
 {
 template <int GlobalDim>
 HydroMechanicsProcess<GlobalDim>::HydroMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -47,7 +48,7 @@ HydroMechanicsProcess<GlobalDim>::HydroMechanicsProcess(
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller,
     bool const use_monolithic_scheme)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller),
               use_monolithic_scheme),

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
@@ -31,6 +31,7 @@ class HydroMechanicsProcess final : public Process
 
 public:
     HydroMechanicsProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/LIE/SmallDeformation/CreateSmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/CreateSmallDeformationProcess.cpp
@@ -29,6 +29,7 @@ namespace SmallDeformation
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createSmallDeformationProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -193,12 +194,14 @@ std::unique_ptr<Process> createSmallDeformationProcess(
                                          named_function_caller);
 
     return std::make_unique<SmallDeformationProcess<DisplacementDim>>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller));
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller));
 }
 
 template std::unique_ptr<Process> createSmallDeformationProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -209,6 +212,7 @@ template std::unique_ptr<Process> createSmallDeformationProcess<2>(
     BaseLib::ConfigTree const& config);
 
 template std::unique_ptr<Process> createSmallDeformationProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/LIE/SmallDeformation/CreateSmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/CreateSmallDeformationProcess.h
@@ -41,6 +41,7 @@ namespace SmallDeformation
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createSmallDeformationProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -30,6 +30,7 @@ namespace SmallDeformation
 {
 template <int DisplacementDim>
 SmallDeformationProcess<DisplacementDim>::SmallDeformationProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -39,7 +40,7 @@ SmallDeformationProcess<DisplacementDim>::SmallDeformationProcess(
     SmallDeformationProcessData<DisplacementDim>&& process_data,
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller)),
       _process_data(std::move(process_data))

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
@@ -28,6 +28,7 @@ class SmallDeformationProcess final : public Process
 
 public:
     SmallDeformationProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.cpp
@@ -26,6 +26,7 @@ namespace ProcessLib
 namespace LiquidFlow
 {
 std::unique_ptr<Process> createLiquidFlowProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -101,11 +102,11 @@ std::unique_ptr<Process> createLiquidFlowProcess(
         INFO("The liquid flow is in homogeneous porous media.");
     }
 
-    return std::unique_ptr<Process>{new LiquidFlowProcess{
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(secondary_variables),
-        std::move(named_function_caller), material_ids, gravity_axis_id, g,
-        reference_temperature, mat_config}};
+    return std::make_unique<LiquidFlowProcess>(
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(secondary_variables), std::move(named_function_caller),
+        material_ids, gravity_axis_id, g, reference_temperature, mat_config);
 }
 
 }  // namespace LiquidFlow

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.h
@@ -20,6 +20,7 @@ namespace ProcessLib
 namespace LiquidFlow
 {
 std::unique_ptr<Process> createLiquidFlowProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -31,6 +31,7 @@ namespace ProcessLib
 namespace LiquidFlow
 {
 LiquidFlowProcess::LiquidFlowProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -44,7 +45,7 @@ LiquidFlowProcess::LiquidFlowProcess(
     double const gravitational_acceleration,
     double const reference_temperature,
     BaseLib::ConfigTree const& config)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller)),
       _gravitational_axis_id(gravitational_axis_id),

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -58,6 +58,7 @@ class LiquidFlowProcess final : public Process
 {
 public:
     LiquidFlowProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
         std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const&

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -14,10 +14,12 @@
 
 #include <memory>
 
+#include "MaterialLib/Fluid/FluidProperties/FluidProperties.h"
 #include "NumLib/DOF/LocalToGlobalIndexMap.h"
 #include "ProcessLib/Process.h"
 
-#include "MaterialLib/Fluid/FluidProperties/FluidProperties.h"
+#include "LiquidFlowLocalAssembler.h"
+#include "LiquidFlowMaterialProperties.h"
 
 namespace MeshLib
 {
@@ -31,9 +33,6 @@ namespace ProcessLib
 {
 namespace LiquidFlow
 {
-class LiquidFlowLocalAssemblerInterface;
-class LiquidFlowMaterialProperties;
-
 /**
  * \brief A class to simulate the liquid flow process in porous media described
  * by

--- a/ProcessLib/PhaseField/CreatePhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/CreatePhaseFieldProcess.cpp
@@ -26,6 +26,7 @@ namespace PhaseField
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createPhaseFieldProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -204,13 +205,14 @@ std::unique_ptr<Process> createPhaseFieldProcess(
                                          named_function_caller);
 
     return std::make_unique<PhaseFieldProcess<DisplacementDim>>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        use_monolithic_scheme);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), use_monolithic_scheme);
 }
 
 template std::unique_ptr<Process> createPhaseFieldProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -221,6 +223,7 @@ template std::unique_ptr<Process> createPhaseFieldProcess<2>(
     BaseLib::ConfigTree const& config);
 
 template std::unique_ptr<Process> createPhaseFieldProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/PhaseField/CreatePhaseFieldProcess.h
+++ b/ProcessLib/PhaseField/CreatePhaseFieldProcess.h
@@ -39,6 +39,7 @@ namespace PhaseField
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createPhaseFieldProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -49,6 +50,7 @@ std::unique_ptr<Process> createPhaseFieldProcess(
     BaseLib::ConfigTree const& config);
 
 extern template std::unique_ptr<Process> createPhaseFieldProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -59,6 +61,7 @@ extern template std::unique_ptr<Process> createPhaseFieldProcess<2>(
     BaseLib::ConfigTree const& config);
 
 extern template std::unique_ptr<Process> createPhaseFieldProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/PhaseField/PhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.cpp
@@ -26,6 +26,7 @@ namespace PhaseField
 {
 template <int DisplacementDim>
 PhaseFieldProcess<DisplacementDim>::PhaseFieldProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -36,7 +37,7 @@ PhaseFieldProcess<DisplacementDim>::PhaseFieldProcess(
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller,
     bool const use_monolithic_scheme)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller),
               use_monolithic_scheme),

--- a/ProcessLib/PhaseField/PhaseFieldProcess.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.h
@@ -49,6 +49,7 @@ class PhaseFieldProcess final : public Process
 {
 public:
     PhaseFieldProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -22,6 +22,7 @@
 namespace ProcessLib
 {
 Process::Process(
+    std::string name_,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -31,7 +32,8 @@ Process::Process(
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller,
     const bool use_monolithic_scheme)
-    : _mesh(mesh),
+    : name(std::move(name_)),
+      _mesh(mesh),
       _secondary_variables(std::move(secondary_variables)),
       _named_function_caller(std::move(named_function_caller)),
       _global_assembler(std::move(jacobian_assembler)),

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -45,7 +45,8 @@ public:
     using NonlinearSolver = NumLib::NonlinearSolverBase;
     using TimeDiscretization = NumLib::TimeDiscretization;
 
-    Process(MeshLib::Mesh& mesh,
+    Process(std::string name_,
+            MeshLib::Mesh& mesh,
             std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
             std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const&
                 parameters,

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -258,6 +258,9 @@ private:
     /// DOF-table.
     void computeSparsityPattern();
 
+public:
+    std::string const name;
+
 protected:
     MeshLib::Mesh& _mesh;
     std::unique_ptr<MeshLib::MeshSubset const> _mesh_subset_all_nodes;

--- a/ProcessLib/ProcessData.h
+++ b/ProcessLib/ProcessData.h
@@ -15,11 +15,7 @@
 #include "NumLib/TimeStepping/Algorithms/TimeStepAlgorithm.h"
 
 #include "CoupledSolutionsForStaggeredScheme.h"
-
-namespace ProcessLib
-{
-class Process;
-}
+#include "Process.h"
 
 namespace ProcessLib
 {

--- a/ProcessLib/RichardsComponentTransport/CreateRichardsComponentTransportProcess.cpp
+++ b/ProcessLib/RichardsComponentTransport/CreateRichardsComponentTransportProcess.cpp
@@ -24,6 +24,7 @@ namespace ProcessLib
 namespace RichardsComponentTransport
 {
 std::unique_ptr<Process> createRichardsComponentTransportProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -171,10 +172,10 @@ std::unique_ptr<Process> createRichardsComponentTransportProcess(
                                          named_function_caller);
 
     return std::make_unique<RichardsComponentTransportProcess>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        use_monolithic_scheme);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), use_monolithic_scheme);
 }
 
 }  // namespace RichardsComponentTransport

--- a/ProcessLib/RichardsComponentTransport/CreateRichardsComponentTransportProcess.h
+++ b/ProcessLib/RichardsComponentTransport/CreateRichardsComponentTransportProcess.h
@@ -17,6 +17,7 @@ namespace ProcessLib
 namespace RichardsComponentTransport
 {
 std::unique_ptr<Process> createRichardsComponentTransportProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
@@ -18,6 +18,7 @@ namespace ProcessLib
 namespace RichardsComponentTransport
 {
 RichardsComponentTransportProcess::RichardsComponentTransportProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -28,7 +29,7 @@ RichardsComponentTransportProcess::RichardsComponentTransportProcess(
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller,
     bool const use_monolithic_scheme)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller),
               use_monolithic_scheme),

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.h
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.h
@@ -102,6 +102,7 @@ class RichardsComponentTransportProcess final : public Process
 {
 public:
     RichardsComponentTransportProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/RichardsFlow/CreateRichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/CreateRichardsFlowProcess.cpp
@@ -23,6 +23,7 @@ namespace ProcessLib
 namespace RichardsFlow
 {
 std::unique_ptr<Process> createRichardsFlowProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -100,10 +101,10 @@ std::unique_ptr<Process> createRichardsFlowProcess(
                                          mass_lumping, temperature};
 
     return std::make_unique<RichardsFlowProcess>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        mat_config, curves);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), mat_config, curves);
 }
 
 }  // namespace RichardsFlow

--- a/ProcessLib/RichardsFlow/CreateRichardsFlowProcess.h
+++ b/ProcessLib/RichardsFlow/CreateRichardsFlowProcess.h
@@ -17,6 +17,7 @@ namespace ProcessLib
 namespace RichardsFlow
 {
 std::unique_ptr<Process> createRichardsFlowProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
@@ -18,6 +18,7 @@ namespace ProcessLib
 namespace RichardsFlow
 {
 RichardsFlowProcess::RichardsFlowProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -31,7 +32,7 @@ RichardsFlowProcess::RichardsFlowProcess(
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
     /*curves*/)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller)),
       _process_data(std::move(process_data))

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.h
@@ -23,6 +23,7 @@ class RichardsFlowProcess final : public Process
 {
 public:
     RichardsFlowProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/RichardsMechanics/CreateRichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/CreateRichardsMechanicsProcess.cpp
@@ -27,6 +27,7 @@ namespace RichardsMechanics
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createRichardsMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -207,13 +208,14 @@ std::unique_ptr<Process> createRichardsMechanicsProcess(
                                          named_function_caller);
 
     return std::make_unique<RichardsMechanicsProcess<DisplacementDim>>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        use_monolithic_scheme);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), use_monolithic_scheme);
 }
 
 template std::unique_ptr<Process> createRichardsMechanicsProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -224,6 +226,7 @@ template std::unique_ptr<Process> createRichardsMechanicsProcess<2>(
     BaseLib::ConfigTree const& config);
 
 template std::unique_ptr<Process> createRichardsMechanicsProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/RichardsMechanics/CreateRichardsMechanicsProcess.h
+++ b/ProcessLib/RichardsMechanics/CreateRichardsMechanicsProcess.h
@@ -44,6 +44,7 @@ namespace RichardsMechanics
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createRichardsMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -54,6 +55,7 @@ std::unique_ptr<Process> createRichardsMechanicsProcess(
     BaseLib::ConfigTree const& config);
 
 extern template std::unique_ptr<Process> createRichardsMechanicsProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -64,6 +66,7 @@ extern template std::unique_ptr<Process> createRichardsMechanicsProcess<2>(
     BaseLib::ConfigTree const& config);
 
 extern template std::unique_ptr<Process> createRichardsMechanicsProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
@@ -25,6 +25,7 @@ namespace RichardsMechanics
 {
 template <int DisplacementDim>
 RichardsMechanicsProcess<DisplacementDim>::RichardsMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -35,7 +36,7 @@ RichardsMechanicsProcess<DisplacementDim>::RichardsMechanicsProcess(
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller,
     bool const use_monolithic_scheme)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller),
               use_monolithic_scheme),

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
@@ -28,6 +28,7 @@ class RichardsMechanicsProcess final : public Process
 {
 public:
     RichardsMechanicsProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.cpp
@@ -25,6 +25,7 @@ namespace SmallDeformation
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createSmallDeformationProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -130,12 +131,14 @@ std::unique_ptr<Process> createSmallDeformationProcess(
                                          named_function_caller);
 
     return std::make_unique<SmallDeformationProcess<DisplacementDim>>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller));
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller));
 }
 
 template std::unique_ptr<Process> createSmallDeformationProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -146,6 +149,7 @@ template std::unique_ptr<Process> createSmallDeformationProcess<2>(
     BaseLib::ConfigTree const& config);
 
 template std::unique_ptr<Process> createSmallDeformationProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.h
@@ -39,6 +39,7 @@ namespace SmallDeformation
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createSmallDeformationProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -49,6 +50,7 @@ std::unique_ptr<Process> createSmallDeformationProcess(
     BaseLib::ConfigTree const& config);
 
 extern template std::unique_ptr<Process> createSmallDeformationProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -59,6 +61,7 @@ extern template std::unique_ptr<Process> createSmallDeformationProcess<2>(
     BaseLib::ConfigTree const& config);
 
 extern template std::unique_ptr<Process> createSmallDeformationProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -24,6 +24,7 @@ namespace SmallDeformation
 {
 template <int DisplacementDim>
 SmallDeformationProcess<DisplacementDim>::SmallDeformationProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -33,7 +34,7 @@ SmallDeformationProcess<DisplacementDim>::SmallDeformationProcess(
     SmallDeformationProcessData<DisplacementDim>&& process_data,
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller)),
       _process_data(std::move(process_data))

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -57,6 +57,7 @@ class SmallDeformationProcess final : public Process
 {
 public:
     SmallDeformationProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/SmallDeformationNonlocal/CreateSmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/CreateSmallDeformationNonlocalProcess.cpp
@@ -27,6 +27,7 @@ namespace SmallDeformationNonlocal
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createSmallDeformationNonlocalProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -121,12 +122,14 @@ std::unique_ptr<Process> createSmallDeformationNonlocalProcess(
                                          named_function_caller);
 
     return std::make_unique<SmallDeformationNonlocalProcess<DisplacementDim>>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller));
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller));
 }
 
 template std::unique_ptr<Process> createSmallDeformationNonlocalProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -137,6 +140,7 @@ template std::unique_ptr<Process> createSmallDeformationNonlocalProcess<2>(
     BaseLib::ConfigTree const& config);
 
 template std::unique_ptr<Process> createSmallDeformationNonlocalProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/SmallDeformationNonlocal/CreateSmallDeformationNonlocalProcess.h
+++ b/ProcessLib/SmallDeformationNonlocal/CreateSmallDeformationNonlocalProcess.h
@@ -41,6 +41,7 @@ namespace SmallDeformationNonlocal
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createSmallDeformationNonlocalProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -52,6 +53,7 @@ std::unique_ptr<Process> createSmallDeformationNonlocalProcess(
 
 extern template std::unique_ptr<Process>
 createSmallDeformationNonlocalProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -63,6 +65,7 @@ createSmallDeformationNonlocalProcess<2>(
 
 extern template std::unique_ptr<Process>
 createSmallDeformationNonlocalProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
@@ -24,6 +24,7 @@ namespace SmallDeformationNonlocal
 template <int DisplacementDim>
 SmallDeformationNonlocalProcess<DisplacementDim>::
     SmallDeformationNonlocalProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,
@@ -35,7 +36,7 @@ SmallDeformationNonlocalProcess<DisplacementDim>::
         SmallDeformationNonlocalProcessData<DisplacementDim>&& process_data,
         SecondaryVariableCollection&& secondary_variables,
         NumLib::NamedFunctionCaller&& named_function_caller)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller)),
       _process_data(std::move(process_data))

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
@@ -30,6 +30,7 @@ class SmallDeformationNonlocalProcess final : public Process
 {
 public:
     SmallDeformationNonlocalProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/TES/CreateTESProcess.cpp
+++ b/ProcessLib/TES/CreateTESProcess.cpp
@@ -17,6 +17,7 @@ namespace ProcessLib
 namespace TES
 {
 std::unique_ptr<Process> createTESProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -54,9 +55,10 @@ std::unique_ptr<Process> createTESProcess(
                                          named_function_caller);
 
     return std::make_unique<TESProcess>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(secondary_variables),
-        std::move(named_function_caller), config);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(secondary_variables), std::move(named_function_caller),
+        config);
 }
 
 }  // namespace TES

--- a/ProcessLib/TES/CreateTESProcess.h
+++ b/ProcessLib/TES/CreateTESProcess.h
@@ -17,6 +17,7 @@ namespace ProcessLib
 namespace TES
 {
 std::unique_ptr<Process> createTESProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -17,6 +17,7 @@ namespace ProcessLib
 namespace TES
 {
 TESProcess::TESProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -26,7 +27,7 @@ TESProcess::TESProcess(
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller,
     const BaseLib::ConfigTree& config)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller))
 {

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -31,6 +31,7 @@ class TESProcess final : public Process
 {
 public:
     TESProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
         std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const&

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/CreateThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/CreateThermalTwoPhaseFlowWithPPProcess.cpp
@@ -27,6 +27,7 @@ namespace ProcessLib
 namespace ThermalTwoPhaseFlowWithPP
 {
 std::unique_ptr<Process> createThermalTwoPhaseFlowWithPPProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -138,10 +139,10 @@ std::unique_ptr<Process> createThermalTwoPhaseFlowWithPPProcess(
                                                       std::move(material)};
 
     return std::make_unique<ThermalTwoPhaseFlowWithPPProcess>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        mat_config, curves);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), mat_config, curves);
 }
 
 }  // namespace ThermalTwoPhaseFlowWithPP

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/CreateThermalTwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/CreateThermalTwoPhaseFlowWithPPProcess.h
@@ -18,6 +18,7 @@ namespace ProcessLib
 namespace ThermalTwoPhaseFlowWithPP
 {
 std::unique_ptr<Process> createThermalTwoPhaseFlowWithPPProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
@@ -25,6 +25,7 @@ namespace ProcessLib
 namespace ThermalTwoPhaseFlowWithPP
 {
 ThermalTwoPhaseFlowWithPPProcess::ThermalTwoPhaseFlowWithPPProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -38,7 +39,7 @@ ThermalTwoPhaseFlowWithPPProcess::ThermalTwoPhaseFlowWithPPProcess(
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
     /*curves*/)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller)),
       _process_data(std::move(process_data))

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
@@ -38,6 +38,7 @@ class ThermalTwoPhaseFlowWithPPProcess final : public Process
 {
 public:
     ThermalTwoPhaseFlowWithPPProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
         std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const&

--- a/ProcessLib/ThermoHydroMechanics/CreateThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/CreateThermoHydroMechanicsProcess.cpp
@@ -27,6 +27,7 @@ namespace ThermoHydroMechanics
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createThermoHydroMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -289,13 +290,14 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
                                          named_function_caller);
 
     return std::make_unique<ThermoHydroMechanicsProcess<DisplacementDim>>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        use_monolithic_scheme);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), use_monolithic_scheme);
 }
 
 template std::unique_ptr<Process> createThermoHydroMechanicsProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -306,6 +308,7 @@ template std::unique_ptr<Process> createThermoHydroMechanicsProcess<2>(
     BaseLib::ConfigTree const& config);
 
 template std::unique_ptr<Process> createThermoHydroMechanicsProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/ThermoHydroMechanics/CreateThermoHydroMechanicsProcess.h
+++ b/ProcessLib/ThermoHydroMechanics/CreateThermoHydroMechanicsProcess.h
@@ -40,6 +40,7 @@ namespace ThermoHydroMechanics
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createThermoHydroMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -50,6 +51,7 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
     BaseLib::ConfigTree const& config);
 
 extern template std::unique_ptr<Process> createThermoHydroMechanicsProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -60,6 +62,7 @@ extern template std::unique_ptr<Process> createThermoHydroMechanicsProcess<2>(
     BaseLib::ConfigTree const& config);
 
 extern template std::unique_ptr<Process> createThermoHydroMechanicsProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
@@ -26,6 +26,7 @@ namespace ThermoHydroMechanics
 {
 template <int DisplacementDim>
 ThermoHydroMechanicsProcess<DisplacementDim>::ThermoHydroMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -36,7 +37,7 @@ ThermoHydroMechanicsProcess<DisplacementDim>::ThermoHydroMechanicsProcess(
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller,
     bool const use_monolithic_scheme)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller),
               use_monolithic_scheme),

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
@@ -30,6 +30,7 @@ class ThermoHydroMechanicsProcess final : public Process
 {
 public:
     ThermoHydroMechanicsProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/ThermoMechanicalPhaseField/CreateThermoMechanicalPhaseFieldProcess.cpp
+++ b/ProcessLib/ThermoMechanicalPhaseField/CreateThermoMechanicalPhaseFieldProcess.cpp
@@ -26,6 +26,7 @@ namespace ThermoMechanicalPhaseField
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createThermoMechanicalPhaseFieldProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -238,14 +239,15 @@ std::unique_ptr<Process> createThermoMechanicalPhaseFieldProcess(
                                          named_function_caller);
 
     return std::make_unique<ThermoMechanicalPhaseFieldProcess<DisplacementDim>>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        mechanics_related_process_id, phase_field_process_id,
-        heat_conduction_process_id);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), mechanics_related_process_id,
+        phase_field_process_id, heat_conduction_process_id);
 }
 
 template std::unique_ptr<Process> createThermoMechanicalPhaseFieldProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -256,6 +258,7 @@ template std::unique_ptr<Process> createThermoMechanicalPhaseFieldProcess<2>(
     BaseLib::ConfigTree const& config);
 
 template std::unique_ptr<Process> createThermoMechanicalPhaseFieldProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/ThermoMechanicalPhaseField/CreateThermoMechanicalPhaseFieldProcess.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/CreateThermoMechanicalPhaseFieldProcess.h
@@ -39,6 +39,7 @@ namespace ThermoMechanicalPhaseField
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createThermoMechanicalPhaseFieldProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -50,6 +51,7 @@ std::unique_ptr<Process> createThermoMechanicalPhaseFieldProcess(
 
 extern template std::unique_ptr<Process>
 createThermoMechanicalPhaseFieldProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -61,6 +63,7 @@ createThermoMechanicalPhaseFieldProcess<2>(
 
 extern template std::unique_ptr<Process>
 createThermoMechanicalPhaseFieldProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess-impl.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess-impl.h
@@ -26,6 +26,7 @@ namespace ThermoMechanicalPhaseField
 template <int DisplacementDim>
 ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
     ThermoMechanicalPhaseFieldProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,
@@ -40,7 +41,7 @@ ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
         int const mechanics_related_process_id,
         int const phase_field_process_id,
         int const heat_conduction_process_id)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller),
               false),

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
@@ -54,6 +54,7 @@ class ThermoMechanicalPhaseFieldProcess final : public Process
 {
 public:
     ThermoMechanicalPhaseFieldProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/ThermoMechanics/CreateThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/CreateThermoMechanicsProcess.cpp
@@ -26,6 +26,7 @@ namespace ThermoMechanics
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createThermoMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -174,13 +175,14 @@ std::unique_ptr<Process> createThermoMechanicsProcess(
                                          named_function_caller);
 
     return std::make_unique<ThermoMechanicsProcess<DisplacementDim>>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        use_monolithic_scheme);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), use_monolithic_scheme);
 }
 
 template std::unique_ptr<Process> createThermoMechanicsProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -191,6 +193,7 @@ template std::unique_ptr<Process> createThermoMechanicsProcess<2>(
     BaseLib::ConfigTree const& config);
 
 template std::unique_ptr<Process> createThermoMechanicsProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/ThermoMechanics/CreateThermoMechanicsProcess.h
+++ b/ProcessLib/ThermoMechanics/CreateThermoMechanicsProcess.h
@@ -39,6 +39,7 @@ namespace ThermoMechanics
 {
 template <int DisplacementDim>
 std::unique_ptr<Process> createThermoMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -49,6 +50,7 @@ std::unique_ptr<Process> createThermoMechanicsProcess(
     BaseLib::ConfigTree const& config);
 
 extern template std::unique_ptr<Process> createThermoMechanicsProcess<2>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -59,6 +61,7 @@ extern template std::unique_ptr<Process> createThermoMechanicsProcess<2>(
     BaseLib::ConfigTree const& config);
 
 extern template std::unique_ptr<Process> createThermoMechanicsProcess<3>(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
@@ -23,6 +23,7 @@ namespace ThermoMechanics
 {
 template <int DisplacementDim>
 ThermoMechanicsProcess<DisplacementDim>::ThermoMechanicsProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -33,7 +34,7 @@ ThermoMechanicsProcess<DisplacementDim>::ThermoMechanicsProcess(
     SecondaryVariableCollection&& secondary_variables,
     NumLib::NamedFunctionCaller&& named_function_caller,
     bool const use_monolithic_scheme)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller),
               use_monolithic_scheme),

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
@@ -63,6 +63,7 @@ class ThermoMechanicsProcess final : public Process
 {
 public:
     ThermoMechanicsProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&&
             jacobian_assembler,

--- a/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.cpp
@@ -24,6 +24,7 @@ namespace ProcessLib
 namespace TwoPhaseFlowWithPP
 {
 std::unique_ptr<Process> createTwoPhaseFlowWithPPProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -98,10 +99,10 @@ std::unique_ptr<Process> createTwoPhaseFlowWithPPProcess(
         specific_body_force, has_gravity, mass_lumping, temperature, std::move(material)};
 
     return std::make_unique<TwoPhaseFlowWithPPProcess>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        mat_config, curves);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), mat_config, curves);
 }
 
 }  // namespace TwoPhaseFlowWithPP

--- a/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.h
@@ -17,6 +17,7 @@ namespace ProcessLib
 namespace TwoPhaseFlowWithPP
 {
 std::unique_ptr<Process> createTwoPhaseFlowWithPPProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
@@ -24,6 +24,7 @@ namespace ProcessLib
 namespace TwoPhaseFlowWithPP
 {
 TwoPhaseFlowWithPPProcess::TwoPhaseFlowWithPPProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -37,7 +38,7 @@ TwoPhaseFlowWithPPProcess::TwoPhaseFlowWithPPProcess(
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
     /*curves*/)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller)),
       _process_data(std::move(process_data))

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
@@ -36,6 +36,7 @@ class TwoPhaseFlowWithPPProcess final : public Process
 {
 public:
     TwoPhaseFlowWithPPProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
         std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const&

--- a/ProcessLib/TwoPhaseFlowWithPrho/CreateTwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/CreateTwoPhaseFlowWithPrhoProcess.cpp
@@ -24,6 +24,7 @@ namespace ProcessLib
 namespace TwoPhaseFlowWithPrho
 {
 std::unique_ptr<Process> createTwoPhaseFlowWithPrhoProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,
@@ -111,10 +112,10 @@ std::unique_ptr<Process> createTwoPhaseFlowWithPrhoProcess(
         diff_coeff_a,        temperature, std::move(material)};
 
     return std::make_unique<TwoPhaseFlowWithPrhoProcess>(
-        mesh, std::move(jacobian_assembler), parameters, integration_order,
-        std::move(process_variables), std::move(process_data),
-        std::move(secondary_variables), std::move(named_function_caller),
-        mat_config, curves);
+        std::move(name), mesh, std::move(jacobian_assembler), parameters,
+        integration_order, std::move(process_variables),
+        std::move(process_data), std::move(secondary_variables),
+        std::move(named_function_caller), mat_config, curves);
 }
 
 }  // namespace TwoPhaseFlowWithPrho

--- a/ProcessLib/TwoPhaseFlowWithPrho/CreateTwoPhaseFlowWithPrhoProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/CreateTwoPhaseFlowWithPrhoProcess.h
@@ -17,6 +17,7 @@ namespace ProcessLib
 namespace TwoPhaseFlowWithPrho
 {
 std::unique_ptr<Process> createTwoPhaseFlowWithPrhoProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<ProcessLib::AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<ProcessVariable> const& variables,

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
@@ -24,6 +24,7 @@ namespace ProcessLib
 namespace TwoPhaseFlowWithPrho
 {
 TwoPhaseFlowWithPrhoProcess::TwoPhaseFlowWithPrhoProcess(
+    std::string name,
     MeshLib::Mesh& mesh,
     std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
@@ -37,7 +38,7 @@ TwoPhaseFlowWithPrhoProcess::TwoPhaseFlowWithPrhoProcess(
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
     /*curves*/)
-    : Process(mesh, std::move(jacobian_assembler), parameters,
+    : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables), std::move(named_function_caller)),
       _process_data(std::move(process_data))

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
@@ -34,6 +34,7 @@ class TwoPhaseFlowWithPrhoProcess final : public Process
 {
 public:
     TwoPhaseFlowWithPrhoProcess(
+        std::string name,
         MeshLib::Mesh& mesh,
         std::unique_ptr<AbstractJacobianAssembler>&& jacobian_assembler,
         std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const&


### PR DESCRIPTION
This allows usage of the process name (*e.g.* for extension of the staggered scheme) w/o access to the ProjectData object.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.1)
