### PR TITLE
Flatten local coupled solutions vector.

### DIFF
--- a/ProcessLib/ComponentTransport/ComponentTransportFEM.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportFEM.h
@@ -430,7 +430,7 @@ public:
             coupled_xs.local_coupled_xs[first_transport_process_id].data(),
             concentration_size);
         auto local_C0 = Eigen::Map<const NodalVectorType>(
-            coupled_xs.local_coupled_xs0[first_transport_process_id].data(),
+            &coupled_xs.local_coupled_xs0[first_concentration_index],
             concentration_size);
 
         auto local_M = MathLib::createZeroedMatrix<LocalBlockMatrixType>(
@@ -541,8 +541,7 @@ public:
             coupled_xs.local_coupled_xs[hydraulic_process_id].data(),
             pressure_size);
         auto local_p0 = Eigen::Map<const NodalVectorType>(
-            coupled_xs.local_coupled_xs0[hydraulic_process_id].data(),
-            pressure_size);
+            &coupled_xs.local_coupled_xs0[pressure_index], pressure_size);
 
         auto local_M = MathLib::createZeroedMatrix<LocalBlockMatrixType>(
             local_M_data, concentration_size, concentration_size);

--- a/ProcessLib/ComponentTransport/ComponentTransportFEM.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportFEM.h
@@ -424,10 +424,9 @@ public:
                                    LocalCoupledSolutions const& coupled_xs)
     {
         auto local_p = Eigen::Map<const NodalVectorType>(
-            coupled_xs.local_coupled_xs[hydraulic_process_id].data(),
-            pressure_size);
+            &coupled_xs.local_coupled_xs[pressure_index], pressure_size);
         auto local_C = Eigen::Map<const NodalVectorType>(
-            coupled_xs.local_coupled_xs[first_transport_process_id].data(),
+            &coupled_xs.local_coupled_xs[first_concentration_index],
             concentration_size);
         auto local_C0 = Eigen::Map<const NodalVectorType>(
             &coupled_xs.local_coupled_xs0[first_concentration_index],
@@ -535,11 +534,12 @@ public:
         LocalCoupledSolutions const& coupled_xs, int const transport_process_id)
     {
         auto local_C = Eigen::Map<const NodalVectorType>(
-            coupled_xs.local_coupled_xs[transport_process_id].data(),
+            &coupled_xs.local_coupled_xs[first_concentration_index +
+                                         (transport_process_id - 1) *
+                                             concentration_size],
             concentration_size);
         auto local_p = Eigen::Map<const NodalVectorType>(
-            coupled_xs.local_coupled_xs[hydraulic_process_id].data(),
-            pressure_size);
+            &coupled_xs.local_coupled_xs[pressure_index], pressure_size);
         auto local_p0 = Eigen::Map<const NodalVectorType>(
             &coupled_xs.local_coupled_xs0[pressure_index], pressure_size);
 
@@ -733,9 +733,10 @@ public:
             auto const local_xs = getCurrentLocalSolutions(
                 *(this->_coupled_solutions), indices_of_all_coupled_processes);
 
-            auto const local_p = MathLib::toVector(local_xs[hydraulic_process_id]);
-            auto const local_C =
-                MathLib::toVector(local_xs[first_transport_process_id]);
+            auto const local_p = Eigen::Map<const NodalVectorType>(
+                &local_xs[pressure_index], pressure_size);
+            auto const local_C = Eigen::Map<const NodalVectorType>(
+                &local_xs[first_concentration_index], concentration_size);
 
             return calculateIntPtDarcyVelocity(t, local_p, local_C, cache);
         }

--- a/ProcessLib/ComponentTransport/ComponentTransportFEM.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportFEM.h
@@ -730,8 +730,9 @@ public:
                 indices_of_all_coupled_processes(
                     _coupled_solutions->coupled_xs.size(), indices);
 
-            auto const local_xs = getCurrentLocalSolutions(
-                *(this->_coupled_solutions), indices_of_all_coupled_processes);
+            auto const local_xs =
+                getCoupledLocalSolutions(_coupled_solutions->coupled_xs,
+                                         indices_of_all_coupled_processes);
 
             auto const local_p = Eigen::Map<const NodalVectorType>(
                 &local_xs[pressure_index], pressure_size);

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
@@ -167,8 +167,8 @@ Eigen::Vector3d ComponentTransportProcess::getFlux(std::size_t const element_id,
         std::vector<std::vector<GlobalIndexType>>
             indices_of_all_coupled_processes{
                 _coupled_solutions->coupled_xs.size(), r_c_indices.rows};
-        auto const local_xs = getCurrentLocalSolutions(
-            *(this->_coupled_solutions), indices_of_all_coupled_processes);
+        auto const local_xs = getCoupledLocalSolutions(
+            _coupled_solutions->coupled_xs, indices_of_all_coupled_processes);
 
         return _local_assemblers[element_id]->getFlux(p, t, local_xs);
 }

