### PR TITLE
MFront state initialization with sigma_prev and eps_prev.

### DIFF
--- a/MaterialLib/SolidModels/MFront/MFront.cpp
+++ b/MaterialLib/SolidModels/MFront/MFront.cpp
@@ -252,9 +252,9 @@ MFront<DisplacementDim>::integrateStress(
     double const t,
     ParameterLib::SpatialPosition const& x,
     double const dt,
-    KelvinVector const& /*eps_prev*/,
+    KelvinVector const& eps_prev,
     KelvinVector const& eps,
-    KelvinVector const& /*sigma_prev*/,
+    KelvinVector const& sigma_prev,
     typename MechanicsBase<DisplacementDim>::MaterialStateVariables const&
         material_state_variables,
     double const T) const
@@ -291,10 +291,23 @@ MFront<DisplacementDim>::integrateStress(
 
     auto v = mgis::behaviour::make_view(behaviour_data);
 
+    auto const eps_prev_MFront = OGSToMFront(eps_prev);
+    for (auto i = 0; i < KelvinVector::SizeAtCompileTime; ++i)
+    {
+        v.s0.gradients[i] = eps_prev_MFront[i];
+    }
+
     auto const eps_MFront = OGSToMFront(eps);
     for (auto i = 0; i < KelvinVector::SizeAtCompileTime; ++i)
     {
         v.s1.gradients[i] = eps_MFront[i];
+    }
+
+    auto const sigma_prev_MFront = OGSToMFront(sigma_prev);
+    for (auto i = 0; i < KelvinVector::SizeAtCompileTime; ++i)
+    {
+        v.s0.thermodynamic_forces[i] = sigma_prev_MFront[i];
+        v.s1.thermodynamic_forces[i] = sigma_prev_MFront[i];
     }
 
     auto const status = mgis::behaviour::integrate(v, _behaviour);

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/load_test_mc.prj
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/load_test_mc.prj
@@ -265,7 +265,7 @@
         <vtkdiff>
             <file>load_test_mc_pcs_0_ts_20_t_20.000000.vtu</file>
             <field>NodalForces</field>
-            <absolute_tolerance>1e-5</absolute_tolerance>
+            <absolute_tolerance>2e-5</absolute_tolerance>
             <relative_tolerance>1e-9</relative_tolerance>
         </vtkdiff>
         <vtkdiff>
@@ -296,7 +296,7 @@
         <vtkdiff>
             <file>load_test_mc_pcs_0_ts_30_t_30.000000.vtu</file>
             <field>displacement</field>
-            <absolute_tolerance>1e-13</absolute_tolerance>
+            <absolute_tolerance>2e-13</absolute_tolerance>
             <relative_tolerance>1e-14</relative_tolerance>
         </vtkdiff>
         <vtkdiff>


### PR DESCRIPTION
Until now the models didn't use `sigma_prev` and `eps_prev`.