### PR TITLE
Pass dt to assemble

### DIFF
--- a/NumLib/ODESolver/ODESystem.h
+++ b/NumLib/ODESolver/ODESystem.h
@@ -49,9 +49,9 @@ public:
     virtual void preAssemble(const double t, GlobalVector const& x) = 0;
 
     //! Assemble \c M, \c K and \c b at the provided state (\c t, \c x).
-    virtual void assemble(const double t, GlobalVector const& x,
-                          GlobalMatrix& M, GlobalMatrix& K,
-                          GlobalVector& b) = 0;
+    virtual void assemble(const double t, double const dt,
+                          GlobalVector const& x, GlobalMatrix& M,
+                          GlobalMatrix& K, GlobalVector& b) = 0;
 
     using Index = MathLib::MatrixVectorTraits<GlobalMatrix>::Index;
 

--- a/NumLib/ODESolver/ODESystem.h
+++ b/NumLib/ODESolver/ODESystem.h
@@ -125,7 +125,8 @@ public:
      * \mathtt{Jac} \f$.
      * \endparblock
      */
-    virtual void assembleWithJacobian(const double t, GlobalVector const& x,
+    virtual void assembleWithJacobian(const double t, double const dt,
+                                      GlobalVector const& x,
                                       GlobalVector const& xdot,
                                       const double dxdot_dx, const double dx_dx,
                                       GlobalMatrix& M, GlobalMatrix& K,

--- a/NumLib/ODESolver/ODESystem.h
+++ b/NumLib/ODESolver/ODESystem.h
@@ -45,8 +45,9 @@ public:
     static const ODESystemTag ODETag =
         ODESystemTag::FirstOrderImplicitQuasilinear;
 
-    //! Calls process' pre-assembly with the provided state (\c t, \c x).
-    virtual void preAssemble(const double t, GlobalVector const& x) = 0;
+    //! Calls process' pre-assembly with the provided state (\c t, \c dt, \c x).
+    virtual void preAssemble(const double t, double const dt,
+                             GlobalVector const& x) = 0;
 
     //! Assemble \c M, \c K and \c b at the provided state (\c t, \c x).
     virtual void assemble(const double t, double const dt,
@@ -78,8 +79,9 @@ class ODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
                        NonlinearSolverTag::Picard>
 {
 public:
-    //! Calls process' pre-assembly with the provided state (\c t, \c x).
-    void preAssemble(const double t, GlobalVector const& x) override = 0;
+    //! Calls process' pre-assembly with the provided state (\c t, \c dt, \c x).
+    void preAssemble(const double t, double const dt,
+                     GlobalVector const& x) override = 0;
 
     /*! Assemble \c M, \c K, \c b and the Jacobian
      * \f$ \mathtt{Jac} := \partial r/\partial x_N \f$

--- a/NumLib/ODESolver/TimeDiscretization.h
+++ b/NumLib/ODESolver/TimeDiscretization.h
@@ -166,6 +166,10 @@ public:
     //! assembled.
     virtual double getCurrentTime() const = 0;
 
+    //! Returns \f$ \Delta t_C \f$, i.e., the time at which the equation will be
+    //! assembled.
+    virtual double getCurrentTimeIncrement() const = 0;
+
     //! Returns \f$ \hat x \f$, i.e. the discretized approximation of \f$ \dot x
     //! \f$.
     void getXdot(GlobalVector const& x_at_new_timestep, GlobalVector& xdot) const
@@ -286,6 +290,7 @@ public:
     }
 
     double getCurrentTime() const override { return _t; }
+    double getCurrentTimeIncrement() const override { return _delta_t; }
     double getNewXWeight() const override { return 1.0 / _delta_t; }
     void getWeightedOldX(GlobalVector& y) const override
     {
@@ -348,6 +353,8 @@ public:
     {
         return _t_old;  // forward Euler does assembly at the preceding timestep
     }
+
+    double getCurrentTimeIncrement() const override { return _delta_t; }
 
     GlobalVector const& getCurrentX(
         const GlobalVector& /*x_at_new_timestep*/) const override
@@ -430,6 +437,7 @@ public:
     }
 
     double getCurrentTime() const override { return _t; }
+    double getCurrentTimeIncrement() const override { return _delta_t; }
     double getNewXWeight() const override { return 1.0 / _delta_t; }
     void getWeightedOldX(GlobalVector& y) const override
     {
@@ -509,6 +517,7 @@ public:
     }
 
     double getCurrentTime() const override { return _t; }
+    double getCurrentTimeIncrement() const override { return _delta_t; }
 
     double getNewXWeight() const override;
 

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
@@ -76,6 +76,7 @@ void TimeDiscretizedODESystem<
     namespace LinAlg = MathLib::LinAlg;
 
     auto const t = _time_disc.getCurrentTime();
+    auto const dt = _time_disc.getCurrentTimeIncrement();
     auto const& x_curr = _time_disc.getCurrentX(x_new_timestep);
     auto const dxdot_dx = _time_disc.getNewXWeight();
     auto const dx_dx = _time_disc.getDxDx();
@@ -89,8 +90,8 @@ void TimeDiscretizedODESystem<
     _Jac->setZero();
 
     _ode.preAssemble(t, x_curr);
-    _ode.assembleWithJacobian(t, x_curr, xdot, dxdot_dx, dx_dx, *_M, *_K, *_b,
-                              *_Jac);
+    _ode.assembleWithJacobian(t, dt, x_curr, xdot, dxdot_dx, dx_dx, *_M, *_K,
+                              *_b, *_Jac);
 
     LinAlg::finalizeAssembly(*_M);
     LinAlg::finalizeAssembly(*_K);

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
@@ -192,6 +192,7 @@ void TimeDiscretizedODESystem<
     namespace LinAlg = MathLib::LinAlg;
 
     auto const t = _time_disc.getCurrentTime();
+    auto const dt = _time_disc.getCurrentTimeIncrement();
     auto const& x_curr = _time_disc.getCurrentX(x_new_timestep);
 
     _M->setZero();
@@ -199,7 +200,7 @@ void TimeDiscretizedODESystem<
     _b->setZero();
 
     _ode.preAssemble(t, x_curr);
-    _ode.assemble(t, x_curr, *_M, *_K, *_b);
+    _ode.assemble(t, dt, x_curr, *_M, *_K, *_b);
 
     LinAlg::finalizeAssembly(*_M);
     LinAlg::finalizeAssembly(*_K);

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
@@ -89,7 +89,7 @@ void TimeDiscretizedODESystem<
     _b->setZero();
     _Jac->setZero();
 
-    _ode.preAssemble(t, x_curr);
+    _ode.preAssemble(t, dt, x_curr);
     _ode.assembleWithJacobian(t, dt, x_curr, xdot, dxdot_dx, dx_dx, *_M, *_K,
                               *_b, *_Jac);
 
@@ -199,7 +199,7 @@ void TimeDiscretizedODESystem<
     _K->setZero();
     _b->setZero();
 
-    _ode.preAssemble(t, x_curr);
+    _ode.preAssemble(t, dt, x_curr);
     _ode.assemble(t, dt, x_curr, *_M, *_K, *_b);
 
     LinAlg::finalizeAssembly(*_M);

--- a/ProcessLib/AbstractJacobianAssembler.h
+++ b/ProcessLib/AbstractJacobianAssembler.h
@@ -24,13 +24,15 @@ class AbstractJacobianAssembler
 public:
     //! Assembles the Jacobian, the matrices \f$M\f$ and \f$K\f$, and the vector
     //! \f$b\f$.
-    virtual void assembleWithJacobian(
-        LocalAssemblerInterface& local_assembler, double const t,
-        std::vector<double> const& local_x,
-        std::vector<double> const& local_xdot, const double dxdot_dx,
-        const double dx_dx, std::vector<double>& local_M_data,
-        std::vector<double>& local_K_data, std::vector<double>& local_b_data,
-        std::vector<double>& local_Jac_data) = 0;
+    virtual void assembleWithJacobian(LocalAssemblerInterface& local_assembler,
+                                      double const t, double const dt,
+                                      std::vector<double> const& local_x,
+                                      std::vector<double> const& local_xdot,
+                                      const double dxdot_dx, const double dx_dx,
+                                      std::vector<double>& local_M_data,
+                                      std::vector<double>& local_K_data,
+                                      std::vector<double>& local_b_data,
+                                      std::vector<double>& local_Jac_data) = 0;
 
     //! Assembles the Jacobian, the matrices \f$M\f$ and \f$K\f$, and the vector
     //! \f$b\f$ with coupling.

--- a/ProcessLib/AbstractJacobianAssembler.h
+++ b/ProcessLib/AbstractJacobianAssembler.h
@@ -38,8 +38,9 @@ public:
     //! \f$b\f$ with coupling.
     virtual void assembleWithJacobianForStaggeredScheme(
         LocalAssemblerInterface& /*local_assembler*/, double const /*t*/,
-        std::vector<double> const& /*local_xdot*/, const double /*dxdot_dx*/,
-        const double /*dx_dx*/, std::vector<double>& /*local_M_data*/,
+        double const /*dt*/, std::vector<double> const& /*local_xdot*/,
+        const double /*dxdot_dx*/, const double /*dx_dx*/,
+        std::vector<double>& /*local_M_data*/,
         std::vector<double>& /*local_K_data*/,
         std::vector<double>& /*local_b_data*/,
         std::vector<double>& /*local_Jac_data*/,

--- a/ProcessLib/AnalyticalJacobianAssembler.cpp
+++ b/ProcessLib/AnalyticalJacobianAssembler.cpp
@@ -15,13 +15,13 @@
 namespace ProcessLib
 {
 void AnalyticalJacobianAssembler::assembleWithJacobian(
-    LocalAssemblerInterface& local_assembler, double const t,
+    LocalAssemblerInterface& local_assembler, double const t, double const dt,
     std::vector<double> const& local_x, std::vector<double> const& local_xdot,
     const double dxdot_dx, const double dx_dx,
     std::vector<double>& local_M_data, std::vector<double>& local_K_data,
     std::vector<double>& local_b_data, std::vector<double>& local_Jac_data)
 {
-    local_assembler.assembleWithJacobian(t, local_x, local_xdot, dxdot_dx,
+    local_assembler.assembleWithJacobian(t, dt, local_x, local_xdot, dxdot_dx,
                                          dx_dx, local_M_data, local_K_data,
                                          local_b_data, local_Jac_data);
 }

--- a/ProcessLib/AnalyticalJacobianAssembler.cpp
+++ b/ProcessLib/AnalyticalJacobianAssembler.cpp
@@ -27,7 +27,7 @@ void AnalyticalJacobianAssembler::assembleWithJacobian(
 }
 
 void AnalyticalJacobianAssembler::assembleWithJacobianForStaggeredScheme(
-    LocalAssemblerInterface& local_assembler, double const t,
+    LocalAssemblerInterface& local_assembler, double const t, double const dt,
     std::vector<double> const& local_xdot, const double dxdot_dx,
     const double dx_dx, std::vector<double>& local_M_data,
     std::vector<double>& local_K_data, std::vector<double>& local_b_data,
@@ -35,7 +35,7 @@ void AnalyticalJacobianAssembler::assembleWithJacobianForStaggeredScheme(
     LocalCoupledSolutions const& local_coupled_solutions)
 {
     local_assembler.assembleWithJacobianForStaggeredScheme(
-        t, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
+        t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
         local_b_data, local_Jac_data, local_coupled_solutions);
 }
 

--- a/ProcessLib/AnalyticalJacobianAssembler.h
+++ b/ProcessLib/AnalyticalJacobianAssembler.h
@@ -31,13 +31,15 @@ public:
     //! \f$b\f$.
     //! In this implementation the call is only forwarded to the respective
     //! method of the given \c local_assembler.
-    void assembleWithJacobian(
-        LocalAssemblerInterface& local_assembler, double const t,
-        std::vector<double> const& local_x,
-        std::vector<double> const& local_xdot, const double dxdot_dx,
-        const double dx_dx, std::vector<double>& local_M_data,
-        std::vector<double>& local_K_data, std::vector<double>& local_b_data,
-        std::vector<double>& local_Jac_data) override;
+    void assembleWithJacobian(LocalAssemblerInterface& local_assembler,
+                              double const t, double const dt,
+                              std::vector<double> const& local_x,
+                              std::vector<double> const& local_xdot,
+                              const double dxdot_dx, const double dx_dx,
+                              std::vector<double>& local_M_data,
+                              std::vector<double>& local_K_data,
+                              std::vector<double>& local_b_data,
+                              std::vector<double>& local_Jac_data) override;
 
     void assembleWithJacobianForStaggeredScheme(
         LocalAssemblerInterface& local_assembler,

--- a/ProcessLib/AnalyticalJacobianAssembler.h
+++ b/ProcessLib/AnalyticalJacobianAssembler.h
@@ -42,8 +42,8 @@ public:
                               std::vector<double>& local_Jac_data) override;
 
     void assembleWithJacobianForStaggeredScheme(
-        LocalAssemblerInterface& local_assembler,
-        double const t, std::vector<double> const& local_xdot,
+        LocalAssemblerInterface& local_assembler, double const t,
+        double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,

--- a/ProcessLib/CentralDifferencesJacobianAssembler.cpp
+++ b/ProcessLib/CentralDifferencesJacobianAssembler.cpp
@@ -26,7 +26,7 @@ CentralDifferencesJacobianAssembler::CentralDifferencesJacobianAssembler(
 }
 
 void CentralDifferencesJacobianAssembler::assembleWithJacobian(
-    LocalAssemblerInterface& local_assembler, const double t,
+    LocalAssemblerInterface& local_assembler, const double t, double const dt,
     const std::vector<double>& local_x_data,
     const std::vector<double>& local_xdot_data, const double dxdot_dx,
     const double dx_dx, std::vector<double>& local_M_data,

--- a/ProcessLib/CentralDifferencesJacobianAssembler.cpp
+++ b/ProcessLib/CentralDifferencesJacobianAssembler.cpp
@@ -71,11 +71,11 @@ void CentralDifferencesJacobianAssembler::assembleWithJacobian(
         auto const eps = _absolute_epsilons[component];
 
         _local_x_perturbed_data[i] += eps;
-        local_assembler.assemble(t, _local_x_perturbed_data, local_M_data,
+        local_assembler.assemble(t, dt, _local_x_perturbed_data, local_M_data,
                                  local_K_data, local_b_data);
 
         _local_x_perturbed_data[i] = local_x_data[i] - eps;
-        local_assembler.assemble(t, _local_x_perturbed_data, _local_M_data,
+        local_assembler.assemble(t, dt, _local_x_perturbed_data, _local_M_data,
                                  _local_K_data, _local_b_data);
 
         _local_x_perturbed_data[i] = local_x_data[i];
@@ -116,7 +116,7 @@ void CentralDifferencesJacobianAssembler::assembleWithJacobian(
     }
 
     // Assemble with unperturbed local x.
-    local_assembler.assemble(t, local_x_data, local_M_data, local_K_data,
+    local_assembler.assemble(t, dt, local_x_data, local_M_data, local_K_data,
                              local_b_data);
 
     // Compute remaining terms of the Jacobian.

--- a/ProcessLib/CentralDifferencesJacobianAssembler.h
+++ b/ProcessLib/CentralDifferencesJacobianAssembler.h
@@ -50,13 +50,15 @@ public:
     //!
     //! \attention It is assumed that the local vectors and matrices are ordered
     //! by component.
-    void assembleWithJacobian(
-        LocalAssemblerInterface& local_assembler, double const t,
-        std::vector<double> const& local_x,
-        std::vector<double> const& local_xdot, const double dxdot_dx,
-        const double dx_dx, std::vector<double>& local_M_data,
-        std::vector<double>& local_K_data, std::vector<double>& local_b_data,
-        std::vector<double>& local_Jac_data) override;
+    void assembleWithJacobian(LocalAssemblerInterface& local_assembler,
+                              double const t, double const dt,
+                              std::vector<double> const& local_x,
+                              std::vector<double> const& local_xdot,
+                              const double dxdot_dx, const double dx_dx,
+                              std::vector<double>& local_M_data,
+                              std::vector<double>& local_K_data,
+                              std::vector<double>& local_b_data,
+                              std::vector<double>& local_Jac_data) override;
 
 private:
     std::vector<double> const _absolute_epsilons;

--- a/ProcessLib/CompareJacobiansJacobianAssembler.cpp
+++ b/ProcessLib/CompareJacobiansJacobianAssembler.cpp
@@ -125,7 +125,7 @@ const std::string msg_fatal =
 namespace ProcessLib
 {
 void CompareJacobiansJacobianAssembler::assembleWithJacobian(
-    LocalAssemblerInterface& local_assembler, double const t,
+    LocalAssemblerInterface& local_assembler, double const t, double const dt,
     std::vector<double> const& local_x, std::vector<double> const& local_xdot,
     const double dxdot_dx, const double dx_dx,
     std::vector<double>& local_M_data, std::vector<double>& local_K_data,
@@ -147,7 +147,7 @@ void CompareJacobiansJacobianAssembler::assembleWithJacobian(
 
     // First assembly -- the one whose results will be added to the global
     // equation system finally.
-    _asm1->assembleWithJacobian(local_assembler, t, local_x, local_xdot,
+    _asm1->assembleWithJacobian(local_assembler, t, dt, local_x, local_xdot,
                                 dxdot_dx, dx_dx, local_M_data, local_K_data,
                                 local_b_data, local_Jac_data);
 
@@ -161,7 +161,7 @@ void CompareJacobiansJacobianAssembler::assembleWithJacobian(
     std::vector<double> local_Jac_data2;
 
     // Second assembly -- used for checking only.
-    _asm2->assembleWithJacobian(local_assembler, t, local_x, local_xdot,
+    _asm2->assembleWithJacobian(local_assembler, t, dt, local_x, local_xdot,
                                 dxdot_dx, dx_dx, local_M_data2, local_K_data2,
                                 local_b_data2, local_Jac_data2);
 

--- a/ProcessLib/CompareJacobiansJacobianAssembler.h
+++ b/ProcessLib/CompareJacobiansJacobianAssembler.h
@@ -52,7 +52,7 @@ public:
     }
 
     void assembleWithJacobian(LocalAssemblerInterface& local_assembler,
-                              double const t,
+                              double const t, double const dt,
                               std::vector<double> const& local_x,
                               std::vector<double> const& local_xdot,
                               const double dxdot_dx, const double dx_dx,

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
@@ -90,11 +90,8 @@ void ComponentTransportProcess::initializeConcreteProcess(
 }
 
 void ComponentTransportProcess::assembleConcreteProcess(
-    const double t,
-    GlobalVector const& x,
-    GlobalMatrix& M,
-    GlobalMatrix& K,
-    GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble ComponentTransportProcess.");
 
@@ -117,7 +114,7 @@ void ComponentTransportProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_tables, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_tables, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 
@@ -135,9 +132,9 @@ void ComponentTransportProcess::setCoupledSolutionsOfPreviousTimeStep()
 }
 
 void ComponentTransportProcess::assembleWithJacobianConcreteProcess(
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac)
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian ComponentTransportProcess.");
 
@@ -148,8 +145,8 @@ void ComponentTransportProcess::assembleWithJacobianConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, x,
-        xdot, dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
+        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 Eigen::Vector3d ComponentTransportProcess::getFlux(std::size_t const element_id,

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.h
@@ -140,14 +140,15 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) override;
 
-    void assembleConcreteProcess(
-        const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-        GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void setCoupledSolutionsOfPreviousTimeStep();
 

--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.cpp
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.cpp
@@ -19,8 +19,8 @@ namespace ProcessLib
 {
 CoupledSolutionsForStaggeredScheme::CoupledSolutionsForStaggeredScheme(
     std::vector<std::reference_wrapper<GlobalVector const>> const& coupled_xs_,
-    const double dt_, const int process_id_)
-    : coupled_xs(coupled_xs_), dt(dt_), process_id(process_id_)
+    const int process_id_)
+    : coupled_xs(coupled_xs_), process_id(process_id_)
 {
     for (auto const& coupled_x : coupled_xs)
     {

--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.h
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.h
@@ -32,7 +32,7 @@ struct CoupledSolutionsForStaggeredScheme
     CoupledSolutionsForStaggeredScheme(
         std::vector<std::reference_wrapper<GlobalVector const>> const&
             coupled_xs_,
-        const double dt_, const int process_id_);
+        const int process_id_);
 
     /// References to the current solutions of the coupled processes.
     std::vector<std::reference_wrapper<GlobalVector const>> const& coupled_xs;
@@ -40,7 +40,6 @@ struct CoupledSolutionsForStaggeredScheme
     /// Pointers to the vector of the solutions of the previous time step.
     std::vector<GlobalVector*> coupled_xs_t0;
 
-    const double dt;  ///< Time step size.
     const int process_id;
 };
 
@@ -54,17 +53,15 @@ struct CoupledSolutionsForStaggeredScheme
  */
 struct LocalCoupledSolutions
 {
-    LocalCoupledSolutions(const double dt_, const int process_id_,
+    LocalCoupledSolutions(const int process_id_,
                           std::vector<std::vector<double>>&& local_coupled_xs0_,
                           std::vector<std::vector<double>>&& local_coupled_xs_)
-        : dt(dt_),
-          process_id(process_id_),
+        : process_id(process_id_),
           local_coupled_xs0(std::move(local_coupled_xs0_)),
           local_coupled_xs(std::move(local_coupled_xs_))
     {
     }
 
-    const double dt;  ///< Time step size.
     const int process_id;
 
     /// Local solutions of the previous time step.

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -100,7 +100,8 @@ public:
     {
     }
 
-    void assemble(double const t, std::vector<double> const& local_x,
+    void assemble(double const t, double const /*dt*/,
+                  std::vector<double> const& local_x,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& local_K_data,
                   std::vector<double>& /*local_b_data*/) override

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -57,11 +57,9 @@ void GroundwaterFlowProcess::initializeConcreteProcess(
             &GroundwaterFlowLocalAssemblerInterface::getIntPtDarcyVelocity));
 }
 
-void GroundwaterFlowProcess::assembleConcreteProcess(const double t,
-                                                     GlobalVector const& x,
-                                                     GlobalMatrix& M,
-                                                     GlobalMatrix& K,
-                                                     GlobalVector& b)
+void GroundwaterFlowProcess::assembleConcreteProcess(
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble GroundwaterFlowProcess.");
 
@@ -72,14 +70,14 @@ void GroundwaterFlowProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 
 void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac)
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian GroundwaterFlowProcess.");
 
@@ -90,7 +88,7 @@ void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, x, xdot,
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
         dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -90,14 +90,15 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     GroundwaterFlowProcessData _process_data;
 

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -86,11 +86,9 @@ void HTProcess::initializeConcreteProcess(
                          &HTLocalAssemblerInterface::getIntPtDarcyVelocity));
 }
 
-void HTProcess::assembleConcreteProcess(const double t,
-                                        GlobalVector const& x,
-                                        GlobalMatrix& M,
-                                        GlobalMatrix& K,
-                                        GlobalVector& b)
+void HTProcess::assembleConcreteProcess(const double t, double const dt,
+                                        GlobalVector const& x, GlobalMatrix& M,
+                                        GlobalMatrix& K, GlobalVector& b)
 {
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_tables;
@@ -124,14 +122,14 @@ void HTProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_tables, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_tables, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 
 void HTProcess::assembleWithJacobianConcreteProcess(
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac)
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian HTProcess.");
 
@@ -154,7 +152,7 @@ void HTProcess::assembleWithJacobianConcreteProcess(
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_tables, t, x, xdot,
+        _local_assemblers, pv.getActiveElementIDs(), dof_tables, t, dt, x, xdot,
         dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 

--- a/ProcessLib/HT/HTProcess.h
+++ b/ProcessLib/HT/HTProcess.h
@@ -91,14 +91,15 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,
                                     double const dt,

--- a/ProcessLib/HT/MonolithicHTFEM.h
+++ b/ProcessLib/HT/MonolithicHTFEM.h
@@ -66,7 +66,8 @@ public:
     {
     }
 
-    void assemble(double const t, std::vector<double> const& local_x,
+    void assemble(double const t, double const /*dt*/,
+                  std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override

--- a/ProcessLib/HT/StaggeredHTFEM-impl.h
+++ b/ProcessLib/HT/StaggeredHTFEM-impl.h
@@ -24,7 +24,7 @@ namespace HT
 template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
 void StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
-    assembleForStaggeredScheme(double const t,
+    assembleForStaggeredScheme(double const t, double const dt,
                                std::vector<double>& local_M_data,
                                std::vector<double>& local_K_data,
                                std::vector<double>& local_b_data,
@@ -37,14 +37,15 @@ void StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
         return;
     }
 
-    assembleHydraulicEquation(t, local_M_data, local_K_data, local_b_data,
+    assembleHydraulicEquation(t, dt, local_M_data, local_K_data, local_b_data,
                               coupled_xs);
 }
 
 template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
 void StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
-    assembleHydraulicEquation(double const t, std::vector<double>& local_M_data,
+    assembleHydraulicEquation(double const t, double const dt,
+                              std::vector<double>& local_M_data,
                               std::vector<double>& local_K_data,
                               std::vector<double>& local_b_data,
                               LocalCoupledSolutions const& coupled_xs)
@@ -59,7 +60,6 @@ void StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
         coupled_xs.local_coupled_xs[_heat_transport_process_id];
     auto const& local_T0 =
         coupled_xs.local_coupled_xs0[_heat_transport_process_id];
-    const double dt = coupled_xs.dt;
 
     auto local_M = MathLib::createZeroedMatrix<LocalMatrixType>(
         local_M_data, local_matrix_size, local_matrix_size);

--- a/ProcessLib/HT/StaggeredHTFEM.h
+++ b/ProcessLib/HT/StaggeredHTFEM.h
@@ -67,7 +67,7 @@ public:
     }
 
     void assembleForStaggeredScheme(
-        double const t, std::vector<double>& local_M_data,
+        double const t, double const dt, std::vector<double>& local_M_data,
         std::vector<double>& local_K_data, std::vector<double>& local_b_data,
         LocalCoupledSolutions const& coupled_xs) override;
 
@@ -78,7 +78,7 @@ public:
         std::vector<double>& cache) const override;
 
 private:
-    void assembleHydraulicEquation(double const t,
+    void assembleHydraulicEquation(double const t, double const dt,
                                    std::vector<double>& local_M_data,
                                    std::vector<double>& local_K_data,
                                    std::vector<double>& local_b_data,

--- a/ProcessLib/HeatConduction/HeatConductionFEM.h
+++ b/ProcessLib/HeatConduction/HeatConductionFEM.h
@@ -90,7 +90,8 @@ public:
         (void)local_matrix_size;
     }
 
-    void assemble(double const t, std::vector<double> const& local_x,
+    void assemble(double const t, double const /*dt*/,
+                  std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& /*local_b_data*/) override

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -72,11 +72,9 @@ void HeatConductionProcess::initializeConcreteProcess(
     }
 }
 
-void HeatConductionProcess::assembleConcreteProcess(const double t,
-                                                    GlobalVector const& x,
-                                                    GlobalMatrix& M,
-                                                    GlobalMatrix& K,
-                                                    GlobalVector& b)
+void HeatConductionProcess::assembleConcreteProcess(
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble HeatConductionProcess.");
 
@@ -88,14 +86,14 @@ void HeatConductionProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 
 void HeatConductionProcess::assembleWithJacobianConcreteProcess(
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac)
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian HeatConductionProcess.");
 
@@ -107,8 +105,8 @@ void HeatConductionProcess::assembleWithJacobianConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, x,
-        xdot, dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
+        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 void HeatConductionProcess::computeSecondaryVariableConcrete(

--- a/ProcessLib/HeatConduction/HeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.h
@@ -50,14 +50,15 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const /*dt*/,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const /*dt*/, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     HeatConductionProcessData _process_data;
 

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
@@ -158,11 +158,9 @@ void HeatTransportBHEProcess::initializeConcreteProcess(
     createBHEBoundaryConditionTopBottom(_bheMeshData.BHE_nodes);
 }
 
-void HeatTransportBHEProcess::assembleConcreteProcess(const double t,
-                                                      GlobalVector const& x,
-                                                      GlobalMatrix& M,
-                                                      GlobalMatrix& K,
-                                                      GlobalVector& b)
+void HeatTransportBHEProcess::assembleConcreteProcess(
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble HeatTransportBHE process.");
 
@@ -174,14 +172,15 @@ void HeatTransportBHEProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 
 void HeatTransportBHEProcess::assembleWithJacobianConcreteProcess(
-    const double /*t*/, GlobalVector const& /*x*/, GlobalVector const& /*xdot*/,
-    const double /*dxdot_dx*/, const double /*dx_dx*/, GlobalMatrix& /*M*/,
-    GlobalMatrix& /*K*/, GlobalVector& /*b*/, GlobalMatrix& /*Jac*/)
+    const double /*t*/, double const /*dt*/, GlobalVector const& /*x*/,
+    GlobalVector const& /*xdot*/, const double /*dxdot_dx*/,
+    const double /*dx_dx*/, GlobalMatrix& /*M*/, GlobalMatrix& /*K*/,
+    GlobalVector& /*b*/, GlobalMatrix& /*Jac*/)
 {
     OGS_FATAL(
         "HeatTransportBHE: analytical Jacobian assembly is not implemented");

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
@@ -54,14 +54,15 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void createBHEBoundaryConditionTopBottom(
         std::vector<std::vector<MeshLib::Node*>> const& all_bhe_nodes);

--- a/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerBHE-impl.h
+++ b/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerBHE-impl.h
@@ -115,7 +115,8 @@ template <typename ShapeFunction, typename IntegrationMethod, typename BHEType>
 void HeatTransportBHELocalAssemblerBHE<ShapeFunction, IntegrationMethod,
                                        BHEType>::
     assemble(
-        double const /*t*/, std::vector<double> const& /*local_x*/,
+        double const /*t*/, double const /*dt*/,
+        std::vector<double> const& /*local_x*/,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& /*local_b_data*/)  // local b vector is not touched
 {

--- a/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerBHE.h
+++ b/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerBHE.h
@@ -59,7 +59,8 @@ public:
         unsigned const integration_order,
         HeatTransportBHEProcessData& process_data);
 
-    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& /*local_x*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override;

--- a/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerSoil-impl.h
+++ b/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerSoil-impl.h
@@ -70,7 +70,7 @@ HeatTransportBHELocalAssemblerSoil<ShapeFunction, IntegrationMethod>::
 
 template <typename ShapeFunction, typename IntegrationMethod>
 void HeatTransportBHELocalAssemblerSoil<ShapeFunction, IntegrationMethod>::
-    assemble(double const t,
+    assemble(double const t, double const /*dt*/,
              std::vector<double> const& local_x,
              std::vector<double>& local_M_data,
              std::vector<double>& local_K_data,

--- a/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerSoil.h
+++ b/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerSoil.h
@@ -49,7 +49,8 @@ public:
         unsigned const integration_order,
         HeatTransportBHEProcessData& process_data);
 
-    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& /*local_x*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override;

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -577,7 +577,7 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                   ShapeFunctionPressure, IntegrationMethod,
                                   DisplacementDim>::
     postNonLinearSolverConcrete(std::vector<double> const& local_x,
-                                double const t,
+                                double const t, double const dt,
                                 bool const use_monolithic_scheme)
 {
     const int displacement_offset =
@@ -587,7 +587,6 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
         Eigen::Map<typename ShapeMatricesTypeDisplacement::template VectorType<
             displacement_size> const>(local_x.data() + displacement_offset,
                                       displacement_size);
-    double const& dt = _process_data.dt;
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());
 

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -105,7 +105,8 @@ template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
 void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                   ShapeFunctionPressure, IntegrationMethod,
                                   DisplacementDim>::
-    assembleWithJacobian(double const t, std::vector<double> const& local_x,
+    assembleWithJacobian(double const t, double const dt,
+                         std::vector<double> const& local_x,
                          std::vector<double> const& local_xdot,
                          const double /*dxdot_dx*/, const double /*dx_dx*/,
                          std::vector<double>& /*local_M_data*/,
@@ -171,7 +172,6 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
     MaterialLib::Solids::MechanicsBase<DisplacementDim> const& solid_material =
         *_process_data.solid_materials[0];
 
-    double const& dt = _process_data.dt;
     double const T_ref = _process_data.reference_temperature;
     auto const& b = _process_data.specific_body_force;
 
@@ -350,7 +350,7 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                   ShapeFunctionPressure, IntegrationMethod,
                                   DisplacementDim>::
     assembleWithJacobianForPressureEquations(
-        const double t, const std::vector<double>& local_xdot,
+        const double t, double const dt, const std::vector<double>& local_xdot,
         const double /*dxdot_dx*/, const double /*dx_dx*/,
         std::vector<double>& /*local_M_data*/,
         std::vector<double>& /*local_K_data*/,
@@ -395,8 +395,6 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
 
     MaterialLib::Solids::MechanicsBase<DisplacementDim> const& solid_material =
         *_process_data.solid_materials[0];
-
-    double const& dt = _process_data.dt;
 
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());
@@ -464,9 +462,9 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                   ShapeFunctionPressure, IntegrationMethod,
                                   DisplacementDim>::
     assembleWithJacobianForDeformationEquations(
-        const double t, const std::vector<double>& /*local_xdot*/,
-        const double /*dxdot_dx*/, const double /*dx_dx*/,
-        std::vector<double>& /*local_M_data*/,
+        const double t, double const dt,
+        const std::vector<double>& /*local_xdot*/, const double /*dxdot_dx*/,
+        const double /*dx_dx*/, std::vector<double>& /*local_M_data*/,
         std::vector<double>& /*local_K_data*/,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         const LocalCoupledSolutions& local_coupled_solutions)
@@ -489,8 +487,6 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
         MathLib::createZeroedVector<typename ShapeMatricesTypeDisplacement::
                                         template VectorType<displacement_size>>(
             local_b_data, displacement_size);
-
-    double const& dt = _process_data.dt;
 
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());
@@ -554,28 +550,24 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                   ShapeFunctionPressure, IntegrationMethod,
                                   DisplacementDim>::
     assembleWithJacobianForStaggeredScheme(
-        const double t,
-        const std::vector<double>& local_xdot,
-        const double dxdot_dx,
-        const double dx_dx,
-        std::vector<double>& local_M_data,
-        std::vector<double>& local_K_data,
-        std::vector<double>& local_b_data,
-        std::vector<double>& local_Jac_data,
+        const double t, double const dt, const std::vector<double>& local_xdot,
+        const double dxdot_dx, const double dx_dx,
+        std::vector<double>& local_M_data, std::vector<double>& local_K_data,
+        std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         const LocalCoupledSolutions& local_coupled_solutions)
 {
     // For the equations with pressure
     if (local_coupled_solutions.process_id == 0)
     {
         assembleWithJacobianForPressureEquations(
-            t, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
+            t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
             local_b_data, local_Jac_data, local_coupled_solutions);
         return;
     }
 
     // For the equations with deformation
     assembleWithJacobianForDeformationEquations(
-        t, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
+        t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
         local_b_data, local_Jac_data, local_coupled_solutions);
 }
 

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -130,7 +130,8 @@ public:
         unsigned const integration_order,
         HydroMechanicsProcessData<DisplacementDim>& process_data);
 
-    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& /*local_x*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_rhs_data*/) override
@@ -140,7 +141,7 @@ public:
             "implemented.");
     }
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x,
                               std::vector<double> const& local_xdot,
                               const double /*dxdot_dx*/, const double /*dx_dx*/,
@@ -150,7 +151,7 @@ public:
                               std::vector<double>& local_Jac_data) override;
 
     void assembleWithJacobianForStaggeredScheme(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
@@ -375,7 +376,7 @@ private:
      *                                processes of an element.
      */
     void assembleWithJacobianForDeformationEquations(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
@@ -410,7 +411,7 @@ private:
      *                                processes of an element.
      */
     void assembleWithJacobianForPressureEquations(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -167,7 +167,9 @@ public:
         }
     }
 
-    void postTimestepConcrete(std::vector<double> const& /*local_x*/) override
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/,
+                              double const /*t*/,
+                              double const /*dt*/) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -184,7 +184,7 @@ public:
     void computeSecondaryVariableConcrete(
         double const t, std::vector<double> const& local_x) override;
     void postNonLinearSolverConcrete(std::vector<double> const& local_x,
-                                     double const t,
+                                     double const t, double const dt,
                                      bool const use_monolithic_scheme) override;
 
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
@@ -374,7 +374,6 @@ void HydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
     DBUG("PreTimestep HydroMechanicsProcess.");
 
     _process_data.dt = dt;
-    _process_data.t = t;
 
     if (hasMechanicalProcess(process_id))
     {
@@ -389,14 +388,14 @@ void HydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
 
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::postTimestepConcreteProcess(
-    GlobalVector const& x, const double /*t*/, const double /*delta_t*/,
+    GlobalVector const& x, double const t, double const dt,
     const int process_id)
 {
     DBUG("PostTimestep HydroMechanicsProcess.");
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerInterface::postTimestep, _local_assemblers,
-        pv.getActiveElementIDs(), getDOFTable(process_id), x);
+        pv.getActiveElementIDs(), getDOFTable(process_id), x, t, dt);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
@@ -371,8 +371,6 @@ void HydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
 {
     DBUG("PreTimestep HydroMechanicsProcess.");
 
-    _process_data.dt = dt;
-
     if (hasMechanicalProcess(process_id))
     {
         ProcessLib::ProcessVariable const& pv =
@@ -398,7 +396,8 @@ void HydroMechanicsProcess<DisplacementDim>::postTimestepConcreteProcess(
 
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::postNonLinearSolverConcreteProcess(
-    GlobalVector const& x, const double t, const int process_id)
+    GlobalVector const& x, const double t, double const dt,
+    const int process_id)
 {
     if (!hasMechanicalProcess(process_id))
     {
@@ -410,7 +409,7 @@ void HydroMechanicsProcess<DisplacementDim>::postNonLinearSolverConcreteProcess(
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerInterface::postNonLinearSolver, _local_assemblers,
-        pv.getActiveElementIDs(), getDOFTable(process_id), x, t,
+        pv.getActiveElementIDs(), getDOFTable(process_id), x, t, dt,
         _use_monolithic_scheme);
 }
 

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
@@ -278,8 +278,8 @@ void HydroMechanicsProcess<DisplacementDim>::initializeBoundaryConditions()
 
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble the equations for HydroMechanics");
 
@@ -292,17 +292,15 @@ void HydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        dof_table, t, x, M, K, b, _coupled_solutions);
+        dof_table, t, dt, x, M, K, b, _coupled_solutions);
 }
 
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::
-    assembleWithJacobianConcreteProcess(const double t, GlobalVector const& x,
-                                        GlobalVector const& xdot,
-                                        const double dxdot_dx,
-                                        const double dx_dx, GlobalMatrix& M,
-                                        GlobalMatrix& K, GlobalVector& b,
-                                        GlobalMatrix& Jac)
+    assembleWithJacobianConcreteProcess(
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_tables;
@@ -339,8 +337,8 @@ void HydroMechanicsProcess<DisplacementDim>::
 
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_tables, t, x,
-        xdot, dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), dof_tables, t, dt, x, xdot,
+        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 
     auto copyRhs = [&](int const variable_id, auto& output_vector) {
         if (_use_monolithic_scheme)

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -72,14 +72,15 @@ private:
 
     void initializeBoundaryConditions() override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const /*dt*/,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const /*dt*/, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,
                                     double const dt,

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -90,8 +90,9 @@ private:
                                      const double delta_t,
                                      int const process_id) override;
 
-    void postNonLinearSolverConcreteProcess(GlobalVector const& x, const double t,
-                                     int const process_id) override;
+    void postNonLinearSolverConcreteProcess(GlobalVector const& x,
+                                            const double t, double const dt,
+                                            int const process_id) override;
 
     NumLib::LocalToGlobalIndexMap const& getDOFTable(
         const int process_id) const override;

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
@@ -121,7 +121,6 @@ struct HydroMechanicsProcessData
 
     MeshLib::PropertyVector<double>* pressure_interpolated = nullptr;
     double dt = std::numeric_limits<double>::quiet_NaN();
-    double t = std::numeric_limits<double>::quiet_NaN();
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
@@ -120,7 +120,6 @@ struct HydroMechanicsProcessData
     }
 
     MeshLib::PropertyVector<double>* pressure_interpolated = nullptr;
-    double dt = std::numeric_limits<double>::quiet_NaN();
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -454,8 +454,9 @@ void HydroMechanicsProcess<GlobalDim>::initializeConcreteProcess(
 }
 
 template <int GlobalDim>
-void HydroMechanicsProcess<GlobalDim>::computeSecondaryVariableConcrete(
-    const double t, GlobalVector const& x, int const process_id)
+void HydroMechanicsProcess<GlobalDim>::postTimestepConcreteProcess(
+    GlobalVector const& x, const double t, double const dt,
+    int const process_id)
 {
     DBUG("Compute the secondary variables for HydroMechanicsProcess.");
     const auto& dof_table = getDOFTable(process_id);
@@ -465,9 +466,8 @@ void HydroMechanicsProcess<GlobalDim>::computeSecondaryVariableConcrete(
             getProcessVariables(process_id)[0];
 
         GlobalExecutor::executeSelectedMemberOnDereferenced(
-            &HydroMechanicsLocalAssemblerInterface::computeSecondaryVariable,
-            _local_assemblers, pv.getActiveElementIDs(),
-            dof_table, t, x, _coupled_solutions);
+            &HydroMechanicsLocalAssemblerInterface::postTimestep,
+            _local_assemblers, pv.getActiveElementIDs(), dof_table, x, t, dt);
     }
 
     // Copy displacement jumps in a solution vector to mesh property
@@ -615,8 +615,6 @@ void HydroMechanicsProcess<GlobalDim>::preTimestepConcreteProcess(
     const int process_id)
 {
     DBUG("PreTimestep HydroMechanicsProcess.");
-
-    _process_data.dt = dt;
 
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -566,8 +566,8 @@ bool HydroMechanicsProcess<GlobalDim>::isLinear() const
 
 template <int GlobalDim>
 void HydroMechanicsProcess<GlobalDim>::assembleConcreteProcess(
-    const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble HydroMechanicsProcess.");
 
@@ -576,14 +576,14 @@ void HydroMechanicsProcess<GlobalDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        dof_table, t, x, M, K, b, _coupled_solutions);
+        dof_table, t, dt, x, M, K, b, _coupled_solutions);
 }
 
 template <int GlobalDim>
 void HydroMechanicsProcess<GlobalDim>::assembleWithJacobianConcreteProcess(
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac)
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian HydroMechanicsProcess.");
 
@@ -596,8 +596,8 @@ void HydroMechanicsProcess<GlobalDim>::assembleWithJacobianConcreteProcess(
        dof_table = {std::ref(*_local_to_global_index_map)};
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, x,
-        xdot, dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
+        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 
     auto copyRhs = [&](int const variable_id, auto& output_vector) {
         transformVariableFromGlobalVector(b, variable_id,

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -617,7 +617,6 @@ void HydroMechanicsProcess<GlobalDim>::preTimestepConcreteProcess(
     DBUG("PreTimestep HydroMechanicsProcess.");
 
     _process_data.dt = dt;
-    _process_data.t = t;
 
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
@@ -51,9 +51,9 @@ public:
     bool isLinear() const override;
     //! @}
 
-    void computeSecondaryVariableConcrete(double const t,
-                                          GlobalVector const& x,
-                                          int const process_id) override;
+    void postTimestepConcreteProcess(GlobalVector const& x, double const t,
+                                     double const dt,
+                                     int const process_id) override;
 
 private:
     using LocalAssemblerInterface = HydroMechanicsLocalAssemblerInterface;

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
@@ -65,14 +65,15 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,
                                     double const dt,
                                     const int /*process_id*/) override;

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcessData.h
@@ -111,8 +111,6 @@ struct HydroMechanicsProcessData
     std::unique_ptr<MeshLib::ElementStatus> p_element_status;
     ParameterLib::Parameter<double> const* p0 = nullptr;
 
-    double dt = 0.0;
-
     // mesh properties for output
     MeshLib::PropertyVector<double>* mesh_prop_stress_xx = nullptr;
     MeshLib::PropertyVector<double>* mesh_prop_stress_yy = nullptr;

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcessData.h
@@ -112,7 +112,6 @@ struct HydroMechanicsProcessData
     ParameterLib::Parameter<double> const* p0 = nullptr;
 
     double dt = 0.0;
-    double t = 0.0;
 
     // mesh properties for output
     MeshLib::PropertyVector<double>* mesh_prop_stress_xx = nullptr;

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
@@ -133,7 +133,7 @@ template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
           typename IntegrationMethod, int GlobalDim>
 void HydroMechanicsLocalAssemblerFracture<
     ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
-    GlobalDim>::assembleWithJacobianConcrete(double const t,
+    GlobalDim>::assembleWithJacobianConcrete(double const t, double const dt,
                                              Eigen::VectorXd const& local_x,
                                              Eigen::VectorXd const& local_xdot,
                                              Eigen::VectorXd& local_b,
@@ -156,8 +156,8 @@ void HydroMechanicsLocalAssemblerFracture<
     auto J_gg = local_J.block(displacement_index, displacement_index,
                               displacement_size, displacement_size);
 
-    assembleBlockMatricesWithJacobian(t, p, p_dot, g, g_dot, rhs_p, rhs_g, J_pp,
-                                      J_pg, J_gg, J_gp);
+    assembleBlockMatricesWithJacobian(t, dt, p, p_dot, g, g_dot, rhs_p, rhs_g,
+                                      J_pp, J_pg, J_gg, J_gp);
 }
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
@@ -166,7 +166,8 @@ void HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
                                           ShapeFunctionPressure,
                                           IntegrationMethod, GlobalDim>::
     assembleBlockMatricesWithJacobian(
-        double const t, Eigen::Ref<const Eigen::VectorXd> const& p,
+        double const t, double const dt,
+        Eigen::Ref<const Eigen::VectorXd> const& p,
         Eigen::Ref<const Eigen::VectorXd> const& p_dot,
         Eigen::Ref<const Eigen::VectorXd> const& g,
         Eigen::Ref<const Eigen::VectorXd> const& g_dot,
@@ -176,7 +177,6 @@ void HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
 {
     auto const& frac_prop = *_process_data.fracture_property;
     auto const& R = frac_prop.R;
-    double const& dt = _process_data.dt;
 
     // the index of a normal (normal to a fracture plane) component
     // in a displacement vector

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture-impl.h
@@ -328,10 +328,10 @@ void HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
           typename IntegrationMethod, int GlobalDim>
-void HydroMechanicsLocalAssemblerFracture<ShapeFunctionDisplacement,
-                                          ShapeFunctionPressure,
-                                          IntegrationMethod, GlobalDim>::
-    computeSecondaryVariableConcreteWithVector(const double t,
+void HydroMechanicsLocalAssemblerFracture<
+    ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
+    GlobalDim>::postTimestepConcreteWithVector(const double t,
+                                               double const /*dt*/,
                                                Eigen::VectorXd const& local_x)
 {
     auto const nodal_g = local_x.segment(displacement_index, displacement_size);

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture.h
@@ -70,30 +70,21 @@ public:
     }
 
 private:
-    void assembleWithJacobianConcrete(double const t,
+    void assembleWithJacobianConcrete(double const t, double const dt,
                                       Eigen::VectorXd const& local_x,
                                       Eigen::VectorXd const& local_xdot,
                                       Eigen::VectorXd& local_b,
                                       Eigen::MatrixXd& local_J) override;
 
     void assembleBlockMatricesWithJacobian(
-        double const t,
+        double const t, double const dt,
         Eigen::Ref<const Eigen::VectorXd> const& p,
         Eigen::Ref<const Eigen::VectorXd> const& p_dot,
         Eigen::Ref<const Eigen::VectorXd> const& g,
         Eigen::Ref<const Eigen::VectorXd> const& g_dot,
-        Eigen::Ref<Eigen::VectorXd>
-            rhs_p,
-        Eigen::Ref<Eigen::VectorXd>
-            rhs_g,
-        Eigen::Ref<Eigen::MatrixXd>
-            J_pp,
-        Eigen::Ref<Eigen::MatrixXd>
-            J_pg,
-        Eigen::Ref<Eigen::MatrixXd>
-            J_gg,
-        Eigen::Ref<Eigen::MatrixXd>
-            J_gp);
+        Eigen::Ref<Eigen::VectorXd> rhs_p, Eigen::Ref<Eigen::VectorXd> rhs_g,
+        Eigen::Ref<Eigen::MatrixXd> J_pp, Eigen::Ref<Eigen::MatrixXd> J_pg,
+        Eigen::Ref<Eigen::MatrixXd> J_gg, Eigen::Ref<Eigen::MatrixXd> J_gp);
 
     // Types for displacement.
     using ShapeMatricesTypeDisplacement =

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerFracture.h
@@ -57,8 +57,9 @@ public:
         }
     }
 
-    void computeSecondaryVariableConcreteWithVector(
-        const double t, Eigen::VectorXd const& local_x) override;
+    void postTimestepConcreteWithVector(
+        const double t, double const dt,
+        Eigen::VectorXd const& local_x) override;
 
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         const unsigned integration_point) const override

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerInterface.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerInterface.h
@@ -46,7 +46,8 @@ public:
         _local_J.resize(_local_u.size(), _local_u.size());
     }
 
-    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& /*local_x*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_rhs_data*/) override
@@ -56,7 +57,7 @@ public:
             "implemented.");
     }
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x_,
                               std::vector<double> const& local_xdot_,
                               const double /*dxdot_dx*/, const double /*dx_dx*/,
@@ -80,7 +81,7 @@ public:
         _local_b.setZero();
         _local_J.setZero();
 
-        assembleWithJacobianConcrete(t, _local_u, _local_udot, _local_b,
+        assembleWithJacobianConcrete(t, dt, _local_u, _local_udot, _local_b,
                                      _local_J);
 
         local_b_data.resize(local_dof_size);
@@ -115,7 +116,7 @@ public:
     }
 
 protected:
-    virtual void assembleWithJacobianConcrete(double const t,
+    virtual void assembleWithJacobianConcrete(double const t, double const dt,
                                               Eigen::VectorXd const& local_u,
                                               Eigen::VectorXd const& local_udot,
                                               Eigen::VectorXd& local_b,

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerInterface.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerInterface.h
@@ -101,8 +101,8 @@ public:
         }
     }
 
-    void computeSecondaryVariableConcrete(
-        const double t, std::vector<double> const& local_x_) override
+    void postTimestepConcrete(std::vector<double> const& local_x_,
+                              const double t, double const dt) override
     {
         auto const local_dof_size = local_x_.size();
 
@@ -112,7 +112,7 @@ public:
             _local_u[_dofIndex_to_localIndex[i]] = local_x_[i];
         }
 
-        computeSecondaryVariableConcreteWithVector(t, _local_u);
+        postTimestepConcreteWithVector(t, dt, _local_u);
     }
 
 protected:
@@ -122,8 +122,8 @@ protected:
                                               Eigen::VectorXd& local_b,
                                               Eigen::MatrixXd& local_J) = 0;
 
-    virtual void computeSecondaryVariableConcreteWithVector(
-        double const t, Eigen::VectorXd const& local_u) = 0;
+    virtual void postTimestepConcreteWithVector(
+        double const t, double const dt, Eigen::VectorXd const& local_u) = 0;
 
     MeshLib::Element const& _element;
     bool const _is_axially_symmetric;

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
@@ -294,10 +294,9 @@ void HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
           typename IntegrationMethod, int GlobalDim>
-void HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
-                                        ShapeFunctionPressure,
-                                        IntegrationMethod, GlobalDim>::
-    computeSecondaryVariableConcreteWithVector(double const t,
+void HydroMechanicsLocalAssemblerMatrix<
+    ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
+    GlobalDim>::postTimestepConcreteWithVector(double const t, double const dt,
                                                Eigen::VectorXd const& local_x)
 {
     auto p = const_cast<Eigen::VectorXd&>(local_x).segment(pressure_index,
@@ -308,7 +307,7 @@ void HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
     }
     auto u = local_x.segment(displacement_index, displacement_size);
 
-    computeSecondaryVariableConcreteWithBlockVectors(t, p, u);
+    postTimestepConcreteWithBlockVectors(t, dt, p, u);
 }
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
@@ -316,8 +315,8 @@ template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
 void HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
                                         ShapeFunctionPressure,
                                         IntegrationMethod, GlobalDim>::
-    computeSecondaryVariableConcreteWithBlockVectors(
-        double const t,
+    postTimestepConcreteWithBlockVectors(
+        double const t, double const dt,
         Eigen::Ref<const Eigen::VectorXd> const& p,
         Eigen::Ref<const Eigen::VectorXd> const& u)
 {
@@ -354,8 +353,8 @@ void HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
         eps.noalias() = B * u;
 
         auto&& solution = _ip_data[ip].solid_material.integrateStress(
-            t, x_position, _process_data.dt, eps_prev, eps, sigma_eff_prev,
-            *state, _process_data.reference_temperature);
+            t, x_position, dt, eps_prev, eps, sigma_eff_prev, *state,
+            _process_data.reference_temperature);
 
         if (!solution)
         {

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix.h
@@ -84,11 +84,12 @@ protected:
         Eigen::Ref<Eigen::MatrixXd> J_pp, Eigen::Ref<Eigen::MatrixXd> J_pu,
         Eigen::Ref<Eigen::MatrixXd> J_uu, Eigen::Ref<Eigen::MatrixXd> J_up);
 
-    void computeSecondaryVariableConcreteWithVector(
-        double const t, Eigen::VectorXd const& local_x) override;
+    void postTimestepConcreteWithVector(
+        double const t, double const dt,
+        Eigen::VectorXd const& local_x) override;
 
-    void computeSecondaryVariableConcreteWithBlockVectors(
-        double const t,
+    void postTimestepConcreteWithBlockVectors(
+        double const t, double const dt,
         Eigen::Ref<const Eigen::VectorXd> const& p,
         Eigen::Ref<const Eigen::VectorXd> const& u);
 

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix.h
@@ -68,30 +68,21 @@ public:
     }
 
 protected:
-    void assembleWithJacobianConcrete(double const t,
+    void assembleWithJacobianConcrete(double const t, double const dt,
                                       Eigen::VectorXd const& local_x,
                                       Eigen::VectorXd const& local_x_dot,
                                       Eigen::VectorXd& local_rhs,
                                       Eigen::MatrixXd& local_Jac) override;
 
     void assembleBlockMatricesWithJacobian(
-        double const t,
+        double const t, double const dt,
         Eigen::Ref<const Eigen::VectorXd> const& p,
         Eigen::Ref<const Eigen::VectorXd> const& p_dot,
         Eigen::Ref<const Eigen::VectorXd> const& u,
         Eigen::Ref<const Eigen::VectorXd> const& u_dot,
-        Eigen::Ref<Eigen::VectorXd>
-            rhs_p,
-        Eigen::Ref<Eigen::VectorXd>
-            rhs_u,
-        Eigen::Ref<Eigen::MatrixXd>
-            J_pp,
-        Eigen::Ref<Eigen::MatrixXd>
-            J_pu,
-        Eigen::Ref<Eigen::MatrixXd>
-            J_uu,
-        Eigen::Ref<Eigen::MatrixXd>
-            J_up);
+        Eigen::Ref<Eigen::VectorXd> rhs_p, Eigen::Ref<Eigen::VectorXd> rhs_u,
+        Eigen::Ref<Eigen::MatrixXd> J_pp, Eigen::Ref<Eigen::MatrixXd> J_pu,
+        Eigen::Ref<Eigen::MatrixXd> J_uu, Eigen::Ref<Eigen::MatrixXd> J_up);
 
     void computeSecondaryVariableConcreteWithVector(
         double const t, Eigen::VectorXd const& local_x) override;

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture-impl.h
@@ -131,8 +131,7 @@ template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
           typename IntegrationMethod, int GlobalDim>
 void HydroMechanicsLocalAssemblerMatrixNearFracture<
     ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
-    GlobalDim>::
-    computeSecondaryVariableConcreteWithVector(double const t,
+    GlobalDim>::postTimestepConcreteWithVector(double const t, double const dt,
                                                Eigen::VectorXd const& local_x)
 {
     auto p = const_cast<Eigen::VectorXd&>(local_x).segment(pressure_index,
@@ -152,7 +151,7 @@ void HydroMechanicsLocalAssemblerMatrixNearFracture<
     if (ele_levelset == 0)
     {
         // no DoF exists for displacement jumps. do the normal assembly
-        Base::computeSecondaryVariableConcreteWithBlockVectors(t, p, u);
+        Base::postTimestepConcreteWithBlockVectors(t, dt, p, u);
         return;
     }
 
@@ -163,7 +162,7 @@ void HydroMechanicsLocalAssemblerMatrixNearFracture<
     Eigen::VectorXd const total_u = u + ele_levelset * g;
 
     // evaluate residuals and Jacobians for pressure and displacements
-    Base::computeSecondaryVariableConcreteWithBlockVectors(t, p, total_u);
+    Base::postTimestepConcreteWithBlockVectors(t, dt, p, total_u);
 }
 
 }  // namespace HydroMechanics

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture-impl.h
@@ -47,7 +47,7 @@ template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
           typename IntegrationMethod, int GlobalDim>
 void HydroMechanicsLocalAssemblerMatrixNearFracture<
     ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
-    GlobalDim>::assembleWithJacobianConcrete(double const t,
+    GlobalDim>::assembleWithJacobianConcrete(double const t, double const dt,
                                              Eigen::VectorXd const& local_x,
                                              Eigen::VectorXd const& local_x_dot,
                                              Eigen::VectorXd& local_b,
@@ -87,8 +87,8 @@ void HydroMechanicsLocalAssemblerMatrixNearFracture<
     if (ele_levelset == 0)
     {
         // no DoF exists for displacement jumps. do the normal assembly
-        Base::assembleBlockMatricesWithJacobian(t, p, p_dot, u, u_dot, rhs_p,
-                                                rhs_u, J_pp, J_pu, J_uu, J_up);
+        Base::assembleBlockMatricesWithJacobian(
+            t, dt, p, p_dot, u, u_dot, rhs_p, rhs_u, J_pp, J_pu, J_uu, J_up);
         return;
     }
 
@@ -102,9 +102,9 @@ void HydroMechanicsLocalAssemblerMatrixNearFracture<
     Eigen::VectorXd const total_u_dot = u_dot + ele_levelset * g_dot;
 
     // evaluate residuals and Jacobians for pressure and displacements
-    Base::assembleBlockMatricesWithJacobian(t, p, p_dot, total_u, total_u_dot,
-                                            rhs_p, rhs_u, J_pp, J_pu, J_uu,
-                                            J_up);
+    Base::assembleBlockMatricesWithJacobian(t, dt, p, p_dot, total_u,
+                                            total_u_dot, rhs_p, rhs_u, J_pp,
+                                            J_pu, J_uu, J_up);
 
     // compute residuals and Jacobians for displacement jumps
     auto rhs_g = local_b.segment(displacement_jump_index, displacement_size);

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture.h
@@ -71,8 +71,9 @@ private:
         }
     }
 
-    void computeSecondaryVariableConcreteWithVector(
-        double const t, Eigen::VectorXd const& local_x) override;
+    void postTimestepConcreteWithVector(
+        double const t, double const dt,
+        Eigen::VectorXd const& local_x) override;
 
     using Base::_element;
     using Base::_ip_data;

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrixNearFracture.h
@@ -55,7 +55,7 @@ public:
         HydroMechanicsProcessData<GlobalDim>& process_data);
 
 private:
-    void assembleWithJacobianConcrete(double const t,
+    void assembleWithJacobianConcrete(double const t, double const dt,
                                       Eigen::VectorXd const& local_x,
                                       Eigen::VectorXd const& local_x_dot,
                                       Eigen::VectorXd& local_b,

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerFracture-impl.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerFracture-impl.h
@@ -110,7 +110,7 @@ template <typename ShapeFunction, typename IntegrationMethod,
           int DisplacementDim>
 void SmallDeformationLocalAssemblerFracture<
     ShapeFunction, IntegrationMethod,
-    DisplacementDim>::assembleWithJacobian(double const t,
+    DisplacementDim>::assembleWithJacobian(double const t, double const /*dt*/,
                                            Eigen::VectorXd const& local_u,
                                            Eigen::VectorXd& local_b,
                                            Eigen::MatrixXd& local_J)

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
@@ -64,7 +64,8 @@ public:
         unsigned const integration_order,
         SmallDeformationProcessData<DisplacementDim>& process_data);
 
-    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& /*local_x*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override
@@ -74,7 +75,7 @@ public:
             "implemented.");
     }
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               Eigen::VectorXd const& local_u,
                               Eigen::VectorXd& local_b,
                               Eigen::MatrixXd& local_J) override;

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerInterface.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerInterface.h
@@ -39,7 +39,7 @@ public:
         _local_J.resize(_local_u.size(), _local_u.size());
     }
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x_,
                               std::vector<double> const& /*local_xdot*/,
                               const double /*dxdot_dx*/, const double /*dx_dx*/,
@@ -58,7 +58,7 @@ public:
         _local_b.setZero();
         _local_J.setZero();
 
-        assembleWithJacobian(t, _local_u, _local_b, _local_J);
+        assembleWithJacobian(t, dt, _local_u, _local_b, _local_J);
 
         local_b_data.resize(local_dof_size);
         for (unsigned i = 0; i < local_dof_size; i++)
@@ -77,15 +77,11 @@ public:
         }
     }
 
-    virtual void assembleWithJacobian(double const t,
-                                      Eigen::VectorXd const& local_u,
-                                      Eigen::VectorXd& local_b,
-                                      Eigen::MatrixXd& local_J)
+    virtual void assembleWithJacobian(double const /*t*/, double const /*dt*/,
+                                      Eigen::VectorXd const& /*local_u*/,
+                                      Eigen::VectorXd& /*local_b*/,
+                                      Eigen::MatrixXd& /*local_J*/)
     {
-        (void)t;
-        (void)local_u;
-        (void)local_b;
-        (void)local_J;
         OGS_FATAL(
             "SmallDeformationLocalAssemblerInterface::assembleWithJacobian() "
             "is not implemented");

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix-impl.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix-impl.h
@@ -99,7 +99,8 @@ template <typename ShapeFunction, typename IntegrationMethod,
           int DisplacementDim>
 void SmallDeformationLocalAssemblerMatrix<ShapeFunction, IntegrationMethod,
                                           DisplacementDim>::
-    assembleWithJacobian(double const t, std::vector<double> const& local_x,
+    assembleWithJacobian(double const t, double const dt,
+                         std::vector<double> const& local_x,
                          std::vector<double> const& /*local_xdot*/,
                          const double /*dxdot_dx*/, const double /*dx_dx*/,
                          std::vector<double>& /*local_M_data*/,
@@ -151,7 +152,7 @@ void SmallDeformationLocalAssemblerMatrix<ShapeFunction, IntegrationMethod,
                     local_x.data(), ShapeFunction::NPOINTS * DisplacementDim);
 
         auto&& solution = _ip_data[ip]._solid_material.integrateStress(
-            t, x_position, _process_data.dt, eps_prev, eps, sigma_prev, *state,
+            t, x_position, dt, eps_prev, eps, sigma_prev, *state,
             _process_data._reference_temperature);
 
         if (!solution)

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
@@ -59,7 +59,8 @@ public:
         unsigned const integration_order,
         SmallDeformationProcessData<DisplacementDim>& process_data);
 
-    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& /*local_x*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override
@@ -69,7 +70,7 @@ public:
             "implemented.");
     }
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x,
                               std::vector<double> const& /*local_xdot*/,
                               const double /*dxdot_dx*/, const double /*dx_dx*/,

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture-impl.h
@@ -124,13 +124,11 @@ SmallDeformationLocalAssemblerMatrixNearFracture<ShapeFunction,
     }
 }
 
-template <typename ShapeFunction,
-          typename IntegrationMethod,
+template <typename ShapeFunction, typename IntegrationMethod,
           int DisplacementDim>
 void SmallDeformationLocalAssemblerMatrixNearFracture<
-    ShapeFunction,
-    IntegrationMethod,
-    DisplacementDim>::assembleWithJacobian(double const t,
+    ShapeFunction, IntegrationMethod,
+    DisplacementDim>::assembleWithJacobian(double const t, double const dt,
                                            Eigen::VectorXd const& local_u,
                                            Eigen::VectorXd& local_b,
                                            Eigen::MatrixXd& local_J)
@@ -255,7 +253,7 @@ void SmallDeformationLocalAssemblerMatrixNearFracture<
         eps.noalias() = B * nodal_total_u;
 
         auto&& solution = _ip_data[ip]._solid_material.integrateStress(
-            t, x_position, _process_data.dt, eps_prev, eps, sigma_prev, *state,
+            t, x_position, dt, eps_prev, eps, sigma_prev, *state,
             _process_data._reference_temperature);
 
         if (!solution)

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
@@ -66,7 +66,8 @@ public:
         unsigned const integration_order,
         SmallDeformationProcessData<DisplacementDim>& process_data);
 
-    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& /*local_x*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override
@@ -76,7 +77,7 @@ public:
             "implemented.");
     }
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               Eigen::VectorXd const& local_u,
                               Eigen::VectorXd& local_b,
                               Eigen::MatrixXd& local_J) override;

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -542,8 +542,8 @@ bool SmallDeformationProcess<DisplacementDim>::isLinear() const
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble SmallDeformationProcess.");
 
@@ -555,17 +555,15 @@ void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::
-    assembleWithJacobianConcreteProcess(const double t, GlobalVector const& x,
-                                        GlobalVector const& xdot,
-                                        const double dxdot_dx,
-                                        const double dx_dx, GlobalMatrix& M,
-                                        GlobalMatrix& K, GlobalVector& b,
-                                        GlobalMatrix& Jac)
+    assembleWithJacobianConcreteProcess(
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian SmallDeformationProcess.");
 
@@ -577,8 +575,8 @@ void SmallDeformationProcess<DisplacementDim>::
         dof_table = {std::ref(*_local_to_global_index_map)};
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t,
-        x, xdot, dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
+        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::preTimestepConcreteProcess(

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -585,9 +585,6 @@ void SmallDeformationProcess<DisplacementDim>::preTimestepConcreteProcess(
 {
     DBUG("PreTimestep SmallDeformationProcess.");
 
-    _process_data.dt = dt;
-    _process_data.t = t;
-
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &SmallDeformationLocalAssemblerInterface::preTimestep,

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
@@ -61,14 +61,15 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,
                                     double const dt,

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcessData.h
@@ -84,9 +84,6 @@ struct SmallDeformationProcessData
     std::vector<std::vector<int>> _vec_ele_connected_fractureIDs;
     std::vector<std::vector<int>> _vec_ele_connected_junctionIDs;
 
-    double dt = 0.0;
-    double t = 0.0;
-
     // mesh properties to output element's stress.
     MeshLib::PropertyVector<double>* _mesh_prop_stress_xx = nullptr;
     MeshLib::PropertyVector<double>* _mesh_prop_stress_yy = nullptr;

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
@@ -23,7 +23,8 @@ namespace LiquidFlow
 template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
 void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
-    assemble(double const t, std::vector<double> const& local_x,
+    assemble(double const t, double const /*dt*/,
+             std::vector<double> const& local_x,
              std::vector<double>& local_M_data,
              std::vector<double>& local_K_data,
              std::vector<double>& local_b_data)

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -122,11 +122,11 @@ public:
         }
     }
 
-    void assemble(double const t, std::vector<double> const& local_x,
+    void assemble(double const t, double const dt,
+                  std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;
-
 
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         const unsigned integration_point) const override

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -78,7 +78,7 @@ void LiquidFlowProcess::initializeConcreteProcess(
             &LiquidFlowLocalAssemblerInterface::getIntPtDarcyVelocity));
 }
 
-void LiquidFlowProcess::assembleConcreteProcess(const double t,
+void LiquidFlowProcess::assembleConcreteProcess(const double t, double const dt,
                                                 GlobalVector const& x,
                                                 GlobalMatrix& M,
                                                 GlobalMatrix& K,
@@ -96,14 +96,14 @@ void LiquidFlowProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(),  dof_table, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 
 void LiquidFlowProcess::assembleWithJacobianConcreteProcess(
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac)
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian LiquidFlowProcess.");
 
@@ -115,8 +115,8 @@ void LiquidFlowProcess::assembleWithJacobianConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t,
-        x, xdot, dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
+        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 void LiquidFlowProcess::computeSecondaryVariableConcrete(const double t,

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -89,14 +89,15 @@ private:
         NumLib::LocalToGlobalIndexMap const& dof_table,
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     const int _gravitational_axis_id;
     const double _gravitational_acceleration;

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -17,6 +17,7 @@
 namespace ProcessLib
 {
 void LocalAssemblerInterface::assemble(double const /*t*/,
+                                       double const /*dt*/,
                                        std::vector<double> const& /*local_x*/,
                                        std::vector<double>& /*local_M_data*/,
                                        std::vector<double>& /*local_K_data*/,
@@ -27,7 +28,7 @@ void LocalAssemblerInterface::assemble(double const /*t*/,
 }
 
 void LocalAssemblerInterface::assembleForStaggeredScheme(
-    double const /*t*/,
+    double const /*t*/, double const /*dt*/,
     std::vector<double>& /*local_M_data*/,
     std::vector<double>& /*local_K_data*/,
     std::vector<double>& /*local_b_data*/,
@@ -53,9 +54,9 @@ void LocalAssemblerInterface::assembleWithJacobian(
 }
 
 void LocalAssemblerInterface::assembleWithJacobianForStaggeredScheme(
-    double const /*t*/, std::vector<double> const& /*local_xdot*/,
-    const double /*dxdot_dx*/, const double /*dx_dx*/,
-    std::vector<double>& /*local_M_data*/,
+    double const /*t*/, double const /*dt*/,
+    std::vector<double> const& /*local_xdot*/, const double /*dxdot_dx*/,
+    const double /*dx_dx*/, std::vector<double>& /*local_M_data*/,
     std::vector<double>& /*local_K_data*/,
     std::vector<double>& /*local_b_data*/,
     std::vector<double>& /*local_Jac_data*/,

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -39,7 +39,8 @@ void LocalAssemblerInterface::assembleForStaggeredScheme(
 }
 
 void LocalAssemblerInterface::assembleWithJacobian(
-    double const /*t*/, std::vector<double> const& /*local_x*/,
+    double const /*t*/, double const /*dt*/,
+    std::vector<double> const& /*local_x*/,
     std::vector<double> const& /*local_xdot*/, const double /*dxdot_dx*/,
     const double /*dx_dx*/, std::vector<double>& /*local_M_data*/,
     std::vector<double>& /*local_K_data*/,

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -112,13 +112,13 @@ void LocalAssemblerInterface::preTimestep(
 
 void LocalAssemblerInterface::postTimestep(
     std::size_t const mesh_item_id,
-    NumLib::LocalToGlobalIndexMap const& dof_table,
-    GlobalVector const& x)
+    NumLib::LocalToGlobalIndexMap const& dof_table, GlobalVector const& x,
+    double const t, double const dt)
 {
     auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
     auto const local_x = x.get(indices);
 
-    postTimestepConcrete(local_x);
+    postTimestepConcrete(local_x, t, dt);
 }
 
 void LocalAssemblerInterface::postNonLinearSolver(

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -125,13 +125,13 @@ void LocalAssemblerInterface::postTimestep(
 
 void LocalAssemblerInterface::postNonLinearSolver(
     std::size_t const mesh_item_id,
-    NumLib::LocalToGlobalIndexMap const& dof_table,
-    GlobalVector const& x, double const t, bool const use_monolithic_scheme)
+    NumLib::LocalToGlobalIndexMap const& dof_table, GlobalVector const& x,
+    double const t, double const dt, bool const use_monolithic_scheme)
 {
     auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
     auto const local_x = x.get(indices);
 
-    postNonLinearSolverConcrete(local_x, t, use_monolithic_scheme);
+    postNonLinearSolverConcrete(local_x, t, dt, use_monolithic_scheme);
 }
 
 }  // namespace ProcessLib

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -92,7 +92,7 @@ public:
     void postNonLinearSolver(std::size_t const mesh_item_id,
                              NumLib::LocalToGlobalIndexMap const& dof_table,
                              GlobalVector const& x, double const t,
-                             bool const use_monolithic_scheme);
+                             double const dt, bool const use_monolithic_scheme);
 
     /// Computes the flux in the point \c p_local_coords that is given in local
     /// coordinates using the values from \c local_x.
@@ -134,7 +134,7 @@ private:
 
     virtual void postNonLinearSolverConcrete(
         std::vector<double> const& /*local_x*/, double const /*t*/,
-        bool const /*use_monolithic_scheme*/)
+        double const /*dt*/, bool const /*use_monolithic_scheme*/)
     {
     }
 

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -46,16 +46,15 @@ public:
     virtual void preAssemble(double const /*t*/,
                              std::vector<double> const& /*local_x*/){};
 
-    virtual void assemble(double const t, std::vector<double> const& local_x,
+    virtual void assemble(double const t, double const dt,
+                          std::vector<double> const& local_x,
                           std::vector<double>& local_M_data,
                           std::vector<double>& local_K_data,
                           std::vector<double>& local_b_data);
 
     virtual void assembleForStaggeredScheme(
-        double const t,
-        std::vector<double>& local_M_data,
-        std::vector<double>& local_K_data,
-        std::vector<double>& local_b_data,
+        double const t, double const dt, std::vector<double>& local_M_data,
+        std::vector<double>& local_K_data, std::vector<double>& local_b_data,
         LocalCoupledSolutions const& coupled_solutions);
 
     virtual void assembleWithJacobian(double const t, double const dt,
@@ -68,7 +67,7 @@ public:
                                       std::vector<double>& local_Jac_data);
 
     virtual void assembleWithJacobianForStaggeredScheme(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -58,7 +58,7 @@ public:
         std::vector<double>& local_b_data,
         LocalCoupledSolutions const& coupled_solutions);
 
-    virtual void assembleWithJacobian(double const t,
+    virtual void assembleWithJacobian(double const t, double const dt,
                                       std::vector<double> const& local_x,
                                       std::vector<double> const& local_xdot,
                                       const double dxdot_dx, const double dx_dx,

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -43,7 +43,7 @@ public:
     virtual void initialize(std::size_t const mesh_item_id,
                             NumLib::LocalToGlobalIndexMap const& dof_table);
 
-    virtual void preAssemble(double const /*t*/,
+    virtual void preAssemble(double const /*t*/, double const /*dt*/,
                              std::vector<double> const& /*local_x*/){};
 
     virtual void assemble(double const t, double const dt,

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -87,7 +87,8 @@ public:
 
     virtual void postTimestep(std::size_t const mesh_item_id,
                               NumLib::LocalToGlobalIndexMap const& dof_table,
-                              GlobalVector const& x);
+                              GlobalVector const& x, double const t,
+                              double const dt);
 
     void postNonLinearSolver(std::size_t const mesh_item_id,
                              NumLib::LocalToGlobalIndexMap const& dof_table,
@@ -127,7 +128,10 @@ private:
     {
     }
 
-    virtual void postTimestepConcrete(std::vector<double> const& /*local_x*/) {}
+    virtual void postTimestepConcrete(std::vector<double> const& /*local_x*/,
+                                      double const /*t*/, double const /*dt*/)
+    {
+    }
 
     virtual void postNonLinearSolverConcrete(
         std::vector<double> const& /*local_x*/, double const /*t*/,

--- a/ProcessLib/PhaseField/PhaseFieldFEM-impl.h
+++ b/ProcessLib/PhaseField/PhaseFieldFEM-impl.h
@@ -22,7 +22,7 @@ template <typename ShapeFunction, typename IntegrationMethod,
 void PhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
                               DisplacementDim>::
     assembleWithJacobianForStaggeredScheme(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
@@ -32,14 +32,14 @@ void PhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
     if (local_coupled_solutions.process_id == 1)
     {
         assembleWithJacobianPhaseFiledEquations(
-            t, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
+            t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
             local_b_data, local_Jac_data, local_coupled_solutions);
         return;
     }
 
     // For the equations with deformation
     assembleWithJacobianForDeformationEquations(
-        t, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
+        t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
         local_b_data, local_Jac_data, local_coupled_solutions);
 }
 
@@ -48,9 +48,9 @@ template <typename ShapeFunction, typename IntegrationMethod,
 void PhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
                               DisplacementDim>::
     assembleWithJacobianForDeformationEquations(
-        double const t, std::vector<double> const& /*local_xdot*/,
-        const double /*dxdot_dx*/, const double /*dx_dx*/,
-        std::vector<double>& /*local_M_data*/,
+        double const t, double const dt,
+        std::vector<double> const& /*local_xdot*/, const double /*dxdot_dx*/,
+        const double /*dx_dx*/, std::vector<double>& /*local_M_data*/,
         std::vector<double>& /*local_K_data*/,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions)
@@ -83,7 +83,6 @@ void PhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
 
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());
-    double const& dt = _process_data.dt;
 
     auto local_pressure = 0.0;
     if (_process_data.crack_pressure)
@@ -152,9 +151,9 @@ template <typename ShapeFunction, typename IntegrationMethod,
 void PhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
                               DisplacementDim>::
     assembleWithJacobianPhaseFiledEquations(
-        double const t, std::vector<double> const& /*local_xdot*/,
-        const double /*dxdot_dx*/, const double /*dx_dx*/,
-        std::vector<double>& /*local_M_data*/,
+        double const t, double const dt,
+        std::vector<double> const& /*local_xdot*/, const double /*dxdot_dx*/,
+        const double /*dx_dx*/, std::vector<double>& /*local_M_data*/,
         std::vector<double>& /*local_K_data*/,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions)
@@ -185,7 +184,6 @@ void PhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
 
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());
-    double const& dt = _process_data.dt;
 
     auto local_pressure = 0.0;
     if (_process_data.crack_pressure)

--- a/ProcessLib/PhaseField/PhaseFieldFEM.h
+++ b/ProcessLib/PhaseField/PhaseFieldFEM.h
@@ -219,8 +219,8 @@ public:
         }
     }
 
-    void postTimestepConcrete(std::vector<double> const& /*local_x*/
-                              ) override
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/,
+                              double const /*t*/, double const /*dt*/) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/PhaseField/PhaseFieldFEM.h
+++ b/ProcessLib/PhaseField/PhaseFieldFEM.h
@@ -191,7 +191,8 @@ public:
         }
     }
 
-    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& /*local_x*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_rhs_data*/) override
@@ -202,7 +203,7 @@ public:
     }
 
     void assembleWithJacobianForStaggeredScheme(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
@@ -311,14 +312,14 @@ private:
     }
 
     void assembleWithJacobianPhaseFiledEquations(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions);
 
     void assembleWithJacobianForDeformationEquations(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,

--- a/ProcessLib/PhaseField/PhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.cpp
@@ -290,7 +290,8 @@ void PhaseFieldProcess<DisplacementDim>::postTimestepConcreteProcess(
 
 template <int DisplacementDim>
 void PhaseFieldProcess<DisplacementDim>::postNonLinearSolverConcreteProcess(
-    GlobalVector const& x, const double t, const int process_id)
+    GlobalVector const& x, const double t, double const /*dt*/,
+    const int process_id)
 {
     _process_data.crack_volume = 0.0;
 

--- a/ProcessLib/PhaseField/PhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.cpp
@@ -246,8 +246,7 @@ void PhaseFieldProcess<DisplacementDim>::preTimestepConcreteProcess(
     DBUG("PreTimestep PhaseFieldProcess %d.", process_id);
 
     _process_data.dt = dt;
-    _process_data.t = t;
-    _process_data.injected_volume = _process_data.t;
+    _process_data.injected_volume = t;
 
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
@@ -258,7 +257,7 @@ void PhaseFieldProcess<DisplacementDim>::preTimestepConcreteProcess(
 
 template <int DisplacementDim>
 void PhaseFieldProcess<DisplacementDim>::postTimestepConcreteProcess(
-    GlobalVector const& x, const double /*t*/, const double /*delta_t*/,
+    GlobalVector const& x, const double t, const double /*delta_t*/,
     int const process_id)
 {
     if (isPhaseFieldProcess(process_id))
@@ -280,7 +279,7 @@ void PhaseFieldProcess<DisplacementDim>::postTimestepConcreteProcess(
 
         GlobalExecutor::executeSelectedMemberOnDereferenced(
             &LocalAssemblerInterface::computeEnergy, _local_assemblers,
-            pv.getActiveElementIDs(), dof_tables, x, _process_data.t,
+            pv.getActiveElementIDs(), dof_tables, x, t,
             _process_data.elastic_energy, _process_data.surface_energy,
             _process_data.pressure_work, _coupled_solutions);
 

--- a/ProcessLib/PhaseField/PhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.cpp
@@ -245,7 +245,6 @@ void PhaseFieldProcess<DisplacementDim>::preTimestepConcreteProcess(
 {
     DBUG("PreTimestep PhaseFieldProcess %d.", process_id);
 
-    _process_data.dt = dt;
     _process_data.injected_volume = t;
 
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];

--- a/ProcessLib/PhaseField/PhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.cpp
@@ -162,8 +162,8 @@ void PhaseFieldProcess<DisplacementDim>::initializeBoundaryConditions()
 
 template <int DisplacementDim>
 void PhaseFieldProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble PhaseFieldProcess.");
 
@@ -192,15 +192,15 @@ void PhaseFieldProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_tables, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_tables, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 
 template <int DisplacementDim>
 void PhaseFieldProcess<DisplacementDim>::assembleWithJacobianConcreteProcess(
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac)
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_tables;
@@ -227,7 +227,7 @@ void PhaseFieldProcess<DisplacementDim>::assembleWithJacobianConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_tables, t, x, xdot,
+        _local_assemblers, pv.getActiveElementIDs(), dof_tables, t, dt, x, xdot,
         dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 
     if (_coupled_solutions->process_id == 0)

--- a/ProcessLib/PhaseField/PhaseFieldProcess.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.h
@@ -106,7 +106,7 @@ private:
                                      int const process_id) override;
 
     void postNonLinearSolverConcreteProcess(GlobalVector const& x,
-                                            const double t,
+                                            const double t, double const dt,
                                             int const process_id) override;
 
 private:

--- a/ProcessLib/PhaseField/PhaseFieldProcess.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.h
@@ -87,14 +87,15 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,
                                     double const dt,

--- a/ProcessLib/PhaseField/PhaseFieldProcessData.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcessData.h
@@ -48,7 +48,6 @@ struct PhaseFieldProcessData
     bool propagating_crack = false;
     bool crack_pressure = false;
 
-    double dt = std::numeric_limits<double>::quiet_NaN();
     double const unity_pressure = 1.0;
     double pressure = 0.0;
     double pressure_old = 0.0;

--- a/ProcessLib/PhaseField/PhaseFieldProcessData.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcessData.h
@@ -49,7 +49,6 @@ struct PhaseFieldProcessData
     bool crack_pressure = false;
 
     double dt = std::numeric_limits<double>::quiet_NaN();
-    double t = std::numeric_limits<double>::quiet_NaN();
     double const unity_pressure = 1.0;
     double pressure = 0.0;
     double pressure_old = 0.0;

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -189,9 +189,10 @@ void Process::updateDeactivatedSubdomains(double const time,
     }
 }
 
-void Process::preAssemble(const double t, GlobalVector const& x)
+void Process::preAssemble(const double t, double const dt,
+                          GlobalVector const& x)
 {
-    preAssembleConcreteProcess(t, x);
+    preAssembleConcreteProcess(t, dt, x);
 }
 
 void Process::assemble(const double t, double const dt, GlobalVector const& x,

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -210,7 +210,8 @@ void Process::assemble(const double t, GlobalVector const& x, GlobalMatrix& M,
     _source_term_collections[pcs_id].integrate(t, x, b, nullptr);
 }
 
-void Process::assembleWithJacobian(const double t, GlobalVector const& x,
+void Process::assembleWithJacobian(const double t, double const dt,
+                                   GlobalVector const& x,
                                    GlobalVector const& xdot,
                                    const double dxdot_dx, const double dx_dx,
                                    GlobalMatrix& M, GlobalMatrix& K,
@@ -219,8 +220,8 @@ void Process::assembleWithJacobian(const double t, GlobalVector const& x,
     MathLib::LinAlg::setLocalAccessibleVector(x);
     MathLib::LinAlg::setLocalAccessibleVector(xdot);
 
-    assembleWithJacobianConcreteProcess(t, x, xdot, dxdot_dx, dx_dx, M, K, b,
-                                        Jac);
+    assembleWithJacobianConcreteProcess(t, dt, x, xdot, dxdot_dx, dx_dx, M, K,
+                                        b, Jac);
 
     // TODO: apply BCs to Jacobian.
     const auto pcs_id =

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -402,10 +402,10 @@ void Process::postTimestep(GlobalVector const& x, const double t,
 }
 
 void Process::postNonLinearSolver(GlobalVector const& x, const double t,
-                                  int const process_id)
+                                  double const dt, int const process_id)
 {
     MathLib::LinAlg::setLocalAccessibleVector(x);
-    postNonLinearSolverConcreteProcess(x, t, process_id);
+    postNonLinearSolverConcreteProcess(x, t, dt, process_id);
 }
 
 void Process::computeSecondaryVariable(const double t, GlobalVector const& x,

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -194,12 +194,12 @@ void Process::preAssemble(const double t, GlobalVector const& x)
     preAssembleConcreteProcess(t, x);
 }
 
-void Process::assemble(const double t, GlobalVector const& x, GlobalMatrix& M,
-                       GlobalMatrix& K, GlobalVector& b)
+void Process::assemble(const double t, double const dt, GlobalVector const& x,
+                       GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     MathLib::LinAlg::setLocalAccessibleVector(x);
 
-    assembleConcreteProcess(t, x, M, K, b);
+    assembleConcreteProcess(t, dt, x, M, K, b);
 
     const auto pcs_id =
         (_coupled_solutions) != nullptr ? _coupled_solutions->process_id : 0;

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -97,7 +97,8 @@ public:
 
     bool isMonolithicSchemeUsed() const { return _use_monolithic_scheme; }
     virtual void setCoupledTermForTheStaggeredSchemeToLocalAssemblers() {}
-    void preAssemble(const double t, GlobalVector const& x) final;
+    void preAssemble(const double t, double const dt,
+                     GlobalVector const& x) final;
     void assemble(const double t, double const dt, GlobalVector const& x,
                   GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) final;
 
@@ -185,6 +186,7 @@ private:
     }
 
     virtual void preAssembleConcreteProcess(const double /*t*/,
+                                            double const /*dt*/,
                                             GlobalVector const& /*x*/)
     {
     }

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -69,7 +69,7 @@ public:
     /// Calculates secondary variables, e.g. stress and strain for deformation
     /// analysis, only after nonlinear solver being successfully conducted.
     void postNonLinearSolver(GlobalVector const& x, const double t,
-                             int const process_id);
+                             double const dt, int const process_id);
 
     void preIteration(const unsigned iter, GlobalVector const& x) final;
 
@@ -217,6 +217,7 @@ private:
 
     virtual void postNonLinearSolverConcreteProcess(GlobalVector const& /*x*/,
                                                     const double /*t*/,
+                                                    double const /*dt*/,
                                                     int const /*process_id*/)
     {
     }

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -98,8 +98,8 @@ public:
     bool isMonolithicSchemeUsed() const { return _use_monolithic_scheme; }
     virtual void setCoupledTermForTheStaggeredSchemeToLocalAssemblers() {}
     void preAssemble(const double t, GlobalVector const& x) final;
-    void assemble(const double t, GlobalVector const& x, GlobalMatrix& M,
-                  GlobalMatrix& K, GlobalVector& b) final;
+    void assemble(const double t, double const dt, GlobalVector const& x,
+                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) final;
 
     void assembleWithJacobian(const double t, double const dt,
                               GlobalVector const& x, GlobalVector const& xdot,
@@ -189,9 +189,9 @@ private:
     {
     }
 
-    virtual void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                         GlobalMatrix& M, GlobalMatrix& K,
-                                         GlobalVector& b) = 0;
+    virtual void assembleConcreteProcess(const double t, double const dt,
+                                         GlobalVector const& x, GlobalMatrix& M,
+                                         GlobalMatrix& K, GlobalVector& b) = 0;
 
     virtual void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -101,10 +101,10 @@ public:
     void assemble(const double t, GlobalVector const& x, GlobalMatrix& M,
                   GlobalMatrix& K, GlobalVector& b) final;
 
-    void assembleWithJacobian(const double t, GlobalVector const& x,
-                              GlobalVector const& xdot, const double dxdot_dx,
-                              const double dx_dx, GlobalMatrix& M,
-                              GlobalMatrix& K, GlobalVector& b,
+    void assembleWithJacobian(const double t, double const dt,
+                              GlobalVector const& x, GlobalVector const& xdot,
+                              const double dxdot_dx, const double dx_dx,
+                              GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
                               GlobalMatrix& Jac) final;
 
     std::vector<NumLib::IndexValueVector<GlobalIndexType>> const*
@@ -194,9 +194,10 @@ private:
                                          GlobalVector& b) = 0;
 
     virtual void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) = 0;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) = 0;
 
     virtual void preTimestepConcreteProcess(GlobalVector const& /*x*/,
                                             const double /*t*/,

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportFEM-impl.h
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportFEM-impl.h
@@ -57,10 +57,8 @@ LocalAssemblerData<ShapeFunction, IntegrationMethod, GlobalDim>::
 template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
 void LocalAssemblerData<ShapeFunction, IntegrationMethod, GlobalDim>::assemble(
-    double const t,
-    std::vector<double> const& local_x,
-    std::vector<double>& local_M_data,
-    std::vector<double>& local_K_data,
+    double const t, double const /*dt*/, std::vector<double> const& local_x,
+    std::vector<double>& local_M_data, std::vector<double>& local_K_data,
     std::vector<double>& local_b_data)
 {
     auto const local_matrix_size = local_x.size();

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportFEM.h
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportFEM.h
@@ -104,7 +104,8 @@ public:
         unsigned const integration_order,
         RichardsComponentTransportProcessData const& process_data);
 
-    void assemble(double const t, std::vector<double> const& local_x,
+    void assemble(double const t, double const dt,
+                  std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
@@ -66,11 +66,8 @@ void RichardsComponentTransportProcess::initializeConcreteProcess(
 }
 
 void RichardsComponentTransportProcess::assembleConcreteProcess(
-    const double t,
-    GlobalVector const& x,
-    GlobalMatrix& M,
-    GlobalMatrix& K,
-    GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble RichardsComponentTransportProcess.");
 
@@ -83,14 +80,14 @@ void RichardsComponentTransportProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 
 void RichardsComponentTransportProcess::assembleWithJacobianConcreteProcess(
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac)
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian RichardsComponentTransportProcess.");
 
@@ -103,8 +100,8 @@ void RichardsComponentTransportProcess::assembleWithJacobianConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, x,
-        xdot, dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
+        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 }  // namespace RichardsComponentTransport

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.h
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.h
@@ -129,14 +129,15 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     RichardsComponentTransportProcessData _process_data;
 

--- a/ProcessLib/RichardsFlow/RichardsFlowFEM.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowFEM.h
@@ -128,7 +128,8 @@ public:
         }
     }
 
-    void assemble(double const t, std::vector<double> const& local_x,
+    void assemble(double const t, double const /*dt*/,
+                  std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
@@ -66,11 +66,8 @@ void RichardsFlowProcess::initializeConcreteProcess(
 }
 
 void RichardsFlowProcess::assembleConcreteProcess(
-    const double t,
-    GlobalVector const& x,
-    GlobalMatrix& M,
-    GlobalMatrix& K,
-    GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble RichardsFlowProcess.");
 
@@ -82,14 +79,14 @@ void RichardsFlowProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 
 void RichardsFlowProcess::assembleWithJacobianConcreteProcess(
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac)
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian RichardsFlowProcess.");
 
@@ -101,8 +98,8 @@ void RichardsFlowProcess::assembleWithJacobianConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, x,
-        xdot, dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
+        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 }  // namespace RichardsFlow

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.h
@@ -53,14 +53,15 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) override;
 
-    void assembleConcreteProcess(
-        const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-        GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     RichardsFlowProcessData _process_data;
 

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
@@ -796,7 +796,7 @@ void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                      ShapeFunctionPressure, IntegrationMethod,
                                      DisplacementDim>::
     postNonLinearSolverConcrete(std::vector<double> const& local_x,
-                                double const t,
+                                double const t, double const dt,
                                 bool const use_monolithic_scheme)
 {
     const int displacement_offset =
@@ -806,7 +806,6 @@ void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
         Eigen::Map<typename ShapeMatricesTypeDisplacement::template VectorType<
             displacement_size> const>(local_x.data() + displacement_offset,
                                       displacement_size);
-    double const& dt = _process_data.dt;
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());
 

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
@@ -120,7 +120,7 @@ template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
           typename IntegrationMethod, int DisplacementDim>
 void RichardsMechanicsLocalAssembler<
     ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
-    DisplacementDim>::assemble(double const t,
+    DisplacementDim>::assemble(double const t, double const dt,
                                std::vector<double> const& local_x,
                                std::vector<double>& local_M_data,
                                std::vector<double>& local_K_data,
@@ -157,7 +157,6 @@ void RichardsMechanicsLocalAssembler<
             displacement_size + pressure_size>>(
         local_rhs_data, displacement_size + pressure_size);
 
-    double const& dt = _process_data.dt;
     auto const material_id =
         _process_data.flow_material->getMaterialID(_element.getID());
 
@@ -295,7 +294,8 @@ template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
 void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                      ShapeFunctionPressure, IntegrationMethod,
                                      DisplacementDim>::
-    assembleWithJacobian(double const t, std::vector<double> const& local_x,
+    assembleWithJacobian(double const t, double const dt,
+                         std::vector<double> const& local_x,
                          std::vector<double> const& local_xdot,
                          const double /*dxdot_dx*/, const double /*dx_dx*/,
                          std::vector<double>& /*local_M_data*/,
@@ -356,7 +356,6 @@ void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
             pressure_size, displacement_size>::Zero(pressure_size,
                                                     displacement_size);
 
-    double const& dt = _process_data.dt;
     auto const material_id =
         _process_data.flow_material->getMaterialID(_element.getID());
 
@@ -736,9 +735,9 @@ void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                      ShapeFunctionPressure, IntegrationMethod,
                                      DisplacementDim>::
     assembleWithJacobianForPressureEquations(
-        const double /*t*/, const std::vector<double>& /*local_xdot*/,
-        const double /*dxdot_dx*/, const double /*dx_dx*/,
-        std::vector<double>& /*local_M_data*/,
+        const double /*t*/, double const /*dt*/,
+        const std::vector<double>& /*local_xdot*/, const double /*dxdot_dx*/,
+        const double /*dx_dx*/, std::vector<double>& /*local_M_data*/,
         std::vector<double>& /*local_K_data*/,
         std::vector<double>& /*local_b_data*/,
         std::vector<double>& /*local_Jac_data*/,
@@ -753,9 +752,9 @@ void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                      ShapeFunctionPressure, IntegrationMethod,
                                      DisplacementDim>::
     assembleWithJacobianForDeformationEquations(
-        const double /*t*/, const std::vector<double>& /*local_xdot*/,
-        const double /*dxdot_dx*/, const double /*dx_dx*/,
-        std::vector<double>& /*local_M_data*/,
+        const double /*t*/, double const /*dt*/,
+        const std::vector<double>& /*local_xdot*/, const double /*dxdot_dx*/,
+        const double /*dx_dx*/, std::vector<double>& /*local_M_data*/,
         std::vector<double>& /*local_K_data*/,
         std::vector<double>& /*local_b_data*/,
         std::vector<double>& /*local_Jac_data*/,
@@ -770,28 +769,24 @@ void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                      ShapeFunctionPressure, IntegrationMethod,
                                      DisplacementDim>::
     assembleWithJacobianForStaggeredScheme(
-        const double t,
-        const std::vector<double>& local_xdot,
-        const double dxdot_dx,
-        const double dx_dx,
-        std::vector<double>& local_M_data,
-        std::vector<double>& local_K_data,
-        std::vector<double>& local_b_data,
-        std::vector<double>& local_Jac_data,
+        const double t, double const dt, const std::vector<double>& local_xdot,
+        const double dxdot_dx, const double dx_dx,
+        std::vector<double>& local_M_data, std::vector<double>& local_K_data,
+        std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         const LocalCoupledSolutions& local_coupled_solutions)
 {
     // For the equations with pressure
     if (local_coupled_solutions.process_id == 0)
     {
         assembleWithJacobianForPressureEquations(
-            t, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
+            t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
             local_b_data, local_Jac_data, local_coupled_solutions);
         return;
     }
 
     // For the equations with deformation
     assembleWithJacobianForDeformationEquations(
-        t, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
+        t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
         local_b_data, local_Jac_data, local_coupled_solutions);
 }
 

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
@@ -120,8 +120,9 @@ public:
         }
     }
 
-    void postTimestepConcrete(std::vector<double> const& /*local_x*/
-                              ) override
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/,
+                              double const /*t*/,
+                              double const /*dt*/) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
@@ -68,12 +68,13 @@ public:
         unsigned const integration_order,
         RichardsMechanicsProcessData<DisplacementDim>& process_data);
 
-    void assemble(double const t, std::vector<double> const& local_x,
+    void assemble(double const t, double const dt,
+                  std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_rhs_data) override;
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x,
                               std::vector<double> const& local_xdot,
                               const double /*dxdot_dx*/, const double /*dx_dx*/,
@@ -83,7 +84,7 @@ public:
                               std::vector<double>& local_Jac_data) override;
 
     void assembleWithJacobianForStaggeredScheme(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
@@ -200,7 +201,7 @@ private:
      *                                processes of an element.
      */
     void assembleWithJacobianForDeformationEquations(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
@@ -235,7 +236,7 @@ private:
      *                                processes of an element.
      */
     void assembleWithJacobianForPressureEquations(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
@@ -138,7 +138,7 @@ public:
         double const t, std::vector<double> const& local_x) override;
 
     void postNonLinearSolverConcrete(std::vector<double> const& local_x,
-                                     double const t,
+                                     double const t, double const dt,
                                      bool const use_monolithic_scheme) override;
 
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
@@ -347,6 +347,7 @@ template <int DisplacementDim>
 void RichardsMechanicsProcess<
     DisplacementDim>::postNonLinearSolverConcreteProcess(GlobalVector const& x,
                                                          const double t,
+                                                         double const dt,
                                                          const int process_id)
 {
     if (!hasMechanicalProcess(process_id))
@@ -360,7 +361,7 @@ void RichardsMechanicsProcess<
     // Calculate strain, stress or other internal variables of mechanics.
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerInterface::postNonLinearSolver, _local_assemblers,
-        pv.getActiveElementIDs(), getDOFTable(process_id), x, t,
+        pv.getActiveElementIDs(), getDOFTable(process_id), x, t, dt,
         _use_monolithic_scheme);
 }
 

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
@@ -335,7 +335,6 @@ void RichardsMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
     DBUG("PreTimestep RichardsMechanicsProcess.");
 
     _process_data.dt = dt;
-    _process_data.t = t;
 
     if (hasMechanicalProcess(process_id))
     {

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
@@ -89,7 +89,7 @@ private:
                                     const int process_id) override;
 
     void postNonLinearSolverConcreteProcess(GlobalVector const& x,
-                                            const double t,
+                                            const double t, double const dt,
                                             int const process_id) override;
 
     NumLib::LocalToGlobalIndexMap const& getDOFTable(

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
@@ -74,14 +74,15 @@ private:
 
     void initializeBoundaryConditions() override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,
                                     double const dt,

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
@@ -74,7 +74,6 @@ struct RichardsMechanicsProcessData
     MeshLib::PropertyVector<double>* pressure_interpolated = nullptr;
 
     double dt = std::numeric_limits<double>::quiet_NaN();
-    double t = std::numeric_limits<double>::quiet_NaN();
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
@@ -73,8 +73,6 @@ struct RichardsMechanicsProcessData
     MeshLib::PropertyVector<double>* element_saturation = nullptr;
     MeshLib::PropertyVector<double>* pressure_interpolated = nullptr;
 
-    double dt = std::numeric_limits<double>::quiet_NaN();
-
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -314,7 +314,8 @@ public:
         }
     }
 
-    void postTimestepConcrete(std::vector<double> const& /*local_x*/) override
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/,
+                              double const t, double const dt) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();
@@ -336,8 +337,8 @@ public:
             // Update free energy density needed for material forces.
             ip_data.free_energy_density =
                 ip_data.solid_material.computeFreeEnergyDensity(
-                    _process_data.t, x_position, _process_data.dt, ip_data.eps,
-                    ip_data.sigma, *ip_data.material_state_variables);
+                    t, x_position, dt, ip_data.eps, ip_data.sigma,
+                    *ip_data.material_state_variables);
         }
     }
 

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -220,7 +220,8 @@ public:
         }
     }
 
-    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& /*local_x*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -230,7 +230,7 @@ public:
             "implemented.");
     }
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x,
                               std::vector<double> const& /*local_xdot*/,
                               const double /*dxdot_dx*/, const double /*dx_dx*/,
@@ -295,8 +295,8 @@ public:
                     local_x.data(), ShapeFunction::NPOINTS * DisplacementDim);
 
             auto&& solution = _ip_data[ip].solid_material.integrateStress(
-                t, x_position, _process_data.dt, eps_prev, eps, sigma_prev,
-                *state, _process_data.reference_temperature);
+                t, x_position, dt, eps_prev, eps, sigma_prev, *state,
+                _process_data.reference_temperature);
 
             if (!solution)
             {

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -260,12 +260,10 @@ void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::
-    assembleWithJacobianConcreteProcess(const double t, GlobalVector const& x,
-                                        GlobalVector const& xdot,
-                                        const double dxdot_dx,
-                                        const double dx_dx, GlobalMatrix& M,
-                                        GlobalMatrix& K, GlobalVector& b,
-                                        GlobalMatrix& Jac)
+    assembleWithJacobianConcreteProcess(
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian SmallDeformationProcess.");
 
@@ -277,21 +275,11 @@ void SmallDeformationProcess<DisplacementDim>::
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, x,
-        xdot, dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
+        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 
     transformVariableFromGlobalVector(b, 0, *_local_to_global_index_map,
                                       *_nodal_forces, std::negate<double>());
-}
-
-template <int DisplacementDim>
-void SmallDeformationProcess<DisplacementDim>::preTimestepConcreteProcess(
-    GlobalVector const& /*x*/, double const /*t*/, double const dt,
-    const int /*process_id*/)
-{
-    DBUG("PreTimestep SmallDeformationProcess.");
-
-    _process_data.dt = dt;
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -286,18 +286,17 @@ void SmallDeformationProcess<DisplacementDim>::
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::preTimestepConcreteProcess(
-    GlobalVector const& /*x*/, double const t, double const dt,
+    GlobalVector const& /*x*/, double const /*t*/, double const dt,
     const int /*process_id*/)
 {
     DBUG("PreTimestep SmallDeformationProcess.");
 
     _process_data.dt = dt;
-    _process_data.t = t;
 }
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::postTimestepConcreteProcess(
-    GlobalVector const& x, const double /*t*/, const double /*delta_t*/,
+    GlobalVector const& x, const double t, const double dt,
     int const process_id)
 {
     DBUG("PostTimestep SmallDeformationProcess.");
@@ -306,7 +305,7 @@ void SmallDeformationProcess<DisplacementDim>::postTimestepConcreteProcess(
 
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerInterface::postTimestep, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map, x);
+        pv.getActiveElementIDs(), *_local_to_global_index_map, x, t, dt);
 
     std::unique_ptr<GlobalVector> material_forces;
     ProcessLib::SmallDeformation::writeMaterialForces(

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -241,8 +241,8 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble SmallDeformationProcess.");
 
@@ -254,7 +254,7 @@ void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -55,13 +55,10 @@ private:
         GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
-
-    void preTimestepConcreteProcess(
-        GlobalVector const& x, double const t, double const dt,
-        const int process_id) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void postTimestepConcreteProcess(GlobalVector const& x, const double t,
                                      const double delta_t,

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -50,9 +50,9 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) override;
 
-    void assembleConcreteProcess(
-        const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-        GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,

--- a/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
@@ -53,8 +53,6 @@ struct SmallDeformationProcessData
 
     double const reference_temperature =
         std::numeric_limits<double>::quiet_NaN();
-
-    double dt = std::numeric_limits<double>::quiet_NaN();
 };
 
 }  // namespace SmallDeformation

--- a/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcessData.h
@@ -55,7 +55,6 @@ struct SmallDeformationProcessData
         std::numeric_limits<double>::quiet_NaN();
 
     double dt = std::numeric_limits<double>::quiet_NaN();
-    double t = std::numeric_limits<double>::quiet_NaN();
 };
 
 }  // namespace SmallDeformation

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
@@ -316,7 +316,7 @@ public:
             "implemented.");
     }
 
-    void preAssemble(double const t,
+    void preAssemble(double const t, double const dt,
                      std::vector<double> const& local_x) override
     {
         auto const n_integration_points =
@@ -369,8 +369,8 @@ public:
                                      // calculateDamage() function.
 
             auto&& solution = _ip_data[ip].solid_material.integrateStress(
-                t, x_position, _process_data.dt, eps_prev, eps, sigma_eff_prev,
-                *state, _process_data.reference_temperature);
+                t, x_position, dt, eps_prev, eps, sigma_eff_prev, *state,
+                _process_data.reference_temperature);
 
             if (!solution)
             {

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
@@ -304,7 +304,8 @@ public:
         }
     }
 
-    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& /*local_x*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override
@@ -418,7 +419,7 @@ public:
         }
     }
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const /*dt*/,
                               std::vector<double> const& local_x,
                               std::vector<double> const& /*local_xdot*/,
                               const double /*dxdot_dx*/, const double /*dx_dx*/,

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
@@ -524,7 +524,8 @@ public:
         }
     }
 
-    void postTimestepConcrete(std::vector<double> const& /*local_x*/) override
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/,
+                              double const /*t*/, double const /*dt*/) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
@@ -231,8 +231,8 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::
 
 template <int DisplacementDim>
 void SmallDeformationNonlocalProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble SmallDeformationNonlocalProcess.");
 
@@ -245,7 +245,8 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b, _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        _coupled_solutions);
 }
 
 template <int DisplacementDim>
@@ -267,12 +268,10 @@ void SmallDeformationNonlocalProcess<
 
 template <int DisplacementDim>
 void SmallDeformationNonlocalProcess<DisplacementDim>::
-    assembleWithJacobianConcreteProcess(const double t, GlobalVector const& x,
-                                        GlobalVector const& xdot,
-                                        const double dxdot_dx,
-                                        const double dx_dx, GlobalMatrix& M,
-                                        GlobalMatrix& K, GlobalVector& b,
-                                        GlobalMatrix& Jac)
+    assembleWithJacobianConcreteProcess(
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian SmallDeformationNonlocalProcess.");
 
@@ -285,7 +284,7 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, x, xdot,
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
         dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 
     b.copyValues(*_nodal_forces);

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
@@ -252,6 +252,7 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::assembleConcreteProcess(
 template <int DisplacementDim>
 void SmallDeformationNonlocalProcess<
     DisplacementDim>::preAssembleConcreteProcess(const double t,
+                                                 double const dt,
                                                  GlobalVector const& x)
 {
     DBUG("preAssemble SmallDeformationNonlocalProcess.");
@@ -263,7 +264,7 @@ void SmallDeformationNonlocalProcess<
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::preAssemble,
         _local_assemblers, pv.getActiveElementIDs(),
-        *_local_to_global_index_map, t, x);
+        *_local_to_global_index_map, t, dt, x);
 }
 
 template <int DisplacementDim>
@@ -290,18 +291,6 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::
     b.copyValues(*_nodal_forces);
     std::transform(_nodal_forces->begin(), _nodal_forces->end(),
                    _nodal_forces->begin(), [](double val) { return -val; });
-}
-
-template <int DisplacementDim>
-void SmallDeformationNonlocalProcess<
-    DisplacementDim>::preTimestepConcreteProcess(GlobalVector const& /*x*/,
-                                                 double const /*t*/,
-                                                 double const dt,
-                                                 int const /*process_id*/)
-{
-    DBUG("PreTimestep SmallDeformationNonlocalProcess.");
-
-    _process_data.dt = dt;
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
@@ -296,21 +296,20 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::
 template <int DisplacementDim>
 void SmallDeformationNonlocalProcess<
     DisplacementDim>::preTimestepConcreteProcess(GlobalVector const& /*x*/,
-                                                 double const t,
+                                                 double const /*t*/,
                                                  double const dt,
                                                  int const /*process_id*/)
 {
     DBUG("PreTimestep SmallDeformationNonlocalProcess.");
 
     _process_data.dt = dt;
-    _process_data.t = t;
 }
 
 template <int DisplacementDim>
 void SmallDeformationNonlocalProcess<
     DisplacementDim>::postTimestepConcreteProcess(GlobalVector const& x,
-                                                  double const /*t*/,
-                                                  double const /*dt*/,
+                                                  double const t,
+                                                  double const dt,
                                                   int const process_id)
 {
     DBUG("PostTimestep SmallDeformationNonlocalProcess.");
@@ -319,7 +318,7 @@ void SmallDeformationNonlocalProcess<
 
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerInterface::postTimestep, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map, x);
+        pv.getActiveElementIDs(), *_local_to_global_index_map, x, t, dt);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
@@ -53,17 +53,18 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void preAssembleConcreteProcess(const double t,
                                     GlobalVector const& x) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,
                                     double const dt,

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
@@ -57,7 +57,7 @@ private:
                                  GlobalVector const& x, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 
-    void preAssembleConcreteProcess(const double t,
+    void preAssembleConcreteProcess(const double t, double const dt,
                                     GlobalVector const& x) override;
 
     void assembleWithJacobianConcreteProcess(
@@ -65,10 +65,6 @@ private:
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
-
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt,
-                                    int const /*process_id*/) override;
 
     void postTimestepConcreteProcess(GlobalVector const& x, double const t,
                                      double const dt,

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcessData.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcessData.h
@@ -52,7 +52,6 @@ struct SmallDeformationNonlocalProcessData
     double crack_volume = 0.0;
 
     double dt = std::numeric_limits<double>::quiet_NaN();
-    double t = std::numeric_limits<double>::quiet_NaN();
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcessData.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcessData.h
@@ -51,8 +51,6 @@ struct SmallDeformationNonlocalProcessData
     double crack_volume_old = 0.0;
     double crack_volume = 0.0;
 
-    double dt = std::numeric_limits<double>::quiet_NaN();
-
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 

--- a/ProcessLib/TES/TESLocalAssembler-impl.h
+++ b/ProcessLib/TES/TESLocalAssembler-impl.h
@@ -136,7 +136,7 @@ TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::
 template <typename ShapeFunction_, typename IntegrationMethod_,
           unsigned GlobalDim>
 void TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::assemble(
-    double const /*t*/, std::vector<double> const& local_x,
+    double const /*t*/, double const /*dt*/, std::vector<double> const& local_x,
     std::vector<double>& local_M_data, std::vector<double>& local_K_data,
     std::vector<double>& local_b_data)
 {

--- a/ProcessLib/TES/TESLocalAssembler.h
+++ b/ProcessLib/TES/TESLocalAssembler.h
@@ -80,7 +80,8 @@ public:
                       unsigned const integration_order,
                       AssemblyParams const& asm_params);
 
-    void assemble(double const t, std::vector<double> const& local_x,
+    void assemble(double const t, double const dt,
+                  std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -228,11 +228,9 @@ void TESProcess::initializeSecondaryVariables()
             nullptr});
 }
 
-void TESProcess::assembleConcreteProcess(const double t,
-                                         GlobalVector const& x,
-                                         GlobalMatrix& M,
-                                         GlobalMatrix& K,
-                                         GlobalVector& b)
+void TESProcess::assembleConcreteProcess(const double t, double const dt,
+                                         GlobalVector const& x, GlobalMatrix& M,
+                                         GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble TESProcess.");
 
@@ -245,14 +243,14 @@ void TESProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 
 void TESProcess::assembleWithJacobianConcreteProcess(
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac)
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
        dof_table = {std::ref(*_local_to_global_index_map)};
@@ -263,8 +261,8 @@ void TESProcess::assembleWithJacobianConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, x,
-        xdot, dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
+        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 void TESProcess::preTimestepConcreteProcess(GlobalVector const& x,

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -59,16 +59,17 @@ private:
         NumLib::LocalToGlobalIndexMap const& dof_table,
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void initializeSecondaryVariables();
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     GlobalVector const& computeVapourPartialPressure(
         const double t,

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPLocalAssembler-impl.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPLocalAssembler-impl.h
@@ -58,7 +58,8 @@ template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
 void ThermalTwoPhaseFlowWithPPLocalAssembler<
     ShapeFunction, IntegrationMethod,
-    GlobalDim>::assemble(double const t, std::vector<double> const& local_x,
+    GlobalDim>::assemble(double const t, double const /*dt*/,
+                         std::vector<double> const& local_x,
                          std::vector<double>& local_M_data,
                          std::vector<double>& local_K_data,
                          std::vector<double>& local_b_data)

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPLocalAssembler.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPLocalAssembler.h
@@ -132,7 +132,8 @@ public:
         }
     }
 
-    void assemble(double const t, std::vector<double> const& local_x,
+    void assemble(double const t, double const dt,
+                  std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
@@ -75,11 +75,8 @@ void ThermalTwoPhaseFlowWithPPProcess::initializeConcreteProcess(
 }
 
 void ThermalTwoPhaseFlowWithPPProcess::assembleConcreteProcess(
-    const double t,
-    GlobalVector const& x,
-    GlobalMatrix& M,
-    GlobalMatrix& K,
-    GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble ThermalTwoPhaseFlowWithPPProcess.");
 
@@ -91,14 +88,14 @@ void ThermalTwoPhaseFlowWithPPProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 
 void ThermalTwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac)
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian ThermalTwoPhaseFlowWithPPProcess.");
 
@@ -110,8 +107,8 @@ void ThermalTwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, x,
-        xdot, dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
+        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 void ThermalTwoPhaseFlowWithPPProcess::preTimestepConcreteProcess(
     GlobalVector const& x, double const t, double const delta_t,

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
@@ -61,14 +61,15 @@ private:
         NumLib::LocalToGlobalIndexMap const& dof_table,
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
-    void assembleConcreteProcess(
-        const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-        GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, const double t,
                                     const double delta_t,

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM-impl.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM-impl.h
@@ -519,7 +519,7 @@ void ThermoHydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                         ShapeFunctionPressure,
                                         IntegrationMethod, DisplacementDim>::
     postNonLinearSolverConcrete(std::vector<double> const& local_x,
-                                double const t,
+                                double const t, double const dt,
                                 bool const use_monolithic_scheme)
 {
     const int displacement_offset =
@@ -536,7 +536,6 @@ void ThermoHydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
     auto p = Eigen::Map<typename ShapeMatricesTypePressure::template VectorType<
         pressure_size> const>(local_x.data() + pressure_index, pressure_size);
 
-    double const& dt = _process_data.dt;
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());
     auto const& medium = _process_data.media_map->getMedium(_element.getID());

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM-impl.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM-impl.h
@@ -101,7 +101,8 @@ template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
 void ThermoHydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                         ShapeFunctionPressure,
                                         IntegrationMethod, DisplacementDim>::
-    assembleWithJacobian(double const t, std::vector<double> const& local_x,
+    assembleWithJacobian(double const t, double const dt,
+                         std::vector<double> const& local_x,
                          std::vector<double> const& local_xdot,
                          const double /*dxdot_dx*/, const double /*dx_dx*/,
                          std::vector<double>& /*local_M_data*/,
@@ -182,8 +183,6 @@ void ThermoHydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
         displacement_size, temperature_size>
         KuT;
     KuT.setZero(displacement_size, temperature_size);
-
-    double const& dt = _process_data.dt;
 
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
@@ -105,8 +105,9 @@ public:
         }
     }
 
-    void postTimestepConcrete(std::vector<double> const& /*local_x*/
-                              ) override
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/,
+                              double const /*t*/,
+                              double const /*dt*/) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
@@ -122,7 +122,7 @@ public:
     void computeSecondaryVariableConcrete(
         double const t, std::vector<double> const& local_x) override;
     void postNonLinearSolverConcrete(std::vector<double> const& local_x,
-                                     double const t,
+                                     double const t, double const dt,
                                      bool const use_monolithic_scheme) override;
 
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
@@ -75,7 +75,8 @@ public:
         unsigned const integration_order,
         ThermoHydroMechanicsProcessData<DisplacementDim>& process_data);
 
-    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& /*local_x*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_rhs_data*/) override
@@ -85,7 +86,7 @@ public:
             "not implemented.");
     }
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x,
                               std::vector<double> const& local_xdot,
                               const double /*dxdot_dx*/, const double /*dx_dx*/,

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
@@ -240,8 +240,8 @@ void ThermoHydroMechanicsProcess<
 
 template <int DisplacementDim>
 void ThermoHydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble the equations for ThermoHydroMechanics");
 
@@ -254,17 +254,15 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        dof_table, t, x, M, K, b, _coupled_solutions);
+        dof_table, t, dt, x, M, K, b, _coupled_solutions);
 }
 
 template <int DisplacementDim>
 void ThermoHydroMechanicsProcess<DisplacementDim>::
-    assembleWithJacobianConcreteProcess(const double t, GlobalVector const& x,
-                                        GlobalVector const& xdot,
-                                        const double dxdot_dx,
-                                        const double dx_dx, GlobalMatrix& M,
-                                        GlobalMatrix& K, GlobalVector& b,
-                                        GlobalMatrix& Jac)
+    assembleWithJacobianConcreteProcess(
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_tables;
@@ -304,7 +302,7 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::
 
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, dof_tables, t, x, xdot, dxdot_dx, dx_dx, M, K, b,
+        _local_assemblers, dof_tables, t, dt, x, xdot, dxdot_dx, dx_dx, M, K, b,
         Jac, _coupled_solutions);
 
     auto copyRhs = [&](int const variable_id, auto& output_vector) {
@@ -337,8 +335,6 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
     const int process_id)
 {
     DBUG("PreTimestep ThermoHydroMechanicsProcess.");
-
-    _process_data.dt = dt;
 
     if (hasMechanicalProcess(process_id))
     {

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
@@ -339,7 +339,6 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
     DBUG("PreTimestep ThermoHydroMechanicsProcess.");
 
     _process_data.dt = dt;
-    _process_data.t = t;
 
     if (hasMechanicalProcess(process_id))
     {
@@ -351,13 +350,13 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
 
 template <int DisplacementDim>
 void ThermoHydroMechanicsProcess<DisplacementDim>::postTimestepConcreteProcess(
-    GlobalVector const& x, const double /*t*/, const double /*delta_t*/,
+    GlobalVector const& x, double const t, double const dt,
     const int process_id)
 {
     DBUG("PostTimestep ThermoHydroMechanicsProcess.");
     GlobalExecutor::executeMemberOnDereferenced(
         &LocalAssemblerInterface::postTimestep, _local_assemblers,
-        getDOFTable(process_id), x);
+        getDOFTable(process_id), x, t, dt);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
@@ -359,6 +359,7 @@ template <int DisplacementDim>
 void ThermoHydroMechanicsProcess<
     DisplacementDim>::postNonLinearSolverConcreteProcess(GlobalVector const& x,
                                                          const double t,
+                                                         double const dt,
                                                          const int process_id)
 {
     if (!hasMechanicalProcess(process_id))
@@ -370,7 +371,7 @@ void ThermoHydroMechanicsProcess<
     // Calculate strain, stress or other internal variables of mechanics.
     GlobalExecutor::executeMemberOnDereferenced(
         &LocalAssemblerInterface::postNonLinearSolver, _local_assemblers,
-        getDOFTable(process_id), x, t, _use_monolithic_scheme);
+        getDOFTable(process_id), x, t, dt, _use_monolithic_scheme);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
@@ -94,7 +94,7 @@ private:
                                      int const process_id) override;
 
     void postNonLinearSolverConcreteProcess(GlobalVector const& x,
-                                            const double t,
+                                            const double t, double const dt,
                                             int const process_id) override;
 
     NumLib::LocalToGlobalIndexMap const& getDOFTable(

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
@@ -75,14 +75,15 @@ private:
 
     void initializeBoundaryConditions() override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,
                                     double const dt,

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcessData.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcessData.h
@@ -52,7 +52,6 @@ struct ThermoHydroMechanicsProcessData
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
 
     double dt = std::numeric_limits<double>::quiet_NaN();
-    double t = std::numeric_limits<double>::quiet_NaN();
 
     MeshLib::PropertyVector<double>* pressure_interpolated = nullptr;
     MeshLib::PropertyVector<double>* temperature_interpolated = nullptr;

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcessData.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcessData.h
@@ -51,8 +51,6 @@ struct ThermoHydroMechanicsProcessData
     /// A vector of displacement dimension's length.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
 
-    double dt = std::numeric_limits<double>::quiet_NaN();
-
     MeshLib::PropertyVector<double>* pressure_interpolated = nullptr;
     MeshLib::PropertyVector<double>* temperature_interpolated = nullptr;
 

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM-impl.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM-impl.h
@@ -24,7 +24,7 @@ template <typename ShapeFunction, typename IntegrationMethod,
 void ThermoMechanicalPhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
                                               DisplacementDim>::
     assembleWithJacobianForStaggeredScheme(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
@@ -41,14 +41,14 @@ void ThermoMechanicalPhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
     if (local_coupled_solutions.process_id == _heat_conduction_process_id)
     {
         assembleWithJacobianForHeatConductionEquations(
-            t, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
+            t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
             local_b_data, local_Jac_data, local_coupled_solutions);
         return;
     }
 
     // For the equations with deformation
     assembleWithJacobianForDeformationEquations(
-        t, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
+        t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
         local_b_data, local_Jac_data, local_coupled_solutions);
 }
 
@@ -57,9 +57,9 @@ template <typename ShapeFunction, typename IntegrationMethod,
 void ThermoMechanicalPhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
                                               DisplacementDim>::
     assembleWithJacobianForDeformationEquations(
-        double const t, std::vector<double> const& /*local_xdot*/,
-        const double /*dxdot_dx*/, const double /*dx_dx*/,
-        std::vector<double>& /*local_M_data*/,
+        double const t, double const dt,
+        std::vector<double> const& /*local_xdot*/, const double /*dxdot_dx*/,
+        const double /*dx_dx*/, std::vector<double>& /*local_M_data*/,
         std::vector<double>& /*local_K_data*/,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions)
@@ -92,8 +92,6 @@ void ThermoMechanicalPhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
     auto local_rhs = MathLib::createZeroedVector<
         typename ShapeMatricesType::template VectorType<displacement_size>>(
         local_b_data, displacement_size);
-
-    double const& dt = _process_data.dt;
 
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());
@@ -167,7 +165,7 @@ template <typename ShapeFunction, typename IntegrationMethod,
 void ThermoMechanicalPhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
                                               DisplacementDim>::
     assembleWithJacobianForHeatConductionEquations(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double /*dxdot_dx*/, const double /*dx_dx*/,
         std::vector<double>& /*local_M_data*/,
         std::vector<double>& /*local_K_data*/,
@@ -199,8 +197,6 @@ void ThermoMechanicalPhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
     auto local_rhs = MathLib::createZeroedVector<
         typename ShapeMatricesType::template VectorType<temperature_size>>(
         local_b_data, temperature_size);
-
-    double const& dt = _process_data.dt;
 
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
@@ -232,8 +232,8 @@ public:
         }
     }
 
-    void postTimestepConcrete(std::vector<double> const& /*local_x*/
-                              ) override
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/,
+                              double const /*t*/, double const /*dt*/) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
@@ -204,7 +204,8 @@ public:
         }
     }
 
-    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& /*local_x*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_rhs_data*/) override
@@ -215,7 +216,7 @@ public:
     }
 
     void assembleWithJacobianForStaggeredScheme(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
@@ -337,14 +338,14 @@ private:
     }
 
     void assembleWithJacobianForDeformationEquations(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions);
 
     void assembleWithJacobianForHeatConductionEquations(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
@@ -190,7 +190,7 @@ void ThermoMechanicalPhaseFieldProcess<
 
 template <int DisplacementDim>
 void ThermoMechanicalPhaseFieldProcess<
-    DisplacementDim>::assembleConcreteProcess(const double t,
+    DisplacementDim>::assembleConcreteProcess(const double t, double const dt,
                                               GlobalVector const& x,
                                               GlobalMatrix& M, GlobalMatrix& K,
                                               GlobalVector& b)
@@ -206,17 +206,16 @@ void ThermoMechanicalPhaseFieldProcess<
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b, _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        _coupled_solutions);
 }
 
 template <int DisplacementDim>
 void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
-    assembleWithJacobianConcreteProcess(const double t, GlobalVector const& x,
-                                        GlobalVector const& xdot,
-                                        const double dxdot_dx,
-                                        const double dx_dx, GlobalMatrix& M,
-                                        GlobalMatrix& K, GlobalVector& b,
-                                        GlobalMatrix& Jac)
+    assembleWithJacobianConcreteProcess(
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_tables;
@@ -258,7 +257,7 @@ void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
 
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_tables, t, x, xdot,
+        _local_assemblers, pv.getActiveElementIDs(), dof_tables, t, dt, x, xdot,
         dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
@@ -270,8 +269,6 @@ void ThermoMechanicalPhaseFieldProcess<
                                                  const int process_id)
 {
     DBUG("PreTimestep ThermoMechanicalPhaseFieldProcess.");
-
-    _process_data.dt = dt;
 
     if (process_id != _mechanics_related_process_id)
     {

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
@@ -304,6 +304,7 @@ template <int DisplacementDim>
 void ThermoMechanicalPhaseFieldProcess<
     DisplacementDim>::postNonLinearSolverConcreteProcess(GlobalVector const& x,
                                                          const double t,
+                                                         double const dt,
                                                          const int process_id)
 {
     if (process_id != _mechanics_related_process_id)
@@ -318,7 +319,7 @@ void ThermoMechanicalPhaseFieldProcess<
 
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerInterface::postNonLinearSolver, _local_assemblers,
-        pv.getActiveElementIDs(), getDOFTable(process_id), x, t,
+        pv.getActiveElementIDs(), getDOFTable(process_id), x, t, dt,
         use_monolithic_scheme);
 }
 

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
@@ -272,7 +272,6 @@ void ThermoMechanicalPhaseFieldProcess<
     DBUG("PreTimestep ThermoMechanicalPhaseFieldProcess.");
 
     _process_data.dt = dt;
-    _process_data.t = t;
 
     if (process_id != _mechanics_related_process_id)
     {
@@ -290,8 +289,8 @@ void ThermoMechanicalPhaseFieldProcess<
 template <int DisplacementDim>
 void ThermoMechanicalPhaseFieldProcess<
     DisplacementDim>::postTimestepConcreteProcess(GlobalVector const& x,
-                                                  double const /*t*/,
-                                                  double const /*dt*/,
+                                                  double const t,
+                                                  double const dt,
                                                   int const process_id)
 {
     DBUG("PostTimestep ThermoMechanicalPhaseFieldProcess.");
@@ -300,8 +299,8 @@ void ThermoMechanicalPhaseFieldProcess<
 
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &ThermoMechanicalPhaseFieldLocalAssemblerInterface::postTimestep,
-        _local_assemblers, pv.getActiveElementIDs(), getDOFTable(process_id),
-        x);
+        _local_assemblers, pv.getActiveElementIDs(), getDOFTable(process_id), x,
+        t, dt);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
@@ -92,14 +92,15 @@ private:
         MeshLib::Mesh const& mesh,
         unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,
                                     double const dt,

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
@@ -111,7 +111,7 @@ private:
                                      int const process_id) override;
 
     void postNonLinearSolverConcreteProcess(GlobalVector const& x,
-                                            const double t,
+                                            const double t, double const dt,
                                             int const process_id) override;
 
     // To be replaced.

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcessData.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcessData.h
@@ -52,7 +52,6 @@ struct ThermoMechanicalPhaseFieldProcessData
         std::numeric_limits<double>::quiet_NaN();
 
     double dt = std::numeric_limits<double>::quiet_NaN();
-    double t = std::numeric_limits<double>::quiet_NaN();
 };
 
 }  // namespace ThermoMechanicalPhaseField

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcessData.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcessData.h
@@ -50,8 +50,6 @@ struct ThermoMechanicalPhaseFieldProcessData
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
     double const reference_temperature =
         std::numeric_limits<double>::quiet_NaN();
-
-    double dt = std::numeric_limits<double>::quiet_NaN();
 };
 
 }  // namespace ThermoMechanicalPhaseField

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
@@ -118,7 +118,8 @@ template <typename ShapeFunction, typename IntegrationMethod,
           int DisplacementDim>
 void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
                                    DisplacementDim>::
