### PR TITLE
Eliminate process_id from coupled solutions class

### DIFF
--- a/NumLib/ODESolver/NonlinearSolver.cpp
+++ b/NumLib/ODESolver/NonlinearSolver.cpp
@@ -22,15 +22,15 @@
 namespace NumLib
 {
 void NonlinearSolver<NonlinearSolverTag::Picard>::assemble(
-    GlobalVector const& x) const
+    GlobalVector const& x, int const process_id) const
 {
-    _equation_system->assemble(x);
+    _equation_system->assemble(x, process_id);
 }
 
 NonlinearSolverStatus NonlinearSolver<NonlinearSolverTag::Picard>::solve(
     GlobalVector& x,
-    std::function<void(int, GlobalVector const&)> const&
-        postIterationCallback)
+    std::function<void(int, GlobalVector const&)> const& postIterationCallback,
+    int const process_id)
 {
     namespace LinAlg = MathLib::LinAlg;
     auto& sys = *_equation_system;
@@ -58,7 +58,7 @@ NonlinearSolverStatus NonlinearSolver<NonlinearSolverTag::Picard>::solve(
         time_iteration.start();
 
         timer_dirichlet.start();
-        sys.computeKnownSolutions(x_new);
+        sys.computeKnownSolutions(x_new, process_id);
         sys.applyKnownSolutions(x_new);
         time_dirichlet += timer_dirichlet.elapsed();
 
@@ -66,7 +66,7 @@ NonlinearSolverStatus NonlinearSolver<NonlinearSolverTag::Picard>::solve(
 
         BaseLib::RunTime time_assembly;
         time_assembly.start();
-        sys.assemble(x_new);
+        sys.assemble(x_new, process_id);
         sys.getA(A);
         sys.getRhs(rhs);
         INFO("[time] Assembly took %g s.", time_assembly.elapsed());
@@ -177,9 +177,9 @@ NonlinearSolverStatus NonlinearSolver<NonlinearSolverTag::Picard>::solve(
 }
 
 void NonlinearSolver<NonlinearSolverTag::Newton>::assemble(
-    GlobalVector const& x) const
+    GlobalVector const& x, int const process_id) const
 {
-    _equation_system->assemble(x);
+    _equation_system->assemble(x, process_id);
     // TODO if the equation system would be reset to nullptr after each
     //      assemble() or solve() call, the user would be forced to set the
     //      equation every time and could not forget it.
@@ -187,8 +187,8 @@ void NonlinearSolver<NonlinearSolverTag::Newton>::assemble(
 
 NonlinearSolverStatus NonlinearSolver<NonlinearSolverTag::Newton>::solve(
     GlobalVector& x,
-    std::function<void(int, GlobalVector const&)> const&
-        postIterationCallback)
+    std::function<void(int, GlobalVector const&)> const& postIterationCallback,
+    int const process_id)
 {
     namespace LinAlg = MathLib::LinAlg;
     auto& sys = *_equation_system;
@@ -220,7 +220,7 @@ NonlinearSolverStatus NonlinearSolver<NonlinearSolverTag::Newton>::solve(
         time_iteration.start();
 
         timer_dirichlet.start();
-        sys.computeKnownSolutions(x);
+        sys.computeKnownSolutions(x, process_id);
         sys.applyKnownSolutions(x);
         time_dirichlet += timer_dirichlet.elapsed();
 
@@ -228,7 +228,7 @@ NonlinearSolverStatus NonlinearSolver<NonlinearSolverTag::Newton>::solve(
 
         BaseLib::RunTime time_assembly;
         time_assembly.start();
-        sys.assemble(x);
+        sys.assemble(x, process_id);
         sys.getResidual(x, res);
         sys.getJacobian(J);
         INFO("[time] Assembly took %g s.", time_assembly.elapsed());

--- a/NumLib/ODESolver/NonlinearSolver.h
+++ b/NumLib/ODESolver/NonlinearSolver.h
@@ -44,13 +44,16 @@ public:
      *
      * \param x             the state at which the equation system will be
      *                      assembled.
+     * \param process_id    the process' id which will be assembled.
      */
-    virtual void assemble(GlobalVector const& x) const = 0;
+    virtual void assemble(GlobalVector const& x,
+                          int const process_id) const = 0;
 
     /*! Assemble and solve the equation system.
      *
      * \param x   in: the initial guess, out: the solution.
      * \param postIterationCallback called after each iteration if set.
+     * \param process_id usually used in staggered schemes.
      *
      * \retval true if the equation system could be solved
      * \retval false otherwise
@@ -58,7 +61,8 @@ public:
     virtual NonlinearSolverStatus solve(
         GlobalVector& x,
         std::function<void(int, GlobalVector const&)> const&
-            postIterationCallback) = 0;
+            postIterationCallback,
+        int const process_id) = 0;
 
     virtual ~NonlinearSolverBase() = default;
 };
@@ -106,12 +110,13 @@ public:
         _convergence_criterion = &conv_crit;
     }
 
-    void assemble(GlobalVector const& x) const override;
+    void assemble(GlobalVector const& x, int const process_id) const override;
 
     NonlinearSolverStatus solve(
         GlobalVector& x,
         std::function<void(int, GlobalVector const&)> const&
-            postIterationCallback) override;
+            postIterationCallback,
+        int const process_id) override;
 
 private:
     GlobalLinearSolver& _linear_solver;
@@ -166,12 +171,13 @@ public:
         _convergence_criterion = &conv_crit;
     }
 
-    void assemble(GlobalVector const& x) const override;
+    void assemble(GlobalVector const& x, int const process_id) const override;
 
     NonlinearSolverStatus solve(
         GlobalVector& x,
         std::function<void(int, GlobalVector const&)> const&
-            postIterationCallback) override;
+            postIterationCallback,
+        int const process_id) override;
 
 private:
     GlobalLinearSolver& _linear_solver;

--- a/NumLib/ODESolver/NonlinearSystem.h
+++ b/NumLib/ODESolver/NonlinearSystem.h
@@ -37,7 +37,7 @@ public:
     //! Assembles the linearized equation system at the point \c x.
     //! The linearized system is \f$A(x) \cdot x = b(x)\f$. Here the matrix
     //! \f$A(x)\f$ and the vector \f$b(x)\f$ are assembled.
-    virtual void assemble(GlobalVector const& x) = 0;
+    virtual void assemble(GlobalVector const& x, int const process_id) = 0;
 
     /*! Writes the residual at point \c x to \c res.
      *
@@ -55,7 +55,8 @@ public:
     virtual void getJacobian(GlobalMatrix& Jac) const = 0;
 
     //! Pre-compute known solutions and possibly store them internally.
-    virtual void computeKnownSolutions(GlobalVector const& x) = 0;
+    virtual void computeKnownSolutions(GlobalVector const& x,
+                                       int const process_id) = 0;
 
     //! Apply known solutions to the solution vector \c x.
     //! \pre computeKnownSolutions() must have been called before.
@@ -82,7 +83,7 @@ public:
     //! Assembles the linearized equation system at the point \c x.
     //! The linearized system is \f$J(x) \cdot \Delta x = (x)\f$. Here the
     //! residual vector \f$r(x)\f$ and its Jacobian \f$J(x)\f$ are assembled.
-    virtual void assemble(GlobalVector const& x) = 0;
+    virtual void assemble(GlobalVector const& x, int const process_id) = 0;
 
     //! Writes the linearized equation system matrix to \c A.
     //! \pre assemble() must have been called before.
@@ -93,7 +94,8 @@ public:
     virtual void getRhs(GlobalVector& rhs) const = 0;
 
     //! Pre-compute known solutions and possibly store them internally.
-    virtual void computeKnownSolutions(GlobalVector const& x) = 0;
+    virtual void computeKnownSolutions(GlobalVector const& x,
+                                       int const process_id) = 0;
 
     //! Apply known solutions to the solution vector \c x.
     //! \pre computeKnownSolutions() must have been called before.

--- a/NumLib/ODESolver/ODESystem.h
+++ b/NumLib/ODESolver/ODESystem.h
@@ -51,18 +51,18 @@ public:
 
     //! Assemble \c M, \c K and \c b at the provided state (\c t, \c x).
     virtual void assemble(const double t, double const dt,
-                          GlobalVector const& x, GlobalMatrix& M,
-                          GlobalMatrix& K, GlobalVector& b) = 0;
+                          GlobalVector const& x, int const process_id,
+                          GlobalMatrix& M, GlobalMatrix& K,
+                          GlobalVector& b) = 0;
 
     using Index = MathLib::MatrixVectorTraits<GlobalMatrix>::Index;
 
     //! Provides known solutions (Dirichlet boundary conditions) vector for
-    //! the ode system at the given time \c t.
+    //! the ode system at the given time \c t and \c process_id.
     virtual std::vector<NumLib::IndexValueVector<Index>> const*
-    getKnownSolutions(double const t, GlobalVector const& x) const
+    getKnownSolutions(double const /*t*/, GlobalVector const& /*x*/,
+                      int const /*process_id*/) const
     {
-        (void)t;
-        (void)x;
         return nullptr;  // by default there are no known solutions
     }
 };
@@ -131,8 +131,9 @@ public:
                                       GlobalVector const& x,
                                       GlobalVector const& xdot,
                                       const double dxdot_dx, const double dx_dx,
-                                      GlobalMatrix& M, GlobalMatrix& K,
-                                      GlobalVector& b, GlobalMatrix& Jac) = 0;
+                                      int const process_id, GlobalMatrix& M,
+                                      GlobalMatrix& K, GlobalVector& b,
+                                      GlobalMatrix& Jac) = 0;
 };
 
 //! @}

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
@@ -71,7 +71,8 @@ TimeDiscretizedODESystem<
 
 void TimeDiscretizedODESystem<
     ODESystemTag::FirstOrderImplicitQuasilinear,
-    NonlinearSolverTag::Newton>::assemble(const GlobalVector& x_new_timestep)
+    NonlinearSolverTag::Newton>::assemble(const GlobalVector& x_new_timestep,
+                                          int const process_id)
 {
     namespace LinAlg = MathLib::LinAlg;
 
@@ -90,8 +91,8 @@ void TimeDiscretizedODESystem<
     _Jac->setZero();
 
     _ode.preAssemble(t, dt, x_curr);
-    _ode.assembleWithJacobian(t, dt, x_curr, xdot, dxdot_dx, dx_dx, *_M, *_K,
-                              *_b, *_Jac);
+    _ode.assembleWithJacobian(t, dt, x_curr, xdot, dxdot_dx, dx_dx, process_id,
+                              *_M, *_K, *_b, *_Jac);
 
     LinAlg::finalizeAssembly(*_M);
     LinAlg::finalizeAssembly(*_K);
@@ -126,9 +127,11 @@ void TimeDiscretizedODESystem<
 
 void TimeDiscretizedODESystem<
     ODESystemTag::FirstOrderImplicitQuasilinear,
-    NonlinearSolverTag::Newton>::computeKnownSolutions(GlobalVector const& x)
+    NonlinearSolverTag::Newton>::computeKnownSolutions(GlobalVector const& x,
+                                                       int const process_id)
 {
-    _known_solutions = _ode.getKnownSolutions(_time_disc.getCurrentTime(), x);
+    _known_solutions =
+        _ode.getKnownSolutions(_time_disc.getCurrentTime(), x, process_id);
 }
 
 void TimeDiscretizedODESystem<
@@ -187,7 +190,8 @@ TimeDiscretizedODESystem<
 
 void TimeDiscretizedODESystem<
     ODESystemTag::FirstOrderImplicitQuasilinear,
-    NonlinearSolverTag::Picard>::assemble(const GlobalVector& x_new_timestep)
+    NonlinearSolverTag::Picard>::assemble(const GlobalVector& x_new_timestep,
+                                          int const process_id)
 {
     namespace LinAlg = MathLib::LinAlg;
 
@@ -200,7 +204,7 @@ void TimeDiscretizedODESystem<
     _b->setZero();
 
     _ode.preAssemble(t, dt, x_curr);
-    _ode.assemble(t, dt, x_curr, *_M, *_K, *_b);
+    _ode.assemble(t, dt, x_curr, process_id, *_M, *_K, *_b);
 
     LinAlg::finalizeAssembly(*_M);
     LinAlg::finalizeAssembly(*_K);
@@ -209,9 +213,11 @@ void TimeDiscretizedODESystem<
 
 void TimeDiscretizedODESystem<
     ODESystemTag::FirstOrderImplicitQuasilinear,
-    NonlinearSolverTag::Picard>::computeKnownSolutions(GlobalVector const& x)
+    NonlinearSolverTag::Picard>::computeKnownSolutions(GlobalVector const& x,
+                                                       int const process_id)
 {
-    _known_solutions = _ode.getKnownSolutions(_time_disc.getCurrentTime(), x);
+    _known_solutions =
+        _ode.getKnownSolutions(_time_disc.getCurrentTime(), x, process_id);
 }
 
 void TimeDiscretizedODESystem<

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.h
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.h
@@ -83,14 +83,16 @@ public:
 
     ~TimeDiscretizedODESystem() override;
 
-    void assemble(const GlobalVector& x_new_timestep) override;
+    void assemble(const GlobalVector& x_new_timestep,
+                  int const process_id) override;
 
     void getResidual(GlobalVector const& x_new_timestep,
                      GlobalVector& res) const override;
 
     void getJacobian(GlobalMatrix& Jac) const override;
 
-    void computeKnownSolutions(GlobalVector const& x) override;
+    void computeKnownSolutions(GlobalVector const& x,
+                               int const process_id) override;
 
     void applyKnownSolutions(GlobalVector& x) const override;
 
@@ -179,7 +181,8 @@ public:
 
     ~TimeDiscretizedODESystem() override;
 
-    void assemble(const GlobalVector& x_new_timestep) override;
+    void assemble(const GlobalVector& x_new_timestep,
+                  int const process_id) override;
 
     void getA(GlobalMatrix& A) const override
     {
@@ -191,7 +194,8 @@ public:
         _mat_trans->computeRhs(*_M, *_K, *_b, rhs);
     }
 
-    void computeKnownSolutions(GlobalVector const& x) override;
+    void computeKnownSolutions(GlobalVector const& x,
+                               int const process_id) override;
 
     void applyKnownSolutions(GlobalVector& x) const override;
 

--- a/ProcessLib/AbstractJacobianAssembler.h
+++ b/ProcessLib/AbstractJacobianAssembler.h
@@ -40,7 +40,7 @@ public:
         LocalAssemblerInterface& /*local_assembler*/, double const /*t*/,
         double const /*dt*/, std::vector<double> const& /*local_xdot*/,
         const double /*dxdot_dx*/, const double /*dx_dx*/,
-        std::vector<double>& /*local_M_data*/,
+        int const /*process_id*/, std::vector<double>& /*local_M_data*/,
         std::vector<double>& /*local_K_data*/,
         std::vector<double>& /*local_b_data*/,
         std::vector<double>& /*local_Jac_data*/,

--- a/ProcessLib/AnalyticalJacobianAssembler.cpp
+++ b/ProcessLib/AnalyticalJacobianAssembler.cpp
@@ -29,14 +29,14 @@ void AnalyticalJacobianAssembler::assembleWithJacobian(
 void AnalyticalJacobianAssembler::assembleWithJacobianForStaggeredScheme(
     LocalAssemblerInterface& local_assembler, double const t, double const dt,
     std::vector<double> const& local_xdot, const double dxdot_dx,
-    const double dx_dx, std::vector<double>& local_M_data,
+    const double dx_dx, int const process_id, std::vector<double>& local_M_data,
     std::vector<double>& local_K_data, std::vector<double>& local_b_data,
     std::vector<double>& local_Jac_data,
     LocalCoupledSolutions const& local_coupled_solutions)
 {
     local_assembler.assembleWithJacobianForStaggeredScheme(
-        t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
-        local_b_data, local_Jac_data, local_coupled_solutions);
+        t, dt, local_xdot, dxdot_dx, dx_dx, process_id, local_M_data,
+        local_K_data, local_b_data, local_Jac_data, local_coupled_solutions);
 }
 
 }  // namespace ProcessLib

--- a/ProcessLib/AnalyticalJacobianAssembler.h
+++ b/ProcessLib/AnalyticalJacobianAssembler.h
@@ -44,7 +44,7 @@ public:
     void assembleWithJacobianForStaggeredScheme(
         LocalAssemblerInterface& local_assembler, double const t,
         double const dt, std::vector<double> const& local_xdot,
-        const double dxdot_dx, const double dx_dx,
+        const double dxdot_dx, const double dx_dx, int const process_id,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions) override;

--- a/ProcessLib/ComponentTransport/ComponentTransportFEM.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportFEM.h
@@ -398,14 +398,12 @@ public:
     }
 
     void assembleForStaggeredScheme(
-        double const t,
-        double const dt,
-        std::vector<double>& local_M_data,
-        std::vector<double>& local_K_data,
+        double const t, double const dt, int const process_id,
+        std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data,
         LocalCoupledSolutions const& coupled_xs) override
     {
-        if (coupled_xs.process_id == hydraulic_process_id)
+        if (process_id == hydraulic_process_id)
         {
             assembleHydraulicEquation(t, dt, local_M_data, local_K_data,
                                       local_b_data, coupled_xs);
@@ -413,8 +411,9 @@ public:
         else
         {
             // Go for assembling in an order of transport process id.
-            assembleComponentTransportEquation(
-                t, dt, local_M_data, local_K_data, local_b_data, coupled_xs);
+            assembleComponentTransportEquation(t, dt, local_M_data,
+                                               local_K_data, local_b_data,
+                                               coupled_xs, process_id);
         }
     }
 
@@ -534,9 +533,8 @@ public:
         double const t, double const dt, std::vector<double>& local_M_data,
         std::vector<double>& local_K_data,
         std::vector<double>& /*local_b_data*/,
-        LocalCoupledSolutions const& coupled_xs)
+        LocalCoupledSolutions const& coupled_xs, int const transport_process_id)
     {
-        auto const& transport_process_id = coupled_xs.process_id;
         auto local_C = Eigen::Map<const NodalVectorType>(
             coupled_xs.local_coupled_xs[transport_process_id].data(),
             concentration_size);

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.h
@@ -123,7 +123,8 @@ public:
         return _process_id_to_component_name_map;
     }
 
