### PR TITLE
Split pushBackState between init and post- timestep

### DIFF
--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -155,9 +155,18 @@ public:
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions) override;
 
-    void preTimestepConcrete(std::vector<double> const& /*local_x*/,
-                             double const /*t*/,
-                             double const /*delta_t*/) override
+    void initializeConcrete() override
+    {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            _ip_data[ip].pushBackState();
+        }
+    }
+
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
@@ -245,6 +245,14 @@ void HydroMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
         MeshLib::getOrCreateMeshProperty<double>(
             const_cast<MeshLib::Mesh&>(mesh), "pressure_interpolated",
             MeshLib::MeshItemType::Node, 1);
+
+    // Initialize local assemblers after all variables have been set.
+    const int process_id = 0;
+    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
+
+    GlobalExecutor::executeSelectedMemberOnDereferenced(
+        &LocalAssemblerInterface::initialize, _local_assemblers,
+        pv.getActiveElementIDs(), *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
@@ -247,12 +247,9 @@ void HydroMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
             MeshLib::MeshItemType::Node, 1);
 
     // Initialize local assemblers after all variables have been set.
-    const int process_id = 0;
-    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
-
-    GlobalExecutor::executeSelectedMemberOnDereferenced(
+    GlobalExecutor::executeMemberOnDereferenced(
         &LocalAssemblerInterface::initialize, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map);
+        *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -91,6 +91,13 @@ void LocalAssemblerInterface::setInitialConditions(
     setInitialConditionsConcrete(local_x, t);
 }
 
+void LocalAssemblerInterface::initialize(
+    std::size_t const /*mesh_item_id*/,
+    NumLib::LocalToGlobalIndexMap const& /*dof_table*/)
+{
+    initializeConcrete();
+}
+
 void LocalAssemblerInterface::preTimestep(
     std::size_t const mesh_item_id,
     NumLib::LocalToGlobalIndexMap const& dof_table, GlobalVector const& x,

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -39,6 +39,9 @@ public:
         NumLib::LocalToGlobalIndexMap const& dof_table, GlobalVector const& x,
         double const t);
 
+    virtual void initialize(std::size_t const mesh_item_id,
+                            NumLib::LocalToGlobalIndexMap const& dof_table);
+
     virtual void preAssemble(double const /*t*/,
                              std::vector<double> const& /*local_x*/){};
 
@@ -115,6 +118,8 @@ private:
         std::vector<double> const& /*local_x*/, double const /*t*/)
     {
     }
+
+    virtual void initializeConcrete() {}
 
     virtual void preTimestepConcrete(std::vector<double> const& /*local_x*/,
                                      double const /*t*/, double const /*dt*/)

--- a/ProcessLib/PhaseField/PhaseFieldFEM.h
+++ b/ProcessLib/PhaseField/PhaseFieldFEM.h
@@ -207,9 +207,19 @@ public:
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions) override;
 
-    void preTimestepConcrete(std::vector<double> const& /*local_x*/,
-                             double const /*t*/,
-                             double const /*delta_t*/) override
+    void initializeConcrete() override
+    {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            _ip_data[ip].pushBackState();
+        }
+    }
+
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/
+                              ) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/PhaseField/PhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.cpp
@@ -142,12 +142,9 @@ void PhaseFieldProcess<DisplacementDim>::initializeConcreteProcess(
                          &LocalAssemblerInterface::getIntPtEpsilon));
 
     // Initialize local assemblers after all variables have been set.
-    const int process_id = 0;
-    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
-
-    GlobalExecutor::executeSelectedMemberOnDereferenced(
+    GlobalExecutor::executeMemberOnDereferenced(
         &LocalAssemblerInterface::initialize, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map);
+        *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/PhaseField/PhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.cpp
@@ -140,6 +140,14 @@ void PhaseFieldProcess<DisplacementDim>::initializeConcreteProcess(
                              DisplacementDim>::RowsAtCompileTime,
                          getExtrapolator(), _local_assemblers,
                          &LocalAssemblerInterface::getIntPtEpsilon));