-    assembleWithJacobian(double const t, std::vector<double> const& local_x,
+    assembleWithJacobian(double const t, double const dt,
+                         std::vector<double> const& local_x,
                          std::vector<double> const& local_xdot,
                          const double /*dxdot_dx*/, const double /*dx_dx*/,
                          std::vector<double>& /*local_M_data*/,
@@ -157,8 +158,6 @@ void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
 
     typename ShapeMatricesType::NodalMatrixType DTT;
     DTT.setZero(temperature_size, temperature_size);
-
-    double const& dt = _process_data.dt;
 
     unsigned const n_integration_points =
         _integration_method.getNumberOfPoints();
@@ -306,14 +305,10 @@ template <typename ShapeFunction, typename IntegrationMethod,
 void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
                                    DisplacementDim>::
     assembleWithJacobianForStaggeredScheme(
-        const double t,
-        const std::vector<double>& local_xdot,
-        const double dxdot_dx,
-        const double dx_dx,
-        std::vector<double>& local_M_data,
-        std::vector<double>& local_K_data,
-        std::vector<double>& local_b_data,
-        std::vector<double>& local_Jac_data,
+        const double t, double const dt, const std::vector<double>& local_xdot,
+        const double dxdot_dx, const double dx_dx,
+        std::vector<double>& local_M_data, std::vector<double>& local_K_data,
+        std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         const LocalCoupledSolutions& local_coupled_solutions)
 {
     // For the equations with pressure
@@ -321,14 +316,14 @@ void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
         _process_data.heat_conduction_process_id)
     {
         assembleWithJacobianForHeatConductionEquations(
-            t, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
+            t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
             local_b_data, local_Jac_data, local_coupled_solutions);
         return;
     }
 
     // For the equations with deformation
     assembleWithJacobianForDeformationEquations(
-        t, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
+        t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
         local_b_data, local_Jac_data, local_coupled_solutions);
 }
 
@@ -337,9 +332,9 @@ template <typename ShapeFunction, typename IntegrationMethod,
 void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
                                    DisplacementDim>::
     assembleWithJacobianForDeformationEquations(
-        const double t, const std::vector<double>& /*local_xdot*/,
-        const double /*dxdot_dx*/, const double /*dx_dx*/,
-        std::vector<double>& /*local_M_data*/,
+        const double t, double const dt,
+        const std::vector<double>& /*local_xdot*/, const double /*dxdot_dx*/,
+        const double /*dx_dx*/, std::vector<double>& /*local_M_data*/,
         std::vector<double>& /*local_K_data*/,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         const LocalCoupledSolutions& local_coupled_solutions)
@@ -373,8 +368,6 @@ void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
     auto local_rhs = MathLib::createZeroedVector<
         typename ShapeMatricesType::template VectorType<displacement_size>>(
         local_b_data, displacement_size);
-
-    double const& dt = _process_data.dt;
 
     unsigned const n_integration_points =
         _integration_method.getNumberOfPoints();
@@ -477,9 +470,9 @@ template <typename ShapeFunction, typename IntegrationMethod,
 void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
                                    DisplacementDim>::
     assembleWithJacobianForHeatConductionEquations(
-        const double t, const std::vector<double>& /*local_xdot*/,
-        const double /*dxdot_dx*/, const double /*dx_dx*/,
-        std::vector<double>& /*local_M_data*/,
+        const double t, double const dt,
+        const std::vector<double>& /*local_xdot*/, const double /*dxdot_dx*/,
+        const double /*dx_dx*/, std::vector<double>& /*local_M_data*/,
         std::vector<double>& /*local_K_data*/,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         const LocalCoupledSolutions& local_coupled_solutions)
@@ -513,8 +506,6 @@ void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
 
     typename ShapeMatricesType::NodalMatrixType laplace;
     laplace.setZero(temperature_size, temperature_size);
-
-    double const& dt = _process_data.dt;
 
     unsigned const n_integration_points =
         _integration_method.getNumberOfPoints();

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
@@ -122,7 +122,8 @@ public:
         double const* values,
         int const integration_order) override;
 
