### PR TITLE
[CL] Option to fix amount of kinetic reactant

### DIFF
--- a/ChemistryLib/CreateOutput.cpp
+++ b/ChemistryLib/CreateOutput.cpp
@@ -32,8 +32,16 @@ std::unique_ptr<Output> createOutput(
                    std::back_inserter(accepted_items), accepted_item);
     std::transform(equilibrium_phases.begin(), equilibrium_phases.end(),
                    std::back_inserter(accepted_items), accepted_item);
-    std::transform(kinetic_reactants.begin(), kinetic_reactants.end(),
-                   std::back_inserter(accepted_items), accepted_item);
+
+    for (auto const& kinetic_reactant : kinetic_reactants)
+    {
+        if (kinetic_reactant.item_type == ItemType::KineticReactant &&
+            kinetic_reactant.fix_amount)
+            continue;
+
+        accepted_items.push_back(
+                    OutputItem(kinetic_reactant.name, kinetic_reactant.item_type));
+    }
 
     // Record ids of which phreeqc output items will be dropped.
     BasicOutputSetups basic_output_setups(project_file_name);

--- a/ChemistryLib/PhreeqcIOData/CreateKineticReactant.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateKineticReactant.cpp
@@ -49,6 +49,10 @@ std::vector<KineticReactant> createKineticReactants(
             reactant_config.getConfigParameter<std::vector<double>>(
                 "parameters", {});
 
+        bool const fix_amount =
+            //! \ogs_file_param{prj__chemical_system__kinetic_reactants__kinetic_reactant__fix_amount}
+            reactant_config.getConfigParameter<bool>("fix_amount", false);
+
         auto amount = MeshLib::getOrCreateMeshProperty<double>(
             const_cast<MeshLib::Mesh&>(mesh),
             name,
@@ -56,10 +60,18 @@ std::vector<KineticReactant> createKineticReactants(
             1);
         std::fill(std::begin(*amount), std::end(*amount), initial_amount);
 
+        if (chemical_formula.empty() && fix_amount)
+        {
+            OGS_FATAL(
+                "fix_amount can only be used if a chemical_formula has been "
+                "defined");
+        }
+
         kinetic_reactants.emplace_back(std::move(name),
                                        std::move(chemical_formula),
                                        amount,
-                                       std::move(parameters));
+                                       std::move(parameters),
+                                       fix_amount);
     }
 
     return kinetic_reactants;

--- a/ChemistryLib/PhreeqcIOData/KineticReactant.h
+++ b/ChemistryLib/PhreeqcIOData/KineticReactant.h
@@ -25,11 +25,13 @@ struct KineticReactant
     KineticReactant(std::string&& name_,
                     std::string&& chemical_formula_,
                     MeshLib::PropertyVector<double>* amount_,
-                    std::vector<double>&& parameters_)
+                    std::vector<double>&& parameters_,
+                    bool const fix_amount_)
         : name(std::move(name_)),
           chemical_formula(std::move(chemical_formula_)),
           amount(amount_),
-          parameters(std::move(parameters_))
+          parameters(std::move(parameters_)),
+          fix_amount(fix_amount_)
     {
     }
 
@@ -39,6 +41,7 @@ struct KineticReactant
     std::string const chemical_formula;
     MeshLib::PropertyVector<double>* amount;
     std::vector<double> const parameters;
+    bool const fix_amount;
     static const ItemType item_type = ItemType::KineticReactant;
 };
 }  // namespace ChemistryLib

--- a/Documentation/ProjectFile/prj/chemical_system/kinetic_reactants/kinetic_reactant/t_fix_amount.md
+++ b/Documentation/ProjectFile/prj/chemical_system/kinetic_reactants/kinetic_reactant/t_fix_amount.md
@@ -1,0 +1,4 @@
+specify if the amount of the kinetic reactant should be fixed to the initial amount during the simulation.
+Possible values: *true* (fixed); *false* (not fixed); default is *false*.
+Fixing the amount of a kinetic reactant may be desireable when the kinetic reactant is used to represents a reaction rate that transfers mass between other reactants.
+Note: fix_amount can only be used if a chemical_formula has been defined!

--- a/ProcessLib/ComponentTransport/Tests.cmake
+++ b/ProcessLib/ComponentTransport/Tests.cmake
@@ -1146,3 +1146,27 @@ AddTest(
     KineticReactant2_2d_pcs_4_ts_16_t_1600.000000_expected.vtu KineticReactant2_2d_pcs_4_ts_16_t_1600.000000.vtu H H 1e-10 1e-16
     KineticReactant2_2d_pcs_4_ts_20_t_2000.000000_expected.vtu KineticReactant2_2d_pcs_4_ts_20_t_2000.000000.vtu H H 1e-10 1e-16
 )
+
+AddTest(
+    NAME 1D_ReactiveMassTransport_Wetland
+    PATH Parabolic/ComponentTransport/ReactiveTransport/Wetland
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS Wetland_1d.prj
+    WRAPPER time
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    DIFF_DATA
+    Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu Wetland_1d_pcs_11_ts_4_t_28800.000000.vtu pressure pressure 1e-6 1e-10
+    Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu Wetland_1d_pcs_11_ts_4_t_28800.000000.vtu H H 1e-10 1e-16
+    Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu Wetland_1d_pcs_11_ts_4_t_28800.000000.vtu Do Do 1e-10 1e-16
+    Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu Wetland_1d_pcs_11_ts_4_t_28800.000000.vtu Sf Sf 1e-10 1e-16
+    Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu Wetland_1d_pcs_11_ts_4_t_28800.000000.vtu Sa Sa 1e-10 1e-16
+    Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu Wetland_1d_pcs_11_ts_4_t_28800.000000.vtu Sin Sin 1e-10 1e-16
+    Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu Wetland_1d_pcs_11_ts_4_t_28800.000000.vtu Xs_m Xs_m 1e-10 1e-16
+    Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu Wetland_1d_pcs_11_ts_4_t_28800.000000.vtu Xi_m Xi_m 1e-10 1e-16
+    Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu Wetland_1d_pcs_11_ts_4_t_28800.000000.vtu Snh Snh 1e-10 1e-16
+    Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu Wetland_1d_pcs_11_ts_4_t_28800.000000.vtu Sno Sno 1e-10 1e-16
+    Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu Wetland_1d_pcs_11_ts_4_t_28800.000000.vtu Sso Sso 1e-10 1e-16
+    Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu Wetland_1d_pcs_11_ts_4_t_28800.000000.vtu Sulphide Sulphide 1e-10 1e-16
+    RUNTIME 140
+)

--- a/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/Wetland/Wetland_1d.gml
+++ b/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/Wetland/Wetland_1d.gml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5cbe55043467113fe641c4cf4a686cb8f48227bbd6eaf654fd3856b580e6c45
+size 397

