### PR TITLE
Simplify *ProcessData classes

### DIFF
--- a/ProcessLib/ComponentTransport/ComponentTransportProcessData.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcessData.h
@@ -53,18 +53,6 @@ struct ComponentTransportProcessData
     {
     }
 
-    ComponentTransportProcessData(ComponentTransportProcessData&&) = default;
-
-    //! Copies are forbidden.
-    ComponentTransportProcessData(ComponentTransportProcessData const&) =
-        delete;
-
-    //! Assignments are not needed.
-    void operator=(ComponentTransportProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(ComponentTransportProcessData&&) = delete;
-
     MaterialLib::PorousMedium::PorousMediaProperties porous_media_properties;
     ParameterLib::Parameter<double> const& fluid_reference_density;
     std::unique_ptr<MaterialLib::Fluid::FluidProperties> fluid_properties;

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcessData.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcessData.h
@@ -19,24 +19,6 @@ namespace GroundwaterFlow
 {
 struct GroundwaterFlowProcessData final
 {
-    explicit GroundwaterFlowProcessData(
-        ParameterLib::Parameter<double> const& hydraulic_conductivity_)
-        : hydraulic_conductivity(hydraulic_conductivity_)
-    {}
-
-    GroundwaterFlowProcessData(GroundwaterFlowProcessData&& other)
-        : hydraulic_conductivity(other.hydraulic_conductivity)
-    {}
-
-    //! Copies are forbidden.
-    GroundwaterFlowProcessData(GroundwaterFlowProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(GroundwaterFlowProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(GroundwaterFlowProcessData&&) = delete;
-
     ParameterLib::Parameter<double> const& hydraulic_conductivity;
 };
 

--- a/ProcessLib/HeatConduction/HeatConductionProcessData.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcessData.h
@@ -19,32 +19,6 @@ namespace ProcessLib::HeatConduction
 {
 struct HeatConductionProcessData
 {
-    HeatConductionProcessData(
-        ParameterLib::Parameter<double> const& thermal_conductivity_,
-        ParameterLib::Parameter<double> const& heat_capacity_,
-        ParameterLib::Parameter<double> const& density_)
-        : thermal_conductivity(thermal_conductivity_),
-          heat_capacity(heat_capacity_),
-          density(density_)
-    {
-    }
-
-    HeatConductionProcessData(HeatConductionProcessData&& other)
-        : thermal_conductivity(other.thermal_conductivity),
-          heat_capacity(other.heat_capacity),
-          density(other.density)
-    {
-    }
-
-    //! Copies are forbidden.
-    HeatConductionProcessData(HeatConductionProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(HeatConductionProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(HeatConductionProcessData&&) = delete;
-
     ParameterLib::Parameter<double> const& thermal_conductivity;
     ParameterLib::Parameter<double> const& heat_capacity;
     ParameterLib::Parameter<double> const& density;

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcessData.h
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcessData.h
@@ -44,9 +44,9 @@ struct HeatTransportBHEProcessData
     ParameterLib::Parameter<double> const& density_fluid;
     ParameterLib::Parameter<double> const& density_gas;
 
-    MeshLib::PropertyVector<int> const* _mesh_prop_materialIDs = nullptr;
-    std::unordered_map<int, int> _map_materialID_to_BHE_ID;
-
     std::vector<BHE::BHETypes> _vec_BHE_property;
+
+    MeshLib::PropertyVector<int> const* _mesh_prop_materialIDs = nullptr;
+    std::unordered_map<int, int> _map_materialID_to_BHE_ID{};
 };
 }  // namespace ProcessLib::HeatTransportBHE

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcessData.h
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcessData.h
@@ -29,41 +29,6 @@ namespace ProcessLib::HeatTransportBHE
 {
 struct HeatTransportBHEProcessData
 {
-    HeatTransportBHEProcessData(
-        ParameterLib::Parameter<double> const& thermal_conductivity_solid_,
-        ParameterLib::Parameter<double> const& thermal_conductivity_fluid_,
-        ParameterLib::Parameter<double> const& thermal_conductivity_gas_,
-        ParameterLib::Parameter<double> const& heat_capacity_solid_,
-        ParameterLib::Parameter<double> const& heat_capacity_fluid_,
-        ParameterLib::Parameter<double> const& heat_capacity_gas_,
-        ParameterLib::Parameter<double> const& density_solid_,
-        ParameterLib::Parameter<double> const& density_fluid_,
-        ParameterLib::Parameter<double> const& density_gas_,
-        std::vector<BHE::BHETypes>&& vec_BHEs_)
-        : thermal_conductivity_solid(thermal_conductivity_solid_),
-          thermal_conductivity_fluid(thermal_conductivity_fluid_),
-          thermal_conductivity_gas(thermal_conductivity_gas_),
-          heat_capacity_solid(heat_capacity_solid_),
-          heat_capacity_fluid(heat_capacity_fluid_),
-          heat_capacity_gas(heat_capacity_gas_),
-          density_solid(density_solid_),
-          density_fluid(density_fluid_),
-          density_gas(density_gas_),
-          _vec_BHE_property(std::move(vec_BHEs_))
-    {
-    }
-
-    HeatTransportBHEProcessData(HeatTransportBHEProcessData&& other) = default;
-
-    //! Copies are forbidden.
-    HeatTransportBHEProcessData(HeatTransportBHEProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(HeatTransportBHEProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(HeatTransportBHEProcessData&&) = delete;
-
     // ! thermal conductivity values for the three phases
     ParameterLib::Parameter<double> const& thermal_conductivity_solid;
     ParameterLib::Parameter<double> const& thermal_conductivity_fluid;

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
@@ -31,7 +31,7 @@ namespace HydroMechanics
 template <int DisplacementDim>
 struct HydroMechanicsProcessData
 {
-    MeshLib::PropertyVector<int> const* const material_ids;
+    MeshLib::PropertyVector<int> const* const material_ids = nullptr;
 
     /// The constitutive relation for the mechanical part.
     /// \note Linear elasticity is the only supported one in the moment.

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
@@ -60,11 +60,12 @@ struct HydroMechanicsProcessData
     /// It is usually used to apply gravitational forces.
     /// A vector of displacement dimension's length.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
-    double const reference_temperature;
+    double const reference_temperature =
+        std::numeric_limits<double>::quiet_NaN();
 
     MeshLib::PropertyVector<double>* pressure_interpolated = nullptr;
-    double dt = 0.0;
-    double t = 0.0;
+    double dt = std::numeric_limits<double>::quiet_NaN();
+    double t = std::numeric_limits<double>::quiet_NaN();
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
@@ -31,47 +31,6 @@ namespace HydroMechanics
 template <int DisplacementDim>
 struct HydroMechanicsProcessData
 {
-    HydroMechanicsProcessData(
-        MeshLib::PropertyVector<int> const* const material_ids_,
-        std::map<int,
-                 std::unique_ptr<
-                     MaterialLib::Solids::MechanicsBase<DisplacementDim>>>&&
-            solid_materials_,
-        ParameterLib::Parameter<double> const& intrinsic_permeability_,
-        ParameterLib::Parameter<double> const& specific_storage_,
-        ParameterLib::Parameter<double> const& fluid_viscosity_,
-        ParameterLib::Parameter<double> const& fluid_density_,
-        ParameterLib::Parameter<double> const& biot_coefficient_,
-        ParameterLib::Parameter<double> const& porosity_,
-        ParameterLib::Parameter<double> const& solid_density_,
-        Eigen::Matrix<double, DisplacementDim, 1>
-            specific_body_force_,
-        double const reference_temperature_)
-        : material_ids(material_ids_),
-          solid_materials{std::move(solid_materials_)},
-          intrinsic_permeability(intrinsic_permeability_),
-          specific_storage(specific_storage_),
-          fluid_viscosity(fluid_viscosity_),
-          fluid_density(fluid_density_),
-          biot_coefficient(biot_coefficient_),
-          porosity(porosity_),
-          solid_density(solid_density_),
-          specific_body_force(std::move(specific_body_force_)),
-          reference_temperature(reference_temperature_)
-    {
-    }
-
-    HydroMechanicsProcessData(HydroMechanicsProcessData&& other) = default;
-
-    //! Copies are forbidden.
-    HydroMechanicsProcessData(HydroMechanicsProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(HydroMechanicsProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(HydroMechanicsProcessData&&) = delete;
-
     MeshLib::PropertyVector<int> const* const material_ids;
 
     /// The constitutive relation for the mechanical part.

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
@@ -60,12 +60,11 @@ struct HydroMechanicsProcessData
     /// It is usually used to apply gravitational forces.
     /// A vector of displacement dimension's length.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
-    double dt = 0.0;
-    double t = 0.0;
-
     double const reference_temperature;
 
     MeshLib::PropertyVector<double>* pressure_interpolated = nullptr;
+    double dt = 0.0;
+    double t = 0.0;
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/ProcessLib/PhaseField/PhaseFieldProcessData.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcessData.h
@@ -32,46 +32,6 @@ namespace PhaseField
 template <int DisplacementDim>
 struct PhaseFieldProcessData
 {
-    PhaseFieldProcessData(
-        MeshLib::PropertyVector<int> const* const material_ids_,
-        std::map<int,
-                 std::unique_ptr<
-                     MaterialLib::Solids::MechanicsBase<DisplacementDim>>>&&
-            solid_materials_,
-        ParameterLib::Parameter<double> const& residual_stiffness_,
-        ParameterLib::Parameter<double> const& crack_resistance_,
-        ParameterLib::Parameter<double> const& crack_length_scale_,
-        ParameterLib::Parameter<double> const& kinetic_coefficient_,
-        ParameterLib::Parameter<double> const& solid_density_,
-        ParameterLib::Parameter<double>& history_field_,
-        Eigen::Matrix<double, DisplacementDim, 1> const& specific_body_force_,
-        bool const propagating_crack_,
-        bool const crack_pressure_)
-        : material_ids(material_ids_),
-          solid_materials{std::move(solid_materials_)},
-          residual_stiffness(residual_stiffness_),
-          crack_resistance(crack_resistance_),
-          crack_length_scale(crack_length_scale_),
-          kinetic_coefficient(kinetic_coefficient_),
-          solid_density(solid_density_),
-          history_field(history_field_),
-          specific_body_force(specific_body_force_),
-          propagating_crack(propagating_crack_),
-          crack_pressure(crack_pressure_)
-    {
-    }
-
-    PhaseFieldProcessData(PhaseFieldProcessData&& other) = default;
-
-    //! Copies are forbidden.
-    PhaseFieldProcessData(PhaseFieldProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(PhaseFieldProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(PhaseFieldProcessData&&) = delete;
-
     MeshLib::PropertyVector<int> const* const material_ids;
 
     std::map<int, std::unique_ptr<

--- a/ProcessLib/PhaseField/PhaseFieldProcessData.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcessData.h
@@ -47,8 +47,8 @@ struct PhaseFieldProcessData
     bool propagating_crack = false;
     bool crack_pressure = false;
 
-    double dt = 0.0;
-    double t = 0.0;
+    double dt = std::numeric_limits<double>::quiet_NaN();
+    double t = std::numeric_limits<double>::quiet_NaN();
     double const unity_pressure = 1.0;
     double pressure = 0.0;
     double pressure_old = 0.0;

--- a/ProcessLib/PhaseField/PhaseFieldProcessData.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcessData.h
@@ -32,7 +32,7 @@ namespace PhaseField
 template <int DisplacementDim>
 struct PhaseFieldProcessData
 {
-    MeshLib::PropertyVector<int> const* const material_ids;
+    MeshLib::PropertyVector<int> const* const material_ids = nullptr;
 
     std::map<int, std::unique_ptr<
                       MaterialLib::Solids::MechanicsBase<DisplacementDim>>>

--- a/ProcessLib/PhaseField/PhaseFieldProcessData.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcessData.h
@@ -44,6 +44,9 @@ struct PhaseFieldProcessData
     ParameterLib::Parameter<double> const& solid_density;
     ParameterLib::Parameter<double>& history_field;
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
+    bool propagating_crack = false;
+    bool crack_pressure = false;
+
     double dt = 0.0;
     double t = 0.0;
     double const unity_pressure = 1.0;
@@ -55,8 +58,6 @@ struct PhaseFieldProcessData
     double elastic_energy = 0.0;
     double surface_energy = 0.0;
     double pressure_work = 0.0;
-    bool propagating_crack = false;
-    bool crack_pressure = false;
 };
 
 }  // namespace PhaseField

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcessData.h
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcessData.h
@@ -26,59 +26,6 @@ namespace RichardsComponentTransport
 {
 struct RichardsComponentTransportProcessData
 {
-    RichardsComponentTransportProcessData(
-        PorousMediaProperties&& porous_media_properties_,
-        ParameterLib::Parameter<double> const& fluid_reference_density_,
-        std::unique_ptr<MaterialLib::Fluid::FluidProperties>&&
-            fluid_properties_,
-        ParameterLib::Parameter<double> const& molecular_diffusion_coefficient_,
-        ParameterLib::Parameter<double> const&
-            solute_dispersivity_longitudinal_,
-        ParameterLib::Parameter<double> const& solute_dispersivity_transverse_,
-        ParameterLib::Parameter<double> const& retardation_factor_,
-        ParameterLib::Parameter<double> const& decay_rate_,
-        Eigen::VectorXd const& specific_body_force_,
-        bool const has_gravity_)
-        : porous_media_properties(std::move(porous_media_properties_)),
-          fluid_reference_density(fluid_reference_density_),
-          fluid_properties(std::move(fluid_properties_)),
-          molecular_diffusion_coefficient(molecular_diffusion_coefficient_),
-          solute_dispersivity_longitudinal(solute_dispersivity_longitudinal_),
-          solute_dispersivity_transverse(solute_dispersivity_transverse_),
-          retardation_factor(retardation_factor_),
-          decay_rate(decay_rate_),
-          specific_body_force(specific_body_force_),
-          has_gravity(has_gravity_)
-    {
-    }
-
-    RichardsComponentTransportProcessData(
-        RichardsComponentTransportProcessData&& other)
-        : porous_media_properties(std::move(other.porous_media_properties)),
-          fluid_reference_density(other.fluid_reference_density),
-          fluid_properties(other.fluid_properties.release()),
-          molecular_diffusion_coefficient(
-              other.molecular_diffusion_coefficient),
-          solute_dispersivity_longitudinal(
-              other.solute_dispersivity_longitudinal),
-          solute_dispersivity_transverse(other.solute_dispersivity_transverse),
-          retardation_factor(other.retardation_factor),
-          decay_rate(other.decay_rate),
-          specific_body_force(other.specific_body_force),
-          has_gravity(other.has_gravity)
-    {
-    }
-
-    //! Copies are forbidden.
-    RichardsComponentTransportProcessData(
-        RichardsComponentTransportProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(RichardsComponentTransportProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(RichardsComponentTransportProcessData&&) = delete;
-
     PorousMediaProperties porous_media_properties;
     ParameterLib::Parameter<double> const& fluid_reference_density;
     std::unique_ptr<MaterialLib::Fluid::FluidProperties> fluid_properties;

--- a/ProcessLib/RichardsFlow/RichardsFlowProcessData.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcessData.h
@@ -19,38 +19,6 @@ namespace RichardsFlow
 {
 struct RichardsFlowProcessData
 {
-    RichardsFlowProcessData(
-        std::unique_ptr<RichardsFlowMaterialProperties>&& material_,
-        Eigen::VectorXd const specific_body_force_,
-        bool const has_gravity_,
-        bool const has_mass_lumping_,
-        ParameterLib::Parameter<double> const& temperature_)
-        : material(std::move(material_)),
-          specific_body_force(specific_body_force_),
-          has_gravity(has_gravity_),
-          has_mass_lumping(has_mass_lumping_),
-          temperature(temperature_)
-    {
-    }
-
-    RichardsFlowProcessData(RichardsFlowProcessData&& other)
-        : material(std::move(other.material)),
-          specific_body_force(other.specific_body_force),
-          has_gravity(other.has_gravity),
-          has_mass_lumping(other.has_mass_lumping),
-          temperature(other.temperature)
-    {
-    }
-
-    //! Copies are forbidden.
-    RichardsFlowProcessData(RichardsFlowProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(RichardsFlowProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(RichardsFlowProcessData&&) = delete;
-
     std::unique_ptr<RichardsFlowMaterialProperties> material;
     Eigen::VectorXd const specific_body_force;
     bool const has_gravity;

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
@@ -61,13 +61,14 @@ struct RichardsMechanicsProcessData
     /// It is usually used to apply gravitational forces.
     /// A vector of displacement dimension's length.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
-    double dt = 0.0;
-    double t = 0.0;
+
+    bool const apply_mass_lumping;
 
     MeshLib::PropertyVector<double>* element_saturation = nullptr;
     MeshLib::PropertyVector<double>* pressure_interpolated = nullptr;
 
-    bool const apply_mass_lumping;
+    double dt = 0.0;
+    double t = 0.0;
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
@@ -33,7 +33,7 @@ namespace RichardsMechanics
 template <int DisplacementDim>
 struct RichardsMechanicsProcessData
 {
-    MeshLib::PropertyVector<int> const* const material_ids;
+    MeshLib::PropertyVector<int> const* const material_ids = nullptr;
 
     std::unique_ptr<ProcessLib::RichardsFlow::RichardsFlowMaterialProperties>
         flow_material;

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
@@ -33,46 +33,6 @@ namespace RichardsMechanics
 template <int DisplacementDim>
 struct RichardsMechanicsProcessData
 {
-    RichardsMechanicsProcessData(
-        MeshLib::PropertyVector<int> const* const material_ids_,
-        std::unique_ptr<
-            ProcessLib::RichardsFlow::RichardsFlowMaterialProperties>&&
-            flow_material_,
-        std::map<int,
-                 std::unique_ptr<
-                     MaterialLib::Solids::MechanicsBase<DisplacementDim>>>&&
-            solid_materials_,
-        ParameterLib::Parameter<double> const& fluid_bulk_modulus_,
-        ParameterLib::Parameter<double> const& biot_coefficient_,
-        ParameterLib::Parameter<double> const& solid_density_,
-        ParameterLib::Parameter<double> const& solid_bulk_modulus_,
-        ParameterLib::Parameter<double> const& temperature_,
-        Eigen::Matrix<double, DisplacementDim, 1>
-            specific_body_force_,
-        bool const apply_mass_lumping_)
-        : material_ids(material_ids_),
-          flow_material{std::move(flow_material_)},
-          solid_materials{std::move(solid_materials_)},
-          fluid_bulk_modulus(fluid_bulk_modulus_),
-          biot_coefficient(biot_coefficient_),
-          solid_density(solid_density_),
-          solid_bulk_modulus(solid_bulk_modulus_),
-          temperature(temperature_),
-          specific_body_force(std::move(specific_body_force_)),
-          apply_mass_lumping(apply_mass_lumping_)
-    {
-    }
-
-    RichardsMechanicsProcessData(RichardsMechanicsProcessData&& other) =
-        default;
-
-    //! Copies are forbidden.
-    RichardsMechanicsProcessData(RichardsMechanicsProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(RichardsMechanicsProcessData const&) = delete;
-    void operator=(RichardsMechanicsProcessData&&) = delete;
-
     MeshLib::PropertyVector<int> const* const material_ids;
 
     std::unique_ptr<ProcessLib::RichardsFlow::RichardsFlowMaterialProperties>

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
@@ -67,8 +67,8 @@ struct RichardsMechanicsProcessData
     MeshLib::PropertyVector<double>* element_saturation = nullptr;
     MeshLib::PropertyVector<double>* pressure_interpolated = nullptr;
 
-    double dt = 0.0;
-    double t = 0.0;
+    double dt = std::numeric_limits<double>::quiet_NaN();
+    double t = std::numeric_limits<double>::quiet_NaN();
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/CreateSmallDeformationProcess.cpp
@@ -120,7 +120,7 @@ std::unique_ptr<Process> createSmallDeformationProcess(
     SmallDeformationProcessData<DisplacementDim> process_data{
         materialIDs(mesh),     std::move(solid_constitutive_relations),
         solid_density,         specific_body_force,
-        reference_temperature, nonequilibrium_stress};
+        nonequilibrium_stress, reference_temperature};
 
     SecondaryVariableCollection secondary_variables;
 

--- a/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
@@ -40,14 +40,16 @@ struct SmallDeformationProcessData
     /// Solid's density. A scalar quantity, ParameterLib::Parameter<double>.
     ParameterLib::Parameter<double> const& solid_density;
 
-    ParameterLib::Parameter<double> const* const nonequilibrium_stress;
     /// Specific body forces applied to the solid.
     /// It is usually used to apply gravitational forces.
     /// A vector of displacement dimension's length.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
+
+    ParameterLib::Parameter<double> const* const nonequilibrium_stress;
+    double const reference_temperature;
+
     double dt = 0;
     double t = 0;
-    double const reference_temperature;
 };
 
 }  // namespace SmallDeformation

--- a/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
@@ -31,7 +31,7 @@ namespace SmallDeformation
 template <int DisplacementDim>
 struct SmallDeformationProcessData
 {
-    MeshLib::PropertyVector<int> const* const material_ids;
+    MeshLib::PropertyVector<int> const* const material_ids = nullptr;
 
     std::map<
         int,
@@ -45,7 +45,8 @@ struct SmallDeformationProcessData
     /// A vector of displacement dimension's length.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
 
-    ParameterLib::Parameter<double> const* const nonequilibrium_stress;
+    ParameterLib::Parameter<double> const* const nonequilibrium_stress =
+        nullptr;
     double const reference_temperature =
         std::numeric_limits<double>::quiet_NaN();
 

--- a/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
@@ -31,37 +31,6 @@ namespace SmallDeformation
 template <int DisplacementDim>
 struct SmallDeformationProcessData
 {
-    SmallDeformationProcessData(
-        MeshLib::PropertyVector<int> const* const material_ids_,
-        std::map<int,
-                 std::unique_ptr<
-                     MaterialLib::Solids::MechanicsBase<DisplacementDim>>>&&
-            solid_materials_,
-        ParameterLib::Parameter<double> const& solid_density_,
-        Eigen::Matrix<double, DisplacementDim, 1>
-            specific_body_force_,
-        double const reference_temperature_,
-        ParameterLib::Parameter<double> const* const nonequilibrium_stress_)
-        : material_ids(material_ids_),
-          solid_materials{std::move(solid_materials_)},
-          solid_density(solid_density_),
-          nonequilibrium_stress(nonequilibrium_stress_),
-          specific_body_force(std::move(specific_body_force_)),
-          reference_temperature(reference_temperature_)
-    {
-    }
-
-    SmallDeformationProcessData(SmallDeformationProcessData&& other) = default;
-
-    //! Copies are forbidden.
-    SmallDeformationProcessData(SmallDeformationProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(SmallDeformationProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(SmallDeformationProcessData&&) = delete;
-
     MeshLib::PropertyVector<int> const* const material_ids;
 
     std::map<

--- a/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
@@ -46,10 +46,11 @@ struct SmallDeformationProcessData
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
 
     ParameterLib::Parameter<double> const* const nonequilibrium_stress;
-    double const reference_temperature;
+    double const reference_temperature =
+        std::numeric_limits<double>::quiet_NaN();
 
-    double dt = 0;
-    double t = 0;
+    double dt = std::numeric_limits<double>::quiet_NaN();
+    double t = std::numeric_limits<double>::quiet_NaN();
 };
 
 }  // namespace SmallDeformation

--- a/ProcessLib/SmallDeformationNonlocal/CreateSmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/CreateSmallDeformationNonlocalProcess.cpp
@@ -111,7 +111,7 @@ std::unique_ptr<Process> createSmallDeformationNonlocalProcess(
     SmallDeformationNonlocalProcessData<DisplacementDim> process_data{
         materialIDs(mesh),     std::move(solid_constitutive_relations),
         solid_density,         specific_body_force,
-        reference_temperature, internal_length};
+        reference_temperature, internal_length * internal_length};
 
     SecondaryVariableCollection secondary_variables;
 

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcessData.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcessData.h
@@ -31,39 +31,6 @@ namespace SmallDeformationNonlocal
 template <int DisplacementDim>
 struct SmallDeformationNonlocalProcessData
 {
-    SmallDeformationNonlocalProcessData(
-        MeshLib::PropertyVector<int> const* const material_ids_,
-        std::map<int,
-                 std::unique_ptr<
-                     MaterialLib::Solids::MechanicsBase<DisplacementDim>>>&&
-            solid_materials_,
-        ParameterLib::Parameter<double> const& solid_density_,
-        Eigen::Matrix<double, DisplacementDim, 1>
-            specific_body_force_,
-        double const reference_temperature_,
-        double const internal_length_)
-        : material_ids(material_ids_),
-          solid_materials{std::move(solid_materials_)},
-          solid_density(solid_density_),
-          specific_body_force(std::move(specific_body_force_)),
-          reference_temperature(reference_temperature_),
-          internal_length_squared(internal_length_ * internal_length_)
-    {
-    }
-
-    SmallDeformationNonlocalProcessData(
-        SmallDeformationNonlocalProcessData&& other) = default;
-
-    //! Copies are forbidden.
-    SmallDeformationNonlocalProcessData(
-        SmallDeformationNonlocalProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(SmallDeformationNonlocalProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(SmallDeformationNonlocalProcessData&&) = delete;
-
     MeshLib::PropertyVector<int> const* const material_ids;
 
     std::map<

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcessData.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcessData.h
@@ -44,14 +44,16 @@ struct SmallDeformationNonlocalProcessData
     /// A vector of displacement dimension's length.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
 
-    double const reference_temperature;
-    double const internal_length_squared;
+    double const reference_temperature =
+        std::numeric_limits<double>::quiet_NaN();
+    double const internal_length_squared =
+        std::numeric_limits<double>::quiet_NaN();
 
     double crack_volume_old = 0.0;
     double crack_volume = 0.0;
 
-    double dt = 0;
-    double t = 0;
+    double dt = std::numeric_limits<double>::quiet_NaN();
+    double t = std::numeric_limits<double>::quiet_NaN();
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcessData.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcessData.h
@@ -31,7 +31,7 @@ namespace SmallDeformationNonlocal
 template <int DisplacementDim>
 struct SmallDeformationNonlocalProcessData
 {
-    MeshLib::PropertyVector<int> const* const material_ids;
+    MeshLib::PropertyVector<int> const* const material_ids = nullptr;
 
     std::map<
         int,

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcessData.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcessData.h
@@ -44,13 +44,14 @@ struct SmallDeformationNonlocalProcessData
     /// A vector of displacement dimension's length.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
 
+    double const reference_temperature;
+    double const internal_length_squared;
+
     double crack_volume_old = 0.0;
     double crack_volume = 0.0;
 
     double dt = 0;
     double t = 0;
-    double const reference_temperature;
-    double const internal_length_squared;
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcessData.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcessData.h
@@ -20,50 +20,6 @@ namespace ThermalTwoPhaseFlowWithPP
 {
 struct ThermalTwoPhaseFlowWithPPProcessData
 {
-    ThermalTwoPhaseFlowWithPPProcessData(
-        Eigen::VectorXd const specific_body_force_,
-        bool const has_gravity_,
-        bool const has_mass_lumping_,
-        ParameterLib::Parameter<double> const& diffusion_coeff_component_b_,
-        ParameterLib::Parameter<double> const& diffusion_coeff_component_a_,
-        ParameterLib::Parameter<double> const& density_solid_,
-        ParameterLib::Parameter<double> const& latent_heat_evaporation_,
-        std::unique_ptr<ThermalTwoPhaseFlowWithPPMaterialProperties>&&
-            material_)
-        : specific_body_force(specific_body_force_),
-          has_gravity(has_gravity_),
-          has_mass_lumping(has_mass_lumping_),
-          diffusion_coeff_component_b(diffusion_coeff_component_b_),
-          diffusion_coeff_component_a(diffusion_coeff_component_a_),
-          density_solid(density_solid_),
-          latent_heat_evaporation(latent_heat_evaporation_),
-          material(std::move(material_))
-
-    {
-    }
-
-    ThermalTwoPhaseFlowWithPPProcessData(
-        ThermalTwoPhaseFlowWithPPProcessData&& other)
-        : specific_body_force(other.specific_body_force),
-          has_gravity(other.has_gravity),
-          has_mass_lumping(other.has_mass_lumping),
-          diffusion_coeff_component_b(other.diffusion_coeff_component_b),
-          diffusion_coeff_component_a(other.diffusion_coeff_component_a),
-          density_solid(other.density_solid),
-          latent_heat_evaporation(other.latent_heat_evaporation),
-          material(std::move(other.material))
-    {
-    }
-
-    //! Copies are forbidden.
-    ThermalTwoPhaseFlowWithPPProcessData(
-        ThermalTwoPhaseFlowWithPPProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(ThermalTwoPhaseFlowWithPPProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(ThermalTwoPhaseFlowWithPPProcessData&&) = delete;
     Eigen::VectorXd const specific_body_force;
 
     bool const has_gravity;

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcessData.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcessData.h
@@ -32,65 +32,6 @@ namespace ThermoHydroMechanics
 template <int DisplacementDim>
 struct ThermoHydroMechanicsProcessData
 {
-    ThermoHydroMechanicsProcessData(
-        MeshLib::PropertyVector<int> const* const material_ids_,
-        std::map<int,
-                 std::unique_ptr<
-                     MaterialLib::Solids::MechanicsBase<DisplacementDim>>>&&
-            solid_materials_,
-        ParameterLib::Parameter<double> const& intrinsic_permeability_,
-        ParameterLib::Parameter<double> const& specific_storage_,
-        ParameterLib::Parameter<double> const& fluid_viscosity_,
-        ParameterLib::Parameter<double> const& fluid_density_,
-        ParameterLib::Parameter<double> const& biot_coefficient_,
-        ParameterLib::Parameter<double> const& porosity_,
-        ParameterLib::Parameter<double> const& solid_density_,
-        ParameterLib::Parameter<double> const&
-            solid_linear_thermal_expansion_coefficient_,
-        ParameterLib::Parameter<double> const&
-            fluid_volumetric_thermal_expansion_coefficient_,
-        ParameterLib::Parameter<double> const& solid_specific_heat_capacity_,
-        ParameterLib::Parameter<double> const& fluid_specific_heat_capacity_,
-        ParameterLib::Parameter<double> const& solid_thermal_conductivity_,
-        ParameterLib::Parameter<double> const& fluid_thermal_conductivity_,
-        ParameterLib::Parameter<double> const& reference_temperature_,
-        Eigen::Matrix<double, DisplacementDim, 1>
-            specific_body_force_)
-        : material_ids(material_ids_),
-          solid_materials{std::move(solid_materials_)},
-          intrinsic_permeability(intrinsic_permeability_),
-          specific_storage(specific_storage_),
-          fluid_viscosity(fluid_viscosity_),
-          fluid_density(fluid_density_),
-          biot_coefficient(biot_coefficient_),
-          porosity(porosity_),
-          solid_density(solid_density_),
-          solid_linear_thermal_expansion_coefficient(
-              solid_linear_thermal_expansion_coefficient_),
-          fluid_volumetric_thermal_expansion_coefficient(
-              fluid_volumetric_thermal_expansion_coefficient_),
-          solid_specific_heat_capacity(solid_specific_heat_capacity_),
-          solid_thermal_conductivity(solid_thermal_conductivity_),
-          fluid_specific_heat_capacity(fluid_specific_heat_capacity_),
-          fluid_thermal_conductivity(fluid_thermal_conductivity_),
-          reference_temperature(reference_temperature_),
-          specific_body_force(std::move(specific_body_force_))
-    {
-    }
-
-    ThermoHydroMechanicsProcessData(ThermoHydroMechanicsProcessData&& other) =
-        default;
-
-    //! Copies are forbidden.
-    ThermoHydroMechanicsProcessData(ThermoHydroMechanicsProcessData const&) =
-        delete;
-
-    //! Assignments are not needed.
-    void operator=(ThermoHydroMechanicsProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(ThermoHydroMechanicsProcessData&&) = delete;
-
     MeshLib::PropertyVector<int> const* const material_ids;
 
     /// The constitutive relation for the mechanical part.

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcessData.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcessData.h
@@ -71,8 +71,8 @@ struct ThermoHydroMechanicsProcessData
     /// A vector of displacement dimension's length.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
 
-    double dt = 0.0;
-    double t = 0.0;
+    double dt = std::numeric_limits<double>::quiet_NaN();
+    double t = std::numeric_limits<double>::quiet_NaN();
 
     MeshLib::PropertyVector<double>* pressure_interpolated = nullptr;
     MeshLib::PropertyVector<double>* temperature_interpolated = nullptr;

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcessData.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcessData.h
@@ -32,7 +32,7 @@ namespace ThermoHydroMechanics
 template <int DisplacementDim>
 struct ThermoHydroMechanicsProcessData
 {
-    MeshLib::PropertyVector<int> const* const material_ids;
+    MeshLib::PropertyVector<int> const* const material_ids = nullptr;
 
     /// The constitutive relation for the mechanical part.
     /// \note Linear elasticity is the only supported one in the moment.

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcessData.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcessData.h
@@ -62,14 +62,15 @@ struct ThermoHydroMechanicsProcessData
     ParameterLib::Parameter<double> const&
         fluid_volumetric_thermal_expansion_coefficient;
     ParameterLib::Parameter<double> const& solid_specific_heat_capacity;
-    ParameterLib::Parameter<double> const& solid_thermal_conductivity;
     ParameterLib::Parameter<double> const& fluid_specific_heat_capacity;
+    ParameterLib::Parameter<double> const& solid_thermal_conductivity;
     ParameterLib::Parameter<double> const& fluid_thermal_conductivity;
     ParameterLib::Parameter<double> const& reference_temperature;
     /// Specific body forces applied to solid and fluid.
     /// It is usually used to apply gravitational forces.
     /// A vector of displacement dimension's length.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
+
     double dt = 0.0;
     double t = 0.0;
 

--- a/ProcessLib/ThermoMechanicalPhaseField/CreateThermoMechanicalPhaseFieldProcess.cpp
+++ b/ProcessLib/ThermoMechanicalPhaseField/CreateThermoMechanicalPhaseFieldProcess.cpp
@@ -227,8 +227,8 @@ std::unique_ptr<Process> createThermoMechanicalPhaseFieldProcess(
         specific_heat_capacity,
         thermal_conductivity,
         residual_thermal_conductivity,
-        reference_temperature,
-        specific_body_force};
+        specific_body_force,
+        reference_temperature};
 
     SecondaryVariableCollection secondary_variables;
 

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcessData.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcessData.h
@@ -47,7 +47,8 @@ struct ThermoMechanicalPhaseFieldProcessData
     ParameterLib::Parameter<double> const& thermal_conductivity;
     ParameterLib::Parameter<double> const& residual_thermal_conductivity;
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
-    double const reference_temperature;
+    double const reference_temperature =
+        std::numeric_limits<double>::quiet_NaN();
 
     double dt = std::numeric_limits<double>::quiet_NaN();
     double t = std::numeric_limits<double>::quiet_NaN();

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcessData.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcessData.h
@@ -32,7 +32,7 @@ namespace ThermoMechanicalPhaseField
 template <int DisplacementDim>
 struct ThermoMechanicalPhaseFieldProcessData
 {
-    MeshLib::PropertyVector<int> const* const material_ids;
+    MeshLib::PropertyVector<int> const* const material_ids = nullptr;
 
     std::map<int, std::unique_ptr<
                       MaterialLib::Solids::MechanicsBase<DisplacementDim>>>

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcessData.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcessData.h
@@ -32,54 +32,6 @@ namespace ThermoMechanicalPhaseField
 template <int DisplacementDim>
 struct ThermoMechanicalPhaseFieldProcessData
 {
-    ThermoMechanicalPhaseFieldProcessData(
-        MeshLib::PropertyVector<int> const* const material_ids_,
-        std::map<int,
-                 std::unique_ptr<
-                     MaterialLib::Solids::MechanicsBase<DisplacementDim>>>&&
-            solid_materials_,
-        ParameterLib::Parameter<double> const& residual_stiffness_,
-        ParameterLib::Parameter<double> const& crack_resistance_,
-        ParameterLib::Parameter<double> const& crack_length_scale_,
-        ParameterLib::Parameter<double> const& kinetic_coefficient_,
-        ParameterLib::Parameter<double> const& solid_density_,
-        ParameterLib::Parameter<double> const&
-            linear_thermal_expansion_coefficient_,
-        ParameterLib::Parameter<double> const& specific_heat_capacity_,
-        ParameterLib::Parameter<double> const& thermal_conductivity_,
-        ParameterLib::Parameter<double> const& residual_thermal_conductivity_,
-        double const reference_temperature_,
-        Eigen::Matrix<double, DisplacementDim, 1> const& specific_body_force_)
-        : material_ids(material_ids_),
-          solid_materials{std::move(solid_materials_)},
-          residual_stiffness(residual_stiffness_),
-          crack_resistance(crack_resistance_),
-          crack_length_scale(crack_length_scale_),
-          kinetic_coefficient(kinetic_coefficient_),
-          solid_density(solid_density_),
-          linear_thermal_expansion_coefficient(
-              linear_thermal_expansion_coefficient_),
-          specific_heat_capacity(specific_heat_capacity_),
-          thermal_conductivity(thermal_conductivity_),
-          residual_thermal_conductivity(residual_thermal_conductivity_),
-          reference_temperature(reference_temperature_),
-          specific_body_force(specific_body_force_)
-    {
-    }
-
-    ThermoMechanicalPhaseFieldProcessData(
-        ThermoMechanicalPhaseFieldProcessData&& other) = default;
-
-    //! Copies are forbidden.
-    ThermoMechanicalPhaseFieldProcessData(
-        ThermoMechanicalPhaseFieldProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(ThermoMechanicalPhaseFieldProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(ThermoMechanicalPhaseFieldProcessData&&) = delete;
-
     MeshLib::PropertyVector<int> const* const material_ids;
 
     std::map<int, std::unique_ptr<

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcessData.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcessData.h
@@ -46,10 +46,11 @@ struct ThermoMechanicalPhaseFieldProcessData
     ParameterLib::Parameter<double> const& specific_heat_capacity;
     ParameterLib::Parameter<double> const& thermal_conductivity;
     ParameterLib::Parameter<double> const& residual_thermal_conductivity;
-    double const reference_temperature;
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
-    double dt;
-    double t;
+    double const reference_temperature;
+
+    double dt = std::numeric_limits<double>::quiet_NaN();
+    double t = std::numeric_limits<double>::quiet_NaN();
 };
 
 }  // namespace ThermoMechanicalPhaseField

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
@@ -31,7 +31,7 @@ namespace ThermoMechanics
 template <int DisplacementDim>
 struct ThermoMechanicsProcessData
 {
-    MeshLib::PropertyVector<int> const* const material_ids;
+    MeshLib::PropertyVector<int> const* const material_ids = nullptr;
 
     /// The constitutive relation for the mechanical part.
     std::map<int, std::unique_ptr<

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
@@ -31,44 +31,6 @@ namespace ThermoMechanics
 template <int DisplacementDim>
 struct ThermoMechanicsProcessData
 {
-    ThermoMechanicsProcessData(
-        MeshLib::PropertyVector<int> const* const material_ids_,
-        std::map<int, std::unique_ptr<MaterialLib::Solids::MechanicsBase<
-                          DisplacementDim>>>&& solid_materials_,
-        ParameterLib::Parameter<double> const& reference_solid_density_,
-        ParameterLib::Parameter<double> const&
-            linear_thermal_expansion_coefficient_,
-        ParameterLib::Parameter<double> const& specific_heat_capacity_,
-        ParameterLib::Parameter<double> const& thermal_conductivity_,
-        Eigen::Matrix<double, DisplacementDim, 1> const& specific_body_force_,
-        ParameterLib::Parameter<double> const* const nonequilibrium_stress_,
-        int const mechanics_process_id_, int const heat_conduction_process_id_)
-        : material_ids(material_ids_),
-          solid_materials{std::move(solid_materials_)},
-          reference_solid_density(reference_solid_density_),
-          linear_thermal_expansion_coefficient(
-              linear_thermal_expansion_coefficient_),
-          specific_heat_capacity(specific_heat_capacity_),
-          thermal_conductivity(thermal_conductivity_),
-          specific_body_force(specific_body_force_),
-          nonequilibrium_stress(nonequilibrium_stress_),
-          mechanics_process_id(mechanics_process_id_),
-          heat_conduction_process_id(heat_conduction_process_id_)
-
-    {
-    }
-
-    ThermoMechanicsProcessData(ThermoMechanicsProcessData&& other) = default;
-
-    //! Copies are forbidden.
-    ThermoMechanicsProcessData(ThermoMechanicsProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(ThermoMechanicsProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(ThermoMechanicsProcessData&&) = delete;
-
     MeshLib::PropertyVector<int> const* const material_ids;
 
     /// The constitutive relation for the mechanical part.

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
@@ -45,14 +45,15 @@ struct ThermoMechanicsProcessData
         thermal_conductivity;  // TODO To be changed as a matrix type variable.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
     ParameterLib::Parameter<double> const* const nonequilibrium_stress;
-    double dt = 0;
-    double t = 0;
 
     /// ID of the mechanical process.
     int const mechanics_process_id;
 
     /// ID of heat conduction process.
     int const heat_conduction_process_id;
+
+    double dt = 0;
+    double t = 0;
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
@@ -52,8 +52,8 @@ struct ThermoMechanicsProcessData
     /// ID of heat conduction process.
     int const heat_conduction_process_id;
 
-    double dt = 0;
-    double t = 0;
+    double dt = std::numeric_limits<double>::quiet_NaN();
+    double t = std::numeric_limits<double>::quiet_NaN();
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcessData.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcessData.h
@@ -19,40 +19,6 @@ namespace TwoPhaseFlowWithPP
 {
 struct TwoPhaseFlowWithPPProcessData
 {
-    TwoPhaseFlowWithPPProcessData(
-        Eigen::VectorXd const specific_body_force_,
-        bool const has_gravity_,
-        bool const has_mass_lumping_,
-        ParameterLib::Parameter<double> const& temperature_,
-        std::unique_ptr<TwoPhaseFlowWithPPMaterialProperties>&& material_)
-        : specific_body_force(specific_body_force_),
-          has_gravity(has_gravity_),
-          has_mass_lumping(has_mass_lumping_),
-          temperature(temperature_),
-          material(std::move(material_))
-
-    {
-    }
-
-    TwoPhaseFlowWithPPProcessData(TwoPhaseFlowWithPPProcessData&& other)
-        : specific_body_force(other.specific_body_force),
-          has_gravity(other.has_gravity),
-          has_mass_lumping(other.has_mass_lumping),
-          temperature(other.temperature),
-          material(std::move(other.material))
-    {
-    }
-
-    //! Copies are forbidden.
-    TwoPhaseFlowWithPPProcessData(TwoPhaseFlowWithPPProcessData const&) =
-        delete;
-
-    //! Assignments are not needed.
-    void operator=(TwoPhaseFlowWithPPProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(TwoPhaseFlowWithPPProcessData&&) = delete;
-
     //! Specific body forces applied to solid and fluid.
     //! It is usually used to apply gravitational forces.
     //! A vector of displacement dimension's length.

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcessData.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcessData.h
@@ -20,45 +20,6 @@ namespace TwoPhaseFlowWithPrho
 {
 struct TwoPhaseFlowWithPrhoProcessData
 {
-    TwoPhaseFlowWithPrhoProcessData(
-        Eigen::VectorXd const specific_body_force_,
-        bool const has_gravity_,
-        bool const has_mass_lumping_,
-        ParameterLib::Parameter<double> const& diffusion_coeff_component_b_,
-        ParameterLib::Parameter<double> const& diffusion_coeff_component_a_,
-        ParameterLib::Parameter<double> const& temperature_,
-        std::unique_ptr<TwoPhaseFlowWithPrhoMaterialProperties>&& material_)
-        : _specific_body_force(specific_body_force_),
-          _has_gravity(has_gravity_),
-          _has_mass_lumping(has_mass_lumping_),
-          _diffusion_coeff_component_b(diffusion_coeff_component_b_),
-          _diffusion_coeff_component_a(diffusion_coeff_component_a_),
-          _temperature(temperature_),
-          _material(std::move(material_))
-
-    {
-    }
-
-    TwoPhaseFlowWithPrhoProcessData(TwoPhaseFlowWithPrhoProcessData&& other)
-        : _specific_body_force(other._specific_body_force),
-          _has_gravity(other._has_gravity),
-          _has_mass_lumping(other._has_mass_lumping),
-          _diffusion_coeff_component_b(other._diffusion_coeff_component_b),
-          _diffusion_coeff_component_a(other._diffusion_coeff_component_a),
-          _temperature(other._temperature),
-          _material(std::move(other._material))
-    {
-    }
-
-    //! Copies are forbidden.
-    TwoPhaseFlowWithPrhoProcessData(TwoPhaseFlowWithPrhoProcessData const&) =
-        delete;
-
-    //! Assignments are not needed.
-    void operator=(TwoPhaseFlowWithPrhoProcessData const&) = delete;
-
-    //! Assignments are not needed.
-    void operator=(TwoPhaseFlowWithPrhoProcessData&&) = delete;
     Eigen::VectorXd const _specific_body_force;
 
     bool const _has_gravity;


### PR DESCRIPTION
All of the special functions are not needed. Smaller reorderings to ensure the same initialization order.
Stricter default initializations, especially using NaN for doubles.