+
+    // Initialize local assemblers after all variables have been set.
+    const int process_id = 0;
+    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
+
+    GlobalExecutor::executeSelectedMemberOnDereferenced(
+        &LocalAssemblerInterface::initialize, _local_assemblers,
+        pv.getActiveElementIDs(), *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
@@ -88,9 +88,19 @@ public:
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions) override;
 
-    void preTimestepConcrete(std::vector<double> const& /*local_x*/,
-                             double const /*t*/,
-                             double const /*delta_t*/) override
+    void initializeConcrete() override
+    {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            _ip_data[ip].pushBackState();
+        }
+    }
+
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/
+                              ) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
@@ -201,6 +201,14 @@ void RichardsMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
         MeshLib::getOrCreateMeshProperty<double>(
             const_cast<MeshLib::Mesh&>(mesh), "pressure_interpolated",
             MeshLib::MeshItemType::Node, 1);
+
+    // Initialize local assemblers after all variables have been set.
+    const int process_id = 0;
+    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
+
+    GlobalExecutor::executeSelectedMemberOnDereferenced(
+        &LocalAssemblerInterface::initialize, _local_assemblers,
+        pv.getActiveElementIDs(), *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
@@ -203,12 +203,9 @@ void RichardsMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
             MeshLib::MeshItemType::Node, 1);
 
     // Initialize local assemblers after all variables have been set.
-    const int process_id = 0;
-    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
-
-    GlobalExecutor::executeSelectedMemberOnDereferenced(
+    GlobalExecutor::executeMemberOnDereferenced(
         &LocalAssemblerInterface::initialize, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map);
+        *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -187,8 +187,6 @@ public:
             ip_data.eps_prev.resize(kelvin_vector_size);
 
             _secondary_data.N[ip] = shape_matrices[ip].N;
-
-            _ip_data[ip].pushBackState();
         }
     }
 
@@ -213,6 +211,17 @@ public:
         }
 
         return 0;
+    }
+
+    void initializeConcrete() override
+    {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            _ip_data[ip].pushBackState();
+        }
     }
 
     void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -187,6 +187,8 @@ public:
             ip_data.eps_prev.resize(kelvin_vector_size);
 
             _secondary_data.N[ip] = shape_matrices[ip].N;
+
+            _ip_data[ip].pushBackState();
         }
     }
 
@@ -309,9 +311,7 @@ public:
         }
     }
 
-    void preTimestepConcrete(std::vector<double> const& /*local_x*/,
-                             double const /*t*/,
-                             double const /*delta_t*/) override
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();
@@ -320,12 +320,6 @@ public:
         {
             _ip_data[ip].pushBackState();
         }
-    }
-
-    void postTimestepConcrete(std::vector<double> const& /*local_x*/) override
-    {
-        unsigned const n_integration_points =
-            _integration_method.getNumberOfPoints();
 
         ParameterLib::SpatialPosition x_position;
         x_position.setElementID(_element.getID());

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -233,12 +233,9 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
     }
 
     // Initialize local assemblers after all variables have been set.
-    const int process_id = 0;
-    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
-
-    GlobalExecutor::executeSelectedMemberOnDereferenced(
+    GlobalExecutor::executeMemberOnDereferenced(
         &LocalAssemblerInterface::initialize, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map);
+        *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -280,20 +280,13 @@ void SmallDeformationProcess<DisplacementDim>::
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt,
-    const int process_id)
+    GlobalVector const& /*x*/, double const t, double const dt,
+    const int /*process_id*/)
 {
     DBUG("PreTimestep SmallDeformationProcess.");
 
     _process_data.dt = dt;
     _process_data.t = t;
-
-    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
-
-    GlobalExecutor::executeSelectedMemberOnDereferenced(
-        &LocalAssemblerInterface::preTimestep, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map,
-        x, t, dt);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -231,6 +231,14 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
             position += integration_points_read * ip_meta_data.n_components;
         }
     }
