### PR TITLE
Remove coupled solutions references

### DIFF
--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.cpp
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.cpp
@@ -18,12 +18,12 @@
 namespace ProcessLib
 {
 CoupledSolutionsForStaggeredScheme::CoupledSolutionsForStaggeredScheme(
-    std::vector<std::reference_wrapper<GlobalVector const>> const& coupled_xs_)
+    std::vector<GlobalVector*> const& coupled_xs_)
     : coupled_xs(coupled_xs_)
 {
-    for (auto const& coupled_x : coupled_xs)
+    for (auto const* coupled_x : coupled_xs)
     {
-        MathLib::LinAlg::setLocalAccessibleVector(coupled_x.get());
+        MathLib::LinAlg::setLocalAccessibleVector(*coupled_x);
     }
 }
 
@@ -63,9 +63,9 @@ std::vector<std::vector<double>> getCurrentLocalSolutions(
     local_xs_t1.reserve(number_of_coupled_solutions);
 
     int coupling_id = 0;
-    for (auto const& x_t1 : cpl_xs.coupled_xs)
+    for (auto const* x_t1 : cpl_xs.coupled_xs)
     {
-        local_xs_t1.emplace_back(x_t1.get().get(indices[coupling_id]));
+        local_xs_t1.emplace_back(x_t1->get(indices[coupling_id]));
         coupling_id++;
     }
     return local_xs_t1;

--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.h
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.h
@@ -30,11 +30,10 @@ namespace ProcessLib
 struct CoupledSolutionsForStaggeredScheme
 {
     CoupledSolutionsForStaggeredScheme(
-        std::vector<std::reference_wrapper<GlobalVector const>> const&
-            coupled_xs_);
+        std::vector<GlobalVector*> const& coupled_xs_);
 
     /// References to the current solutions of the coupled processes.
-    std::vector<std::reference_wrapper<GlobalVector const>> const& coupled_xs;
+    std::vector<GlobalVector*> const& coupled_xs;
 
     /// Pointers to the vector of the solutions of the previous time step.
     std::vector<GlobalVector*> coupled_xs_t0;

--- a/ProcessLib/PhaseField/PhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.cpp
@@ -323,7 +323,7 @@ void PhaseFieldProcess<DisplacementDim>::postNonLinearSolverConcreteProcess(
                 _process_data.pressure;
             INFO("Internal pressure: %g and Pressure error: %.4e",
                  _process_data.pressure, _process_data.pressure_error);
-            auto& u = _coupled_solutions->coupled_xs[0].get();
+            auto& u = *_coupled_solutions->coupled_xs[0];
             MathLib::LinAlg::scale(const_cast<GlobalVector&>(u),
                                    _process_data.pressure);
         }
@@ -332,7 +332,7 @@ void PhaseFieldProcess<DisplacementDim>::postNonLinearSolverConcreteProcess(
     {
         if (_process_data.propagating_crack)
         {
-            auto& u = _coupled_solutions->coupled_xs[0].get();
+            auto& u = *_coupled_solutions->coupled_xs[0];
             MathLib::LinAlg::scale(const_cast<GlobalVector&>(u),
                                    1 / _process_data.pressure);
         }

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -575,7 +575,7 @@ void postTimestepForAllProcesses(
         if (is_staggered_coupling)
         {
             CoupledSolutionsForStaggeredScheme coupled_solutions(
-                solutions_of_coupled_processes);
+                _process_solutions);
             pcs.setCoupledSolutionsForStaggeredScheme(&coupled_solutions);
         }
         auto& x = *_process_solutions[process_id];
@@ -663,7 +663,7 @@ TimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
             auto& x = *_process_solutions[process_id];
 
             CoupledSolutionsForStaggeredScheme coupled_solutions(
-                _solutions_of_coupled_processes);
+                _process_solutions);
 
             process_data->process.setCoupledSolutionsForStaggeredScheme(
                 &coupled_solutions);
@@ -788,7 +788,7 @@ void TimeLoop::outputSolutions(bool const output_initial_condition,
         if (is_staggered_coupling)
         {
             CoupledSolutionsForStaggeredScheme coupled_solutions(
-                _solutions_of_coupled_processes);
+                _process_solutions);
 
             process_data->process.setCoupledSolutionsForStaggeredScheme(
                 &coupled_solutions);

--- a/ProcessLib/TimeLoop.h
+++ b/ProcessLib/TimeLoop.h
@@ -126,13 +126,6 @@ private:
         _global_coupling_conv_crit;
 
     std::unique_ptr<ChemistryLib::ChemicalSolverInterface> _chemical_system;
-    /**
-     *  Vector of solutions of the coupled processes.
-     *  Each vector element stores the references of the solution vectors
-     *  (stored in _process_solutions) of the coupled processes of a process.
-     */
-    std::vector<std::reference_wrapper<GlobalVector const>>
-        _solutions_of_coupled_processes;
 
     /// Solutions of the previous coupling iteration for the convergence
     /// criteria of the coupling iteration.


### PR DESCRIPTION
~Follow up of #2679.~ (rebased)

Remove coupled solutions references in `TimeLoop`. The pointers are stored in the same object, `_process_solutions`, which is reused.