### PR TITLE
Create Methods for MPL Properties

### DIFF
--- a/MaterialLib/MPL/CreateProperty.cpp
+++ b/MaterialLib/MPL/CreateProperty.cpp
@@ -43,41 +43,7 @@ std::unique_ptr<MaterialPropertyLib::Property> createProperty(
     }
     if (property_type == "Linear")
     {
-        auto const reference_value =
-            //! \ogs_file_param{properties__property__LinearProperty__reference_value}
-            config.getConfigParameter<double>("reference_value");
-
-        std::vector<MaterialPropertyLib::IndependentVariable> ivs;
-        auto const& independent_variables_config =
-            //! \ogs_file_param{properties__property__LinearProperty__independent_variables}
-            config.getConfigSubtree("independent_variables");
-        for (auto const& independent_variable_config :
-             independent_variables_config.getConfigSubtreeList(
-                 "independent_variable"))
-        {
-            auto const& variable_name =
-                //! \ogs_file_param{properties__property__LinearProperty__independent_variables__independent_variable__variable_name}
-                independent_variable_config.getConfigParameter<std::string>(
-                    "variable_name");
-            auto const reference_condition =
-                //! \ogs_file_param{properties__property__LinearProperty__independent_variables__independent_variable__reference_condition}
-                independent_variable_config.getConfigParameter<double>(
-                    "reference_condition");
-            auto const slope =
-                //! \ogs_file_param{properties__property__LinearProperty__independent_variables__independent_variable__slope}
-                independent_variable_config.getConfigParameter<double>("slope");
-
-            MaterialPropertyLib::Variable ivt =
-                MaterialPropertyLib::convertStringToVariable(variable_name);
-
-            MaterialPropertyLib::IndependentVariable iv{
-                ivt, reference_condition, slope};
-
-            ivs.push_back(std::move(iv));
-        }
-
-        return std::make_unique<MaterialPropertyLib::LinearProperty>(
-            reference_value, ivs);
+        return createLinearProperty(config);
     }
 
     if (property_type == "Exponential")

