### PR TITLE
[PL/HT] Move the porosity specification from solid phase to medium scale.

### DIFF
--- a/ProcessLib/HT/MonolithicHTFEM.h
+++ b/ProcessLib/HT/MonolithicHTFEM.h
@@ -137,8 +137,7 @@ public:
             NumLib::shapeFunctionInterpolate(local_x, N, T_int_pt, p_int_pt);
 
             auto const porosity =
-                solid_phase
-                    .property(MaterialPropertyLib::PropertyType::porosity)
+                medium.property(MaterialPropertyLib::PropertyType::porosity)
                     .template value<double>(vars, pos, t);
 
             auto const intrinsic_permeability =

--- a/ProcessLib/HT/StaggeredHTFEM-impl.h
+++ b/ProcessLib/HT/StaggeredHTFEM-impl.h
@@ -104,7 +104,7 @@ void StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
             p_int_pt;
 
         auto const porosity =
-            solid_phase.property(MaterialPropertyLib::PropertyType::porosity)
+            medium.property(MaterialPropertyLib::PropertyType::porosity)
                 .template value<double>(vars, pos, t);
         auto const fluid_density =
             liquid_phase.property(MaterialPropertyLib::PropertyType::density)
@@ -209,7 +209,6 @@ void StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
     auto const& medium =
         *process_data.media_map->getMedium(this->_element.getID());
     auto const& liquid_phase = medium.phase("AqueousLiquid");
-    auto const& solid_phase = medium.phase("Solid");
 
     auto const& b = process_data.specific_body_force;
 
@@ -241,7 +240,7 @@ void StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
             p_at_xi;
 
         auto const porosity =
-            solid_phase.property(MaterialPropertyLib::PropertyType::porosity)
+            medium.property(MaterialPropertyLib::PropertyType::porosity)
                 .template value<double>(vars, pos, t);
 
         // Use the fluid density model to compute the density

--- a/Tests/Data/Parabolic/HT/ConstViscosity/square_5500x5500.prj
+++ b/Tests/Data/Parabolic/HT/ConstViscosity/square_5500x5500.prj
@@ -54,11 +54,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -96,6 +91,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-14 0 0 1.e-14</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/ConstViscosity/square_5500x5500.prj
+++ b/Tests/Data/Parabolic/HT/ConstViscosity/square_5500x5500.prj
@@ -37,11 +37,11 @@
                             <name>density</name>
                             <type>Linear</type>
                             <reference_value>1000</reference_value>
-                                <independent_variable>
-                                    <variable_name>temperature</variable_name>
-                                    <slope>-4.3e-4</slope>
-                                    <reference_condition>20</reference_condition>
-                                </independent_variable>
+                            <independent_variable>
+                                <variable_name>temperature</variable_name>
+                                <slope>-4.3e-4</slope>
+                                <reference_condition>20</reference_condition>
+                            </independent_variable>
                         </property>
                         <property>
                             <name>viscosity</name>