--- a/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/Wetland/Wetland_1d.prj
+++ b/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/Wetland/Wetland_1d.prj
@@ -1,0 +1,2145 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<OpenGeoSysProject>
+    <mesh>Wetland_1d.vtu</mesh>
+    <geometry>Wetland_1d.gml</geometry>
+    <processes>
+        <process>
+            <name>hc</name>
+            <type>ComponentTransport</type>
+            <integration_order>2</integration_order>
+            <coupling_scheme>staggered</coupling_scheme>
+            <process_variables>
+                <pressure>pressure</pressure>
+                <concentration>H</concentration>
+                <concentration>Do</concentration>
+                <concentration>Sf</concentration>
+                <concentration>Sa</concentration>
+                <concentration>Sin</concentration>
+                <concentration>Snh</concentration>
+                <concentration>Sno</concentration>
+                <concentration>Sulphide</concentration>
+                <concentration>Sso</concentration>
+                <concentration>Xs_m</concentration>
+                <concentration>Xi_m</concentration>
+            </process_variables>
+            <specific_body_force>0 0</specific_body_force>
+            <secondary_variables>
+                <secondary_variable type="static" internal_name="darcy_velocity" output_name="darcy_velocity"/>
+            </secondary_variables>
+        </process>
+    </processes>
+    <media>
+        <medium id="0">
+            <phases>
+                <phase>
+                    <type>AqueousLiquid</type>
+                    <components>
+                        <component>
+                            <name>H</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Do</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sf</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sa</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sin</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Snh</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sno</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sulphide</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sso</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Xs_m</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Xi_m</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                    </components>
+                    <properties>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1e3</value>
+                        </property>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+            <properties>
+                <property>
+                    <name>permeability</name>
+                    <type>Parameter</type>
+                    <parameter_name>kappa0</parameter_name>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Parameter</type>
+                    <parameter_name>porosity</parameter_name>
+                </property>
+                <property>
+                    <name>longitudinal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0.45</value>
+                </property>
+                <property>
+                    <name>transversal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0.00</value>
+                </property>
+            </properties>
+        </medium>
+        <medium id="1">
+            <phases>
+                <phase>
+                    <type>AqueousLiquid</type>
+                    <components>
+                        <component>
+                            <name>H</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Do</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sf</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sa</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sin</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Snh</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sno</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sulphide</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sso</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Xs_m</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Xi_m</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                    </components>
+                    <properties>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1e3</value>
+                        </property>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+            <properties>
+                <property>
+                    <name>permeability</name>
+                    <type>Parameter</type>
+                    <parameter_name>kappa1</parameter_name>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Parameter</type>
+                    <parameter_name>porosity</parameter_name>
+                </property>
+                <property>
+                    <name>longitudinal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0.4</value>
+                </property>
+                <property>
+                    <name>transversal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0.00</value>
+                </property>
+            </properties>
+        </medium>
+        <medium id="2">
+            <phases>
+                <phase>
+                    <type>AqueousLiquid</type>
+                    <components>
+                        <component>
+                            <name>H</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Do</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sf</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sa</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sin</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Snh</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sno</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sulphide</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Sso</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Xs_m</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                        <component>
+                            <name>Xi_m</name>
+                            <properties>
+                                <property>
+                                    <name>molecular_diffusion</name>
+                                    <type>Constant</type>
+                                    <value>0.0e-9</value>
+                                </property>
+                                <property>
+                                    <name>retardation_factor</name>
+                                    <type>Constant</type>
+                                    <value>1</value>
+                                </property>
+                                <property>
+                                    <name>decay_rate</name>
+                                    <type>Parameter</type>
+                                    <parameter_name>decay</parameter_name>
+                                </property>
+                            </properties>
+                        </component>
+                    </components>
+                    <properties>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1e3</value>
+                        </property>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+            <properties>
+                <property>
+                    <name>permeability</name>
+                    <type>Parameter</type>
+                    <parameter_name>kappa0</parameter_name>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Parameter</type>
+                    <parameter_name>porosity</parameter_name>
+                </property>
+                <property>
+                    <name>longitudinal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0.45</value>
+                </property>
+                <property>
+                    <name>transversal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0.00</value>
+                </property>
+            </properties>
+        </medium>
+    </media>
+    <time_loop>
+        <global_process_coupling>
+            <max_iter>6</max_iter>
+            <convergence_criteria>
+                <!-- convergence criterion for the first process (p) -->
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+            </convergence_criteria>
+        </global_process_coupling>
+        <processes>
+            <!-- convergence criterion for hydraulic equation -->
+             <process ref="hc">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>28800</t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>4</repeat>
+                            <delta_t>7200</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+            <process ref="hc">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>28800</t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>4</repeat>
+                            <delta_t>7200</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+            <process ref="hc">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>28800</t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>4</repeat>
+                            <delta_t>7200</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+            <process ref="hc">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>28800</t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>4</repeat>
+                            <delta_t>7200</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+            <process ref="hc">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>28800</t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>4</repeat>
+                            <delta_t>7200</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+            <process ref="hc">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>28800</t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>4</repeat>
+                            <delta_t>7200</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+            <process ref="hc">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>28800</t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>4</repeat>
+                            <delta_t>7200</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+            <process ref="hc">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>28800</t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>4</repeat>
+                            <delta_t>7200</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+            <process ref="hc">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>28800</t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>4</repeat>
+                            <delta_t>7200</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+            <process ref="hc">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>28800</t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>4</repeat>
+                            <delta_t>7200</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+            <process ref="hc">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>28800</t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>4</repeat>
+                            <delta_t>7200</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+            <process ref="hc">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <reltol>1e-14</reltol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>28800</t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>4</repeat>
+                            <delta_t>7200</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+        </processes>
+        <output>
+            <type>VTK</type>
+            <prefix>Wetland_1d</prefix>
+            <timesteps>
+                <pair>
+                    <repeat>1</repeat>
+                    <each_steps>4</each_steps>
+                </pair>
+            </timesteps>
+            <variables>
+                <variable>pressure</variable>
+                <variable>darcy_velocity</variable>
+                <variable>H</variable>
+                <variable>Do</variable>
+                <variable>Sf</variable>
+                <variable>Sa</variable>
+                <variable>Sin</variable>
+                <variable>Snh</variable>
+                <variable>Sno</variable>
+                <variable>Sulphide</variable>
+                <variable>Sso</variable>
+                <variable>Xs_m</variable>
+                <variable>Xi_m</variable>
+            </variables>
+        </output>
+    </time_loop>
+        <chemical_system chemical_solver="Phreeqc">
+        <database>cwm1.dat</database>
+        <solution>
+            <temperature>10</temperature>
+            <pressure>1</pressure>
+            <pe>4</pe>
+            <means_of_adjusting_charge>pH</means_of_adjusting_charge>
+            <components>
+                <component>Do</component>
+                <component>Sf</component>
+                <component>Sa</component>
+                <component>Sin</component>
+                <component>Snh</component>
+                <component>Sno</component>
+                <component>Sulphide</component>
+                <component>Sso</component>
+                <component>Xs_m</component>
+                <component>Xi_m</component>
+            </components>
+        </solution>
+                <kinetic_reactants>
+                    <kinetic_reactant>
+                        <name>Aeration</name>
+                        <chemical_formula>Do 1</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>AttDetachment_Xi</name>
+                        <chemical_formula>Xi_m -1</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>AttDetachment_Xs</name>
+                        <chemical_formula>Xs_m -1</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Hydrolysis_Xs_m</name>
+                        <chemical_formula>Sf 1 Sin 0  Snh 0.01  Xs_m -1</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Hydrolysis_Xs_im</name>
+                        <chemical_formula>Sf  1  Sin    0  Snh 0.01</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Aerobic_Growth_Xh_on_Sf</name>
+                        <chemical_formula>Do -0.587301587301587  Sf -1.58730158730159  Snh -0.022380952</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Anoxic_Growth_Xh_on_Sf</name>
+                        <chemical_formula>Sf  -1.58730158730159  Sno -0.205350205  Snh -0.02238095</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Aerobic_Growth_Xh_on_Sa</name>
+                        <chemical_formula>Do  -0.587301587301587  Sa -1.58730158730159  Snh -0.07</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Anoxic_Growth_Xh_on_Sa</name>
+                        <chemical_formula>Sa -1.58730158730159  Sno -0.205350205  Snh -0.07</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Lysis_Xh</name>
+                        <chemical_formula>Sf 0.05  Snh 0.0315</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Aerobic_Growth_Xa_on_Snh</name>
+                        <chemical_formula>Do -18.04166667  Sno 4.166666667  Snh -4.236666667</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Lysis_Xa</name>
+                <chemical_formula>Sf 0.05  Snh 0.0315</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Growth_Xfb</name>
+                        <chemical_formula>Sf -18.86792453  Sa 17.86792453  Snh 0.496037736</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Lysis_Xfb</name>
+                        <chemical_formula>Sf 0.05  Snh 0.0315</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Growth_Xamb</name>
+                        <chemical_formula>Sa -31.25 Snh -0.07</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Lysis_Xamb</name>
+                        <chemical_formula>Sf 0.05   Snh 0.0315</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Growth_Xasrb</name>
+                        <chemical_formula>Sa -20  Sso -9.5  Sulphide 9.5  Snh   -0.07</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Lysis_Xasrb</name>
+                        <chemical_formula>Sf 0.05   Snh 0.0315</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Aerobic_Growth_Xsob</name>
+                        <chemical_formula>Do    -15.66666667  Sso 8.333333333       Sulphide -8.333333333   Snh -0.07</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Anoxic_Growth_Xsob</name>
+                        <chemical_formula>Sno -8.380952381  Sso 8.333333333     Sulphide -8.333333333   Snh -0.07</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Lysis_Xsob</name>
+                        <chemical_formula>Sf 0.05   Snh 0.0315</chemical_formula>
+                        <initial_amount>1.0</initial_amount>
+                        <fix_amount>true</fix_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Xh</name>
+                        <chemical_formula>Do 0</chemical_formula>
+                        <initial_amount>1.0e-3</initial_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Xa</name>
+                        <chemical_formula>Do 0</chemical_formula>
+                        <initial_amount>1.0e-3</initial_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Xfb</name>
+                        <chemical_formula>Do 0</chemical_formula>
+                        <initial_amount>1.0e-3</initial_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Xamb</name>
+                        <chemical_formula>Do 0</chemical_formula>
+                        <initial_amount>1.0e-3</initial_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Xasrb</name>
+                        <chemical_formula>Do 0</chemical_formula>
+                        <initial_amount>1.0e-3</initial_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Xsob</name>
+                        <chemical_formula>Do 0</chemical_formula>
+                        <initial_amount>1.0e-3</initial_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Xs_im</name>
+                        <chemical_formula>Do 0</chemical_formula>
+                        <initial_amount>1.0e-4</initial_amount>
+                    </kinetic_reactant>
+                    <kinetic_reactant>
+                        <name>Xi_im</name>
+                        <chemical_formula>Do 0</chemical_formula>
+                        <initial_amount>1.0e-4</initial_amount>
+                    </kinetic_reactant>
+                </kinetic_reactants>
+        <rates>
+            <rate>
+                <kinetic_reactant>Aeration</kinetic_reactant>
+                <expression>
+                    <statement>So2 = MOL("Do")</statement>
+                    <statement>So2_sat = CALC_VALUE("So_sat")</statement>
+                    <statement>if So2 > So2_sat then goto 8</statement>
+                    <statement>kLa = 2 / 3600</statement>
+                    <statement>r_So2 = So2_sat - So2</statement>
+                    <statement>rates = CALC_VALUE("kLa_theta") * kLa * r_So2</statement>
+                    <statement>dGrowth= rates*time</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+                        <rate>
+                <kinetic_reactant>AttDetachment_Xi</kinetic_reactant>
+                <expression>
+                    <statement>Xi_mob = MOL("Xi_m")</statement>
+                    <statement>Xi_immob = KIN("Xi_im")</statement>
+                    <statement>IF Xi_immob >= 30.0 THEN GOTO 10</statement>
+                    <statement>k_att = 0.1 /3600</statement>
+                    <statement>k_det = 0</statement>
+                    <statement>r_Att = k_att * Xi_mob</statement>
+                    <statement>r_Det = k_det * Xi_immob</statement>
+                    <statement>rates = r_Att - r_Det</statement>
+                    <statement>dGrowth= rates*time</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+                        <rate>
+                <kinetic_reactant>AttDetachment_Xs</kinetic_reactant>
+                <expression>
+                    <statement>Xs_mob = MOL("Xs_m")</statement>
+                    <statement>Xs_immob = KIN("Xs_im")</statement>
+                    <statement>k_att = 0.1 /3600</statement>
+                    <statement>k_det = 0</statement>
+                    <statement>r_Att = k_att * Xs_mob</statement>
+                    <statement>r_Det = k_det * Xs_immob</statement>
+                    <statement>rates = r_Att - r_Det</statement>
+                    <statement>dGrowth= rates*time</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Hydrolysis_Xs_m</kinetic_reactant>
+                <expression>
+                    <statement>Xs_m = MOL("Xs_m")</statement>
+                    <statement>Xfb = KIN("Xfb")</statement>
+                    <statement>Xh = KIN("Xh")</statement>
+                    <statement>r_Xs = (Xs_m/(Xh+Xfb))</statement>
+                    <statement>r_Xs = r_Xs / (CALC_VALUE("Kx") + r_Xs)</statement>
+                    <statement>rates = CALC_VALUE("Kh") * r_Xs * (Xh + CALC_VALUE("eta_h") * Xfb)</statement>
+                    <statement>dHydrolysis = rates * time</statement>
+                    <statement>dHydrolysis = dHydrolysis</statement>
+                    <statement>SAVE dHydrolysis</statement>
+                </expression>
+            </rate>
+                        <rate>
+                <kinetic_reactant>Hydrolysis_Xs_im</kinetic_reactant>
+                <expression>
+                    <statement>Xs_im = KIN("Xs_im")</statement>
+                    <statement>Xfb = KIN("Xfb")</statement>
+                    <statement>Xh = KIN("Xh")</statement>
+                    <statement>r_Xs = (Xs_im/(Xh+Xfb))</statement>
+                    <statement>r_Xs = r_Xs / (CALC_VALUE("Kx") + r_Xs)</statement>
+                    <statement>rates = CALC_VALUE("Kh") * r_Xs * (Xh + CALC_VALUE("eta_h") * Xfb)</statement>
+                    <statement>dHydrolysis = rates * time</statement>
+                    <statement>dHydrolysis = dHydrolysis</statement>
+                    <statement>SAVE dHydrolysis</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Aerobic_Growth_Xh_on_Sf</kinetic_reactant>
+                <expression>
+                    <statement>Sf = MOL("Sf")</statement>
+                    <statement>So2 = MOL("Do")</statement>
+                    <statement>Sa = MOL("Sa")</statement>
+                    <statement>Snh = MOL("Snh")</statement>
+                    <statement>Sh2S = MOL("Sulphide")</statement>
+                    <statement>Xh = KIN("Xh")</statement>
+                    <statement>r_Sf = Sf/(CALC_VALUE("Ksf")+ Sf)</statement>
+                    <statement>r_So2 = So2/(CALC_VALUE("Koh")+ So2)</statement>
+                    <statement>r_Sa = Sf/(Sf + Sa)</statement>
+                    <statement>r_Snh = Snh /(CALC_VALUE("Knhh")+ Snh)</statement>
+                    <statement>r_Sh2s = CALC_VALUE("Kh2s_h") / (CALC_VALUE("Kh2s_h") + Sh2S )</statement>
+                    <statement>rates = CALC_VALUE("muh") * r_Sf * r_So2 * r_Sa * r_Snh *  r_Sh2s * Xh * CALC_VALUE("bac_growth_limit")</statement>
+                    <statement>dGrowth= rates*time</statement>
+                    <statement>dGrowth = dGrowth</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+                        <rate>
+                <kinetic_reactant>Anoxic_Growth_Xh_on_Sf</kinetic_reactant>
+                <expression>
+                    <statement>Sf = MOL("Sf")</statement>
+                    <statement>So2 = MOL("Do")</statement>
+                    <statement>Sa = MOL("Sa")</statement>
+                    <statement>Snh = MOL("Snh")</statement>
+                    <statement>Sno = MOL("Sno")</statement>
+                    <statement>Sh2S = MOL("Sulphide")</statement>
+                    <statement>Xh = KIN("Xh")</statement>
+                    <statement>r_Sf = Sf/(CALC_VALUE("Ksf")+ Sf)</statement>
+                    <statement>r_Koh = CALC_VALUE("Koh")/(CALC_VALUE("Koh")+ So2)</statement>
+                    <statement>r_Sa = Sf/(Sf + Sa)</statement>
+                    <statement>r_Snh = Snh /(CALC_VALUE("Knhh")+ Snh)</statement>
+                    <statement>r_Sno = Sno /(CALC_VALUE("Knoh")+ Sno)</statement>
+                    <statement>r_Sh2s = CALC_VALUE("Kh2s_h") / (CALC_VALUE("Kh2s_h") + Sh2S)</statement>
+                    <statement>rates = CALC_VALUE("eta_g") * CALC_VALUE("muh") * r_Sf * r_Sa * r_Koh * r_Snh * r_Sno * r_Sh2s * Xh * CALC_VALUE("bac_growth_limit")</statement>
+                    <statement>dGrowth= rates*time</statement>
+                    <statement>dGrowth = dGrowth</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Aerobic_Growth_Xh_on_Sa</kinetic_reactant>
+                <expression>
+                    <statement>Sf = MOL("Sf")</statement>
+                    <statement>So2 = MOL("Do")</statement>
+                    <statement>Sa = MOL("Sa")</statement>
+                    <statement>Snh = MOL("Snh")</statement>
+                    <statement>Sh2S = MOL("Sulphide")</statement>
+                    <statement>Xh = KIN("Xh")</statement>
+                    <statement>r_Sa1 = Sa /(CALC_VALUE("Ksa")+ Sa)</statement>
+                    <statement>r_Sa2 = Sa /(Sf + Sa)</statement>
+                    <statement>r_So2 = So2/(CALC_VALUE("Koh")+ So2)</statement>
+                    <statement>r_Snh = Snh /(CALC_VALUE("Knhh")+ Snh)</statement>
+                    <statement>r_Sh2s = CALC_VALUE("Kh2s_h") / (CALC_VALUE("Kh2s_h") + Sh2S)</statement>
+                    <statement>rates = CALC_VALUE("muh") * r_Sa1 * r_Sa2 * r_So2 * r_Snh *  r_Sh2s * Xh * CALC_VALUE("bac_growth_limit")</statement>
+                    <statement>dGrowth= rates * time</statement>
+                    <statement>dGrowth = dGrowth</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+                        <rate>
+                <kinetic_reactant>Anoxic_Growth_Xh_on_Sa</kinetic_reactant>
+                <expression>
+                    <statement>Sf = MOL("Sf")</statement>
+                    <statement>So2 = MOL("Do")</statement>
+                    <statement>Sa = MOL("Sa")</statement>
+                    <statement>Snh = MOL("Snh")</statement>
+                    <statement>Sno = MOL("Sno")</statement>
+                    <statement>Sh2S = MOL("Sulphide")</statement>
+                    <statement>Xh = KIN("Xh")</statement>
+                    <statement>r_Sa1 = Sa/(CALC_VALUE("Ksa")+ Sa)</statement>
+                    <statement>r_Sa2 = Sa/(Sf + Sa)</statement>
+                    <statement>r_Koh = CALC_VALUE("Koh")/(CALC_VALUE("Koh")+ So2)</statement>
+                    <statement>r_Snh = Snh /(CALC_VALUE("Knhh")+ Snh)</statement>
+                    <statement>r_Sno = Sno /(CALC_VALUE("Knoh")+ Sno)</statement>
+                    <statement>r_Sh2s = CALC_VALUE("Kh2s_h") / (CALC_VALUE("Kh2s_h") + Sh2S)</statement>
+                    <statement>rates = CALC_VALUE("eta_g") * CALC_VALUE("muh") * r_Sa1 * r_Sa2 * r_Koh * r_Sno * r_Snh * r_Sh2s * Xh * CALC_VALUE("bac_growth_limit")</statement>
+                    <statement>dGrowth= rates*time</statement>
+                    <statement>dGrowth = dGrowth</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Lysis_Xh</kinetic_reactant>
+                <expression>
+                    <statement>Xh = KIN("Xh")</statement>
+                    <statement>rates = CALC_VALUE("bh") * Xh</statement>
+                    <statement>dLysis = rates * time</statement>
+                    <statement>dLysis = dLysis</statement>
+                    <statement>SAVE dLysis</statement>
+                </expression>
+            </rate>
+                        <rate>
+                <kinetic_reactant>Aerobic_Growth_Xa_on_Snh</kinetic_reactant>
+                <expression>
+                    <statement>So2 = MOL("Do")</statement>
+                    <statement>Snh = MOL("Snh")</statement>
+                    <statement>Sh2S = MOL("Sulphide")</statement>
+                    <statement>Xa = KIN("Xa")</statement>
+                    <statement>r_So2_a = So2 /(CALC_VALUE("Koa")+ So2)</statement>
+                    <statement>r_Snh_a = Snh /(CALC_VALUE("Knha")+ Snh)</statement>
+                    <statement>r_Sh2s_a = CALC_VALUE("Kh2s_a") / (CALC_VALUE("Kh2s_a") + Sh2S)</statement>
+                    <statement>rates = CALC_VALUE("mu_a") * r_So2_a * r_Snh_a *  r_Sh2s_a * Xa * CALC_VALUE("bac_growth_limit")</statement>
+                    <statement>dGrowth= rates*time</statement>
+                    <statement>dGrowth = dGrowth</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Lysis_Xa</kinetic_reactant>
+                <expression>
+                    <statement>Xa = KIN("Xa")</statement>
+                    <statement>rates = CALC_VALUE("ba") * Xa</statement>
+                    <statement>dLysis = rates * time</statement>
+                    <statement>dLysis = dLysis</statement>
+                    <statement>SAVE dLysis</statement>
+                </expression>
+            </rate>
+                        <rate>
+                <kinetic_reactant>Growth_Xfb</kinetic_reactant>
+                <expression>
+                    <statement>Sf = MOL("Sf")</statement>
+                    <statement>So2 = MOL("Do")</statement>
+                    <statement>Snh = MOL("Snh")</statement>
+                    <statement>Sno = MOL("Sno")</statement>
+                    <statement>Sh2S = MOL("Sulphide")</statement>
+                    <statement>Xfb = KIN("Xfb")</statement>
+                    <statement>r_Sf_fb = Sf/(CALC_VALUE("Ksfb")+ Sf)</statement>
+                    <statement>r_Ko_fb = CALC_VALUE("Kofb")/(CALC_VALUE("Kofb")+ So2)</statement>
+                    <statement>r_Snh_fb = Snh /(CALC_VALUE("Knhfb")+ Snh)</statement>
+                    <statement>r_Kno_fb = CALC_VALUE("Knofb")/(CALC_VALUE("Knofb")+ Sno)</statement>
+                    <statement>r_Sh2s_fb = CALC_VALUE("Kh2s_fb") / (CALC_VALUE("Kh2s_fb") + Sh2S)</statement>
+                    <statement>rates = CALC_VALUE("mu_fb") * r_Sf_fb * r_Ko_fb * r_Snh_fb * r_Kno_fb * r_Sh2s_fb * Xfb * CALC_VALUE("bac_growth_limit")</statement>
+                    <statement>dGrowth= rates*time</statement>
+                    <statement>dGrowth = dGrowth</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+                        <rate>
+                <kinetic_reactant>Lysis_Xfb</kinetic_reactant>
+                <expression>
+                    <statement>Xfb = KIN("Xfb")</statement>
+                    <statement>rates = CALC_VALUE("b_fb") * Xfb</statement>
+                    <statement>dLysis = rates * time</statement>
+                    <statement>dLysis = dLysis</statement>
+                    <statement>SAVE dLysis</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Growth_Xamb</kinetic_reactant>
+                <expression>
+                    <statement>Sa = MOL("Sa")</statement>
+                    <statement>So2 = MOL("Do")</statement>
+                    <statement>Snh = MOL("Snh")</statement>
+                    <statement>Sno = MOL("Sno")</statement>
+                    <statement>Sh2S = MOL("Sulphide")</statement>
+                    <statement>Xamb = KIN("Xamb")</statement>
+                    <statement>r_Sa_amb = Sa/(CALC_VALUE("Ksamb")+ Sa)</statement>
+                    <statement>r_Ko_amb = CALC_VALUE("Koamb")/(CALC_VALUE("Koamb")+ So2)</statement>
+                    <statement>r_Snh_amb = Snh /(CALC_VALUE("Knhamb")+ Snh)</statement>
+                    <statement>r_Kno_amb = CALC_VALUE("Knoamb") /(CALC_VALUE("Knoamb")+ Sno)</statement>
+                    <statement>r_Sh2s_amb = CALC_VALUE("Kh2s_amb") / (CALC_VALUE("Kh2s_amb") + Sh2S)</statement>
+                    <statement>rates = CALC_VALUE("mu_amb") * r_Sa_amb * r_Ko_amb * r_Snh_amb * r_Kno_amb * r_Sh2s_amb * Xamb * CALC_VALUE("bac_growth_limit")</statement>
+                    <statement>dGrowth= rates*time</statement>
+                    <statement>dGrowth = dGrowth</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Lysis_Xamb</kinetic_reactant>
+                <expression>
+                    <statement>Xamb = KIN("Xamb")</statement>
+                    <statement>rates = CALC_VALUE("b_amb") * Xamb</statement>
+                    <statement>dLysis = rates * time</statement>
+                    <statement>dLysis = dLysis</statement>
+                    <statement>SAVE dLysis</statement>
+                </expression>
+            </rate>
+                        <rate>
+                <kinetic_reactant>Growth_Xasrb</kinetic_reactant>
+                <expression>
+                    <statement>Sa = MOL("Sa")</statement>
+                    <statement>So2 = MOL("Do")</statement>
+                    <statement>Snh = MOL("Snh")</statement>
+                    <statement>Sno = MOL("Sno")</statement>
+                    <statement>Sh2S = MOL("Sulphide")</statement>
+                    <statement>Sso4 = MOL("Sso")</statement>
+                    <statement>Xasrb = KIN("Xasrb")</statement>
+                    <statement>r_Sa_asrb = Sa/(CALC_VALUE("Ks_asrb")+ Sa)</statement>
+                    <statement>r_Ko_asrb = CALC_VALUE("Ko_asrb")/(CALC_VALUE("Ko_asrb")+ So2)</statement>
+                    <statement>r_Snh_asrb = Snh /(CALC_VALUE("Knh_asrb")+ Snh)</statement>
+                    <statement>r_Kno_asrb = CALC_VALUE("Kno_asrb") /(CALC_VALUE("Kno_asrb")+ Sno)</statement>
+                    <statement>r_Sh2s_asrb = CALC_VALUE("Kh2s_asrb") / (CALC_VALUE("Kh2s_asrb") + Sh2S)</statement>
+                    <statement>r_Sso4_asrb = Sso4 / (CALC_VALUE("Kso_asrb") + Sso4)</statement>
+                    <statement>rates = CALC_VALUE("mu_asrb") * r_Sa_asrb * r_Ko_asrb * r_Snh_asrb * r_Kno_asrb * r_Sh2s_asrb * r_Sso4_asrb * Xasrb * CALC_VALUE("bac_growth_limit")</statement>
+                    <statement>dGrowth= rates*time</statement>
+                    <statement>dGrowth = dGrowth</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Lysis_Xasrb</kinetic_reactant>
+                <expression>
+                    <statement>Xasrb = KIN("Xasrb")</statement>
+                    <statement>rates = CALC_VALUE("b_asrb") * Xasrb</statement>
+                    <statement>dLysis = rates * time</statement>
+                    <statement>dLysis = dLysis</statement>
+                    <statement>SAVE dLysis</statement>
+                </expression>
+            </rate>
+                        <rate>
+                <kinetic_reactant>Aerobic_Growth_Xsob</kinetic_reactant>
+                <expression>
+                    <statement>So2 = MOL("Do")</statement>
+                    <statement>Snh = MOL("Snh")</statement>
+                    <statement>Sh2S = MOL("Sulphide")</statement>
+                    <statement>Xsob = KIN("Xsob")</statement>
+                    <statement>r_So2_sob = So2 /(CALC_VALUE("Ko_sob")+ So2)</statement>
+                    <statement>r_Snh_sob = Snh /(CALC_VALUE("Knh_sob")+ Snh)</statement>
+                    <statement>r_Sh2s_sob = Sh2s / (CALC_VALUE("Kh2s_sob") + Sh2S)</statement>
+                    <statement>rates = CALC_VALUE("mu_sob") * r_So2_sob * r_Sh2s_sob * r_Snh_sob * Xsob * CALC_VALUE("bac_growth_limit")</statement>
+                    <statement>dGrowth= rates*time</statement>
+                    <statement>dGrowth = dGrowth</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Anoxic_Growth_Xsob</kinetic_reactant>
+                <expression>
+                    <statement>So2 = MOL("Do")</statement>
+                    <statement>Snh = MOL("Snh")</statement>
+                    <statement>Sno = MOL("Sno")</statement>
+                    <statement>Sh2S = MOL("Sulphide")</statement>
+                    <statement>Xsob = KIN("Xsob")</statement>
+                    <statement>r_Ko2_sob = CALC_VALUE("Ko_sob") /(CALC_VALUE("Ko_sob")+ So2)</statement>
+                    <statement>r_Snh_sob = Snh /(CALC_VALUE("Knh_sob")+ Snh)</statement>
+                    <statement>r_Sh2s_sob = Sh2s / (CALC_VALUE("Kh2s_sob") + Sh2S)</statement>
+                    <statement>r_Sno_sob = Sno / (CALC_VALUE("Kno_sob") + Sno)</statement>
+                    <statement>rates = CALC_VALUE("mu_sob") * CALC_VALUE("eta_sob") * r_Ko2_sob * r_Sh2s_sob * r_Snh_sob * r_Sno_sob * Xsob * CALC_VALUE("bac_growth_limit")</statement>
+                    <statement>dGrowth= rates*time</statement>
+                    <statement>dGrowth = dGrowth</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Lysis_Xsob</kinetic_reactant>
+                <expression>
+                    <statement>Xsob = KIN("Xsob")</statement>
+                    <statement>rates = CALC_VALUE("b_sob") * Xsob</statement>
+                    <statement>dLysis = rates * time</statement>
+                    <statement>dLysis = dLysis</statement>
+                    <statement>SAVE dLysis</statement>
+                </expression>
+            </rate>
+                        <rate>
+                <kinetic_reactant>Xs_im</kinetic_reactant>
+                <expression>
+                    <statement>dGrowth = KIN_DELTA("AttDetachment_Xs")</statement>
+                    <statement>dGrowth = dGrowth - KIN_DELTA("Hydrolysis_Xs_im")</statement>
+                    <statement>dGrowth = dGrowth + 0.85*KIN_DELTA("Lysis_Xh")</statement>
+                    <statement>dGrowth = dGrowth + 0.85*KIN_DELTA("Lysis_Xa")</statement>
+                    <statement>dGrowth = dGrowth + 0.85*KIN_DELTA("Lysis_Xfb")</statement>
+                    <statement>dGrowth = dGrowth + 0.85*KIN_DELTA("Lysis_Xamb")</statement>
+                    <statement>dGrowth = dGrowth + 0.85*KIN_DELTA("Lysis_Xasrb")</statement>
+                    <statement>dGrowth = dGrowth + 0.85*KIN_DELTA("Lysis_Xsob")</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Xi_im</kinetic_reactant>
+                <expression>
+                    <statement>dGrowth = KIN_DELTA("AttDetachment_Xi")</statement>
+                    <statement>dGrowth = dGrowth + 0.1*KIN_DELTA("Lysis_Xh")</statement>
+                    <statement>dGrowth = dGrowth + 0.1*KIN_DELTA("Lysis_Xa")</statement>
+                    <statement>dGrowth = dGrowth + 0.1*KIN_DELTA("Lysis_Xfb")</statement>
+                    <statement>dGrowth = dGrowth + 0.1*KIN_DELTA("Lysis_Xamb")</statement>
+                    <statement>dGrowth = dGrowth + 0.1*KIN_DELTA("Lysis_Xasrb")</statement>
+                    <statement>dGrowth = dGrowth + 0.1*KIN_DELTA("Lysis_Xsob")</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Xh</kinetic_reactant>
+                <expression>
+                    <statement>dGrowth = KIN_DELTA("Aerobic_Growth_Xh_on_Sf")</statement>
+                    <statement>dGrowth = dGrowth + KIN_DELTA("Anoxic_Growth_Xh_on_Sf")</statement>
+                    <statement>dGrowth = dGrowth + KIN_DELTA("Aerobic_Growth_Xh_on_Sa")</statement>
+                    <statement>dGrowth = dGrowth + KIN_DELTA("Anoxic_Growth_Xh_on_Sa")</statement>
+                    <statement>dGrowth = dGrowth - KIN_DELTA("Lysis_Xh")</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Xa</kinetic_reactant>
+                <expression>
+                    <statement>dGrowth = KIN_DELTA("Aerobic_Growth_Xa_on_Snh")</statement>
+                    <statement>dGrowth = dGrowth - KIN_DELTA("Lysis_Xa")</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Xfb</kinetic_reactant>
+                <expression>
+                    <statement>dGrowth = KIN_DELTA("Growth_Xfb")</statement>
+                    <statement>dGrowth = dGrowth - KIN_DELTA("Lysis_Xfb")</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Xamb</kinetic_reactant>
+                <expression>
+                    <statement>dGrowth = KIN_DELTA("Growth_Xamb")</statement>
+                    <statement>dGrowth = dGrowth - KIN_DELTA("Lysis_Xamb")</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Xasrb</kinetic_reactant>
+                <expression>
+                    <statement>dGrowth = KIN_DELTA("Growth_Xasrb")</statement>
+                    <statement>dGrowth = dGrowth - KIN_DELTA("Lysis_Xasrb")</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+            <rate>
+                <kinetic_reactant>Xsob</kinetic_reactant>
+                <expression>
+                    <statement>dGrowth = KIN_DELTA("Aerobic_Growth_Xsob")</statement>
+                    <statement>dGrowth = dGrowth + KIN_DELTA("Anoxic_Growth_Xsob")</statement>
+                    <statement>dGrowth = dGrowth - KIN_DELTA("Lysis_Xsob")</statement>
+                    <statement>SAVE dGrowth</statement>
+                </expression>
+            </rate>
+                </rates>
+    </chemical_system>
+    <parameters>
+        <parameter>
+            <name>kappa0</name>
+            <type>Constant</type>
+            <values>1.0e-7</values>
+        </parameter>
+        <parameter>
+            <name>kappa1</name>
+            <type>Constant</type>
+            <values>1.0e-8</values>
+        </parameter>
+        <parameter>
+            <name>porosity</name>
+            <type>Constant</type>
+            <value>0.38</value>
+        </parameter>
+        <parameter>
+            <name>decay</name>
+            <type>Constant</type>
+            <value>0</value>
+        </parameter>
+        <!-- pressure related -->
+        <parameter>
+            <name>p0</name>
+            <type>Constant</type>
+            <value>8829</value>
+        </parameter>
+        <parameter>
+            <name>p_Neumann_inlet</name>
+            <type>Constant</type>
+            <!--6.666e-3/1.2m ogs6 does not account for DOMAIN thickness -->
+            <value>5.555e-3</value>
+        </parameter>
+        <parameter>
+            <name>p_Dirichlet_right</name>
+            <type>Constant</type>
+            <value>8829</value>
+        </parameter>
+        <!-- components related -->
+         <parameter>
+            <name>c_CurveScaled</name>
+            <type>Constant</type>
+            <value>1.0</value>
+        </parameter>
+        <parameter>
+            <name>c_H</name>
+            <type>Constant</type>
+            <!--pH=7-->
+            <value>1e-7</value>
+        </parameter>
+        <parameter>
+            <name>c0_CWM1</name>
+            <type>Constant</type>
+            <value>1e-4</value>
+        </parameter>
+        <parameter>
+            <name>c_Do_inlet</name>
+            <type>CurveScaled</type>
+            <curve>c_t_Do</curve>
+            <parameter>c_CurveScaled</parameter>
+        </parameter>
+        <parameter>
+            <name>c_Sf_inlet</name>
+            <type>CurveScaled</type>
+            <curve>c_t_Sf</curve>
+            <parameter>c_CurveScaled</parameter>
+        </parameter>
+        <parameter>
+            <name>c_Sa_inlet</name>
+            <type>CurveScaled</type>
+            <curve>c_t_Sa</curve>
+            <parameter>c_CurveScaled</parameter>
+        </parameter>
+        <parameter>
+            <name>c_Sin_inlet</name>
+            <type>CurveScaled</type>
+            <curve>c_t_Sin</curve>
+            <parameter>c_CurveScaled</parameter>
+        </parameter>
+        <parameter>
+            <name>c_Xsm_inlet</name>
+            <type>CurveScaled</type>
+            <curve>c_t_Xsm</curve>
+            <parameter>c_CurveScaled</parameter>
+        </parameter>
+        <parameter>
+            <name>c_Xim_inlet</name>
+            <type>CurveScaled</type>
+            <curve>c_t_Xim</curve>
+            <parameter>c_CurveScaled</parameter>
+        </parameter>
+        <parameter>
+            <name>c_Snh_inlet</name>
+            <type>CurveScaled</type>
+            <curve>c_t_Snh</curve>
+            <parameter>c_CurveScaled</parameter>
+        </parameter>
+        <parameter>
+            <name>c_Sno_inlet</name>
+            <type>CurveScaled</type>
+            <curve>c_t_Sno</curve>
+            <parameter>c_CurveScaled</parameter>
+        </parameter>
+        <parameter>
+            <name>c_Sso_inlet</name>
+            <type>Constant</type>
+            <value>5.66e-2</value>
+        </parameter>
+        <parameter>
+            <name>c_Sulphide_inlet</name>
+            <type>Constant</type>
+            <value>8.6e-3</value>
+        </parameter>
+    </parameters>
+    <curves>
+        <curve>
+            <name>c_t_Do</name>
+            <coords>0   604800  1209600 1814400 2419200 3024000 3628800 4233600 4838400 5529600 6048000 6652800 7257600 8470800 9075600 10198800    10890000    11667600    12099600    13914000    14518800    15210000    15814800    16333200    16938000    17542800    18147600    18752400    19357200    19962000    20563200    21168000    21772800    22377600    22896000
+</coords>
+            <values>9.00E-04    2.00E-04    0.00018 0.00021 0.00055 0.00074 0.00054 0.00093 0.00085 0.00055 0.00038 0.00034 0.00037 0.00049 0.00062 4.00E-04    0.00072 0.00031 0.00078 0.00061 0.00072 0.00089 0.00054 0.00125 0.00083 0.00052 0.00064 0.00071 0.00087 0.00059 0.00101 0.00097 0.00063 0.00043 0.00068
+</values>
+        </curve>
+        <curve>
+            <name>c_t_Sf</name>
+            <coords>0   604800  1209600 1814400 2419200 3024000 3628800 4233600 4838400 5529600 6048000 6652800 7257600 8470800 9075600 10198800    10890000    11667600    12099600    13914000    14518800    15210000    15814800    16333200    16938000    17542800    18147600    18752400    19357200    19962000    20563200    21168000    21772800    22377600    22896000
+</coords>
+            <values>2.29E-01    1.92E-01    0.187574    0.2529343   0.2244159   0.2772126   0.2811686   0.2861437   0.209862    0.1226828   0.3143407   0.3353002   0.3534289   0.103283    0.0971518   5.82E-02    0.1027765   0.1537516   0.1811263   0.0806371   0.1088622   0.1340445   0.1565852   0.1631798   0.1713685   0.1830446   0.1945754   0.1854146   0.1791338   0.1705848   0.1620868   0.154141    0.1461953   0.1365357   0.0911085
+</values>
+        </curve>
+        <curve>
+            <name>c_t_Sa</name>
+            <coords>0   604800  1209600 1814400 2419200 3024000 3628800 4233600 4838400 5529600 6048000 6652800 7257600 8470800 9075600 10198800    10890000    11667600    12099600    13914000    14518800    15210000    15814800    16333200    16938000    17542800    18147600    18752400    19357200    19962000    20563200    21168000    21772800    22377600    22896000
+</coords>
+            <values>1.53E-01    1.28E-01    0.1250493   0.1686229   0.1496106   0.1848084   0.1874457   0.1907625   0.139908    0.0817885   0.2095605   0.2235335   0.2356192   0.0688553   0.0647679   3.88E-02    0.0685177   0.1025011   0.1207509   0.053758    0.0725748   0.089363    0.1043901   0.1087865   0.1142457   0.1220298   0.129717    0.1236097   0.1194225   0.1137232   0.1080579   0.1027607   0.0974635   0.0910238   0.060739
+</values>
+        </curve>
+        <curve>
+            <name>c_t_Sin</name>
+            <coords>0   604800  1209600 1814400 2419200 3024000 3628800 4233600 4838400 5529600 6048000 6652800 7257600 8470800 9075600 10198800    10890000    11667600    12099600    13914000    14518800    15210000    15814800    16333200    16938000    17542800    18147600    18752400    19357200    19962000    20563200    21168000    21772800    22377600    22896000
+</coords>
+            <values>1.48E-02    1.64E-02    0.0179034   0.0192179   0.0208604   0.0176998   0.0205697   0.0217411   0.0229125   0.0242513   0.0198148   0.0220722   0.023953    0.0227709   0.022143    2.19E-02    0.0230327   0.0214195   0.022098    0.0226606   0.0236999   0.0245914   0.0245276   0.0241703   0.0229284   0.024961    0.0272358   0.0285153   0.0249947   0.0252544   0.0255125   0.0247668   0.0240212   0.0261319   0.0236982
+</values>
+        </curve>
+        <curve>
+            <name>c_t_Xsm</name>
+            <coords>0   604800  1209600 1814400 2419200 3024000 3628800 4233600 4838400 5529600 6048000 6652800 7257600 8470800 9075600 10198800    10890000    11667600    12099600    13914000    14518800    15210000    15814800    16333200    16938000    17542800    18147600    18752400    19357200    19962000    20563200    21168000    21772800    22377600    22896000
+</coords>
+            <values>8.98E-02    8.83E-02    0.1103771   0.0021094   7.69E-05    0.0305699   0.0307991   0.0920976   0.1937629   0.3099518   0.0143083   0.001983    0.0161316   0.0884845   0.0836935   9.82E-02    0.1125255   0.0328301   0.0345647   0.1685278   0.2101795   0.1536543   0.1033509   0.0664341   0.078712    0.0885889   0.0987081   0.105789    0.0698635   0.0227084   0.0682557   0.0432921   0.1179384   0.1872539   0.3011724
+</values>
+        </curve>
+        <curve>
+            <name>c_t_Xim</name>
+            <coords>0   604800  1209600 1814400 2419200 3024000 3628800 4233600 4838400 5529600 6048000 6652800 7257600 8470800 9075600 10198800    10890000    11667600    12099600    13914000    14518800    15210000    15814800    16333200    16938000    17542800    18147600    18752400    19357200    19962000    20563200    21168000    21772800    22377600    22896000
+</coords>
+            <values>6.93E-04    2.89E-02    0   0.0021094   2.07E-02    0   0.0117404   0   0.0220868   0.0576956   0.0143083   0.0415899   0.0161316   0.0783689   0.0690938   3.78E-02    0.063681    0.1475792   0.0345647   0.1729577   0.0701732   0.0845583   0.0979891   0.1074293   0.1642352   0.1330902   0.1520012   0.1076714   0.1255855   0.1067292   0.0690872   0.0740393   0.0953817   0.1854669   0.0673989
+</values>
+        </curve>
+        <curve>
+            <name>c_t_Snh</name>
+            <coords>0   604800  1209600 1814400 2419200 3024000 3628800 4233600 4838400 5529600 6048000 6652800 7257600 8470800 9075600 10198800    10890000    11667600    12099600    13914000    14518800    15210000    15814800    16333200    16938000    17542800    18147600    18752400    19357200    19962000    20563200    21168000    21772800    22377600    22896000
+</coords>
+            <values>7.96E-02    7.96E-02    0.0699766   0.0750936   7.94E-02    0.0759865   0.0828972   0.0836815   0.0661563   0.0523349   0.0631047   0.0659777   0.072438    0.0523659   0.0526066   4.36E-02    0.0624447   0.0511158   0.0494541   0.0462939   0.053686    0.050184    0.0545944   0.0602861   0.0600376   0.0635007   0.0505101   0.0696194   0.0513876   0.0511003   0.0441663   0.0596649   0.0537869   0.0509217   0.0561862
+</values>
+        </curve>
+        <curve>
+            <name>c_t_Sno</name>
+            <coords>0   604800  1209600 1814400 2419200 3024000 3628800 4233600 4838400 5529600 6048000 6652800 7257600 8470800 9075600 10198800    10890000    11667600    12099600    13914000    14518800    15210000    15814800    16333200    16938000    17542800    18147600    18752400    19357200    19962000    20563200    21168000    21772800    22377600    22896000
+</coords>
+            <values>7.39E-05    7.39E-05    9.64E-05    9.64E-05    9.64E-05    7.39E-05    7.39E-05    7.39E-05    8.30E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    9.64E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05    7.39E-05
+</values>
+        </curve>
+    </curves>
+    <process_variables>
+        <process_variable>
+            <name>pressure</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>p0</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>geometry</geometrical_set>
+                    <geometry>outlet</geometry>
+                    <type>Dirichlet</type>
+                    <parameter>p_Dirichlet_right</parameter>
+                </boundary_condition>
+        <boundary_condition>
+            <geometrical_set>geometry</geometrical_set>
+            <geometry>inlet</geometry>
+            <type>Neumann</type>
+            <parameter>p_Neumann_inlet</parameter>
+         </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+        <process_variable>
+            <name>H</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>c_H</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>geometry</geometrical_set>
+                    <geometry>inlet</geometry>
+                    <type>Dirichlet</type>
+                    <parameter>c_H</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+        <process_variable>
+            <name>Do</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>c0_CWM1</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>geometry</geometrical_set>
+                    <geometry>inlet</geometry>
+                    <type>Dirichlet</type>
+                    <parameter>c_Do_inlet</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+        <process_variable>
+            <name>Sf</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>c0_CWM1</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>geometry</geometrical_set>
+                    <geometry>inlet</geometry>
+                    <type>Dirichlet</type>
+                    <parameter>c_Sf_inlet</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+        <process_variable>
+            <name>Sa</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>c0_CWM1</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>geometry</geometrical_set>
+                    <geometry>inlet</geometry>
+                    <type>Dirichlet</type>
+                    <parameter>c_Sa_inlet</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+        <process_variable>
+            <name>Sin</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>c0_CWM1</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>geometry</geometrical_set>
+                    <geometry>inlet</geometry>
+                    <type>Dirichlet</type>
+                    <parameter>c_Sin_inlet</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+        <process_variable>
+            <name>Xs_m</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>c0_CWM1</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>geometry</geometrical_set>
+                    <geometry>inlet</geometry>
+                    <type>Dirichlet</type>
+                    <parameter>c_Xsm_inlet</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+        <process_variable>
+            <name>Xi_m</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>c0_CWM1</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>geometry</geometrical_set>
+                    <geometry>inlet</geometry>
+                    <type>Dirichlet</type>
+                    <parameter>c_Xim_inlet</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+        <process_variable>
+            <name>Snh</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>c0_CWM1</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>geometry</geometrical_set>
+                    <geometry>inlet</geometry>
+                    <type>Dirichlet</type>
+                    <parameter>c_Snh_inlet</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+        <process_variable>
+            <name>Sno</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>c0_CWM1</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>geometry</geometrical_set>
+                    <geometry>inlet</geometry>
+                    <type>Dirichlet</type>
+                    <parameter>c_Sno_inlet</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+        <process_variable>
+            <name>Sso</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>c0_CWM1</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>geometry</geometrical_set>
+                    <geometry>inlet</geometry>
+                    <type>Dirichlet</type>
+                    <parameter>c_Sso_inlet</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+        <process_variable>
+            <name>Sulphide</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>c0_CWM1</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>geometry</geometrical_set>
+                    <geometry>inlet</geometry>
+                    <type>Dirichlet</type>
+                    <parameter>c_Sulphide_inlet</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+    </process_variables>
+    <nonlinear_solvers>
+        <nonlinear_solver>
+            <name>basic_picard</name>
+            <type>Picard</type>
+            <max_iter>10</max_iter>
+            <linear_solver>general_linear_solver</linear_solver>
+        </nonlinear_solver>
+    </nonlinear_solvers>
+    <linear_solvers>
+        <linear_solver>
+            <name>general_linear_solver</name>
+            <eigen>
+                <solver_type>BiCGSTAB</solver_type>
+                <precon_type>ILUT</precon_type>
+                <max_iteration_step>1000</max_iteration_step>
+                <error_tolerance>1e-14</error_tolerance>
+            </eigen>
+        </linear_solver>
+    </linear_solvers>
+</OpenGeoSysProject>