-    void assemble(double const /*t*/, std::vector<double> const& /*local_x*/,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& /*local_x*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_rhs_data*/) override
@@ -133,13 +134,13 @@ public:
     }
 
     void assembleWithJacobianForStaggeredScheme(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions) override;
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x,
                               std::vector<double> const& local_xdot,
                               const double /*dxdot_dx*/, const double /*dx_dx*/,
@@ -227,7 +228,7 @@ private:
      */
 
     void assembleWithJacobianForDeformationEquations(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
@@ -259,7 +260,7 @@ private:
      *                                displacement of an element.
      */
     void assembleWithJacobianForHeatConductionEquations(
-        double const t, std::vector<double> const& local_xdot,
+        double const t, double const dt, std::vector<double> const& local_xdot,
         const double dxdot_dx, const double dx_dx,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
@@ -177,7 +177,8 @@ public:
         }
     }
 
-    void postTimestepConcrete(std::vector<double> const& /*local_x*/) override
+    void postTimestepConcrete(std::vector<double> const& /*local_x*/,
+                              double const /*t*/, double const /*dt*/) override
     {
         unsigned const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
@@ -395,7 +395,6 @@ void ThermoMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
     DBUG("PreTimestep ThermoMechanicsProcess.");
 
     _process_data.dt = dt;
-    _process_data.t = t;
 
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
@@ -427,7 +426,7 @@ void ThermoMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
 
 template <int DisplacementDim>
 void ThermoMechanicsProcess<DisplacementDim>::postTimestepConcreteProcess(
-    GlobalVector const& x, const double /*t*/, const double /*delta_t*/,
+    GlobalVector const& x, double const t, double const dt,
     int const process_id)
 {
     if (process_id != _process_data.mechanics_process_id)
@@ -442,7 +441,7 @@ void ThermoMechanicsProcess<DisplacementDim>::postTimestepConcreteProcess(
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &ThermoMechanicsLocalAssemblerInterface::postTimestep,
         _local_assemblers, pv.getActiveElementIDs(),
-        *_local_to_global_index_map, x);
+        *_local_to_global_index_map, x, t, dt);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
@@ -277,8 +277,8 @@ void ThermoMechanicsProcess<DisplacementDim>::initializeBoundaryConditions()
 
 template <int DisplacementDim>
 void ThermoMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble ThermoMechanicsProcess.");
 
@@ -291,17 +291,16 @@ void ThermoMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b, _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        _coupled_solutions);
 }
 
 template <int DisplacementDim>
 void ThermoMechanicsProcess<DisplacementDim>::
