### PR TITLE
Time loop refactorings

### DIFF
--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -235,6 +235,7 @@ int main(int argc, char* argv[])
             INFO("Solve processes.");
 
             auto& time_loop = project.getTimeLoop();
+            time_loop.initialize();
             solver_succeeded = time_loop.loop();
 
 #ifdef USE_INSITU

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -539,8 +539,6 @@ static NumLib::NonlinearSolverStatus solveMonolithicProcess(
 
     auto const nonlinear_solver_status = solveOneTimeStepOneProcess(
         process_data.process_id, x, timestep_id, t, dt, process_data, output);
-    pcs.postTimestep(x, t, dt, process_data.process_id);
-    pcs.computeSecondaryVariable(t, x, process_data.process_id);
 
     INFO("[time] Solving process #%u took %g s in time step #%u ",
          process_data.process_id, time_timestep_process.elapsed(), timestep_id);
@@ -582,6 +580,14 @@ NumLib::NonlinearSolverStatus TimeLoop::solveUncoupledEquationSystems(
 
             return nonlinear_solver_status;
         }
+    }  // end of for (auto& process_data : _per_process_data)
+
+    for (auto& process_data : _per_process_data)
+    {
+        auto& x = *_process_solutions[process_data->process_id];
+        process_data->process.postTimestep(x, t, dt, process_data->process_id);
+        process_data->process.computeSecondaryVariable(
+            t, x, process_data->process_id);
     }  // end of for (auto& process_data : _per_process_data)
 
     return nonlinear_solver_status;

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -433,7 +433,7 @@ void TimeLoop::initialize()
  * TODO:
  * Now we have a structure inside the time loop which is very similar to the
  * nonlinear solver. And admittedly, the control flow inside the nonlinear
- * solver is rather complicated. Maybe in the future con can introduce an
+ * solver is rather complicated. Maybe in the future one can introduce an
  * abstraction that can do both the convergence checks of the coupling loop and
  * of the nonlinear solver.
  */

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -787,14 +787,8 @@ void TimeLoop::outputSolutions(bool const output_initial_condition,
                 &coupled_solutions);
             process_data->process
                 .setCoupledTermForTheStaggeredSchemeToLocalAssemblers();
-            (output_object.*output_class_member)(pcs, process_id, timestep, t,
-                                                 x);
         }
-        else
-        {
-            (output_object.*output_class_member)(pcs, process_id, timestep, t,
-                                                 x);
-        }
+        (output_object.*output_class_member)(pcs, process_id, timestep, t, x);
 
         ++process_id;
     }

--- a/ProcessLib/TimeLoop.h
+++ b/ProcessLib/TimeLoop.h
@@ -52,18 +52,13 @@ public:
     ~TimeLoop();
 
 private:
-
     /**
-     *  This function fills the vector of solutions of coupled processes of
-     *  processes, _solutions_of_coupled_processes, and initializes the vector
-     * of
-     *  solutions of the previous coupling iteration,
-     *  _solutions_of_last_cpl_iteration.
-     *
-     *  \return a boolean value as a flag to indicate there should be a coupling
-     *          among processes or not.
+     * This function fills the vector of solutions of coupled processes of
+     * processes, _solutions_of_coupled_processes, and initializes the vector
+     * of solutions of the previous coupling iteration,
+     * _solutions_of_last_cpl_iteration.
      */
-    bool setCoupledSolutions();
+    void setCoupledSolutions();
 
     /**
      * \brief Member to solver non coupled systems of equations, which can be

--- a/ProcessLib/TimeLoop.h
+++ b/ProcessLib/TimeLoop.h
@@ -47,6 +47,7 @@ public:
              std::unique_ptr<ChemistryLib::PhreeqcIO>&& chemical_system,
              const double start_time, const double end_time);
 
+    void initialize();
     bool loop();
 
     ~TimeLoop();

--- a/ProcessLib/TimeLoop.h
+++ b/ProcessLib/TimeLoop.h
@@ -104,8 +104,7 @@ private:
                                std::size_t& rejected_steps);
 
     template <typename OutputClass, typename OutputClassMember>
-    void outputSolutions(bool const output_initial_condition,
-                         bool const is_staggered_coupling, unsigned timestep,
+    void outputSolutions(bool const output_initial_condition, unsigned timestep,
                          const double t, OutputClass& output_object,
                          OutputClassMember output_class_member) const;
 


### PR DESCRIPTION
Moving and extracting functions.
One behavioural change is that now the `postTimestep` calls for monolithic processes happen in a batch after solve for all process as it is done in the staggered scheme.