--- a/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/Wetland/Wetland_1d.vtu
+++ b/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/Wetland/Wetland_1d.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:813e535931d7e40283421640c9881017584e315ad53b265065b2254f87bb979e
+size 5061

--- a/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/Wetland/Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu
+++ b/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/Wetland/Wetland_1d_pcs_11_ts_4_t_28800.000000_expected.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ca538c44eeee85b62ab9f32c65a0e32e3681c016ac2f5baad7e540b46b67afa
+size 29829

--- a/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/Wetland/cwm1.dat
+++ b/Tests/Data/Parabolic/ComponentTransport/ReactiveTransport/Wetland/cwm1.dat
@@ -1,0 +1,629 @@
+# database: cwm1.dat
+# author: Johannes Boog
+# 21.08.2019
+
+
+# this database is a simplifyied version of the data base provided
+# in Boog et al. (2019)
+#
+# Boog, J., Kalbacher, T., Forquet, N., van Afferden, M., Mueller, R., A. 2019.
+# Modeling the relationship of aeration, oxygen transfer and treatment performance
+# in aerated horizontal flow treatment wetlands. Water Research. 157. 321-334.
+
+
+SOLUTION_MASTER_SPECIES
+#
+#  elemen     species        alk   gfw_formula element_gfw atomic
+#                                                          number
+E       e-             0.0     0.0             0.0
+H       H+             -1.0    H               1.008
+H(0)    H2             0       H
+H(1)    H+             -1.0    0
+O       H2O            0       O               16.0
+O(-2)   H2O            0       0
+O(0)    O2             0       O
+#cwm1 data
+Ogas Ogas       0       1       1
+Do    Do        0       1       1
+Sf      Sf      0       1       1
+Sa      Sa      0       1       1
+Sin     Sin     0       1       1
+Snh     Snh     0       1       1
+Sno     Sno     0       1       1
+Sulphide Sulphide 0     1       1
+Sso     Sso     0       1       1
+Xs_m    Xs_m    0       1       1
+Xs_im   Xs_im   0       1       1
+Xi_m    Xi_m    0       1       1
+Xi_im   Xi_im   0       1       1
+Xh      Xh      0       1       1
+Xa      Xa      0       1       1
+Xfb     Xfb     0       1       1
+Xamb    Xamb    0       1       1
+Xasrb   Xasrb   0       1       1
+Xsob    Xsob    0       1       1
+Tracer  Tracer  0       1       1
+Snh_im  Snh_im  0       1       1
+
+
+SOLUTION_SPECIES
+
+### Primary Master Species
+e- =  e-
+    -log_k 0
+
+H+ = H+
+    -log_k 0
+
+H2O =  H2O
+    -log_k   0
+
+Ogas = Ogas
+    log_k     0
+Do = Do
+    log_k     0
+Sf = Sf
+    log_k     0
+Sa = Sa
+    log_k     0
+Sin = Sin
+    log_k     0
+Snh = Snh
+    log_k     0
+Sno = Sno
+    log_k     0
+Sulphide = Sulphide
+    log_k     0
+Sso = Sso
+    log_k     0
+Xs_m = Xs_m
+    log_k       0
+Xs_im = Xs_im
+    log_k       0
+Xi_m = Xi_m
+    log_k       0
+Xi_im = Xi_im
+    log_k       0
+Xh = Xh
+    log_k     0
+Xa = Xa
+    log_k     0
+Xfb = Xfb
+    log_k     0
+Xamb = Xamb
+    log_k     0
+Xasrb = Xasrb
+    log_k     0
+Xsob = Xsob
+    log_k     0
+Tracer = Tracer
+    log_k     0
+Snh_im = Snh_im
+    log_k     0
+
+### Secondary Master Species
+
+2 H+ + 2 e- = H2
+    -log_k -3.15
+
+2 H2O - 4 H+ - 4 e- = O2
+    -log_k -86.08
+
+### Aquaeous Species
+
+H2O - H+ =  OH-
+    -log_k -13.9951
+
+
+CALCULATE_VALUES
+
+#=== Aeration ================================================================
+#
+So_sat                                          # saturated dissolved oxygen concentration as f(T,p)
+-start
+1 REM ln(DO) = A1 + A2*100/T + A3*ln(T/100) + A4*T/100 + S*[B1 + B2*T/100 + B3*(T/100)2] (Weiss, 1970)
+
+10 A1 = -173.4292
+11 A2 = 249.6339
+12 A3 = 143.3483
+13 A4 = -21.8492
+14 B1 = -0.033096
+15 B2 = 0.014259
+16 B3 = -0.001700
+17 p_air = 101325
+18 S = 2.95              # g/kg converted from 1500µS/cm at 20°C
+
+20 value = A1 + A2*100/TK + A3*LOG(TK/100) + A4*TK/100 + S*(B1 + B2*TK/100 + B3*(TK/100)^2)
+22 value = EXP(value) * 0.55130 * ((760*p_air/101325)/TK) * 1/1000
+
+30 SAVE value
+-end
+
+#
+kLa_theta                                                                       # Temperature correction for kLa
+-start
+1 REM kLa(T) = kLa(20°C) * 1.024^(T-20°C)       (Tchobanoglous, 2003)
+10 value = 1.024^(TC - 20)
+11      SAVE value
+-end
+
+# Kinetic parameters
+#===================
+
+
+#=== Biomass Growth limitation (Samso 2013) ==================================
+#
+bac_growth_limit
+-start
+1 Xh    = MOL("Xh") * GFW("Xh") / SOLN_VOL
+2 Xfb   = MOL("Xfb") * GFW("Xfb") / SOLN_VOL
+3 Xamb  = MOL("Xamb") * GFW("Xamb") / SOLN_VOL
+4 Xa    = MOL("Xa") * GFW("Xa") / SOLN_VOL
+5 Xasrb = MOL("Xasrb") * GFW("Xasrb") / SOLN_VOL
+6 Xsob  = MOL("Xsob") * GFW("Xsob") / SOLN_VOL
+
+10 M_bio_max = 10.0   # biomass concentration limit in gCOD/L
+
+110 value = 1 - (Xh + Xfb + Xamb + Xa + Xasrb + Xsob) / M_bio_max
+
+120 SAVE value
+-end
+
+
+
+#=============================================================================
+#=== CWM1 Langergraber (2009) ================================================
+#=============================================================================
+
+#=== Hydrolysis ==============================================================
+#
+Kh                                                                      # Hydrolysis rate constant
+-start
+# literature values
+1 value_20 = 3 / (24*3600)                              # at 20°C in 1/s
+2 value_10 = 2 / (24*3600)                              # at 10 °C in 1/s
+
+# correct to current temperature
+3 k20=value_20
+4 k1=value_20
+5 k2=value_10
+6 T1=20                                                         # temp in °C
+7 T2=10                                                         # temp in °C
+8 theta = LOG(k1/k2)/(T1-T2)            # Henze (2000)
+9 value_T=k20*EXP(theta*(TC-20))                # Henze (2000)
+
+10      SAVE value_T
+-end
+#
+Kx                                                                      # Saturation/ Inhibition coefficient for hydrolysis
+-start
+# literature values
+1 value_20 = 0.1                                                                                # at 20°C in g CODsf/ gCODbm
+2 value_10 = 0.22                                                                               # at 10 °C in g CODsf/ gCODbm
+
+# correct to current temperature
+3 k20=value_20
+4 k1=value_20
+5 k2=value_10
+6 T1=20                                                         # temp in °C
+7 T2=10                                                         # temp in °C
+8 theta = LOG(k1/k2)/(T1-T2)            # Henze (2000)
+9 value_T=k20*EXP(theta*(TC-20))                # Henze (2000)
+
+10      SAVE value_T
+-end
+#
+#
+eta_h                                                           # Correction factor for hydrolysis by Xfb
+-start
+1       value = 0.1                                             #
+3       SAVE value
+-end
+#
+#
+#=== Heterotrophic Bacteria Xh ==================================================
+muh                                                                     # Max aerobic growth rate on Sf and Sa
+-start
+# literature values
+1 value_20 = 6 /(24*3600)                                                               # 1/d -> 1/s
+2 value_10 = 3 /(24*3600)                                                               # 1/d -> 1/s
+
+# correct to current temperature
+3 k20=value_20
+4 k1=value_20
+5 k2=value_10
+6 T1=20                                                         # temp in °C
+7 T2=10                                                         # temp in °C
+8 theta = LOG(k1/k2)/(T1-T2)            # Henze (2000)
+9 value_T=k20*EXP(theta*(TC-20))                # Henze (2000)
+
+10      SAVE value_T
+-end
+#
+bh                                                                      # Rate constant for lysis of Xh
+-start
+# literature values
+1 value_20 = 0.4 /(24*3600)                                                             # 1/d -> 1/s
+2 value_10 = 0.2 /(24*3600)                                                             # 1/d -> 1/s
+
+# correct to current temperature
+3 k20=value_20
+4 k1=value_20
+5 k2=value_10
+6 T1=20                                                         # temp in °C
+7 T2=10                                                         # temp in °C
+8 theta = LOG(k1/k2)/(T1-T2)            # Henze (2000)
+9 value_T=k20*EXP(theta*(TC-20))                # Henze (2000)
+
+10      SAVE value_T
+-end
+#
+eta_g                                                           # Correction factor for denitrification by heterotrophs
+-start
+1       value = 0.8                                             #
+10      SAVE value
+-end
+#
+Koh                                                                     # Saturation/ inhibition coefficient for So
+-start
+1       value = 0.2                                             # mg 02/L
+2       value = value / 1000                    # convert to g O2/L
+10      SAVE value
+-end
+#
+Ksf                                                                     # Saturation/ inhibition coefficient for Sf
+-start
+1       value = 2                                               # mg CODsf/L
+2       value = value / 1000                    # convert to g O2/L
+10      SAVE value
+-end
+#
+Ksa                                                                             # Saturation/ inhibition coefficient for Sa
+-start
+1       value = 4                                                       # mg CODsa/L
+2       value = value / 1000                            # convert to g CODsa/L
+10      SAVE value
+-end
+#
+Knhh                                                                    # Saturation/ inhibition coefficient for Snh
+-start
+1       value = 0.05                                            # mg N /L
+2       value = value / 1000                            # convert to g N/L
+10      SAVE value
+-end
+#
+Knoh                                                                    # Saturation/ inhibition coefficient for Sno
+-start
+1       value = 0.5                                             # mg N /L
+2       value = value / 1000                            # convert to g N/L
+10      SAVE value
+-end
+#
+Kh2s_h                                                                  # Saturation/ inhibition coefficient for Sulphide
+-start
+1       value = 140                                             # mg S /L
+2       value = value / 1000                            # convert to g S /L
+10      SAVE value
+-end
+#
+#
+#=== Autotrophic Bacteria Xa ==================================================
+mu_a                                                                    # Max aerobic growth rate on Snh
+-start
+# literature values
+1 value_20 = 1 /(24*3600)                                                               # 1/d -> 1/s
+2 value_10 = 0.35 /(24*3600)                                                    # 1/d -> 1/s
+
+# correct to current temperature
+3 k20=value_20
+4 k1=value_20
+5 k2=value_10
+6 T1=20                                                         # temp in °C
+7 T2=10                                                         # temp in °C
+8 theta = LOG(k1/k2)/(T1-T2)            # Henze (2000)
+9 value_T=k20*EXP(theta*(TC-20))                # Henze (2000)
+
+10      SAVE value_T
+-end
+#
+ba                                                                              # Rate constant for lysis of Xa
+-start
+# literature values
+1 value_20 = 0.15 /(24*3600)                                                            # 1/d -> 1/s
+2 value_10 = 0.05 /(24*3600)                                                    # 1/d -> 1/s
+
+# correct to current temperature
+3 k20=value_20
+4 k1=value_20
+5 k2=value_10
+6 T1=20                                                         # temp in °C
+7 T2=10                                                         # temp in °C
+8 theta = LOG(k1/k2)/(T1-T2)            # Henze (2000)
+9 value_T=k20*EXP(theta*(TC-20))                # Henze (2000)
+
+10      SAVE value_T
+-end
+#
+Koa                                                                             # Saturation/ inhibition coefficient for So
+-start
+1       value = 1.0                                                     # mg 02/L
+2       value = value / 1000                            # convert to g O2/L
+10      SAVE value
+-end
+#
+Knha                                                                    # Saturation/ inhibition coefficient for Snh
+-start
+# literature values
+1 value_20 = 0.5 / 1000                                                                 # mg N /L -> g N/L
+2 value_10 = 5   / 1000                                                                 # mg N /L -> g N/L
+
+# correct to current temperature
+3 k20=value_20
+4 k1=value_20
+5 k2=value_10
+6 T1=20                                                         # temp in °C
+7 T2=10                                                         # temp in °C
+8 theta = LOG(k1/k2)/(T1-T2)            # Henze (2000)
+9 value_T=k20*EXP(theta*(TC-20))                # Henze (2000)
+
+10      SAVE value_T
+-end
+#
+Kh2s_a                                                                  # Saturation/ inhibition coefficient for Sulphide
+-start
+1       value = 140                                             # mg S /L
+2       value = value / 1000                            # convert to g S /L
+10      SAVE value
+-end
+#
+#
+#=== Fermenting Bacteria Xfb ==================================================
+mu_fb                                                                   # Max growth rate on Sf
+-start
+# literature values
+1 value_20 = 3 /(24*3600)                                                       # 1/d -> 1/s
+2 value_10 = 1.5 /(24*3600)                                                     # 1/d -> 1/s
+
+# correct to current temperature
+3 k20=value_20
+4 k1=value_20
+5 k2=value_10
+6 T1=20                                                         # temp in °C
+7 T2=10                                                         # temp in °C
+8 theta = LOG(k1/k2)/(T1-T2)            # Henze (2000)
+9 value_T=k20*EXP(theta*(TC-20))                # Henze (2000)
+
+10      SAVE value_T
+-end
+#
+b_fb                                                                    # Rate constant for lysis of Xfb
+-start
+1       value = 0.02                                            # 1/d
+2       value = value /(24*3600)                        # convert to 1/s
+10      SAVE value
+-end
+#
+Kofb                                                                    # Saturation/ inhibition coefficient for So
+-start
+1       value = 0.2                                                     # mg 02/L
+2       value = value / 1000                            # convert to g O2/L
+10      SAVE value
+-end
+#
+Ksfb                                                                    # Saturation/ inhibition coefficient for Sf
+-start
+1       value = 28                                                      # mg CODsf /L
+2       value = value / 1000                            # convert to g N/L
+10      SAVE value
+-end
+#
+Knofb                                                                   # Saturation/ inhibition coefficient for Sno
+-start
+1       value = 0.5                                             # mg N /L
+2       value = value / 1000                            # convert to g N/L
+10      SAVE value
+-end
+#
+Knhfb                                                                   # Saturation/ inhibition coefficient for Snh
+-start
+1       value = 0.01                                            # mg N /L
+2       value = value / 1000                            # convert to g N/L
+10      SAVE value
+-end
+#
+Kh2s_fb                                                                 # Saturation/ inhibition coefficient for Sulphide
+-start
+1       value = 140                                             # mg S /L
+2       value = value / 1000                            # convert to g S /L
+10      SAVE value
+-end
+#
+#
+#=== Acetotrohpic Methanogenic Bacteria Xamb =====================================
+mu_amb                                                                  # Max growth rate on Sa
+-start
+# literature values
+1 value_20 = 0.085 /(24*3600)                                                   # 1/d -> 1/s
+2 value_10 = 0.04 /(24*3600)                                                    # 1/d -> 1/s
+
+# correct to current temperature
+3 k20=value_20
+4 k1=value_20
+5 k2=value_10
+6 T1=20                                                                 # temp in °C
+7 T2=10                                                                 # temp in °C
+8 theta = LOG(k1/k2)/(T1-T2)                    # Henze (2000)
+9 value_T=k20*EXP(theta*(TC-20))                # Henze (2000)
+
+10      SAVE value_T
+-end
+#
+#
+b_amb                                                                   # Rate constant for lysis of Xamb
+-start
+# literature values
+1 value_20 = 0.008 /(24*3600)                                                   # 1/d -> 1/s
+2 value_10 = 0.004 /(24*3600)                                                   # 1/d -> 1/s
+
+# correct to current temperature
+3 k20=value_20
+4 k1=value_20
+5 k2=value_10
+6 T1=20                                                                 # temp in °C
+7 T2=10                                                                 # temp in °C
+8 theta = LOG(k1/k2)/(T1-T2)                    # Henze (2000)
+9 value_T=k20*EXP(theta*(TC-20))                # Henze (2000)
+
+10      SAVE value_T
+-end
+#
+#
+Koamb                                                                   # Saturation/ inhibition coefficient for So
+-start
+1       value = 0.0002                                          # mg 02/L
+2       value = value / 1000                            # convert to g O2/L
+10      SAVE value
+-end
+#
+Ksamb                                                                   # Saturation/ inhibition coefficient for Sf
+-start
+1       value = 56                                                      # mg CODsf /L
+2       value = value / 1000                            # convert to g N/L
+10      SAVE value
+-end
+#
+Knoamb                                                                  # Saturation/ inhibition coefficient for Sno
+-start
+1       value = 0.0005                                          # mg N /L
+2       value = value / 1000                            # convert to g N/L
+10      SAVE value
+-end
+#
+Knhamb                                                                  # Saturation/ inhibition coefficient for Snh
+-start
+1       value = 0.01                                            # mg N /L
+2       value = value / 1000                            # convert to g N/L
+10      SAVE value
+-end
+#
+Kh2s_amb                                                                # Saturation/ inhibition coefficient for Sulphide
+-start
+1       value = 140                                             # mg S /L
+2       value = value / 1000                            # convert to g S /L
+10      SAVE value
+-end
+#
+#
+#=== Acetotrohpic sulphate reducing bacteria Xarsb =====================================
+mu_asrb                                                                 # Max growth rate on Sso4
+-start
+1       value = 0.18                                            # 1/d
+2       value = value /(24*3600)                        # convert to 1/s
+10      SAVE value
+-end
+#
+b_asrb                                                                  # Rate constant for lysis of Xasrb
+-start
+1       value = 0.012                                           # 1/d
+2       value = value /(24*3600)                        # convert to 1/s
+10      SAVE value
+-end
+#
+Ko_asrb                                                                 # Saturation/ inhibition coefficient for So
+-start
+1       value = 0.0002                                          # mg 02/L
+2       value = value / 1000                    # convert to g O2/L
+10      SAVE value
+-end
+#
+Ks_asrb                                                                 # Saturation/ inhibition coefficient for Sf
+-start
+1       value = 24                                              # mg CODsf /L
+2       value = value / 1000                    # convert to g N/L
+10      SAVE value
+-end
+#
+Kno_asrb                                                                        # Saturation/ inhibition coefficient for Sno
+-start
+1       value = 0.0005                                          # mg N /L
+2       value = value / 1000                    # convert to g N/L
+10      SAVE value
+-end
+#
+Knh_asrb                                                                        # Saturation/ inhibition coefficient for Snh
+-start
+1       value = 0.01                                            # mg N /L
+2       value = value / 1000                    # convert to g N/L
+10      SAVE value
+-end
+#
+Kso_asrb                                                                        # Saturation/ inhibition coefficient for Sso4
+-start
+1       value = 19.0                                            # mg S /L
+2       value = value / 1000                    # convert to g S /L
+10      SAVE value
+-end
+#
+#
+Kh2s_asrb                                                                       # Saturation/ inhibition coefficient for Sulphide
+-start
+1       value = 140                                             # mg S /L
+2       value = value / 1000                    # convert to g S /L
+10      SAVE value
+-end
+#
+#
+#=== Sulphide oxidizing bacteria Xsob =====================================
+#
+mu_sob                                                                  # Max growth rate on Sulphide
+-start
+1       value = 5.28                                            # 1/d
+2       value = value /(24*3600)                        # convert to 1/s
+10      SAVE value
+-end
+#
+b_sob                                                                   # Rate constant for lysis of Xsob
+-start
+1       value = 0.15                                            # 1/d
+2       value = value /(24*3600)                        # convert to 1/s
+10      SAVE value
+-end
+#
+eta_sob                                                                 # Correction factor for anoxic growth of Xsob
+-start
+1value = 0.8
+10      SAVE value
+-end
+#
+Ko_sob                                                                  # Saturation/ inhibition coefficient for So
+-start
+1       value = 0.2                                                     # mg 02/L
+2       value = value / 1000                            # convert to g O2/L
+10      SAVE value
+-end
+#
+Kno_sob                                                                 # Saturation/ inhibition coefficient for Sno
+-start
+1       value = 0.5                                                     # mg N /L
+2       value = value / 1000                            # convert to g N/L
+10      SAVE value
+-end
+#
+Knh_sob                                                                 # Saturation/ inhibition coefficient for Snh
+-start
+1       value = 0.05                                            # mg N /L
+2       value = value / 1000                            # convert to g N/L
+10      SAVE value
+-end
+#
+Kh2s_sob                                                                        # Saturation/ inhibition coefficient for Sulphide
+-start
+1       value = 0.24                                            # mg S /L
+2       value = value / 1000                            # convert to g S /L
+10      SAVE value
+-end
+#
+
+#=============================================================================
+
+END

