### PR TITLE
LIE/HM fracture permeability models; CubicLaw

### DIFF
--- a/Documentation/ProjectFile/material/fracture_properties/i_fracture_properties.md
+++ b/Documentation/ProjectFile/material/fracture_properties/i_fracture_properties.md
@@ -1,0 +1,1 @@
+Collection of fracture properties for a specific fracture given by material id.

--- a/Documentation/ProjectFile/material/fracture_properties/permeability_model/CubicLaw/c_CubicLaw.md
+++ b/Documentation/ProjectFile/material/fracture_properties/permeability_model/CubicLaw/c_CubicLaw.md
@@ -1,0 +1,3 @@
+The permeability is calculated using the mechanical aperture \f$b_m\f$:
+\f[ K(b_m) = b_m^3/12,\f]
+which is called the cubic law.

--- a/Documentation/ProjectFile/material/fracture_properties/permeability_model/i_permeability_model.md
+++ b/Documentation/ProjectFile/material/fracture_properties/permeability_model/i_permeability_model.md
@@ -1,0 +1,3 @@
+A hydraulic permeability model for the fracture. It describes the permeability
+calculation based on the current mechanical aperture, the initial aperture, and
+permeability model specific parameters.

--- a/Documentation/ProjectFile/material/fracture_properties/permeability_model/t_type.md
+++ b/Documentation/ProjectFile/material/fracture_properties/permeability_model/t_type.md
@@ -1,0 +1,1 @@
+The permeability model type.

--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/fracture_properties/permeability_model
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS_WITH_LIE/fracture_properties/permeability_model
@@ -1,0 +1,1 @@
+../../../../../material/fracture_properties/permeability_model

--- a/MaterialLib/CMakeLists.txt
+++ b/MaterialLib/CMakeLists.txt
@@ -3,6 +3,7 @@ get_source_files(SOURCES)
 append_source_files(SOURCES Adsorption)
 append_source_files(SOURCES SolidModels)
 append_source_files(SOURCES FractureModels)
+append_source_files(SOURCES FractureModels/Permeability)
 
 append_source_files(SOURCES Fluid)
 append_source_files(SOURCES Fluid/Density)

--- a/MaterialLib/FractureModels/Permeability/CreateCubicLaw.cpp
+++ b/MaterialLib/FractureModels/Permeability/CreateCubicLaw.cpp
@@ -1,0 +1,27 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "CreateCubicLaw.h"
+
+#include "BaseLib/ConfigTree.h"
+
+#include "CubicLaw.h"
+
+namespace MaterialLib::Fracture::Permeability
+{
+std::unique_ptr<Permeability> createCubicLaw(BaseLib::ConfigTree const& config)
+{
+    //! \ogs_file_param{material__fracture_properties__permeability_model__type}
+    config.checkConfigParameter("type", "CubicLaw");
+
+    //! \ogs_file_param_special{material__fracture_properties__permeability_model__CubicLaw}
+    return std::make_unique<CubicLaw>();
+}
+}  // namespace MaterialLib::Fracture::Permeability

--- a/MaterialLib/FractureModels/Permeability/CreateCubicLaw.h
+++ b/MaterialLib/FractureModels/Permeability/CreateCubicLaw.h
@@ -1,0 +1,28 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace BaseLib
+{
+class ConfigTree;
+}
+namespace MaterialLib::Fracture::Permeability
+{
+class CubicLaw;
+class Permeability;
+}  // namespace MaterialLib::Fracture::Permeability
+
+namespace MaterialLib::Fracture::Permeability
+{
+std::unique_ptr<Permeability> createCubicLaw(BaseLib::ConfigTree const& config);
+}  // namespace MaterialLib::Fracture::Permeability