--- a/Tests/Data/Parabolic/HT/FaultedCube/Ra_795_fault_bcgs_jacobi.prj
+++ b/Tests/Data/Parabolic/HT/FaultedCube/Ra_795_fault_bcgs_jacobi.prj
@@ -66,11 +66,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -108,6 +103,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-18 0 0 0 1.e-18 0 0 0 1.e-18</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>
@@ -152,11 +152,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -194,6 +189,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.7e-13 0 0 0 1.7e-13 0 0 0 1.7e-13</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/CoupledPressureParabolicTemperatureParabolic.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/CoupledPressureParabolicTemperatureParabolic.prj
@@ -49,11 +49,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0</value>
@@ -91,6 +86,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-8 0 0 1.e-8</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/CoupledPressureParabolicTemperatureParabolicStaggered.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/CoupledPressureParabolicTemperatureParabolicStaggered.prj
@@ -50,11 +50,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0</value>
@@ -92,6 +87,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-8 0 0 1.e-8</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlow.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlow.prj
@@ -49,11 +49,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -91,6 +86,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-14 0 0 1.e-14</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlowStaggered.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlowStaggered.prj
@@ -50,11 +50,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -92,6 +87,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-14 0 0 1.e-14</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlowWithGravity.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlowWithGravity.prj
@@ -49,11 +49,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -91,6 +86,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-14 0 0 1.e-14</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlowWithGravityStaggered.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/IsothermalFluidFlowWithGravityStaggered.prj
@@ -50,11 +50,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -92,6 +87,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-14 0 0 1.e-14</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureDiffusionTemperatureDiffusion.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureDiffusionTemperatureDiffusion.prj
@@ -49,11 +49,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -91,6 +86,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-14 0 0 1.e-14</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureDiffusionTemperatureDiffusionStaggered.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureDiffusionTemperatureDiffusionStaggered.prj
@@ -50,11 +50,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -92,6 +87,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-14 0 0 1.e-14</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureParabolicTemperatureParabolic.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureParabolicTemperatureParabolic.prj
@@ -49,11 +49,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>1e-5</value>
@@ -91,6 +86,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-8 0 0 1.e-8</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureParabolicTemperatureParabolicStaggered.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/PressureParabolicTemperatureParabolicStaggered.prj
@@ -50,11 +50,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>1e-5</value>
@@ -92,6 +87,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-8 0 0 1.e-8</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/calculatesurfaceflux_ht_cube_1e3.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/calculatesurfaceflux_ht_cube_1e3.prj
@@ -58,11 +58,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -100,6 +95,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-14 0 0 0 1.e-14 0 0 0 1.e-14</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/calculatesurfaceflux_ht_cube_1e4.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/calculatesurfaceflux_ht_cube_1e4.prj
@@ -63,11 +63,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -105,6 +100,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-14 0 0 0 1.e-14 0 0 0 1.e-14</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/SimpleSynthetics/constraint_bc_1e3.prj
+++ b/Tests/Data/Parabolic/HT/SimpleSynthetics/constraint_bc_1e3.prj
@@ -54,11 +54,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -96,6 +91,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-14 0 0 0 1.e-14 0 0 0 1.e-14</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/StaggeredCoupling/ADecovalexTHMCBasedHTExample/th_decovalex.prj
+++ b/Tests/Data/Parabolic/HT/StaggeredCoupling/ADecovalexTHMCBasedHTExample/th_decovalex.prj
@@ -56,11 +56,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.01</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -98,6 +93,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>6.3072e-14 0. 0. 6.3072e-14</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.01</value>
                 </property>
             </properties>
         </medium>
@@ -137,11 +137,6 @@
                 <phase>
                     <type>Solid</type>
                     <properties>
-                        <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.41</value>
-                        </property>
                         <property>
                             <name>density</name>
                             <type>Parameter</type>
@@ -185,6 +180,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>3.1536e-10 0. 0. 3.1536e-10</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.41</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/StaggeredCoupling/ConstViscosity/square_5500x5500_staggered_scheme.prj
+++ b/Tests/Data/Parabolic/HT/StaggeredCoupling/ConstViscosity/square_5500x5500_staggered_scheme.prj
@@ -55,11 +55,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -97,6 +92,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-14 0 0 1.e-14</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>

--- a/Tests/Data/Parabolic/HT/StaggeredCoupling/ConstViscosity/square_5500x5500_staggered_scheme_adaptive_dt.prj
+++ b/Tests/Data/Parabolic/HT/StaggeredCoupling/ConstViscosity/square_5500x5500_staggered_scheme_adaptive_dt.prj
@@ -55,11 +55,6 @@
                     <type>Solid</type>
                     <properties>
                         <property>
-                            <name>porosity</name>
-                            <type>Constant</type>
-                            <value>0.001</value>
-                        </property>
-                        <property>
                             <name>storage</name>
                             <type>Constant</type>
                             <value>0.0</value>
@@ -97,6 +92,11 @@
                     <name>permeability</name>
                     <type>Constant</type>
                     <value>1.e-14 0 0 1.e-14</value>
+                </property>
+                <property>
+                    <name>porosity</name>
+                    <type>Constant</type>
+                    <value>0.001</value>
                 </property>
             </properties>
         </medium>


### PR DESCRIPTION
For changes in the project files the following script was used:
```
#!/usr/bin/env bash

number_of_medium_tags=`xmlstarlet sel -t -v "count(///*/medium)" $1`
number_of_medium_tags=$(($number_of_medium_tags - 1))

xmlstarlet ed --move "//OpenGeoSysProject/media/medium[@id=0]/phases/phase/properties/property[name='porosity']" "//OpenGeoSysProject/media/medium[@id=0]/properties" $1 > /tmp/t0.prj

for i in `seq 1 ${number_of_medium_tags}`;
do
    i_m_e=$(($i-1))
    #echo "${i}, ${i_m_e}"
    path="//OpenGeoSysProject/media/medium[@id="${i}"]"
    xmlstarlet ed --move "$path/phases/phase/properties/property[name='porosity']" "$path/properties" /tmp/t$i_m_e.prj > /tmp/t${i}.prj
done

#format the result file
xmlstarlet fo -s 4 /tmp/t${number_of_medium_tags}.prj > ${1}
```