### PR TITLE
Using MPL in Heat_Transport_BHE process

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -557,7 +557,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                 ProcessLib::HeatTransportBHE::createHeatTransportBHEProcess(
                     name, *_mesh_vec[0], std::move(jacobian_assembler),
                     _process_variables, _parameters, integration_order,
-                    process_config, _curves);
+                    process_config, _curves, _media);
         }
         else
 #endif

--- a/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_density_fluid.md
+++ b/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_density_fluid.md
@@ -1,1 +1,0 @@
-The density of fluid in the soil.

--- a/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_density_gas.md
+++ b/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_density_gas.md
@@ -1,1 +1,0 @@
-The density of the gas in the soil if there is gas existing.

--- a/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_density_solid.md
+++ b/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_density_solid.md
@@ -1,1 +1,0 @@
-The density of the solid in the soil. Different strata have different solid density.

--- a/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_heat_capacity_fluid.md
+++ b/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_heat_capacity_fluid.md
@@ -1,1 +1,0 @@
-Heat capacity of the fluid in the soil.

--- a/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_heat_capacity_gas.md
+++ b/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_heat_capacity_gas.md
@@ -1,1 +1,0 @@
-Heat capacity of the gas in the soil.

--- a/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_heat_capacity_solid.md
+++ b/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_heat_capacity_solid.md
@@ -1,1 +1,0 @@
-Heat capacity of the solid in the soil.

--- a/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_thermal_conductivity_fluid.md
+++ b/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_thermal_conductivity_fluid.md
@@ -1,1 +1,0 @@
-Thermal conductivity of the fluid in the soil, such as groundwater flowing in the subsurface will affect the temperature distribution.

--- a/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_thermal_conductivity_gas.md
+++ b/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_thermal_conductivity_gas.md
@@ -1,1 +1,0 @@
-Thermal conductivity of the gas in the soil.

--- a/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_thermal_conductivity_solid.md
+++ b/Documentation/ProjectFile/prj/processes/process/HEAT_TRANSPORT_BHE/t_thermal_conductivity_solid.md
@@ -1,1 +1,0 @@
-Thermal conductivity of the solid in the soil.

--- a/MaterialLib/MPL/CreateMaterialSpatialDistributionMap.cpp
+++ b/MaterialLib/MPL/CreateMaterialSpatialDistributionMap.cpp
@@ -28,7 +28,7 @@ createMaterialSpatialDistributionMap(
 
     if (max_material_id > static_cast<int>(media.size() - 1))
     {
-        OGS_FATAL(
+        WARN(
             "The maximum value of MaterialIDs in mesh is %d. As the given "
             "number of porous media definitions in the project file is %d, the "
             "maximum value of MaterialIDs in mesh must be %d (index starts "

--- a/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.cpp
+++ b/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.cpp
@@ -89,86 +89,6 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     // end of reading primary variables for each
     // BHE----------------------------------------------------------
 
-    // solid phase thermal conductivity parameter.
-    auto& thermal_conductivity_solid = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__thermal_conductivity_solid}
-        "thermal_conductivity_solid", parameters, 1, &mesh);
-
-    DBUG("Use '%s' as solid phase thermal conductivity parameter.",
-         thermal_conductivity_solid.name.c_str());
-
-    // solid phase thermal conductivity parameter.
-    auto& thermal_conductivity_fluid = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__thermal_conductivity_fluid}
-        "thermal_conductivity_fluid", parameters, 1, &mesh);
-
-    DBUG("Use '%s' as fluid phase thermal conductivity parameter.",
-         thermal_conductivity_fluid.name.c_str());
-
-    // gas phase thermal conductivity parameter.
-    auto& thermal_conductivity_gas = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__thermal_conductivity_gas}
-        "thermal_conductivity_gas", parameters, 1, &mesh);
-
-    DBUG("Use '%s' as gas phase thermal conductivity parameter.",
-         thermal_conductivity_gas.name.c_str());
-
-    // solid phase heat capacity parameter.
-    auto& heat_capacity_solid = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__heat_capacity_solid}
-        "heat_capacity_solid", parameters, 1, &mesh);
-
-    DBUG("Use '%s' as solid phase heat capacity parameter.",
-         heat_capacity_solid.name.c_str());
-
-    // fluid phase heat capacity parameter.
-    auto& heat_capacity_fluid = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__heat_capacity_fluid}
-        "heat_capacity_fluid", parameters, 1, &mesh);
-
-    DBUG("Use '%s' as fluid phase heat capacity parameter.",
-         heat_capacity_fluid.name.c_str());
-
-    // gas phase heat capacity parameter.
-    auto& heat_capacity_gas = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__heat_capacity_gas}
-        "heat_capacity_gas", parameters, 1, &mesh);
-
-    DBUG("Use '%s' as gas phase heat capacity parameter.",
-         heat_capacity_gas.name.c_str());
-
-    // solid phase density parameter.
-    auto& density_solid = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__density_solid}
-        "density_solid", parameters, 1, &mesh);
-
-    DBUG("Use '%s' as solid phase density parameter.",
-         density_solid.name.c_str());
-
-    // fluid phase density parameter.
-    auto& density_fluid = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__density_fluid}
-        "density_fluid", parameters, 1, &mesh);
-
-    DBUG("Use '%s' as fluid phase density parameter.",
-         density_fluid.name.c_str());
-
-    // gas phase density parameter.
-    auto& density_gas = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HEAT_TRANSPORT_BHE__density_gas}
-        "density_gas", parameters, 1, &mesh);
-
-    DBUG("Use '%s' as gas phase density parameter.", density_gas.name.c_str());
-
     // reading BHE parameters --------------------------------------------------
     std::vector<BHE::BHETypes> bhes;
     auto const& bhe_configs =