-    void setCoupledTermForTheStaggeredSchemeToLocalAssemblers() override;
+    void setCoupledTermForTheStaggeredSchemeToLocalAssemblers(
+        int const process_id) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, const double /*t*/,
                                     const double /*delta_t*/,
@@ -141,13 +142,14 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void setCoupledSolutionsOfPreviousTimeStep();

--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.cpp
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.cpp
@@ -18,9 +18,8 @@
 namespace ProcessLib
 {
 CoupledSolutionsForStaggeredScheme::CoupledSolutionsForStaggeredScheme(
-    std::vector<std::reference_wrapper<GlobalVector const>> const& coupled_xs_,
-    const int process_id_)
-    : coupled_xs(coupled_xs_), process_id(process_id_)
+    std::vector<std::reference_wrapper<GlobalVector const>> const& coupled_xs_)
+    : coupled_xs(coupled_xs_)
 {
     for (auto const& coupled_x : coupled_xs)
     {

--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.h
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.h
@@ -31,16 +31,13 @@ struct CoupledSolutionsForStaggeredScheme
 {
     CoupledSolutionsForStaggeredScheme(
         std::vector<std::reference_wrapper<GlobalVector const>> const&
-            coupled_xs_,
-        const int process_id_);
+            coupled_xs_);
 
     /// References to the current solutions of the coupled processes.
     std::vector<std::reference_wrapper<GlobalVector const>> const& coupled_xs;
 
     /// Pointers to the vector of the solutions of the previous time step.
     std::vector<GlobalVector*> coupled_xs_t0;
-
-    const int process_id;
 };
 
 /**
@@ -53,16 +50,12 @@ struct CoupledSolutionsForStaggeredScheme
  */
 struct LocalCoupledSolutions
 {
-    LocalCoupledSolutions(const int process_id_,
-                          std::vector<std::vector<double>>&& local_coupled_xs0_,
+    LocalCoupledSolutions(std::vector<std::vector<double>>&& local_coupled_xs0_,
                           std::vector<std::vector<double>>&& local_coupled_xs_)
-        : process_id(process_id_),
-          local_coupled_xs0(std::move(local_coupled_xs0_)),
+        : local_coupled_xs0(std::move(local_coupled_xs0_)),
           local_coupled_xs(std::move(local_coupled_xs_))
     {
     }
-
-    const int process_id;
 
     /// Local solutions of the previous time step.
     std::vector<std::vector<double>> const local_coupled_xs0;

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -58,30 +58,29 @@ void GroundwaterFlowProcess::initializeConcreteProcess(
 }
 
 void GroundwaterFlowProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble GroundwaterFlowProcess.");
 
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_table = {std::ref(*_local_to_global_index_map)};
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
 void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(
     const double t, double const dt, GlobalVector const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+    GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian GroundwaterFlowProcess.");
 
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_table = {std::ref(*_local_to_global_index_map)};
@@ -89,7 +88,7 @@ void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 
 }   // namespace GroundwaterFlow

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -91,13 +91,14 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     GroundwaterFlowProcessData _process_data;

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -87,7 +87,8 @@ void HTProcess::initializeConcreteProcess(
 }
 
 void HTProcess::assembleConcreteProcess(const double t, double const dt,
-                                        GlobalVector const& x, GlobalMatrix& M,
+                                        GlobalVector const& x,
+                                        int const process_id, GlobalMatrix& M,
                                         GlobalMatrix& K, GlobalVector& b)
 {
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
@@ -99,7 +100,7 @@ void HTProcess::assembleConcreteProcess(const double t, double const dt,
     }
     else
     {
-        if (_coupled_solutions->process_id == _heat_transport_process_id)
+        if (process_id == _heat_transport_process_id)
         {
             DBUG(
                 "Assemble the equations of heat transport process within "
@@ -116,20 +117,19 @@ void HTProcess::assembleConcreteProcess(const double t, double const dt,
         dof_tables.emplace_back(*_local_to_global_index_map);
     }
 
-    const int process_id =
-        _use_monolithic_scheme ? 0 : _coupled_solutions->process_id;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_tables, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_tables, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
 void HTProcess::assembleWithJacobianConcreteProcess(
     const double t, double const dt, GlobalVector const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+    GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian HTProcess.");
 
@@ -147,13 +147,11 @@ void HTProcess::assembleWithJacobianConcreteProcess(
     }
 
     // Call global assembler for each local assembly item.
-    const int process_id =
-        _use_monolithic_scheme ? 0 : _coupled_solutions->process_id;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_tables, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 
 void HTProcess::preTimestepConcreteProcess(GlobalVector const& x,
@@ -183,12 +181,11 @@ void HTProcess::preTimestepConcreteProcess(GlobalVector const& x,
     MathLib::LinAlg::setLocalAccessibleVector(x0);
 }
 
-void HTProcess::setCoupledTermForTheStaggeredSchemeToLocalAssemblers()
+void HTProcess::setCoupledTermForTheStaggeredSchemeToLocalAssemblers(
+    int const process_id)
 {
     DBUG("Set the coupled term for the staggered scheme to local assembers.");
 
-    const int process_id =
-        _use_monolithic_scheme ? 0 : _coupled_solutions->process_id;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &HTLocalAssemblerInterface::setStaggeredCoupledSolutions,

--- a/ProcessLib/HT/HTProcess.h
+++ b/ProcessLib/HT/HTProcess.h
@@ -78,7 +78,8 @@ public:
                             double const t,
                             GlobalVector const& x) const override;
 
-    void setCoupledTermForTheStaggeredSchemeToLocalAssemblers() override;
+    void setCoupledTermForTheStaggeredSchemeToLocalAssemblers(
+        int const process_id) override;
 
     void postTimestepConcreteProcess(GlobalVector const& x,
                                      const double t,
@@ -92,13 +93,14 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/HT/StaggeredHTFEM-impl.h
+++ b/ProcessLib/HT/StaggeredHTFEM-impl.h
@@ -25,12 +25,13 @@ template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
 void StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
     assembleForStaggeredScheme(double const t, double const dt,
+                               int const process_id,
                                std::vector<double>& local_M_data,
                                std::vector<double>& local_K_data,
                                std::vector<double>& local_b_data,
                                LocalCoupledSolutions const& coupled_xs)
 {
-    if (coupled_xs.process_id == _heat_transport_process_id)
+    if (process_id == _heat_transport_process_id)
     {
         assembleHeatTransportEquation(t, local_M_data, local_K_data,
                                       local_b_data, coupled_xs);

--- a/ProcessLib/HT/StaggeredHTFEM.h
+++ b/ProcessLib/HT/StaggeredHTFEM.h
@@ -67,8 +67,9 @@ public:
     }
 
     void assembleForStaggeredScheme(
-        double const t, double const dt, std::vector<double>& local_M_data,
-        std::vector<double>& local_K_data, std::vector<double>& local_b_data,
+        double const t, double const dt, int const process_id,
+        std::vector<double>& local_M_data, std::vector<double>& local_K_data,
+        std::vector<double>& local_b_data,
         LocalCoupledSolutions const& coupled_xs) override;
 
     std::vector<double> const& getIntPtDarcyVelocity(

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -73,12 +73,11 @@ void HeatConductionProcess::initializeConcreteProcess(
 }
 
 void HeatConductionProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble HeatConductionProcess.");
 
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
@@ -86,18 +85,18 @@ void HeatConductionProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
 void HeatConductionProcess::assembleWithJacobianConcreteProcess(
     const double t, double const dt, GlobalVector const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+    GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian HeatConductionProcess.");
 
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
@@ -106,7 +105,7 @@ void HeatConductionProcess::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 
 void HeatConductionProcess::computeSecondaryVariableConcrete(

--- a/ProcessLib/HeatConduction/HeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.h
@@ -51,13 +51,14 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const /*dt*/,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const /*dt*/, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     HeatConductionProcessData _process_data;

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
@@ -159,12 +159,11 @@ void HeatTransportBHEProcess::initializeConcreteProcess(
 }
 
 void HeatTransportBHEProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble HeatTransportBHE process.");
 
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
@@ -172,15 +171,15 @@ void HeatTransportBHEProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
 void HeatTransportBHEProcess::assembleWithJacobianConcreteProcess(
     const double /*t*/, double const /*dt*/, GlobalVector const& /*x*/,
     GlobalVector const& /*xdot*/, const double /*dxdot_dx*/,
-    const double /*dx_dx*/, GlobalMatrix& /*M*/, GlobalMatrix& /*K*/,
-    GlobalVector& /*b*/, GlobalMatrix& /*Jac*/)
+    const double /*dx_dx*/, int const /*process_id*/, GlobalMatrix& /*M*/,
+    GlobalMatrix& /*K*/, GlobalVector& /*b*/, GlobalMatrix& /*Jac*/)
 {
     OGS_FATAL(
         "HeatTransportBHE: analytical Jacobian assembly is not implemented");

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
@@ -55,13 +55,14 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void createBHEBoundaryConditionTopBottom(

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -551,13 +551,13 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                   DisplacementDim>::
     assembleWithJacobianForStaggeredScheme(
         const double t, double const dt, const std::vector<double>& local_xdot,
-        const double dxdot_dx, const double dx_dx,
+        const double dxdot_dx, const double dx_dx, int const process_id,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         const LocalCoupledSolutions& local_coupled_solutions)
 {
     // For the equations with pressure
-    if (local_coupled_solutions.process_id == 0)
+    if (process_id == 0)
     {
         assembleWithJacobianForPressureEquations(
             t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -152,7 +152,7 @@ public:
 
     void assembleWithJacobianForStaggeredScheme(
         double const t, double const dt, std::vector<double> const& local_xdot,
-        const double dxdot_dx, const double dx_dx,
+        const double dxdot_dx, const double dx_dx, int const process_id,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions) override;

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -73,13 +73,14 @@ private:
     void initializeBoundaryConditions() override;
 
     void assembleConcreteProcess(const double t, double const /*dt*/,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const /*dt*/, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -566,8 +566,8 @@ bool HydroMechanicsProcess<GlobalDim>::isLinear() const
 
 template <int GlobalDim>
 void HydroMechanicsProcess<GlobalDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble HydroMechanicsProcess.");
 
@@ -576,19 +576,18 @@ void HydroMechanicsProcess<GlobalDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        dof_table, t, dt, x, M, K, b, _coupled_solutions);
+        dof_table, t, dt, x, process_id, M, K, b, _coupled_solutions);
 }
 
 template <int GlobalDim>
 void HydroMechanicsProcess<GlobalDim>::assembleWithJacobianConcreteProcess(
     const double t, double const dt, GlobalVector const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+    GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian HydroMechanicsProcess.");
 
-    const int process_id =
-        _use_monolithic_scheme ? 0 : _coupled_solutions->process_id;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
@@ -597,7 +596,7 @@ void HydroMechanicsProcess<GlobalDim>::assembleWithJacobianConcreteProcess(
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 
     auto copyRhs = [&](int const variable_id, auto& output_vector) {
         transformVariableFromGlobalVector(b, variable_id,

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
@@ -66,13 +66,14 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,
                                     double const dt,

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -542,12 +542,11 @@ bool SmallDeformationProcess<DisplacementDim>::isLinear() const
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble SmallDeformationProcess.");
 
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
@@ -555,7 +554,7 @@ void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 template <int DisplacementDim>
@@ -563,12 +562,12 @@ void SmallDeformationProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian SmallDeformationProcess.");
 
     // Call global assembler for each local assembly item.
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
@@ -576,7 +575,7 @@ void SmallDeformationProcess<DisplacementDim>::
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::preTimestepConcreteProcess(

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
@@ -62,13 +62,14 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -78,45 +78,41 @@ void LiquidFlowProcess::initializeConcreteProcess(
             &LiquidFlowLocalAssemblerInterface::getIntPtDarcyVelocity));
 }
 
-void LiquidFlowProcess::assembleConcreteProcess(const double t, double const dt,
-                                                GlobalVector const& x,
-                                                GlobalMatrix& M,
-                                                GlobalMatrix& K,
-                                                GlobalVector& b)
+void LiquidFlowProcess::assembleConcreteProcess(
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble LiquidFlowProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_table = {std::ref(*_local_to_global_index_map)};
 
-
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
 void LiquidFlowProcess::assembleWithJacobianConcreteProcess(
     const double t, double const dt, GlobalVector const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+    GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian LiquidFlowProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 
 void LiquidFlowProcess::computeSecondaryVariableConcrete(const double t,

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -90,13 +90,14 @@ private:
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     const int _gravitational_axis_id;

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -28,7 +28,7 @@ void LocalAssemblerInterface::assemble(double const /*t*/,
 }
 
 void LocalAssemblerInterface::assembleForStaggeredScheme(
-    double const /*t*/, double const /*dt*/,
+    double const /*t*/, double const /*dt*/, int const /*process_id*/,
     std::vector<double>& /*local_M_data*/,
     std::vector<double>& /*local_K_data*/,
     std::vector<double>& /*local_b_data*/,
@@ -56,7 +56,8 @@ void LocalAssemblerInterface::assembleWithJacobian(
 void LocalAssemblerInterface::assembleWithJacobianForStaggeredScheme(
     double const /*t*/, double const /*dt*/,
     std::vector<double> const& /*local_xdot*/, const double /*dxdot_dx*/,
-    const double /*dx_dx*/, std::vector<double>& /*local_M_data*/,
+    const double /*dx_dx*/, int const /*process_id*/,
+    std::vector<double>& /*local_M_data*/,
     std::vector<double>& /*local_K_data*/,
     std::vector<double>& /*local_b_data*/,
     std::vector<double>& /*local_Jac_data*/,

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -53,8 +53,9 @@ public:
                           std::vector<double>& local_b_data);
 
     virtual void assembleForStaggeredScheme(
-        double const t, double const dt, std::vector<double>& local_M_data,
-        std::vector<double>& local_K_data, std::vector<double>& local_b_data,
+        double const t, double const dt, int const process_id,
+        std::vector<double>& local_M_data, std::vector<double>& local_K_data,
+        std::vector<double>& local_b_data,
         LocalCoupledSolutions const& coupled_solutions);
 
     virtual void assembleWithJacobian(double const t, double const dt,
@@ -68,7 +69,7 @@ public:
 
     virtual void assembleWithJacobianForStaggeredScheme(
         double const t, double const dt, std::vector<double> const& local_xdot,
-        const double dxdot_dx, const double dx_dx,
+        const double dxdot_dx, const double dx_dx, int const process_id,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions);

--- a/ProcessLib/PhaseField/PhaseFieldFEM-impl.h
+++ b/ProcessLib/PhaseField/PhaseFieldFEM-impl.h
@@ -23,13 +23,13 @@ void PhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
                               DisplacementDim>::
     assembleWithJacobianForStaggeredScheme(
         double const t, double const dt, std::vector<double> const& local_xdot,
-        const double dxdot_dx, const double dx_dx,
+        const double dxdot_dx, const double dx_dx, int const process_id,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions)
 {
     // For the equations with phase field.
-    if (local_coupled_solutions.process_id == 1)
+    if (process_id == 1)
     {
         assembleWithJacobianPhaseFiledEquations(
             t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,

--- a/ProcessLib/PhaseField/PhaseFieldFEM.h
+++ b/ProcessLib/PhaseField/PhaseFieldFEM.h
@@ -204,7 +204,7 @@ public:
 
     void assembleWithJacobianForStaggeredScheme(
         double const t, double const dt, std::vector<double> const& local_xdot,
-        const double dxdot_dx, const double dx_dx,
+        const double dxdot_dx, const double dx_dx, int const process_id,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions) override;

--- a/ProcessLib/PhaseField/PhaseFieldProcess.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.h
@@ -88,13 +88,14 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -96,24 +96,28 @@ public:
     void updateDeactivatedSubdomains(double const time, const int process_id);
 
     bool isMonolithicSchemeUsed() const { return _use_monolithic_scheme; }
-    virtual void setCoupledTermForTheStaggeredSchemeToLocalAssemblers() {}
+    virtual void setCoupledTermForTheStaggeredSchemeToLocalAssemblers(
+        int const /*process_id*/)
+    {
+    }
     void preAssemble(const double t, double const dt,
                      GlobalVector const& x) final;
     void assemble(const double t, double const dt, GlobalVector const& x,
-                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) final;
+                  int const process_id, GlobalMatrix& M, GlobalMatrix& K,
+                  GlobalVector& b) final;
 
     void assembleWithJacobian(const double t, double const dt,
                               GlobalVector const& x, GlobalVector const& xdot,
                               const double dxdot_dx, const double dx_dx,
-                              GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+                              int const process_id, GlobalMatrix& M,
+                              GlobalMatrix& K, GlobalVector& b,
                               GlobalMatrix& Jac) final;
 
     std::vector<NumLib::IndexValueVector<GlobalIndexType>> const*
-    getKnownSolutions(double const t, GlobalVector const& x) const final
+    getKnownSolutions(double const t, GlobalVector const& x,
+                      int const process_id) const final
     {
-        const auto pcs_id =
-            (_coupled_solutions) ? _coupled_solutions->process_id : 0;
-        return _boundary_conditions[pcs_id].getKnownSolutions(t, x);
+        return _boundary_conditions[process_id].getKnownSolutions(t, x);
     }
 
     virtual NumLib::LocalToGlobalIndexMap const& getDOFTable(
@@ -192,13 +196,14 @@ private:
     }
 
     virtual void assembleConcreteProcess(const double t, double const dt,
-                                         GlobalVector const& x, GlobalMatrix& M,
+                                         GlobalVector const& x,
+                                         int const process_id, GlobalMatrix& M,
                                          GlobalMatrix& K, GlobalVector& b) = 0;
 
     virtual void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) = 0;
 
     virtual void preTimestepConcreteProcess(GlobalVector const& /*x*/,

--- a/ProcessLib/ProcessData.h
+++ b/ProcessLib/ProcessData.h
@@ -27,6 +27,7 @@ struct ProcessData
                 NumLib::NonlinearSolver<NLTag>& nonlinear_solver,
                 std::unique_ptr<NumLib::ConvergenceCriterion>&& conv_crit_,
                 std::unique_ptr<NumLib::TimeDiscretization>&& time_disc_,
+                int const process_id_,
                 Process& process_)
         : timestepper(std::move(timestepper_)),
           nonlinear_solver_tag(NLTag),
@@ -34,6 +35,7 @@ struct ProcessData
           nonlinear_solver_status{true, 0},
           conv_crit(std::move(conv_crit_)),
           time_disc(std::move(time_disc_)),
+          process_id(process_id_),
           process(process_)
     {
     }
@@ -47,6 +49,7 @@ struct ProcessData
           time_disc(std::move(pd.time_disc)),
           tdisc_ode_sys(std::move(pd.tdisc_ode_sys)),
           mat_strg(pd.mat_strg),
+          process_id(pd.process_id),
           process(pd.process)
     {
         pd.mat_strg = nullptr;
@@ -67,9 +70,7 @@ struct ProcessData
     //! cast of \c tdisc_ode_sys to NumLib::InternalMatrixStorage
     NumLib::InternalMatrixStorage* mat_strg = nullptr;
 
-    /// Process ID. It is alway 0 when the monolithic scheme is used or
-    /// a single process is modelled.
-    int process_id = 0;
+    int const process_id;
 
     Process& process;
 };

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
@@ -66,42 +66,39 @@ void RichardsComponentTransportProcess::initializeConcreteProcess(
 }
 
 void RichardsComponentTransportProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble RichardsComponentTransportProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
        dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id =
-        _use_monolithic_scheme ? 0 : _coupled_solutions->process_id;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
 void RichardsComponentTransportProcess::assembleWithJacobianConcreteProcess(
     const double t, double const dt, GlobalVector const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+    GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian RichardsComponentTransportProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id =
-        _use_monolithic_scheme ? 0 : _coupled_solutions->process_id;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 
 }  // namespace RichardsComponentTransport

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.h
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.h
@@ -130,13 +130,14 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     RichardsComponentTransportProcessData _process_data;

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
@@ -66,40 +66,39 @@ void RichardsFlowProcess::initializeConcreteProcess(
 }
 
 void RichardsFlowProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble RichardsFlowProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
        dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
 void RichardsFlowProcess::assembleWithJacobianConcreteProcess(
     const double t, double const dt, GlobalVector const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+    GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian RichardsFlowProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
        dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 
 }  // namespace RichardsFlow

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.h
@@ -54,13 +54,14 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     RichardsFlowProcessData _process_data;

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
@@ -770,13 +770,13 @@ void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                      DisplacementDim>::
     assembleWithJacobianForStaggeredScheme(
         const double t, double const dt, const std::vector<double>& local_xdot,
-        const double dxdot_dx, const double dx_dx,
+        const double dxdot_dx, const double dx_dx, int const process_id,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         const LocalCoupledSolutions& local_coupled_solutions)
 {
     // For the equations with pressure
-    if (local_coupled_solutions.process_id == 0)
+    if (process_id == 0)
     {
         assembleWithJacobianForPressureEquations(
             t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
@@ -85,7 +85,7 @@ public:
 
     void assembleWithJacobianForStaggeredScheme(
         double const t, double const dt, std::vector<double> const& local_xdot,
-        const double dxdot_dx, const double dx_dx,
+        const double dxdot_dx, const double dx_dx, int const process_id,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions) override;

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
@@ -234,8 +234,8 @@ void RichardsMechanicsProcess<DisplacementDim>::initializeBoundaryConditions()
 
 template <int DisplacementDim>
 void RichardsMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble the equations for RichardsMechanics");
 
@@ -245,14 +245,12 @@ void RichardsMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id =
-        _use_monolithic_scheme ? 0 : _coupled_solutions->process_id;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
@@ -261,7 +259,8 @@ void RichardsMechanicsProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac)
 {
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_tables;
@@ -276,7 +275,7 @@ void RichardsMechanicsProcess<DisplacementDim>::
     else
     {
         // For the staggered scheme
-        if (_coupled_solutions->process_id == 0)
+        if (process_id == 0)
         {
             DBUG(
                 "Assemble the Jacobian equations of liquid fluid process in "
@@ -292,14 +291,12 @@ void RichardsMechanicsProcess<DisplacementDim>::
         dof_tables.emplace_back(*_local_to_global_index_map);
     }
 
-    const int process_id =
-        _use_monolithic_scheme ? 0 : _coupled_solutions->process_id;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_tables, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 
     auto copyRhs = [&](int const variable_id, auto& output_vector) {
         if (_use_monolithic_scheme)
@@ -310,16 +307,16 @@ void RichardsMechanicsProcess<DisplacementDim>::
         }
         else
         {
-            transformVariableFromGlobalVector(
-                b, 0, dof_tables[_coupled_solutions->process_id], output_vector,
-                std::negate<double>());
+            transformVariableFromGlobalVector(b, 0, dof_tables[process_id],
+                                              output_vector,
+                                              std::negate<double>());
         }
     };
-    if (_use_monolithic_scheme || _coupled_solutions->process_id == 0)
+    if (_use_monolithic_scheme || process_id == 0)
     {
         copyRhs(0, *_hydraulic_flow);
     }
-    if (_use_monolithic_scheme || _coupled_solutions->process_id == 1)
+    if (_use_monolithic_scheme || process_id == 1)
     {
         copyRhs(1, *_nodal_forces);
     }

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
@@ -75,13 +75,14 @@ private:
     void initializeBoundaryConditions() override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -241,12 +241,11 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble SmallDeformationProcess.");
 
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
@@ -254,7 +253,7 @@ void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
@@ -263,11 +262,11 @@ void SmallDeformationProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian SmallDeformationProcess.");
 
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
@@ -276,7 +275,7 @@ void SmallDeformationProcess<DisplacementDim>::
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 
     transformVariableFromGlobalVector(b, 0, *_local_to_global_index_map,
                                       *_nodal_forces, std::negate<double>());

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -51,13 +51,14 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void postTimestepConcreteProcess(GlobalVector const& x, const double t,

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
@@ -231,21 +231,20 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::
 
 template <int DisplacementDim>
 void SmallDeformationNonlocalProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble SmallDeformationNonlocalProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_table = {std::ref(*_local_to_global_index_map)};
 
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
@@ -272,21 +271,21 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian SmallDeformationNonlocalProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_table = {std::ref(*_local_to_global_index_map)};
 
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 
     b.copyValues(*_nodal_forces);
     std::transform(_nodal_forces->begin(), _nodal_forces->end(),

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
@@ -54,8 +54,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void preAssembleConcreteProcess(const double t, double const dt,
                                     GlobalVector const& x) override;
@@ -63,7 +64,7 @@ private:
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void postTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -229,40 +229,38 @@ void TESProcess::initializeSecondaryVariables()
 }
 
 void TESProcess::assembleConcreteProcess(const double t, double const dt,
-                                         GlobalVector const& x, GlobalMatrix& M,
+                                         GlobalVector const& x,
+                                         int const process_id, GlobalMatrix& M,
                                          GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble TESProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
        dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id =
-        _use_monolithic_scheme ? 0 : _coupled_solutions->process_id;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
 void TESProcess::assembleWithJacobianConcreteProcess(
     const double t, double const dt, GlobalVector const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+    GlobalMatrix& Jac)
 {
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
        dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id =
-        _use_monolithic_scheme ? 0 : _coupled_solutions->process_id;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 
 void TESProcess::preTimestepConcreteProcess(GlobalVector const& x,

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -60,15 +60,16 @@ private:
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void initializeSecondaryVariables();
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     GlobalVector const& computeVapourPartialPressure(

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
@@ -75,40 +75,39 @@ void ThermalTwoPhaseFlowWithPPProcess::initializeConcreteProcess(
 }
 
 void ThermalTwoPhaseFlowWithPPProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble ThermalTwoPhaseFlowWithPPProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
        dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
 void ThermalTwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
     const double t, double const dt, GlobalVector const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+    GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian ThermalTwoPhaseFlowWithPPProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
        dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 void ThermalTwoPhaseFlowWithPPProcess::preTimestepConcreteProcess(
     GlobalVector const& x, double const t, double const delta_t,

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
@@ -62,13 +62,14 @@ private:
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, const double t,

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
@@ -240,8 +240,8 @@ void ThermoHydroMechanicsProcess<
 
 template <int DisplacementDim>
 void ThermoHydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble the equations for ThermoHydroMechanics");
 
@@ -254,7 +254,7 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        dof_table, t, dt, x, M, K, b, _coupled_solutions);
+        dof_table, t, dt, x, process_id, M, K, b, _coupled_solutions);
 }
 
 template <int DisplacementDim>
@@ -262,7 +262,8 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac)
 {
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_tables;
@@ -277,13 +278,13 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::
     else
     {
         // For the staggered scheme
-        if (_coupled_solutions->process_id == 0)
+        if (process_id == 0)
         {
             DBUG(
                 "Assemble the Jacobian equations of heat transport process in "
                 "ThermoHydroMechanics for the staggered scheme.");
         }
-        else if (_coupled_solutions->process_id == 1)
+        else if (process_id == 1)
         {
             DBUG(
                 "Assemble the Jacobian equations of liquid fluid process in "
@@ -302,8 +303,8 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::
 
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
-        _local_assemblers, dof_tables, t, dt, x, xdot, dxdot_dx, dx_dx, M, K, b,
-        Jac, _coupled_solutions);
+        _local_assemblers, dof_tables, t, dt, x, xdot, dxdot_dx, dx_dx,
+        process_id, M, K, b, Jac, _coupled_solutions);
 
     auto copyRhs = [&](int const variable_id, auto& output_vector) {
         if (_use_monolithic_scheme)
@@ -314,16 +315,16 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::
         }
         else
         {
-            transformVariableFromGlobalVector(
-                b, 0, dof_tables[_coupled_solutions->process_id], output_vector,
-                std::negate<double>());
+            transformVariableFromGlobalVector(b, 0, dof_tables[process_id],
+                                              output_vector,
+                                              std::negate<double>());
         }
     };
-    if (_use_monolithic_scheme || _coupled_solutions->process_id == 1)
+    if (_use_monolithic_scheme || process_id == 1)
     {
         copyRhs(0, *_hydraulic_flow);
     }
-    if (_use_monolithic_scheme || _coupled_solutions->process_id == 2)
+    if (_use_monolithic_scheme || process_id == 2)
     {
         copyRhs(1, *_nodal_forces);
     }

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
@@ -76,13 +76,14 @@ private:
     void initializeBoundaryConditions() override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM-impl.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM-impl.h
@@ -25,12 +25,12 @@ void ThermoMechanicalPhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
                                               DisplacementDim>::
     assembleWithJacobianForStaggeredScheme(
         double const t, double const dt, std::vector<double> const& local_xdot,
-        const double dxdot_dx, const double dx_dx,
+        const double dxdot_dx, const double dx_dx, int const process_id,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions)
 {
-    if (local_coupled_solutions.process_id == _phase_field_process_id)
+    if (process_id == _phase_field_process_id)
     {
         assembleWithJacobianForPhaseFieldEquations(
             t, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,
@@ -38,7 +38,7 @@ void ThermoMechanicalPhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
         return;
     }
 
-    if (local_coupled_solutions.process_id == _heat_conduction_process_id)
+    if (process_id == _heat_conduction_process_id)
     {
         assembleWithJacobianForHeatConductionEquations(
             t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
@@ -217,7 +217,7 @@ public:
 
     void assembleWithJacobianForStaggeredScheme(
         double const t, double const dt, std::vector<double> const& local_xdot,
-        const double dxdot_dx, const double dx_dx,
+        const double dxdot_dx, const double dx_dx, int const process_id,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions) override;

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
@@ -93,13 +93,14 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
@@ -306,14 +306,13 @@ void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
                                    DisplacementDim>::
     assembleWithJacobianForStaggeredScheme(
         const double t, double const dt, const std::vector<double>& local_xdot,
-        const double dxdot_dx, const double dx_dx,
+        const double dxdot_dx, const double dx_dx, int const process_id,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         const LocalCoupledSolutions& local_coupled_solutions)
 {
     // For the equations with pressure
-    if (local_coupled_solutions.process_id ==
-        _process_data.heat_conduction_process_id)
+    if (process_id == _process_data.heat_conduction_process_id)
     {
         assembleWithJacobianForHeatConductionEquations(
             t, dt, local_xdot, dxdot_dx, dx_dx, local_M_data, local_K_data,

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
@@ -135,7 +135,7 @@ public:
 
     void assembleWithJacobianForStaggeredScheme(
         double const t, double const dt, std::vector<double> const& local_xdot,
-        const double dxdot_dx, const double dx_dx,
+        const double dxdot_dx, const double dx_dx, int const process_id,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions) override;
@@ -143,9 +143,9 @@ public:
     void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x,
                               std::vector<double> const& local_xdot,
-                              const double /*dxdot_dx*/, const double /*dx_dx*/,
-                              std::vector<double>& /*local_M_data*/,
-                              std::vector<double>& /*local_K_data*/,
+                              const double dxdot_dx, const double dx_dx,
+                              std::vector<double>& local_M_data,
+                              std::vector<double>& local_K_data,
                               std::vector<double>& local_rhs_data,
                               std::vector<double>& local_Jac_data) override;
 

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
@@ -277,21 +277,19 @@ void ThermoMechanicsProcess<DisplacementDim>::initializeBoundaryConditions()
 
 template <int DisplacementDim>
 void ThermoMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble ThermoMechanicsProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
         dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id =
-        _use_monolithic_scheme ? 0 : _coupled_solutions->process_id;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
@@ -300,7 +298,8 @@ void ThermoMechanicsProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac)
 {
     DBUG("AssembleJacobian ThermoMechanicsProcess.");
 
@@ -317,8 +316,7 @@ void ThermoMechanicsProcess<DisplacementDim>::
     else
     {
         // For the staggered scheme
-        if (_coupled_solutions->process_id ==
-            _process_data.heat_conduction_process_id)
+        if (process_id == _process_data.heat_conduction_process_id)
         {
             DBUG(
                 "Assemble the Jacobian equations of heat conduction process in "
@@ -349,14 +347,12 @@ void ThermoMechanicsProcess<DisplacementDim>::
         setCoupledSolutionsOfPreviousTimeStep();
     }
 
-    const int process_id =
-        _use_monolithic_scheme ? 0 : _coupled_solutions->process_id;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_tables, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 
     // TODO (naumov): Refactor the copy rhs part. This is copy from HM.
     auto copyRhs = [&](int const variable_id, auto& output_vector) {
@@ -368,19 +364,18 @@ void ThermoMechanicsProcess<DisplacementDim>::
         }
         else
         {
-            transformVariableFromGlobalVector(
-                b, 0, dof_tables[_coupled_solutions->process_id], output_vector,
-                std::negate<double>());
+            transformVariableFromGlobalVector(b, 0, dof_tables[process_id],
+                                              output_vector,
+                                              std::negate<double>());
         }
     };
     if (_use_monolithic_scheme ||
-        _coupled_solutions->process_id ==
-            _process_data.heat_conduction_process_id)
+        process_id == _process_data.heat_conduction_process_id)
     {
         copyRhs(0, *_heat_flux);
     }
     if (_use_monolithic_scheme ||
-        _coupled_solutions->process_id == _process_data.mechanics_process_id)
+        process_id == _process_data.mechanics_process_id)
     {
         copyRhs(1, *_nodal_forces);
     }

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
@@ -68,13 +68,14 @@ private:
     void initializeBoundaryConditions() override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, double const t,

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
@@ -73,40 +73,39 @@ void TwoPhaseFlowWithPPProcess::initializeConcreteProcess(
 }
 
 void TwoPhaseFlowWithPPProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble TwoPhaseFlowWithPPProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
        dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
 void TwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
     const double t, double const dt, GlobalVector const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+    GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian TwoPhaseFlowWithPPProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
        dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 
 }  // namespace TwoPhaseFlowWithPP

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
@@ -61,13 +61,14 @@ private:
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     TwoPhaseFlowWithPPProcessData _process_data;

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
@@ -73,40 +73,39 @@ void TwoPhaseFlowWithPrhoProcess::initializeConcreteProcess(
 }
 
 void TwoPhaseFlowWithPrhoProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x, GlobalMatrix& M,
-    GlobalMatrix& K, GlobalVector& b)
+    const double t, double const dt, GlobalVector const& x,
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble TwoPhaseFlowWithPrhoProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
        dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, M, K, b,
+        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
         _coupled_solutions);
 }
 
 void TwoPhaseFlowWithPrhoProcess::assembleWithJacobianConcreteProcess(
     const double t, double const dt, GlobalVector const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac)
+    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+    GlobalMatrix& Jac)
 {
     DBUG("AssembleWithJacobian TwoPhaseFlowWithPrhoProcess.");
 
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>>
        dof_table = {std::ref(*_local_to_global_index_map)};
-    const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assembleWithJacobian,
         _local_assemblers, pv.getActiveElementIDs(), dof_table, t, dt, x, xdot,
-        dxdot_dx, dx_dx, M, K, b, Jac, _coupled_solutions);
+        dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 void TwoPhaseFlowWithPrhoProcess::preTimestepConcreteProcess(
     GlobalVector const& x, double const t, double const dt,

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
@@ -58,13 +58,14 @@ private:
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, GlobalMatrix& M,
-                                 GlobalMatrix& K, GlobalVector& b) override;
+                                 GlobalVector const& x, int const process_id,
+                                 GlobalMatrix& M, GlobalMatrix& K,
+                                 GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(GlobalVector const& x, const double t,

--- a/ProcessLib/VectorMatrixAssembler.h
+++ b/ProcessLib/VectorMatrixAssembler.h
@@ -48,7 +48,8 @@ public:
                   std::vector<std::reference_wrapper<
                       NumLib::LocalToGlobalIndexMap>> const& dof_tables,
                   double const t, double const dt, GlobalVector const& x,
-                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+                  int const process_id, GlobalMatrix& M, GlobalMatrix& K,
+                  GlobalVector& b,
                   CoupledSolutionsForStaggeredScheme const* const cpl_xs);
 
     //! Assembles \c M, \c K, \c b, and the Jacobian \c Jac of the residual.
@@ -61,7 +62,8 @@ public:
             dof_tables,
         const double t, double const dt, GlobalVector const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b, GlobalMatrix& Jac,
+        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        GlobalMatrix& Jac,
         CoupledSolutionsForStaggeredScheme const* const cpl_xs);
 
 private:

--- a/Tests/NumLib/ODEs.h
+++ b/Tests/NumLib/ODEs.h
@@ -32,8 +32,8 @@ public:
     }
 
     void assemble(const double /*t*/, double const /*dt*/,
-                  GlobalVector const& /*x*/, GlobalMatrix& M, GlobalMatrix& K,
-                  GlobalVector& b) override
+                  GlobalVector const& /*x*/, int const /*process_id*/,
+                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) override
     {
         MathLib::setMatrix(M, { 1.0, 0.0,  0.0, 1.0 });
         MathLib::setMatrix(K, { 0.0, 1.0, -1.0, 0.0 });
@@ -45,12 +45,13 @@ public:
                               GlobalVector const& x_curr,
                               GlobalVector const& /*xdot*/,
                               const double dxdot_dx, const double dx_dx,
-                              GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+                              int const process_id, GlobalMatrix& M,
+                              GlobalMatrix& K, GlobalVector& b,
                               GlobalMatrix& Jac) override
     {
         namespace LinAlg = MathLib::LinAlg;
 
-        assemble(t, dt, x_curr, M, K, b);
+        assemble(t, dt, x_curr, process_id, M, K, b);
 
         // compute Jac = M*dxdot_dx + dx_dx*K
         LinAlg::finalizeAssembly(M);
@@ -117,8 +118,8 @@ public:
     }
 
     void assemble(const double /*t*/, double const /*dt*/,
-                  GlobalVector const& x, GlobalMatrix& M, GlobalMatrix& K,
-                  GlobalVector& b) override
+                  GlobalVector const& x, int const /*process_id*/,
+                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) override
     {
         MathLib::setMatrix(M, {1.0});
         MathLib::LinAlg::setLocalAccessibleVector(x);
@@ -130,10 +131,11 @@ public:
                               GlobalVector const& x,
                               GlobalVector const& /*xdot*/,
                               const double dxdot_dx, const double dx_dx,
-                              GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+                              int const process_id, GlobalMatrix& M,
+                              GlobalMatrix& K, GlobalVector& b,
                               GlobalMatrix& Jac) override
     {
-        assemble(t, dt, x, M, K, b);
+        assemble(t, dt, x, process_id, M, K, b);
 
         namespace LinAlg = MathLib::LinAlg;
 
@@ -210,8 +212,8 @@ public:
     }
 
     void assemble(const double /*t*/, double const /*dt*/,
-                  GlobalVector const& x_curr, GlobalMatrix& M, GlobalMatrix& K,
-                  GlobalVector& b) override
+                  GlobalVector const& x_curr, int const /*process_id*/,
+                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) override
     {
         MathLib::LinAlg::setLocalAccessibleVector(x_curr);
         auto const u = x_curr[0];
@@ -226,13 +228,13 @@ public:
     void assembleWithJacobian(const double t, double const dt,
                               GlobalVector const& x_curr,
                               GlobalVector const& xdot, const double dxdot_dx,
-                              const double dx_dx, GlobalMatrix& M,
-                              GlobalMatrix& K, GlobalVector& b,
+                              const double dx_dx, int const process_id,
+                              GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
                               GlobalMatrix& Jac) override
     {
         MathLib::LinAlg::setLocalAccessibleVector(x_curr);
         MathLib::LinAlg::setLocalAccessibleVector(xdot);
-        assemble(t, dt, x_curr, M, K, b);
+        assemble(t, dt, x_curr, process_id, M, K, b);
 
         auto const u = x_curr[0];
         auto const v = x_curr[1];

--- a/Tests/NumLib/TimeLoopSingleODE.h
+++ b/Tests/NumLib/TimeLoopSingleODE.h
@@ -96,8 +96,9 @@ NumLib::NonlinearSolverStatus TimeLoopSingleODE<NLTag>::loop(
 
     if (time_disc.needsPreload())
     {
+        int const process_id = 0;
         MathLib::LinAlg::setLocalAccessibleVector(x);
-        _nonlinear_solver->assemble(x);
+        _nonlinear_solver->assemble(x, process_id);
         time_disc.pushState(t0, x0,
                             _ode_sys);  // TODO: that might do duplicate work
     }
@@ -113,7 +114,9 @@ NumLib::NonlinearSolverStatus TimeLoopSingleODE<NLTag>::loop(
         // INFO("time: %e, delta_t: %e", t, delta_t);
         time_disc.nextTimestep(t, delta_t);
 
-        nonlinear_solver_status = _nonlinear_solver->solve(x, nullptr);
+        int const process_id = 0;
+        nonlinear_solver_status =
+            _nonlinear_solver->solve(x, nullptr, process_id);
         if (!nonlinear_solver_status.error_norms_met)
         {
             break;


### PR DESCRIPTION
Continuing the time loop refactorings, a second change (with big trail in the processes) eliminating `process_id` from the CoupledSolutionsForStaggeredScheme (and the local class therein).

Review commit-wise.

Main change in [ProcessLib/CoupledSolutionsForStaggeredScheme.h](https://github.com/ufz/ogs/pull/2679/files#diff-81c8910638eee8d67ecaaca35bd29ac9)