### PR TITLE
[utils] netCDF converter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,6 +27,7 @@
 *.pvtu* filter=lfs diff=lfs merge=lfs -text
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.mp4 filter=lfs diff=lfs merge=lfs -text
+*.nc filter=lfs diff=lfs merge=lfs -text
 web/resources/_gen/**/*.content filter=lfs diff=lfs merge=lfs -text
 # Gocad files
 *.sg filter=lfs diff=lfs merge=lfs -text

--- a/Applications/DataExplorer/NetCdfDialog/CMakeLists.txt
+++ b/Applications/DataExplorer/NetCdfDialog/CMakeLists.txt
@@ -4,9 +4,12 @@ if(BUILD_SHARED_LIBS)
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 target_link_libraries(NetCdfDialogLib
-                      PUBLIC Qt5::Widgets ${ZLIB_LIBRARIES}
-                      PRIVATE MathLib ${NETCDF_LIBRARIES_C}
-                              ${NETCDF_LIBRARIES_CXX} ${HDF5_LIBRARIES})
+                      PUBLIC Qt5::Widgets
+                             ${NETCDF_LIBRARIES_C}
+                             ${NETCDF_LIBRARIES_CXX}
+                             ${HDF5_LIBRARIES}
+                             ${HDF5_HL_LIBRARIES}
+                      PRIVATE MathLib)
 set_property(TARGET NetCdfDialogLib PROPERTY FOLDER "DataExplorer")
 
 # Workaround for system installed VTK (tested on arch)

--- a/Applications/DataExplorer/NetCdfDialog/CMakeLists.txt
+++ b/Applications/DataExplorer/NetCdfDialog/CMakeLists.txt
@@ -4,15 +4,16 @@ if(BUILD_SHARED_LIBS)
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 target_link_libraries(NetCdfDialogLib
-                      PUBLIC Qt5::Widgets
-                      PRIVATE MathLib vtknetcdfcpp)
+                      PUBLIC Qt5::Widgets ${ZLIB_LIBRARIES}
+                      PRIVATE MathLib ${NETCDF_LIBRARIES_C}
+                              ${NETCDF_LIBRARIES_CXX} ${HDF5_LIBRARIES})
 set_property(TARGET NetCdfDialogLib PROPERTY FOLDER "DataExplorer")
 
 # Workaround for system installed VTK (tested on arch)
 if(NOT OGS_USE_CONAN)
-    target_include_directories(
-        NetCdfDialogLib SYSTEM
-        PUBLIC ${VTK_INSTALL_PREFIX}/include/vtk/vtknetcdfcpp)
+    target_include_directories(NetCdfDialogLib SYSTEM
+                               PUBLIC ${NETCDF_INCLUDES_C}
+                               PUBLIC ${NETCDF_INCLUDES_CXX})
 endif()
 
 add_autogen_include(NetCdfDialogLib)

--- a/Applications/DataExplorer/NetCdfDialog/CMakeLists.txt
+++ b/Applications/DataExplorer/NetCdfDialog/CMakeLists.txt
@@ -5,10 +5,10 @@ if(BUILD_SHARED_LIBS)
 endif()
 target_link_libraries(NetCdfDialogLib
                       PUBLIC Qt5::Widgets
-                             ${NETCDF_LIBRARIES_C}
                              ${NETCDF_LIBRARIES_CXX}
-                             ${HDF5_LIBRARIES}
+                             ${NETCDF_LIBRARIES_C}
                              ${HDF5_HL_LIBRARIES}
+                             ${HDF5_LIBRARIES}
                       PRIVATE MathLib)
 set_property(TARGET NetCdfDialogLib PROPERTY FOLDER "DataExplorer")
 

--- a/Applications/DataExplorer/NetCdfDialog/NetCdfConfigure.ui
+++ b/Applications/DataExplorer/NetCdfDialog/NetCdfConfigure.ui
@@ -167,68 +167,6 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <widget class="QDateTimeEdit" name="dateTimeEditDim3">
-        <property name="minimumSize">
-         <size>
-          <width>110</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>110</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="autoFillBackground">
-         <bool>false</bool>
-        </property>
-        <property name="dateTime">
-         <datetime>
-          <hour>0</hour>
-          <minute>0</minute>
-          <second>0</second>
-          <year>1900</year>
-          <month>1</month>
-          <day>1</day>
-         </datetime>
-        </property>
-        <property name="date">
-         <date>
-          <year>1900</year>
-          <month>1</month>
-          <day>1</day>
-         </date>
-        </property>
-        <property name="maximumDateTime">
-         <datetime>
-          <hour>23</hour>
-          <minute>59</minute>
-          <second>59</second>
-          <year>2200</year>
-          <month>12</month>
-          <day>31</day>
-         </datetime>
-        </property>
-        <property name="minimumDateTime">
-         <datetime>
-          <hour>0</hour>
-          <minute>0</minute>
-          <second>0</second>
-          <year>1900</year>
-          <month>1</month>
-          <day>1</day>
-         </datetime>
-        </property>
-        <property name="displayFormat">
-         <string>dd.MM.yyyy</string>
-        </property>
-        <property name="calendarPopup">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
       <item row="3" column="3">
        <spacer name="horizontalSpacer_8">
         <property name="orientation">
@@ -254,6 +192,9 @@
          </size>
         </property>
        </spacer>
+      </item>
+      <item row="0" column="2">
+       <widget class="QSpinBox" name="dateTimeEditDim3"/>
       </item>
      </layout>
     </widget>
@@ -720,7 +661,6 @@
   <tabstop>doubleSpinBoxDim2Start</tabstop>
   <tabstop>doubleSpinBoxDim2End</tabstop>
   <tabstop>comboBoxDim3</tabstop>
-  <tabstop>dateTimeEditDim3</tabstop>
   <tabstop>comboBoxDim4</tabstop>
   <tabstop>spinBoxDim4</tabstop>
   <tabstop>doubleSpinBoxResolution</tabstop>