-    assembleWithJacobianConcreteProcess(const double t, GlobalVector const& x,
-                                        GlobalVector const& xdot,
-                                        const double dxdot_dx,
-                                        const double dx_dx, GlobalMatrix& M,
-                                        GlobalMatrix& K, GlobalVector& b,
-                                        GlobalMatrix& Jac)
+    assembleWithJacobianConcreteProcess(
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleJacobian ThermoMechanicsProcess.");
 
@@ -356,7 +355,7 @@ void ThermoMechanicsProcess<DisplacementDim>::
 
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_tables, t, x, xdot,
+        _local_assemblers, pv.getActiveElementIDs(), dof_tables, t, dt, x, xdot,
         dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 
     // TODO (naumov): Refactor the copy rhs part. This is copy from HM.
@@ -393,8 +392,6 @@ void ThermoMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
     const int process_id)
 {
     DBUG("PreTimestep ThermoMechanicsProcess.");
-
-    _process_data.dt = dt;
 
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
@@ -67,14 +67,15 @@ private:
 
     void initializeBoundaryConditions() override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,
                                     double const dt,

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
@@ -56,8 +56,6 @@ struct ThermoMechanicsProcessData
     /// ID of heat conduction process.
     int const heat_conduction_process_id;
 
-    double dt = std::numeric_limits<double>::quiet_NaN();
-
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcessData.h
@@ -57,7 +57,6 @@ struct ThermoMechanicsProcessData
     int const heat_conduction_process_id;
 
     double dt = std::numeric_limits<double>::quiet_NaN();
-    double t = std::numeric_limits<double>::quiet_NaN();
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -201,7 +201,7 @@ NumLib::NonlinearSolverStatus solveOneTimeStepOneProcess(
 
     if (nonlinear_solver_status.error_norms_met)
     {
-        process.postNonLinearSolver(x, t, process_id);
+        process.postNonLinearSolver(x, t, delta_t, process_id);
     }
 
     return nonlinear_solver_status;

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -581,7 +581,7 @@ void postTimestepForAllProcesses(
         if (is_staggered_coupling)
         {
             CoupledSolutionsForStaggeredScheme coupled_solutions(
-                solutions_of_coupled_processes, dt, process_id);
+                solutions_of_coupled_processes, process_id);
             pcs.setCoupledSolutionsForStaggeredScheme(&coupled_solutions);
         }
         auto& x = *_process_solutions[process_id];
@@ -669,7 +669,7 @@ TimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
             auto& x = *_process_solutions[process_id];
 
             CoupledSolutionsForStaggeredScheme coupled_solutions(
-                _solutions_of_coupled_processes, dt, process_id);
+                _solutions_of_coupled_processes, process_id);
 
             process_data->process.setCoupledSolutionsForStaggeredScheme(
                 &coupled_solutions);
@@ -797,7 +797,7 @@ void TimeLoop::outputSolutions(bool const output_initial_condition,
         if (is_staggered_coupling)
         {
             CoupledSolutionsForStaggeredScheme coupled_solutions(
-                _solutions_of_coupled_processes, 0.0, process_id);
+                _solutions_of_coupled_processes, process_id);
 
             process_data->process.setCoupledSolutionsForStaggeredScheme(
                 &coupled_solutions);

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler-impl.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler-impl.h
@@ -45,7 +45,8 @@ template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
 void TwoPhaseFlowWithPPLocalAssembler<
     ShapeFunction, IntegrationMethod,
-    GlobalDim>::assemble(double const t, std::vector<double> const& local_x,
+    GlobalDim>::assemble(double const t, double const /*dt*/,
+                         std::vector<double> const& local_x,
                          std::vector<double>& local_M_data,
                          std::vector<double>& local_K_data,
                          std::vector<double>& local_b_data)

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler.h
@@ -127,7 +127,8 @@ public:
         }
     }
 
-    void assemble(double const t, std::vector<double> const& local_x,
+    void assemble(double const t, double const dt,
+                  std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
@@ -72,11 +72,9 @@ void TwoPhaseFlowWithPPProcess::initializeConcreteProcess(
             &TwoPhaseFlowWithPPLocalAssemblerInterface::getIntPtWetPressure));
 }
 
-void TwoPhaseFlowWithPPProcess::assembleConcreteProcess(const double t,
-                                                        GlobalVector const& x,
-                                                        GlobalMatrix& M,
-                                                        GlobalMatrix& K,
-                                                        GlobalVector& b)
+void TwoPhaseFlowWithPPProcess::assembleConcreteProcess(
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble TwoPhaseFlowWithPPProcess.");
 
@@ -88,14 +86,14 @@ void TwoPhaseFlowWithPPProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 
 void TwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac)
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian TwoPhaseFlowWithPPProcess.");
 
@@ -107,8 +105,8 @@ void TwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, x,
-        xdot, dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
+        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 
 }  // namespace TwoPhaseFlowWithPP

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
@@ -60,14 +60,15 @@ private:
         NumLib::LocalToGlobalIndexMap const& dof_table,
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     TwoPhaseFlowWithPPProcessData _process_data;
 

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler-impl.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler-impl.h
@@ -24,7 +24,8 @@ template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
 void TwoPhaseFlowWithPrhoLocalAssembler<
     ShapeFunction, IntegrationMethod,