--- a/MaterialLib/FractureModels/Permeability/CreatePermeabilityModel.cpp
+++ b/MaterialLib/FractureModels/Permeability/CreatePermeabilityModel.cpp
@@ -1,0 +1,33 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "CreatePermeabilityModel.h"
+
+#include "BaseLib/ConfigTree.h"
+#include "BaseLib/Error.h"
+
+#include "CreateCubicLaw.h"
+
+namespace MaterialLib::Fracture::Permeability
+{
+std::unique_ptr<Permeability> createPermeabilityModel(
+    BaseLib::ConfigTree const& config)
+{
+    auto const permeability_model_type =
+        //! \ogs_file_param{material__fracture_properties__permeability_model__type}
+        config.peekConfigParameter<std::string>("type");
+    if (permeability_model_type == "CubicLaw")
+    {
+        return MaterialLib::Fracture::Permeability::createCubicLaw(config);
+    }
+    OGS_FATAL("Unknown fracture permeability model type \"%s\".",
+              permeability_model_type.c_str());
+}
+}  // namespace MaterialLib::Fracture::Permeability

--- a/MaterialLib/FractureModels/Permeability/CreatePermeabilityModel.h
+++ b/MaterialLib/FractureModels/Permeability/CreatePermeabilityModel.h
@@ -1,0 +1,24 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include <memory>
+
+#include "Permeability.h"
+
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace MaterialLib::Fracture::Permeability
+{
+std::unique_ptr<Permeability> createPermeabilityModel(
+    BaseLib::ConfigTree const& config);
+}  // namespace MaterialLib::Fracture::Permeability

--- a/MaterialLib/FractureModels/Permeability/CubicLaw.cpp
+++ b/MaterialLib/FractureModels/Permeability/CubicLaw.cpp
@@ -1,0 +1,29 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "CubicLaw.h"
+
+namespace MaterialLib::Fracture::Permeability
+{
+double CubicLaw::permeability(PermeabilityState const* const /*state*/,
+                              double const /*aperture0*/,
+                              double const aperture_m) const
+{
+    return aperture_m * aperture_m / 12;
+}
+
+double CubicLaw::dpermeability_daperture(
+    PermeabilityState const* const /*state*/,
+    double const /*aperture0*/,
+    double const aperture_m) const
+{
+    return aperture_m / 6;
+}
+}  // namespace MaterialLib::Fracture::Permeability

--- a/MaterialLib/FractureModels/Permeability/CubicLaw.h
+++ b/MaterialLib/FractureModels/Permeability/CubicLaw.h
@@ -1,0 +1,29 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include "Permeability.h"
+
+namespace MaterialLib::Fracture::Permeability
+{
+/// Hydraulic aperture equals the mechanical aperture s.t. multiplication of the
+/// permeability by the mechanical aperture yields the cubic law.
+class CubicLaw final : public Permeability
+{
+    double permeability(PermeabilityState const* const /*state*/,
+                        double const /*aperture0*/,
+                        double const aperture_m) const override;
+
+    double dpermeability_daperture(PermeabilityState const* const /*state*/,
+                                   double const /*aperture0*/,
+                                   double const aperture_m) const override;
+};
+}  // namespace MaterialLib::Fracture::Permeability

--- a/MaterialLib/FractureModels/Permeability/Permeability.h
+++ b/MaterialLib/FractureModels/Permeability/Permeability.h
@@ -1,0 +1,43 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace MaterialLib::Fracture::Permeability
+{
+struct PermeabilityState
+{
+    virtual ~PermeabilityState() = default;
+};
+
+/**
+ * Interface for fracture permeability models.
+ */
+class Permeability
+{
+public:
+    virtual double permeability(PermeabilityState const* const state,
+                                double const aperture0,
+                                double const aperture_m) const = 0;
+
+    virtual double dpermeability_daperture(PermeabilityState const* const state,
+                                           double const aperture0,
+                                           double const aperture_m) const = 0;
+
+    virtual ~Permeability() = default;
+
+    virtual std::unique_ptr<PermeabilityState> getNewState() const
+    {
+        return nullptr;
+    }
+};
+}  // namespace MaterialLib::Fracture::Permeability