@@ -220,15 +140,6 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
         MaterialPropertyLib::createMaterialSpatialDistributionMap(media, mesh);
 
     HeatTransportBHEProcessData process_data{std::move(media_map),
-                                             thermal_conductivity_solid,
-                                             thermal_conductivity_fluid,
-                                             thermal_conductivity_gas,
-                                             heat_capacity_solid,
-                                             heat_capacity_fluid,
-                                             heat_capacity_gas,
-                                             density_solid,
-                                             density_fluid,
-                                             density_gas,
                                              std::move(bhes)};
 
     SecondaryVariableCollection secondary_variables;

--- a/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.cpp
+++ b/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.cpp
@@ -35,7 +35,8 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     BaseLib::ConfigTree const& config,
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
-        curves)
+        curves,
+    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media)
 {
     //! \ogs_file_param{prj__processes__process__type}
     config.checkConfigParameter("type", "HEAT_TRANSPORT_BHE");
@@ -215,7 +216,11 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     }
     // end of reading BHE parameters -------------------------------------------
 
-    HeatTransportBHEProcessData process_data{thermal_conductivity_solid,
+    auto media_map =
+        MaterialPropertyLib::createMaterialSpatialDistributionMap(media, mesh);
+
+    HeatTransportBHEProcessData process_data{std::move(media_map),
+                                             thermal_conductivity_solid,
                                              thermal_conductivity_fluid,
                                              thermal_conductivity_gas,
                                              heat_capacity_solid,

--- a/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.h
+++ b/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 #include "ProcessLib/Process.h"
+#include "MaterialLib/MPL/CreateMaterialSpatialDistributionMap.h"
 
 namespace ProcessLib
 {
@@ -27,6 +28,7 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     BaseLib::ConfigTree const& config,
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
-        curves);
+        curves,
+    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
 }  // namespace HeatTransportBHE
 }  // namespace ProcessLib

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcessData.h
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcessData.h
@@ -12,20 +12,13 @@
 
 #include <unordered_map>
 
-#include "MeshLib/PropertyVector.h"
-#include "ParameterLib/Parameter.h"
-#include "ProcessLib/HeatTransportBHE/BHE/BHETypes.h"
 #include "MaterialLib/MPL/MaterialSpatialDistributionMap.h"
+#include "MeshLib/PropertyVector.h"
+#include "ProcessLib/HeatTransportBHE/BHE/BHETypes.h"
 
 namespace MeshLib
 {
 class Element;
-}
-
-namespace ParameterLib
-{
-template <typename T>
-struct Parameter;
 }
 
 namespace ProcessLib::HeatTransportBHE