--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.cpp
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.cpp
@@ -17,9 +17,19 @@
 #include "MathLib/LinAlg/LinAlg.h"
 #include "Process.h"
 
-namespace
+namespace ProcessLib
 {
-std::vector<double> getLocalSolutions(
+CoupledSolutionsForStaggeredScheme::CoupledSolutionsForStaggeredScheme(
+    std::vector<GlobalVector*> const& coupled_xs_)
+    : coupled_xs(coupled_xs_)
+{
+    for (auto const* coupled_x : coupled_xs)
+    {
+        MathLib::LinAlg::setLocalAccessibleVector(*coupled_x);
+    }
+}
+
+std::vector<double> getCoupledLocalSolutions(
     std::vector<GlobalVector*> const& global_solutions,
     std::vector<std::vector<GlobalIndexType>> const& indices)
 {
@@ -49,32 +59,4 @@ std::vector<double> getLocalSolutions(
     }
     return local_solutions;
 }
-}  // namespace
-
-namespace ProcessLib
-{
-CoupledSolutionsForStaggeredScheme::CoupledSolutionsForStaggeredScheme(
-    std::vector<GlobalVector*> const& coupled_xs_)
-    : coupled_xs(coupled_xs_)
-{
-    for (auto const* coupled_x : coupled_xs)
-    {
-        MathLib::LinAlg::setLocalAccessibleVector(*coupled_x);
-    }
-}
-
-std::vector<double> getPreviousLocalSolutions(
-    const CoupledSolutionsForStaggeredScheme& cpl_xs,
-    const std::vector<std::vector<GlobalIndexType>>& indices)
-{
-    return getLocalSolutions(cpl_xs.coupled_xs_t0, indices);
-}
-
-std::vector<double> getCurrentLocalSolutions(
-    const CoupledSolutionsForStaggeredScheme& cpl_xs,
-    const std::vector<std::vector<GlobalIndexType>>& indices)
-{
-    return getLocalSolutions(cpl_xs.coupled_xs, indices);
-}
-
 }  // namespace ProcessLib

--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.h
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.h
@@ -49,7 +49,7 @@ struct CoupledSolutionsForStaggeredScheme
  */
 struct LocalCoupledSolutions
 {
-    LocalCoupledSolutions(std::vector<std::vector<double>>&& local_coupled_xs0_,
+    LocalCoupledSolutions(std::vector<double>&& local_coupled_xs0_,
                           std::vector<std::vector<double>>&& local_coupled_xs_)
         : local_coupled_xs0(std::move(local_coupled_xs0_)),
           local_coupled_xs(std::move(local_coupled_xs_))
@@ -57,7 +57,7 @@ struct LocalCoupledSolutions
     }
 
     /// Local solutions of the previous time step.
-    std::vector<std::vector<double>> const local_coupled_xs0;
+    std::vector<double> const local_coupled_xs0;
     /// Local solutions of the current time step.
     std::vector<std::vector<double>> const local_coupled_xs;
 };
@@ -69,7 +69,7 @@ struct LocalCoupledSolutions
  * @param indices Nodal indices of an element.
  * @return Nodal solutions of the previous time step of an element
  */
-std::vector<std::vector<double>> getPreviousLocalSolutions(
+std::vector<double> getPreviousLocalSolutions(
     const CoupledSolutionsForStaggeredScheme& cpl_xs,
     const std::vector<std::vector<GlobalIndexType>>& indices);
 

--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.h
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.h
@@ -50,7 +50,7 @@ struct CoupledSolutionsForStaggeredScheme
 struct LocalCoupledSolutions
 {
     LocalCoupledSolutions(std::vector<double>&& local_coupled_xs0_,
-                          std::vector<std::vector<double>>&& local_coupled_xs_)
+                          std::vector<double>&& local_coupled_xs_)
         : local_coupled_xs0(std::move(local_coupled_xs0_)),
           local_coupled_xs(std::move(local_coupled_xs_))
     {
@@ -59,7 +59,7 @@ struct LocalCoupledSolutions
     /// Local solutions of the previous time step.
     std::vector<double> const local_coupled_xs0;
     /// Local solutions of the current time step.
-    std::vector<std::vector<double>> const local_coupled_xs;
+    std::vector<double> const local_coupled_xs;
 };
 
 /**
@@ -80,7 +80,7 @@ std::vector<double> getPreviousLocalSolutions(
  * @param indices Nodal indices of an element.
  * @return Nodal solutions of the current time step of an element
  */
-std::vector<std::vector<double>> getCurrentLocalSolutions(
+std::vector<double> getCurrentLocalSolutions(
     const CoupledSolutionsForStaggeredScheme& cpl_xs,
     const std::vector<std::vector<GlobalIndexType>>& indices);
 }  // namespace ProcessLib

--- a/ProcessLib/CoupledSolutionsForStaggeredScheme.h
+++ b/ProcessLib/CoupledSolutionsForStaggeredScheme.h
@@ -63,24 +63,11 @@ struct LocalCoupledSolutions
 };
 
 /**
- * Fetch the nodal solutions of all coupled processes of the previous time step
- * of an element.
- * @param cpl_xs  Solutions of all coupled equations.
- * @param indices Nodal indices of an element.
- * @return Nodal solutions of the previous time step of an element
+ * Fetch the nodal solutions of all coupled processes from the given vector of
+ * global solutions for each process into a flat vector.
  */
-std::vector<double> getPreviousLocalSolutions(
-    const CoupledSolutionsForStaggeredScheme& cpl_xs,
-    const std::vector<std::vector<GlobalIndexType>>& indices);
+std::vector<double> getCoupledLocalSolutions(
+    std::vector<GlobalVector*> const& global_solutions,
+    std::vector<std::vector<GlobalIndexType>> const& indices);
 
-/**
- * Fetch the nodal solutions of all coupled processes of the current time step
- * of an element.
- * @param cpl_xs  Solutions of all coupled equations.
- * @param indices Nodal indices of an element.
- * @return Nodal solutions of the current time step of an element
- */
-std::vector<double> getCurrentLocalSolutions(
-    const CoupledSolutionsForStaggeredScheme& cpl_xs,
-    const std::vector<std::vector<GlobalIndexType>>& indices);
 }  // namespace ProcessLib