--- a/MaterialLib/PorousMedium/Permeability/Permeability.h
+++ b/MaterialLib/PorousMedium/Permeability/Permeability.h
@@ -1,12 +1,10 @@
 /**
+ * \file
  * \copyright
  * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
  *            Distributed under a Modified BSD License.
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
- *
- * \file:   Permeability.h
- *
  */
 
 #pragma once

--- a/ProcessLib/LIE/Common/FractureProperty.h
+++ b/ProcessLib/LIE/Common/FractureProperty.h
@@ -10,8 +10,9 @@
 #pragma once
 
 #include <memory>
-
 #include <Eigen/Eigen>
+
+#include "MaterialLib/FractureModels/Permeability/Permeability.h"
 
 #include "BranchProperty.h"
 #include "JunctionProperty.h"
@@ -68,6 +69,9 @@ struct FracturePropertyHM : public FractureProperty
     }
     ParameterLib::Parameter<double> const& specific_storage;
     ParameterLib::Parameter<double> const& biot_coefficient;
+
+    std::unique_ptr<MaterialLib::Fracture::Permeability::Permeability>
+        permeability_model;
 };
 
 /// configure fracture property based on a fracture element assuming

--- a/ProcessLib/LIE/HydroMechanics/CreateHydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/CreateHydroMechanicsProcess.cpp
@@ -14,6 +14,7 @@
 #include "MaterialLib/FractureModels/CreateCohesiveZoneModeI.h"
 #include "MaterialLib/FractureModels/CreateLinearElasticIsotropic.h"
 #include "MaterialLib/FractureModels/CreateMohrCoulomb.h"
+#include "MaterialLib/FractureModels/Permeability/CreatePermeabilityModel.h"
 #include "MaterialLib/SolidModels/CreateConstitutiveRelation.h"
 #include "ParameterLib/Utils.h"
 #include "ProcessLib/Output/CreateSecondaryVariables.h"
@@ -282,6 +283,13 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
                 "time-dependent.",
                 frac_prop->aperture0.name.c_str());
         }
+
+        auto permeability_model_config =
+            //! \ogs_file_param{prj__processes__process__HYDRO_MECHANICS_WITH_LIE__fracture_properties__permeability_model}
+            fracture_properties_config.getConfigSubtree("permeability_model");
+        frac_prop->permeability_model =
+            MaterialLib::Fracture::Permeability::createPermeabilityModel(
+                permeability_model_config);
     }
 
     // initial effective stress in matrix

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
@@ -115,6 +115,9 @@ HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
         ip_data.aperture0 = aperture0_node_values.dot(sm_u.N);
         ip_data.aperture = ip_data.aperture0;
 
+        ip_data.permeability_state =
+            frac_prop.permeability_model->getNewState();
+
         auto const initial_effective_stress =
             _process_data.initial_fracture_effective_stress(0, x_position);
         for (int i = 0; i < GlobalDim; i++)
@@ -252,16 +255,17 @@ void HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
             t, x_position, ip_data.aperture0, stress0, w_prev, w,
             effective_stress_prev, effective_stress, C, state);
 
-        // permeability
-        double const local_k = b_m * b_m / 12;
         auto& permeability = ip_data.permeability;
-        ip_data.permeability = local_k;
+        permeability = frac_prop.permeability_model->permeability(
+            ip_data.permeability_state.get(), ip_data.aperture0, b_m);
 
         GlobalDimMatrix const k =
             createRotatedTensor<GlobalDim>(R, permeability);
 
         // derivative of permeability respect to aperture
-        double const local_dk_db = b_m / 6.;
+        double const local_dk_db =
+            frac_prop.permeability_model->dpermeability_daperture(
+                ip_data.permeability_state.get(), ip_data.aperture0, b_m);
         GlobalDimMatrix const dk_db =
             createRotatedTensor<GlobalDim>(R, local_dk_db);
 

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/IntegrationPointDataFracture.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/IntegrationPointDataFracture.h
@@ -47,6 +47,10 @@ struct IntegrationPointDataFracture final
         GlobalDim>::MaterialStateVariables>
         material_state_variables;
 