@@ -34,20 +27,6 @@ struct HeatTransportBHEProcessData final
 {
     std::unique_ptr<MaterialPropertyLib::MaterialSpatialDistributionMap>
         media_map;
-    // ! thermal conductivity values for the three phases
-    ParameterLib::Parameter<double> const& thermal_conductivity_solid;
-    ParameterLib::Parameter<double> const& thermal_conductivity_fluid;
-    ParameterLib::Parameter<double> const& thermal_conductivity_gas;
-
-    // ! heat capacity values for the three phases
-    ParameterLib::Parameter<double> const& heat_capacity_solid;
-    ParameterLib::Parameter<double> const& heat_capacity_fluid;
-    ParameterLib::Parameter<double> const& heat_capacity_gas;
-
-    // ! density values for the three phases
-    ParameterLib::Parameter<double> const& density_solid;
-    ParameterLib::Parameter<double> const& density_fluid;
-    ParameterLib::Parameter<double> const& density_gas;
 
     std::vector<BHE::BHETypes> _vec_BHE_property;
 

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcessData.h
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcessData.h
@@ -13,7 +13,9 @@
 #include <unordered_map>
 
 #include "MeshLib/PropertyVector.h"
+#include "ParameterLib/Parameter.h"
 #include "ProcessLib/HeatTransportBHE/BHE/BHETypes.h"
+#include "MaterialLib/MPL/MaterialSpatialDistributionMap.h"
 
 namespace MeshLib
 {
@@ -28,8 +30,10 @@ struct Parameter;
 
 namespace ProcessLib::HeatTransportBHE
 {
-struct HeatTransportBHEProcessData
+struct HeatTransportBHEProcessData final
 {
+    std::unique_ptr<MaterialPropertyLib::MaterialSpatialDistributionMap>
+        media_map;
     // ! thermal conductivity values for the three phases
     ParameterLib::Parameter<double> const& thermal_conductivity_solid;
     ParameterLib::Parameter<double> const& thermal_conductivity_fluid;

--- a/Tests/Data/Parabolic/T/3D_2U_BHE/3D_2U_BHE.prj
+++ b/Tests/Data/Parabolic/T/3D_2U_BHE/3D_2U_BHE.prj
@@ -11,15 +11,6 @@
                 <process_variable>temperature_soil</process_variable>
                 <process_variable>temperature_BHE1</process_variable>
             </process_variables>
-            <thermal_conductivity_solid>K_s</thermal_conductivity_solid>
-            <heat_capacity_solid>Cp_s</heat_capacity_solid>
-            <density_solid>rho_s</density_solid>
-            <thermal_conductivity_fluid>K_f</thermal_conductivity_fluid>
-            <heat_capacity_fluid>Cp_f</heat_capacity_fluid>
-            <density_fluid>rho_f</density_fluid>
-            <thermal_conductivity_gas>K_g</thermal_conductivity_gas>
-            <heat_capacity_gas>Cp_g</heat_capacity_gas>
-            <density_gas>rho_g</density_gas>
             <borehole_heat_exchangers>
                 <borehole_heat_exchanger>
                     <type>2U</type>
@@ -63,6 +54,84 @@
             </borehole_heat_exchangers>
         </process>
     </processes>
+    <media>
+        <medium id="0">
+            <phases>
+                <phase>
+                    <type>AqueousLiquid</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>4068</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>0.1</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>992.92</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>1778</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>2.78018</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1800</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>1000</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.2</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>2500</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+            <properties>
+                <property>
+                    <name>thermal_longitudinal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0</value>
+                </property>
+                <property>
+                    <name>thermal_transversal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0</value>
+                </property>
+            </properties>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HeatTransportBHE">
@@ -115,51 +184,6 @@
     </time_loop>
     <parameters>
         <parameter>
-            <name>K_s</name>
-            <type>Constant</type>
-            <value>2.78018</value>
-        </parameter>
-        <parameter>
-            <name>Cp_s</name>
-            <type>Constant</type>
-            <value>1778</value>
-        </parameter>
-        <parameter>
-            <name>rho_s</name>
-            <type>Constant</type>
-            <value>1800</value>
-        </parameter>
-        <parameter>
-            <name>K_f</name>
-            <type>Constant</type>
-            <value>0.1</value>
-        </parameter>
-        <parameter>
-            <name>Cp_f</name>
-            <type>Constant</type>
-            <value>4068</value>
-        </parameter>
-        <parameter>
-            <name>rho_f</name>
-            <type>Constant</type>
-            <value>992.92</value>
-        </parameter>
-        <parameter>
-            <name>K_g</name>
-            <type>Constant</type>
-            <value>3.2</value>
-        </parameter>
-        <parameter>
-            <name>Cp_g</name>
-            <type>Constant</type>
-            <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>rho_g</name>
-            <type>Constant</type>
-            <value>2500</value>
-        </parameter>
-        <parameter>
             <name>T0</name>
             <type>Constant</type>
             <value>22</value>
@@ -210,7 +234,7 @@
             </petsc>
         </linear_solver>
     </linear_solvers>
-	<curves>
+    <curves>
         <curve>
             <name>inflow_temperature</name>
             <coords>0 60 120 180 240 300 360 420 480 540 600 1200 1800 2400 3000 3600</coords>

--- a/Tests/Data/Parabolic/T/3D_Beier_sandbox/beier_sandbox.prj
+++ b/Tests/Data/Parabolic/T/3D_Beier_sandbox/beier_sandbox.prj
@@ -11,15 +11,6 @@
                 <process_variable>temperature_soil</process_variable>
                 <process_variable>temperature_BHE1</process_variable>
             </process_variables>
-            <thermal_conductivity_solid>K_s</thermal_conductivity_solid>
-            <heat_capacity_solid>Cp_s</heat_capacity_solid>
-            <density_solid>rho_s</density_solid>
-            <thermal_conductivity_fluid>K_f</thermal_conductivity_fluid>
-            <heat_capacity_fluid>Cp_f</heat_capacity_fluid>
-            <density_fluid>rho_f</density_fluid>
-            <thermal_conductivity_gas>K_g</thermal_conductivity_gas>
-            <heat_capacity_gas>Cp_g</heat_capacity_gas>
-            <density_gas>rho_g</density_gas>
             <borehole_heat_exchangers>
                 <borehole_heat_exchanger>
                     <type>1U</type>
@@ -63,6 +54,84 @@
             </borehole_heat_exchangers>
         </process>
     </processes>
+    <media>
+        <medium id="0">
+            <phases>
+                <phase>
+                    <type>AqueousLiquid</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>4068</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>0.1</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>992.92</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>1778</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>2.78018</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1800</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>1000</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.2</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>2500</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+            <properties>
+                <property>
+                    <name>thermal_longitudinal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0</value>
+                </property>
+                <property>
+                    <name>thermal_transversal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0</value>
+                </property>
+            </properties>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HeatTransportBHE">
@@ -114,51 +183,6 @@
         </output>
     </time_loop>
     <parameters>
-        <parameter>
-            <name>K_s</name>
-            <type>Constant</type>
-            <value>2.78018</value>
-        </parameter>
-        <parameter>
-            <name>Cp_s</name>
-            <type>Constant</type>
-            <value>1778</value>
-        </parameter>
-        <parameter>
-            <name>rho_s</name>
-            <type>Constant</type>
-            <value>1800</value>
-        </parameter>
-        <parameter>
-            <name>K_f</name>
-            <type>Constant</type>
-            <value>0.1</value>
-        </parameter>
-        <parameter>
-            <name>Cp_f</name>
-            <type>Constant</type>
-            <value>4068</value>
-        </parameter>
-        <parameter>
-            <name>rho_f</name>
-            <type>Constant</type>
-            <value>992.92</value>
-        </parameter>
-        <parameter>
-            <name>K_g</name>
-            <type>Constant</type>
-            <value>3.2</value>
-        </parameter>
-        <parameter>
-            <name>Cp_g</name>
-            <type>Constant</type>
-            <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>rho_g</name>
-            <type>Constant</type>
-            <value>2500</value>
-        </parameter>
         <parameter>
             <name>T0</name>
             <type>Constant</type>

--- a/Tests/Data/Parabolic/T/3D_Beier_sandbox/fixed_power_constant_flow.prj
+++ b/Tests/Data/Parabolic/T/3D_Beier_sandbox/fixed_power_constant_flow.prj
@@ -11,15 +11,6 @@
                 <process_variable>temperature_soil</process_variable>
                 <process_variable>temperature_BHE1</process_variable>
             </process_variables>
-            <thermal_conductivity_solid>K_s</thermal_conductivity_solid>
-            <heat_capacity_solid>Cp_s</heat_capacity_solid>
-            <density_solid>rho_s</density_solid>
-            <thermal_conductivity_fluid>K_f</thermal_conductivity_fluid>
-            <heat_capacity_fluid>Cp_f</heat_capacity_fluid>
-            <density_fluid>rho_f</density_fluid>
-            <thermal_conductivity_gas>K_g</thermal_conductivity_gas>
-            <heat_capacity_gas>Cp_g</heat_capacity_gas>
-            <density_gas>rho_g</density_gas>
             <borehole_heat_exchangers>
                 <borehole_heat_exchanger>
                     <type>1U</type>
@@ -63,6 +54,84 @@
             </borehole_heat_exchangers>
         </process>
     </processes>
+	<media>
+        <medium id="0">
+            <phases>
+                <phase>
+                    <type>AqueousLiquid</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>4068</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>0.1</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>992.92</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>1778</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>2.78018</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1800</value>
+                        </property>
+                    </properties>
+                </phase>
+				<phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>1000</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.2</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>2500</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+            <properties>
+                <property>
+                    <name>thermal_longitudinal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0</value>
+                </property>
+                <property>
+                    <name>thermal_transversal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0</value>
+                </property>
+            </properties>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HeatTransportBHE">
@@ -110,51 +179,6 @@
         </output>
     </time_loop>
     <parameters>
-        <parameter>
-            <name>K_s</name>
-            <type>Constant</type>
-            <value>2.78018</value>
-        </parameter>
-        <parameter>
-            <name>Cp_s</name>
-            <type>Constant</type>
-            <value>1778</value>
-        </parameter>
-        <parameter>
-            <name>rho_s</name>
-            <type>Constant</type>
-            <value>1800</value>
-        </parameter>
-        <parameter>
-            <name>K_f</name>
-            <type>Constant</type>
-            <value>0.1</value>
-        </parameter>
-        <parameter>
-            <name>Cp_f</name>
-            <type>Constant</type>
-            <value>4068</value>
-        </parameter>
-        <parameter>
-            <name>rho_f</name>
-            <type>Constant</type>
-            <value>992.92</value>
-        </parameter>
-        <parameter>
-            <name>K_g</name>
-            <type>Constant</type>
-            <value>3.2</value>
-        </parameter>
-        <parameter>
-            <name>Cp_g</name>
-            <type>Constant</type>
-            <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>rho_g</name>
-            <type>Constant</type>
-            <value>2500</value>
-        </parameter>
         <parameter>
             <name>T0</name>
             <type>Constant</type>

--- a/Tests/Data/Parabolic/T/3D_deep_BHE/3D_deep_BHE_CXA.prj
+++ b/Tests/Data/Parabolic/T/3D_deep_BHE/3D_deep_BHE_CXA.prj
@@ -11,15 +11,6 @@
                 <process_variable>temperature_soil</process_variable>
                 <process_variable>temperature_BHE1</process_variable>
             </process_variables>
-            <thermal_conductivity_solid>K_s</thermal_conductivity_solid>
-            <heat_capacity_solid>Cp_s</heat_capacity_solid>
-            <density_solid>rho_s</density_solid>
-            <thermal_conductivity_fluid>K_f</thermal_conductivity_fluid>
-            <heat_capacity_fluid>Cp_f</heat_capacity_fluid>
-            <density_fluid>rho_f</density_fluid>
-            <thermal_conductivity_gas>K_g</thermal_conductivity_gas>
-            <heat_capacity_gas>Cp_g</heat_capacity_gas>
-            <density_gas>rho_g</density_gas>
             <borehole_heat_exchangers>
                 <borehole_heat_exchanger>
                     <type>CXA</type>
@@ -62,6 +53,84 @@
             </borehole_heat_exchangers>
         </process>
     </processes>
+    <media>
+        <medium id="0">
+            <phases>
+                <phase>
+                    <type>AqueousLiquid</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>4068</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>0.1</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>992.92</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>2000</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>2.5</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1120</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>1000</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.2</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>2500</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+            <properties>
+                <property>
+                    <name>thermal_longitudinal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0</value>
+                </property>
+                <property>
+                    <name>thermal_transversal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0</value>
+                </property>
+            </properties>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HeatTransportBHE">
@@ -110,51 +179,6 @@
         </output>
     </time_loop>
     <parameters>
-        <parameter>
-            <name>K_s</name>
-            <type>Constant</type>
-            <value>2.5</value>
-        </parameter>
-        <parameter>
-            <name>Cp_s</name>
-            <type>Constant</type>
-            <value>2000</value>
-        </parameter>
-        <parameter>
-            <name>rho_s</name>
-            <type>Constant</type>
-            <value>1120</value>
-        </parameter>
-        <parameter>
-            <name>K_f</name>
-            <type>Constant</type>
-            <value>0.1</value>
-        </parameter>
-        <parameter>
-            <name>Cp_f</name>
-            <type>Constant</type>
-            <value>4068</value>
-        </parameter>
-        <parameter>
-            <name>rho_f</name>
-            <type>Constant</type>
-            <value>992.92</value>
-        </parameter>
-        <parameter>
-            <name>K_g</name>
-            <type>Constant</type>
-            <value>3.2</value>
-        </parameter>
-        <parameter>
-            <name>Cp_g</name>
-            <type>Constant</type>
-            <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>rho_g</name>
-            <type>Constant</type>
-            <value>2500</value>
-        </parameter>
         <parameter>
             <name>T0</name>
             <type>Constant</type>

--- a/Tests/Data/Parabolic/T/3D_deep_BHE/3D_deep_BHE_CXC.prj
+++ b/Tests/Data/Parabolic/T/3D_deep_BHE/3D_deep_BHE_CXC.prj
@@ -11,15 +11,6 @@
                 <process_variable>temperature_soil</process_variable>
                 <process_variable>temperature_BHE1</process_variable>
             </process_variables>
-            <thermal_conductivity_solid>K_s</thermal_conductivity_solid>
-            <heat_capacity_solid>Cp_s</heat_capacity_solid>
-            <density_solid>rho_s</density_solid>
-            <thermal_conductivity_fluid>K_f</thermal_conductivity_fluid>
-            <heat_capacity_fluid>Cp_f</heat_capacity_fluid>
-            <density_fluid>rho_f</density_fluid>
-            <thermal_conductivity_gas>K_g</thermal_conductivity_gas>
-            <heat_capacity_gas>Cp_g</heat_capacity_gas>
-            <density_gas>rho_g</density_gas>
             <borehole_heat_exchangers>
                 <borehole_heat_exchanger>
                     <type>CXC</type>
@@ -62,6 +53,84 @@
             </borehole_heat_exchangers>
         </process>
     </processes>
+    <media>
+        <medium id="0">
+            <phases>
+                <phase>
+                    <type>AqueousLiquid</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>4068</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>0.1</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>992.92</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>2000</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>2.5</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1120</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>specific_heat_capacity</name>
+                            <type>Constant</type>
+                            <value>1000</value>
+                        </property>
+                        <property>
+                            <name>thermal_conductivity</name>
+                            <type>Constant</type>
+                            <value>3.2</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>2500</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+            <properties>
+                <property>
+                    <name>thermal_longitudinal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0</value>
+                </property>
+                <property>
+                    <name>thermal_transversal_dispersivity</name>
+                    <type>Constant</type>
+                    <value>0</value>
+                </property>
+            </properties>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HeatTransportBHE">
@@ -110,51 +179,6 @@
         </output>
     </time_loop>
     <parameters>
-        <parameter>
-            <name>K_s</name>
-            <type>Constant</type>
-            <value>2.5</value>
-        </parameter>
-        <parameter>
-            <name>Cp_s</name>
-            <type>Constant</type>
-            <value>2000</value>
-        </parameter>
-        <parameter>
-            <name>rho_s</name>
-            <type>Constant</type>
-            <value>1120</value>
-        </parameter>
-        <parameter>
-            <name>K_f</name>
-            <type>Constant</type>
-            <value>0.1</value>
-        </parameter>
-        <parameter>
-            <name>Cp_f</name>
-            <type>Constant</type>
-            <value>4068</value>
-        </parameter>
-        <parameter>
-            <name>rho_f</name>
-            <type>Constant</type>
-            <value>992.92</value>
-        </parameter>
-        <parameter>
-            <name>K_g</name>
-            <type>Constant</type>
-            <value>3.2</value>
-        </parameter>
-        <parameter>
-            <name>Cp_g</name>
-            <type>Constant</type>
-            <value>1000</value>
-        </parameter>
-        <parameter>
-            <name>rho_g</name>
-            <type>Constant</type>
-            <value>2500</value>
-        </parameter>
         <parameter>
             <name>T0</name>
             <type>Constant</type>


### PR DESCRIPTION
In this PR, the source code and input files related to HEAT_TRANSPORT_BHE process were changed in order to use the MPL data structure for reading in soil parameters such as thermal conductivity and heat capacity. 

1. The MPL data structure was used when assembling the local matrix for soil part. 
2. All test files have been updated accordingly. 
3. When checking the number of material groups, the original FATAL error was replaced by a WARNING, as the BHEs are additional material groups than the number of medias defined. 