--- a/ProcessLib/HT/HTFEM.h
+++ b/ProcessLib/HT/HTFEM.h
@@ -251,9 +251,16 @@ protected:
     }
 
     std::vector<double> const& getIntPtDarcyVelocityLocal(
-        const double t, std::vector<double> const& local_p,
-        std::vector<double> const& local_T, std::vector<double>& cache) const
+        const double t, std::vector<double> const& local_x,
+        std::vector<double>& cache) const
     {
+        std::vector<double> local_p{
+            local_x.data() + pressure_index,
+            local_x.data() + pressure_index + pressure_size};
+        std::vector<double> local_T{
+            local_x.data() + temperature_index,
+            local_x.data() + temperature_index + temperature_size};
+
         auto const n_integration_points =
             _integration_method.getNumberOfPoints();
 

--- a/ProcessLib/HT/MonolithicHTFEM.h
+++ b/ProcessLib/HT/MonolithicHTFEM.h
@@ -211,15 +211,9 @@ public:
         auto const indices =
             NumLib::getIndices(this->_element.getID(), dof_table);
         assert(!indices.empty());
-        auto local_x = current_solution.get(indices);
+        auto const& local_x = current_solution.get(indices);
 
-        std::vector<double> local_p(
-            std::make_move_iterator(local_x.begin() + local_x.size() / 2),
-            std::make_move_iterator(local_x.end()));
-        // only T is kept in local_x
-        local_x.erase(local_x.begin() + local_x.size() / 2, local_x.end());
-
-        return this->getIntPtDarcyVelocityLocal(t, local_p, local_x, cache);
+        return this->getIntPtDarcyVelocityLocal(t, local_x, cache);
     }
 
 private:

--- a/ProcessLib/HT/StaggeredHTFEM-impl.h
+++ b/ProcessLib/HT/StaggeredHTFEM-impl.h
@@ -59,8 +59,10 @@ void StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
 
     auto const& local_T1 =
         coupled_xs.local_coupled_xs[_heat_transport_process_id];
-    auto const& local_T0 =
-        coupled_xs.local_coupled_xs0[_heat_transport_process_id];
+    auto const local_T0 =
+        Eigen::Map<typename ShapeMatricesType::template VectorType<
+            temperature_size> const>(
+            &coupled_xs.local_coupled_xs0[temperature_index], temperature_size);
 
     auto local_M = MathLib::createZeroedMatrix<LocalMatrixType>(
         local_M_data, local_matrix_size, local_matrix_size);