--- a/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.cpp
+++ b/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.cpp
@@ -124,6 +124,7 @@ void NetCdfConfigureDialog::on_comboBoxDim3_currentIndexChanged(int id)
 //set up additional dimension
 void NetCdfConfigureDialog::on_comboBoxDim4_currentIndexChanged(int id)
 {
+    Q_UNUSED(id);
     if (_currentVar.getDimCount() > 3)
     {
         double firstValue=0, lastValue=0;
@@ -228,7 +229,7 @@ int NetCdfConfigureDialog::getDim4() const
 {
     NcVar const& dim3Var =
         _currentFile.getVar(comboBoxDim4->currentText().toStdString());
-    std::vector<std::size_t> start{{static_cast<std::size_t>(spinBoxDim4->value())}};
+    std::vector<std::size_t> start{static_cast<std::size_t>(spinBoxDim4->value())};
     int value(0);
     dim3Var.getVar(start, {1}, &value);
     if (value < 0)
@@ -344,7 +345,7 @@ QString NetCdfConfigureDialog::setName()
 std::string NetCdfConfigureDialog::getName()
 {
     std::string name = (lineEditName->text()).toStdString();
-    QString const date = dateTimeEditDim3->value();
+    QString const date = QString::number(dateTimeEditDim3->value());
     name.append(" - ").append(date.toStdString());
     return name;
 }

--- a/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.cpp
+++ b/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.cpp
@@ -139,12 +139,12 @@ int NetCdfConfigureDialog::setVariableSelect()
     int max_dim = 0;
     int max_dim_idx = 0;
     auto const& names =_currentFile.getVars();
-    for (auto it = names.cbegin(); it != names.cend(); ++it)
+    for (auto [name, var] : names)
     {
-        int const var_dim_count = it->second.getDimCount();
+        int const var_dim_count = var.getDimCount();
         if (var_dim_count > 1)
         {
-            comboBoxVariable->addItem(QString::fromStdString(it->first));
+            comboBoxVariable->addItem(QString::fromStdString(name));
             if (var_dim_count > max_dim)
             {
                 max_dim = var_dim_count;
@@ -223,8 +223,6 @@ void NetCdfConfigureDialog::getDimEdges(std::string const& name, unsigned& size,
 
 int NetCdfConfigureDialog::getTimeStep() const
 {
-    NcVar const& time_var =
-        _currentFile.getVar(comboBoxDim3->currentText().toStdString());
     return dateTimeEditDim3->value();
 }
 

--- a/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.cpp
+++ b/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.cpp
@@ -73,6 +73,7 @@ void NetCdfConfigureDialog::reject()
 
 void NetCdfConfigureDialog::on_comboBoxVariable_currentIndexChanged(int id)
 {
+    Q_UNUSED(id);
     std::string const var_name = comboBoxVariable->currentText().toStdString();
     _currentVar = _currentFile.getVar(var_name);
     setDimensionSelect();
@@ -213,11 +214,8 @@ void NetCdfConfigureDialog::getDimEdges(std::string const& name, unsigned& size,
     if ((tmpVarOfDim.getDimCount()) == 1)
     {
         size = tmpVarOfDim.getDim(0).getSize();
-        std::vector<std::size_t> start_val{{0}};
-        std::vector<std::size_t> length{{1}};
-        tmpVarOfDim.getVar(start_val, length, &firstValue);
-        start_val[0] = size-1;
-        tmpVarOfDim.getVar(start_val, length, &lastValue);
+        tmpVarOfDim.getVar({0}, {1}, &firstValue);
+        tmpVarOfDim.getVar({size - 1}, {1}, &lastValue);
     }
 }
 
@@ -231,9 +229,8 @@ int NetCdfConfigureDialog::getDim4() const
     NcVar const& dim3Var =
         _currentFile.getVar(comboBoxDim4->currentText().toStdString());
     std::vector<std::size_t> start{{static_cast<std::size_t>(spinBoxDim4->value())}};
-    std::vector<std::size_t> length{{1}};
     int value(0);
-    dim3Var.getVar(start, length, &value);
+    dim3Var.getVar(start, {1}, &value);
     if (value < 0)
         value = 0; //if the value isn't found in the array, set it to 0 as default...
     return value;
@@ -347,7 +344,7 @@ QString NetCdfConfigureDialog::setName()
 std::string NetCdfConfigureDialog::getName()
 {
     std::string name = (lineEditName->text()).toStdString();
-    QString date = dateTimeEditDim3->value();
+    QString const date = dateTimeEditDim3->value();
     name.append(" - ").append(date.toStdString());
     return name;
 }

--- a/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.h
+++ b/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <netcdfcpp.h>
+#include <netcdf>
 
 #include <QDialog>
 #include "ui_NetCdfConfigure.h"
@@ -65,8 +65,8 @@ private:
     QString setName();
     void reverseNorthSouth(double* data, std::size_t width, std::size_t height);
 
-    NcFile *_currentFile;
-    NcVar *_currentVar;
+    netCDF::NcFile _currentFile;
+    netCDF::NcVar _currentVar;
     QDateTime _currentInitialDateTime;
     MeshLib::Mesh* _currentMesh;
     VtkGeoImageSource* _currentRaster;

--- a/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.h
+++ b/Applications/DataExplorer/NetCdfDialog/NetCdfConfigureDialog.h
@@ -55,11 +55,12 @@ private:
     /// returns the index of the first variable with the highest dimension.
     int setVariableSelect();
     void setDimensionSelect();
-    void getDimEdges(int dimId, unsigned &size, double &firstValue, double &lastValue);
-    void getDaysTime(double minSince, QTime &time, int &days);
-    long convertDateToMinutes(QDateTime initialDateTime,QDate selectedDate, QTime selectedTime);
+    void getDimEdges(std::string const& name,
+                     unsigned& size,
+                     double& firstValue,
+                     double& lastValue);
     void createDataObject();
-    int getTimeStep();
+    int getTimeStep() const;
     int getDim4() const;
     double getResolution();
     QString setName();
@@ -67,9 +68,7 @@ private:
 
     netCDF::NcFile _currentFile;
     netCDF::NcVar _currentVar;
-    QDateTime _currentInitialDateTime;
     MeshLib::Mesh* _currentMesh;
     VtkGeoImageSource* _currentRaster;
     std::string _currentPath;
-    std::vector<int> _id_map;
 };

--- a/Applications/Utils/FileConverter/CMakeLists.txt
+++ b/Applications/Utils/FileConverter/CMakeLists.txt
@@ -9,7 +9,8 @@ set(TOOLS
     TecPlotTools
     GocadSGridReader
     GocadTSurfaceReader
-    Mesh2Raster)
+    Mesh2Raster
+    NetCdfConverter)
 
 if(OGS_BUILD_GUI)
     if(Shapelib_FOUND)
@@ -33,43 +34,14 @@ if(TARGET ConvertSHPToGLI)
     target_link_libraries(ConvertSHPToGLI GeoLib Qt5::Xml ${Shapelib_LIBRARIES})
 endif()
 
-add_executable(OGS2VTK OGS2VTK.cpp)
-set_target_properties(OGS2VTK PROPERTIES FOLDER Utilities)
-target_link_libraries(OGS2VTK MeshLib)
-ADD_VTK_DEPENDENCY(OGS2VTK)
-
-add_executable(VTK2OGS VTK2OGS.cpp)
-set_target_properties(VTK2OGS PROPERTIES FOLDER Utilities)
-target_link_libraries(VTK2OGS MeshLib)
-ADD_VTK_DEPENDENCY(VTK2OGS)
-
-add_executable(VTK2TIN VTK2TIN.cpp)
-set_target_properties(VTK2TIN PROPERTIES FOLDER Utilities)
-target_link_libraries(VTK2TIN MeshLib)
-ADD_VTK_DEPENDENCY(VTK2TIN)
-
-add_executable(TIN2VTK TIN2VTK.cpp)
-set_target_properties(TIN2VTK PROPERTIES FOLDER Utilities)
-target_link_libraries(TIN2VTK MeshLib)
-ADD_VTK_DEPENDENCY(TIN2VTK)
-
-add_executable(NetCdfConverter NetCdfConverter.cpp)
-set_target_properties(NetCdfConverter PROPERTIES FOLDER Utilities)
-target_link_libraries(NetCdfConverter MeshLib)
-ADD_VTK_DEPENDENCY(NetCdfConverter)
-
-####################
-### Installation ###
-####################
-install(TARGETS generateMatPropsFromMatID GMSH2OGS OGS2VTK VTK2OGS VTK2TIN
-    RUNTIME DESTINATION bin COMPONENT ogs_converter)
-
-if(Qt5XmlPatterns_FOUND)
-    if(Shapelib_FOUND)
-        install(TARGETS ConvertSHPToGLI
-            RUNTIME DESTINATION bin COMPONENT ogs_converter)
-    endif()
-    install(TARGETS  FEFLOW2OGS convertGEO
-        RUNTIME DESTINATION bin COMPONENT ogs_converter)
+if(TARGET Mesh2Shape)
+    target_link_libraries(Mesh2Shape ${Shapelib_LIBRARIES})
 endif()
 
+if(TARGET NetCdfConverter)
+    target_link_libraries(NetCdfConverter
+                          ${NETCDF_LIBRARIES_C}
+                          ${NETCDF_LIBRARIES_CXX}
+                          ${HDF5_LIBRARIES}
+                          ${HDF5_HL_LIBRARIES})
+endif()

--- a/Applications/Utils/FileConverter/CMakeLists.txt
+++ b/Applications/Utils/FileConverter/CMakeLists.txt
@@ -43,8 +43,8 @@ endif()
 
 if(TARGET NetCdfConverter)
     target_link_libraries(NetCdfConverter
-                          ${NETCDF_LIBRARIES_C}
                           ${NETCDF_LIBRARIES_CXX}
-                          ${HDF5_LIBRARIES}
-                          ${HDF5_HL_LIBRARIES})
+                          ${NETCDF_LIBRARIES_C}
+                          ${HDF5_HL_LIBRARIES}
+                          ${HDF5_LIBRARIES})
 endif()

--- a/Applications/Utils/FileConverter/CMakeLists.txt
+++ b/Applications/Utils/FileConverter/CMakeLists.txt
@@ -33,7 +33,43 @@ if(TARGET ConvertSHPToGLI)
     target_link_libraries(ConvertSHPToGLI GeoLib Qt5::Xml ${Shapelib_LIBRARIES})
 endif()
 
-if(TARGET Mesh2Shape)
-    target_link_libraries(Mesh2Shape ${Shapelib_LIBRARIES})
+add_executable(OGS2VTK OGS2VTK.cpp)
+set_target_properties(OGS2VTK PROPERTIES FOLDER Utilities)
+target_link_libraries(OGS2VTK MeshLib)
+ADD_VTK_DEPENDENCY(OGS2VTK)
+
+add_executable(VTK2OGS VTK2OGS.cpp)
+set_target_properties(VTK2OGS PROPERTIES FOLDER Utilities)
+target_link_libraries(VTK2OGS MeshLib)
+ADD_VTK_DEPENDENCY(VTK2OGS)
+
+add_executable(VTK2TIN VTK2TIN.cpp)
+set_target_properties(VTK2TIN PROPERTIES FOLDER Utilities)
+target_link_libraries(VTK2TIN MeshLib)
+ADD_VTK_DEPENDENCY(VTK2TIN)
+
+add_executable(TIN2VTK TIN2VTK.cpp)
+set_target_properties(TIN2VTK PROPERTIES FOLDER Utilities)
+target_link_libraries(TIN2VTK MeshLib)
+ADD_VTK_DEPENDENCY(TIN2VTK)
+
+add_executable(NetCdfConverter NetCdfConverter.cpp)
+set_target_properties(NetCdfConverter PROPERTIES FOLDER Utilities)
+target_link_libraries(NetCdfConverter MeshLib)
+ADD_VTK_DEPENDENCY(NetCdfConverter)
+
+####################
+### Installation ###
+####################
+install(TARGETS generateMatPropsFromMatID GMSH2OGS OGS2VTK VTK2OGS VTK2TIN
+    RUNTIME DESTINATION bin COMPONENT ogs_converter)
+
+if(Qt5XmlPatterns_FOUND)
+    if(Shapelib_FOUND)
+        install(TARGETS ConvertSHPToGLI
+            RUNTIME DESTINATION bin COMPONENT ogs_converter)
+    endif()
+    install(TARGETS  FEFLOW2OGS convertGEO
+        RUNTIME DESTINATION bin COMPONENT ogs_converter)
 endif()
 

--- a/Applications/Utils/FileConverter/CMakeLists.txt
+++ b/Applications/Utils/FileConverter/CMakeLists.txt
@@ -9,8 +9,11 @@ set(TOOLS
     TecPlotTools
     GocadSGridReader
     GocadTSurfaceReader
-    Mesh2Raster
-    NetCdfConverter)
+    Mesh2Raster)
+
+if(OGS_USE_NETCDF)
+    list(APPEND TOOLS NetCdfConverter)
+endif()
 
 if(OGS_BUILD_GUI)
     if(Shapelib_FOUND)

--- a/Applications/Utils/FileConverter/NetCdfConverter.cpp
+++ b/Applications/Utils/FileConverter/NetCdfConverter.cpp
@@ -426,18 +426,23 @@ static bool assignDimParams(NcVar const& var,
                      TCLAP::ValueArg<std::size_t>& arg_dim2,
                      TCLAP::ValueArg<std::size_t>& arg_dim3)
 {
-    if (arg_dim3.isSet() && !arg_dim2.isSet())
+    std::size_t dim_param_count = 0;
+    if (arg_dim_time.isSet())
+        dim_param_count++;
+    if (arg_dim1.isSet())
+        dim_param_count++;
+    if (arg_dim2.isSet())
+        dim_param_count++;
+    if (arg_dim3.isSet())
+        dim_param_count++;
+
+    std::size_t const n_dims = var.getDimCount();
+    if (dim_param_count != n_dims)
     {
-        ERR("Parameter for dim2 is not set. Ignoring dimension parameters.");
-        return false;
-    }
-    if (!arg_dim1.isSet() || !arg_dim2.isSet())
-    {
-        ERR("dim1 and dim2 need to be set for extracting mesh.");
+        ERR("Number of parameters set does not fit number of parameters for specified variable.");
         return false;
     }
 
-    std::size_t const n_dims = var.getDimCount();
     if (arg_dim_time.getValue() >= n_dims || arg_dim1.getValue() >= n_dims ||
         arg_dim2.getValue() >= n_dims || arg_dim3.getValue() >= n_dims)
     {
@@ -695,7 +700,7 @@ int main(int argc, char* argv[])
                 : timestepSelectionLoop(var, dim_idx_map[0]);
 
     bool use_single_file(true);
-    if (arg_time_start.isSet())
+    if (arg_time_start.isSet() && time_bounds.first != time_bounds.second)
     {
         use_single_file = arg_single_file.isSet();
     }

--- a/Applications/Utils/FileConverter/NetCdfConverter.cpp
+++ b/Applications/Utils/FileConverter/NetCdfConverter.cpp
@@ -24,6 +24,7 @@
 // BaseLib
 #include "BaseLib/BuildInfo.h"
 #include "BaseLib/LogogSimpleFormatter.h"
+#include "BaseLib/FileTools.h"
 
 // GeoLib
 #include "GeoLib/Raster.h"
@@ -35,17 +36,55 @@
 #include "MeshLib/IO/VtkIO/VtuInterface.h"
 
 
+void checkExit(std::string const& str)
+{
+    if (str == "exit")
+        exit(0);
+}
+
 void showErrorMessage(std::size_t error_id, std::size_t max = 0)
 {
     if (error_id == 0)
     {
-        ERR ("Index not recognised.");
-        std::cout << "\"info\" will display the available options again. \"exit\" will exit the programme.\n";
+        ERR ("Input not valid.");
     }
     else if (error_id == 1)
     {
         ERR ("Index not valid. Valid indices are in [0,%d].", max);
     }
+    else if (error_id == 2)
+    {
+        showErrorMessage(0);
+        std::cout << "Type \"info\" to display the available options again. \"exit\" will exit the programme.\n";
+    }
+}
+
+std::size_t parseInput(std::string const& request_str, std::size_t max_val, bool has_info = false)
+{
+    while (true)
+    {
+        std::cout << request_str;
+        std::string str;
+        std::size_t val;
+        std::getline(std::cin, str);
+        checkExit(str);
+        if (has_info && str == "info")
+            return (max_val);
+        std::stringstream str_stream(str);
+        if (!(str_stream >> val))
+        {
+            std::size_t error_val = (has_info) ? 2 : 0;
+            showErrorMessage(error_val);
+            continue;
+        }
+        if (val > max_val - 1)
+        {
+            showErrorMessage(1, max_val - 1);
+            continue;
+        }
+        return val;
+    }
+    return std::numeric_limits<std::size_t>::max();
 }
 
 void showArrays(NcFile const& dataset)
@@ -62,7 +101,7 @@ void showArrays(NcFile const& dataset)
     std::cout << "\n";
 }
 
-bool showArraysDims(NcFile const& dataset, NcVar const& var)
+bool showArraysDims(NcVar const& var)
 {
     std::cout << "Data array \"" << var.name() << "\" contains the following dimensions:\n";
     std::size_t const n_dims (var.num_dims());
@@ -74,7 +113,7 @@ bool showArraysDims(NcFile const& dataset, NcVar const& var)
 
 std::size_t getDimensionBoundaries(NcFile const& dataset, NcVar const& var, std::size_t dim, double &start, double &end)
 {
-    NcVar dim_var = *dataset.get_var(var.get_dim(dim)->name());
+    NcVar& dim_var = *dataset.get_var(var.get_dim(dim)->name());
     if ((dim_var.num_dims()) == 1)
     {
         std::size_t size = dim_var.get_dim(0)->size();
@@ -95,22 +134,32 @@ std::size_t getDimensionBoundaries(NcFile const& dataset, NcVar const& var, std:
     return 0;
 }
 
+MathLib::Point3d getOrigin(std::array<std::pair<double, double>,3> bounds, std::size_t n_dims)
+{
+    MathLib::Point3d origin(std::array<double, 3>{ {0, 0, 0}});
+    for (std::size_t i=0; i<n_dims; ++i)
+        origin[i] = (bounds[i].first < bounds[i].second) ? bounds[i].first : bounds[i].second;
+    if (n_dims > 1)
+        std::swap(origin[0], origin[1]);
+    return origin;
+}
+
 void reverseNorthSouth(double* data, std::size_t width, std::size_t height)
 {
-    double* cp_array = new double[width*height];
+    std::size_t const total_length (width * height);
+    double* cp_array = new double[total_length];
 
     for (std::size_t i=0; i<height; i++)
     {
         for (std::size_t j=0; j<width; j++)
         {
-            std::size_t const old_index ((width*height)-(width*(i+1)));
+            std::size_t const old_index (total_length - (width*(i+1)));
             std::size_t const new_index (width*i);
             cp_array[new_index+j] = data[old_index+j];
         }
     }
 
-    std::size_t const length(height*width);
-    for (std::size_t i=0; i<length; i++)
+    for (std::size_t i=0; i<total_length; i++)
         data[i] = cp_array[i];
 
     delete[] cp_array;
@@ -119,39 +168,17 @@ void reverseNorthSouth(double* data, std::size_t width, std::size_t height)
 std::size_t arraySelectionLoop(NcFile const& dataset)
 {
     showArrays(dataset);
-    while (true)
-    {
-        cout << "Enter data array index: ";
-        std::string var_idx_str ("");
-        std::getline(std::cin, var_idx_str);
-        if (var_idx_str == "info")
-        {
-            showArrays(dataset);
-            continue;
-        }
-        if (var_idx_str == "exit")
-            exit(0);
-    
-        std::stringstream str_stream(var_idx_str);
-        std::size_t var_idx;
-        if (!(str_stream >> var_idx))
-        {
-            showErrorMessage(0);
-            continue;
-        }
-        if (var_idx > dataset.num_vars()-1)
-        {
-            showErrorMessage(1, dataset.num_vars()-1);
-            continue;
-        }
-        return var_idx;
-    }
-    return std::numeric_limits<std::size_t>::max();
+    std::size_t idx = parseInput("Enter data array index: ", dataset.num_vars(), true);
+
+    if (idx == dataset.num_vars())
+        return arraySelectionLoop(dataset);
+
+    return idx;
 }
 
-bool dimensionSelectionLoop(NcFile const& dataset, NcVar const& var, std::array<std::size_t,4> &dim_idx_map)
+bool dimensionSelectionLoop(NcVar const& var, std::array<std::size_t,4> &dim_idx_map)
 {
-    showArraysDims(dataset, var);
+    showArraysDims(var);
     std::size_t const n_dims (var.num_dims());
     dim_idx_map[0] = std::numeric_limits<std::size_t>::max();
     bool is_time_dep (true);
@@ -166,57 +193,58 @@ bool dimensionSelectionLoop(NcFile const& dataset, NcVar const& var, std::array<
             cout << "Enter ID for temporal dimension or \"c\" to continue: ";
             std::getline(std::cin, temp_str);
             std::stringstream str_stream(temp_str);
-            if (str_stream.str() == "c")
+            if (str_stream.str() == "c" || str_stream.str() == "continue")
                 is_time_dep = false;
             else 
             {
-                if (str_stream >> dim_idx_map[0])
+                if (!(str_stream >> dim_idx_map[0]))
                 {
-                    if (dim_idx_map[0] > n_dims-1)
-                    {
-                        showErrorMessage(1, var.num_dims()-1);
-                        dim_idx_map[0] = std::numeric_limits<std::size_t>::max();
-                    }
+                    showErrorMessage(0);
+                    continue;
+                }
+                if (dim_idx_map[0] > n_dims-1)
+                {
+                    showErrorMessage(1, var.num_dims()-1);
+                    dim_idx_map[0] = std::numeric_limits<std::size_t>::max();
                 }
             }
         }
     }
+    else
+        is_time_dep = false;
 
     // get spatial dimension(s)
     std::size_t const start_idx = (is_time_dep) ? 1 : 0;
     for (std::size_t i=start_idx; i<n_dims; ++i)
     {
         dim_idx_map[i] = std::numeric_limits<std::size_t>::max();
-        while (dim_idx_map[i] == std::numeric_limits<std::size_t>::max())
-        {
-            std::string dim_idx_str;
-            cout << "Enter ID for dimension " << i << ": ";
-            std::getline(std::cin, dim_idx_str);
-            if (dim_idx_str == "info")
-            {
-                showArraysDims(dataset, var);
-                continue;
-            }
-            if (dim_idx_str == "exit")
-                exit(0);
 
-            std::stringstream str_stream(dim_idx_str);
-            std::size_t dim_idx;
-            if (!(str_stream >> dim_idx))
-            {
-                showErrorMessage(0);
-                continue;
-            }
-            if (dim_idx > var.num_dims()-1)
-            {
-                showErrorMessage(1, var.num_dims()-1);
-                continue;
-            }
-            dim_idx_map[i] = dim_idx;
+        std::string request_str ("Enter ID for dimension " + std::to_string(i) + ": ");
+        std::size_t idx = parseInput(request_str, var.num_dims(), true);
+
+        if (idx == var.num_dims())
+        {
+            showArraysDims(var);
+            i--;
+            continue;
         }
+        dim_idx_map[i] = idx;
     }
 
     return is_time_dep;
+}
+
+std::pair<std::size_t, std::size_t> timestepSelectionLoop(NcFile const& dataset, NcVar const& var, std::size_t dim)
+{
+    double start, end;
+    std::string str("");
+    std::pair<std::size_t, std::size_t> bounds(0,std::numeric_limits<std::size_t>::max());
+    std::size_t n_time_steps = getDimensionBoundaries(dataset, var, dim, start, end);
+    std::cout << "\nThe dataset contains " << n_time_steps << " time steps.\n";
+    bounds.first = parseInput("Specify first time step to export: ", n_time_steps, false);
+    while (bounds.first > bounds.second || bounds.second == std::numeric_limits<std::size_t>::max())
+        bounds.second = parseInput("Specify last time step to export: ", n_time_steps, false);
+    return bounds;
 }
 
 MeshLib::MeshElemType elemSelectionLoop(std::size_t const dim)
@@ -233,12 +261,12 @@ MeshLib::MeshElemType elemSelectionLoop(std::size_t const dim)
         if (dim==3) std::cout << "(p)rism or (h)exahedron: ";
         std::string type ("");
         std::getline(std::cin, type);
-
+        checkExit(type);
         if (dim==2)
         {
-            if (type != "t" || type != "q" ||
-                type != "tri" || type != "quad" ||
-                type != "triangle" || type != "quatliteral")
+            if (type != "t" && type != "q" &&
+                type != "tri" && type != "quad" &&
+                type != "triangle" && type != "quatliteral")
                 continue;
             if (type == "t" || type == "tri" || type == "triangle")
                 return MeshLib::MeshElemType::TRIANGLE;
@@ -261,7 +289,17 @@ MeshLib::MeshElemType elemSelectionLoop(std::size_t const dim)
     return t;
 }
 
-void setOrigin(NcVar &var, std::size_t time_step)
+bool multFilesSelectionLoop(std::pair<std::size_t, std::size_t> const& time_bounds)
+{
+    std::size_t n_time_steps(time_bounds.second - time_bounds.first);
+    std::cout << "\nThe selection includes " << n_time_steps << " time steps.\n";
+    std::cout << "0. Save data in " << n_time_steps << " mesh files with one scalar array each.\n";
+    std::cout << "1. Save data in one mesh file with " << n_time_steps << " scalar arrays.\n";
+    std::size_t ret = parseInput("Select preferred method: ", 2, false);
+    return (ret == 0) ? true : false;
+}
+
+void setTimeStep(NcVar &var, std::size_t time_step)
 {
     long* newOrigin = new long[var.num_dims()];
     for (int i=0; i < var.num_dims(); ++i) 
@@ -271,12 +309,13 @@ void setOrigin(NcVar &var, std::size_t time_step)
     delete [] newOrigin;
 }
 
-/*
-MeshLib::Mesh convert(double* data_array, std::array<std::size_t,3> length, GeoLib::Point &origin, double resolution, MeshLib::MeshElemType meshElemType, MeshLib::UseIntensityAs useIntensity, std::string &name)
+std::string getIterationString(std::size_t i, std::size_t max)
 {
-    return 
+    std::size_t const max_length (std::to_string(max).length());
+    std::string const current_str (std::to_string(i));
+    return std::string(max_length - current_str.length(), '0') + current_str;
 }
-*/
+
 int main (int argc, char* argv[])
 {
     ApplicationsLib::LogogSetup logog_setup;
@@ -294,126 +333,137 @@ int main (int argc, char* argv[])
 
     NcFile dataset(input.getValue().c_str(), NcFile::ReadOnly);
 
+    if (!dataset.is_valid())
+    {
+        ERR("Error opening file.");
+        return -1;
+    }
+
     std::cout << "OpenGeoSys NetCDF Converter\n";
     std::cout << "File " << input.getValue() << " loaded. Press ENTER to display available data arrays.\n";
     std::cin.ignore();
+    std::string output_name (output.getValue());
 
     std::size_t const var_idx = arraySelectionLoop(dataset);
+    NcVar& var = *dataset.get_var(var_idx);
 
     std::array<std::size_t, 4> dim_idx_map;
-    NcVar var = *dataset.get_var(var_idx);
-    bool const is_time_dep = dimensionSelectionLoop(dataset, var, dim_idx_map);
-
-    std::cin.ignore();
+    bool const is_time_dep = dimensionSelectionLoop(var, dim_idx_map);
 
     std::size_t temp_offset = (is_time_dep) ? 1 : 0;
     std::size_t const n_dims = (var.num_dims());
     std::size_t* length = new std::size_t[n_dims];
     for(int i=0; i < n_dims; i++) 
         length[i]=1;
-    std::array<double, 3> spatial_size = {0,0,0};
-    std::array<double, 3> start = {0,0,0};
-    std::array<double, 3> end   = {0,0,0};
+    std::array<std::size_t, 3> spatial_size = {0,0,0};
+    std::array<std::pair<double, double>,3> spatial_bounds;
+    for (std::size_t i=0; i<3; ++i)
+        spatial_bounds[i] = std::pair<double, double>(0, 0);
     std::size_t array_length = 1;
     for (std::size_t i=temp_offset; i<n_dims; ++i)
     {
-        length[i] = getDimensionBoundaries(dataset, var, dim_idx_map[i], start[i-temp_offset], end[i-temp_offset]);
-        spatial_size[i-temp_offset] = length[i];
-        array_length *= length[i];
+        length[dim_idx_map[i]] = getDimensionBoundaries(dataset, var, dim_idx_map[i], spatial_bounds[i-temp_offset].first, spatial_bounds[i-temp_offset].second);
+        spatial_size[i-temp_offset] = length[dim_idx_map[i]];
+        array_length *= length[dim_idx_map[i]];
     }
 
-    setOrigin(var, 0);
-
-    double* data_array = new double[array_length];
-    for (std::size_t i=0; i < array_length; i++) 
-        data_array[i]=0;
-    var.get(data_array, length); //create Array of Values
-
-    for (std::size_t i=0; i < array_length; i++)
-        if (data_array[i] < -9999 ) data_array[i] = -9999; // all values < -10000, set to "no-value"
-
-    double origin_x = (start[1] < end[1]) ? start[1] : end[1];
-    double origin_y = (start[0] < end[0]) ? start[0] : end[0];
-    MathLib::Point3d origin (std::array<double,3>{{origin_x, origin_y, 0}});
-    double const resolution = fabs(end[0]-start[0])/(spatial_size[0]-1);
-
-    // reverse lines in vertical direction if the original file has its origin in the northwest corner
-    if (start[0] > end[0])
-        reverseNorthSouth(data_array, spatial_size[1], spatial_size[0]);
-
-    GeoLib::RasterHeader header = {spatial_size[1], spatial_size[0], origin, resolution, -9999};
-
-    //MeshLib::MeshElemType meshElemType = elemSelectionLoop(n_dims-temp_offset);
-
-    MeshLib::MeshElemType meshElemType = MeshLib::MeshElemType::TRIANGLE;
+    MathLib::Point3d origin = getOrigin(spatial_bounds, n_dims);
+    double const resolution = fabs(spatial_bounds[0].second - spatial_bounds[0].first) / (spatial_size[0] - 1);
+    GeoLib::RasterHeader header = { spatial_size[1], spatial_size[0], origin, resolution, -9999 };
+    MeshLib::MeshElemType meshElemType = elemSelectionLoop(n_dims - temp_offset);
     MeshLib::UseIntensityAs useIntensity = MeshLib::UseIntensityAs::DATAVECTOR;
 
-    MeshLib::Mesh* mesh = MeshLib::RasterToMesh::convert(data_array, header, meshElemType, useIntensity, var.name());
+    std::pair<std::size_t, std::size_t> time_bounds(0,0);
+    if (is_time_dep)
+        time_bounds = timestepSelectionLoop(dataset, var, dim_idx_map[0]);
 
-    /***********************
-    std::size_t const n_time_steps = getDimensionBoundaries(dataset, var, dim_idx_map[2], start_lat, end_lat);
-    std::size_t const array_length (sizeLat * sizeLon);
-    for (std::size_t j=1; j<n_time_steps; ++j)
+    bool mult_files (false);
+    if (is_time_dep && time_bounds.first != time_bounds.second)
+        mult_files = multFilesSelectionLoop(time_bounds);
+
+    double* data_array = nullptr;
+    std::unique_ptr<MeshLib::Mesh> mesh;
+    for (std::size_t i=time_bounds.first; i<=time_bounds.second; ++i)
     {
-        setOrigin(var, j);
-        var.get(data_array, length); //create Array of Values
+        if (is_time_dep)
+            setTimeStep(var, i);
 
-        for (std::size_t i=0; i < (sizeLat*sizeLon); i++)
+        data_array = new double[array_length];
+        for (std::size_t i = 0; i < array_length; i++)
+            data_array[i] = 0;
+        var.get(data_array, length);
+
+        for (std::size_t i=0; i < array_length; i++)
             if (data_array[i] < -9999 ) data_array[i] = -9999; // all values < -10000, set to "no-value"
 
-        double const resolution = fabs(end_lat-start_lat)/(sizeLat-1);
-
         // reverse lines in vertical direction if the original file has its origin in the northwest corner
-        if (start_lat > end_lat)
-            reverseNorthSouth(data_array, sizeLon, sizeLat);
-        GeoLib::RasterHeader header = {sizeLon, sizeLat, origin, resolution, -9999};
+        if (spatial_bounds[0].first > spatial_bounds[0].second)
+            reverseNorthSouth(data_array, spatial_size[1], spatial_size[0]);
 
-        MeshLib::MeshElemType meshElemType = MeshLib::MeshElemType::TRIANGLE;
-        MeshLib::UseIntensityAs useIntensity = MeshLib::UseIntensityAs::DATAVECTOR;
-        std::unique_ptr<MeshLib::Mesh> tmp_mesh (MeshLib::RasterToMesh::convert(data_array, header, meshElemType, useIntensity, var.name()));
-
-        boost::optional< MeshLib::PropertyVector<double>& > tmp_vec = tmp_mesh->getProperties().getPropertyVector<double>(var.name());
-        if (!tmp_vec)
+        if (mult_files)
         {
-            ERR("Vector not found");
-            continue;
+            mesh.reset(MeshLib::RasterToMesh::convert(data_array, header, meshElemType, useIntensity, var.name()));
+            std::string const output_file_name (BaseLib::dropFileExtension(output_name) + getIterationString(i, time_bounds.second) + ".vtu");
+            MeshLib::IO::VtuInterface vtu(mesh.get());
+            vtu.writeToFile(output_file_name);
         }
-
-        if (tmp_vec->size() != mesh->getNumberOfElements())
+        else
         {
-            ERR("Vector size doesn't fit.");
-            continue;
+            std::string array_name (var.name());
+            if (time_bounds.first != time_bounds.second)
+                array_name.append(getIterationString(i, time_bounds.second));
+            if (i==time_bounds.first) // create persistent mesh
+                mesh.reset(MeshLib::RasterToMesh::convert(data_array, header, meshElemType, useIntensity, array_name));
+            else
+            {
+                //copy array to mesh
+            }
+            if (i==time_bounds.second)
+            {
+                MeshLib::IO::VtuInterface vtu(mesh.get());
+                vtu.writeToFile(output_name);
+            }
         }
+    }
 
-        MeshLib::Properties& props (mesh->getProperties());
 
-        std::string prefix ("");
-        if (j<100) prefix = "0";
-        if (j<10) prefix = "00";
-        std::string var_name_str (prefix + std::to_string(j));
+    /***********************
+    for (std::size_t j = time_bounds.first; j <= time_bounds.second; ++j)
+    {
+            boost::optional< MeshLib::PropertyVector<double>& > tmp_vec = tmp_mesh->getProperties().getPropertyVector<double>(var.name());
+            if (!tmp_vec)
+            {
+                ERR("Vector not found");
+                continue;
+            }
 
-        boost::optional< MeshLib::PropertyVector<double>& > vec = 
-            props.createNewPropertyVector<double>(std::string(var.name() + var_name_str), MeshLib::MeshItemType::Cell, 1);
+            if (tmp_vec->size() != mesh->getNumberOfElements())
+            {
+                ERR("Vector size doesn't fit.");
+                continue;
+            }
 
-        if (!vec)
-        {
-            ERR ("Error creating vector");
-            continue;
-        }
-        vec->reserve(tmp_vec->size());
-        for (std::size_t i=0; i<tmp_vec->size(); ++i)
-            vec->push_back((*tmp_vec)[i]);
+            MeshLib::Properties& props (mesh->getProperties());
 
-        std::cout << "time step " << j << " written.\n";
+            std::string iter_str (getIterationString(j, time_bounds.second);
+
+            boost::optional< MeshLib::PropertyVector<double>& > vec = 
+                props.createNewPropertyVector<double>(std::string(var.name() + iter_str), MeshLib::MeshItemType::Cell, 1);
+
+            if (!vec)
+            {
+                ERR ("Error creating vector");
+                continue;
+            }
+            vec->reserve(tmp_vec->size());
+            for (std::size_t i=0; i<tmp_vec->size(); ++i)
+                vec->push_back((*tmp_vec)[i]);
+
+            std::cout << "time step " << j << " written.\n";
     }
     /***********************/
 
-    MeshLib::IO::VtuInterface vtu(mesh);
-    vtu.writeToFile("d:/nctest.vtu");
-
     delete[] length;
     delete[] data_array;
-
-
     return 0;
 }

--- a/Applications/Utils/FileConverter/NetCdfConverter.cpp
+++ b/Applications/Utils/FileConverter/NetCdfConverter.cpp
@@ -280,14 +280,17 @@ static std::pair<std::size_t, std::size_t> timestepSelectionLoop(
     NcVar const& var, std::size_t const dim_idx)
 {
     std::size_t const n_time_steps = var.getDim(dim_idx).getSize();
-    std::pair<std::size_t, std::size_t> bounds(
-        std::numeric_limits<std::size_t>::max(),
-        std::numeric_limits<std::size_t>::max());
+    std::size_t const max_val = std::numeric_limits<std::size_t>::max();
+    std::pair<std::size_t, std::size_t> bounds(max_val, max_val);
     std::cout << "\nThe dataset contains " << n_time_steps << " time steps.\n";
-    bounds.first = parseInput("Specify first time step to export: ", n_time_steps, false);
+    while (bounds.first == max_val)
+    {
+        bounds.first = parseInput("Specify first time step to export: ", n_time_steps, false);
+    }
     while (bounds.first > bounds.second || bounds.second > n_time_steps)
-        bounds.second = parseInput(
-            "Specify last time step to export: ", n_time_steps, false);
+    {
+        bounds.second = parseInput( "Specify last time step to export: ", n_time_steps, false);
+    }
     return bounds;
 }
 
@@ -511,7 +514,9 @@ static bool convert(NcFile const& dataset, NcVar const& var,
         length.cbegin(), length.cend(), 1, std::multiplies<std::size_t>());
     for (std::size_t i = time_bounds.first; i <= time_bounds.second; ++i)
     {
-        std::cout << "Converting time step " << i << "...\n";
+        std::string const step_str = (time_bounds.first != time_bounds.second)
+                ? std::string(" time step " + std::to_string(i)) : "";
+        std::cout << "Converting" << step_str << "...\n";
         std::vector<double> const data_vec =
             getData(dataset, var, array_length, i, length);
 

--- a/Applications/Utils/FileConverter/NetCdfConverter.cpp
+++ b/Applications/Utils/FileConverter/NetCdfConverter.cpp
@@ -19,12 +19,12 @@
 
 #include "Applications/ApplicationsLib/LogogSetup.h"
 
-#include <netcdfcpp.h>
+#include <netcdf>
 
 // BaseLib
-#include "BaseLib/BuildInfo.h"
-#include "BaseLib/LogogSimpleFormatter.h"
 #include "BaseLib/FileTools.h"
+#include "BaseLib/LogogSimpleFormatter.h"
+#include "InfoLib/GitInfo.h"
 
 // GeoLib
 #include "GeoLib/Raster.h"
@@ -35,10 +35,11 @@
 
 #include "MeshLib/IO/VtkIO/VtuInterface.h"
 
+using namespace netCDF;
 
 void checkExit(std::string const& str)
 {
-    if (str == "exit")
+    if (str == "x" || str == "exit")
         exit(0);
 }
 
@@ -87,60 +88,63 @@ std::size_t parseInput(std::string const& request_str, std::size_t max_val, bool
     return std::numeric_limits<std::size_t>::max();
 }
 
-void showArrays(NcFile const& dataset)
+NcVar getDimVar(NcFile const& dataset, NcVar const& var, std::size_t const dim)
 {
-    std::size_t const n_vars (dataset.num_vars());
+    NcDim const& dim_obj = var.getDim(dim);
+    return dataset.getVar(dim_obj.getName());
+}
+
+std::vector<std::string> showArrays(NcFile const& dataset)
+{
+    std::size_t const n_vars(dataset.getDimCount());
     std::cout << "The NetCDF file contains the following " << n_vars << " arrays:\n\n";
     std::cout << "\tIndex\tArray Name\t#Dimensions\n";
     std::cout << "-------------------------------------------\n";
-    for (std::size_t i=0; i<n_vars; ++i)
+    auto const& names = dataset.getVars();
+    std::vector<std::string> var_names;
+    for (auto [name, var] : names)
     {
-        NcVar const& var = *dataset.get_var(i);
-        std::cout << "\t" << i << "\t" << var.name() << "\t(" << var.num_dims() << "D array)\n";
+        std::cout << "\t" << var_names.size() << "\t" << name << "\t(" << var.getDimCount() << "D array)\n";
+        var_names.push_back(name);
     }
     std::cout << "\n";
+    return var_names;
 }
 
 bool showArraysDims(NcVar const& var)
 {
-    std::cout << "Data array \"" << var.name() << "\" contains the following dimensions:\n";
-    std::size_t const n_dims (var.num_dims());
+    std::cout << "Data array \"" << var.getName()
+              << "\" contains the following dimensions:\n";
+    std::size_t const n_dims (var.getDimCount());
     for (std::size_t i=0; i<n_dims; ++i)
-        std::cout << "\t" << i << "\t" << var.get_dim(i)->name() << "\t(" << var.get_dim(i)->size() << " values)\n";
+        std::cout << "\t" << i << "\t" << var.getDim(i).getName() << "\t(" << var.getDim(i).getSize() << " values)\n";
     std::cout << "\n";
     return true;
 }
 
-std::size_t getDimensionBoundaries(NcFile const& dataset, NcVar const& var, std::size_t dim, double &start, double &end)
+std::pair<double, double> getBoundaries(NcVar const& var)
 {
-    NcVar& dim_var = *dataset.get_var(var.get_dim(dim)->name());
-    if ((dim_var.num_dims()) == 1)
+    if ((var.getDimCount()) == 1)
     {
-        std::size_t size = dim_var.get_dim(0)->size();
-
-        std::size_t length[1] = {1};
-        long idx[1] = {0};
-        dim_var.set_cur(idx);
-        double val_at_idx[1] = {0};
-        dim_var.get(val_at_idx, length);
-        start = val_at_idx[0];
-
-        idx[0] = size-1;
-        dim_var.set_cur(idx);
-        dim_var.get(val_at_idx, length);
-        end = val_at_idx[0];
-        return size;
+        double start, end;
+        std::size_t size = var.getDim(0).getSize();
+        var.getVar({0}, {1}, &start);
+        var.getVar({size - 1}, {1}, &end);
+        return std::make_pair(start, end);
     }
-    return 0;
+    return std::make_pair(0, 0);
 }
 
-MathLib::Point3d getOrigin(std::array<std::pair<double, double>,3> bounds, std::size_t n_dims)
+MathLib::Point3d getOrigin(NcFile const& dataset, NcVar const& var)
 {
     MathLib::Point3d origin(std::array<double, 3>{ {0, 0, 0}});
-    for (std::size_t i=0; i<n_dims; ++i)
-        origin[i] = (bounds[i].first < bounds[i].second) ? bounds[i].first : bounds[i].second;
-    if (n_dims > 1)
-        std::swap(origin[0], origin[1]);
+    std::size_t const n_dims = var.getDimCount();
+    for (std::size_t i=1; i<n_dims; ++i)
+    {
+        NcVar const& dim = getDimVar(dataset, var, var.getDimCount() - i);
+        auto const bounds = getBoundaries(dim);
+        origin[n_dims - i] = (bounds.first < bounds.second) ? bounds.first : bounds.second;
+    }
     return origin;
 }
 
@@ -165,21 +169,29 @@ void reverseNorthSouth(double* data, std::size_t width, std::size_t height)
     delete[] cp_array;
 }
 
-std::size_t arraySelectionLoop(NcFile const& dataset)
+bool canConvert(NcVar const& var)
 {
-    showArrays(dataset);
-    std::size_t idx = parseInput("Enter data array index: ", dataset.num_vars(), true);
+    bool ret (true);
+    if (ret = (var.getDimCount() < 2))
+        ERR ("Only 2+ dimensional variables can be converted into OGS Meshes.\n");
+    return !ret;
+}
 
-    if (idx == dataset.num_vars())
+std::string arraySelectionLoop(NcFile const& dataset)
+{
+    std::vector<std::string> const& names = showArrays(dataset);
+    std::size_t idx = parseInput("Enter data array index: ", dataset.getVarCount(), true);
+
+    if (idx == dataset.getVarCount() || !canConvert(dataset.getVar(names[idx])))
         return arraySelectionLoop(dataset);
 
-    return idx;
+    return names[idx];
 }
 
 bool dimensionSelectionLoop(NcVar const& var, std::array<std::size_t,4> &dim_idx_map)
 {
     showArraysDims(var);
-    std::size_t const n_dims (var.num_dims());
+    std::size_t const n_dims(var.getDimCount());
     dim_idx_map[0] = std::numeric_limits<std::size_t>::max();
     bool is_time_dep (true);
 
@@ -195,16 +207,17 @@ bool dimensionSelectionLoop(NcVar const& var, std::array<std::size_t,4> &dim_idx
             std::stringstream str_stream(temp_str);
             if (str_stream.str() == "c" || str_stream.str() == "continue")
                 is_time_dep = false;
-            else 
+            else
             {
                 if (!(str_stream >> dim_idx_map[0]))
                 {
                     showErrorMessage(0);
+                    dim_idx_map[0] = std::numeric_limits<std::size_t>::max();
                     continue;
                 }
                 if (dim_idx_map[0] > n_dims-1)
                 {
-                    showErrorMessage(1, var.num_dims()-1);
+                    showErrorMessage(1, var.getDimCount() - 1);
                     dim_idx_map[0] = std::numeric_limits<std::size_t>::max();
                 }
             }
@@ -220,9 +233,9 @@ bool dimensionSelectionLoop(NcVar const& var, std::array<std::size_t,4> &dim_idx
         dim_idx_map[i] = std::numeric_limits<std::size_t>::max();
 
         std::string request_str ("Enter ID for dimension " + std::to_string(i) + ": ");
-        std::size_t idx = parseInput(request_str, var.num_dims(), true);
+        std::size_t idx = parseInput(request_str, var.getDimCount(), true);
 
-        if (idx == var.num_dims())
+        if (idx == var.getDimCount())
         {
             showArraysDims(var);
             i--;
@@ -234,15 +247,16 @@ bool dimensionSelectionLoop(NcVar const& var, std::array<std::size_t,4> &dim_idx
     return is_time_dep;
 }
 
-std::pair<std::size_t, std::size_t> timestepSelectionLoop(NcFile const& dataset, NcVar const& var, std::size_t dim)
+std::pair<std::size_t, std::size_t> timestepSelectionLoop(NcFile const& dataset, NcVar const& var, std::size_t dim_idx)
 {
-    double start, end;
-    std::string str("");
-    std::pair<std::size_t, std::size_t> bounds(0,std::numeric_limits<std::size_t>::max());
-    std::size_t n_time_steps = getDimensionBoundaries(dataset, var, dim, start, end);
+    NcVar const& dim_var = getDimVar(dataset, var, dim_idx);
+    std::size_t const n_time_steps = var.getDim(dim_idx).getSize();
+    std::pair<std::size_t, std::size_t> bounds(
+        std::numeric_limits<std::size_t>::max(),
+        std::numeric_limits<std::size_t>::max());
     std::cout << "\nThe dataset contains " << n_time_steps << " time steps.\n";
     bounds.first = parseInput("Specify first time step to export: ", n_time_steps, false);
-    while (bounds.first > bounds.second || bounds.second == std::numeric_limits<std::size_t>::max())
+    while (bounds.first > bounds.second || bounds.second > n_time_steps)
         bounds.second = parseInput("Specify last time step to export: ", n_time_steps, false);
     return bounds;
 }
@@ -256,7 +270,7 @@ MeshLib::MeshElemType elemSelectionLoop(std::size_t const dim)
     while (t == MeshLib::MeshElemType::INVALID)
     {
         std::cout << "\nSelect element type for result, choose ";
-    
+
         if (dim==2) std::cout << "(t)riangle or (q)uadliteral: ";
         if (dim==3) std::cout << "(p)rism or (h)exahedron: ";
         std::string type ("");
@@ -291,22 +305,12 @@ MeshLib::MeshElemType elemSelectionLoop(std::size_t const dim)
 
 bool multFilesSelectionLoop(std::pair<std::size_t, std::size_t> const& time_bounds)
 {
-    std::size_t n_time_steps(time_bounds.second - time_bounds.first);
+    std::size_t n_time_steps(time_bounds.second - time_bounds.first + 1);
     std::cout << "\nThe selection includes " << n_time_steps << " time steps.\n";
     std::cout << "0. Save data in " << n_time_steps << " mesh files with one scalar array each.\n";
     std::cout << "1. Save data in one mesh file with " << n_time_steps << " scalar arrays.\n";
     std::size_t ret = parseInput("Select preferred method: ", 2, false);
     return (ret == 0) ? true : false;
-}
-
-void setTimeStep(NcVar &var, std::size_t time_step)
-{
-    long* newOrigin = new long[var.num_dims()];
-    for (int i=0; i < var.num_dims(); ++i) 
-        newOrigin[i]=0;
-    newOrigin[0] = time_step;
-    var.set_cur(newOrigin);
-    delete [] newOrigin;
 }
 
 std::string getIterationString(std::size_t i, std::size_t max)
@@ -316,11 +320,39 @@ std::string getIterationString(std::size_t i, std::size_t max)
     return std::string(max_length - current_str.length(), '0') + current_str;
 }
 
+double getResolution(NcFile const& dataset, NcVar const& var)
+{
+    std::size_t dim_idx = var.getDimCount() - 1;
+    auto const bounds = getBoundaries(getDimVar(dataset, var, dim_idx));
+    return fabs(bounds.second - bounds.first) / static_cast<double>(var.getDim(dim_idx).getSize());
+}
+
+GeoLib::RasterHeader createRasterHeader(
+    NcFile const& dataset, NcVar const& var,
+    std::array<std::size_t, 4> const& dim_idx_map,
+    std::vector<std::size_t> const& length, bool is_time_dep)
+{
+    MathLib::Point3d origin = getOrigin(dataset, var);
+    double const res = getResolution(dataset, var);
+    std::size_t n_dims = var.getDimCount();
+    std::size_t temp_offset = (is_time_dep) ? 1 : 0;
+    std::size_t z_length = (n_dims - temp_offset == 3) ? length[dim_idx_map.back()] : 1;
+    return {length[dim_idx_map[0 + temp_offset]], length[dim_idx_map[1 + temp_offset]], z_length, origin, res, -9999};
+}
+
 int main (int argc, char* argv[])
 {
     ApplicationsLib::LogogSetup logog_setup;
 
-    TCLAP::CmdLine cmd("Converts NetCDF into mesh file.", ' ', BaseLib::BuildInfo::git_describe);
+    TCLAP::CmdLine cmd(
+        "Converts NetCDF into mesh file(s).\n\n "
+        "OpenGeoSys-6 software, version " +
+            GitInfoLib::GitInfo::ogs_version +
+            ".\n"
+            "Copyright (c) 2012-2019, OpenGeoSys Community "
+            "(http://www.opengeosys.org)",
+        ' ', GitInfoLib::GitInfo::ogs_version);
+
     TCLAP::ValueArg<std::string> input("i", "input-file",
                                        "the NetCDF input file", true,
                                        "", "the NetCDF input file");
@@ -331,9 +363,9 @@ int main (int argc, char* argv[])
     cmd.add(output);
     cmd.parse(argc, argv);
 
-    NcFile dataset(input.getValue().c_str(), NcFile::ReadOnly);
+    NcFile dataset(input.getValue().c_str(), NcFile::read);
 
-    if (!dataset.is_valid())
+    if (dataset.isNull())
     {
         ERR("Error opening file.");
         return -1;
@@ -344,34 +376,25 @@ int main (int argc, char* argv[])
     std::cin.ignore();
     std::string output_name (output.getValue());
 
-    std::size_t const var_idx = arraySelectionLoop(dataset);
-    NcVar& var = *dataset.get_var(var_idx);
+    std::string const& var_name = arraySelectionLoop(dataset);
+    NcVar& var = dataset.getVar(var_name);
 
     std::array<std::size_t, 4> dim_idx_map;
     bool const is_time_dep = dimensionSelectionLoop(var, dim_idx_map);
 
-    std::size_t temp_offset = (is_time_dep) ? 1 : 0;
-    std::size_t const n_dims = (var.num_dims());
-    std::size_t* length = new std::size_t[n_dims];
-    for(int i=0; i < n_dims; i++) 
-        length[i]=1;
-    std::array<std::size_t, 3> spatial_size = {0,0,0};
-    std::array<std::pair<double, double>,3> spatial_bounds;
-    for (std::size_t i=0; i<3; ++i)
-        spatial_bounds[i] = std::pair<double, double>(0, 0);
+    std::size_t const temp_offset = (is_time_dep) ? 1 : 0;
+    std::size_t const n_dims = (var.getDimCount());
+    std::vector<std::size_t> offset(n_dims, 0);
+    std::vector<std::size_t> length(n_dims, 1);
     std::size_t array_length = 1;
     for (std::size_t i=temp_offset; i<n_dims; ++i)
     {
-        length[dim_idx_map[i]] = getDimensionBoundaries(dataset, var, dim_idx_map[i], spatial_bounds[i-temp_offset].first, spatial_bounds[i-temp_offset].second);
-        spatial_size[i-temp_offset] = length[dim_idx_map[i]];
-        array_length *= length[dim_idx_map[i]];
+        length[i] = var.getDim(i).getSize();
+        array_length *= length[i];
     }
 
-    MathLib::Point3d origin = getOrigin(spatial_bounds, n_dims);
-    double const resolution = fabs(spatial_bounds[0].second - spatial_bounds[0].first) / (spatial_size[0] - 1);
-    GeoLib::RasterHeader header = { spatial_size[1], spatial_size[0], origin, resolution, -9999 };
-    MeshLib::MeshElemType meshElemType = elemSelectionLoop(n_dims - temp_offset);
-    MeshLib::UseIntensityAs useIntensity = MeshLib::UseIntensityAs::DATAVECTOR;
+    GeoLib::RasterHeader header =
+        createRasterHeader(dataset, var, dim_idx_map, length, is_time_dep);
 
     std::pair<std::size_t, std::size_t> time_bounds(0,0);
     if (is_time_dep)
@@ -381,42 +404,45 @@ int main (int argc, char* argv[])
     if (is_time_dep && time_bounds.first != time_bounds.second)
         mult_files = multFilesSelectionLoop(time_bounds);
 
-    double* data_array = nullptr;
     std::unique_ptr<MeshLib::Mesh> mesh;
+    MeshLib::MeshElemType const meshElemType = elemSelectionLoop(n_dims - temp_offset);
     for (std::size_t i=time_bounds.first; i<=time_bounds.second; ++i)
     {
-        if (is_time_dep)
-            setTimeStep(var, i);
-
-        data_array = new double[array_length];
-        for (std::size_t i = 0; i < array_length; i++)
-            data_array[i] = 0;
-        var.get(data_array, length);
-
-        for (std::size_t i=0; i < array_length; i++)
-            if (data_array[i] < -9999 ) data_array[i] = -9999; // all values < -10000, set to "no-value"
+        std::cout << "Converting time step " << i << "...\n";
+        offset[0] = i;
+        std::vector<double> data_array(array_length,0);
+        var.getVar(offset, length, data_array.data());
+        std::replace_if(data_array.begin(), data_array.end(),
+                        [](double& x) { return x <= -9999; }, -9999);
 
         // reverse lines in vertical direction if the original file has its origin in the northwest corner
-        if (spatial_bounds[0].first > spatial_bounds[0].second)
-            reverseNorthSouth(data_array, spatial_size[1], spatial_size[0]);
+        NcVar const& dim_var = getDimVar(dataset, var, n_dims - 1);
+        auto const bounds = getBoundaries(dim_var);
+        if (bounds.first > bounds.second)
+            reverseNorthSouth(data_array.data(), length[n_dims-2], length[n_dims-1]);
 
+        MeshLib::UseIntensityAs const useIntensity = MeshLib::UseIntensityAs::DATAVECTOR;
         if (mult_files)
         {
-            mesh.reset(MeshLib::RasterToMesh::convert(data_array, header, meshElemType, useIntensity, var.name()));
+            mesh.reset(MeshLib::RasterToMesh::convert(data_array.data(), header, meshElemType, useIntensity, var.getName()));
             std::string const output_file_name (BaseLib::dropFileExtension(output_name) + getIterationString(i, time_bounds.second) + ".vtu");
             MeshLib::IO::VtuInterface vtu(mesh.get());
             vtu.writeToFile(output_file_name);
         }
         else
         {
-            std::string array_name (var.name());
+            std::string array_name (var.getName());
             if (time_bounds.first != time_bounds.second)
                 array_name.append(getIterationString(i, time_bounds.second));
             if (i==time_bounds.first) // create persistent mesh
-                mesh.reset(MeshLib::RasterToMesh::convert(data_array, header, meshElemType, useIntensity, array_name));
-            else
+                mesh.reset(MeshLib::RasterToMesh::convert(data_array.data(), header, meshElemType, useIntensity, array_name));
+            else // copy array to mesh
             {
-                //copy array to mesh
+                std::unique_ptr<MeshLib::Mesh> temp (MeshLib::RasterToMesh::convert(data_array.data(), header, meshElemType, useIntensity, array_name));
+                MeshLib::PropertyVector<double> const*const vec = temp->getProperties().getPropertyVector<double>(array_name);
+                if (vec == nullptr)
+                    return EXIT_FAILURE;
+                MeshLib::addPropertyToMesh<double>(*mesh, array_name, MeshLib::MeshItemType::Cell, 1, *vec);
             }
             if (i==time_bounds.second)
             {
@@ -426,44 +452,6 @@ int main (int argc, char* argv[])
         }
     }
 
-
-    /***********************
-    for (std::size_t j = time_bounds.first; j <= time_bounds.second; ++j)
-    {
-            boost::optional< MeshLib::PropertyVector<double>& > tmp_vec = tmp_mesh->getProperties().getPropertyVector<double>(var.name());
-            if (!tmp_vec)
-            {
-                ERR("Vector not found");
-                continue;
-            }
-
-            if (tmp_vec->size() != mesh->getNumberOfElements())
-            {
-                ERR("Vector size doesn't fit.");
-                continue;
-            }
-
-            MeshLib::Properties& props (mesh->getProperties());
-
-            std::string iter_str (getIterationString(j, time_bounds.second);
-
-            boost::optional< MeshLib::PropertyVector<double>& > vec = 
-                props.createNewPropertyVector<double>(std::string(var.name() + iter_str), MeshLib::MeshItemType::Cell, 1);
-
-            if (!vec)
-            {
-                ERR ("Error creating vector");
-                continue;
-            }
-            vec->reserve(tmp_vec->size());
-            for (std::size_t i=0; i<tmp_vec->size(); ++i)
-                vec->push_back((*tmp_vec)[i]);
-
-            std::cout << "time step " << j << " written.\n";
-    }
-    /***********************/
-
-    delete[] length;
-    delete[] data_array;
-    return 0;
+    std::cout << "Conversion finished successfully.\n";
+    return EXIT_SUCCESS;
 }

--- a/Applications/Utils/FileConverter/NetCdfConverter.cpp
+++ b/Applications/Utils/FileConverter/NetCdfConverter.cpp
@@ -109,6 +109,7 @@ static std::vector<std::string> getArrays(NcFile const& dataset)
     std::vector<std::string> var_names;
     for (auto [name, var] : names)
     {
+        (void)var;
         var_names.push_back(name);
     }
     return var_names;

--- a/Applications/Utils/FileConverter/NetCdfConverter.cpp
+++ b/Applications/Utils/FileConverter/NetCdfConverter.cpp
@@ -47,20 +47,22 @@ void showErrorMessage(std::size_t error_id, std::size_t max = 0)
 {
     if (error_id == 0)
     {
-        ERR ("Input not valid.");
+        ERR("Input not valid.");
     }
     else if (error_id == 1)
     {
-        ERR ("Index not valid. Valid indices are in [0,%d].", max);
+        ERR("Index not valid. Valid indices are in [0,%d].", max);
     }
     else if (error_id == 2)
     {
         showErrorMessage(0);
-        std::cout << "Type \"info\" to display the available options again. \"exit\" will exit the programme.\n";
+        std::cout << "Type \"info\" to display the available options again. "
+                     "\"exit\" will exit the programme.\n";
     }
 }
 
-std::size_t parseInput(std::string const& request_str, std::size_t max_val, bool has_info = false)
+std::size_t parseInput(std::string const& request_str, std::size_t max_val,
+                       bool has_info = false)
 {
     while (true)
     {
@@ -97,14 +99,16 @@ NcVar getDimVar(NcFile const& dataset, NcVar const& var, std::size_t const dim)
 std::vector<std::string> showArrays(NcFile const& dataset)
 {
     std::size_t const n_vars(dataset.getDimCount());
-    std::cout << "The NetCDF file contains the following " << n_vars << " arrays:\n\n";
+    std::cout << "The NetCDF file contains the following " << n_vars
+              << " arrays:\n\n";
     std::cout << "\tIndex\tArray Name\t#Dimensions\n";
     std::cout << "-------------------------------------------\n";
     auto const& names = dataset.getVars();
     std::vector<std::string> var_names;
     for (auto [name, var] : names)
     {
-        std::cout << "\t" << var_names.size() << "\t" << name << "\t(" << var.getDimCount() << "D array)\n";
+        std::cout << "\t" << var_names.size() << "\t" << name << "\t("
+                  << var.getDimCount() << "D array)\n";
         var_names.push_back(name);
     }
     std::cout << "\n";
@@ -115,9 +119,10 @@ bool showArraysDims(NcVar const& var)
 {
     std::cout << "Data array \"" << var.getName()
               << "\" contains the following dimensions:\n";
-    std::size_t const n_dims (var.getDimCount());
-    for (std::size_t i=0; i<n_dims; ++i)
-        std::cout << "\t" << i << "\t" << var.getDim(i).getName() << "\t(" << var.getDim(i).getSize() << " values)\n";
+    std::size_t const n_dims(var.getDimCount());
+    for (std::size_t i = 0; i < n_dims; ++i)
+        std::cout << "\t" << i << "\t" << var.getDim(i).getName() << "\t("
+                  << var.getDim(i).getSize() << " values)\n";
     std::cout << "\n";
     return true;
 }
@@ -140,25 +145,27 @@ MathLib::Point3d getOrigin(NcFile const& dataset, NcVar const& var,
                            bool is_time_dep)
 {
     std::size_t const temp_offset = (is_time_dep) ? 1 : 0;
-    MathLib::Point3d origin(std::array<double, 3>{ {0, 0, 0}});
+    MathLib::Point3d origin(std::array<double, 3>{{0, 0, 0}});
     std::size_t const n_dims = var.getDimCount();
     for (std::size_t i = temp_offset; i < n_dims; ++i)
     {
         NcVar const& dim = getDimVar(dataset, var, dim_idx_map[i]);
         auto const bounds = getBoundaries(dim);
-        origin[i-temp_offset] = (bounds.first < bounds.second) ? bounds.first : bounds.second;
+        origin[i - temp_offset] =
+            (bounds.first < bounds.second) ? bounds.first : bounds.second;
     }
     return origin;
 }
 
-void flipRaster(std::vector<double>& data, std::size_t width, std::size_t height)
+void flipRaster(std::vector<double>& data, std::size_t width,
+                std::size_t height)
 {
-    std::size_t const length (data.size());
-    std::vector<double> tmp_vec (length);
-    for (std::size_t i=0; i<height; i++)
+    std::size_t const length(data.size());
+    std::vector<double> tmp_vec(length);
+    for (std::size_t i = 0; i < height; i++)
     {
         std::size_t const line_idx(length - (width * (i + 1)));
-        for (std::size_t j=0; j<width; j++)
+        for (std::size_t j = 0; j < width; j++)
         {
             tmp_vec.push_back(data[line_idx + j]);
         }
@@ -168,16 +175,18 @@ void flipRaster(std::vector<double>& data, std::size_t width, std::size_t height
 
 bool canConvert(NcVar const& var)
 {
-    bool ret (true);
+    bool ret(true);
     if (ret = (var.getDimCount() < 2))
-        ERR ("Only 2+ dimensional variables can be converted into OGS Meshes.\n");
+        ERR("Only 2+ dimensional variables can be converted into OGS "
+            "Meshes.\n");
     return !ret;
 }
 
 std::string arraySelectionLoop(NcFile const& dataset)
 {
     std::vector<std::string> const& names = showArrays(dataset);
-    std::size_t idx = parseInput("Enter data array index: ", dataset.getVarCount(), true);
+    std::size_t idx =
+        parseInput("Enter data array index: ", dataset.getVarCount(), true);
 
     if (idx == dataset.getVarCount() || !canConvert(dataset.getVar(names[idx])))
         return arraySelectionLoop(dataset);
@@ -185,19 +194,21 @@ std::string arraySelectionLoop(NcFile const& dataset)
     return names[idx];
 }
 
-bool dimensionSelectionLoop(NcVar const& var, std::array<std::size_t,4> &dim_idx_map)
+bool dimensionSelectionLoop(NcVar const& var,
+                            std::array<std::size_t, 4>& dim_idx_map)
 {
     showArraysDims(var);
     std::size_t const n_dims(var.getDimCount());
     dim_idx_map[0] = std::numeric_limits<std::size_t>::max();
-    bool is_time_dep (true);
+    bool is_time_dep(true);
 
     // get temporal dimension
     if (n_dims > 1)
     {
         std::string temp_str("");
         cout << "Is the parameter time-dependent?\n";
-        while (dim_idx_map[0] == std::numeric_limits<std::size_t>::max() && is_time_dep == true)
+        while (dim_idx_map[0] == std::numeric_limits<std::size_t>::max() &&
+               is_time_dep == true)
         {
             cout << "Enter ID for temporal dimension or \"c\" to continue: ";
             std::getline(std::cin, temp_str);
@@ -212,7 +223,7 @@ bool dimensionSelectionLoop(NcVar const& var, std::array<std::size_t,4> &dim_idx
                     dim_idx_map[0] = std::numeric_limits<std::size_t>::max();
                     continue;
                 }
-                if (dim_idx_map[0] > n_dims-1)
+                if (dim_idx_map[0] > n_dims - 1)
                 {
                     showErrorMessage(1, var.getDimCount() - 1);
                     dim_idx_map[0] = std::numeric_limits<std::size_t>::max();
@@ -225,11 +236,15 @@ bool dimensionSelectionLoop(NcVar const& var, std::array<std::size_t,4> &dim_idx
 
     // get spatial dimension(s)
     std::size_t const start_idx = (is_time_dep) ? 1 : 0;
-    for (std::size_t i=start_idx; i<n_dims; ++i)
+    std::array<std::string, 4> dim_comment{
+        "(x / longitude)", "(y / latitude)", "(z / height / depth)",
+        "[Error: 4-dimensional non-temporal arrays are not supported]"};
+    for (std::size_t i = start_idx; i < n_dims; ++i)
     {
         dim_idx_map[i] = std::numeric_limits<std::size_t>::max();
 
-        std::string request_str ("Enter ID for dimension " + std::to_string(i) + ": ");
+        std::string request_str("Enter ID for dimension " + std::to_string(i) +
+                                " " + dim_comment[i - start_idx] + ": ");
         std::size_t idx = parseInput(request_str, var.getDimCount(), true);
 
         if (idx == var.getDimCount())
@@ -244,7 +259,9 @@ bool dimensionSelectionLoop(NcVar const& var, std::array<std::size_t,4> &dim_idx
     return is_time_dep;
 }
 
-std::pair<std::size_t, std::size_t> timestepSelectionLoop(NcFile const& dataset, NcVar const& var, std::size_t dim_idx)
+std::pair<std::size_t, std::size_t> timestepSelectionLoop(NcFile const& dataset,
+                                                          NcVar const& var,
+                                                          std::size_t dim_idx)
 {
     NcVar const& dim_var = getDimVar(dataset, var, dim_idx);
     std::size_t const n_time_steps = var.getDim(dim_idx).getSize();
@@ -252,15 +269,17 @@ std::pair<std::size_t, std::size_t> timestepSelectionLoop(NcFile const& dataset,
         std::numeric_limits<std::size_t>::max(),
         std::numeric_limits<std::size_t>::max());
     std::cout << "\nThe dataset contains " << n_time_steps << " time steps.\n";
-    bounds.first = parseInput("Specify first time step to export: ", n_time_steps, false);
+    bounds.first =
+        parseInput("Specify first time step to export: ", n_time_steps, false);
     while (bounds.first > bounds.second || bounds.second > n_time_steps)
-        bounds.second = parseInput("Specify last time step to export: ", n_time_steps, false);
+        bounds.second = parseInput(
+            "Specify last time step to export: ", n_time_steps, false);
     return bounds;
 }
 
 MeshLib::MeshElemType elemSelectionLoop(std::size_t const dim)
 {
-    if (dim ==1)
+    if (dim == 1)
         return MeshLib::MeshElemType::LINE;
 
     MeshLib::MeshElemType t = MeshLib::MeshElemType::INVALID;
@@ -268,15 +287,16 @@ MeshLib::MeshElemType elemSelectionLoop(std::size_t const dim)
     {
         std::cout << "\nSelect element type for result, choose ";
 
-        if (dim==2) std::cout << "(t)riangle or (q)uadliteral: ";
-        if (dim==3) std::cout << "(p)rism or (h)exahedron: ";
-        std::string type ("");
+        if (dim == 2)
+            std::cout << "(t)riangle or (q)uadliteral: ";
+        if (dim == 3)
+            std::cout << "(p)rism or (h)exahedron: ";
+        std::string type("");
         std::getline(std::cin, type);
         checkExit(type);
-        if (dim==2)
+        if (dim == 2)
         {
-            if (type != "t" && type != "q" &&
-                type != "tri" && type != "quad" &&
+            if (type != "t" && type != "q" && type != "tri" && type != "quad" &&
                 type != "triangle" && type != "quatliteral")
                 continue;
             if (type == "t" || type == "tri" || type == "triangle")
@@ -285,11 +305,10 @@ MeshLib::MeshElemType elemSelectionLoop(std::size_t const dim)
                 return MeshLib::MeshElemType::QUAD;
         }
 
-        if (dim==3)
+        if (dim == 3)
         {
-            if (type != "p" && type != "h" &&
-                type != "prism" && type != "hex" &&
-                type != "hexahedron")
+            if (type != "p" && type != "h" && type != "prism" &&
+                type != "hex" && type != "hexahedron")
                 continue;
             if (type == "p" || type == "prism")
                 return MeshLib::MeshElemType::PRISM;
@@ -300,20 +319,24 @@ MeshLib::MeshElemType elemSelectionLoop(std::size_t const dim)
     return t;
 }
 
-bool multFilesSelectionLoop(std::pair<std::size_t, std::size_t> const& time_bounds)
+bool multFilesSelectionLoop(
+    std::pair<std::size_t, std::size_t> const& time_bounds)
 {
     std::size_t n_time_steps(time_bounds.second - time_bounds.first + 1);
-    std::cout << "\nThe selection includes " << n_time_steps << " time steps.\n";
-    std::cout << "0. Save data in " << n_time_steps << " mesh files with one scalar array each.\n";
-    std::cout << "1. Save data in one mesh file with " << n_time_steps << " scalar arrays.\n";
+    std::cout << "\nThe selection includes " << n_time_steps
+              << " time steps.\n";
+    std::cout << "0. Save data in " << n_time_steps
+              << " mesh files with one scalar array each.\n";
+    std::cout << "1. Save data in one mesh file with " << n_time_steps
+              << " scalar arrays.\n";
     std::size_t ret = parseInput("Select preferred method: ", 2, false);
     return (ret == 0) ? true : false;
 }
 
 std::string getIterationString(std::size_t i, std::size_t max)
 {
-    std::size_t const max_length (std::to_string(max).length());
-    std::string const current_str (std::to_string(i));
+    std::size_t const max_length(std::to_string(max).length());
+    std::string const current_str(std::to_string(i));
     return std::string(max_length - current_str.length(), '0') + current_str;
 }
 
@@ -321,7 +344,8 @@ double getResolution(NcFile const& dataset, NcVar const& var)
 {
     std::size_t dim_idx = var.getDimCount() - 1;
     auto const bounds = getBoundaries(getDimVar(dataset, var, dim_idx));
-    return fabs(bounds.second - bounds.first) / static_cast<double>(var.getDim(dim_idx).getSize());
+    return fabs(bounds.second - bounds.first) /
+           static_cast<double>(var.getDim(dim_idx).getSize());
 }
 
 GeoLib::RasterHeader createRasterHeader(
@@ -333,11 +357,18 @@ GeoLib::RasterHeader createRasterHeader(
     double const res = getResolution(dataset, var);
     std::size_t n_dims = var.getDimCount();
     std::size_t temp_offset = (is_time_dep) ? 1 : 0;
-    std::size_t z_length = (n_dims - temp_offset == 3) ? length[dim_idx_map.back()] : 1;
-    return {length[dim_idx_map[0 + temp_offset]], length[dim_idx_map[1 + temp_offset]], z_length, origin, res, -9999};
+    std::size_t z_length =
+        (n_dims - temp_offset == 3) ? length[dim_idx_map.back()] : 1;
+    return {length[dim_idx_map[0 + temp_offset]],
+            length[dim_idx_map[1 + temp_offset]],
+            z_length,
+            origin,
+            res,
+            -9999};
 }
 
-std::size_t getLength(NcVar const& var, bool const is_time_dep, std::vector<std::size_t> &length)
+std::size_t getLength(NcVar const& var, bool const is_time_dep,
+                      std::vector<std::size_t>& length)
 {
     std::size_t const temp_offset = (is_time_dep) ? 1 : 0;
     std::size_t const n_dims = (var.getDimCount());
@@ -356,7 +387,7 @@ std::vector<double> getData(NcFile const& dataset, NcVar const& var,
                             std::size_t const time_step,
                             std::vector<std::size_t> const& length)
 {
-    std::size_t const n_dims (var.getDimCount());
+    std::size_t const n_dims(var.getDimCount());
     std::vector<std::size_t> offset(n_dims, 0);
     offset[0] = time_step;
     std::vector<double> data_vec(total_length, 0);
@@ -364,7 +395,8 @@ std::vector<double> getData(NcFile const& dataset, NcVar const& var,
     std::replace_if(data_vec.begin(), data_vec.end(),
                     [](double& x) { return x <= -9999; }, -9999);
 
-    // reverse lines in vertical direction if the original file has its origin in the northwest corner
+    // reverse lines in vertical direction if the original file has its origin
+    // in the northwest corner
     NcVar const& dim_var = getDimVar(dataset, var, n_dims - 1);
     auto const bounds = getBoundaries(dim_var);
     if (bounds.first > bounds.second)
@@ -372,7 +404,88 @@ std::vector<double> getData(NcFile const& dataset, NcVar const& var,
     return data_vec;
 }
 
-int main (int argc, char* argv[])
+bool assignDimParams(NcVar const& var,
+                     std::array<std::size_t, 4>& dim_idx_map,
+                     TCLAP::ValueArg<std::size_t>& arg_dim_time,
+                     TCLAP::ValueArg<std::size_t>& arg_dim1,
+                     TCLAP::ValueArg<std::size_t>& arg_dim2,
+                     TCLAP::ValueArg<std::size_t>& arg_dim3)
+{
+    if (arg_dim3.isSet() && !arg_dim2.isSet())
+    {
+        ERR("Parameter for dim2 is not set. Ignoring dimension parameters.");
+        return false;
+    }
+    if (!arg_dim1.isSet() || !arg_dim2.isSet())
+    {
+        ERR("dim1 and dim2 need to be set for extracting mesh.");
+        return false;
+    }
+
+    std::size_t const n_dims = var.getDimCount();
+    if (arg_dim_time.getValue() >= n_dims || arg_dim1.getValue() >= n_dims ||
+        arg_dim2.getValue() >= n_dims || arg_dim3.getValue() >= n_dims)
+    {
+        ERR("Maximum allowed dimension for variable \"%s\" is %d.", var.getName().c_str(), n_dims-1);
+        return false;
+    }
+
+    bool is_time_dep = arg_dim_time.isSet();
+    if (is_time_dep)
+        dim_idx_map[0] = arg_dim_time.getValue();
+    std::size_t const temp_offset = (is_time_dep) ? 1 : 0;
+    dim_idx_map[0 + temp_offset] = arg_dim1.getValue();
+    dim_idx_map[1 + temp_offset] = arg_dim2.getValue();
+    if (n_dims == (3 + temp_offset))
+        dim_idx_map[2 + temp_offset] = arg_dim3.getValue();
+
+    return true;
+}
+
+std::pair<std::size_t, std::size_t> assignTimeBounds(NcVar const& var,
+                     TCLAP::ValueArg<std::size_t>& arg_time_start,
+                     TCLAP::ValueArg<std::size_t>& arg_time_end)
+{
+    auto const bounds = getBoundaries(var);
+    if (arg_time_start.getValue() > bounds.second)
+    {
+        ERR("Start time step larger than total number of time steps. Resetting to 0.");
+        arg_time_start.reset();
+    }
+
+    if (!arg_time_end.isSet())
+        return {arg_time_start.getValue(), arg_time_start.getValue()};
+
+    if (arg_time_end.getValue() > bounds.second)
+    {
+        ERR("End time step larger than total number of time steps. Resetting to starting time step");
+        return {arg_time_start.getValue(), arg_time_start.getValue()};
+    }
+
+    if (arg_time_end.getValue() < arg_time_start.getValue())
+    {
+        ERR("End time step larger than starting time step. Swapping values");
+        return {arg_time_end.getValue(), arg_time_start.getValue()};
+    }
+
+    return {arg_time_start.getValue(), arg_time_end.getValue()};
+}
+
+MeshLib::MeshElemType assignElemType(TCLAP::ValueArg<std::string>& arg_elem_type)
+{
+    if (arg_elem_type.getValue() == "tri")
+        return MeshLib::MeshElemType::TRIANGLE;
+    if (arg_elem_type.getValue() == "quad")
+        return MeshLib::MeshElemType::QUAD;
+    if (arg_elem_type.getValue() == "prism")
+        return MeshLib::MeshElemType::PRISM;
+    if (arg_elem_type.getValue() == "hex")
+        return MeshLib::MeshElemType::HEXAHEDRON;
+    // this should never happen
+    return MeshLib::MeshElemType::INVALID;
+}
+
+int main(int argc, char* argv[])
 {
     ApplicationsLib::LogogSetup logog_setup;
 
@@ -385,17 +498,74 @@ int main (int argc, char* argv[])
             "(http://www.opengeosys.org)",
         ' ', GitInfoLib::GitInfo::ogs_version);
 
-    TCLAP::ValueArg<std::string> input("i", "input-file",
-                                       "the NetCDF input file", true,
-                                       "", "the NetCDF input file");
-    cmd.add(input);
-    TCLAP::ValueArg<std::string> output("o", "output-file",
-                                        "the OGS mesh output file", true,
-                                        "", "the OGS mesh output file");
-    cmd.add(output);
+    std::vector<std::string> allowed_elems{"tri", "quad", "prism", "hex"};
+    TCLAP::ValuesConstraint<std::string> allowed_elem_vals(allowed_elems);
+    TCLAP::ValueArg<std::string> arg_elem_type(
+        "e", "elem-type", "the element type used in the resulting OGS mesh",
+        false, "", &allowed_elem_vals);
+    cmd.add(arg_elem_type);
+
+    TCLAP::SwitchArg arg_single_file(
+        "", "single-file",
+        "if set, all time steps will be written to a single mesh file (with "
+        "one scalar array per time step)");
+    cmd.add(arg_single_file);
+
+    TCLAP::ValueArg<std::size_t> arg_time_end(
+        "", "timestep-last",
+        "last time step to be extracted (only for time-dependent variables!)",
+        false, 0, "integer specifying index of time step");
+    cmd.add(arg_time_end);
+
+    TCLAP::ValueArg<std::size_t> arg_time_start(
+        "", "timestep-first",
+        "first time step to be extracted (only for time-dependent variables!)",
+        false, 0, "integer specifying index of time step");
+    cmd.add(arg_time_start);
+
+    std::vector<std::size_t> allowed_dims{0, 1, 2, 3};
+    TCLAP::ValuesConstraint<std::size_t> allowed_dim_vals(allowed_dims);
+    TCLAP::ValueArg<std::size_t> arg_dim3(
+        "", "dim3",
+        "index of third dimension (z/height/depth) for the selected variable",
+        false, 0, &allowed_dim_vals);
+    cmd.add(arg_dim3);
+
+    TCLAP::ValueArg<std::size_t> arg_dim2(
+        "", "dim2",
+        "index of second dimension (y/latitude) for the selected "
+        "variable",
+        false, 0, &allowed_dim_vals);
+    cmd.add(arg_dim2);
+
+    TCLAP::ValueArg<std::size_t> arg_dim1(
+        "", "dim1",
+        "index of first dimension (x/longitude) for the selected variable",
+        false, 0, &allowed_dim_vals);
+    cmd.add(arg_dim1);
+
+    TCLAP::ValueArg<std::size_t> arg_dim_time(
+        "t", "time",
+        "index of the time-dependent dimension for the selected variable",
+        false, 0, &allowed_dim_vals);
+    cmd.add(arg_dim_time);
+
+    TCLAP::ValueArg<std::string> arg_varname(
+        "v", "var", "variable from the netCDF file", false, "",
+        "string containing the variable name");
+    cmd.add(arg_varname);
+
+    TCLAP::ValueArg<std::string> arg_output(
+        "o", "output", "the OGS mesh output file", true, "",
+        "string containing the path and file name");
+    cmd.add(arg_output);
+    TCLAP::ValueArg<std::string> arg_input(
+        "i", "input", "the netCDF input file", true, "",
+        "string containing the path and file name");
+    cmd.add(arg_input);
     cmd.parse(argc, argv);
 
-    NcFile dataset(input.getValue().c_str(), NcFile::read);
+    NcFile dataset(arg_input.getValue().c_str(), NcFile::read);
 
     if (dataset.isNull())
     {
@@ -404,23 +574,54 @@ int main (int argc, char* argv[])
     }
 
     std::cout << "OpenGeoSys NetCDF Converter\n";
-    std::cout << "File " << input.getValue() << " loaded. Press ENTER to display available data arrays.\n";
-    std::cin.ignore();
-    std::string output_name (output.getValue());
+    if (!arg_varname.isSet())
+    {
+        std::cout << "File " << arg_input.getValue()
+                  << " loaded. Press ENTER to display available data arrays.\n";
+        std::cin.ignore();
+    }
 
-    std::string const& var_name = arraySelectionLoop(dataset);
-    NcVar& var = dataset.getVar(var_name);
+    std::string const output_name(arg_output.getValue());
+    std::string const& var_name = (arg_varname.isSet())
+                                      ? arg_varname.getValue()
+                                      : arraySelectionLoop(dataset);
+    NcVar const& var = dataset.getVar(var_name);
+    if (var.isNull())
+    {
+        ERR("Variable \"%s\" not found in file.", arg_varname.getValue().c_str());
+        return EXIT_FAILURE;
+    }
 
     std::array<std::size_t, 4> dim_idx_map;
-    bool const is_time_dep = dimensionSelectionLoop(var, dim_idx_map);
+    bool is_time_dep (false);
+    if (arg_dim1.isSet() && arg_dim2.isSet())
+    {
+        is_time_dep = arg_dim_time.isSet();
+        if (!assignDimParams(var, dim_idx_map, arg_dim_time, arg_dim1, arg_dim2, arg_dim3))
+            return EXIT_FAILURE;
+    }
+    else
+    {
+        is_time_dep = dimensionSelectionLoop(var, dim_idx_map);
+    }
 
-    std::pair<std::size_t, std::size_t> time_bounds(0,0);
+    std::pair<std::size_t, std::size_t> time_bounds(0, 0);
     if (is_time_dep)
-        time_bounds = timestepSelectionLoop(dataset, var, dim_idx_map[0]);
+        time_bounds = (arg_time_start.isSet())
+                ? assignTimeBounds(getDimVar(dataset, var, dim_idx_map[0]),
+                                   arg_time_start, arg_time_end)
+                : timestepSelectionLoop(dataset, var, dim_idx_map[0]);
 
-    bool mult_files (false);
-    if (is_time_dep && time_bounds.first != time_bounds.second)
-        mult_files = multFilesSelectionLoop(time_bounds);
+    bool use_single_file(true);
+    if (arg_time_start.isSet())
+    {
+        use_single_file = arg_single_file.isSet();
+    }
+    else
+    {
+        if (is_time_dep && time_bounds.first != time_bounds.second)
+            use_single_file = multFilesSelectionLoop(time_bounds);
+    }
 
     std::unique_ptr<MeshLib::Mesh> mesh;
     std::size_t const temp_offset = (is_time_dep) ? 1 : 0;
@@ -428,38 +629,53 @@ int main (int argc, char* argv[])
     std::vector<std::size_t> length;
     std::size_t const array_length = getLength(var, is_time_dep, length);
 
-    MeshLib::MeshElemType const meshElemType = elemSelectionLoop(n_dims - temp_offset);
-    for (std::size_t i=time_bounds.first; i<=time_bounds.second; ++i)
+    MeshLib::MeshElemType const meshElemType = (arg_elem_type.isSet())
+        ? assignElemType(arg_elem_type)
+        : elemSelectionLoop(n_dims - temp_offset);
+    for (std::size_t i = time_bounds.first; i <= time_bounds.second; ++i)
     {
         std::cout << "Converting time step " << i << "...\n";
-        std::vector<double> data_vec = getData(dataset, var, array_length, i, length);
+        std::vector<double> data_vec =
+            getData(dataset, var, array_length, i, length);
 
         GeoLib::RasterHeader header =
             createRasterHeader(dataset, var, dim_idx_map, length, is_time_dep);
-        MeshLib::UseIntensityAs const useIntensity = MeshLib::UseIntensityAs::DATAVECTOR;
-        if (mult_files)
+        MeshLib::UseIntensityAs const useIntensity =
+            MeshLib::UseIntensityAs::DATAVECTOR;
+        if (!use_single_file)
         {
-            mesh.reset(MeshLib::RasterToMesh::convert(data_vec.data(), header, meshElemType, useIntensity, var.getName()));
-            std::string const output_file_name (BaseLib::dropFileExtension(output_name) + getIterationString(i, time_bounds.second) + ".vtu");
+            mesh.reset(MeshLib::RasterToMesh::convert(
+                data_vec.data(), header, meshElemType, useIntensity,
+                var.getName()));
+            std::string const output_file_name(
+                BaseLib::dropFileExtension(output_name) +
+                getIterationString(i, time_bounds.second) + ".vtu");
             MeshLib::IO::VtuInterface vtu(mesh.get());
             vtu.writeToFile(output_file_name);
         }
         else
         {
-            std::string array_name (var.getName());
+            std::string array_name(var.getName());
             if (time_bounds.first != time_bounds.second)
                 array_name.append(getIterationString(i, time_bounds.second));
-            if (i==time_bounds.first) // create persistent mesh
-                mesh.reset(MeshLib::RasterToMesh::convert(data_vec.data(), header, meshElemType, useIntensity, array_name));
-            else // copy array to mesh
+            if (i == time_bounds.first)  // create persistent mesh
+                mesh.reset(MeshLib::RasterToMesh::convert(
+                    data_vec.data(), header, meshElemType, useIntensity,
+                    array_name));
+            else  // copy array to mesh
             {
-                std::unique_ptr<MeshLib::Mesh> temp (MeshLib::RasterToMesh::convert(data_vec.data(), header, meshElemType, useIntensity, array_name));
-                MeshLib::PropertyVector<double> const*const vec = temp->getProperties().getPropertyVector<double>(array_name);
+                std::unique_ptr<MeshLib::Mesh> temp(
+                    MeshLib::RasterToMesh::convert(data_vec.data(), header,
+                                                   meshElemType, useIntensity,
+                                                   array_name));
+                MeshLib::PropertyVector<double> const* const vec =
+                    temp->getProperties().getPropertyVector<double>(array_name);
                 if (vec == nullptr)
                     return EXIT_FAILURE;
-                MeshLib::addPropertyToMesh<double>(*mesh, array_name, MeshLib::MeshItemType::Cell, 1, *vec);
+                MeshLib::addPropertyToMesh<double>(
+                    *mesh, array_name, MeshLib::MeshItemType::Cell, 1, *vec);
             }
-            if (i==time_bounds.second)
+            if (i == time_bounds.second)
             {
                 MeshLib::IO::VtuInterface vtu(mesh.get());
                 vtu.writeToFile(output_name);

--- a/Applications/Utils/FileConverter/NetCdfConverter.cpp
+++ b/Applications/Utils/FileConverter/NetCdfConverter.cpp
@@ -175,8 +175,8 @@ void flipRaster(std::vector<double>& data, std::size_t width,
 
 bool canConvert(NcVar const& var)
 {
-    bool ret(true);
-    if (ret = (var.getDimCount() < 2))
+    bool ret(var.getDimCount() < 2);
+    if (ret)
         ERR("Only 2+ dimensional variables can be converted into OGS Meshes.\n");
     return !ret;
 }
@@ -187,7 +187,8 @@ std::string arraySelectionLoop(NcFile const& dataset)
     std::size_t const idx =
         parseInput("Enter data array index: ", dataset.getVarCount(), true);
 
-    if (idx == dataset.getVarCount() || !canConvert(dataset.getVar(names[idx])))
+    if (static_cast<int>(idx) == dataset.getVarCount() ||
+        !canConvert(dataset.getVar(names[idx])))
         return arraySelectionLoop(dataset);
 
     return names[idx];
@@ -246,7 +247,7 @@ bool dimensionSelectionLoop(NcVar const& var,
                                 " " + dim_comment[i - start_idx] + ": ");
         std::size_t const idx = parseInput(request_str, var.getDimCount(), true);
 
-        if (idx == var.getDimCount())
+        if (static_cast<int>(idx) == var.getDimCount())
         {
             showArraysDims(var);
             i--;
@@ -262,7 +263,6 @@ std::pair<std::size_t, std::size_t> timestepSelectionLoop(NcFile const& dataset,
                                                           NcVar const& var,
                                                           std::size_t dim_idx)
 {
-    NcVar const& dim_var = getDimVar(dataset, var, dim_idx);
     std::size_t const n_time_steps = var.getDim(dim_idx).getSize();
     std::pair<std::size_t, std::size_t> bounds(
         std::numeric_limits<std::size_t>::max(),
@@ -488,8 +488,6 @@ bool convert(NcFile const& dataset, NcVar const& var,
              bool const use_single_file, MeshLib::MeshElemType const elem_type)
 {
     std::unique_ptr<MeshLib::Mesh> mesh;
-    std::size_t const temp_offset = (is_time_dep) ? 1 : 0;
-    std::size_t const n_dims = (var.getDimCount());
     std::vector<std::size_t> length;
     std::size_t const array_length = getLength(var, is_time_dep, length);
     for (std::size_t i = time_bounds.first; i <= time_bounds.second; ++i)

--- a/Applications/Utils/FileConverter/NetCdfConverter.cpp
+++ b/Applications/Utils/FileConverter/NetCdfConverter.cpp
@@ -34,13 +34,14 @@ using namespace netCDF;
 
 const double no_data = -9999;
 
-void checkExit(std::string const& str)
+static void checkExit(std::string const& str)
 {
     if (str == "x" || str == "exit")
         exit(0);
 }
 
-void showErrorMessage(std::size_t const error_id, std::size_t const max = 0)
+static void showErrorMessage(std::size_t const error_id,
+                             std::size_t const max = 0)
 {
     if (error_id == 0)
     {
@@ -58,8 +59,9 @@ void showErrorMessage(std::size_t const error_id, std::size_t const max = 0)
     }
 }
 
-std::size_t parseInput(std::string const& request_str, std::size_t max_val,
-                       bool has_info = false)
+static std::size_t parseInput(std::string const& request_str,
+                              std::size_t const max_val,
+                              bool const has_info = false)
 {
     while (true)
     {
@@ -87,13 +89,14 @@ std::size_t parseInput(std::string const& request_str, std::size_t max_val,
     return std::numeric_limits<std::size_t>::max();
 }
 
-NcVar getDimVar(NcFile const& dataset, NcVar const& var, std::size_t const dim)
+static NcVar getDimVar(NcFile const& dataset, NcVar const& var,
+                       std::size_t const dim)
 {
     NcDim const& dim_obj = var.getDim(dim);
     return dataset.getVar(dim_obj.getName());
 }
 
-std::vector<std::string> getArrays(NcFile const& dataset)
+static std::vector<std::string> getArrays(NcFile const& dataset)
 {
     auto const& names = dataset.getVars();
     std::vector<std::string> var_names;
@@ -104,7 +107,7 @@ std::vector<std::string> getArrays(NcFile const& dataset)
     return var_names;
 }
 
-void showArrays(NcFile const& dataset)
+static void showArrays(NcFile const& dataset)
 {
     std::size_t const n_vars(dataset.getDimCount());
     std::cout << "The NetCDF file contains the following " << n_vars
@@ -121,7 +124,7 @@ void showArrays(NcFile const& dataset)
     std::cout << "\n";
 }
 
-void showArraysDims(NcVar const& var)
+static void showArraysDims(NcVar const& var)
 {
     std::cout << "Data array \"" << var.getName()
               << "\" contains the following dimensions:\n";
@@ -132,7 +135,7 @@ void showArraysDims(NcVar const& var)
     std::cout << "\n";
 }
 
-std::pair<double, double> getBoundaries(NcVar const& var)
+static std::pair<double, double> getBoundaries(NcVar const& var)
 {
     if (var.getDimCount() == 1)
     {
@@ -145,7 +148,7 @@ std::pair<double, double> getBoundaries(NcVar const& var)
     return std::make_pair(0, 0);
 }
 
-MathLib::Point3d getOrigin(NcFile const& dataset, NcVar const& var,
+static MathLib::Point3d getOrigin(NcFile const& dataset, NcVar const& var,
                            std::array<std::size_t, 4> const& dim_idx_map,
                            bool is_time_dep)
 {
@@ -162,8 +165,8 @@ MathLib::Point3d getOrigin(NcFile const& dataset, NcVar const& var,
     return origin;
 }
 
-void flipRaster(std::vector<double>& data, std::size_t width,
-                std::size_t height)
+static void flipRaster(std::vector<double>& data, std::size_t const width,
+                std::size_t const height)
 {
     std::size_t const length(data.size());
     std::vector<double> tmp_vec(length);
@@ -178,7 +181,7 @@ void flipRaster(std::vector<double>& data, std::size_t width,
     std::copy(tmp_vec.cbegin(), tmp_vec.cend(), data.begin());
 }
 
-bool canConvert(NcVar const& var)
+static bool canConvert(NcVar const& var)
 {
     bool ret(var.getDimCount() < 2);
     if (ret)
@@ -186,7 +189,7 @@ bool canConvert(NcVar const& var)
     return !ret;
 }
 
-std::string arraySelectionLoop(NcFile const& dataset)
+static std::string arraySelectionLoop(NcFile const& dataset)
 {
     std::vector<std::string> const& names = getArrays(dataset);
     showArrays(dataset);
@@ -200,7 +203,7 @@ std::string arraySelectionLoop(NcFile const& dataset)
     return names[idx];
 }
 
-bool dimensionSelectionLoop(NcVar const& var,
+static bool dimensionSelectionLoop(NcVar const& var,
                             std::array<std::size_t, 4>& dim_idx_map)
 {
     showArraysDims(var);
@@ -265,9 +268,8 @@ bool dimensionSelectionLoop(NcVar const& var,
     return is_time_dep;
 }
 
-std::pair<std::size_t, std::size_t> timestepSelectionLoop(NcFile const& dataset,
-                                                          NcVar const& var,
-                                                          std::size_t dim_idx)
+static std::pair<std::size_t, std::size_t> timestepSelectionLoop(
+    NcFile const& dataset, NcVar const& var, std::size_t const dim_idx)
 {
     std::size_t const n_time_steps = var.getDim(dim_idx).getSize();
     std::pair<std::size_t, std::size_t> bounds(
@@ -282,7 +284,7 @@ std::pair<std::size_t, std::size_t> timestepSelectionLoop(NcFile const& dataset,
     return bounds;
 }
 
-MeshLib::MeshElemType elemSelectionLoop(std::size_t const dim)
+static MeshLib::MeshElemType elemSelectionLoop(std::size_t const dim)
 {
     if (dim == 1)
         return MeshLib::MeshElemType::LINE;
@@ -323,7 +325,7 @@ MeshLib::MeshElemType elemSelectionLoop(std::size_t const dim)
     return t;
 }
 
-bool multFilesSelectionLoop(
+static bool multFilesSelectionLoop(
     std::pair<std::size_t, std::size_t> const& time_bounds)
 {
     std::size_t const n_time_steps(time_bounds.second - time_bounds.first + 1);
@@ -334,17 +336,17 @@ bool multFilesSelectionLoop(
     std::cout << "1. Save data in one mesh file with " << n_time_steps
               << " scalar arrays.\n";
     std::size_t ret = parseInput("Select preferred method: ", 2, false);
-    return (ret == 0);
+    return (ret != 0);
 }
 
-std::string getIterationString(std::size_t i, std::size_t max)
+static std::string getIterationString(std::size_t i, std::size_t max)
 {
     std::size_t const max_length(std::to_string(max).length());
     std::string const current_str(std::to_string(i));
     return std::string(max_length - current_str.length(), '0') + current_str;
 }
 
-double getResolution(NcFile const& dataset, NcVar const& var)
+static double getResolution(NcFile const& dataset, NcVar const& var)
 {
     std::size_t const dim_idx = var.getDimCount() - 1;
     auto const bounds = getBoundaries(getDimVar(dataset, var, dim_idx));
@@ -352,7 +354,7 @@ double getResolution(NcFile const& dataset, NcVar const& var)
            static_cast<double>(var.getDim(dim_idx).getSize());
 }
 
-GeoLib::RasterHeader createRasterHeader(
+static GeoLib::RasterHeader createRasterHeader(
     NcFile const& dataset, NcVar const& var,
     std::array<std::size_t, 4> const& dim_idx_map,
     std::vector<std::size_t> const& length, bool is_time_dep)
@@ -368,12 +370,12 @@ GeoLib::RasterHeader createRasterHeader(
             z_length, origin, res, no_data};
 }
 
-std::size_t getLength(NcVar const& var, bool const is_time_dep,
+static std::size_t getLength(NcVar const& var, bool const is_time_dep,
                       std::vector<std::size_t>& length)
 {
     std::size_t const temp_offset = (is_time_dep) ? 1 : 0;
     std::size_t const n_dims = (var.getDimCount());
-    length.resize(4, 1);
+    length.resize(n_dims, 1);
     std::size_t array_length = 1;
     for (std::size_t i = temp_offset; i < n_dims; ++i)
     {
@@ -383,8 +385,8 @@ std::size_t getLength(NcVar const& var, bool const is_time_dep,
     return array_length;
 }
 
-std::vector<double> getData(NcFile const& dataset, NcVar const& var,
-                            std::size_t total_length,
+static std::vector<double> getData(NcFile const& dataset, NcVar const& var,
+                            std::size_t const total_length,
                             std::size_t const time_step,
                             std::vector<std::size_t> const& length)
 {
@@ -404,7 +406,7 @@ std::vector<double> getData(NcFile const& dataset, NcVar const& var,
     return data_vec;
 }
 
-bool assignDimParams(NcVar const& var,
+static bool assignDimParams(NcVar const& var,
                      std::array<std::size_t, 4>& dim_idx_map,
                      TCLAP::ValueArg<std::size_t>& arg_dim_time,
                      TCLAP::ValueArg<std::size_t>& arg_dim1,
@@ -442,9 +444,10 @@ bool assignDimParams(NcVar const& var,
     return true;
 }
 
-std::pair<std::size_t, std::size_t> assignTimeBounds(NcVar const& var,
-                     TCLAP::ValueArg<std::size_t>& arg_time_start,
-                     TCLAP::ValueArg<std::size_t>& arg_time_end)
+static std::pair<std::size_t, std::size_t> assignTimeBounds(
+    NcVar const& var,
+    TCLAP::ValueArg<std::size_t>& arg_time_start,
+    TCLAP::ValueArg<std::size_t>& arg_time_end)
 {
     auto const bounds = getBoundaries(var);
     if (arg_time_start.getValue() > bounds.second)
@@ -471,7 +474,8 @@ std::pair<std::size_t, std::size_t> assignTimeBounds(NcVar const& var,
     return {arg_time_start.getValue(), arg_time_end.getValue()};
 }
 
-MeshLib::MeshElemType assignElemType(TCLAP::ValueArg<std::string>& arg_elem_type)
+static MeshLib::MeshElemType assignElemType(
+    TCLAP::ValueArg<std::string>& arg_elem_type)
 {
     if (arg_elem_type.getValue() == "tri")
         return MeshLib::MeshElemType::TRIANGLE;
@@ -485,7 +489,7 @@ MeshLib::MeshElemType assignElemType(TCLAP::ValueArg<std::string>& arg_elem_type
     return MeshLib::MeshElemType::INVALID;
 }
 
-bool convert(NcFile const& dataset, NcVar const& var,
+static bool convert(NcFile const& dataset, NcVar const& var,
              std::string const& output_name,
              std::array<std::size_t, 4> const& dim_idx_map,
              bool const is_time_dep,

--- a/Applications/Utils/FileConverter/NetCdfConverter.cpp
+++ b/Applications/Utils/FileConverter/NetCdfConverter.cpp
@@ -1,0 +1,419 @@
+/**
+ * @copyright
+ * Copyright (c) 2012-2016, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/LICENSE.txt
+ */
+
+// STL
+#include <cctype>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include <tclap/CmdLine.h>
+
+#include "Applications/ApplicationsLib/LogogSetup.h"
+
+#include <netcdfcpp.h>
+
+// BaseLib
+#include "BaseLib/BuildInfo.h"
+#include "BaseLib/LogogSimpleFormatter.h"
+
+// GeoLib
+#include "GeoLib/Raster.h"
+
+// MeshLib
+#include "MeshLib/Mesh.h"
+#include "MeshLib/MeshGenerators/RasterToMesh.h"
+
+#include "MeshLib/IO/VtkIO/VtuInterface.h"
+
+
+void showErrorMessage(std::size_t error_id, std::size_t max = 0)
+{
+    if (error_id == 0)
+    {
+        ERR ("Index not recognised.");
+        std::cout << "\"info\" will display the available options again. \"exit\" will exit the programme.\n";
+    }
+    else if (error_id == 1)
+    {
+        ERR ("Index not valid. Valid indices are in [0,%d].", max);
+    }
+}
+
+void showArrays(NcFile const& dataset)
+{
+    std::size_t const n_vars (dataset.num_vars());
+    std::cout << "The NetCDF file contains the following " << n_vars << " arrays:\n\n";
+    std::cout << "\tIndex\tArray Name\t#Dimensions\n";
+    std::cout << "-------------------------------------------\n";
+    for (std::size_t i=0; i<n_vars; ++i)
+    {
+        NcVar const& var = *dataset.get_var(i);
+        std::cout << "\t" << i << "\t" << var.name() << "\t(" << var.num_dims() << "D array)\n";
+    }
+    std::cout << "\n";
+}
+
+bool showArraysDims(NcFile const& dataset, NcVar const& var)
+{
+    std::cout << "Data array \"" << var.name() << "\" contains the following dimensions:\n";
+    std::size_t const n_dims (var.num_dims());
+    for (std::size_t i=0; i<n_dims; ++i)
+        std::cout << "\t" << i << "\t" << var.get_dim(i)->name() << "\t(" << var.get_dim(i)->size() << " values)\n";
+    std::cout << "\n";
+    return true;
+}
+
+std::size_t getDimensionBoundaries(NcFile const& dataset, NcVar const& var, std::size_t dim, double &start, double &end)
+{
+    NcVar dim_var = *dataset.get_var(var.get_dim(dim)->name());
+    if ((dim_var.num_dims()) == 1)
+    {
+        std::size_t size = dim_var.get_dim(0)->size();
+
+        std::size_t length[1] = {1};
+        long idx[1] = {0};
+        dim_var.set_cur(idx);
+        double val_at_idx[1] = {0};
+        dim_var.get(val_at_idx, length);
+        start = val_at_idx[0];
+
+        idx[0] = size-1;
+        dim_var.set_cur(idx);
+        dim_var.get(val_at_idx, length);
+        end = val_at_idx[0];
+        return size;
+    }
+    return 0;
+}
+
+void reverseNorthSouth(double* data, std::size_t width, std::size_t height)
+{
+    double* cp_array = new double[width*height];
+
+    for (std::size_t i=0; i<height; i++)
+    {
+        for (std::size_t j=0; j<width; j++)
+        {
+            std::size_t const old_index ((width*height)-(width*(i+1)));
+            std::size_t const new_index (width*i);
+            cp_array[new_index+j] = data[old_index+j];
+        }
+    }
+
+    std::size_t const length(height*width);
+    for (std::size_t i=0; i<length; i++)
+        data[i] = cp_array[i];
+
+    delete[] cp_array;
+}
+
+std::size_t arraySelectionLoop(NcFile const& dataset)
+{
+    showArrays(dataset);
+    while (true)
+    {
+        cout << "Enter data array index: ";
+        std::string var_idx_str ("");
+        std::getline(std::cin, var_idx_str);
+        if (var_idx_str == "info")
+        {
+            showArrays(dataset);
+            continue;
+        }
+        if (var_idx_str == "exit")
+            exit(0);
+    
+        std::stringstream str_stream(var_idx_str);
+        std::size_t var_idx;
+        if (!(str_stream >> var_idx))
+        {
+            showErrorMessage(0);
+            continue;
+        }
+        if (var_idx > dataset.num_vars()-1)
+        {
+            showErrorMessage(1, dataset.num_vars()-1);
+            continue;
+        }
+        return var_idx;
+    }
+    return std::numeric_limits<std::size_t>::max();
+}
+
+bool dimensionSelectionLoop(NcFile const& dataset, NcVar const& var, std::array<std::size_t,4> &dim_idx_map)
+{
+    showArraysDims(dataset, var);
+    std::size_t const n_dims (var.num_dims());
+    dim_idx_map[0] = std::numeric_limits<std::size_t>::max();
+    bool is_time_dep (true);
+
+    // get temporal dimension
+    if (n_dims > 1)
+    {
+        std::string temp_str("");
+        cout << "Is the parameter time-dependent?\n";
+        while (dim_idx_map[0] == std::numeric_limits<std::size_t>::max() && is_time_dep == true)
+        {
+            cout << "Enter ID for temporal dimension or \"c\" to continue: ";
+            std::getline(std::cin, temp_str);
+            std::stringstream str_stream(temp_str);
+            if (str_stream.str() == "c")
+                is_time_dep = false;
+            else 
+            {
+                if (str_stream >> dim_idx_map[0])
+                {
+                    if (dim_idx_map[0] > n_dims-1)
+                    {
+                        showErrorMessage(1, var.num_dims()-1);
+                        dim_idx_map[0] = std::numeric_limits<std::size_t>::max();
+                    }
+                }
+            }
+        }
+    }
+
+    // get spatial dimension(s)
+    std::size_t const start_idx = (is_time_dep) ? 1 : 0;
+    for (std::size_t i=start_idx; i<n_dims; ++i)
+    {
+        dim_idx_map[i] = std::numeric_limits<std::size_t>::max();
+        while (dim_idx_map[i] == std::numeric_limits<std::size_t>::max())
+        {
+            std::string dim_idx_str;
+            cout << "Enter ID for dimension " << i << ": ";
+            std::getline(std::cin, dim_idx_str);
+            if (dim_idx_str == "info")
+            {
+                showArraysDims(dataset, var);
+                continue;
+            }
+            if (dim_idx_str == "exit")
+                exit(0);
+
+            std::stringstream str_stream(dim_idx_str);
+            std::size_t dim_idx;
+            if (!(str_stream >> dim_idx))
+            {
+                showErrorMessage(0);
+                continue;
+            }
+            if (dim_idx > var.num_dims()-1)
+            {
+                showErrorMessage(1, var.num_dims()-1);
+                continue;
+            }
+            dim_idx_map[i] = dim_idx;
+        }
+    }
+
+    return is_time_dep;
+}
+
+MeshLib::MeshElemType elemSelectionLoop(std::size_t const dim)
+{
+    if (dim ==1)
+        return MeshLib::MeshElemType::LINE;
+
+    MeshLib::MeshElemType t = MeshLib::MeshElemType::INVALID;
+    while (t == MeshLib::MeshElemType::INVALID)
+    {
+        std::cout << "\nSelect element type for result, choose ";
+    
+        if (dim==2) std::cout << "(t)riangle or (q)uadliteral: ";
+        if (dim==3) std::cout << "(p)rism or (h)exahedron: ";
+        std::string type ("");
+        std::getline(std::cin, type);
+
+        if (dim==2)
+        {
+            if (type != "t" || type != "q" ||
+                type != "tri" || type != "quad" ||
+                type != "triangle" || type != "quatliteral")
+                continue;
+            if (type == "t" || type == "tri" || type == "triangle")
+                return MeshLib::MeshElemType::TRIANGLE;
+            else
+                return MeshLib::MeshElemType::QUAD;
+        }
+
+        if (dim==3)
+        {
+            if (type != "p" || type != "h" ||
+                type != "prism" || type != "hex" ||
+                type != "hexahedron")
+                continue;
+            if (type == "p" || type == "prism")
+                return MeshLib::MeshElemType::PRISM;
+            else
+                return MeshLib::MeshElemType::HEXAHEDRON;
+        }
+    }
+    return t;
+}
+
+void setOrigin(NcVar &var, std::size_t time_step)
+{
+    long* newOrigin = new long[var.num_dims()];
+    for (int i=0; i < var.num_dims(); ++i) 
+        newOrigin[i]=0;
+    newOrigin[0] = time_step;
+    var.set_cur(newOrigin);
+    delete [] newOrigin;
+}
+
+/*
+MeshLib::Mesh convert(double* data_array, std::array<std::size_t,3> length, GeoLib::Point &origin, double resolution, MeshLib::MeshElemType meshElemType, MeshLib::UseIntensityAs useIntensity, std::string &name)
+{
+    return 
+}
+*/
+int main (int argc, char* argv[])
+{
+    ApplicationsLib::LogogSetup logog_setup;
+
+    TCLAP::CmdLine cmd("Converts NetCDF into mesh file.", ' ', BaseLib::BuildInfo::git_describe);
+    TCLAP::ValueArg<std::string> input("i", "input-file",
+                                       "the NetCDF input file", true,
+                                       "", "the NetCDF input file");
+    cmd.add(input);
+    TCLAP::ValueArg<std::string> output("o", "output-file",
+                                        "the OGS mesh output file", true,
+                                        "", "the OGS mesh output file");
+    cmd.add(output);
+    cmd.parse(argc, argv);
+
+    NcFile dataset(input.getValue().c_str(), NcFile::ReadOnly);
+
+    std::cout << "OpenGeoSys NetCDF Converter\n";
+    std::cout << "File " << input.getValue() << " loaded. Press ENTER to display available data arrays.\n";
+    std::cin.ignore();
+
+    std::size_t const var_idx = arraySelectionLoop(dataset);
+
+    std::array<std::size_t, 4> dim_idx_map;
+    NcVar var = *dataset.get_var(var_idx);
+    bool const is_time_dep = dimensionSelectionLoop(dataset, var, dim_idx_map);
+
+    std::cin.ignore();
+
+    std::size_t temp_offset = (is_time_dep) ? 1 : 0;
+    std::size_t const n_dims = (var.num_dims());
+    std::size_t* length = new std::size_t[n_dims];
+    for(int i=0; i < n_dims; i++) 
+        length[i]=1;
+    std::array<double, 3> spatial_size = {0,0,0};
+    std::array<double, 3> start = {0,0,0};
+    std::array<double, 3> end   = {0,0,0};
+    std::size_t array_length = 1;
+    for (std::size_t i=temp_offset; i<n_dims; ++i)
+    {
+        length[i] = getDimensionBoundaries(dataset, var, dim_idx_map[i], start[i-temp_offset], end[i-temp_offset]);
+        spatial_size[i-temp_offset] = length[i];
+        array_length *= length[i];
+    }
+
+    setOrigin(var, 0);
+
+    double* data_array = new double[array_length];
+    for (std::size_t i=0; i < array_length; i++) 
+        data_array[i]=0;
+    var.get(data_array, length); //create Array of Values
+
+    for (std::size_t i=0; i < array_length; i++)
+        if (data_array[i] < -9999 ) data_array[i] = -9999; // all values < -10000, set to "no-value"
+
+    double origin_x = (start[1] < end[1]) ? start[1] : end[1];
+    double origin_y = (start[0] < end[0]) ? start[0] : end[0];
+    MathLib::Point3d origin (std::array<double,3>{{origin_x, origin_y, 0}});
+    double const resolution = fabs(end[0]-start[0])/(spatial_size[0]-1);
+
+    // reverse lines in vertical direction if the original file has its origin in the northwest corner
+    if (start[0] > end[0])
+        reverseNorthSouth(data_array, spatial_size[1], spatial_size[0]);
+
+    GeoLib::RasterHeader header = {spatial_size[1], spatial_size[0], origin, resolution, -9999};
+
+    //MeshLib::MeshElemType meshElemType = elemSelectionLoop(n_dims-temp_offset);
+
+    MeshLib::MeshElemType meshElemType = MeshLib::MeshElemType::TRIANGLE;
+    MeshLib::UseIntensityAs useIntensity = MeshLib::UseIntensityAs::DATAVECTOR;
+
+    MeshLib::Mesh* mesh = MeshLib::RasterToMesh::convert(data_array, header, meshElemType, useIntensity, var.name());
+
+    /***********************
+    std::size_t const n_time_steps = getDimensionBoundaries(dataset, var, dim_idx_map[2], start_lat, end_lat);
+    std::size_t const array_length (sizeLat * sizeLon);
+    for (std::size_t j=1; j<n_time_steps; ++j)
+    {
+        setOrigin(var, j);
+        var.get(data_array, length); //create Array of Values
+
+        for (std::size_t i=0; i < (sizeLat*sizeLon); i++)
+            if (data_array[i] < -9999 ) data_array[i] = -9999; // all values < -10000, set to "no-value"
+
+        double const resolution = fabs(end_lat-start_lat)/(sizeLat-1);
+
+        // reverse lines in vertical direction if the original file has its origin in the northwest corner
+        if (start_lat > end_lat)
+            reverseNorthSouth(data_array, sizeLon, sizeLat);
+        GeoLib::RasterHeader header = {sizeLon, sizeLat, origin, resolution, -9999};
+
+        MeshLib::MeshElemType meshElemType = MeshLib::MeshElemType::TRIANGLE;
+        MeshLib::UseIntensityAs useIntensity = MeshLib::UseIntensityAs::DATAVECTOR;
+        std::unique_ptr<MeshLib::Mesh> tmp_mesh (MeshLib::RasterToMesh::convert(data_array, header, meshElemType, useIntensity, var.name()));
+
+        boost::optional< MeshLib::PropertyVector<double>& > tmp_vec = tmp_mesh->getProperties().getPropertyVector<double>(var.name());
+        if (!tmp_vec)
+        {
+            ERR("Vector not found");
+            continue;
+        }
+
+        if (tmp_vec->size() != mesh->getNumberOfElements())
+        {
+            ERR("Vector size doesn't fit.");
+            continue;
+        }
+
+        MeshLib::Properties& props (mesh->getProperties());
+
+        std::string prefix ("");
+        if (j<100) prefix = "0";
+        if (j<10) prefix = "00";
+        std::string var_name_str (prefix + std::to_string(j));
+
+        boost::optional< MeshLib::PropertyVector<double>& > vec = 
+            props.createNewPropertyVector<double>(std::string(var.name() + var_name_str), MeshLib::MeshItemType::Cell, 1);
+
+        if (!vec)
+        {
+            ERR ("Error creating vector");
+            continue;
+        }
+        vec->reserve(tmp_vec->size());
+        for (std::size_t i=0; i<tmp_vec->size(); ++i)
+            vec->push_back((*tmp_vec)[i]);
+
+        std::cout << "time step " << j << " written.\n";
+    }
+    /***********************/
+
+    MeshLib::IO::VtuInterface vtu(mesh);
+    vtu.writeToFile("d:/nctest.vtu");
+
+    delete[] length;
+    delete[] data_array;
+
+
+    return 0;
+}

--- a/Applications/Utils/FileConverter/NetCdfConverter.cpp
+++ b/Applications/Utils/FileConverter/NetCdfConverter.cpp
@@ -93,7 +93,18 @@ NcVar getDimVar(NcFile const& dataset, NcVar const& var, std::size_t const dim)
     return dataset.getVar(dim_obj.getName());
 }
 
-std::vector<std::string> showArrays(NcFile const& dataset)
+std::vector<std::string> getArrays(NcFile const& dataset)
+{
+    auto const& names = dataset.getVars();
+    std::vector<std::string> var_names;
+    for (auto [name, var] : names)
+    {
+        var_names.push_back(name);
+    }
+    return var_names;
+}
+
+void showArrays(NcFile const& dataset)
 {
     std::size_t const n_vars(dataset.getDimCount());
     std::cout << "The NetCDF file contains the following " << n_vars
@@ -101,15 +112,13 @@ std::vector<std::string> showArrays(NcFile const& dataset)
     std::cout << "\tIndex\tArray Name\t#Dimensions\n";
     std::cout << "-------------------------------------------\n";
     auto const& names = dataset.getVars();
-    std::vector<std::string> var_names;
+    std::size_t count = 0;
     for (auto [name, var] : names)
     {
-        std::cout << "\t" << var_names.size() << "\t" << name << "\t("
+        std::cout << "\t" << count++ << "\t" << name << "\t("
                   << var.getDimCount() << "D array)\n";
-        var_names.push_back(name);
     }
     std::cout << "\n";
-    return var_names;
 }
 
 void showArraysDims(NcVar const& var)
@@ -179,7 +188,8 @@ bool canConvert(NcVar const& var)
 
 std::string arraySelectionLoop(NcFile const& dataset)
 {
-    std::vector<std::string> const& names = showArrays(dataset);
+    std::vector<std::string> const& names = getArrays(dataset);
+    showArrays(dataset);
     std::size_t const idx =
         parseInput("Enter data array index: ", dataset.getVarCount(), true);
 

--- a/Applications/Utils/Tests.cmake
+++ b/Applications/Utils/Tests.cmake
@@ -285,3 +285,27 @@ AddTest(
     DIFF_DATA
     AmmerSubsurfaceGrid.vtu AmmerGridOutput.vtu MaterialIDs MaterialIDs 0 0
 )
+
+if(OGS_USE_NETCDF)
+    AddTest(
+        NAME NetCDF_2D_Test
+        PATH FileConverter/
+        EXECUTABLE NetCdfConverter
+        EXECUTABLE_ARGS -i sresa1b_ncar_ccsm3-example.nc -o ${Data_BINARY_DIR}/FileConverter/sresa1b_ncar_ccsm3-example.vtu -v pr -t 0 --dim1 2 --dim2 1 --timestep-first 0 --timestep-last 0 -e tri
+        REQUIREMENTS NOT OGS_USE_MPI
+        TESTER vtkdiff
+        DIFF_DATA
+        sresa1b_ncar_ccsm3-example.vtu sresa1b_ncar_ccsm3-example.vtu pr pr 1e-16 0
+    )
+
+    AddTest(
+        NAME NetCDF_3D_Test
+        PATH FileConverter/
+        EXECUTABLE NetCdfConverter
+        EXECUTABLE_ARGS -i slim_100897_198.nc -o ${Data_BINARY_DIR}/FileConverter/slim_100897_198.vtu -v NO -t 0 --dim1 3 --dim2 2 --dim3 1 --timestep-first 0 --timestep-last 0 -e hex
+        REQUIREMENTS NOT OGS_USE_MPI
+        TESTER vtkdiff
+        DIFF_DATA
+        slim_100897_198.vtu slim_100897_198.vtu NO NO 1e-16 0
+    )
+endif()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,7 +204,8 @@ pipeline {
                   '-DOGS_BUILD_GUI=ON ' +
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_CONAN_BUILD=missing ' +
-                  '-DOGS_BUILD_TESTS=OFF '
+                  '-DOGS_BUILD_TESTS=OFF ' +
+                  '-DOGS_USE_NETCDF=ON '
               }
               build {
                 target="package"
@@ -406,7 +407,8 @@ pipeline {
                   '-DOGS_BUILD_GUI=ON ' +
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_CONAN_BUILD=missing ' +
-                  '-DOGS_BUILD_SWMM=ON '
+                  '-DOGS_BUILD_SWMM=ON ' +
+                  '-DOGS_USE_NETCDF=ON '
               }
               build {
                 target="package"
@@ -463,7 +465,8 @@ pipeline {
                   '-DOGS_BUILD_GUI=OFF ' + // Temp. disabled
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_CONAN_BUILD=missing ' +
-                  '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.14" '
+                  '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.14" ' +
+                  '-DOGS_USE_NETCDF=ON '
               }
               build {
                 target="package"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -226,6 +226,7 @@ pipeline {
             always {
               recordIssues enabledForFailure: true, filters: [
                 excludeFile('.*qrc_icons\\.cpp.*'),
+                excludeFile('ncGroup\\.h'),
                 excludeMessage('.*tmpnam.*')],
                 tools: [gcc4(name: 'GCC-GUI', id: 'gcc4-gui',
                              pattern: 'build/build*.log')],
@@ -233,7 +234,7 @@ pipeline {
               recordIssues enabledForFailure: true,
                 tools: [cppCheck(pattern: 'build/cppcheck.log')]
             }
-            success { archiveArtifacts 'build/*.tar.gz,build/conaninfo.txt' }
+            success { archiveArtifacts 'build/*.tar.gz,build/conaninfo.txt,build/cppcheck.log' }
           }
         }
         // ********************* Docker-Conan-Debug ****************************

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -466,7 +466,7 @@ pipeline {
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.14" ' +
-                  '-DOGS_USE_NETCDF=ON '
+                  '-DOGS_USE_NETCDF=OFF '
               }
               build {
                 target="package"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -462,11 +462,10 @@ pipeline {
                   "-DBUILD_SHARED_LIBS=${build_shared} " +
                   '-DOGS_CPU_ARCHITECTURE=core2 ' +
                   '-DOGS_DOWNLOAD_ADDITIONAL_CONTENT=ON ' +
-                  '-DOGS_BUILD_GUI=OFF ' + // Temp. disabled
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.14" ' +
-                  '-DOGS_USE_NETCDF=OFF '
+                  '-DOGS_USE_NETCDF=ON '
               }
               build {
                 target="package"

--- a/Tests/Data/FileConverter/slim_100897_198.nc
+++ b/Tests/Data/FileConverter/slim_100897_198.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb278e02f075784b28241b476a1745dcad93131d9751415afbf00b9657e01718
+size 5352788

--- a/Tests/Data/FileConverter/slim_100897_198.vtu
+++ b/Tests/Data/FileConverter/slim_100897_198.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ceec1ea5ea0967e7111c945e5e41032a8351a60bddd5ecc8675ef40ab46432e
+size 4462866

--- a/Tests/Data/FileConverter/sresa1b_ncar_ccsm3-example.nc
+++ b/Tests/Data/FileConverter/sresa1b_ncar_ccsm3-example.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c2047ee329654f3bebf0a4b0d99eada50f1183728a3c7c129b0bc50d404511b
+size 2767916

--- a/Tests/Data/FileConverter/sresa1b_ncar_ccsm3-example.vtu
+++ b/Tests/Data/FileConverter/sresa1b_ncar_ccsm3-example.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dc1627a4ea12e0d223c59f7155ad22eda205fbd0a8f4745516d08cd9a80f63f
+size 4644854

--- a/scripts/cmake/ConanSetup.cmake
+++ b/scripts/cmake/ConanSetup.cmake
@@ -70,6 +70,8 @@ if(OGS_BUILD_GUI)
         shapelib/1.3.0@bilke/stable
         libgeotiff/1.4.2@bilke/stable
         qt/5.13.2@bincrafters/stable
+        # Fix for "Conflict in pcre/8.41@bincrafters/stable"
+        bzip2/1.0.8
     )
     set(CONAN_OPTIONS ${CONAN_OPTIONS}
         vtk:minimal=False

--- a/scripts/cmake/ConanSetup.cmake
+++ b/scripts/cmake/ConanSetup.cmake
@@ -88,6 +88,9 @@ if(OGS_BUILD_GUI)
         qt:with_sdl2=False
         qt:with_sqlite3=False
     )
+    if(MSVC)
+        set(CONAN_OPTIONS ${CONAN_OPTIONS} qt:with_harfbuzz=False)
+    endif()
 endif()
 
 if(OGS_USE_NETCDF)

--- a/scripts/cmake/ConanSetup.cmake
+++ b/scripts/cmake/ConanSetup.cmake
@@ -69,9 +69,7 @@ if(OGS_BUILD_GUI)
     set(CONAN_REQUIRES ${CONAN_REQUIRES}
         shapelib/1.3.0@bilke/stable
         libgeotiff/1.4.2@bilke/stable
-        qt/5.12.4@bincrafters/stable
-        # Overwrite VTK requirement to match Qt requirement
-        bzip2/1.0.8@conan/stable
+        qt/5.13.2@bincrafters/stable
     )
     set(CONAN_OPTIONS ${CONAN_OPTIONS}
         vtk:minimal=False

--- a/scripts/cmake/ConanSetup.cmake
+++ b/scripts/cmake/ConanSetup.cmake
@@ -92,7 +92,7 @@ if(OGS_USE_NETCDF)
     set(CONAN_REQUIRES ${CONAN_REQUIRES} netcdf-cxx/4.3.1@bilke/testing)
 endif()
 
-conan_check(VERSION 1.19.2)
+conan_check(VERSION 1.20.0)
 
 message(STATUS "Third-party libraries:")
 foreach(LIB ${OGS_LIBS})

--- a/scripts/cmake/Find.cmake
+++ b/scripts/cmake/Find.cmake
@@ -106,6 +106,8 @@ if(OGS_USE_NETCDF)
     set(NETCDF_ROOT ${CONAN_NETCDF-C_ROOT})
     set(NETCDF_CXX_ROOT ${CONAN_NETCDF-CXX_ROOT})
     find_package(NetCDF REQUIRED)
+    find_package(HDF5 REQUIRED)
+    find_package(ZLIB REQUIRED)
 endif()
 
 # lapack

--- a/scripts/cmake/Find.cmake
+++ b/scripts/cmake/Find.cmake
@@ -106,8 +106,7 @@ if(OGS_USE_NETCDF)
     set(NETCDF_ROOT ${CONAN_NETCDF-C_ROOT})
     set(NETCDF_CXX_ROOT ${CONAN_NETCDF-CXX_ROOT})
     find_package(NetCDF REQUIRED)
-    find_package(HDF5 REQUIRED)
-    find_package(ZLIB REQUIRED)
+    find_package(HDF5 REQUIRED COMPONENTS C HL)
 endif()
 
 # lapack

--- a/scripts/docker/Dockerfile.clang.full
+++ b/scripts/docker/Dockerfile.clang.full
@@ -31,8 +31,10 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.sh && \
+    mkdir -p /usr/local && \
     /bin/sh /var/tmp/cmake-3.12.4-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
     rm -rf /var/tmp/cmake-3.12.4-Linux-x86_64.sh
+ENV PATH=/usr/local/bin:$PATH
 
 # OGS base building block
 # Python
@@ -84,12 +86,12 @@ RUN apt-get update -y && \
         python3-setuptools \
         python3-wheel && \
     rm -rf /var/lib/apt/lists/*
-RUN pip3 install conan==1.19.2
+RUN pip3 install conan==1.20.5
 RUN mkdir -p /opt/conan && \
     chmod 777 /opt/conan
 ENV CONAN_USER_HOME=/opt/conan
 LABEL org.opengeosys.pm=conan \
-    org.opengeosys.pm.conan.version=1.19.2
+    org.opengeosys.pm.conan.version=1.20.5
 LABEL org.opengeosys.pm.conan.user_home=/opt/conan
 
 # Include-what-you-use for clang version 8
@@ -100,11 +102,13 @@ RUN apt-get update -y && \
         llvm-8-dev \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
+# https://github.com/include-what-you-use/include-what-you-use/archive/clang_8.0.tar.gz
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/include-what-you-use/include-what-you-use/archive/clang_8.0.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/clang_8.0.tar.gz -C /var/tmp -z && \
-    mkdir -p /var/tmp/build && cd /var/tmp/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local/iwyy -DIWYU_LLVM_ROOT_PATH=/usr/lib/llvm-8 /var/tmp/include-what-you-use-clang_8.0 && \
-    cmake --build /var/tmp/build --target install -- -j$(nproc) && \
-    rm -rf /var/tmp/clang_8.0.tar.gz /var/tmp/build /var/tmp/include-what-you-use-clang_8.0
+    mkdir -p /var/tmp/include-what-you-use-clang_8.0/build && cd /var/tmp/include-what-you-use-clang_8.0/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local/iwyy -D IWYU_LLVM_ROOT_PATH=/usr/lib/llvm-8 /var/tmp/include-what-you-use-clang_8.0 && \
+    cmake --build /var/tmp/include-what-you-use-clang_8.0/build --target all -- -j$(nproc) && \
+    cmake --build /var/tmp/include-what-you-use-clang_8.0/build --target install -- -j$(nproc) && \
+    rm -rf /var/tmp/clang_8.0.tar.gz /var/tmp/include-what-you-use-clang_8.0
 ENV PATH=/usr/local/iwyy/bin:$PATH
 
 # Package manager Conan building block

--- a/scripts/docker/Dockerfile.gcc.full
+++ b/scripts/docker/Dockerfile.gcc.full
@@ -24,8 +24,10 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.sh && \
+    mkdir -p /usr/local && \
     /bin/sh /var/tmp/cmake-3.12.4-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
     rm -rf /var/tmp/cmake-3.12.4-Linux-x86_64.sh
+ENV PATH=/usr/local/bin:$PATH
 
 # OGS base building block
 # Python
@@ -77,20 +79,22 @@ RUN apt-get update -y && \
         python3-setuptools \
         python3-wheel && \
     rm -rf /var/lib/apt/lists/*
-RUN pip3 install conan==1.19.2
+RUN pip3 install conan==1.20.5
 RUN mkdir -p /opt/conan && \
     chmod 777 /opt/conan
 ENV CONAN_USER_HOME=/opt/conan
 LABEL org.opengeosys.pm=conan \
-    org.opengeosys.pm.conan.version=1.19.2
+    org.opengeosys.pm.conan.version=1.20.5
 LABEL org.opengeosys.pm.conan.user_home=/opt/conan
 
 # cppcheck version 1.87
+# https://github.com/danmar/cppcheck/archive/1.87.tar.gz
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/danmar/cppcheck/archive/1.87.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/1.87.tar.gz -C /var/tmp -z && \
-    mkdir -p /var/tmp/build && cd /var/tmp/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_PREFIX=/usr/local/cppcheck -DCMAKE_BUILD_TYPE=RELEASE /var/tmp/cppcheck-1.87 && \
-    cmake --build /var/tmp/build --target install -- -j$(nproc) && \
-    rm -rf /var/tmp/1.87.tar.gz /var/tmp/build /var/tmp/cppcheck-1.87
+    mkdir -p /var/tmp/cppcheck-1.87/build && cd /var/tmp/cppcheck-1.87/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local/cppcheck -D CMAKE_BUILD_TYPE=Release /var/tmp/cppcheck-1.87 && \
+    cmake --build /var/tmp/cppcheck-1.87/build --target all -- -j$(nproc) && \
+    cmake --build /var/tmp/cppcheck-1.87/build --target install -- -j$(nproc) && \
+    rm -rf /var/tmp/1.87.tar.gz /var/tmp/cppcheck-1.87
 ENV PATH=/usr/local/cppcheck/bin:$PATH
 
 RUN apt-get update -y && \

--- a/scripts/docker/Dockerfile.gcc.gui
+++ b/scripts/docker/Dockerfile.gcc.gui
@@ -24,8 +24,10 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.sh && \
+    mkdir -p /usr/local && \
     /bin/sh /var/tmp/cmake-3.12.4-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
     rm -rf /var/tmp/cmake-3.12.4-Linux-x86_64.sh
+ENV PATH=/usr/local/bin:$PATH
 
 # OGS base building block
 # Python
@@ -85,20 +87,22 @@ RUN apt-get update -y && \
         python3-setuptools \
         python3-wheel && \
     rm -rf /var/lib/apt/lists/*
-RUN pip3 install conan==1.19.2
+RUN pip3 install conan==1.20.5
 RUN mkdir -p /opt/conan && \
     chmod 777 /opt/conan
 ENV CONAN_USER_HOME=/opt/conan
 LABEL org.opengeosys.pm=conan \
-    org.opengeosys.pm.conan.version=1.19.2
+    org.opengeosys.pm.conan.version=1.20.5
 LABEL org.opengeosys.pm.conan.user_home=/opt/conan
 
 # cppcheck version 1.87
+# https://github.com/danmar/cppcheck/archive/1.87.tar.gz
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/danmar/cppcheck/archive/1.87.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/1.87.tar.gz -C /var/tmp -z && \
-    mkdir -p /var/tmp/build && cd /var/tmp/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_PREFIX=/usr/local/cppcheck -DCMAKE_BUILD_TYPE=RELEASE /var/tmp/cppcheck-1.87 && \
-    cmake --build /var/tmp/build --target install -- -j$(nproc) && \
-    rm -rf /var/tmp/1.87.tar.gz /var/tmp/build /var/tmp/cppcheck-1.87
+    mkdir -p /var/tmp/cppcheck-1.87/build && cd /var/tmp/cppcheck-1.87/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local/cppcheck -D CMAKE_BUILD_TYPE=Release /var/tmp/cppcheck-1.87 && \
+    cmake --build /var/tmp/cppcheck-1.87/build --target all -- -j$(nproc) && \
+    cmake --build /var/tmp/cppcheck-1.87/build --target install -- -j$(nproc) && \
+    rm -rf /var/tmp/1.87.tar.gz /var/tmp/cppcheck-1.87
 ENV PATH=/usr/local/cppcheck/bin:$PATH
 
 # pip


### PR DESCRIPTION
Command line utility to conver netCDF-files into OGS meshes. Works for both 2d and 3d meshes + time. Multiple time steps can be saved as seperate meshes or as one mesh with one scalar array per time step.

(A follow-up PR will move all non-ui functionality into FileIO and adjust the DataExplorer interface to use that as well.)

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.2)

**Please note:**

- Conan minimum version was bumped to `1.20`, do `pip install --upgrade conan`!
- Updated Conan Qt package to 5.13.2