### PR TITLE
Time loop refactorings; Extract pre and post.

### DIFF
--- a/NumLib/ODESolver/NonlinearSolverStatus.h
+++ b/NumLib/ODESolver/NonlinearSolverStatus.h
@@ -14,7 +14,7 @@ namespace NumLib
 /// Status of the non-linear solver.
 struct NonlinearSolverStatus
 {
-    bool error_norms_met;
-    int number_iterations;
+    bool error_norms_met = false;
+    int number_iterations = -1;
 };
 }  // namespace NumLib

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -447,7 +447,7 @@ bool TimeLoop::loop()
     double t = _start_time;
     std::size_t accepted_steps = 0;
     std::size_t rejected_steps = 0;
-    NumLib::NonlinearSolverStatus nonlinear_solver_status{true, 0};
+    NumLib::NonlinearSolverStatus nonlinear_solver_status;
 
     double dt = computeTimeStepping(0.0, t, accepted_steps, rejected_steps);
 
@@ -595,7 +595,7 @@ NumLib::NonlinearSolverStatus TimeLoop::solveUncoupledEquationSystems(
 {
     preTimestepForAllProcesses(t, dt, _per_process_data, _process_solutions);
 
-    NumLib::NonlinearSolverStatus nonlinear_solver_status{false, -1};
+    NumLib::NonlinearSolverStatus nonlinear_solver_status;
     for (auto& process_data : _per_process_data)
     {
         nonlinear_solver_status = solveMonolithicProcess(

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -595,7 +595,7 @@ NumLib::NonlinearSolverStatus TimeLoop::solveUncoupledEquationSystems(
 {
     preTimestepForAllProcesses(t, dt, _per_process_data, _process_solutions);
 
-    NumLib::NonlinearSolverStatus nonlinear_solver_status;
+    NumLib::NonlinearSolverStatus nonlinear_solver_status{false, -1};
     for (auto& process_data : _per_process_data)
     {
         nonlinear_solver_status = solveMonolithicProcess(
@@ -651,7 +651,7 @@ TimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
 
     preTimestepForAllProcesses(t, dt, _per_process_data, _process_solutions);
 
-    NumLib::NonlinearSolverStatus nonlinear_solver_status{true, 0};
+    NumLib::NonlinearSolverStatus nonlinear_solver_status{false, -1};
     bool coupling_iteration_converged = true;
     for (int global_coupling_iteration = 0;
          global_coupling_iteration < _global_coupling_max_iterations;


### PR DESCRIPTION
Extract `preTimestep` and `postTimestep` calls into individual functions merging the monolithic and staggered implementations.

No behavioural change for the staggered scheme.
For the monolithic scheme the `preTimestep` calls are now executed separately in the beginning.