### PR TITLE
[PL/CT] Retardation Factor invoked from MPL 

### DIFF
--- a/Documentation/ProjectFile/prj/processes/process/ComponentTransport/t_retardation_factor.md
+++ b/Documentation/ProjectFile/prj/processes/process/ComponentTransport/t_retardation_factor.md
@@ -1,1 +1,0 @@
-Parameter for the specification of the retardation factor.

--- a/MaterialLib/MPL/PropertyType.h
+++ b/MaterialLib/MPL/PropertyType.h
@@ -65,6 +65,8 @@ enum PropertyType : int
     relative_permeability,
     residual_gas_saturation,
     residual_liquid_saturation,
+    /// specify retardation factor used in component transport process.
+    retardation_factor,
     saturation,
     specific_heat_capacity,
     storage,
@@ -201,6 +203,10 @@ inline PropertyType convertStringToProperty(std::string const& inString)
     {
         return PropertyType::residual_liquid_saturation;
     }
+    if (boost::iequals(inString, "retardation_factor"))
+    {
+        return PropertyType::retardation_factor;
+    }
     if (boost::iequals(inString, "saturation"))
     {
         return PropertyType::saturation;
@@ -276,6 +282,7 @@ static const std::array<std::string, PropertyType::number_of_properties>
                              "relative_permeability",
                              "residual_gas_saturation",
                              "residual_liquid_saturation",
+                             "retardation_factor",
                              "saturation",
                              "specific_heat_capacity",
                              "storage",

--- a/ProcessLib/ComponentTransport/ComponentTransportFEM.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportFEM.h
@@ -275,8 +275,8 @@ public:
                 _process_data.porous_media_properties.getPorosity(t, pos)
                     .getValue(t, pos, 0.0, C_int_pt);
 
-            auto const retardation_factor =
-                _process_data.retardation_factor(t, pos)[0];
+            auto const& retardation_factor = component.template value<double>(
+                MaterialPropertyLib::PropertyType::retardation_factor);
 
             auto const& solute_dispersivity_transverse =
                 medium.template value<double>(
@@ -567,8 +567,8 @@ public:
                 _process_data.porous_media_properties.getPorosity(t, pos)
                     .getValue(t, pos, 0.0, C_int_pt);
 
-            auto const retardation_factor =
-                _process_data.retardation_factor(t, pos)[0];
+            auto const& retardation_factor = component.template value<double>(
+                MaterialPropertyLib::PropertyType::retardation_factor);
 
             auto const& solute_dispersivity_transverse =
                 medium.template value<double>(

--- a/ProcessLib/ComponentTransport/ComponentTransportFEM.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportFEM.h
@@ -278,13 +278,14 @@ public:
             auto const& retardation_factor = component.template value<double>(
                 MaterialPropertyLib::PropertyType::retardation_factor);
 
-            auto const& solute_dispersivity_transverse =
-                medium.template value<double>(
-                    MaterialPropertyLib::transversal_dispersivity);
+            auto const& solute_dispersivity_transverse = medium.template value<
+                double>(
+                MaterialPropertyLib::PropertyType::transversal_dispersivity);
 
             auto const& solute_dispersivity_longitudinal =
                 medium.template value<double>(
-                    MaterialPropertyLib::longitudinal_dispersivity);
+                    MaterialPropertyLib::PropertyType::
+                        longitudinal_dispersivity);
 
             // Use the fluid density model to compute the density
             // TODO (renchao): concentration of which component as the argument
@@ -299,7 +300,7 @@ public:
 
             auto const& molecular_diffusion_coefficient =
                 component.template value<double>(
-                    MaterialPropertyLib::molecular_diffusion);
+                    MaterialPropertyLib::PropertyType::molecular_diffusion);
 
             auto const& K =
                 _process_data.porous_media_properties.getIntrinsicPermeability(
@@ -570,12 +571,13 @@ public:
             auto const& retardation_factor = component.template value<double>(
                 MaterialPropertyLib::PropertyType::retardation_factor);
 
-            auto const& solute_dispersivity_transverse =
-                medium.template value<double>(
-                    MaterialPropertyLib::transversal_dispersivity);
+            auto const& solute_dispersivity_transverse = medium.template value<
+                double>(
+                MaterialPropertyLib::PropertyType::transversal_dispersivity);
             auto const& solute_dispersivity_longitudinal =
                 medium.template value<double>(
-                    MaterialPropertyLib::longitudinal_dispersivity);
+                    MaterialPropertyLib::PropertyType::
+                        longitudinal_dispersivity);
 
             // Use the fluid density model to compute the density
             vars[static_cast<int>(
@@ -588,7 +590,7 @@ public:
 
             auto const& molecular_diffusion_coefficient =
                 component.template value<double>(
-                    MaterialPropertyLib::molecular_diffusion);
+                    MaterialPropertyLib::PropertyType::molecular_diffusion);
 
             auto const& K =
                 _process_data.porous_media_properties.getIntrinsicPermeability(

--- a/ProcessLib/ComponentTransport/ComponentTransportProcessData.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcessData.h
@@ -39,7 +39,6 @@ struct ComponentTransportProcessData
             fluid_properties_,
         std::unique_ptr<MaterialPropertyLib::MaterialSpatialDistributionMap>&&
             media_map_,
-        ParameterLib::Parameter<double> const& retardation_factor_,
         ParameterLib::Parameter<double> const& decay_rate_,
         Eigen::VectorXd const& specific_body_force_, bool const has_gravity_,
         bool const non_advective_form_)
@@ -47,7 +46,6 @@ struct ComponentTransportProcessData
           fluid_reference_density(fluid_reference_density_),
           fluid_properties(std::move(fluid_properties_)),
           media_map(std::move(media_map_)),
-          retardation_factor(retardation_factor_),
           decay_rate(decay_rate_),
           specific_body_force(specific_body_force_),
           has_gravity(has_gravity_),
@@ -72,7 +70,6 @@ struct ComponentTransportProcessData
     std::unique_ptr<MaterialLib::Fluid::FluidProperties> fluid_properties;
     std::unique_ptr<MaterialPropertyLib::MaterialSpatialDistributionMap>
         media_map;
-    ParameterLib::Parameter<double> const& retardation_factor;
     ParameterLib::Parameter<double> const& decay_rate;
     Eigen::VectorXd const specific_body_force;
     bool const has_gravity;

--- a/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
@@ -128,12 +128,6 @@ std::unique_ptr<Process> createComponentTransportProcess(
     DBUG("Use '%s' as fluid_reference_density parameter.",
          fluid_reference_density.name.c_str(), &mesh);
 
-    // Parameter for the retardation factor.
-    auto const& retardation_factor = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__ComponentTransport__retardation_factor}
-        "retardation_factor", parameters, 1, &mesh);
-
     // Parameter for the decay rate.
     auto const& decay_rate = ParameterLib::findParameter<double>(
         config,
@@ -172,7 +166,6 @@ std::unique_ptr<Process> createComponentTransportProcess(
         fluid_reference_density,
         std::move(fluid_properties),
         std::move(media_map),
-        retardation_factor,
         decay_rate,
         specific_body_force,
         has_gravity,

--- a/Tests/Data/Elliptic/square_100x100_ComponentTransport/square_1e4_heterogeneity.prj
+++ b/Tests/Data/Elliptic/square_100x100_ComponentTransport/square_1e4_heterogeneity.prj
@@ -38,7 +38,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -59,6 +58,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-5</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -125,11 +129,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/MassConservation/mass_conservation.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/MassConservation/mass_conservation.prj
@@ -44,7 +44,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0 0</specific_body_force>
             <secondary_variables>
@@ -65,6 +64,11 @@
                                 <name>molecular_diffusion</name>
                                 <value>1e-7</value>
                                 <type>Constant</type>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -132,11 +136,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/EquilibriumPhase/calcite.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/EquilibriumPhase/calcite.prj
@@ -43,7 +43,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -65,6 +64,11 @@
                                     <type>Constant</type>
                                     <value>0</value>
                                 </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
                             </properties>
                         </component>
                         <component>
@@ -74,6 +78,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>0</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -85,6 +94,11 @@
                                     <type>Constant</type>
                                     <value>0</value>
                                 </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
                             </properties>
                         </component>
                         <component>
@@ -95,6 +109,11 @@
                                     <type>Constant</type>
                                     <value>0</value>
                                 </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
                             </properties>
                         </component>
                         <component>
@@ -104,6 +123,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>0</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -368,11 +392,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/KineticReactant/1d_isofrac.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/KineticReactant/1d_isofrac.prj
@@ -41,7 +41,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -63,6 +62,11 @@
                                     <type>Constant</type>
                                     <value>1e-7</value>
                                 </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
                             </properties>
                         </component>
                         <component>
@@ -73,6 +77,11 @@
                                     <type>Constant</type>
                                     <value>1e-7</value>
                                 </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
                             </properties>
                         </component>
                         <component>
@@ -82,6 +91,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-7</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -289,11 +303,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/KineticReactant/1d_isofrac_flag_formula.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/KineticReactant/1d_isofrac_flag_formula.prj
@@ -41,7 +41,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -63,6 +62,11 @@
                                     <type>Constant</type>
                                     <value>1e-7</value>
                                 </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
                             </properties>
                         </component>
                         <component>
@@ -73,6 +77,11 @@
                                     <type>Constant</type>
                                     <value>1e-7</value>
                                 </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
                             </properties>
                         </component>
                         <component>
@@ -82,6 +91,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-7</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -290,11 +304,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/ConcentrationDiffusionAndStorage.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/ConcentrationDiffusionAndStorage.prj
@@ -56,7 +56,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -77,6 +76,11 @@
                                     <name>molecular_diffusion</name>
                                     <value>1</value>
                                     <type>Constant</type>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -156,11 +160,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/ConcentrationDiffusionOnly.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/ConcentrationDiffusionOnly.prj
@@ -54,7 +54,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -75,6 +74,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>0</value>
                                 </property>
                             </properties>
                         </component>
@@ -156,11 +160,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/ConcentrationDiffusionOnly_3Components.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/ConcentrationDiffusionOnly_3Components.prj
@@ -56,7 +56,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -78,6 +77,11 @@
                                     <type>Constant</type>
                                     <value>1</value>
                                 </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>0</value>
+                                </property>
                             </properties>
                         </component>
                         <component>
@@ -88,6 +92,11 @@
                                     <type>Constant</type>
                                     <value>1</value>
                                 </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>0</value>
+                                </property>
                             </properties>
                         </component>
                         <component>
@@ -97,6 +106,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>0</value>
                                 </property>
                             </properties>
                         </component>
@@ -180,11 +194,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/DiffusionAndStorageAndAdvection.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/DiffusionAndStorageAndAdvection.prj
@@ -56,7 +56,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -77,6 +76,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-5</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -175,11 +179,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/DiffusionAndStorageAndAdvectionAndDecay.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/DiffusionAndStorageAndAdvectionAndDecay.prj
@@ -56,7 +56,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -77,6 +76,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-5</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -175,11 +179,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/DiffusionAndStorageAndAdvectionAndDispersion.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/DiffusionAndStorageAndAdvectionAndDispersion.prj
@@ -56,7 +56,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -77,6 +76,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-5</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -175,11 +179,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/DiffusionAndStorageAndAdvectionAndDispersionHalf.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/DiffusionAndStorageAndAdvectionAndDispersionHalf.prj
@@ -56,7 +56,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -77,6 +76,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-5</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -175,11 +179,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/DiffusionAndStorageAndGravityAndDispersionHalf.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/DiffusionAndStorageAndGravityAndDispersionHalf.prj
@@ -56,7 +56,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 -1</specific_body_force>
             <secondary_variables>
@@ -77,6 +76,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-5</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -151,11 +155,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/open_boundary_component-transport_cube_1e3.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/open_boundary_component-transport_cube_1e3.prj
@@ -43,7 +43,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0 0</specific_body_force>
             <secondary_variables>
@@ -62,6 +61,11 @@
                             <properties>
                                 <property>
                                     <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
                                     <type>Constant</type>
                                     <value>1</value>
                                 </property>
@@ -140,11 +144,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/open_boundary_component-transport_cube_1e3_advective_form.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/open_boundary_component-transport_cube_1e3_advective_form.prj
@@ -42,7 +42,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0 0</specific_body_force>
             <secondary_variables>
@@ -61,6 +60,11 @@
                             <properties>
                                 <property>
                                     <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
                                     <type>Constant</type>
                                     <value>1</value>
                                 </property>
@@ -139,11 +143,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/surfaceflux_component-transport_cube_1e3.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/SimpleSynthetics/surfaceflux_component-transport_cube_1e3.prj
@@ -44,7 +44,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0 0</specific_body_force>
             <secondary_variables>
@@ -70,6 +69,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>0</value>
                                 </property>
                             </properties>
                         </component>
@@ -151,11 +155,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/ConcentrationDiffusionAndStorage.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/ConcentrationDiffusionAndStorage.prj
@@ -43,7 +43,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -64,6 +63,11 @@
                                     <name>molecular_diffusion</name>
                                     <value>1</value>
                                     <type>Constant</type>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -192,11 +196,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/ConcentrationDiffusionOnly.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/ConcentrationDiffusionOnly.prj
@@ -41,7 +41,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -62,6 +61,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>0</value>
                                 </property>
                             </properties>
                         </component>
@@ -179,11 +183,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/DiffusionAndStorageAndAdvection.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/DiffusionAndStorageAndAdvection.prj
@@ -43,7 +43,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -64,6 +63,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-5</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -235,11 +239,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/DiffusionAndStorageAndAdvectionAndDecay.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/DiffusionAndStorageAndAdvectionAndDecay.prj
@@ -43,7 +43,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -64,6 +63,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-5</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -235,11 +239,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/DiffusionAndStorageAndAdvectionAndDispersion.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/DiffusionAndStorageAndAdvectionAndDispersion.prj
@@ -43,7 +43,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -64,6 +63,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-5</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -235,11 +239,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/DiffusionAndStorageAndAdvectionAndDispersionHalf.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/DiffusionAndStorageAndAdvectionAndDispersionHalf.prj
@@ -43,7 +43,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -64,6 +63,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-5</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -235,11 +239,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/DiffusionAndStorageAndAdvectionAndDispersion_3Components.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/DiffusionAndStorageAndAdvectionAndDispersion_3Components.prj
@@ -45,7 +45,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -67,6 +66,11 @@
                                     <type>Constant</type>
                                     <value>1e-5</value>
                                 </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
                             </properties>
                         </component>
                         <component>
@@ -77,6 +81,11 @@
                                     <type>Constant</type>
                                     <value>1e-5</value>
                                 </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
                             </properties>
                         </component>
                         <component>
@@ -86,6 +95,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-5</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -381,11 +395,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/DiffusionAndStorageAndGravityAndDispersionHalf.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/DiffusionAndStorageAndGravityAndDispersionHalf.prj
@@ -43,7 +43,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 -1</specific_body_force>
             <secondary_variables>
@@ -64,6 +63,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-5</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -183,11 +187,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/surfaceflux_component-transport_cube_1e3.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/StaggeredScheme/surfaceflux_component-transport_cube_1e3.prj
@@ -45,7 +45,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0 0</specific_body_force>
             <secondary_variables>
@@ -71,6 +70,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>0</value>
                                 </property>
                             </properties>
                         </component>
@@ -193,11 +197,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/Theis/theis.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/Theis/theis.prj
@@ -57,7 +57,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0 -9.81</specific_body_force>
         </process>
@@ -75,6 +74,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>2e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -185,11 +189,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/TracerSimulation/TracerSimulation.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/TracerSimulation/TracerSimulation.prj
@@ -39,7 +39,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -60,6 +59,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>1e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -177,11 +181,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/VariableNeumannBoundary/vdbc_input.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/VariableNeumannBoundary/vdbc_input.prj
@@ -41,7 +41,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -62,6 +61,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>0</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -148,11 +152,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/elder/elder-python.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/elder/elder-python.prj
@@ -44,7 +44,6 @@
             </porous_medium>
             <decay_rate>decay_rate</decay_rate>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation_factor</retardation_factor>
             <specific_body_force>0 0 -9.81</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -64,6 +63,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>3.57e-6</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -135,11 +139,6 @@
             <name>decay_rate</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>retardation_factor</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>p_ini</name>

--- a/Tests/Data/Parabolic/ComponentTransport/elder/elder.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/elder/elder.prj
@@ -45,7 +45,6 @@
             </porous_medium>
             <decay_rate>decay_rate</decay_rate>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation_factor</retardation_factor>
             <specific_body_force>0 0 -9.81</specific_body_force>
             <secondary_variables>
                 <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
@@ -65,6 +64,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>3.57e-6</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -139,11 +143,6 @@
             <name>decay_rate</name>
             <type>Constant</type>
             <value>0.0</value>
-        </parameter>
-        <parameter>
-            <name>retardation_factor</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>c0</name>

--- a/Tests/Data/Parabolic/ComponentTransport/goswami/goswami_input.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/goswami/goswami_input.prj
@@ -43,7 +43,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 -9.81</specific_body_force>
             <secondary_variables>
@@ -64,6 +63,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>0</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -150,11 +154,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/heterogeneous/ogs5_H_2D/ogs5_H_2d.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/heterogeneous/ogs5_H_2D/ogs5_H_2d.prj
@@ -38,7 +38,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0</specific_body_force>
             <secondary_variables>
@@ -59,6 +58,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>2e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -125,11 +129,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>

--- a/Tests/Data/Parabolic/ComponentTransport/heterogeneous/ogs5_H_3D/ogs5_H_3d.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/heterogeneous/ogs5_H_3D/ogs5_H_3d.prj
@@ -41,7 +41,6 @@
                 </porous_medium>
             </porous_medium>
             <fluid_reference_density>rho_fluid</fluid_reference_density>
-            <retardation_factor>retardation</retardation_factor>
             <decay_rate>decay</decay_rate>
             <specific_body_force>0 0 -9.81</specific_body_force>
             <secondary_variables>
@@ -62,6 +61,11 @@
                                     <name>molecular_diffusion</name>
                                     <type>Constant</type>
                                     <value>2e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
                                 </property>
                             </properties>
                         </component>
@@ -128,11 +132,6 @@
             <name>rho_fluid</name>
             <type>Constant</type>
             <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>retardation</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>decay</name>


### PR DESCRIPTION
Previously, the retardation factor assigned in the project file was shared among the multi-component transport processes. With the committed changes, assigning component-specific retardation factor is allowed.