+
+    // Initialize local assemblers after all variables have been set.
+    const int process_id = 0;
+    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
+
+    GlobalExecutor::executeSelectedMemberOnDereferenced(
+        &LocalAssemblerInterface::initialize, _local_assemblers,
+        pv.getActiveElementIDs(), *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
@@ -514,9 +514,18 @@ public:
         }
     }
 
-    void preTimestepConcrete(std::vector<double> const& /*local_x*/,
-                             double const /*t*/,
-                             double const /*delta_t*/) override
+    void initializeConcrete() override
+    {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            _ip_data[ip].pushBackState();
+        }
+    }
+
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
@@ -223,6 +223,14 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::
             }
         }
     }
+
+    // Initialize local assemblers after all variables have been set.
+    const int process_id = 0;
+    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
+
+    GlobalExecutor::executeSelectedMemberOnDereferenced(
+        &LocalAssemblerInterface::initialize, _local_assemblers,
+        pv.getActiveElementIDs(), *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>
@@ -291,7 +299,7 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::
 
 template <int DisplacementDim>
 void SmallDeformationNonlocalProcess<
-    DisplacementDim>::preTimestepConcreteProcess(GlobalVector const& x,
+    DisplacementDim>::preTimestepConcreteProcess(GlobalVector const& /*x*/,
                                                  double const t,
                                                  double const dt,
                                                  int const /*process_id*/)
@@ -300,13 +308,22 @@ void SmallDeformationNonlocalProcess<
 
     _process_data.dt = dt;
     _process_data.t = t;
+}
 
-    const int process_id = 0;
+template <int DisplacementDim>
+void SmallDeformationNonlocalProcess<
+    DisplacementDim>::postTimestepConcreteProcess(GlobalVector const& x,
+                                                  double const /*t*/,
+                                                  double const /*dt*/,
+                                                  int const process_id)
+{
+    DBUG("PostTimestep SmallDeformationNonlocalProcess.");
+
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     GlobalExecutor::executeSelectedMemberOnDereferenced(
-        &LocalAssemblerInterface::preTimestep, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map, x, t, dt);
+        &LocalAssemblerInterface::postTimestep, _local_assemblers,
+        pv.getActiveElementIDs(), *_local_to_global_index_map, x);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
@@ -225,12 +225,9 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::
     }
 
     // Initialize local assemblers after all variables have been set.
-    const int process_id = 0;
-    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
-
-    GlobalExecutor::executeSelectedMemberOnDereferenced(
+    GlobalExecutor::executeMemberOnDereferenced(
         &LocalAssemblerInterface::initialize, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map);
+        *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
@@ -70,6 +70,10 @@ private:
                                     double const dt,
                                     int const /*process_id*/) override;
 
+    void postTimestepConcreteProcess(GlobalVector const& x, double const t,
+                                     double const dt,
+                                     int const process_id) override;
+
     NumLib::IterationResult postIterationConcreteProcess(
         GlobalVector const& x) override;
 

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
@@ -88,9 +88,19 @@ public:
                               std::vector<double>& local_rhs_data,
                               std::vector<double>& local_Jac_data) override;
 
-    void preTimestepConcrete(std::vector<double> const& /*local_x*/,
-                             double const /*t*/,
-                             double const /*delta_t*/) override
+    void initializeConcrete() override
+    {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            _ip_data[ip].pushBackState();
+        }
+    }
+
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/
+                              ) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
@@ -204,12 +204,9 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
             MeshLib::MeshItemType::Node, 1);
 
     // Initialize local assemblers after all variables have been set.
