### PR TITLE
Cleanup of clang-tidy warnings

### DIFF
--- a/Applications/DataExplorer/Base/LastSavedFileDirectory.h
+++ b/Applications/DataExplorer/Base/LastSavedFileDirectory.h
@@ -1,5 +1,5 @@
 /**
- * \file   LastSavedFileDirectory.h
+ * \file
  * \author Karsten Rink
  * \date   2014-02-04
  * \brief  Manages the last directory used for saving a file

--- a/Applications/DataExplorer/DataView/AddLayerToMeshDialog.cpp
+++ b/Applications/DataExplorer/DataView/AddLayerToMeshDialog.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   AddLayerToMeshDialog.cpp
+ * \file
  * \author Karsten Rink
  * \date   2016-01-18
  * \brief  Implementation of the AddLayerToMeshDialog class.

--- a/Applications/DataExplorer/DataView/AddLayerToMeshDialog.h
+++ b/Applications/DataExplorer/DataView/AddLayerToMeshDialog.h
@@ -1,5 +1,5 @@
 /**
- * \file   AddLayerToMeshDialog.h
+ * \file
  * \author Karsten Rink
  * \date   2016-01-18
  * \brief  Definition of the AddLayerToMeshDialog class.

--- a/Applications/DataExplorer/DataView/CreateStructuredGridDialog.cpp
+++ b/Applications/DataExplorer/DataView/CreateStructuredGridDialog.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   CreateStructuredGridDialog.cpp
+ * \file
  * \author Karsten Rink
  * \date   2016-02-04
  * \brief  Implementation of the CreateStructuredGridDialog class.

--- a/Applications/DataExplorer/DataView/CreateStructuredGridDialog.h
+++ b/Applications/DataExplorer/DataView/CreateStructuredGridDialog.h
@@ -1,5 +1,5 @@
 /**
- * \file   CreateStructuredGridDialog.h
+ * \file
  * \author Karsten Rink
  * \date   2016-02-04
  * \brief  Definition of the CreateStructuredGridDialog class.

--- a/Applications/DataExplorer/DataView/DataExplorerSettingsDialog.cpp
+++ b/Applications/DataExplorer/DataView/DataExplorerSettingsDialog.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   DataExplorerSettingsDialog.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-02-05
  * \brief  Implementation of the DataExplorerSettingsDialog class.

--- a/Applications/DataExplorer/DataView/DataExplorerSettingsDialog.h
+++ b/Applications/DataExplorer/DataView/DataExplorerSettingsDialog.h
@@ -1,5 +1,5 @@
 /**
- * \file   DataExplorerSettingsDialog.h
+ * \file
  * \author Karsten Rink
  * \date   2014-02-05
  * \brief  Definition of the DataExplorerSettingsDialog class.

--- a/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
+++ b/Applications/DataExplorer/DataView/DiagramView/DiagramList.cpp
@@ -34,7 +34,9 @@ float DiagramList::calcMinXValue()
         _coords.begin(), _coords.end(),
         [](auto const& c0, auto const& c1) { return c0.first < c1.first; });
     if (min != _coords.end())
+    {
         return min->first;
+    }
     return std::numeric_limits<float>::max();
 }
 

--- a/Applications/DataExplorer/DataView/MeshAnalysisDialog.cpp
+++ b/Applications/DataExplorer/DataView/MeshAnalysisDialog.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   MeshAnalysisDialog.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-02-24
  * \brief  Implementation of the MeshAnalysisDialog class.

--- a/Applications/DataExplorer/DataView/MeshAnalysisDialog.h
+++ b/Applications/DataExplorer/DataView/MeshAnalysisDialog.h
@@ -1,5 +1,5 @@
 /**
- * \file   MeshAnalysisDialog.h
+ * \file
  * \author Karsten Rink
  * \date   2014-02-24
  * \brief  Definition of the MeshAnalysisDialog class.

--- a/Applications/DataExplorer/DataView/SaveMeshDialog.cpp
+++ b/Applications/DataExplorer/DataView/SaveMeshDialog.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   SaveMeshDialog.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-10-27
  * \brief  Implementation of the SaveMeshDialog class.

--- a/Applications/DataExplorer/DataView/SaveMeshDialog.h
+++ b/Applications/DataExplorer/DataView/SaveMeshDialog.h
@@ -1,5 +1,5 @@
 /**
- * \file   SaveMeshDialog.h
+ * \file
  * \author Karsten Rink
  * \date   2014-10-27
  * \brief  Definition of the SaveMeshDialog class.

--- a/Applications/DataExplorer/DataView/SurfaceExtractionDialog.cpp
+++ b/Applications/DataExplorer/DataView/SurfaceExtractionDialog.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   SurfaceExtractionDialog.cpp
+ * \file
  * \author Karsten Rink
  * \date   2015-01-29
  * \brief  Implementation of the SaveMeshDialog class.

--- a/Applications/DataExplorer/DataView/SurfaceExtractionDialog.h
+++ b/Applications/DataExplorer/DataView/SurfaceExtractionDialog.h
@@ -1,5 +1,5 @@
 /**
- * \file   SurfaceExtractionDialog.h
+ * \file
  * \author Karsten Rink
  * \date   2015-01-29
  * \brief  Definition of the SurfaceExtractionDialog class.

--- a/Applications/FileIO/GMSInterface.cpp
+++ b/Applications/FileIO/GMSInterface.cpp
@@ -50,7 +50,6 @@ int GMSInterface::readBoreholesFromGMS(std::vector<GeoLib::Point*>* boreholes,
     std::string cName;
     std::string sName;
     std::list<std::string>::const_iterator it;
-    auto* pnt = new GeoLib::Point();
     GeoLib::StationBorehole* newBorehole = nullptr;
 
     /* skipping first line because it contains field names */