--- a/MaterialLib/MPL/CreateProperty.cpp
+++ b/MaterialLib/MPL/CreateProperty.cpp
@@ -34,7 +34,7 @@ std::unique_ptr<MaterialPropertyLib::Property> createProperty(
     using namespace MaterialPropertyLib;
     // Parsing the property type:
     //! \ogs_file_param{properties__property__type}
-    auto const property_type = config.getConfigParameter<std::string>("type");
+    auto const property_type = config.peekConfigParameter<std::string>("type");
 
     // If (and only if) the given property type is 'constant', a corresponding
     // value is needed.

--- a/MaterialLib/MPL/CreateProperty.cpp
+++ b/MaterialLib/MPL/CreateProperty.cpp
@@ -39,66 +39,7 @@ std::unique_ptr<MaterialPropertyLib::Property> createProperty(
 
     if (property_type == "Constant")
     {
-        std::vector<double> const values =
-            //! \ogs_file_param{properties__property__Constant__value}
-            config.getConfigParameter<std::vector<double>>("value");
-
-        switch (values.size())
-        {
-            case 1:
-            {
-                // scalar
-                PropertyDataType property_value = values[0];
-                return std::make_unique<Constant>(property_value);
-            }
-            case 2:
-            {
-                // Pair
-                PropertyDataType property_value = Pair{values[0], values[1]};
-                return std::make_unique<Constant>(property_value);
-            }
-            case 3:
-            {
-                // Vector
-                PropertyDataType property_value =
-                    Vector{values[0], values[1], values[2]};
-                return std::make_unique<Constant>(property_value);
-            }
-            case 4:
-            {
-                // Tensor
-                PropertyDataType property_value =
-                    Tensor2d{values[0], values[1], values[2], values[3]};
-                return std::make_unique<Constant>(property_value);
-            }
-            case 6:
-            {
-                // Symmetric Tensor - xx, yy, zz, xy, xz, yz
-                PropertyDataType property_value =
-                    SymmTensor{values[0], values[1], values[2],
-                               values[3], values[4], values[5]};
-                return std::make_unique<Constant>(property_value);
-            }
-            case 9:
-            {
-                // Tensor
-                PropertyDataType property_value = Tensor{
-                    values[0], values[1], values[2], values[3], values[4],
-                    values[5], values[6], values[7], values[8]};
-                return std::make_unique<Constant>(property_value);
-            }
-
-            default:
-            {
-                OGS_FATAL(
-                    "Creation of a constant property with %i components is not "
-                    "implemented.",
-                    values.size());
-            }
-        }
-
-        PropertyDataType property_value;
-        return std::make_unique<Constant>(property_value);
+        return createConstant(config);
     }
     if (property_type == "Linear")
     {

--- a/MaterialLib/MPL/CreateProperty.cpp
+++ b/MaterialLib/MPL/CreateProperty.cpp
@@ -19,6 +19,7 @@
 #include "ParameterLib/Parameter.h"
 #include "ParameterLib/Utils.h"
 
+#include "Properties/CreateProperties.h"
 #include "Properties/Properties.h"
 
 #include "Component.h"

--- a/MaterialLib/MPL/CreateProperty.cpp
+++ b/MaterialLib/MPL/CreateProperty.cpp
@@ -48,34 +48,7 @@ std::unique_ptr<MaterialPropertyLib::Property> createProperty(
 
     if (property_type == "Exponential")
     {
-        auto const reference_value =
-            //! \ogs_file_param{properties__property__ExponentialProperty__reference_value}
-            config.getConfigParameter<double>("reference_value");
-
-        auto const& exponent_data_config =
-            //! \ogs_file_param{properties__property__ExponentialProperty__exponent}
-            config.getConfigSubtree("exponent");
-
-        auto const& variable_name =
-            //! \ogs_file_param{properties__property__ExponentialProperty__exponent__variable_name}
-            exponent_data_config.getConfigParameter<std::string>(
-                "variable_name");
-        auto const reference_condition =
-            //! \ogs_file_param{properties__property__ExponentialProperty__exponent__reference_condition}
-            exponent_data_config.getConfigParameter<double>(
-                "reference_condition");
-        auto const factor =
-            //! \ogs_file_param{properties__property__ExponentialProperty__exponent__factor}
-            exponent_data_config.getConfigParameter<double>("factor");
-
-        MaterialPropertyLib::Variable exp_data_type =
-            MaterialPropertyLib::convertStringToVariable(variable_name);
-
-        MaterialPropertyLib::ExponentData const exp_data{
-            exp_data_type, reference_condition, factor};
-
-        return std::make_unique<MaterialPropertyLib::ExponentialProperty>(
-            reference_value, exp_data);
+        return createExponentialProperty(config);
     }
 
     if (property_type == "Parameter")

--- a/MaterialLib/MPL/CreateProperty.cpp
+++ b/MaterialLib/MPL/CreateProperty.cpp
@@ -37,8 +37,6 @@ std::unique_ptr<MaterialPropertyLib::Property> createProperty(
     //! \ogs_file_param{properties__property__type}
     auto const property_type = config.peekConfigParameter<std::string>("type");
 
-    // If (and only if) the given property type is 'constant', a corresponding
-    // value is needed.
     if (property_type == "Constant")
     {
         std::vector<double> const values =
@@ -102,14 +100,6 @@ std::unique_ptr<MaterialPropertyLib::Property> createProperty(
         PropertyDataType property_value;
         return std::make_unique<Constant>(property_value);
     }
-    // Properties can be medium, phase, or component properties.
-    // Some of them require information about the respective material.
-    // Thus, we pass a pointer to the material that requests the property.
-    // In this method, this pointer is realized via typename MaterialType, which
-    // replaces either Medium*, Phase*, or Component*.
-    // Note that most property constructors (only those that request material
-    // pointers) must be overloaded for any type of material.
-
     if (property_type == "Linear")
     {
         auto const reference_value =

--- a/MaterialLib/MPL/CreateProperty.cpp
+++ b/MaterialLib/MPL/CreateProperty.cpp
@@ -16,8 +16,6 @@
 #include <string>
 #include <vector>
 #include "BaseLib/ConfigTree.h"
-#include "ParameterLib/Parameter.h"
-#include "ParameterLib/Utils.h"
 
 #include "Properties/CreateProperties.h"
 #include "Properties/Properties.h"
@@ -53,13 +51,7 @@ std::unique_ptr<MaterialPropertyLib::Property> createProperty(
 
     if (property_type == "Parameter")
     {
-        std::string const& parameter_name =
-            //! \ogs_file_param{properties__property__Parameter__parameter_name}
-            config.getConfigParameter<std::string>("parameter_name");
-        auto const& parameter = ParameterLib::findParameter<double>(
-            parameter_name, parameters, 0, nullptr);
-        return std::make_unique<MaterialPropertyLib::ParameterProperty>(
-            parameter);
+        return createParameterProperty(config, parameters);
     }
 
     if (boost::iequals(property_type, "IdealGasLaw"))

--- a/MaterialLib/MPL/Properties/CreateConstant.cpp
+++ b/MaterialLib/MPL/Properties/CreateConstant.cpp
@@ -1,0 +1,84 @@
+/**
+ * \file
+ * \author Norbert Grunwald
+ * \date   Sep 10, 2019
+ *
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "BaseLib/ConfigTree.h"
+#include "Constant.h"
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<Constant> createConstant(BaseLib::ConfigTree const& config)
+{
+    config.checkConfigParameter("type", "Constant");
+    DBUG("Create Constant property");
+    std::vector<double> const values =
+        //! \ogs_file_param{properties__property__Constant__value}
+        config.getConfigParameter<std::vector<double>>("value");
+
+    switch (values.size())
+    {
+        case 1:
+        {
+            // scalar
+            PropertyDataType property_value = values[0];
+            return std::make_unique<Constant>(property_value);
+        }
+        case 2:
+        {
+            // Pair
+            PropertyDataType property_value = Pair{values[0], values[1]};
+            return std::make_unique<Constant>(property_value);
+        }
+        case 3:
+        {
+            // Vector
+            PropertyDataType property_value =
+                Vector{values[0], values[1], values[2]};
+            return std::make_unique<Constant>(property_value);
+        }
+        case 4:
+        {
+            // Tensor
+            PropertyDataType property_value =
+                Tensor2d{values[0], values[1], values[2], values[3]};
+            return std::make_unique<Constant>(property_value);
+        }
+        case 6:
+        {
+            // Symmetric Tensor - xx, yy, zz, xy, xz, yz
+            PropertyDataType property_value =
+                SymmTensor{values[0], values[1], values[2],
+                           values[3], values[4], values[5]};
+            return std::make_unique<Constant>(property_value);
+        }
+        case 9:
+        {
+            // Tensor
+            PropertyDataType property_value =
+                Tensor{values[0], values[1], values[2], values[3], values[4],
+                       values[5], values[6], values[7], values[8]};
+            return std::make_unique<Constant>(property_value);
+        }
+
+        default:
+        {
+            OGS_FATAL(
+                "Creation of a constant property with %i components is not "
+                "implemented.",
+                values.size());
+        }
+    }
+
+    PropertyDataType property_value;
+    return std::make_unique<Constant>(property_value);
+}
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateConstant.h
+++ b/MaterialLib/MPL/Properties/CreateConstant.h
@@ -10,7 +10,21 @@
  *              http://www.opengeosys.org/project/license
  *
  */
+
 #pragma once
 
-#include "CreateConstant.h"
-#include "CreateIdealGasLaw.h"
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace MaterialPropertyLib
+{
+class Constant;
+}
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<Constant> createConstant(
+    BaseLib::ConfigTree const& config);
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateExponentialProperty.cpp
+++ b/MaterialLib/MPL/Properties/CreateExponentialProperty.cpp
@@ -1,0 +1,54 @@
+/**
+ * \file
+ * \author Norbert Grunwald
+ * \date   Sep 10, 2019
+ *
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "BaseLib/ConfigTree.h"
+#include "ExponentialProperty.h"
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<ExponentialProperty> createExponentialProperty(
+    BaseLib::ConfigTree const& config)
+{
+    config.checkConfigParameter("type", "Exponential");
+    DBUG("Create Exponential property");
+        auto const reference_value =
+            //! \ogs_file_param{properties__property__ExponentialProperty__reference_value}
+            config.getConfigParameter<double>("reference_value");
+
+        auto const& exponent_data_config =
+            //! \ogs_file_param{properties__property__ExponentialProperty__exponent}
+            config.getConfigSubtree("exponent");
+
+        auto const& variable_name =
+            //! \ogs_file_param{properties__property__ExponentialProperty__exponent__variable_name}
+            exponent_data_config.getConfigParameter<std::string>(
+                "variable_name");
+        auto const reference_condition =
+            //! \ogs_file_param{properties__property__ExponentialProperty__exponent__reference_condition}
+            exponent_data_config.getConfigParameter<double>(
+                "reference_condition");
+        auto const factor =
+            //! \ogs_file_param{properties__property__ExponentialProperty__exponent__factor}
+            exponent_data_config.getConfigParameter<double>("factor");
+
+        MaterialPropertyLib::Variable exp_data_type =
+            MaterialPropertyLib::convertStringToVariable(variable_name);
+
+        MaterialPropertyLib::ExponentData const exp_data{
+            exp_data_type, reference_condition, factor};
+
+        return std::make_unique<MaterialPropertyLib::ExponentialProperty>(
+            reference_value, exp_data);
+
+}
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateExponentialProperty.h
+++ b/MaterialLib/MPL/Properties/CreateExponentialProperty.h
@@ -10,9 +10,21 @@
  *              http://www.opengeosys.org/project/license
  *
  */
+
 #pragma once
 
-#include "CreateConstant.h"
-#include "CreateExponentialProperty.h"
-#include "CreateIdealGasLaw.h"
-#include "CreateLinearProperty.h"
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace MaterialPropertyLib
+{
+class ExponentialProperty;
+}
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<ExponentialProperty> createExponentialProperty(
+    BaseLib::ConfigTree const& config);
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateIdealGasLaw.cpp
+++ b/MaterialLib/MPL/Properties/CreateIdealGasLaw.cpp
@@ -1,0 +1,26 @@
+/**
+ * \file
+ * \author Norbert Grunwald
+ * \date   Sep 10, 2019
+ *
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "BaseLib/ConfigTree.h"
+#include "IdealGasLaw.h"
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<IdealGasLaw> createIdealGasLaw(
+    BaseLib::ConfigTree const& config)
+{
+    config.checkConfigParameter("type", "IdealGasLaw");
+    DBUG("Create IdealGasLaw medium property");
+    return std::make_unique<IdealGasLaw>();
+}
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateIdealGasLaw.h
+++ b/MaterialLib/MPL/Properties/CreateIdealGasLaw.h
@@ -1,0 +1,30 @@
+/**
+ * \file
+ * \author Norbert Grunwald
+ * \date   Sep 10, 2019
+ *
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace MaterialPropertyLib
+{
+class IdealGasLaw;
+}
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<IdealGasLaw> createIdealGasLaw(
+    BaseLib::ConfigTree const& config);
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateLinearProperty.cpp
+++ b/MaterialLib/MPL/Properties/CreateLinearProperty.cpp
@@ -1,0 +1,61 @@
+/**
+ * \file
+ * \author Norbert Grunwald
+ * \date   Sep 10, 2019
+ *
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "BaseLib/ConfigTree.h"
+#include "LinearProperty.h"
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<LinearProperty> createLinearProperty(
+    BaseLib::ConfigTree const& config)
+{
+    config.checkConfigParameter("type", "Linear");
+    DBUG("Create Linear property");
+
+    auto const reference_value =
+        //! \ogs_file_param{properties__property__LinearProperty__reference_value}
+        config.getConfigParameter<double>("reference_value");
+
+    std::vector<MaterialPropertyLib::IndependentVariable> ivs;
+    auto const& independent_variables_config =
+        //! \ogs_file_param{properties__property__LinearProperty__independent_variables}
+        config.getConfigSubtree("independent_variables");
+    for (auto const& independent_variable_config :
+         independent_variables_config.getConfigSubtreeList(
+             "independent_variable"))
+    {
+        auto const& variable_name =
+            //! \ogs_file_param{properties__property__LinearProperty__independent_variables__independent_variable__variable_name}
+            independent_variable_config.getConfigParameter<std::string>(
+                "variable_name");
+        auto const reference_condition =
+            //! \ogs_file_param{properties__property__LinearProperty__independent_variables__independent_variable__reference_condition}
+            independent_variable_config.getConfigParameter<double>(
+                "reference_condition");
+        auto const slope =
+            //! \ogs_file_param{properties__property__LinearProperty__independent_variables__independent_variable__slope}
+            independent_variable_config.getConfigParameter<double>("slope");
+
+        MaterialPropertyLib::Variable ivt =
+            MaterialPropertyLib::convertStringToVariable(variable_name);
+
+        MaterialPropertyLib::IndependentVariable iv{ivt, reference_condition,
+                                                    slope};
+
+        ivs.push_back(std::move(iv));
+    }
+
+    return std::make_unique<MaterialPropertyLib::LinearProperty>(
+        reference_value, ivs);
+}
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateLinearProperty.h
+++ b/MaterialLib/MPL/Properties/CreateLinearProperty.h
@@ -10,8 +10,21 @@
  *              http://www.opengeosys.org/project/license
  *
  */
+
 #pragma once
 
-#include "CreateConstant.h"
-#include "CreateIdealGasLaw.h"
-#include "CreateLinearProperty.h"
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace MaterialPropertyLib
+{
+class LinearProperty;
+}
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<LinearProperty> createLinearProperty(
+    BaseLib::ConfigTree const& config);
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateParameterProperty.cpp
+++ b/MaterialLib/MPL/Properties/CreateParameterProperty.cpp
@@ -1,0 +1,36 @@
+/**
+ * \file
+ * \author Norbert Grunwald
+ * \date   Sep 10, 2019
+ *
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "BaseLib/ConfigTree.h"
+#include "ParameterLib/Parameter.h"
+#include "ParameterLib/Utils.h"
+
+#include "ParameterProperty.h"
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<ParameterProperty> createParameterProperty(
+    BaseLib::ConfigTree const& config,
+    std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters)
+{
+    config.checkConfigParameter("type", "Parameter");
+    DBUG("Create Parameter property");
+
+    std::string const& parameter_name =
+        //! \ogs_file_param{properties__property__Parameter__parameter_name}
+        config.getConfigParameter<std::string>("parameter_name");
+    auto const& parameter = ParameterLib::findParameter<double>(
+        parameter_name, parameters, 0, nullptr);
+    return std::make_unique<MaterialPropertyLib::ParameterProperty>(parameter);
+}
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateParameterProperty.h
+++ b/MaterialLib/MPL/Properties/CreateParameterProperty.h
@@ -1,0 +1,32 @@
+/**
+ * \file
+ * \author Norbert Grunwald
+ * \date   Sep 10, 2019
+ *
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace MaterialPropertyLib
+{
+class ParameterProperty;
+}
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<ParameterProperty> createParameterProperty(
+    BaseLib::ConfigTree const& config,
+    std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const&
+        parameters);
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateProperties.h
+++ b/MaterialLib/MPL/Properties/CreateProperties.h
@@ -16,3 +16,4 @@
 #include "CreateExponentialProperty.h"
 #include "CreateIdealGasLaw.h"
 #include "CreateLinearProperty.h"
+#include "CreateParameterProperty.h"

--- a/MaterialLib/MPL/Properties/CreateProperties.h
+++ b/MaterialLib/MPL/Properties/CreateProperties.h
@@ -1,0 +1,15 @@
+/**
+ * \file
+ * \author Norbert Grunwald
+ * \date   Sep 10, 2019
+ *
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+#pragma once
+
+#include "CreateIdealGasLaw.h"

--- a/MaterialLib/MPL/Properties/IdealGasLaw.h
+++ b/MaterialLib/MPL/Properties/IdealGasLaw.h
@@ -71,11 +71,4 @@ private:
     Component* _component;
 };
 
-inline std::unique_ptr<IdealGasLaw> createIdealGasLaw(
-    BaseLib::ConfigTree const& /*config*/)
-{
-    DBUG("Create IdealGasLaw medium property");
-    return std::make_unique<IdealGasLaw>();
-}
-
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/IdealGasLaw.h
+++ b/MaterialLib/MPL/Properties/IdealGasLaw.h
@@ -67,8 +67,8 @@ public:
                              double const t) const override;
 
 private:
-    Phase* _phase;
-    Component* _component;
+    Phase* _phase = nullptr;
+    Component* _component = nullptr;
 };
 
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/ParameterProperty.h
+++ b/MaterialLib/MPL/Properties/ParameterProperty.h
@@ -24,7 +24,8 @@ class ParameterProperty final : public Property
 {
 public:
     /// This constructor accepts a Parameter.
-    ParameterProperty(ParameterLib::Parameter<double> const& parameter);
+    explicit ParameterProperty(
+        ParameterLib::Parameter<double> const& parameter);
 
     /// This method computes the value of a property depending linearly on
     /// the value of the given primary variable.

--- a/Tests/MaterialLib/TestMPLIdealGasLaw.cpp
+++ b/Tests/MaterialLib/TestMPLIdealGasLaw.cpp
@@ -44,7 +44,7 @@ TEST(MaterialPropertyLib, IdealGasLawOfPurePhase)
     m << "  <properties>\n";
     m << "    <property>\n";
     m << "      <name>density</name>\n";
-    m << "      <type>IdealGaslaw</type>\n";
+    m << "      <type>IdealGasLaw</type>\n";
     m << "    </property>\n";
     m << "    <property>\n";
     m << "      <name>molar_mass</name>\n";


### PR DESCRIPTION
All MPL Properties are now constructed via a new create method. Parsing the parameter type is done by peeking the config object rather than reading it. The actual check is done in the individual create methods. 

1. [ ] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.2)
2. [ ] Tests covering your feature were added?
3. [ ] Any new feature or behavior change was documented?
