### PR TITLE
[ML/SM] extended interface to get bulk modulus

### DIFF
--- a/MaterialLib/SolidModels/Ehlers.h
+++ b/MaterialLib/SolidModels/Ehlers.h
@@ -330,6 +330,12 @@ public:
         return MaterialProperties(t, x, _mp);
     }
 
+    double getBulkModulus(double const t,
+                          ParameterLib::SpatialPosition const& x) const override
+    {
+        return _mp.K(t, x)[0];
+    }
+
     DamageProperties evaluatedDamageProperties(
         double const t, ParameterLib::SpatialPosition const& x) const
     {

--- a/MaterialLib/SolidModels/LinearElasticIsotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticIsotropic.h
@@ -104,6 +104,14 @@ public:
 
     MaterialProperties getMaterialProperties() const { return _mp; }
 
+    double getBulkModulus(double const t,
+                          ParameterLib::SpatialPosition const& x) const override
+    {
+        return _mp.bulk_modulus(t, x);
+    }
+
+
+
 protected:
     MaterialProperties _mp;
 };

--- a/MaterialLib/SolidModels/Lubby2.h
+++ b/MaterialLib/SolidModels/Lubby2.h
@@ -155,6 +155,12 @@ public:
             new MaterialStateVariables};
     }
 
+    double getBulkModulus(double const t,
+                          ParameterLib::SpatialPosition const& x) const override
+    {
+        return _mp.KM0(t, x)[0];
+    }
+
 public:
     static int const KelvinVectorSize =
         MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;

--- a/MaterialLib/SolidModels/MechanicsBase.h
+++ b/MaterialLib/SolidModels/MechanicsBase.h
@@ -148,6 +148,13 @@ struct MechanicsBase
         return ConstitutiveModel::Invalid;
     }
 
+    virtual double getBulkModulus(double const /*t*/,
+                                  ParameterLib::SpatialPosition const& /*x*/) const
+    {
+        OGS_FATAL(
+            "getBulkModulus is not yet implemented for this Solid Material.");
+    }
+
     /// Get temperature related coefficient for the global assembly if there is
     /// one.
     virtual double getTemperatureRelatedCoefficient(


### PR DESCRIPTION
Allows to fetch the bulk modulus inside a process without specifying a material model.
Solid Materials without own implementation will cause an OGS_FATAL.