-    GlobalDim>::assemble(double const t, std::vector<double> const& local_x,
+    GlobalDim>::assemble(double const t, double const /*dt*/,
+                         std::vector<double> const& local_x,
                          std::vector<double>& local_M_data,
                          std::vector<double>& local_K_data,
                          std::vector<double>& local_b_data)

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler.h
@@ -133,7 +133,8 @@ public:
         }
     }
 
-    void assemble(double const t, std::vector<double> const& local_x,
+    void assemble(double const t, double const /*dt*/,
+                  std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
@@ -72,11 +72,9 @@ void TwoPhaseFlowWithPrhoProcess::initializeConcreteProcess(
                              getIntPtNonWettingPressure));
 }
 
-void TwoPhaseFlowWithPrhoProcess::assembleConcreteProcess(const double t,
-                                                          GlobalVector const& x,
-                                                          GlobalMatrix& M,
-                                                          GlobalMatrix& K,
-                                                          GlobalVector& b)
+void TwoPhaseFlowWithPrhoProcess::assembleConcreteProcess(
+    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble TwoPhaseFlowWithPrhoProcess.");
 
@@ -88,14 +86,14 @@ void TwoPhaseFlowWithPrhoProcess::assembleConcreteProcess(const double t,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
         _coupled_solutions);
 }
 
 void TwoPhaseFlowWithPrhoProcess::assembleWithJacobianConcreteProcess(
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac)
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian TwoPhaseFlowWithPrhoProcess.");
 