+    std::unique_ptr<
+        typename MaterialLib::Fracture::Permeability::PermeabilityState>
+        permeability_state;
+
     Eigen::MatrixXd C;
     double integration_weight;
 

--- a/Tests/Data/LIE/HydroMechanics/TaskB.prj
+++ b/Tests/Data/LIE/HydroMechanics/TaskB.prj
@@ -41,6 +41,9 @@
                 <initial_aperture>aperture0</initial_aperture>
                 <specific_storage>S_f</specific_storage>
                 <biot_coefficient>biot_f</biot_coefficient>
+                <permeability_model>
+                    <type>CubicLaw</type>
+                </permeability_model>
             </fracture_properties>
             <secondary_variables>
             </secondary_variables>

--- a/Tests/Data/LIE/HydroMechanics/single_fracture.prj
+++ b/Tests/Data/LIE/HydroMechanics/single_fracture.prj
@@ -39,6 +39,9 @@
                 <initial_aperture>aperture0</initial_aperture>
                 <specific_storage>S_f</specific_storage>
                 <biot_coefficient>biot_f</biot_coefficient>
+                <permeability_model>
+                    <type>CubicLaw</type>
+                </permeability_model>
             </fracture_properties>
             <initial_fracture_effective_stress>fracture_effective_stress0</initial_fracture_effective_stress>
             <secondary_variables>

--- a/Tests/Data/LIE/HydroMechanics/single_fracture_3D.prj
+++ b/Tests/Data/LIE/HydroMechanics/single_fracture_3D.prj
@@ -39,6 +39,9 @@
                 <initial_aperture>aperture0</initial_aperture>
                 <specific_storage>S_f</specific_storage>
                 <biot_coefficient>biot_f</biot_coefficient>
+                <permeability_model>
+                    <type>CubicLaw</type>
+                </permeability_model>
             </fracture_properties>
             <initial_fracture_effective_stress>fracture_effective_stress0</initial_fracture_effective_stress>
             <secondary_variables>

--- a/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow.prj
+++ b/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow.prj
@@ -39,6 +39,9 @@
                 <initial_aperture>aperture0</initial_aperture>
                 <specific_storage>S_f</specific_storage>
                 <biot_coefficient>biot_f</biot_coefficient>
+                <permeability_model>
+                    <type>CubicLaw</type>
+                </permeability_model>
             </fracture_properties>
             <initial_fracture_effective_stress>fracture_effective_stress0</initial_fracture_effective_stress>
             <deactivate_matrix_in_flow>true</deactivate_matrix_in_flow>

--- a/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow_linear_aperture0.prj
+++ b/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow_linear_aperture0.prj
@@ -39,6 +39,9 @@
                 <initial_aperture>aperture0</initial_aperture>
                 <specific_storage>S_f</specific_storage>
                 <biot_coefficient>biot_f</biot_coefficient>
+                <permeability_model>
+                    <type>CubicLaw</type>
+                </permeability_model>
             </fracture_properties>
             <initial_fracture_effective_stress>fracture_effective_stress0</initial_fracture_effective_stress>
             <deactivate_matrix_in_flow>true</deactivate_matrix_in_flow>

--- a/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow_linear_aperture0_e.prj
+++ b/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow_linear_aperture0_e.prj
@@ -39,6 +39,9 @@
                 <initial_aperture>aperture0</initial_aperture>
                 <specific_storage>S_f</specific_storage>
                 <biot_coefficient>biot_f</biot_coefficient>
+                <permeability_model>
+                    <type>CubicLaw</type>
+                </permeability_model>
             </fracture_properties>
             <initial_fracture_effective_stress>fracture_effective_stress0</initial_fracture_effective_stress>
             <deactivate_matrix_in_flow>true</deactivate_matrix_in_flow>


### PR DESCRIPTION
Based on #2541.

Generalizes the permeability computation in the fracture. Adding infrastructure and the currently only used cubic law.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.1)
2. [x] Tests covering your feature were added? Project files updated, no changes to references.
3. [x] Any new feature or behavior change was documented?
