### PR TITLE
Use std::variant instead of boost::variant.

### DIFF
--- a/MaterialLib/MPL/Component.cpp
+++ b/MaterialLib/MPL/Component.cpp
@@ -43,6 +43,6 @@ Property const& Component::property(PropertyType const& p) const
 
 std::string Component::name() const
 {
-    return boost::get<std::string>(_properties[PropertyType::name]->value());
+    return std::get<std::string>(_properties[PropertyType::name]->value());
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Phase.cpp
+++ b/MaterialLib/MPL/Phase.cpp
@@ -59,6 +59,6 @@ std::size_t Phase::numberOfComponents() const
 
 std::string Phase::name() const
 {
-    return boost::get<std::string>(_properties[PropertyType::name]->value());
+    return std::get<std::string>(_properties[PropertyType::name]->value());
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/Constant.cpp
+++ b/MaterialLib/MPL/Properties/Constant.cpp
@@ -18,7 +18,7 @@ namespace MaterialPropertyLib
 Constant::Constant(PropertyDataType const& v)
 {
     _value = v;
-    _dvalue = boost::apply_visitor(
+    _dvalue = std::visit(
         [](auto const& value) -> PropertyDataType { return decltype(value){}; },
         v);
 };

--- a/MaterialLib/MPL/Properties/ExponentialProperty.cpp
+++ b/MaterialLib/MPL/Properties/ExponentialProperty.cpp
@@ -27,26 +27,25 @@ ExponentialProperty::ExponentialProperty(
 PropertyDataType ExponentialProperty::value(
     VariableArray const& variable_array) const
 {
-    return boost::get<double>(_value) *
+    return std::get<double>(_value) *
            std::exp(
-               -boost::get<double>(_exponent_data.factor) *
-               (boost::get<double>(
+               -std::get<double>(_exponent_data.factor) *
+               (std::get<double>(
                     variable_array[static_cast<int>(_exponent_data.type)]) -
-                boost::get<double>(_exponent_data.reference_condition)));
+                std::get<double>(_exponent_data.reference_condition)));
 }
 
 PropertyDataType ExponentialProperty::dValue(
     VariableArray const& variable_array, Variable const primary_variable) const
 {
     return _exponent_data.type == primary_variable
-               ? -boost::get<double>(_value) *
-                     boost::get<double>(_exponent_data.factor) *
+               ? -std::get<double>(_value) *
+                     std::get<double>(_exponent_data.factor) *
                      std::exp(
-                         -boost::get<double>(_exponent_data.factor) *
-                         (boost::get<double>(variable_array[static_cast<int>(
+                         -std::get<double>(_exponent_data.factor) *
+                         (std::get<double>(variable_array[static_cast<int>(
                               _exponent_data.type)]) -
-                          boost::get<double>(
-                              _exponent_data.reference_condition)))
+                          std::get<double>(_exponent_data.reference_condition)))
                : decltype(_value){};
 }
 
@@ -56,15 +55,14 @@ PropertyDataType ExponentialProperty::d2Value(
     Variable const pv2) const
 {
     return _exponent_data.type == pv1 && _exponent_data.type == pv2
-               ? boost::get<double>(_value) *
+               ? std::get<double>(_value) *
                      boost::math::pow<2>(
-                         boost::get<double>(_exponent_data.factor)) *
+                         std::get<double>(_exponent_data.factor)) *
                      std::exp(
-                         -boost::get<double>(_exponent_data.factor) *
-                         (boost::get<double>(variable_array[static_cast<int>(
+                         -std::get<double>(_exponent_data.factor) *
+                         (std::get<double>(variable_array[static_cast<int>(
                               _exponent_data.type)]) -
-                          boost::get<double>(
-                              _exponent_data.reference_condition)))
+                          std::get<double>(_exponent_data.reference_condition)))
                : decltype(_value){};
 }
 

--- a/MaterialLib/MPL/Properties/LinearProperty.cpp
+++ b/MaterialLib/MPL/Properties/LinearProperty.cpp
@@ -23,20 +23,20 @@ LinearProperty::LinearProperty(PropertyDataType const& property_reference_value,
 PropertyDataType LinearProperty::value(
     VariableArray const& variable_array) const
 {
-    return boost::get<double>(_value) *
-           (1 + boost::get<double>(_independent_variable.slope) *
-                    (boost::get<double>(variable_array[static_cast<int>(
-                         _independent_variable.type)]) -
-                     boost::get<double>(
-                         _independent_variable.reference_condition)));
+    return std::get<double>(_value) *
+           (1 +
+            std::get<double>(_independent_variable.slope) *
+                (std::get<double>(variable_array[static_cast<int>(
+                     _independent_variable.type)]) -
+                 std::get<double>(_independent_variable.reference_condition)));
 }
 
 PropertyDataType LinearProperty::dValue(VariableArray const& /*variable_array*/,
                                         Variable const primary_variable) const
 {
     return _independent_variable.type == primary_variable
-               ? boost::get<double>(_value) *
-                     boost::get<double>(_independent_variable.slope)
+               ? std::get<double>(_value) *
+                     std::get<double>(_independent_variable.slope)
                : decltype(_value){};
 }
 

--- a/MaterialLib/MPL/Property.h
+++ b/MaterialLib/MPL/Property.h
@@ -13,8 +13,8 @@
 #pragma once
 
 #include <array>
-#include <boost/variant.hpp>
 #include <string>
+#include <variant>
 
 #include "PropertyType.h"
 #include "VariableType.h"
@@ -22,7 +22,7 @@
 namespace MaterialPropertyLib
 {
 /// This is a custom data type for arbitrary properties, based on the
-/// boost::variant container. It can hold scalars, vectors, tensors, and so
+/// std::variant container. It can hold scalars, vectors, tensors, and so
 /// forth.
 enum PropertyDataTypeName
 {
@@ -33,7 +33,7 @@ enum PropertyDataTypeName
     nTensor
 };
 
-using PropertyDataType = boost::
+using PropertyDataType = std::
     variant<double, Pair, Vector, Tensor2d, SymmTensor, Tensor, std::string>;
 
 /// This class is the base class for any material property of any
@@ -67,25 +67,25 @@ public:
     template <typename T>
     T value() const
     {
-        return boost::get<T>(value());
+        return std::get<T>(value());
     }
     template <typename T>
     T value(VariableArray const& variable_array) const
     {
-        return boost::get<T>(value(variable_array));
+        return std::get<T>(value(variable_array));
     }
     template <typename T>
     T dValue(VariableArray const& variable_array,
              Variable const variable) const
     {
-        return boost::get<T>(dValue(variable_array, variable));
+        return std::get<T>(dValue(variable_array, variable));
     }
     template <typename T>
     T d2Value(VariableArray const& variable_array,
               Variable const& variable1,
               Variable const& variable2) const
     {
-        return boost::get<T>(d2Value(variable_array, variable1, variable2));
+        return std::get<T>(d2Value(variable_array, variable1, variable2));
     }
 
 protected:
@@ -98,7 +98,7 @@ protected:
 /// enhanced by using enums.
 inline std::size_t getType(Property const& p)
 {
-    return p.value().which();
+    return p.value().index();
 }
 
 inline void overwriteExistingProperties(PropertyArray& properties,

--- a/MaterialLib/MPL/Utils/FormEigenTensor.cpp
+++ b/MaterialLib/MPL/Utils/FormEigenTensor.cpp
@@ -11,15 +11,12 @@
 
 #include "FormEigenTensor.h"
 
-#include <boost/variant/static_visitor.hpp>
-
 #include "MaterialLib/MPL/PropertyType.h"
 
 namespace MaterialPropertyLib
 {
 template <int GlobalDim>
 struct FormEigenTensor
-    : boost::static_visitor<Eigen::Matrix<double, GlobalDim, GlobalDim>>
 {
     Eigen::Matrix<double, GlobalDim, GlobalDim> operator()(
         double const& value) const
@@ -74,7 +71,7 @@ template <int GlobalDim>
 Eigen::Matrix<double, GlobalDim, GlobalDim> formEigenTensor(
     MaterialPropertyLib::PropertyDataType const& values)
 {
-    return boost::apply_visitor(FormEigenTensor<GlobalDim>(), values);
+    return std::visit(FormEigenTensor<GlobalDim>(), values);
 }
 
 template Eigen::Matrix<double, 1, 1> formEigenTensor<1>(

--- a/MaterialLib/MPL/VariableType.h
+++ b/MaterialLib/MPL/VariableType.h
@@ -14,7 +14,7 @@
 #pragma once
 
 #include <array>
-#include <boost/variant.hpp>
+#include <variant>
 
 namespace MaterialPropertyLib
 {
@@ -53,7 +53,7 @@ enum class Variable : int
 
 /// Data type for primary variables, designed to contain both scalar and vector
 /// data.
-using VariableType = boost::variant<double, Vector>;
+using VariableType = std::variant<double, Vector>;
 
 /// The VariableArray is a std::array of fixed size. Its size is determined by
 /// the Variable enumerator list. Data type of that array is defined by the
@@ -64,7 +64,7 @@ using VariableArray =
 /// This method returns a value of type double from the variables array
 inline double getScalar(VariableType pv)
 {
-    return boost::get<double>(pv);
+    return std::get<double>(pv);
 }
 
 Variable convertStringToVariable(std::string const& input);

--- a/ProcessLib/HeatTransportBHE/BHE/BHECommonCoaxial.cpp
+++ b/ProcessLib/HeatTransportBHE/BHE/BHECommonCoaxial.cpp
@@ -38,9 +38,9 @@ BHECommonCoaxial::pipeHeatCapacities() const
 double BHECommonCoaxial::updateFlowRateAndTemperature(double const T_out,
                                              double const current_time)
 {
-    auto values = apply_visitor(
-        [&](auto const& control) { return control(T_out, current_time); },
-        flowAndTemperatureControl);
+    auto values =
+        visit([&](auto const& control) { return control(T_out, current_time); },
+              flowAndTemperatureControl);
     updateHeatTransferCoefficients(values.flow_rate);
     return values.temperature;
 }

--- a/ProcessLib/HeatTransportBHE/BHE/BHETypes.h
+++ b/ProcessLib/HeatTransportBHE/BHE/BHETypes.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <boost/variant.hpp>
+#include <variant>
 #include "BHE_1U.h"
 #include "BHE_CXA.h"
 #include "BHE_CXC.h"
@@ -22,7 +22,7 @@ namespace HeatTransportBHE
 {
 namespace BHE
 {
-using BHETypes = boost::variant<BHE_1U, BHE_CXA, BHE_CXC>;
+using BHETypes = std::variant<BHE_1U, BHE_CXA, BHE_CXC>;
 }  // end of namespace BHE
 }  // end of namespace HeatTransportBHE
 }  // end of namespace ProcessLib

--- a/ProcessLib/HeatTransportBHE/BHE/BHE_1U.cpp
+++ b/ProcessLib/HeatTransportBHE/BHE/BHE_1U.cpp
@@ -29,7 +29,7 @@ BHE_1U::BHE_1U(BoreholeGeometry const& borehole,
       _pipes(pipes)
 {
     // Initialize thermal resistances.
-    auto values = apply_visitor(
+    auto values = visit(
         [&](auto const& control) {
             return control(refrigerant.reference_temperature,
                            0. /* initial time */);
@@ -239,9 +239,9 @@ std::array<double, BHE_1U::number_of_unknowns> BHE_1U::calcThermalResistances(
 double BHE_1U::updateFlowRateAndTemperature(double const T_out,
                                             double const current_time)
 {
-    auto values = apply_visitor(
-        [&](auto const& control) { return control(T_out, current_time); },
-        flowAndTemperatureControl);
+    auto values =
+        visit([&](auto const& control) { return control(T_out, current_time); },
+              flowAndTemperatureControl);
     updateHeatTransferCoefficients(values.flow_rate);
     return values.temperature;
 }

--- a/ProcessLib/HeatTransportBHE/BHE/BHE_CXA.h
+++ b/ProcessLib/HeatTransportBHE/BHE/BHE_CXA.h
@@ -46,7 +46,7 @@ public:
                            flowAndTemperatureControl, pipes}
     {
         // Initialize thermal resistances.
-        auto values = apply_visitor(
+        auto values = visit(
             [&](auto const& control) {
                 return control(refrigerant.reference_temperature,
                                0. /* initial time */);

--- a/ProcessLib/HeatTransportBHE/BHE/BHE_CXC.h
+++ b/ProcessLib/HeatTransportBHE/BHE/BHE_CXC.h
@@ -46,7 +46,7 @@ public:
                            flowAndTemperatureControl, pipes}
     {
         // Initialize thermal resistances.
-        auto values = apply_visitor(
+        auto values = visit(
             [&](auto const& control) {
                 return control(refrigerant.reference_temperature,
                                0. /* initial time */);

--- a/ProcessLib/HeatTransportBHE/BHE/FlowAndTemperatureControl.h
+++ b/ProcessLib/HeatTransportBHE/BHE/FlowAndTemperatureControl.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <boost/variant.hpp>
+#include <variant>
 #include "MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h"
 
 namespace ProcessLib
@@ -78,10 +78,10 @@ struct PowerCurveConstantFlow
     double density;
 };
 
-using FlowAndTemperatureControl = boost::variant<TemperatureCurveConstantFlow,
-                                                 FixedPowerConstantFlow,
-                                                 FixedPowerFlowCurve,
-                                                 PowerCurveConstantFlow>;
+using FlowAndTemperatureControl = std::variant<TemperatureCurveConstantFlow,
+                                               FixedPowerConstantFlow,
+                                               FixedPowerFlowCurve,
+                                               PowerCurveConstantFlow>;
 
 }  // namespace BHE
 }  // namespace HeatTransportBHE

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
@@ -97,9 +97,9 @@ void HeatTransportBHEProcess::constructDofTable()
     // the BHE nodes need to be cherry-picked from the vector
     for (int i = 0; i < n_BHEs; i++)
     {
-        auto const number_of_unknowns = apply_visitor(
-            [](auto const& bhe) { return bhe.number_of_unknowns; },
-            _process_data._vec_BHE_property[i]);
+        auto const number_of_unknowns =
+            visit([](auto const& bhe) { return bhe.number_of_unknowns; },
+                  _process_data._vec_BHE_property[i]);
         auto const& bhe_nodes = _bheMeshData.BHE_nodes[i];
         auto const& bhe_elements = _bheMeshData.BHE_elements[i];
 
@@ -256,7 +256,7 @@ void HeatTransportBHEProcess::createBHEBoundaryConditionTopBottom(
                                                   in_out_component_id)));
             }
         };
-        apply_visitor(createBCs, _process_data._vec_BHE_property[bhe_i]);
+        visit(createBCs, _process_data._vec_BHE_property[bhe_i]);
     }
 }
 }  // namespace HeatTransportBHE

--- a/ProcessLib/HeatTransportBHE/LocalAssemblers/LocalDataInitializer.h
+++ b/ProcessLib/HeatTransportBHE/LocalAssemblers/LocalDataInitializer.h
@@ -255,24 +255,24 @@ private:
                   ConstructorArgs&&... args) -> LADataIntfPtr {
             auto& bhe = *element_to_bhe_map.at(e.getID());
 
-            if (bhe.type() == typeid(BHE::BHE_1U))
+            if (std::holds_alternative<BHE::BHE_1U>(bhe))
             {
                 return LADataIntfPtr{new LADataBHE<ShapeFunction, BHE::BHE_1U>{
-                    e, boost::get<BHE::BHE_1U>(bhe),
+                    e, std::get<BHE::BHE_1U>(bhe),
                     std::forward<ConstructorArgs>(args)...}};
             }
 
-            if (bhe.type() == typeid(BHE::BHE_CXA))
+            if (std::holds_alternative<BHE::BHE_CXA>(bhe))
             {
                 return LADataIntfPtr{new LADataBHE<ShapeFunction, BHE::BHE_CXA>{
-                    e, boost::get<BHE::BHE_CXA>(bhe),
+                    e, std::get<BHE::BHE_CXA>(bhe),
                     std::forward<ConstructorArgs>(args)...}};
             }
 
-            if (bhe.type() == typeid(BHE::BHE_CXC))
+            if (std::holds_alternative<BHE::BHE_CXC>(bhe))
             {
                 return LADataIntfPtr{new LADataBHE<ShapeFunction, BHE::BHE_CXC>{
-                    e, boost::get<BHE::BHE_CXC>(bhe),
+                    e, std::get<BHE::BHE_CXC>(bhe),
                     std::forward<ConstructorArgs>(args)...}};
             }
             OGS_FATAL(

--- a/Tests/MaterialLib/TestMPLExponentialProperty.cpp
+++ b/Tests/MaterialLib/TestMPLExponentialProperty.cpp
@@ -27,33 +27,33 @@ TEST(MaterialPropertyLib, ExponentialProperty)
     variable_array[static_cast<int>(
         MaterialPropertyLib::Variable::temperature)] = 20;
     ASSERT_NEAR(
-        boost::get<double>(exp_property.value(variable_array)),
+        std::get<double>(exp_property.value(variable_array)),
         y_ref * (std::exp(-factor *
-                          (boost::get<double>(variable_array[static_cast<int>(
+                          (std::get<double>(variable_array[static_cast<int>(
                                MaterialPropertyLib::Variable::temperature)]) -
                            reference_condition))),
         1.e-10);
     ASSERT_EQ(
-        boost::get<double>(exp_property.dValue(
+        std::get<double>(exp_property.dValue(
             variable_array, MaterialPropertyLib::Variable::phase_pressure)),
         0.0);
     ASSERT_NEAR(
-        boost::get<double>(exp_property.dValue(
+        std::get<double>(exp_property.dValue(
             variable_array, MaterialPropertyLib::Variable::temperature)),
         -y_ref * factor *
             std::exp(-factor *
-                     (boost::get<double>(variable_array[static_cast<int>(
+                     (std::get<double>(variable_array[static_cast<int>(
                           MaterialPropertyLib::Variable::temperature)]) -
                       reference_condition)),
         1.e-16);
     ASSERT_NEAR(
-        boost::get<double>(
+        std::get<double>(
             exp_property.d2Value(variable_array,
                                  MaterialPropertyLib::Variable::temperature,
                                  MaterialPropertyLib::Variable::temperature)),
         y_ref * std::pow(factor, 2) *
             std::exp(-factor *
-                     (boost::get<double>(variable_array[static_cast<int>(
+                     (std::get<double>(variable_array[static_cast<int>(
                           MaterialPropertyLib::Variable::temperature)]) -
                       reference_condition)),
         1.e-16);

--- a/Tests/MaterialLib/TestMPLLinearProperty.cpp
+++ b/Tests/MaterialLib/TestMPLLinearProperty.cpp
@@ -25,20 +25,20 @@ TEST(MaterialPropertyLib, LinearProperty)
     variable_array[static_cast<int>(
         MaterialPropertyLib::Variable::temperature)] = 303.15;
     ASSERT_NEAR(
-        boost::get<double>(linear_property.value(variable_array)),
-        y_ref * (1 + m * (boost::get<double>(variable_array[static_cast<int>(
+        std::get<double>(linear_property.value(variable_array)),
+        y_ref * (1 + m * (std::get<double>(variable_array[static_cast<int>(
                               MaterialPropertyLib::Variable::temperature)]) -
                           x_ref)),
         1.e-10);
     ASSERT_EQ(
-        boost::get<double>(linear_property.dValue(
+        std::get<double>(linear_property.dValue(
             variable_array, MaterialPropertyLib::Variable::phase_pressure)),
         0.0);
     ASSERT_NEAR(
-        boost::get<double>(linear_property.dValue(
+        std::get<double>(linear_property.dValue(
             variable_array, MaterialPropertyLib::Variable::temperature)),
         y_ref * m, 1.e-16);
-    ASSERT_EQ(boost::get<double>(linear_property.d2Value(
+    ASSERT_EQ(std::get<double>(linear_property.d2Value(
                   variable_array,
                   MaterialPropertyLib::Variable::temperature,
                   MaterialPropertyLib::Variable::temperature)),

--- a/Tests/MeshLib/ConvertToLinearMesh.cpp
+++ b/Tests/MeshLib/ConvertToLinearMesh.cpp
@@ -10,9 +10,9 @@
 
 #include <gtest/gtest.h>
 #include <algorithm>
-#include <boost/variant.hpp>
 #include <numeric>
 #include <random>
+#include <variant>
 
 #include "MeshLib/Elements/Element.h"
 #include "MeshLib/Mesh.h"
@@ -42,7 +42,7 @@ public:
 
 // Returns the (inverse) permutation vector of b_nodes to a_nodes, or an error
 // message.
-boost::variant<std::vector<std::size_t>, std::string> compareNodes(
+std::variant<std::vector<std::size_t>, std::string> compareNodes(
     std::vector<Node*> const& a_nodes, std::vector<Node*> const& b_nodes)
 {
     // For each 'a' mesh node find a corresponding 'b' mesh node, not checking
@@ -167,7 +167,7 @@ std::vector<Node*> permuteNodes(std::vector<std::size_t> const& permutation,
 
 // Tests the nodes of two meshes and returns a string in case of error with
 // message, otherwise a permutation vector as in compareNodes().
-boost::variant<std::vector<std::size_t>, std::string> compareNodeVectors(
+std::variant<std::vector<std::size_t>, std::string> compareNodeVectors(
     std::vector<Node*> const& a, std::vector<Node*> const& b)
 {
     if (a.size() != b.size())
@@ -178,13 +178,13 @@ boost::variant<std::vector<std::size_t>, std::string> compareNodeVectors(
     }
 
     auto const compare_nodes_result = compareNodes(a, b);
-    if (compare_nodes_result.type() == typeid(std::string))
+    if (std::holds_alternative<std::string>(compare_nodes_result))
     {
         return "Node comparison failed: " +
-               boost::get<std::string>(compare_nodes_result);
+               std::get<std::string>(compare_nodes_result);
     }
 
-    return boost::get<std::vector<std::size_t>>(compare_nodes_result);
+    return std::get<std::vector<std::size_t>>(compare_nodes_result);
 }
 
 TEST_F(ConvertToLinearMesh, GeneratedHexMeshRandomizedNodes)
@@ -204,13 +204,13 @@ TEST_F(ConvertToLinearMesh, GeneratedHexMeshRandomizedNodes)
     //
     auto const compare_nodes_result = compareNodeVectors(
         quadratic_mesh->getNodes(), permuted_quadratic_nodes);
-    ASSERT_FALSE(compare_nodes_result.type() == typeid(std::string))
+    ASSERT_FALSE(std::holds_alternative<std::string>(compare_nodes_result))
         << "Quadratic mesh nodes comparison with permuted quadratic nodes "
            "failed.\n"
-        << boost::get<std::string>(compare_nodes_result);
+        << std::get<std::string>(compare_nodes_result);
 
     auto const& inverse_permutation =
-        boost::get<std::vector<std::size_t>>(compare_nodes_result);
+        std::get<std::vector<std::size_t>>(compare_nodes_result);
     {
         auto const result =
             inversePermutationIdentityTest(permutation, inverse_permutation);
@@ -268,10 +268,10 @@ TEST_F(ConvertToLinearMesh, GeneratedHexMeshRandomizedNodes)
         //
         auto const compare_nodes_result = compareNodeVectors(
             linear_mesh->getNodes(), converted_mesh->getNodes());
-        ASSERT_FALSE(compare_nodes_result.type() == typeid(std::string))
+        ASSERT_FALSE(std::holds_alternative<std::string>(compare_nodes_result))
             << "Linear mesh nodes comparison with converted linear mesh nodes "
                "failed.\n"
-            << boost::get<std::string>(compare_nodes_result);
+            << std::get<std::string>(compare_nodes_result);
         // TODO (naumov) check inverse permutation, but it requires the reduced
         // to base nodes forward permutation vector first.
 
@@ -304,10 +304,10 @@ TEST_F(ConvertToLinearMesh, GeneratedHexMeshBackToLinear)
     //
     auto const compare_nodes_result =
         compareNodeVectors(linear_mesh->getNodes(), converted_mesh->getNodes());
-    ASSERT_FALSE(compare_nodes_result.type() == typeid(std::string))
+    ASSERT_FALSE(std::holds_alternative<std::string>(compare_nodes_result))
         << "Linear mesh nodes comparison with converted linear mesh nodes "
            "failed.\n"
-        << boost::get<std::string>(compare_nodes_result);
+        << std::get<std::string>(compare_nodes_result);
 
     // Two meshes are equal if their elements share same nodes.
     ASSERT_EQ(linear_mesh->getNumberOfElements(),


### PR DESCRIPTION
Replaces boost::variant.

Fixes #2611 