--- a/web/content/docs/benchmarks/reactive-transport/wetland/Wetland.pandoc
+++ b/web/content/docs/benchmarks/reactive-transport/wetland/Wetland.pandoc
@@ -1,0 +1,119 @@
++++
+author = "Johannes Boog"
+weight = 143
+project = "Parabolic/ComponentTransport/ReactiveTransport/Wetland/Wetland_1d.prj"
+date = "2019-08-25T14:41:09+01:00"
+title = "Complex kinetic reaction network"
+
+[menu]
+  [menu.benchmarks]
+    parent = "Reactive transport"
+
++++
+
+{{< data-link >}}
+
+
+
+
+## Overview
+
+The studied system represents a treatment wetland, which can be considered as an engineered ecosystem that mimics natural occuring microbiological processes to treat wastewater.
+Basically, such a system consists of a basin filled with a grained solid media (e.g. gravel or sand) and wastewater is passed through it.
+Multiple types of microbial organisms are present that can metabolize chemical pollutants (e.g. ammoni or organic molecules) present in wastewater, which drives the cycling of carbon and nutrients.
+
+
+The scenario presented here is a modification of a case already described in Boog et al. (2019) without considering heat transport.
+The experimental system consists of a basin of 4.7 m in length, 1.2 m in width and 0.9 m in depth (Figure 1) filled with gravel and saturated with water.
+The domestic wastewater enters the system at a constant flow rate on the left side and leaves it via an overflow at the right side.
+
+
+The coupling of OGS-6 and IPhreeqc used in the simulation requires to include the transport of H^+^--ions to adjust the compulsory charge balance computated by Phreeqc.
+The results obtained by OGS-6--IPhreeqc will be compared to the ones of OGS-5--IPhreeqc.
+
+
+## Problem Description
+
+The scenario includes the transport of multiple solutes (i.e. organic molecules, ammonia, etc.) through a saturated media (during 20 days) involving a complex biokinetic reaction network.
+The 1D model domain is 4.7 m long, discretized into 94 line elements, including an influent (12 elements, 0.6 m) and an effluent zone (12 elements, 0.6m) (Figure 1).
+The domain is saturated at start--up with an initial hydrostatic pressure of ($p(t=0)=$ 8829 Pa).
+For the water mass influx a constant Neumann boundary condition (BC) is set at the left side ($g_{N,\text{in}}^p$).
+For the water efflux, a constant pressure is defined as boundary ($g_{D,\text{out}}^p$).
+
+![Schematic representation of the experimental system and 1D model domain used in the simulation. The influent and effluent zone in the 1D model are represented by solid lines.](../Wetland_domain.png)
+
+The microbiological processes are modeled by a complex network of kinetic reactions based on the Constructed Wetland Model No. 1 (CWM1) described in Langergraber, (2009).
+The network includes dissolved oxygen ($So$) and nine different soluble and particulated components ("pollutants") that some of them can be metabolized by six bacterial groups resulting in 17 kinetic reactions (Figure 2).
+A "clean" system is assumed at start-up in the basin, therefore, initial concentrations of all components (oxygen + "pollutants") and bacteria are set to 1.0e-4 and 1.0e-3 mg L^-1^, respectively.
+For the wastewater components ("pollutants" and oxygen) entering the system, time-dependent Dirichlet BC are defined at the influx point.
+Respective material properties, initial and boundary conditions are listed in Table 1--2.
+
+![Network of microbiological reactions described by CWM1. $S_I$ = inert soluble organic matter (COD), $X_I$ = inert particulated COD, $X_S$ = Slowly biodegradable particulate COD, $S_F$ = Fermentable, readily biodegradable soluble COD, $S_A$ = Fermentation products as acetate, $S_{NH}$ = Ammonium and ammonia nitrogen, $S_{NO}$ = Nitrate and nitrite nitrogen, $S_O$ = Dissolved oxygen, $S_{SO}$ = Sulphate sulfur, $S_{H2S}$ = Sulphide sulfur; different type of bacterias are identified as $X_H$, $X_A$, $X_{FB}$, $X_{AMB}$, $X_{ASRB}$ and $X_{SOB}$](../Wetland_cwm1.png){width=60%}
+
+
+-----------------------------------------
+
+|Parameter | Description | Value | Unit |
+|:-------- | :---------- | :---- | :--- |
+| Influent & effluent zone |||
+| $\phi$   | Porosity    | 0.38  | - |
+| $\kappa$ | Permeability | 1.0e-7 | m^2^ |
+| $S$   | Storage | 0.0     | - |
+| $a_L$ | long. Dispersion length | 0.45   | m |
+| Treatment zone |||
+| $\phi$   | Porosity    | 0.38  | - |
+| $\kappa$ | Permeability | 1.0e-8 | m^2^ |
+| $S$   | Storage | 0.0     | - |
+| $a_L$ | long. Dispersion length | 0.40   | m |
+
+-----------------------------------------
+
+Table 1: Media, material and component properties
+
+
+-----------------------------------------
+
+| Parameter | Description | Value | Unit |
+|:--------- | :---------- | :---- | :--- |
+| $p(t=0)$  | Initial pressure | 8829  | Pa |
+| $g_{N,in}^p$ | Water influx | 5.555e-3 | kg s^-1^ |
+| $g_{D,out}^p$ | Pressure at outlet | 8829 | Pa |
+| $c_{components}(t=0)$  | Initial component concentrations | 1.0e-4     | g kg^-1^~water~ |
+| $c_{bacteria}(t=0)$  | Initial bacteria concentrations | 1.0e-3  | g kg^-1^~water~ |
+| $c_{\text{H}^+}(t=0)$  | Initial concentration of $\text{H}^+$ | 1.0e-7     |  mol kg^-1^~water~ |
+|  $g_{D,in}^{components_c}$ | Influent component concentrations |  $f(t)$ | g kg^-1^~water~ |
+|  $g_{D,in}^{\text{H}^+}$ | Influent concentration of $\text{H}^+$ |  1.0e-7 | mol kg^-1^~water~ |
+
+-----------------------------------------
+
+Table 2: Initial and boundary conditions
+
+
+-----------------------------------------
+
+
+## Results
+
+Influent wastewater components (oxygen and pollutants) spread through the model domain by advective--dispersive transport (Figure 3).
+The aeration increases dissolved oxygen concentration $S_O$ in the entire domain.
+After 2.5 days (2.16e+5 seconds), rapidly growing heterotrophic bacteria $X_H$ starts to consume available $S_O$ and influent organic carbon ($S_A$, $S_F$).
+Initial growth of $X_H$ and the high concentrations of organic carbon sources at the influent region result in an oxygen depletion.
+This triggers the growth of anaerobic fermenting bacteria $X_{FB}$ at the front and pushes $X_H$ downstream were enough $S_O$ is available.
+After organic carbon concentration profiles of $S_F$ and $S_A$ stabilized, autotrophic nitrifying bacteria $X_A$ starts to grow by oxidizing available ammonia ($S_{NH}$) to nitrate/nitrite $S_{NO}$.
+After 20 days (1.7286e+6 seconds) the microbial reaction network in the wetland has reached a quasi steady--state.
+The biochemical reactions are now governing the system behaviour.
+
+Both, OGS-6 and OGS-5 simulations yield the same results.
+For instance, the difference between the OGS-6 and the OGS-5 computation for the concentration of $S_A$  expressed as root mean squared error is 1.11e-4 g L^-1^ (over all time steps and mesh nodes); the corresponding relative mean squared error is 0.37%.
+The relatively high error may be associated with the missing transport or charge in the OGS-6 simulation, which affects computations by Phreeqc.
+Please note that due to the long computation time of the simulation (~13 h), the corresponding test (Wetland_1d.prj) is reduced to the first four time steps (28800 s).
+
+{{< img src="../Wetland_1d.gif" title="Fig. 3: Simulated concentrations of solutes (left) and bacteria (right). Solid lines represent solutions by OGS-5; dashed lines represent solution by OGS-6.">}}
+
+-----------------------------------------
+
+## References
+
+Boog, J., Kalbacher, T., Nivala, J., Forquet, N., van Afferden, M., Müller, R.A., 2019. Modeling the relationship of aeration, oxygen transfer and treatment performance in aerated horizontal flow treatment wetlands. Water Research. 157 , 321 - 334. https://doi.org/10.1016/j.watres.2019.03.062.
+
+Langergraber, G., Rousseau, D.P.L., García, J., Mena, J., 2009. CWM1: A general model to describe biokinetic processes in subsurface flow constructed wetlands. Water Science and Technology, 59 (9), 1687-1697. https://doi.org/10.2166/wst.2009.131.