@@ -59,6 +58,7 @@ int GMSInterface::readBoreholesFromGMS(std::vector<GeoLib::Point*>* boreholes,
     /* read all stations */
     while (std::getline(in, line))
     {
+        std::array<double, 3> pnt;
         std::list<std::string> fields = BaseLib::splitString(line, '\t');
 
         if (fields.size() >= 5)
@@ -66,19 +66,18 @@ int GMSInterface::readBoreholesFromGMS(std::vector<GeoLib::Point*>* boreholes,
             if (*fields.begin() == cName)  // add new layer
             {
                 it = fields.begin();
-                (*pnt)[0] = strtod((++it)->c_str(), nullptr);
-                (*pnt)[1] = strtod((++it)->c_str(), nullptr);
-                (*pnt)[2] = strtod((++it)->c_str(), nullptr);
+                pnt[0] = strtod((++it)->c_str(), nullptr);
+                pnt[1] = strtod((++it)->c_str(), nullptr);
+                pnt[2] = strtod((++it)->c_str(), nullptr);
 
                 // check if current layer has a thickness of 0.0.
                 // if so skip it since it will mess with the vtk-visualisation
                 // later on!
-                if ((*pnt)[2] != depth)
+                if (pnt[2] != depth)
                 {
-                    newBorehole->addSoilLayer(
-                        (*pnt)[0], (*pnt)[1], (*pnt)[2], sName);
+                    newBorehole->addSoilLayer(pnt[0], pnt[1], pnt[2], sName);
                     sName = (*(++it));
-                    depth = (*pnt)[2];
+                    depth = pnt[2];
                 }
                 else
                     WARN(
@@ -95,13 +94,13 @@ int GMSInterface::readBoreholesFromGMS(std::vector<GeoLib::Point*>* boreholes,
                 }
                 cName = *fields.begin();
                 it = fields.begin();
-                (*pnt)[0] = strtod((++it)->c_str(), nullptr);
-                (*pnt)[1] = strtod((++it)->c_str(), nullptr);
-                (*pnt)[2] = strtod((++it)->c_str(), nullptr);
+                pnt[0] = strtod((++it)->c_str(), nullptr);
+                pnt[1] = strtod((++it)->c_str(), nullptr);
+                pnt[2] = strtod((++it)->c_str(), nullptr);
                 sName = (*(++it));
                 newBorehole = GeoLib::StationBorehole::createStation(
-                    cName, (*pnt)[0], (*pnt)[1], (*pnt)[2], 0);
-                depth = (*pnt)[2];
+                    cName, pnt[0], pnt[1], pnt[2], 0);
+                depth = pnt[2];
             }
         }
         else

--- a/Applications/FileIO/GMSInterface.cpp
+++ b/Applications/FileIO/GMSInterface.cpp
@@ -75,6 +75,8 @@ int GMSInterface::readBoreholesFromGMS(std::vector<GeoLib::Point*>* boreholes,
                 // later on!
                 if (pnt[2] != depth)
                 {
+                    if (newBorehole == nullptr)
+                        OGS_FATAL("Trying to access a nullptr.");
                     newBorehole->addSoilLayer(
                         pnt[0], pnt[1], pnt[2], sName);
                     sName = (*(++it));

--- a/Applications/FileIO/GMSInterface.cpp
+++ b/Applications/FileIO/GMSInterface.cpp
@@ -32,6 +32,17 @@
 #include "MeshLib/MeshEnums.h"
 #include "MeshLib/Node.h"
 
+namespace
+{
+template <typename It>
+std::array<double, 3> parsePointCoordinates(It& it)
+{
+    return {std::strtod((++it)->c_str(), nullptr),
+            std::strtod((++it)->c_str(), nullptr),
+            std::strtod((++it)->c_str(), nullptr)};
+}
+}  // namespace
+
 namespace FileIO
 {
 int GMSInterface::readBoreholesFromGMS(std::vector<GeoLib::Point*>* boreholes,
@@ -58,7 +69,6 @@ int GMSInterface::readBoreholesFromGMS(std::vector<GeoLib::Point*>* boreholes,
     /* read all stations */
     while (std::getline(in, line))
     {
-        std::array<double, 3> pnt;
         std::list<std::string> fields = BaseLib::splitString(line, '\t');
 
         if (fields.size() >= 5)
@@ -66,9 +76,7 @@ int GMSInterface::readBoreholesFromGMS(std::vector<GeoLib::Point*>* boreholes,
             if (*fields.begin() == cName)  // add new layer
             {
                 it = fields.begin();
-                pnt[0] = strtod((++it)->c_str(), nullptr);
-                pnt[1] = strtod((++it)->c_str(), nullptr);
-                pnt[2] = strtod((++it)->c_str(), nullptr);
+                auto const pnt = parsePointCoordinates(it);
 
                 // check if current layer has a thickness of 0.0.
                 // if so skip it since it will mess with the vtk-visualisation
@@ -97,9 +105,7 @@ int GMSInterface::readBoreholesFromGMS(std::vector<GeoLib::Point*>* boreholes,
                 }
                 cName = *fields.begin();
                 it = fields.begin();
-                pnt[0] = strtod((++it)->c_str(), nullptr);
-                pnt[1] = strtod((++it)->c_str(), nullptr);
-                pnt[2] = strtod((++it)->c_str(), nullptr);
+                auto const pnt = parsePointCoordinates(it);
                 sName = (*(++it));
                 newBorehole = GeoLib::StationBorehole::createStation(
                     cName, pnt[0], pnt[1], pnt[2], 0);

--- a/Applications/FileIO/GMSInterface.cpp
+++ b/Applications/FileIO/GMSInterface.cpp
@@ -75,7 +75,8 @@ int GMSInterface::readBoreholesFromGMS(std::vector<GeoLib::Point*>* boreholes,
                 // later on!
                 if (pnt[2] != depth)
                 {
-                    newBorehole->addSoilLayer(pnt[0], pnt[1], pnt[2], sName);
+                    newBorehole->addSoilLayer(
+                        pnt[0], pnt[1], pnt[2], sName);
                     sName = (*(++it));
                     depth = pnt[2];
                 }

--- a/Applications/FileIO/GocadIO/GocadAsciiReader.cpp
+++ b/Applications/FileIO/GocadIO/GocadAsciiReader.cpp
@@ -537,7 +537,9 @@ MeshLib::Mesh* createMesh(std::ifstream& in, DataType type,
     return_val = parser(in, nodes, elems, node_id_map, mesh_prop);
 
     if (return_val)
+    {
         return new MeshLib::Mesh(mesh_name, nodes, elems, mesh_prop);
+    }
     ERR("Error parsing %s %s.", dataType2ShortString(type).c_str(),
         mesh_name.c_str());
     clearData(nodes, elems);

--- a/Applications/FileIO/GocadIO/GocadAsciiReader.cpp
+++ b/Applications/FileIO/GocadIO/GocadAsciiReader.cpp
@@ -116,23 +116,20 @@ DataType datasetFound(std::ifstream& in)
         {
             return DataType::VSET;
         }
-        else if (isKeyword(DataType::PLINE, line))
+        if (isKeyword(DataType::PLINE, line))
         {
             return DataType::PLINE;
         }
-        else if (isKeyword(DataType::TSURF, line))
+        if (isKeyword(DataType::TSURF, line))
         {
             return DataType::TSURF;
         }
-        else if (isKeyword(DataType::MODEL3D, line))
+        if (isKeyword(DataType::MODEL3D, line))
         {
             return DataType::MODEL3D;
         }
-        else
-        {
-            ERR("No known identifier found...");
-            return DataType::UNDEFINED;
-        }
+        ERR("No known identifier found...");
+        return DataType::UNDEFINED;
     }
     return DataType::UNDEFINED;
 }
@@ -274,7 +271,7 @@ bool parseNodes(std::ifstream& in,
             return true;
         }
 
-        else if (line.substr(0, 4) == "TRGL")
+        if (line.substr(0, 4) == "TRGL")
         {
             in.seekg(pos);
             return true;

--- a/Applications/FileIO/TetGenInterface.cpp
+++ b/Applications/FileIO/TetGenInterface.cpp
@@ -384,10 +384,11 @@ bool TetGenInterface::parseNodes(std::ifstream &ins,
     return true;
 }
 
-bool TetGenInterface::readElementsFromStream(std::ifstream &ins,
-                                             std::vector<MeshLib::Element*> &elements,
-                                             std::vector<int> &materials,
-                                             const std::vector<MeshLib::Node*> &nodes) const
+bool TetGenInterface::readElementsFromStream(
+    std::ifstream& ins,
+    std::vector<MeshLib::Element*>& elements,
+    std::vector<int>& materials,
+    const std::vector<MeshLib::Node*>& nodes) const
 {
     std::string line;
     std::getline(ins, line);
@@ -398,7 +399,7 @@ bool TetGenInterface::readElementsFromStream(std::ifstream &ins,
     while (!ins.fail())
     {
         BaseLib::simplify(line);
-        if (line.empty() || line.compare(0,1,"#") == 0)
+        if (line.empty() || line.compare(0, 1, "#") == 0)
         {
             // this line is a comment - skip
             std::getline(ins, line);
@@ -406,7 +407,8 @@ bool TetGenInterface::readElementsFromStream(std::ifstream &ins,
         }
 
         // read header line
-        bool header_okay = parseElementsFileHeader(line, n_tets, n_nodes_per_tet, region_attributes);
+        bool header_okay = parseElementsFileHeader(
+            line, n_tets, n_nodes_per_tet, region_attributes);
         if (!header_okay)
         {
             return false;

--- a/Applications/FileIO/TetGenInterface.cpp
+++ b/Applications/FileIO/TetGenInterface.cpp
@@ -329,7 +329,7 @@ bool TetGenInterface::parseNodes(std::ifstream &ins,
     while (k < n_nodes && !ins.fail())
     {
         std::vector<double> coordinates(dim);
-        getline(ins, line);
+        std::getline(ins, line);
         if (ins.fail())
         {
             ERR("TetGenInterface::parseNodes(): Error reading node %d.", k);
@@ -390,7 +390,7 @@ bool TetGenInterface::readElementsFromStream(std::ifstream &ins,
                                              const std::vector<MeshLib::Node*> &nodes) const
 {
     std::string line;
-    getline (ins, line);
+    std::getline(ins, line);
     std::size_t n_tets;
     std::size_t n_nodes_per_tet;
     bool region_attributes;
@@ -401,7 +401,7 @@ bool TetGenInterface::readElementsFromStream(std::ifstream &ins,
         if (line.empty() || line.compare(0,1,"#") == 0)
         {
             // this line is a comment - skip
-            getline (ins, line);
+            std::getline(ins, line);
             continue;
         }
 

--- a/Applications/FileIO/TetGenInterface.cpp
+++ b/Applications/FileIO/TetGenInterface.cpp
@@ -323,12 +323,12 @@ bool TetGenInterface::parseNodes(std::ifstream &ins,
                                  std::size_t dim)
 {
     std::string line;
-    auto* coordinates(new double[dim]);
     nodes.reserve(n_nodes);
 
     std::size_t k(0);
     while (k < n_nodes && !ins.fail())
     {
+        std::vector<double> coordinates(dim);
         getline(ins, line);
         if (ins.fail())
         {
@@ -354,7 +354,6 @@ bool TetGenInterface::parseNodes(std::ifstream &ins,
             }
         } else {
             ERR("TetGenInterface::parseNodes(): Error reading ID of node %d.", k);
-            delete [] coordinates;
             return false;
         }
         // read coordinates
@@ -373,17 +372,15 @@ bool TetGenInterface::parseNodes(std::ifstream &ins,
             else
             {
                 ERR("TetGenInterface::parseNodes(): error reading coordinate %d of node %d.", i, k);
-                delete [] coordinates;
                 return false;
             }
         }
 
-        nodes.push_back(new MeshLib::Node(coordinates, id-offset));
+        nodes.push_back(new MeshLib::Node(coordinates.data(), id-offset));
         // read attributes and boundary markers ... - at the moment we do not use this information
         ++k;
     }
 
-    delete [] coordinates;
     return true;
 }
 

--- a/Applications/FileIO/XmlIO/Qt/XmlNumInterface.cpp
+++ b/Applications/FileIO/XmlIO/Qt/XmlNumInterface.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   XmlNumInterface.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-08-05
  * \brief  Implementation of the XmlNumInterface class.

--- a/Applications/FileIO/XmlIO/Qt/XmlNumInterface.h
+++ b/Applications/FileIO/XmlIO/Qt/XmlNumInterface.h
@@ -1,5 +1,5 @@
 /**
- * \file   XmlNumInterface.h
+ * \file
  * \author Karsten Rink
  * \date   2014-08-05
  * \brief  Definition of the XmlNumInterface class.

--- a/Applications/Utils/FileConverter/GocadTSurfaceReader.cpp
+++ b/Applications/Utils/FileConverter/GocadTSurfaceReader.cpp
@@ -74,9 +74,13 @@ int main(int argc, char* argv[])
 
     FileIO::Gocad::DataType t(FileIO::Gocad::DataType::ALL);
     if (export_lines_arg.isSet())
+    {
         t = FileIO::Gocad::DataType::PLINE;
+    }
     if (export_surfaces_arg.isSet())
+    {
         t = FileIO::Gocad::DataType::TSURF;
+    }
     std::vector<std::unique_ptr<MeshLib::Mesh>> meshes;
     if (!FileIO::Gocad::GocadAsciiReader::readFile(file_name, meshes, t))
     {
@@ -90,7 +94,9 @@ int main(int argc, char* argv[])
     for (auto& mesh : meshes)
     {
         if (mesh == nullptr)
+        {
             continue;
+        }
         INFO("Writing mesh \"%s\"", mesh->getName().c_str());
         int data_mode = (write_binary) ? 2 : 0;
         bool compressed = (write_binary);

--- a/Applications/Utils/FileConverter/Mesh2Shape.cpp
+++ b/Applications/Utils/FileConverter/Mesh2Shape.cpp
@@ -46,6 +46,8 @@ int main(int argc, char* argv[])
     std::unique_ptr<MeshLib::Mesh> const mesh(
         MeshLib::IO::readMeshFromFile(file_name));
     if (FileIO::SHPInterface::write2dMeshToSHP(output_arg.getValue(), *mesh))
+    {
         return EXIT_SUCCESS;
+    }
     return EXIT_FAILURE;
 }

--- a/Applications/Utils/GeoTools/MoveGeometry.cpp
+++ b/Applications/Utils/GeoTools/MoveGeometry.cpp
@@ -1,5 +1,5 @@
 /**
- * \file MoveGeometry.cpp
+ * \file
  * \author Karsten Rink
  * \date   2015-08-04
  * \brief  A small tool to translate geometries.

--- a/Applications/Utils/GeoTools/TriangulatePolyline.cpp
+++ b/Applications/Utils/GeoTools/TriangulatePolyline.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   TriangulatePolyline.cpp
+ * \file
  * \author Karsten Rink
  * \date   2015-02-02
  * \brief  Utility for triangulating polylines.

--- a/Applications/Utils/MeshEdit/NodeReordering.cpp
+++ b/Applications/Utils/MeshEdit/NodeReordering.cpp
@@ -1,5 +1,5 @@
 /**
- * \file NodeReordering.cpp
+ * \file
  * 2013/13/06 KR Initial implementation
  *
  * @copyright

--- a/Applications/Utils/MeshEdit/moveMeshNodes.cpp
+++ b/Applications/Utils/MeshEdit/moveMeshNodes.cpp
@@ -1,5 +1,5 @@
 /**
- * \file moveMeshNodes.cpp
+ * \file
  * 2012/03/07 KR Initial implementation
  *
  * \copyright

--- a/Applications/Utils/MeshGeoTools/createIntermediateRasters.cpp
+++ b/Applications/Utils/MeshGeoTools/createIntermediateRasters.cpp
@@ -56,7 +56,9 @@ int main(int argc, char* argv[])
         FileIO::AsciiRasterInterface::readRaster(input2_arg.getValue()));
 
     if (dem1 == nullptr || dem2 == nullptr)
+    {
         return 1;
+    }
 
     GeoLib::RasterHeader const& h1 = dem1->getHeader();
     GeoLib::RasterHeader const& h2 = dem2->getHeader();
@@ -89,7 +91,9 @@ int main(int argc, char* argv[])
     }
 
     if (errors_found)
+    {
         return 2;
+    }
 
     std::size_t const n = number_arg.getValue();
     std::vector<std::vector<double>> raster;
@@ -111,7 +115,9 @@ int main(int argc, char* argv[])
         if (*it1 == h1.no_data || *it2 == h2.no_data)
         {
             for (std::size_t i = 0; i < n; ++i)
+            {
                 raster[i].push_back(h1.no_data);
+            }
         }
         else
         {
@@ -119,7 +125,9 @@ int main(int argc, char* argv[])
             double const max = std::max(*it1, *it2);
             double const step = (max - min) / static_cast<double>(n + 1);
             for (std::size_t i = 0; i < n; ++i)
+            {
                 raster[i].push_back(min + ((i+1) * step));
+            }
         }
         it2++;
     }

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.cpp
@@ -1,5 +1,5 @@
 /*!
-  \file NodeWiseMeshPartitioner.cpp
+  \file
   \date   2016.05
 
   \brief  Define the members of class NodeWiseMeshPartitioner

--- a/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/NodeWiseMeshPartitioner.h
@@ -1,5 +1,5 @@
 /*!
-  \file NodeWiseMeshPartitioner.h
+  \file
   \date   2016.05
 
   \brief  Declare a class to perform node wise mesh partitioning

--- a/Applications/Utils/ModelPreparation/PartitionMesh/PartitionMesh.cpp
+++ b/Applications/Utils/ModelPreparation/PartitionMesh/PartitionMesh.cpp
@@ -1,5 +1,5 @@
 /*!
-  \file PartitionMesh.cpp
+  \file
   \date   2016.05
 
   \brief  A tool for mesh partitioning.

--- a/Applications/Utils/OGSFileConverter/FileListDialog.cpp
+++ b/Applications/Utils/OGSFileConverter/FileListDialog.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   FileListDialog.cpp
+ * \file
  * \author Karsten Rink
  * \date   2012-04-04
  * \brief  Implementation of FileListDialog class.

--- a/Applications/Utils/OGSFileConverter/FileListDialog.h
+++ b/Applications/Utils/OGSFileConverter/FileListDialog.h
@@ -1,5 +1,5 @@
 /**
- * \file   FileListDialog.h
+ * \file
  * \author Karsten Rink
  * \date   2012-04-04
  * \brief  Definition of FileListDialog class.

--- a/Applications/Utils/OGSFileConverter/OGSFileConverter.cpp
+++ b/Applications/Utils/OGSFileConverter/OGSFileConverter.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   OGSFileConverter.cpp
+ * \file
  * \author Karsten Rink
  * \date   2012-04-04
  * \brief  Implementation of OGSFileConverter class.

--- a/Applications/Utils/OGSFileConverter/OGSFileConverter.h
+++ b/Applications/Utils/OGSFileConverter/OGSFileConverter.h
@@ -1,5 +1,5 @@
 /**
- * \file   OGSFileConverter.h
+ * \file
  * \author Karsten Rink
  * \date   2012-04-04
  * \brief  Definition of OGSFileConverter class.

--- a/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   BoostXmlGmlInterface.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-01-31
  * \brief  Implementation of the BoostXmlGmlInterface class.

--- a/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.h
+++ b/GeoLib/IO/XmlIO/Boost/BoostXmlGmlInterface.h
@@ -1,5 +1,5 @@
 /**
- * \file   BoostXmlGmlInterface.h
+ * \file
  * \author Karsten Rink
  * \date   2014-01-31
  * \brief  Definition of the BoostXmlGmlInterface class.

--- a/GeoLib/MinimalBoundingSphere.cpp
+++ b/GeoLib/MinimalBoundingSphere.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   MinimalBoundingSphere.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-07-11
  * \brief  Calculation of a minimum bounding sphere for a vector of points.

--- a/GeoLib/MinimalBoundingSphere.h
+++ b/GeoLib/MinimalBoundingSphere.h
@@ -1,5 +1,5 @@
 /**
- * \file   MinimalBoundingSphere.h
+ * \file
  * \author Karsten Rink
  * \date   2014-07-11
  * \brief  Calculation of a minimum bounding sphere for a vector of points

--- a/GeoLib/SensorData.cpp
+++ b/GeoLib/SensorData.cpp
@@ -103,7 +103,7 @@ int SensorData::readDataFromFile(const std::string &file_name)
     std::string line;
 
     /* first line contains field names */
-    getline(in, line);
+    std::getline(in, line);
     std::list<std::string> fields = BaseLib::splitString(line, '\t');
     std::list<std::string>::const_iterator it (fields.begin());
     std::size_t nFields = fields.size();
@@ -124,7 +124,7 @@ int SensorData::readDataFromFile(const std::string &file_name)
         this->_data_vecs.push_back(data);
     }
 
-    while ( getline(in, line) )
+    while (std::getline(in, line))
     {
         fields = BaseLib::splitString(line, '\t');
 

--- a/GeoLib/Station.cpp
+++ b/GeoLib/Station.cpp
@@ -70,14 +70,10 @@ Station* Station::createStation(const std::string & line)
     return station;
 }
 
-Station* Station::createStation(const std::string &name, double x, double y, double z)
+Station* Station::createStation(const std::string& name, double x, double y,
+                                double z)
 {
-    Station* station = new Station();
-    station->_name = name;
-    (*station)[0] = x;
-    (*station)[1] = y;
-    (*station)[2] = z;
-    return station;
+    return new Station(x, y, z, name);
 }
 
 bool isStation(GeoLib::Point const* pnt)

--- a/GeoLib/StationBorehole.cpp
+++ b/GeoLib/StationBorehole.cpp
@@ -66,7 +66,7 @@ int StationBorehole::readStratigraphyFile(const std::string &path,
         return 0;
     }
 
-    while ( getline(in, line) )
+    while (std::getline(in, line))
     {
         std::list<std::string> fields = BaseLib::splitString(line, '\t');
         data.push_back(fields);

--- a/MaterialLib/Fluid/ConstantFluidProperty.h
+++ b/MaterialLib/Fluid/ConstantFluidProperty.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file:   ConstantFluidProperty.h
+ * \file
  *
  * Created on August 15, 2016, 12:11 PM
  */

--- a/MaterialLib/Fluid/Density/CreateFluidDensityModel.cpp
+++ b/MaterialLib/Fluid/Density/CreateFluidDensityModel.cpp
@@ -1,5 +1,5 @@
 /*!
-   \file  CreateFluidDensityModel.cpp
+   \file
    \brief create an instance of a fluid density class.
 
    \copyright

--- a/MaterialLib/Fluid/Density/CreateFluidDensityModel.h
+++ b/MaterialLib/Fluid/Density/CreateFluidDensityModel.h
@@ -1,5 +1,5 @@
 /*!
-   \file  CreateFluidDensityModel.h
+   \file
    \brief create an instance of a fluid density class.
 
    \copyright

--- a/MaterialLib/Fluid/Density/IdealGasLaw.h
+++ b/MaterialLib/Fluid/Density/IdealGasLaw.h
@@ -1,5 +1,5 @@
 /*!
-   \file  IdealGasLaw.h
+   \file
    \brief Declaration of class IdealGasLow for fluid density by the ideal gas
           law depending on one variable linearly.
 

--- a/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
+++ b/MaterialLib/Fluid/Density/LinearTemperatureDependentDensity.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file:   LinearTemperatureDependentDensity.h
+ * \file
  * \author: wenqing
  *
  * Created on August 10, 2016, 11:34 AM

--- a/MaterialLib/Fluid/Density/LiquidDensity.h
+++ b/MaterialLib/Fluid/Density/LiquidDensity.h
@@ -6,7 +6,7 @@
  *              http://www.opengeosys.org/project/license
  *
  * \author wenqing
- * \file   LiquidDensity.h
+ * \file
  *
  * Created on August 4, 2016, 10:15 AM
  */

--- a/MaterialLib/Fluid/Density/WaterDensityIAPWSIF97Region1.h
+++ b/MaterialLib/Fluid/Density/WaterDensityIAPWSIF97Region1.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   WaterDensityIAPWSIF97Region1.h
+ * \file
  *
  * Created on December 8, 2016, 4:19 PM
  */

--- a/MaterialLib/Fluid/FluidProperties/CreateFluidProperties.cpp
+++ b/MaterialLib/Fluid/FluidProperties/CreateFluidProperties.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateFluidProperties.cpp
+ *  \file
  *
  * Created on December 13, 2016, 3:32 PM
  */

--- a/MaterialLib/Fluid/FluidProperties/CreateFluidProperties.h
+++ b/MaterialLib/Fluid/FluidProperties/CreateFluidProperties.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateFluidProperties.h
+ *  \file
  *
  * Created on December 13, 2016, 3:32 PM
  */

--- a/MaterialLib/Fluid/FluidProperties/FluidProperties.h
+++ b/MaterialLib/Fluid/FluidProperties/FluidProperties.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   FluidProperties.h
+ * \file
  *
  * Created on November 29, 2016, 2:23 PM
  */

--- a/MaterialLib/Fluid/FluidProperties/FluidPropertiesWithDensityDependentModels.cpp
+++ b/MaterialLib/Fluid/FluidProperties/FluidPropertiesWithDensityDependentModels.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   FluidPropertiesWithDensityDependentModels.cpp
+ * \file
  *
  * Created on November 29, 2016, 3:19 PM
  */

--- a/MaterialLib/Fluid/FluidProperties/FluidPropertiesWithDensityDependentModels.h
+++ b/MaterialLib/Fluid/FluidProperties/FluidPropertiesWithDensityDependentModels.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   FluidPropertiesWithDensityDependentModels.h
+ * \file
  *
  * Created on November 29, 2016, 4:18 PM
  */

--- a/MaterialLib/Fluid/FluidProperties/PrimaryVariableDependentFluidProperties.h
+++ b/MaterialLib/Fluid/FluidProperties/PrimaryVariableDependentFluidProperties.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   PrimaryVariableDependentFluidProperties.h
+ * \file
  *
  * Created on November 29, 2016, 3:19 PM
  */

--- a/MaterialLib/Fluid/FluidProperty.h
+++ b/MaterialLib/Fluid/FluidProperty.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file:   FluidProperty.h
+ * \file
  *
  * Created on August 12, 2016, 3:34 PM
  */

--- a/MaterialLib/Fluid/FluidType/FluidType.cpp
+++ b/MaterialLib/Fluid/FluidType/FluidType.cpp
@@ -17,11 +17,17 @@ namespace FluidType
 Fluid_Type strToFluidType(std::string const& s)
 {
     if (s == "incompressible_fluid")
+    {
         return Fluid_Type::INCOMPRESSIBLE_FLUID;
+    }
     if (s == "compressible_fluid")
+    {
         return Fluid_Type::COMPRESSIBLE_FLUID;
+    }
     if (s == "ideal_gas")
+    {
         return Fluid_Type::IDEAL_GAS;
+    }
     OGS_FATAL("This fluid type is unavailable. The available types are \n"
                "incompressible_fluid, compressible_fluid and ideal_gas.\n");
 }

--- a/MaterialLib/Fluid/FluidType/FluidType.h
+++ b/MaterialLib/Fluid/FluidType/FluidType.h
@@ -13,7 +13,6 @@
 
 namespace FluidType
 {
-
 enum class Fluid_Type
 {
     INCOMPRESSIBLE_FLUID,
@@ -30,4 +29,4 @@ bool checkRequiredParams(Fluid_Type const& f_type,
 
 const char* getErrorMsg(Fluid_Type const& f_type);
 
-}  // namespace FluidTypeLib
+}  // namespace FluidType

--- a/MaterialLib/Fluid/GibbsFreeEnergy/DimensionLessGibbsFreeEnergyRegion1.cpp
+++ b/MaterialLib/Fluid/GibbsFreeEnergy/DimensionLessGibbsFreeEnergyRegion1.cpp
@@ -7,7 +7,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   DimensionLessGibbsFreeEnergyRegion1.cpp
+ *  \file
  *
  * Created on December 8, 2016, 12:31 PM
  */

--- a/MaterialLib/Fluid/GibbsFreeEnergy/DimensionLessGibbsFreeEnergyRegion1.h
+++ b/MaterialLib/Fluid/GibbsFreeEnergy/DimensionLessGibbsFreeEnergyRegion1.h
@@ -7,7 +7,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   DimensionLessGibbsFreeEnergyRegion1.h
+ *  \file
  *
  * Created on December 8, 2016, 12:31 PM
  */

--- a/MaterialLib/Fluid/PropertyVariableType.h
+++ b/MaterialLib/Fluid/PropertyVariableType.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   PropertyVariableType.h
+ * \file
  *
  * Created on November 29, 2016, 2:28 PM
  */

--- a/MaterialLib/Fluid/SpecificHeatCapacity/CreateSpecificFluidHeatCapacityModel.cpp
+++ b/MaterialLib/Fluid/SpecificHeatCapacity/CreateSpecificFluidHeatCapacityModel.cpp
@@ -7,7 +7,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *   \file CreateSpecificFluidHeatCapacityModel.cpp
+ *   \file
  *
  */
 

--- a/MaterialLib/Fluid/SpecificHeatCapacity/CreateSpecificFluidHeatCapacityModel.h
+++ b/MaterialLib/Fluid/SpecificHeatCapacity/CreateSpecificFluidHeatCapacityModel.h
@@ -7,7 +7,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *   \file CreateSpecificFluidHeatCapacityModel.h
+ *   \file
  *
  */
 

--- a/MaterialLib/Fluid/ThermalConductivity/CreateFluidThermalConductivityModel.cpp
+++ b/MaterialLib/Fluid/ThermalConductivity/CreateFluidThermalConductivityModel.cpp
@@ -7,7 +7,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *   \file CreateFluidThermalConductivityModel.cpp
+ *   \file
  *
  */
 

--- a/MaterialLib/Fluid/ThermalConductivity/CreateFluidThermalConductivityModel.h
+++ b/MaterialLib/Fluid/ThermalConductivity/CreateFluidThermalConductivityModel.h
@@ -7,7 +7,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *   \file CreateFluidThermalConductivityModel.h
+ *   \file
  *
  */
 

--- a/MaterialLib/Fluid/Viscosity/CreateViscosityModel.cpp
+++ b/MaterialLib/Fluid/Viscosity/CreateViscosityModel.cpp
@@ -7,7 +7,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *   \file  CreateViscosityModel.cpp
+ *   \file
  *
  */
 

--- a/MaterialLib/Fluid/Viscosity/CreateViscosityModel.h
+++ b/MaterialLib/Fluid/Viscosity/CreateViscosityModel.h
@@ -7,7 +7,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *   \file  CreateViscosityModel.h
+ *   \file
  *
  */
 

--- a/MaterialLib/Fluid/Viscosity/LinearPressureDependentViscosity.h
+++ b/MaterialLib/Fluid/Viscosity/LinearPressureDependentViscosity.h
@@ -7,7 +7,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *   \file  LinearPressureDependentViscosity.h
+ *   \file
  */
 #pragma once
 

--- a/MaterialLib/Fluid/Viscosity/TemperatureDependentViscosity.h
+++ b/MaterialLib/Fluid/Viscosity/TemperatureDependentViscosity.h
@@ -7,7 +7,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file:   TemperatureDependentViscosity.h
+ * \file
  *
  *  Created on August 10, 2016, 10:45 AM
  */

--- a/MaterialLib/Fluid/Viscosity/VogelsLiquidDynamicViscosity.h
+++ b/MaterialLib/Fluid/Viscosity/VogelsLiquidDynamicViscosity.h
@@ -7,7 +7,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file  VogelsLiquidDynamicViscosity.h
+ *  \file
  *
  */
 

--- a/MaterialLib/Fluid/Viscosity/WaterViscosityIAPWS.cpp
+++ b/MaterialLib/Fluid/Viscosity/WaterViscosityIAPWS.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   WaterViscosityIAPWS.cpp
+ * \file
  *
  * Created on December 1, 2016, 1:41 PM
  */

--- a/MaterialLib/Fluid/Viscosity/WaterViscosityIAPWS.h
+++ b/MaterialLib/Fluid/Viscosity/WaterViscosityIAPWS.h
@@ -9,7 +9,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   WaterViscosityIAPWS.h
+ * \file
  *
  * Created on December 1, 2016, 1:41 PM
  */

--- a/MaterialLib/Fluid/WaterVaporProperties/WaterVaporProperties.cpp
+++ b/MaterialLib/Fluid/WaterVaporProperties/WaterVaporProperties.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   WaterVaporProperties.cpp
+ * \file
  *
  */
 

--- a/MaterialLib/Fluid/WaterVaporProperties/WaterVaporProperties.h
+++ b/MaterialLib/Fluid/WaterVaporProperties/WaterVaporProperties.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file:   WaterVaporProperties.h
+ * \file
  */
 
 #pragma once

--- a/MaterialLib/PorousMedium/Permeability/createPermeabilityModel.cpp
+++ b/MaterialLib/PorousMedium/Permeability/createPermeabilityModel.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   createPermeabilityModel.cpp
+ * \file
  *
  * Created on August 17, 2016, 2:36 PM
  */

--- a/MaterialLib/PorousMedium/Permeability/createPermeabilityModel.h
+++ b/MaterialLib/PorousMedium/Permeability/createPermeabilityModel.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   createPermeabilityModel.h
+ * \file
  *
  * Created on August 17, 2016, 2:36 PM
  */

--- a/MaterialLib/PorousMedium/Porosity/Porosity.h
+++ b/MaterialLib/PorousMedium/Porosity/Porosity.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file:   Porosity.h
+ * \file
  *
  * Created on August 16, 2016, 12:53 PM
  */

--- a/MaterialLib/PorousMedium/Porosity/createPorosityModel.cpp
+++ b/MaterialLib/PorousMedium/Porosity/createPorosityModel.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file:   createPorosityModel.cpp
+ * \file
  *
  * Created on August 16, 2016, 1:16 PM
  */

--- a/MaterialLib/PorousMedium/Porosity/createPorosityModel.h
+++ b/MaterialLib/PorousMedium/Porosity/createPorosityModel.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file:   createPorosityModel.h
+ * \file
  *
  * Created on August 16, 2016, 1:16 PM
  */

--- a/MaterialLib/PorousMedium/Storage/ConstantStorage.h
+++ b/MaterialLib/PorousMedium/Storage/ConstantStorage.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   ConstantStorage.h
+ * \file
  *
  * Created on August 16, 2016, 1:03 PM
  */

--- a/MaterialLib/PorousMedium/Storage/Storage.h
+++ b/MaterialLib/PorousMedium/Storage/Storage.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file:   Storage.h
+ * \file
  *
  * Created on August 16, 2016, 12:53 PM
  */

--- a/MaterialLib/PorousMedium/Storage/createStorageModel.cpp
+++ b/MaterialLib/PorousMedium/Storage/createStorageModel.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file:   createStorageModel.cpp
+ * \file
  *
  * Created on August 16, 2016, 1:16 PM
  */

--- a/MaterialLib/PorousMedium/Storage/createStorageModel.h
+++ b/MaterialLib/PorousMedium/Storage/createStorageModel.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file:   createStorageModel.h
+ * \file
  *
  * Created on August 16, 2016, 1:16 PM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/BrooksCoreyCapillaryPressureSaturation.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/BrooksCoreyCapillaryPressureSaturation.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   BrooksCoreyCapillaryPressureSaturation.h
+ * \file
  *
  *  Created on November 1, 2016, 9:45 AM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturation.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturation.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file:   CapillaryPressureSaturation.h
+ * \file
  *
  */
 

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturationCurve.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CapillaryPressureSaturationCurve.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   CapillaryPressureSaturationCurve.h
+ * \file
  *
  * Created on November 3, 2016, 9:50 AM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CreateCapillaryPressureModel.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CreateCapillaryPressureModel.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   CreateCapillaryPressureModel.cpp
+ * \file
  *
  * Created on November 1, 2016, 10:06 AM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CreateCapillaryPressureModel.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/CreateCapillaryPressureModel.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   CreateCapillaryPressureModel.h
+ * \file
  *
  * Created on November 1, 2016, 10:06 AM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/VanGenuchtenCapillaryPressureSaturation.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/VanGenuchtenCapillaryPressureSaturation.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   VanGenuchtenCapillaryPressureSaturation.cpp
+ * \file
  *
  *  Created on October 28, 2016, 6:05 PM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/VanGenuchtenCapillaryPressureSaturation.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/CapillaryPressure/VanGenuchtenCapillaryPressureSaturation.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   VanGenuchtenCapillaryPressureSaturation.h
+ * \file
  *
  *  Created on October 28, 2016, 6:05 PM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/CreateRelativePermeabilityModel.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/CreateRelativePermeabilityModel.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   CreateRelativePermeabilityModel.cpp
+ * \file
  *
  * Created on November 2, 2016, 11:43 AM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/CreateRelativePermeabilityModel.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/CreateRelativePermeabilityModel.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   CreateRelativePermeabilityModel.h
+ * \file
  *
  * Created on November 2, 2016, 11:43 AM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/NonWettingPhaseBrooksCoreyOilGas.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/NonWettingPhaseBrooksCoreyOilGas.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   NonWettingPhaseBrooksCoreyOilGas.cpp
+ * \file
  *
  * Created on November 2, 2016, 10:47 AM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/NonWettingPhaseBrooksCoreyOilGas.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/NonWettingPhaseBrooksCoreyOilGas.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   NonWettingPhaseBrooksCoreyOilGas.h
+ * \file
  *
  * Created on November 2, 2016, 10:47 AM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/NonWettingPhaseVanGenuchten.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/NonWettingPhaseVanGenuchten.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   NonWettingPhaseVanGenuchten.cpp
+ * \file
  *
  * Created on November 2, 2016, 11:24 AM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/NonWettingPhaseVanGenuchten.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/NonWettingPhaseVanGenuchten.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   NonWettingPhaseVanGenuchten.h
+ * \file
  *
  * Created on November 2, 2016, 11:24 AM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/RelativePermeability.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/RelativePermeability.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file:   RelativePermeability.h
+ * \file
  *
  */
 

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/RelativePermeabilityCurve.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/RelativePermeabilityCurve.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   RelativePermeabilityCurve.h
+ *  \file
  *
  * Created on November 2, 2016, 1:41 PM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/WettingPhaseBrooksCoreyOilGas.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/WettingPhaseBrooksCoreyOilGas.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   WettingPhaseBrooksCoreyOilGas.cpp
+ * \file
  *
  * Created on November 1, 2016, 3:37 PM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/WettingPhaseBrooksCoreyOilGas.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/WettingPhaseBrooksCoreyOilGas.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   WettingPhaseBrooksCoreyOilGas.h
+ * \file
  *
  * Created on November 1, 2016, 3:37 PM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/WettingPhaseVanGenuchten.cpp
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/WettingPhaseVanGenuchten.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   WettingPhaseVanGenuchten.cpp
+ * \file
  *
  * Created on November 2, 2016, 11:24 AM
  */

--- a/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/WettingPhaseVanGenuchten.h
+++ b/MaterialLib/PorousMedium/UnsaturatedProperty/RelativePermeability/WettingPhaseVanGenuchten.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   WettingPhaseVanGenuchten.h
+ * \file
  *
  * Created on November 2, 2016, 11:24 AM
  */

--- a/MaterialLib/SolidModels/CreateConstitutiveRelation.cpp
+++ b/MaterialLib/SolidModels/CreateConstitutiveRelation.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateConstitutiveRelation.cpp
+ *  \file
  *  Created on July 10, 2018, 12:09 PM
  */
 

--- a/MaterialLib/SolidModels/CreateConstitutiveRelation.h
+++ b/MaterialLib/SolidModels/CreateConstitutiveRelation.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateConstitutiveRelation.h
+ *  \file
  *  Created on July 10, 2018, 12:09 PM
  */
 

--- a/MaterialLib/SolidModels/CreateCreepBGRa.cpp
+++ b/MaterialLib/SolidModels/CreateCreepBGRa.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateCreepBGRa.cpp
+ *  \file
  *  Created on July 11, 2018, 2:26 PM
  */
 

--- a/MaterialLib/SolidModels/CreateCreepBGRa.h
+++ b/MaterialLib/SolidModels/CreateCreepBGRa.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateCreepBGRa.h
+ *  \file
  *  Created on July 11, 2018, 2:26 PM
  */
 

--- a/MaterialLib/SolidModels/CreateNewtonRaphsonSolverParameters.cpp
+++ b/MaterialLib/SolidModels/CreateNewtonRaphsonSolverParameters.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateNewtonRaphsonSolverParameters.cpp
+ *  \file
  *  Created on July 10, 2018, 11:32 AM
  */
 

--- a/MaterialLib/SolidModels/CreateNewtonRaphsonSolverParameters.h
+++ b/MaterialLib/SolidModels/CreateNewtonRaphsonSolverParameters.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateNewtonRaphsonSolverParameters.h
+ *  \file
  *  Created on July 10, 2018, 11:32 AM
  */
 

--- a/MaterialLib/SolidModels/CreepBGRa.cpp
+++ b/MaterialLib/SolidModels/CreepBGRa.cpp
@@ -74,31 +74,26 @@ CreepBGRa<DisplacementDim>::integrateStress(
         dt * constant_coefficient *
         std::exp(-Q / (MaterialLib::PhysicalConstant::IdealGasConstant * T));
 
-    // In newton_solver.solve(), the Jacobian is calculated first, and then
-    // then comes the assembly of the residue vector. In order to save
-    // computation time, the following two variables are set visible in this
-    // function. The two variables keep the computation results of the
-    // norm of the deviatoric stress and 2bG||s_{n+1}||^{n-1} in
-    // update_jacobian, and then they are directly used in update_residual
-    // without repeating the computation. Of course, update_jacobian is not a
-    // pure function anymore, but has side effects.
-    double pow_norm_s_n1_n_minus_one_2b_G = 0.;
+    double const G2b = 2.0 * b * this->_mp.mu(t, x);
 
-    KelvinVector s_n1;
-    auto const update_jacobian = [&](JacobianMatrix& jacobian) {
-        // side effect
-        s_n1 = deviatoric_matrix * solution;
+    auto const update_jacobian = [&solution, &G2b, &n](JacobianMatrix& jacobian) {
+        auto const& D = Invariants::deviatoric_projection;
+        KelvinVector const s_n1 = D * solution;
         double const norm_s_n1 = Invariants::FrobeniusNorm(s_n1);
-        double const G2b = 2.0 * b * this->_mp.mu(t, x);
-        // side effect
-        pow_norm_s_n1_n_minus_one_2b_G = G2b * std::pow(norm_s_n1, n - 1);
+        double const pow_norm_s_n1_n_minus_one_2b_G =
+            G2b * std::pow(norm_s_n1, n - 1);
         jacobian = KelvinMatrix::Identity() +
-                   (pow_norm_s_n1_n_minus_one_2b_G * deviatoric_matrix +
+                   (pow_norm_s_n1_n_minus_one_2b_G * D +
                     (n - 1) * G2b * std::pow(norm_s_n1, n - 3) * s_n1 *
                         s_n1.transpose());
     };
 
-    auto const update_residual = [&](ResidualVectorType& r) {
+    auto const update_residual = [&solution, &G2b, &n,
+                                  &sigma_try](ResidualVectorType& r) {
+        KelvinVector const s_n1 = Invariants::deviatoric_projection * solution;
+        double const norm_s_n1 = Invariants::FrobeniusNorm(s_n1);
+        double const pow_norm_s_n1_n_minus_one_2b_G =
+            G2b * std::pow(norm_s_n1, n - 1);
         r = solution - sigma_try + pow_norm_s_n1_n_minus_one_2b_G * s_n1;
     };
 

--- a/MaterialLib/SolidModels/CreepBGRa.cpp
+++ b/MaterialLib/SolidModels/CreepBGRa.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreepBGRa.cpp
+ *  \file
  *  Created on July 6, 2018, 9:53 AM
  */
 

--- a/MaterialLib/SolidModels/CreepBGRa.h
+++ b/MaterialLib/SolidModels/CreepBGRa.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreepBGRa.h
+ *  \file
  *  Created on July 6, 2018, 9:53 AM
  */
 

--- a/MathLib/Curve/CreatePiecewiseLinearCurve-impl.h
+++ b/MathLib/Curve/CreatePiecewiseLinearCurve-impl.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   CreatePiecewiseLinearCurve-impl.h
+ * \file
  *
  * Created on November 11, 2016, 10:49 AM
  */

--- a/MathLib/Curve/CreatePiecewiseLinearCurve.h
+++ b/MathLib/Curve/CreatePiecewiseLinearCurve.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   CreatePiecewiseLinearCurve.h
+ * \file
  *
  * Created on November 11, 2016, 10:49 AM
  */

--- a/MathLib/Curve/PiecewiseLinearMonotonicCurve.cpp
+++ b/MathLib/Curve/PiecewiseLinearMonotonicCurve.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   PiecewiseLinearMonotonicCurve.cpp
+ * \file
  *
  * Created on November 11, 2016, 10:49 AM
  */

--- a/MathLib/Curve/PiecewiseLinearMonotonicCurve.h
+++ b/MathLib/Curve/PiecewiseLinearMonotonicCurve.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   PiecewiseLinearMonotonicCurve.h
+ * \file
  *
  * Created on November 11, 2016, 10:49 AM
  */

--- a/MathLib/LinAlg/FinalizeVectorAssembly.h
+++ b/MathLib/LinAlg/FinalizeVectorAssembly.h
@@ -1,5 +1,5 @@
 /**
- * \file FinalizeVectorAssembly.h
+ * \file
  * \author Wenqing Wang
  * \date Oct, 2013
  *

--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.cpp
@@ -1,5 +1,5 @@
 /*!
-   \file  PETScLinearSolver.cpp
+   \file
    \brief Definition of class PETScLinearSolver, which defines a solver object
          based on PETSc routines.
 

--- a/MathLib/LinAlg/PETSc/PETScLinearSolver.h
+++ b/MathLib/LinAlg/PETSc/PETScLinearSolver.h
@@ -1,5 +1,5 @@
 /*!
-   \file  PETScLinearSolver.h
+   \file
    \brief Declaration of class PETScLinearSolver, which defines a solver object
          based on PETSc routines.
 

--- a/MathLib/LinAlg/PETSc/PETScMatrix.cpp
+++ b/MathLib/LinAlg/PETSc/PETScMatrix.cpp
@@ -1,5 +1,5 @@
 /*!
-   \file  PETScMatrix.cpp
+   \file
    \brief Definition of member functions of class PETScMatrix, which provides an
    interface to
           PETSc matrix routines.

--- a/MathLib/LinAlg/PETSc/PETScMatrix.h
+++ b/MathLib/LinAlg/PETSc/PETScMatrix.h
@@ -1,5 +1,5 @@
 /*!
-   \file  PETScMatrix.h
+   \file
    \brief Declaration of class PETScMatrix, which provides an interface to
           PETSc matrix routines.
 

--- a/MathLib/LinAlg/PETSc/PETScMatrixOption.h
+++ b/MathLib/LinAlg/PETSc/PETScMatrixOption.h
@@ -1,5 +1,5 @@
 /*!
-   \file  PETScMatrixOption.h
+   \file
    \brief Define data for the configuration of PETSc matrix and linear solver.
 
    \author Wenqing Wang

--- a/MathLib/LinAlg/PETSc/PETScTools.cpp
+++ b/MathLib/LinAlg/PETSc/PETScTools.cpp
@@ -1,5 +1,5 @@
 /*!
-   \file  PETScTools.cpp
+   \file
    \brief Definition of a function related to PETSc solver interface to assign
          the Dirichlet boundary conditions.
 

--- a/MathLib/LinAlg/PETSc/PETScTools.h
+++ b/MathLib/LinAlg/PETSc/PETScTools.h
@@ -1,5 +1,5 @@
 /*!
-   \file  PETScTools.h
+   \file
    \brief Declaration of a function related to PETSc solver interface to assign
          the Dirichlet boundary conditions.
 

--- a/MathLib/LinAlg/PETSc/PETScVector.cpp
+++ b/MathLib/LinAlg/PETSc/PETScVector.cpp
@@ -1,5 +1,5 @@
 /**
- * \file  PETScVector.cpp
+ * \file
  * \brief Definition of member functions of class PETScVector,
  *        which provides an interface to PETSc vector routines.
  *

--- a/MathLib/LinAlg/PETSc/PETScVector.h
+++ b/MathLib/LinAlg/PETSc/PETScVector.h
@@ -1,5 +1,5 @@
 /**
- * \file  PETScVector.h
+ * \file
  * \brief Declaration of class PETScVector, which provides an interface to
  *        PETSc vector routines.
  *

--- a/MeshLib/ElementStatus.cpp
+++ b/MeshLib/ElementStatus.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   ElementStatus.cpp
+ * \file
  * \author Karsten Rink
  * \date   2012-12-18
  * \brief  Implementation of the ElementStatus class.

--- a/MeshLib/ElementStatus.h
+++ b/MeshLib/ElementStatus.h
@@ -1,5 +1,5 @@
 /**
- * \file   ElementStatus.h
+ * \file
  * \author Karsten Rink
  * \date   2012-12-18
  * \brief  Definition of the ElementStatus class.

--- a/MeshLib/Elements/ElementErrorCode.h
+++ b/MeshLib/Elements/ElementErrorCode.h
@@ -1,5 +1,5 @@
 /**
- * \file    ElementErrorCode.h
+ * \file
  * \author  Karsten Rink
  * \date    2014-02-21
  * \brief   Definition of ElementErrorCodes.

--- a/MeshLib/Elements/Elements.h
+++ b/MeshLib/Elements/Elements.h
@@ -1,5 +1,5 @@
 /*
- * \file Elements.h
+ * \file
  * \brief Cumulative include for all available mesh element types.
  *
  * \copyright

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.cpp
@@ -1,5 +1,5 @@
 /*!
-  \file NodePartitionedMeshReader.cpp
+  \file
   \author Wenqing Wang
   \date   2014.08
   \brief  Define members of class NodePartitionedMeshReader to read node-wise

--- a/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
+++ b/MeshLib/IO/MPI_IO/NodePartitionedMeshReader.h
@@ -1,5 +1,5 @@
 /*!
-  \file NodePartitionedMeshReader.h
+  \file
   \author Wenqing Wang
   \date   2014.08
   \brief  Declare a class to read node-wise partitioned mesh with MPI functions.

--- a/MeshLib/IO/VtkIO/VtuInterface-impl.h
+++ b/MeshLib/IO/VtkIO/VtuInterface-impl.h
@@ -1,5 +1,5 @@
 /**
- * \file VtuInterface-impl.h
+ * \file
  * \author Lars Bilke
  * \date   2014-09-25
  * \brief  Implementation of the VtuInterface class.

--- a/MeshLib/MeshEditing/AddLayerToMesh.cpp
+++ b/MeshLib/MeshEditing/AddLayerToMesh.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   AddLayerToMesh.cpp
+ * \file
  * \date   2016-01-18
  * \brief  Implementation of AddLayerToMesh class.
  *

--- a/MeshLib/MeshEditing/AddLayerToMesh.h
+++ b/MeshLib/MeshEditing/AddLayerToMesh.h
@@ -1,5 +1,5 @@
 /**
- * \file   AddLayerToMesh.h
+ * \file
  * \author Karsten Rink
  * \date   2016-01-18
  * \brief  Definition of AddLayerToMesh class

--- a/MeshLib/MeshEditing/DuplicateMeshComponents.cpp
+++ b/MeshLib/MeshEditing/DuplicateMeshComponents.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   DuplicateMeshComponents.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-03-25
  * \brief  Implementation of Duplicate functions.

--- a/MeshLib/MeshEditing/DuplicateMeshComponents.h
+++ b/MeshLib/MeshEditing/DuplicateMeshComponents.h
@@ -1,5 +1,5 @@
 /**
- * \file   DuplicateMeshComponents.h
+ * \file
  * \author Karsten Rink
  * \date   2014-03-25
  * \brief  Definition of Duplicate functions

--- a/MeshLib/MeshEditing/MeshRevision.cpp
+++ b/MeshLib/MeshEditing/MeshRevision.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   MeshRevision.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-02-14
  * \brief  Implementation of the MeshRevision class.

--- a/MeshLib/MeshEditing/MeshRevision.h
+++ b/MeshLib/MeshEditing/MeshRevision.h
@@ -1,5 +1,5 @@
 /**
- * \file   MeshRevision.h
+ * \file
  * \author Karsten Rink
  * \date   2014-02-14
  * \brief  Definition of the MeshRevision class.

--- a/MeshLib/MeshEditing/projectMeshOntoPlane.h
+++ b/MeshLib/MeshEditing/projectMeshOntoPlane.h
@@ -1,5 +1,5 @@
 /**
- * \file   projectMeshOntoPlane.h
+ * \file
  * \author Karsten Rink
  * \date   2015-04-10
  * \brief  Definition of the projectMeshOntoPlane

--- a/MeshLib/MeshGenerators/LayeredMeshGenerator.cpp
+++ b/MeshLib/MeshGenerators/LayeredMeshGenerator.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   LayeredMeshGenerator.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-09-18
  * \brief  Implementation of the SubsurfaceMapper class.

--- a/MeshLib/MeshGenerators/LayeredMeshGenerator.h
+++ b/MeshLib/MeshGenerators/LayeredMeshGenerator.h
@@ -1,5 +1,5 @@
 /**
- * \file   LayeredMeshGenerator.h
+ * \file
  * \author Karsten Rink
  * \date   2014-09-18
  * \brief  Definition of the SubsurfaceMapper class

--- a/MeshLib/MeshGenerators/LayeredVolume.cpp
+++ b/MeshLib/MeshGenerators/LayeredVolume.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   LayeredVolume.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-04-11
  * \brief  Implementation of the LayeredVolume class.

--- a/MeshLib/MeshGenerators/LayeredVolume.h
+++ b/MeshLib/MeshGenerators/LayeredVolume.h
@@ -1,5 +1,5 @@
 /**
- * \file   LayeredVolume.h
+ * \file
  * \author Karsten Rink
  * \date   2014-04-11
  * \brief  Definition of the LayeredVolume class

--- a/MeshLib/MeshGenerators/MeshLayerMapper.cpp
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   MeshLayerMapper.cpp
+ * \file
  * \author Karsten Rink
  * \date   2010-11-01
  * \brief  Implementation of the MeshLayerMapper class.

--- a/MeshLib/MeshGenerators/MeshLayerMapper.h
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.h
@@ -1,5 +1,5 @@
 /**
- * \file   MeshLayerMapper.h
+ * \file
  * \author Karsten Rink
  * \date   2010-11-01
  * \brief  Definition of the MeshLayerMapper class.

--- a/MeshLib/MeshQuality/AngleSkewMetric.cpp
+++ b/MeshLib/MeshQuality/AngleSkewMetric.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   AngleSkewMetric.cpp
+ * \file
  * \author Thomas Fischer
  * \date   2011-03-17
  * \brief  Implementation of the AngleSkewMetric class.

--- a/MeshLib/MeshQuality/AngleSkewMetric.h
+++ b/MeshLib/MeshQuality/AngleSkewMetric.h
@@ -1,5 +1,5 @@
 /**
- * \file   AngleSkewMetric.h
+ * \file
  * \author Thomas Fischer
  * \date   2011-03-17
  * \brief  Definition of the AngleSkewMetric class.

--- a/MeshLib/MeshQuality/EdgeRatioMetric.cpp
+++ b/MeshLib/MeshQuality/EdgeRatioMetric.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   EdgeRatioMetric.cpp
+ * \file
  * \author Thomas Fischer
  * \date   2011-03-03
  * \brief  Implementation of the EdgeRatioMetric class.

--- a/MeshLib/MeshQuality/EdgeRatioMetric.h
+++ b/MeshLib/MeshQuality/EdgeRatioMetric.h
@@ -1,5 +1,5 @@
 /**
- * \file   EdgeRatioMetric.h
+ * \file
  * \author Thomas Fischer
  * \date   2011-03-03
  * \brief  Definition of the AreaMetric class.

--- a/MeshLib/MeshQuality/ElementQualityInterface.h
+++ b/MeshLib/MeshQuality/ElementQualityInterface.h
@@ -1,5 +1,5 @@
 /**
- * \file   ElementQualityInterface.h
+ * \file
  * \author Karsten Rink
  * \date   2015-03-24
  * \brief  Definition of the ElementQualityInterface class.

--- a/MeshLib/MeshQuality/ElementQualityMetric.cpp
+++ b/MeshLib/MeshQuality/ElementQualityMetric.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   ElementQualityMetric.cpp
+ * \file
  * \author Thomas Fischer
  * \date   2010-12-08
  * \brief  Implementation of the ElementQualityMetricBase class.

--- a/MeshLib/MeshQuality/ElementQualityMetric.h
+++ b/MeshLib/MeshQuality/ElementQualityMetric.h
@@ -1,5 +1,5 @@
 /**
- * \file   ElementQualityMetric.h
+ * \file
  * \author Thomas Fischer
  * \date   2010-12-08
  * \brief  Definition of the ElementQualityMetricBase class.

--- a/MeshLib/MeshQuality/ElementSizeMetric.cpp
+++ b/MeshLib/MeshQuality/ElementSizeMetric.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   ElementSizeMetric.cpp
+ * \file
  * \author Karsten Rink
  * \date   2011-03-17
  * \brief  Implementation of the ElementSizeMetric class.

--- a/MeshLib/MeshQuality/ElementSizeMetric.h
+++ b/MeshLib/MeshQuality/ElementSizeMetric.h
@@ -1,5 +1,5 @@
 /**
- * \file   ElementSizeMetric.h
+ * \file
  * \author Karsten Rink
  * \date   2011-03-17
  * \brief  Implementation of the AreaMetric class.

--- a/MeshLib/MeshQuality/MeshValidation.cpp
+++ b/MeshLib/MeshQuality/MeshValidation.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   MeshValidation.cpp
+ * \file
  * \author Karsten Rink
  * \date   2013-04-04
  * \brief  Implementation of the MeshValidation class.

--- a/MeshLib/MeshQuality/MeshValidation.h
+++ b/MeshLib/MeshQuality/MeshValidation.h
@@ -1,5 +1,5 @@
 /**
- * \file   MeshValidation.h
+ * \file
  * \author Karsten Rink
  * \date   2013-04-04
  * \brief  Definition of the MeshValidation class

--- a/MeshLib/MeshQuality/RadiusEdgeRatioMetric.cpp
+++ b/MeshLib/MeshQuality/RadiusEdgeRatioMetric.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   RadiusEdgeRatioMetric.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-09-02
  * \brief  Implementation of the RadiusEdgeRadioMetric class.

--- a/MeshLib/MeshQuality/RadiusEdgeRatioMetric.h
+++ b/MeshLib/MeshQuality/RadiusEdgeRatioMetric.h
@@ -1,5 +1,5 @@
 /**
- * \file   RadiusEdgeRatioMetric.h
+ * \file
  * \author Karsten Rink
  * \date   2014-09-02
  * \brief  Definition of the RadiusEdgeRatioMetric class.

--- a/MeshLib/MeshQuality/SizeDifferenceMetric.cpp
+++ b/MeshLib/MeshQuality/SizeDifferenceMetric.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   SizeDifferenceMetric.cpp
+ * \file
  * \author Karsten Rink
  * \date   2015-03-24
  * \brief  Implementation of the SizeDifferenceMetric class.

--- a/MeshLib/MeshQuality/SizeDifferenceMetric.h
+++ b/MeshLib/MeshQuality/SizeDifferenceMetric.h
@@ -1,5 +1,5 @@
 /**
- * \file   SizeDifferenceMetric.h
+ * \file
  * \author Karsten Rink
  * \date   2015-03-24
  * \brief  Definition of the SizeDifferenceMetric class.

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   MeshSurfaceExtraction.cpp
+ * \file
  * \author Karsten Rink
  * \date   2013-04-04
  * \brief  Implementation of the MeshSurfaceExtraction class.

--- a/MeshLib/MeshSurfaceExtraction.h
+++ b/MeshLib/MeshSurfaceExtraction.h
@@ -1,5 +1,5 @@
 /**
- * \file   MeshSurfaceExtraction.h
+ * \file
  * \author Karsten Rink
  * \date   2013-04-04
  * \brief  Definition of the MeshSurfaceExtraction class

--- a/MeshLib/NodePartitionedMesh.h
+++ b/MeshLib/NodePartitionedMesh.h
@@ -1,5 +1,5 @@
 /*!
-  \file NodePartitionedMesh.h
+  \file
   \author Wenqing Wang
   \date   2014.06
   \brief  Definition of mesh class for partitioned mesh (by node) for parallel

--- a/NumLib/Fem/ShapeFunction/ShapeStaticConsts.cpp
+++ b/NumLib/Fem/ShapeFunction/ShapeStaticConsts.cpp
@@ -1,5 +1,5 @@
 /**
- * \file ShapeStaticConsts.cpp
+ * \file
  *
  * \copyright
  * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)

--- a/NumLib/ODESolver/TimeDiscretization.cpp
+++ b/NumLib/ODESolver/TimeDiscretization.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   TimeDiscretization.cpp
+ *  \file
  *  Created on March 31, 2017, 10:30 AM
  */
 

--- a/NumLib/TimeStepping/Algorithms/CreateEvolutionaryPIDcontroller.cpp
+++ b/NumLib/TimeStepping/Algorithms/CreateEvolutionaryPIDcontroller.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateEvolutionaryPIDcontroller.cpp
+ *  \file
  *  Created on June 26, 2017, 4:43 PM
  */
 

--- a/NumLib/TimeStepping/Algorithms/CreateEvolutionaryPIDcontroller.h
+++ b/NumLib/TimeStepping/Algorithms/CreateEvolutionaryPIDcontroller.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateEvolutionaryPIDcontroller.h
+ *  \file
  *  Created on June 26, 2017, 4:43 PM
  */
 

--- a/NumLib/TimeStepping/Algorithms/CreateFixedTimeStepping.cpp
+++ b/NumLib/TimeStepping/Algorithms/CreateFixedTimeStepping.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateFixedTimeStepping.cpp
+ *  \file
  *  Created on June 26, 2017, 5:03 PM
  */
 

--- a/NumLib/TimeStepping/Algorithms/CreateFixedTimeStepping.h
+++ b/NumLib/TimeStepping/Algorithms/CreateFixedTimeStepping.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateFixedTimeStepping.h
+ *  \file
  *  Created on June 26, 2017, 5:02 PM
  */
 

--- a/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.cpp
+++ b/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   EvolutionaryPIDcontroller.cpp
+ *  \file
  *  Created on March 31, 2017, 4:13 PM
  */
 

--- a/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.h
+++ b/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   EvolutionaryPIDcontroller.h
+ *  \file
  *  Created on March 31, 2017, 4:13 PM
  */
 

--- a/NumLib/TimeStepping/CreateTimeStepper.cpp
+++ b/NumLib/TimeStepping/CreateTimeStepper.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateTimeStepper.cpp
+ *  \file
  *  Created on May 2, 2017, 12:18 PM
  */
 

--- a/NumLib/TimeStepping/CreateTimeStepper.h
+++ b/NumLib/TimeStepping/CreateTimeStepper.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   CreateTimeStepper.h
+ *  \file
  *  Created on May 2, 2017, 12:18 PM
  */
 

--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.cpp
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   CoupledSolutionsForStaggeredScheme.cpp
+ * \file
  *
  * Created on November 7, 2016, 12:14 PM
  */

--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.h
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   CoupledSolutionsForStaggeredScheme.h
+ * \file
  *
  * Created on November 7, 2016, 12:14 PM
  */

--- a/ProcessLib/HT/HTLocalAssemblerInterface.h
+++ b/ProcessLib/HT/HTLocalAssemblerInterface.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   HTLocalAssemblerInterface.h
+ *  \file
  *  Created on October 11, 2017, 1:35 PM
  */
 

--- a/ProcessLib/HT/MonolithicHTFEM.h
+++ b/ProcessLib/HT/MonolithicHTFEM.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   MonolithicHTFEM.h
+ *  \file
  *  Created on October 11, 2017, 2:33 PM
  */
 

--- a/ProcessLib/HT/StaggeredHTFEM-impl.h
+++ b/ProcessLib/HT/StaggeredHTFEM-impl.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   StaggeredHTFEM-impl.h
+ *  \file
  *  Created on October 13, 2017, 3:52 PM
  */
 

--- a/ProcessLib/HT/StaggeredHTFEM.h
+++ b/ProcessLib/HT/StaggeredHTFEM.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   StaggeredHTFEM.h
+ *  \file
  *  Created on October 11, 2017, 1:42 PM
  */
 

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   HydroMechanicsFEM-impl.h
+ *  \file
  *  Created on November 29, 2017, 2:03 PM
  */
 

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowMaterialProperties.cpp
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowMaterialProperties.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   CreateLiquidFlowMaterialProperties.cpp
+ * \file
  *
  *   Created on December 14, 2016, 1:20 PM
  */

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowMaterialProperties.h
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowMaterialProperties.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   CreateLiquidFlowMaterialProperties.h
+ * \file
  *
  *   Created on December 14, 2016, 1:20 PM
  */

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   CreateLiquidFlowProcess.cpp
+ * \file
  *
  * Created on August 19, 2016, 1:30 PM
  */

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   CreateLiquidFlowProcess.h
+ * \file
  *
  * Created on August 19, 2016, 1:30 PM
  */

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   LiquidFlowLocalAssembler.h
+ * \file
  *
  * Created on August 19, 2016, 2:28 PM
  */

--- a/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   LiquidFlowMaterialProperties.cpp
+ * \file
  *
  * Created on August 18, 2016, 11:49 AM
  */

--- a/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowMaterialProperties.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   LiquidFlowMaterialProperties.h
+ * \file
  *
  * Created on August 18, 2016, 11:03 AM
  */

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   LiquidFlowProcess.cpp
+ * \file
  *
  * Created on August 19, 2016, 1:38 PM
  */

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   LiquidFlowProcess.h
+ * \file
  *
  * Created on August 19, 2016, 1:38 PM
  */

--- a/ProcessLib/PhaseField/PhaseFieldFEM-impl.h
+++ b/ProcessLib/PhaseField/PhaseFieldFEM-impl.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   PhaseFieldFEM-impl.h
+ *  \file
  *  Created on January 8, 2018, 3:00 PM
  */
 #pragma once

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   RichardsMechanicsFEM-impl.h
+ *  \file
  *  Created on November 29, 2017, 2:03 PM
  */
 

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM-impl.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM-impl.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   ThermoMechanicalPhaseFieldFEM-impl.h
+ *  \file
  *  Created on January 8, 2018, 3:00 PM
  */
 #pragma once

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file ThermoMechanicsFEM-impl.h
+ * \file
  *
  * Created on July 2, 2019, 2:12 PM
  *

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
@@ -433,7 +433,9 @@ void ThermoMechanicsProcess<DisplacementDim>::postTimestepConcreteProcess(
     int const process_id)
 {
     if (process_id != _process_data.mechanics_process_id)
+    {
         return;
+    }
 
     DBUG("PostTimestep ThermoMechanicsProcess.");
 

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
@@ -148,11 +148,8 @@ void ThermoMechanicsProcess<DisplacementDim>::constructDofTable()
         constructMonolithicProcessDofTable();
         return;
     }
-    else
-    {
-        constructDofTableOfSpecifiedProsessStaggerdScheme(
-            _process_data.mechanics_process_id);
-    }
+    constructDofTableOfSpecifiedProsessStaggerdScheme(
+        _process_data.mechanics_process_id);
 
     // TODO move the two data members somewhere else.
     // for extrapolation of secondary variables of stress or strain

--- a/Tests/FileIO/TestBoostGmlInterface.cpp
+++ b/Tests/FileIO/TestBoostGmlInterface.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   TestBoostGmlInterface.cpp
+ * \file
  * \author Karsten Rink
  * \date   2016-02-16
  *

--- a/Tests/FileIO/TestCsvReader.cpp
+++ b/Tests/FileIO/TestCsvReader.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   TestCsvReader.cpp
+ * \file
  * \author Karsten Rink
  * \date   2015-04-09
  *

--- a/Tests/FileIO/TestGmlInterface.h
+++ b/Tests/FileIO/TestGmlInterface.h
@@ -1,5 +1,5 @@
 /**
- * \file   TestGmlInterface.h
+ * \file
  * \author Karsten Rink
  * \date   2016-02-21
  *

--- a/Tests/FileIO/TestTetGenInterface.cpp
+++ b/Tests/FileIO/TestTetGenInterface.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   TestTetGenInterface.cpp
+ * \file
  * \author Karsten Rink
  * \date   2016-02-19
  *

--- a/Tests/FileIO_Qt/TestQtGmlInterface.cpp
+++ b/Tests/FileIO_Qt/TestQtGmlInterface.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   TestQtGmlInterface.cpp
+ * \file
  * \author Karsten Rink
  * \date   2013-03-20
  *

--- a/Tests/GeoLib/TestBoundingSphere.cpp
+++ b/Tests/GeoLib/TestBoundingSphere.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   TestBoundingSphere.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-08-29
  *

--- a/Tests/GeoLib/TestPointsOnAPlane.cpp
+++ b/Tests/GeoLib/TestPointsOnAPlane.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   TestPointsOnAPlane.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-02-26
  *

--- a/Tests/MaterialLib/TestCapillaryPressureSaturationModel.cpp
+++ b/Tests/MaterialLib/TestCapillaryPressureSaturationModel.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   TestCapillaryPressureSaturationModel.cpp
+ * \file
  *
  * Created on November 1, 2016, 11:06 AM
  */

--- a/Tests/MaterialLib/TestDimensionLessGibbsFreeEnergy.cpp
+++ b/Tests/MaterialLib/TestDimensionLessGibbsFreeEnergy.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   TestDimensionLessGibbsFreeEnergy.cpp
+ *  \file
  *
  * Created on December 9, 2016, 12:31 PM
  */

--- a/Tests/MaterialLib/TestFluidDensity.cpp
+++ b/Tests/MaterialLib/TestFluidDensity.cpp
@@ -1,5 +1,5 @@
 /*!
-   \file  TestFluidDensity.cpp
+   \file
    \brief Test classes for fluid density models.
 
    \author Wenqing Wang

--- a/Tests/MaterialLib/TestFluidProperties.cpp
+++ b/Tests/MaterialLib/TestFluidProperties.cpp
@@ -7,7 +7,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file  TestFluidProperties.cpp
+ *  \file
  *
  */
 

--- a/Tests/MaterialLib/TestFluidSpecificHeatCapacityModel.cpp
+++ b/Tests/MaterialLib/TestFluidSpecificHeatCapacityModel.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *   \file TestFluidSpecificHeatCapacityModel.cpp
+ *   \file
  *
  */
 

--- a/Tests/MaterialLib/TestFluidThermalConductivityModel.cpp
+++ b/Tests/MaterialLib/TestFluidThermalConductivityModel.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *   \file TestFluidThermalConductivityModel.cpp
+ *   \file
  *
  */
 

--- a/Tests/MaterialLib/TestFluidViscosity.cpp
+++ b/Tests/MaterialLib/TestFluidViscosity.cpp
@@ -7,7 +7,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file  TestFluidViscosity.cpp
+ *  \file
  *
  */
 

--- a/Tests/MaterialLib/TestPorousMediumStorage.cpp
+++ b/Tests/MaterialLib/TestPorousMediumStorage.cpp
@@ -1,5 +1,5 @@
 /*!
-   \file  TestPorousMediumStorage.cpp
+   \file
    \brief Test the classes for storage models.
 
    \copyright

--- a/Tests/MaterialLib/TestRelativePermeabilityModel.cpp
+++ b/Tests/MaterialLib/TestRelativePermeabilityModel.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   TestRelativePermeabilityModel.cpp
+ * \file
  *
  * Created on November 2, 2016, 3:09 PM
  */

--- a/Tests/MathLib/TestDividedByPlane.cpp
+++ b/Tests/MathLib/TestDividedByPlane.cpp
@@ -1,5 +1,5 @@
 /**
- * \file   TestDividedByPlane.cpp
+ * \file
  * \author Karsten Rink
  * \date   2014-02-26
  *

--- a/Tests/MathLib/TestPiecewiseLinearCurve.cpp
+++ b/Tests/MathLib/TestPiecewiseLinearCurve.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- * \file   TestPiecewiseLinearCurve.cpp
+ * \file
  *
  * Created on November 11, 2016, 10:58 AM
  */

--- a/Tests/NumLib/FeTestData/TestFeHEX20.h
+++ b/Tests/NumLib/FeTestData/TestFeHEX20.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   TestFeHEX20.h
+ *  \file
  *  Created on July 13, 2017, 2:40 PM
  */
 

--- a/Tests/NumLib/FeTestData/TestFePRISM15.h
+++ b/Tests/NumLib/FeTestData/TestFePRISM15.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   TestFePRISM15.h
+ *  \file
  *  Created on July 13, 2017, 2:56 PM
  */
 

--- a/Tests/NumLib/FeTestData/TestFePYRA13.h
+++ b/Tests/NumLib/FeTestData/TestFePYRA13.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   TestFePYRA13.h
+ *  \file
  *  Created on July 13, 2017, 2:57 PM
  */
 

--- a/Tests/NumLib/FeTestData/TestFeQUAD8.h
+++ b/Tests/NumLib/FeTestData/TestFeQUAD8.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   TestFeQUAD8.h
+ *  \file
  *  Created on July 13, 2017, 3:00 PM
  */
 

--- a/Tests/NumLib/FeTestData/TestFeQUAD9.h
+++ b/Tests/NumLib/FeTestData/TestFeQUAD9.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   TestFeQuad9.h
+ *  \file
  *  Created on July 13, 2017, 2:52 PM
  */
 

--- a/Tests/NumLib/FeTestData/TestFeTET10.h
+++ b/Tests/NumLib/FeTestData/TestFeTET10.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   TestFeTET10.h
+ *  \file
  *  Created on July 13, 2017, 2:57 PM
  */
 

--- a/Tests/NumLib/FeTestData/TestFeTRI6.h
+++ b/Tests/NumLib/FeTestData/TestFeTRI6.h
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   TestFeTRI6.h
+ *  \file
  *  Created on July 13, 2017, 2:58 PM
  */
 

--- a/Tests/NumLib/TestGradShapeFunction.cpp
+++ b/Tests/NumLib/TestGradShapeFunction.cpp
@@ -8,7 +8,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   TestGradShapeFunction.cpp
+ *  \file
  *  Created on July 14, 2017, 10:08 AM
  */
 

--- a/Tests/NumLib/TestTimeSteppingEvolutionaryPIDcontroller.cpp
+++ b/Tests/NumLib/TestTimeSteppingEvolutionaryPIDcontroller.cpp
@@ -5,7 +5,7 @@
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
- *  \file   TestTimeSteppingEvolutionaryPIDcontroller.cpp
+ *  \file
  *  Created on April 5, 2017, 12:09 PM
  */
 


### PR DESCRIPTION
The clang-tidy warnings have exceeded a threshold of 200 warnings recently.
This causes the CI builds to fail.

A doxygen warning and potential for future warnings is also fixed.
Review commit-wise.