--- a/ProcessLib/HT/StaggeredHTFEM-impl.h
+++ b/ProcessLib/HT/StaggeredHTFEM-impl.h
@@ -302,8 +302,8 @@ StaggeredHTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::
     assert(!indices.empty());
     std::vector<std::vector<GlobalIndexType>> indices_of_all_coupled_processes =
         {indices, indices};
-    auto const& local_xs = getCurrentLocalSolutions(
-        *(this->_coupled_solutions), indices_of_all_coupled_processes);
+    auto const local_xs = getCoupledLocalSolutions(
+        this->_coupled_solutions->coupled_xs, indices_of_all_coupled_processes);
 
     return this->getIntPtDarcyVelocityLocal(t, local_xs, cache);
 }

--- a/ProcessLib/HT/StaggeredHTFEM.h
+++ b/ProcessLib/HT/StaggeredHTFEM.h
@@ -50,6 +50,11 @@ class StaggeredHTFEM : public HTFEM<ShapeFunction, IntegrationMethod, GlobalDim>
         typename ShapeMatricesType::GlobalDimNodalMatrixType;
     using GlobalDimMatrixType = typename ShapeMatricesType::GlobalDimMatrixType;
 
+    using HTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::pressure_index;
+    using HTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::pressure_size;
+    using HTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::temperature_index;
+    using HTFEM<ShapeFunction, IntegrationMethod, GlobalDim>::temperature_size;
+
 public:
     StaggeredHTFEM(MeshLib::Element const& element,
                    std::size_t const local_matrix_size,

--- a/ProcessLib/PhaseField/PhaseFieldFEM-impl.h
+++ b/ProcessLib/PhaseField/PhaseFieldFEM-impl.h
@@ -55,31 +55,25 @@ void PhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions)
 {
-    using DeformationVector =
-        typename ShapeMatricesType::template VectorType<displacement_size>;
     using DeformationMatrix =
         typename ShapeMatricesType::template MatrixType<displacement_size,
                                                         displacement_size>;
-    using PhaseFieldVector =
-        typename ShapeMatricesType::template VectorType<phasefield_size>;
 
-    auto const& local_u = local_coupled_solutions.local_coupled_xs[0];
-    auto const& local_d = local_coupled_solutions.local_coupled_xs[1];
-    assert(local_u.size() == displacement_size);
-    assert(local_d.size() == phasefield_size);
+    assert(local_coupled_solutions.local_coupled_xs.size() ==
+           phasefield_size + displacement_size);
 
-    auto const local_matrix_size = local_u.size();
-    auto d =
-        Eigen::Map<PhaseFieldVector const>(local_d.data(), phasefield_size);
-
-    auto u =
-        Eigen::Map<DeformationVector const>(local_u.data(), displacement_size);
+    auto const d = Eigen::Map<PhaseFieldVector const>(
+        &local_coupled_solutions.local_coupled_xs[phasefield_index],
+        phasefield_size);
+    auto const u = Eigen::Map<DeformationVector const>(
+        &local_coupled_solutions.local_coupled_xs[displacement_index],
+        displacement_size);
 
     auto local_Jac = MathLib::createZeroedMatrix<DeformationMatrix>(
-        local_Jac_data, local_matrix_size, local_matrix_size);
+        local_Jac_data, displacement_size, displacement_size);
 
     auto local_rhs = MathLib::createZeroedVector<DeformationVector>(
-        local_b_data, local_matrix_size);
+        local_b_data, displacement_size);
 
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());
@@ -158,29 +152,17 @@ void PhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions)
 {
-    using DeformationVector =
-        typename ShapeMatricesType::template VectorType<displacement_size>;
-    using PhaseFieldVector =
-        typename ShapeMatricesType::template VectorType<phasefield_size>;
-    using PhaseFieldMatrix =
-        typename ShapeMatricesType::template MatrixType<phasefield_size,
-                                                        phasefield_size>;
-
-    auto const& local_u = local_coupled_solutions.local_coupled_xs[0];
-    auto const& local_d = local_coupled_solutions.local_coupled_xs[1];
-    assert(local_u.size() == displacement_size);
-    assert(local_d.size() == phasefield_size);
-
-    auto const local_matrix_size = local_d.size();
-    auto d =
-        Eigen::Map<PhaseFieldVector const>(local_d.data(), phasefield_size);
-    auto u =
-        Eigen::Map<DeformationVector const>(local_u.data(), displacement_size);
+    auto const d = Eigen::Map<PhaseFieldVector const>(
+        &local_coupled_solutions.local_coupled_xs[phasefield_index],
+        phasefield_size);
+    auto const u = Eigen::Map<DeformationVector const>(
+        &local_coupled_solutions.local_coupled_xs[displacement_index],
+        displacement_size);
 
     auto local_Jac = MathLib::createZeroedMatrix<PhaseFieldMatrix>(
-        local_Jac_data, local_matrix_size, local_matrix_size);
+        local_Jac_data, phasefield_size, phasefield_size);
     auto local_rhs = MathLib::createZeroedVector<PhaseFieldVector>(
-        local_b_data, local_matrix_size);
+        local_b_data, phasefield_size);
 
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());
@@ -281,20 +263,12 @@ void PhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
 
     auto local_coupled_xs =
         getCurrentLocalSolutions(*cpl_xs, indices_of_processes);