--- a/web/content/docs/benchmarks/reactive-transport/wetland/Wetland_1d.gif
+++ b/web/content/docs/benchmarks/reactive-transport/wetland/Wetland_1d.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbc35d56d0ae41febb714e7439623100a4fb69e07a62779ea79c7f1b051d6e63
+size 1203998

--- a/web/content/docs/benchmarks/reactive-transport/wetland/Wetland_cwm1.png
+++ b/web/content/docs/benchmarks/reactive-transport/wetland/Wetland_cwm1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c05f7dd7d10e4c53328e57113e1e794b04665f839427f12350cb5553ae8e55c8
+size 92630

--- a/web/content/docs/benchmarks/reactive-transport/wetland/Wetland_domain.png
+++ b/web/content/docs/benchmarks/reactive-transport/wetland/Wetland_domain.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f4376db559150f434e3129ec9b00b71210f758e414e5e6bf61647903ecac5b6
+size 110245


### PR DESCRIPTION
This pull request adds an option to fix the *amount* of a defined *kinetic_reactant* to its *initial_amount*. Subsequently the change of  the *amount* of a *kinetic_reactant* in time step i does not affect the *amount* in subsequent time steps. 
This is necessary when using a *kinetic_reactant* as reaction rate that only transfers mass between different reactants but does not represent a reactive species itself. 

1. [ ] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.2)
2. [x] Tests covering your feature were added?
3. [x ] Any new feature or behavior change was documented?