-    const int process_id = 0;
-    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
-
-    GlobalExecutor::executeSelectedMemberOnDereferenced(
+    GlobalExecutor::executeMemberOnDereferenced(
         &LocalAssemblerInterface::initialize, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map);
+        *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
@@ -202,6 +202,14 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
         MeshLib::getOrCreateMeshProperty<double>(
             const_cast<MeshLib::Mesh&>(mesh), "temperature_interpolated",
             MeshLib::MeshItemType::Node, 1);
+
+    // Initialize local assemblers after all variables have been set.
+    const int process_id = 0;
+    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
+
+    GlobalExecutor::executeSelectedMemberOnDereferenced(
+        &LocalAssemblerInterface::initialize, _local_assemblers,
+        pv.getActiveElementIDs(), *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
@@ -220,9 +220,19 @@ public:
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions) override;
 
-    void preTimestepConcrete(std::vector<double> const& /*local_x*/,
-                             double const /*t*/,
-                             double const /*delta_t*/) override
+    void initializeConcrete() override
+    {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            _ip_data[ip].pushBackState();
+        }
+    }
+
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/
+                              ) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
@@ -161,6 +161,14 @@ void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
                          _local_assemblers,
                          &ThermoMechanicalPhaseFieldLocalAssemblerInterface::
                              getIntPtHeatFlux));
+
+    // Initialize local assemblers after all variables have been set.
+    const int process_id = 0;
+    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
+
+    GlobalExecutor::executeSelectedMemberOnDereferenced(
+        &LocalAssemblerInterface::initialize, _local_assemblers,
+        pv.getActiveElementIDs(), *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
@@ -163,12 +163,9 @@ void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
                              getIntPtHeatFlux));
 
     // Initialize local assemblers after all variables have been set.
-    const int process_id = 0;
-    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
-
-    GlobalExecutor::executeSelectedMemberOnDereferenced(
+    GlobalExecutor::executeMemberOnDereferenced(
         &LocalAssemblerInterface::initialize, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map);
+        *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
@@ -153,9 +153,18 @@ public:
                               std::vector<double>& local_rhs_data,
                               std::vector<double>& local_Jac_data) override;
 
-    void preTimestepConcrete(std::vector<double> const& /*local_x*/,
-                             double const /*t*/,
-                             double const /*delta_t*/) override
+    void initializeConcrete() override
+    {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+
+        for (unsigned ip = 0; ip < n_integration_points; ip++)
+        {
+            _ip_data[ip].pushBackState();
+        }
+    }
+
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
@@ -248,6 +248,14 @@ void ThermoMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
             position += integration_points_read * ip_meta_data.n_components;
         }
     }
+
+    // Initialize local assemblers after all variables have been set.
+    const int process_id = 0;
+    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
+
+    GlobalExecutor::executeSelectedMemberOnDereferenced(
+        &LocalAssemblerInterface::initialize, _local_assemblers,
+        pv.getActiveElementIDs(), *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
@@ -250,12 +250,9 @@ void ThermoMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
     }
 
     // Initialize local assemblers after all variables have been set.
-    const int process_id = 0;
-    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
-
-    GlobalExecutor::executeSelectedMemberOnDereferenced(
+    GlobalExecutor::executeMemberOnDereferenced(
         &LocalAssemblerInterface::initialize, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map);
+        *_local_to_global_index_map);
 }
 
 template <int DisplacementDim>


### PR DESCRIPTION
In case when a time step is repeated `preTimestep` is called again. The `pushBackState` call must be executed only after successful time step, *i.e.* in `postTimestep`. Then an additional call in the initialization is needed; therefore a new interface function in local assemblers: `initialize`.

The first `pushBackState` call must be executed after the secondary variables are set, therefore a new function is needed. If you have better ideas, w/o adding a new interface function, I'd be happy to implement those.

Didn't apply the changes to LIE.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.2)
2. [x] Tests covering your feature were added? (Covered by current ctests)
3. [ ] Any new feature or behavior change was documented? Will not do, unless explicitly asked.