-    assert(local_coupled_xs.size() == 2);
+    assert(local_coupled_xs.size() == displacement_size + phasefield_size);
 
-    auto const& local_u = local_coupled_xs[0];
-    auto const& local_d = local_coupled_xs[1];
-
-    assert(local_u.size() == displacement_size);
-    assert(local_d.size() == phasefield_size);
-
-    auto d = Eigen::Map<
-        typename ShapeMatricesType::template VectorType<phasefield_size> const>(
-        local_d.data(), phasefield_size);
-
-    auto u = Eigen::Map<typename ShapeMatricesType::template VectorType<
-        displacement_size> const>(local_u.data(), displacement_size);
+    auto const d = Eigen::Map<PhaseFieldVector const>(
+        &local_coupled_xs[phasefield_index], phasefield_size);
+    auto const u = Eigen::Map<DeformationVector const>(
+        &local_coupled_xs[displacement_index], displacement_size);
 
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());
@@ -346,22 +320,14 @@ void PhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
                        return NumLib::getIndices(mesh_item_id, dof_table);
                    });
 
-    auto local_coupled_xs =
+    auto const local_coupled_xs =
         getCurrentLocalSolutions(*cpl_xs, indices_of_processes);
-    assert(local_coupled_xs.size() == 2);
+    assert(local_coupled_xs.size() == displacement_size + phasefield_size);
 
-    auto const& local_u = local_coupled_xs[0];
-    auto const& local_d = local_coupled_xs[1];
-
-    assert(local_u.size() == displacement_size);
-    assert(local_d.size() == phasefield_size);
-
-    auto d = Eigen::Map<
-        typename ShapeMatricesType::template VectorType<phasefield_size> const>(
-        local_d.data(), phasefield_size);
-
-    auto u = Eigen::Map<typename ShapeMatricesType::template VectorType<
-        displacement_size> const>(local_u.data(), displacement_size);
+    auto const d = Eigen::Map<PhaseFieldVector const>(
+        &local_coupled_xs[phasefield_index], phasefield_size);
+    auto const u = Eigen::Map<DeformationVector const>(
+        &local_coupled_xs[displacement_index], displacement_size);
 
     ParameterLib::SpatialPosition x_position;
     x_position.setElementID(_element.getID());

--- a/ProcessLib/PhaseField/PhaseFieldFEM-impl.h
+++ b/ProcessLib/PhaseField/PhaseFieldFEM-impl.h
@@ -262,7 +262,7 @@ void PhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
                    });
 
     auto local_coupled_xs =
-        getCurrentLocalSolutions(*cpl_xs, indices_of_processes);
+        getCoupledLocalSolutions(cpl_xs->coupled_xs, indices_of_processes);
     assert(local_coupled_xs.size() == displacement_size + phasefield_size);
 
     auto const d = Eigen::Map<PhaseFieldVector const>(
@@ -321,7 +321,7 @@ void PhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
                    });
 
     auto const local_coupled_xs =
