### PR TITLE
Overwrite Conan build type

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -248,6 +248,7 @@ pipeline {
                 cmakeOptions =
                   "-DBUILD_SHARED_LIBS=${build_shared} " +
                   '-DOGS_CONAN_BUILD=outdated ' +
+                  '-DOGS_CONAN_BUILD_TYPE=Release ' +
                   '-DOGS_CPU_ARCHITECTURE=generic '
                 config = 'Debug'
               }

--- a/scripts/cmake/ConanSetup.cmake
+++ b/scripts/cmake/ConanSetup.cmake
@@ -27,7 +27,7 @@ include(${PROJECT_SOURCE_DIR}/scripts/cmake/conan/conan.cmake)
 set(CONAN_REQUIRES
     boost/1.66.0@conan/stable
     eigen/3.3.4@conan/stable
-    vtk/8.2.0@bilke/testing
+    vtk/8.2.0@bilke/stable
     CACHE INTERNAL ""
 )
 

--- a/scripts/cmake/ConanSetup.cmake
+++ b/scripts/cmake/ConanSetup.cmake
@@ -127,6 +127,12 @@ else()
     message(STATUS "Conan: Skipping update step.")
 endif()
 
+if(DEFINED OGS_CONAN_BUILD_TYPE)
+    set(CONAN_BUILD_TYPE ${OGS_CONAN_BUILD_TYPE})
+else()
+    set(CONAN_BUILD_TYPE ${CMAKE_BUILD_TYPE})
+endif()
+
 if(MSVC)
     set(CC_CACHE $ENV{CC})
     set(CXX_CACHE $ENV{CXX})
@@ -142,6 +148,7 @@ conan_cmake_run(
     BUILD ${OGS_CONAN_BUILD}
     IMPORTS ${CONAN_IMPORTS}
     GENERATORS virtualrunenv
+    BUILD_TYPE ${CONAN_BUILD_TYPE}
 )
 if(MSVC)
     set(ENV{CC} ${CC_CACHE}) # Restore vars


### PR DESCRIPTION
 Added CMake option `OGS_CONAN_BUILD_TYPE` to overwrite Conan build type

Can be useful to build / pull Conan release packages when building OGS in debug mode:

```bash
cmake ../ogs -DCMAKE_BUILD_TYPE=Debug -DOGS_CONAN_BUILD_TYPE=Release
```

1. [ ] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.1)
2. [x] Tests covering your feature were added?