### PR TITLE
Condensed constructDofTable() of some process classes

### DIFF
--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -235,7 +235,29 @@ private:
     }
 
 protected:
+    /** This function is for general cases, in which all equations of the
+     coupled processes have the same number of unknowns. For the general cases
+     with the staggered scheme, all equations of the coupled processes share one
+     DOF table hold by \verb{_local_to_global_index_map}. Other cases can be
+     considered by overloading this member function in the
+     derived class.
+     */
     virtual void constructDofTable();
+
+    /**
+     * Construct the DOF table for the monolithic scheme,
+     * which is stored in the
+     * member of this class, \verb{_local_to_global_index_map}.
+     */
+    void constructMonolithicProcessDofTable();
+
+    /**
+     * Construct the DOF table for a specified process in the staggered scheme,
+     * which is stored in the
+     * member of this class, \verb{_local_to_global_index_map}.
+     */
+    void constructDofTableOfSpecifiedProsessStaggerdScheme(
+        const int specified_prosess_id);
 
     /**
      * Get the address of a LocalToGlobalIndexMap, and the status of its memory.


### PR DESCRIPTION
- made constructDofTable of the base class, Process,  more general.
- replaced the repeated part in constructDofTable() of ThermoMechanicsProcess, ThermoMechanicalPhaseField and PhaseFieldProcess with the calling of Process::constructDofTable.

Note:
1. The condensed part in this PR will be further improved when the staggered scheme is refactored.
2. constructDofTable() of HydroMechanicsProcess and RichardsMechanicsProcess, which use the Talyor-Hood element, are identical and will be improved in the future in the work of unify the common part of mechanics related processes.
3. This PR contains a commit of #2581: [ThermoMechanicalPhaseFieldProcess] Removed an unnecessary file. 
  


