### PR TITLE
[conan] Set qt version 5.12.5@bincrafters/stable.

### DIFF
--- a/scripts/cmake/ConanSetup.cmake
+++ b/scripts/cmake/ConanSetup.cmake
@@ -69,7 +69,7 @@ if(OGS_BUILD_GUI)
     set(CONAN_REQUIRES ${CONAN_REQUIRES}
         shapelib/1.3.0@bilke/stable
         libgeotiff/1.4.2@bilke/stable
-        qt/5.12.4@bincrafters/stable
+        qt/5.12.5@bincrafters/stable
         # Overwrite VTK requirement to match Qt requirement
         bzip2/1.0.8@conan/stable
     )


### PR DESCRIPTION
This should fix an error by conan:

ERROR: E:\Conan\.conan\data\glib\2.58.3\bincrafters\stable\export\conanfile.py: Error while initializing requirements. Wrong package recipe reference zlib/1.2.11
Write something like OpenCV/1.0.6@user/stable