@@ -107,8 +105,8 @@ void TwoPhaseFlowWithPrhoProcess::assembleWithJacobianConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, x,
-        xdot, dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
+        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
 }
 void TwoPhaseFlowWithPrhoProcess::preTimestepConcreteProcess(
     GlobalVector const& x, double const t, double const dt,

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
@@ -57,14 +57,15 @@ private:
         NumLib::LocalToGlobalIndexMap const& dof_table,
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
-    void assembleConcreteProcess(const double t, GlobalVector const& x,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+    void assembleConcreteProcess(const double t, double const dt,
+                                 GlobalVector const& x, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac) override;
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, const double t,
                                     const double dt,

--- a/ProcessLib/VectorMatrixAssembler.cpp
+++ b/ProcessLib/VectorMatrixAssembler.cpp
@@ -43,8 +43,9 @@ void VectorMatrixAssembler::assemble(
     const std::size_t mesh_item_id, LocalAssemblerInterface& local_assembler,
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>> const&
         dof_tables,
-    const double t, const GlobalVector& x, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, CoupledSolutionsForStaggeredScheme const* const cpl_xs)
+    const double t, double const dt, const GlobalVector& x, GlobalMatrix& M,
+    GlobalMatrix& K, GlobalVector& b,
+    CoupledSolutionsForStaggeredScheme const* const cpl_xs)
 {
     std::vector<std::vector<GlobalIndexType>> indices_of_processes;
     indices_of_processes.reserve(dof_tables.size());
@@ -64,7 +65,7 @@ void VectorMatrixAssembler::assemble(
     if (cpl_xs == nullptr)
     {
         auto const local_x = x.get(indices);
-        local_assembler.assemble(t, local_x, _local_M_data, _local_K_data,
+        local_assembler.assemble(t, dt, local_x, _local_M_data, _local_K_data,
                                  _local_b_data);
     }
     else
@@ -78,7 +79,7 @@ void VectorMatrixAssembler::assemble(
             cpl_xs->dt, cpl_xs->process_id, std::move(local_coupled_xs0),
             std::move(local_coupled_xs));
 
-        local_assembler.assembleForStaggeredScheme(t, _local_M_data,
+        local_assembler.assembleForStaggeredScheme(t, dt, _local_M_data,
                                                    _local_K_data, _local_b_data,
                                                    local_coupled_solutions);
     }
@@ -150,7 +151,7 @@ void VectorMatrixAssembler::assembleWithJacobian(
             std::move(local_coupled_xs));
 
         _jacobian_assembler->assembleWithJacobianForStaggeredScheme(
-            local_assembler, t, local_xdot, dxdot_dx, dx_dx, _local_M_data,
+            local_assembler, t, dt, local_xdot, dxdot_dx, dx_dx, _local_M_data,
             _local_K_data, _local_b_data, _local_Jac_data,
             local_coupled_solutions);
     }

--- a/ProcessLib/VectorMatrixAssembler.cpp
+++ b/ProcessLib/VectorMatrixAssembler.cpp
@@ -31,12 +31,12 @@ VectorMatrixAssembler::VectorMatrixAssembler(
 void VectorMatrixAssembler::preAssemble(
     const std::size_t mesh_item_id, LocalAssemblerInterface& local_assembler,
     const NumLib::LocalToGlobalIndexMap& dof_table, const double t,
-    const GlobalVector& x)
+    double const dt, const GlobalVector& x)
 {
     auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
     auto const local_x = x.get(indices);
 
-    local_assembler.preAssemble(t, local_x);
+    local_assembler.preAssemble(t, dt, local_x);
 }
 
 void VectorMatrixAssembler::assemble(

--- a/ProcessLib/VectorMatrixAssembler.cpp
+++ b/ProcessLib/VectorMatrixAssembler.cpp
@@ -108,9 +108,9 @@ void VectorMatrixAssembler::assembleWithJacobian(
     std::size_t const mesh_item_id, LocalAssemblerInterface& local_assembler,
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>> const&
         dof_tables,
-    const double t, GlobalVector const& x, GlobalVector const& xdot,
-    const double dxdot_dx, const double dx_dx, GlobalMatrix& M, GlobalMatrix& K,
-    GlobalVector& b, GlobalMatrix& Jac,
+    const double t, double const dt, GlobalVector const& x,
+    GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
     CoupledSolutionsForStaggeredScheme const* const cpl_xs)
 {
     std::vector<std::vector<GlobalIndexType>> indices_of_processes;
@@ -135,7 +135,7 @@ void VectorMatrixAssembler::assembleWithJacobian(
     {
         auto const local_x = x.get(indices);
         _jacobian_assembler->assembleWithJacobian(
-            local_assembler, t, local_x, local_xdot, dxdot_dx, dx_dx,
+            local_assembler, t, dt, local_x, local_xdot, dxdot_dx, dx_dx,
             _local_M_data, _local_K_data, _local_b_data, _local_Jac_data);
     }
     else

--- a/ProcessLib/VectorMatrixAssembler.cpp
+++ b/ProcessLib/VectorMatrixAssembler.cpp
@@ -76,7 +76,7 @@ void VectorMatrixAssembler::assemble(
             getCurrentLocalSolutions(*cpl_xs, indices_of_processes);
 
         ProcessLib::LocalCoupledSolutions local_coupled_solutions(
-            cpl_xs->dt, cpl_xs->process_id, std::move(local_coupled_xs0),
+            cpl_xs->process_id, std::move(local_coupled_xs0),
             std::move(local_coupled_xs));
 
         local_assembler.assembleForStaggeredScheme(t, dt, _local_M_data,
@@ -147,7 +147,7 @@ void VectorMatrixAssembler::assembleWithJacobian(
             getCurrentLocalSolutions(*cpl_xs, indices_of_processes);
 
         ProcessLib::LocalCoupledSolutions local_coupled_solutions(
-            cpl_xs->dt, cpl_xs->process_id, std::move(local_coupled_xs0),
+            cpl_xs->process_id, std::move(local_coupled_xs0),
             std::move(local_coupled_xs));
 
         _jacobian_assembler->assembleWithJacobianForStaggeredScheme(

--- a/ProcessLib/VectorMatrixAssembler.h
+++ b/ProcessLib/VectorMatrixAssembler.h
@@ -39,7 +39,7 @@ public:
     void preAssemble(const std::size_t mesh_item_id,
                      LocalAssemblerInterface& local_assembler,
                      const NumLib::LocalToGlobalIndexMap& dof_table,
-                     const double t, const GlobalVector& x);
+                     const double t, double const dt, const GlobalVector& x);
 
     //! Assembles\c M, \c K, and \c b.
     //! \remark Jacobian is not assembled here, see assembleWithJacobian().

--- a/ProcessLib/VectorMatrixAssembler.h
+++ b/ProcessLib/VectorMatrixAssembler.h
@@ -47,8 +47,8 @@ public:
                   LocalAssemblerInterface& local_assembler,
                   std::vector<std::reference_wrapper<
                       NumLib::LocalToGlobalIndexMap>> const& dof_tables,
-                  double const t, GlobalVector const& x, GlobalMatrix& M,
-                  GlobalMatrix& K, GlobalVector& b,
+                  double const t, double const dt, GlobalVector const& x,
+                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
                   CoupledSolutionsForStaggeredScheme const* const cpl_xs);
 
     //! Assembles \c M, \c K, \c b, and the Jacobian \c Jac of the residual.

--- a/ProcessLib/VectorMatrixAssembler.h
+++ b/ProcessLib/VectorMatrixAssembler.h
@@ -59,9 +59,9 @@ public:
         std::vector<
             std::reference_wrapper<NumLib::LocalToGlobalIndexMap>> const&
             dof_tables,
-        const double t, GlobalVector const& x, GlobalVector const& xdot,
-        const double dxdot_dx, const double dx_dx, GlobalMatrix& M,
-        GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
+        const double t, double const dt, GlobalVector const& x,
+        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
         CoupledSolutionsForStaggeredScheme const* const cpl_xs);
 
 private:

--- a/Tests/NumLib/ODEs.h
+++ b/Tests/NumLib/ODEs.h
@@ -28,8 +28,9 @@ class ODE1 final : public NumLib::ODESystem<
 public:
     void preAssemble(const double /*t*/, GlobalVector const& /*x*/) override {}
 
-    void assemble(const double /*t*/, GlobalVector const& /*x*/,
-                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) override
+    void assemble(const double /*t*/, double const /*dt*/,
+                  GlobalVector const& /*x*/, GlobalMatrix& M, GlobalMatrix& K,
+                  GlobalVector& b) override
     {
         MathLib::setMatrix(M, { 1.0, 0.0,  0.0, 1.0 });
         MathLib::setMatrix(K, { 0.0, 1.0, -1.0, 0.0 });
@@ -37,7 +38,8 @@ public:
         MathLib::setVector(b, { 0.0, 0.0 });
     }
 
-    void assembleWithJacobian(const double t, GlobalVector const& x_curr,
+    void assembleWithJacobian(const double t, double const dt,
+                              GlobalVector const& x_curr,
                               GlobalVector const& /*xdot*/,
                               const double dxdot_dx, const double dx_dx,
                               GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
@@ -45,7 +47,7 @@ public:
     {
         namespace LinAlg = MathLib::LinAlg;
 
-        assemble(t, x_curr, M, K, b);
+        assemble(t, dt, x_curr, M, K, b);
 
         // compute Jac = M*dxdot_dx + dx_dx*K
         LinAlg::finalizeAssembly(M);
@@ -108,8 +110,9 @@ class ODE2 final : public NumLib::ODESystem<
 public:
     void preAssemble(const double /*t*/, GlobalVector const& /*x*/) override {}
 
-    void assemble(const double /*t*/, GlobalVector const& x, GlobalMatrix& M,
-                  GlobalMatrix& K, GlobalVector& b) override
+    void assemble(const double /*t*/, double const /*dt*/,
+                  GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
+                  GlobalVector& b) override
     {
         MathLib::setMatrix(M, {1.0});
         MathLib::LinAlg::setLocalAccessibleVector(x);
@@ -117,13 +120,14 @@ public:
         MathLib::setVector(b, {0.0});
     }
 
-    void assembleWithJacobian(const double t, GlobalVector const& x,
+    void assembleWithJacobian(const double t, double const dt,
+                              GlobalVector const& x,
                               GlobalVector const& /*xdot*/,
                               const double dxdot_dx, const double dx_dx,
                               GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
                               GlobalMatrix& Jac) override
     {
-        assemble(t, x, M, K, b);
+        assemble(t, dt, x, M, K, b);
 
         namespace LinAlg = MathLib::LinAlg;
 
@@ -196,8 +200,9 @@ class ODE3 final : public NumLib::ODESystem<
 public:
     void preAssemble(const double /*t*/, GlobalVector const& /*x*/) override {}
 
-    void assemble(const double /*t*/, GlobalVector const& x_curr, GlobalMatrix& M,
-                  GlobalMatrix& K, GlobalVector& b) override
+    void assemble(const double /*t*/, double const /*dt*/,
+                  GlobalVector const& x_curr, GlobalMatrix& M, GlobalMatrix& K,
+                  GlobalVector& b) override
     {
         MathLib::LinAlg::setLocalAccessibleVector(x_curr);
         auto const u = x_curr[0];
@@ -209,7 +214,8 @@ public:
             b, {-2 * u + 2.0 * u * v, -2.0 * v * v + 5.0 * v - 4.0});
     }
 
-    void assembleWithJacobian(const double t, GlobalVector const& x_curr,
+    void assembleWithJacobian(const double t, double const dt,
+                              GlobalVector const& x_curr,
                               GlobalVector const& xdot, const double dxdot_dx,
                               const double dx_dx, GlobalMatrix& M,
                               GlobalMatrix& K, GlobalVector& b,
@@ -217,7 +223,7 @@ public:
     {
         MathLib::LinAlg::setLocalAccessibleVector(x_curr);
         MathLib::LinAlg::setLocalAccessibleVector(xdot);
-        assemble(t, x_curr, M, K, b);
+        assemble(t, dt, x_curr, M, K, b);
 
         auto const u = x_curr[0];
         auto const v = x_curr[1];

--- a/Tests/NumLib/ODEs.h
+++ b/Tests/NumLib/ODEs.h
@@ -26,7 +26,10 @@ class ODE1 final : public NumLib::ODESystem<
                        NumLib::NonlinearSolverTag::Newton>
 {
 public:
-    void preAssemble(const double /*t*/, GlobalVector const& /*x*/) override {}
+    void preAssemble(const double /*t*/, double const /*dt*/,
+                     GlobalVector const& /*x*/) override
+    {
+    }
 
     void assemble(const double /*t*/, double const /*dt*/,
                   GlobalVector const& /*x*/, GlobalMatrix& M, GlobalMatrix& K,
@@ -108,7 +111,10 @@ class ODE2 final : public NumLib::ODESystem<
                        NumLib::NonlinearSolverTag::Newton>
 {
 public:
-    void preAssemble(const double /*t*/, GlobalVector const& /*x*/) override {}
+    void preAssemble(const double /*t*/, double const /*dt*/,
+                     GlobalVector const& /*x*/) override
+    {
+    }
 
     void assemble(const double /*t*/, double const /*dt*/,
                   GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
@@ -198,7 +204,10 @@ class ODE3 final : public NumLib::ODESystem<
                        NumLib::NonlinearSolverTag::Newton>
 {
 public:
-    void preAssemble(const double /*t*/, GlobalVector const& /*x*/) override {}
+    void preAssemble(const double /*t*/, double const /*dt*/,
+                     GlobalVector const& /*x*/) override
+    {
+    }
 
     void assemble(const double /*t*/, double const /*dt*/,
                   GlobalVector const& x_curr, GlobalMatrix& M, GlobalMatrix& K,

--- a/Tests/ProcessLib/TestJacobianAssembler.cpp
+++ b/Tests/ProcessLib/TestJacobianAssembler.cpp
@@ -293,7 +293,8 @@ template <typename MatVec>
 class LocalAssemblerM final : public ProcessLib::LocalAssemblerInterface
 {
 public:
-    void assemble(double const /*t*/, std::vector<double> const& local_x,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override
@@ -301,7 +302,7 @@ public:
         MatVec::Mat::getMat(local_x, local_M_data);
     }
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x,
                               std::vector<double> const& local_xdot,
                               const double dxdot_dx, const double /*dx_dx*/,
@@ -310,7 +311,7 @@ public:
                               std::vector<double>& local_b_data,
                               std::vector<double>& local_Jac_data) override
     {
-        assemble(t, local_x, local_M_data, local_K_data, local_b_data);
+        assemble(t, dt, local_x, local_M_data, local_K_data, local_b_data);
 
         // dM/dx * xdot
         MatVec::Mat::getDMatDxTimesY(local_x, local_xdot, local_Jac_data);
@@ -333,7 +334,8 @@ template <typename MatVec>
 class LocalAssemblerK final : public ProcessLib::LocalAssemblerInterface
 {
 public:
-    void assemble(double const /*t*/, std::vector<double> const& local_x,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& local_x,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& local_K_data,
                   std::vector<double>& /*local_b_data*/) override
@@ -341,7 +343,7 @@ public:
         MatVec::Mat::getMat(local_x, local_K_data);
     }
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x,
                               std::vector<double> const& /*local_xdot*/,
                               const double /*dxdot_dx*/, const double dx_dx,
@@ -350,7 +352,7 @@ public:
                               std::vector<double>& local_b_data,
                               std::vector<double>& local_Jac_data) override
     {
-        assemble(t, local_x, local_M_data, local_K_data, local_b_data);
+        assemble(t, dt, local_x, local_M_data, local_K_data, local_b_data);
 
         // dK/dx * x
         MatVec::Mat::getDMatDxTimesY(local_x, local_x, local_Jac_data);
@@ -373,7 +375,8 @@ template <typename MatVec>
 class LocalAssemblerB final : public ProcessLib::LocalAssemblerInterface
 {
 public:
-    void assemble(double const /*t*/, std::vector<double> const& local_x,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& local_x,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& local_b_data) override
@@ -381,7 +384,7 @@ public:
         MatVec::Vec::getVec(local_x, local_b_data);
     }
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x,
                               std::vector<double> const& /*local_xdot*/,
                               const double /*dxdot_dx*/, const double /*dx_dx*/,
@@ -390,7 +393,7 @@ public:
                               std::vector<double>& local_b_data,
                               std::vector<double>& local_Jac_data) override
     {
-        assemble(t, local_x, local_M_data, local_K_data, local_b_data);
+        assemble(t, dt, local_x, local_M_data, local_K_data, local_b_data);
 
         // db/dx
         MatVec::Vec::getDVecDx(local_x, local_Jac_data);
@@ -412,7 +415,8 @@ template <typename MatVecM, typename MatVecK, typename MatVecB>
 class LocalAssemblerMKb final : public ProcessLib::LocalAssemblerInterface
 {
 public:
-    void assemble(double const /*t*/, std::vector<double> const& local_x,
+    void assemble(double const /*t*/, double const /*dt*/,
+                  std::vector<double> const& local_x,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override
@@ -422,7 +426,7 @@ public:
         MatVecB::Vec::getVec(local_x, local_b_data);
     }
 
-    void assembleWithJacobian(double const t,
+    void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x,
                               std::vector<double> const& local_xdot,
                               const double dxdot_dx, const double dx_dx,
@@ -431,7 +435,7 @@ public:
                               std::vector<double>& local_b_data,
                               std::vector<double>& local_Jac_data) override
     {
-        assemble(t, local_x, local_M_data, local_K_data, local_b_data);
+        assemble(t, dt, local_x, local_M_data, local_K_data, local_b_data);
 
         std::vector<double> local_JacM_data;
         // dM/dx * xdot
@@ -524,13 +528,15 @@ private:
         std::vector<double> b_data_ana;
         std::vector<double> Jac_data_ana;
         double const t = 0.0;
+        double const dt = 0.0;
 
-        jac_asm_cd.assembleWithJacobian(loc_asm, t, x, xdot, dxdot_dx, dx_dx, M_data_cd,
-                                     K_data_cd, b_data_cd, Jac_data_cd);
+        jac_asm_cd.assembleWithJacobian(loc_asm, t, dt, x, xdot, dxdot_dx,
+                                        dx_dx, M_data_cd, K_data_cd, b_data_cd,
+                                        Jac_data_cd);
 
-        jac_asm_ana.assembleWithJacobian(loc_asm, t, x, xdot, dxdot_dx, dx_dx,
-                                         M_data_ana, K_data_ana, b_data_ana,
-                                         Jac_data_ana);
+        jac_asm_ana.assembleWithJacobian(loc_asm, t, dt, x, xdot, dxdot_dx,
+                                         dx_dx, M_data_ana, K_data_ana,
+                                         b_data_ana, Jac_data_ana);
 
         if (LocAsm::asmM) {
             ASSERT_EQ(x.size()*x.size(), M_data_cd.size());


### PR DESCRIPTION
Refactoring only.

The time and time increment are stored in different places like process data or coupled solutions. Another set of time and time increment is passed through the interfaces of assemble *etc.* functions.
To simplify (and to avoid unintentional mismatch between those) now `t` and `dt` are passed through interface to few more functions.

The bulk of the changes is to the interfaces. Some notable changes:
 - drop `dt` in coupled solutions: https://github.com/ufz/ogs/pull/2673/files#diff-81c8910638eee8d67ecaaca35bd29ac9
 - drop `t` and `dt` in all process data, *e.g.* in HM: https://github.com/ufz/ogs/pull/2673/files#diff-5caaa3748f350278bfadf3a7ef72be64
 - add getter for time increment in time discretizations: https://github.com/ufz/ogs/pull/2673/files#diff-1205c5023ac964f635a60cbde2984929
 - some changes in the time loop: https://github.com/ufz/ogs/pull/2673/files#diff-837505db22a18ac0f5a3d8dc15bb35cd

Changelog updated.