-        getCurrentLocalSolutions(*cpl_xs, indices_of_processes);
+        getCoupledLocalSolutions(cpl_xs->coupled_xs, indices_of_processes);
     assert(local_coupled_xs.size() == displacement_size + phasefield_size);
 
     auto const d = Eigen::Map<PhaseFieldVector const>(

--- a/ProcessLib/PhaseField/PhaseFieldFEM.h
+++ b/ProcessLib/PhaseField/PhaseFieldFEM.h
@@ -107,6 +107,14 @@ template <typename ShapeFunction, typename IntegrationMethod,
           int DisplacementDim>
 class PhaseFieldLocalAssembler : public PhaseFieldLocalAssemblerInterface
 {
+private:
+    static constexpr int displacement_index = 0;
+    static constexpr int displacement_size =
+        ShapeFunction::NPOINTS * DisplacementDim;
+    static constexpr int phasefield_index =
+        displacement_index + displacement_size;
+    static constexpr int phasefield_size = ShapeFunction::NPOINTS;
+
 public:
     using ShapeMatricesType =
         ShapeMatrixPolicyType<ShapeFunction, DisplacementDim>;
@@ -116,6 +124,14 @@ public:
     using BMatricesType = BMatrixPolicyType<ShapeFunction, DisplacementDim>;
 
     using NodalForceVectorType = typename BMatricesType::NodalForceVectorType;
+
+    using DeformationVector =
+        typename ShapeMatricesType::template VectorType<displacement_size>;
+    using PhaseFieldVector =
+        typename ShapeMatricesType::template VectorType<phasefield_size>;
+    using PhaseFieldMatrix =
+        typename ShapeMatricesType::template MatrixType<phasefield_size,
+                                                        phasefield_size>;
 
     PhaseFieldLocalAssembler(PhaseFieldLocalAssembler const&) = delete;
     PhaseFieldLocalAssembler(PhaseFieldLocalAssembler&&) = delete;
@@ -337,12 +353,6 @@ private:
     MeshLib::Element const& _element;
     SecondaryData<typename ShapeMatrices::ShapeType> _secondary_data;
     bool const _is_axially_symmetric;
-
-    static const int phasefield_index = 0;
-    static const int phasefield_size = ShapeFunction::NPOINTS;
-    static const int displacement_index = ShapeFunction::NPOINTS;
-    static const int displacement_size =
-        ShapeFunction::NPOINTS * DisplacementDim;
 };
 
 }  // namespace PhaseField

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM-impl.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM-impl.h
@@ -64,25 +64,18 @@ void ThermoMechanicalPhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions)
 {
-    auto const& local_d =
-        local_coupled_solutions.local_coupled_xs[_phase_field_process_id];
-    auto const& local_u =
-        local_coupled_solutions.local_coupled_xs[_mechanics_related_process_id];
-    auto const& local_T =
-        local_coupled_solutions.local_coupled_xs[_heat_conduction_process_id];
-    assert(local_T.size() == temperature_size);
-    assert(local_d.size() == phasefield_size);
-    assert(local_u.size() == displacement_size);
+    assert(local_coupled_solutions.local_coupled_xs.size() ==
+           phasefield_size + displacement_size + temperature_size);
 
-    auto d = Eigen::Map<
-        typename ShapeMatricesType::template VectorType<phasefield_size> const>(
-        local_d.data(), phasefield_size);
-
-    auto u = Eigen::Map<typename ShapeMatricesType::template VectorType<
-        displacement_size> const>(local_u.data(), displacement_size);
-
-    auto T = Eigen::Map<typename ShapeMatricesType::template VectorType<
-        temperature_size> const>(local_T.data(), temperature_size);
+    auto const d = Eigen::Map<PhaseFieldVector const>(
+        &local_coupled_solutions.local_coupled_xs[phasefield_index],
+        phasefield_size);
+    auto const u = Eigen::Map<DeformationVector const>(
+        &local_coupled_solutions.local_coupled_xs[displacement_index],
+        displacement_size);
+    auto const T = Eigen::Map<TemperatureVector const>(
+        &local_coupled_solutions.local_coupled_xs[temperature_index],
+        temperature_size);
 
     auto local_Jac = MathLib::createZeroedMatrix<
         typename ShapeMatricesType::template MatrixType<displacement_size,
@@ -172,19 +165,15 @@ void ThermoMechanicalPhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions)
 {
-    auto const& local_d =
-        local_coupled_solutions.local_coupled_xs[_phase_field_process_id];
-    auto const& local_T =
-        local_coupled_solutions.local_coupled_xs[_heat_conduction_process_id];
-    assert(local_T.size() == temperature_size);
-    assert(local_d.size() == phasefield_size);
+    assert(local_coupled_solutions.local_coupled_xs.size() ==
+           phasefield_size + displacement_size + temperature_size);
 
-    auto d = Eigen::Map<
-        typename ShapeMatricesType::template VectorType<phasefield_size> const>(
-        local_d.data(), phasefield_size);
-
-    auto T = Eigen::Map<typename ShapeMatricesType::template VectorType<
-        temperature_size> const>(local_T.data(), temperature_size);
+    auto const d = Eigen::Map<PhaseFieldVector const>(
+        &local_coupled_solutions.local_coupled_xs[phasefield_index],
+        phasefield_size);
+    auto const T = Eigen::Map<TemperatureVector const>(
+        &local_coupled_solutions.local_coupled_xs[temperature_index],
+        temperature_size);
 
     auto T_dot = Eigen::Map<typename ShapeMatricesType::template VectorType<
         temperature_size> const>(local_xdot.data(), temperature_size);
@@ -276,13 +265,12 @@ void ThermoMechanicalPhaseFieldLocalAssembler<ShapeFunction, IntegrationMethod,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         LocalCoupledSolutions const& local_coupled_solutions)
 {
-    auto const& local_d =
-        local_coupled_solutions.local_coupled_xs[_phase_field_process_id];
-    assert(local_d.size() == phasefield_size);
+    assert(local_coupled_solutions.local_coupled_xs.size() ==
+           phasefield_size + displacement_size + temperature_size);
 
-    auto d = Eigen::Map<
-        typename ShapeMatricesType::template VectorType<phasefield_size> const>(
-        local_d.data(), phasefield_size);
+    auto const d = Eigen::Map<PhaseFieldVector const>(
+        &local_coupled_solutions.local_coupled_xs[phasefield_index],
+        phasefield_size);
 
     auto local_Jac = MathLib::createZeroedMatrix<
         typename ShapeMatricesType::template MatrixType<phasefield_size,

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
@@ -111,6 +111,17 @@ template <typename ShapeFunction, typename IntegrationMethod,
 class ThermoMechanicalPhaseFieldLocalAssembler
     : public ThermoMechanicalPhaseFieldLocalAssemblerInterface
 {
+private:
+    static constexpr int temperature_index = 0;
+    static constexpr int temperature_size = ShapeFunction::NPOINTS;
+    static constexpr int displacement_index =
+        temperature_index + temperature_size;
+    static constexpr int displacement_size =
+        ShapeFunction::NPOINTS * DisplacementDim;
+    static constexpr int phasefield_index =
+        displacement_index + displacement_size;
+    static constexpr int phasefield_size = ShapeFunction::NPOINTS;
+
 public:
     using ShapeMatricesType =
         ShapeMatrixPolicyType<ShapeFunction, DisplacementDim>;
@@ -122,6 +133,13 @@ public:
     using NodalForceVectorType = typename BMatricesType::NodalForceVectorType;
 
     using GlobalDimVectorType = typename ShapeMatricesType::GlobalDimVectorType;
+
+    using TemperatureVector =
+        typename ShapeMatricesType::template VectorType<temperature_size>;
+    using DeformationVector =
+        typename ShapeMatricesType::template VectorType<displacement_size>;
+    using PhaseFieldVector =
+        typename ShapeMatricesType::template VectorType<phasefield_size>;
 
     ThermoMechanicalPhaseFieldLocalAssembler(
         ThermoMechanicalPhaseFieldLocalAssembler const&) = delete;
@@ -370,14 +388,6 @@ private:
     MeshLib::Element const& _element;
     SecondaryData<typename ShapeMatrices::ShapeType> _secondary_data;
     bool const _is_axially_symmetric;
-
-    static const int temperature_index = 0;
-    static const int temperature_size = ShapeFunction::NPOINTS;
-    static const int phasefield_index = ShapeFunction::NPOINTS;
-    static const int phasefield_size = ShapeFunction::NPOINTS;
-    static const int displacement_index = 2 * ShapeFunction::NPOINTS;
-    static const int displacement_size =
-        ShapeFunction::NPOINTS * DisplacementDim;
 
     /// ID of the processes that contains mechanical process.
     int const _mechanics_related_process_id;

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
@@ -338,13 +338,11 @@ void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         const LocalCoupledSolutions& local_coupled_solutions)
 {
-    auto const& local_T_vector =
-        local_coupled_solutions
-            .local_coupled_xs[_process_data.heat_conduction_process_id];
-    assert(local_T_vector.size() == temperature_size);
     auto const local_T =
         Eigen::Map<typename ShapeMatricesType::template VectorType<
-            temperature_size> const>(local_T_vector.data(), temperature_size);
+            temperature_size> const>(
+            &local_coupled_solutions.local_coupled_xs[temperature_index],
+            temperature_size);
 
     auto const local_T0 =
         Eigen::Map<typename ShapeMatricesType::template VectorType<
@@ -352,12 +350,10 @@ void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
             &local_coupled_solutions.local_coupled_xs0[temperature_index],
             temperature_size);
 
-    auto const& local_u_vector =
-        local_coupled_solutions
-            .local_coupled_xs[_process_data.mechanics_process_id];
-    assert(local_u_vector.size() == displacement_size);
     auto const u = Eigen::Map<typename ShapeMatricesType::template VectorType<
-        displacement_size> const>(local_u_vector.data(), displacement_size);
+        displacement_size> const>(
+        &local_coupled_solutions.local_coupled_xs[displacement_index],
+        displacement_size);
 
     auto local_Jac = MathLib::createZeroedMatrix<
         typename ShapeMatricesType::template MatrixType<displacement_size,
@@ -476,19 +472,18 @@ void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
         std::vector<double>& local_b_data, std::vector<double>& local_Jac_data,
         const LocalCoupledSolutions& local_coupled_solutions)
 {
-    auto const& local_T_vector =
-        local_coupled_solutions
-            .local_coupled_xs[_process_data.heat_conduction_process_id];
-    assert(local_T_vector.size() == temperature_size);
     auto const local_T =
         Eigen::Map<typename ShapeMatricesType::template VectorType<
-            temperature_size> const>(local_T_vector.data(), temperature_size);
+            temperature_size> const>(
+            &local_coupled_solutions.local_coupled_xs[temperature_index],
+            temperature_size);
 
     auto const local_T0 =
         Eigen::Map<typename ShapeMatricesType::template VectorType<
             temperature_size> const>(
             &local_coupled_solutions.local_coupled_xs0[temperature_index],
             temperature_size);
+
     auto const local_dT = local_T - local_T0;
 
     auto local_Jac = MathLib::createZeroedMatrix<

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
@@ -346,11 +346,11 @@ void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
         Eigen::Map<typename ShapeMatricesType::template VectorType<
             temperature_size> const>(local_T_vector.data(), temperature_size);
 
-    auto const& local_T0_vector = local_coupled_solutions.local_coupled_xs0[0];
-    assert(local_T0_vector.size() == temperature_size);
     auto const local_T0 =
         Eigen::Map<typename ShapeMatricesType::template VectorType<
-            temperature_size> const>(local_T0_vector.data(), temperature_size);
+            temperature_size> const>(
+            &local_coupled_solutions.local_coupled_xs0[temperature_index],
+            temperature_size);
 
     auto const& local_u_vector =
         local_coupled_solutions
@@ -484,12 +484,12 @@ void ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
         Eigen::Map<typename ShapeMatricesType::template VectorType<
             temperature_size> const>(local_T_vector.data(), temperature_size);
 
-    auto const& local_T0_vector = local_coupled_solutions.local_coupled_xs0[0];
-    assert(local_T0_vector.size() == temperature_size);
-    auto const local_dT =
-        local_T -
+    auto const local_T0 =
         Eigen::Map<typename ShapeMatricesType::template VectorType<
-            temperature_size> const>(local_T0_vector.data(), temperature_size);
+            temperature_size> const>(
+            &local_coupled_solutions.local_coupled_xs0[temperature_index],
+            temperature_size);
+    auto const local_dT = local_T - local_T0;
 
     auto local_Jac = MathLib::createZeroedMatrix<
         typename ShapeMatricesType::template MatrixType<temperature_size,

--- a/ProcessLib/VectorMatrixAssembler.cpp
+++ b/ProcessLib/VectorMatrixAssembler.cpp
@@ -68,10 +68,10 @@ void VectorMatrixAssembler::assemble(
     }
     else
     {
-        auto local_coupled_xs0 =
-            getPreviousLocalSolutions(*cpl_xs, indices_of_processes);
+        auto local_coupled_xs0 = getCoupledLocalSolutions(cpl_xs->coupled_xs_t0,
+                                                          indices_of_processes);
         auto local_coupled_xs =
-            getCurrentLocalSolutions(*cpl_xs, indices_of_processes);
+            getCoupledLocalSolutions(cpl_xs->coupled_xs, indices_of_processes);
 
         ProcessLib::LocalCoupledSolutions local_coupled_solutions(
             std::move(local_coupled_xs0), std::move(local_coupled_xs));
@@ -136,10 +136,10 @@ void VectorMatrixAssembler::assembleWithJacobian(
     }
     else
     {
-        auto local_coupled_xs0 =
-            getPreviousLocalSolutions(*cpl_xs, indices_of_processes);
+        auto local_coupled_xs0 = getCoupledLocalSolutions(cpl_xs->coupled_xs_t0,
+                                                          indices_of_processes);
         auto local_coupled_xs =
-            getCurrentLocalSolutions(*cpl_xs, indices_of_processes);
+            getCoupledLocalSolutions(cpl_xs->coupled_xs, indices_of_processes);
 
         ProcessLib::LocalCoupledSolutions local_coupled_solutions(
             std::move(local_coupled_xs0), std::move(local_coupled_xs));


### PR DESCRIPTION
Yet another staggered coupling refactoring.

Instead of passing a vector of a vector with data, pass a flat vector of (local) solutions ordered the same as the processes.

Review commit-wise.