### PR TITLE
Pass xs to assemblers

### DIFF
--- a/NumLib/ODESolver/NonlinearSolver.h
+++ b/NumLib/ODESolver/NonlinearSolver.h
@@ -46,7 +46,7 @@ public:
      *                      assembled.
      * \param process_id    the process' id which will be assembled.
      */
-    virtual void assemble(GlobalVector const& x,
+    virtual void assemble(std::vector<GlobalVector*> const& x,
                           int const process_id) const = 0;
 
     /*! Assemble and solve the equation system.
@@ -59,7 +59,7 @@ public:
      * \retval false otherwise
      */
     virtual NonlinearSolverStatus solve(
-        GlobalVector& x,
+        std::vector<GlobalVector*>& x,
         std::function<void(int, GlobalVector const&)> const&
             postIterationCallback,
         int const process_id) = 0;
@@ -110,10 +110,11 @@ public:
         _convergence_criterion = &conv_crit;
     }
 
-    void assemble(GlobalVector const& x, int const process_id) const override;
+    void assemble(std::vector<GlobalVector*> const& x,
+                  int const process_id) const override;
 
     NonlinearSolverStatus solve(
-        GlobalVector& x,
+        std::vector<GlobalVector*>& x,
         std::function<void(int, GlobalVector const&)> const&
             postIterationCallback,
         int const process_id) override;
@@ -171,10 +172,11 @@ public:
         _convergence_criterion = &conv_crit;
     }
 
-    void assemble(GlobalVector const& x, int const process_id) const override;
+    void assemble(std::vector<GlobalVector*> const& x,
+                  int const process_id) const override;
 
     NonlinearSolverStatus solve(
-        GlobalVector& x,
+        std::vector<GlobalVector*>& x,
         std::function<void(int, GlobalVector const&)> const&
             postIterationCallback,
         int const process_id) override;

--- a/NumLib/ODESolver/NonlinearSystem.h
+++ b/NumLib/ODESolver/NonlinearSystem.h
@@ -37,7 +37,8 @@ public:
     //! Assembles the linearized equation system at the point \c x.
     //! The linearized system is \f$A(x) \cdot x = b(x)\f$. Here the matrix
     //! \f$A(x)\f$ and the vector \f$b(x)\f$ are assembled.
-    virtual void assemble(GlobalVector const& x, int const process_id) = 0;
+    virtual void assemble(std::vector<GlobalVector*> const& x,
+                          int const process_id) = 0;
 
     /*! Writes the residual at point \c x to \c res.
      *
@@ -83,7 +84,8 @@ public:
     //! Assembles the linearized equation system at the point \c x.
     //! The linearized system is \f$J(x) \cdot \Delta x = (x)\f$. Here the
     //! residual vector \f$r(x)\f$ and its Jacobian \f$J(x)\f$ are assembled.
-    virtual void assemble(GlobalVector const& x, int const process_id) = 0;
+    virtual void assemble(std::vector<GlobalVector*> const& x,
+                          int const process_id) = 0;
 
     //! Writes the linearized equation system matrix to \c A.
     //! \pre assemble() must have been called before.

--- a/NumLib/ODESolver/ODESystem.h
+++ b/NumLib/ODESolver/ODESystem.h
@@ -128,7 +128,7 @@ public:
      * \endparblock
      */
     virtual void assembleWithJacobian(const double t, double const dt,
-                                      GlobalVector const& x,
+                                      std::vector<GlobalVector*> const& x,
                                       GlobalVector const& xdot,
                                       const double dxdot_dx, const double dx_dx,
                                       int const process_id, GlobalMatrix& M,

--- a/NumLib/ODESolver/ODESystem.h
+++ b/NumLib/ODESolver/ODESystem.h
@@ -51,9 +51,9 @@ public:
 
     //! Assemble \c M, \c K and \c b at the provided state (\c t, \c x).
     virtual void assemble(const double t, double const dt,
-                          GlobalVector const& x, int const process_id,
-                          GlobalMatrix& M, GlobalMatrix& K,
-                          GlobalVector& b) = 0;
+                          std::vector<GlobalVector*> const& x,
+                          int const process_id, GlobalMatrix& M,
+                          GlobalMatrix& K, GlobalVector& b) = 0;
 
     using Index = MathLib::MatrixVectorTraits<GlobalMatrix>::Index;
 

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
@@ -204,7 +204,7 @@ void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
     _b->setZero();
 
     _ode.preAssemble(t, dt, x_curr);
-    _ode.assemble(t, dt, x_curr, process_id, *_M, *_K, *_b);
+    _ode.assemble(t, dt, x_new_timestep, process_id, *_M, *_K, *_b);
 
     LinAlg::finalizeAssembly(*_M);
     LinAlg::finalizeAssembly(*_K);

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
@@ -91,8 +91,8 @@ void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
     _Jac->setZero();
 
     _ode.preAssemble(t, dt, x_curr);
-    _ode.assembleWithJacobian(t, dt, x_curr, xdot, dxdot_dx, dx_dx, process_id,
-                              *_M, *_K, *_b, *_Jac);
+    _ode.assembleWithJacobian(t, dt, x_new_timestep, xdot, dxdot_dx, dx_dx,
+                              process_id, *_M, *_K, *_b, *_Jac);
 
     LinAlg::finalizeAssembly(*_M);
     LinAlg::finalizeAssembly(*_K);

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
@@ -69,21 +69,21 @@ TimeDiscretizedODESystem<
     NumLib::GlobalVectorProvider::provider.releaseVector(*_b);
 }
 
-void TimeDiscretizedODESystem<
-    ODESystemTag::FirstOrderImplicitQuasilinear,
-    NonlinearSolverTag::Newton>::assemble(const GlobalVector& x_new_timestep,
-                                          int const process_id)
+void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
+                              NonlinearSolverTag::Newton>::
+    assemble(std::vector<GlobalVector*> const& x_new_timestep,
+             int const process_id)
 {
     namespace LinAlg = MathLib::LinAlg;
 
     auto const t = _time_disc.getCurrentTime();
     auto const dt = _time_disc.getCurrentTimeIncrement();
-    auto const& x_curr = _time_disc.getCurrentX(x_new_timestep);
+    auto const& x_curr = _time_disc.getCurrentX(*x_new_timestep[process_id]);
     auto const dxdot_dx = _time_disc.getNewXWeight();
     auto const dx_dx = _time_disc.getDxDx();
 
     auto& xdot = NumLib::GlobalVectorProvider::provider.getVector(_xdot_id);
-    _time_disc.getXdot(x_new_timestep, xdot);
+    _time_disc.getXdot(*x_new_timestep[process_id], xdot);
 
     _M->setZero();
     _K->setZero();
@@ -188,16 +188,16 @@ TimeDiscretizedODESystem<
     NumLib::GlobalVectorProvider::provider.releaseVector(*_b);
 }
 
-void TimeDiscretizedODESystem<
-    ODESystemTag::FirstOrderImplicitQuasilinear,
-    NonlinearSolverTag::Picard>::assemble(const GlobalVector& x_new_timestep,
-                                          int const process_id)
+void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
+                              NonlinearSolverTag::Picard>::
+    assemble(std::vector<GlobalVector*> const& x_new_timestep,
+             int const process_id)
 {
     namespace LinAlg = MathLib::LinAlg;
 
     auto const t = _time_disc.getCurrentTime();
     auto const dt = _time_disc.getCurrentTimeIncrement();
-    auto const& x_curr = _time_disc.getCurrentX(x_new_timestep);
+    auto const& x_curr = _time_disc.getCurrentX(*x_new_timestep[process_id]);
 
     _M->setZero();
     _K->setZero();

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.h
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.h
@@ -83,7 +83,7 @@ public:
 
     ~TimeDiscretizedODESystem() override;
 
-    void assemble(const GlobalVector& x_new_timestep,
+    void assemble(std::vector<GlobalVector*> const& x_new_timestep,
                   int const process_id) override;
 
     void getResidual(GlobalVector const& x_new_timestep,
@@ -181,7 +181,7 @@ public:
 
     ~TimeDiscretizedODESystem() override;
 
-    void assemble(const GlobalVector& x_new_timestep,
+    void assemble(std::vector<GlobalVector*> const& x_new_timestep,
                   int const process_id) override;
 
     void getA(GlobalMatrix& A) const override

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
@@ -131,7 +131,7 @@ void ComponentTransportProcess::setCoupledSolutionsOfPreviousTimeStep()
 }
 
 void ComponentTransportProcess::assembleWithJacobianConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac)

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
@@ -90,7 +90,7 @@ void ComponentTransportProcess::initializeConcreteProcess(
 }
 
 void ComponentTransportProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble ComponentTransportProcess.");

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.h
@@ -148,7 +148,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.h
@@ -143,9 +143,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -74,7 +74,7 @@ void GroundwaterFlowProcess::assembleConcreteProcess(
 }
 
 void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac)

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -58,7 +58,7 @@ void GroundwaterFlowProcess::initializeConcreteProcess(
 }
 
 void GroundwaterFlowProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble GroundwaterFlowProcess.");

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -92,9 +92,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -97,7 +97,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -87,7 +87,7 @@ void HTProcess::initializeConcreteProcess(
 }
 
 void HTProcess::assembleConcreteProcess(const double t, double const dt,
-                                        GlobalVector const& x,
+                                        std::vector<GlobalVector*> const& x,
                                         int const process_id, GlobalMatrix& M,
                                         GlobalMatrix& K, GlobalVector& b)
 {

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -126,7 +126,7 @@ void HTProcess::assembleConcreteProcess(const double t, double const dt,
 }
 
 void HTProcess::assembleWithJacobianConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac)

--- a/ProcessLib/HT/HTProcess.h
+++ b/ProcessLib/HT/HTProcess.h
@@ -93,9 +93,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/HT/HTProcess.h
+++ b/ProcessLib/HT/HTProcess.h
@@ -98,7 +98,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -73,7 +73,7 @@ void HeatConductionProcess::initializeConcreteProcess(
 }
 
 void HeatConductionProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble HeatConductionProcess.");

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -90,7 +90,7 @@ void HeatConductionProcess::assembleConcreteProcess(
 }
 
 void HeatConductionProcess::assembleWithJacobianConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac)

--- a/ProcessLib/HeatConduction/HeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.h
@@ -51,9 +51,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const /*dt*/,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const /*dt*/,

--- a/ProcessLib/HeatConduction/HeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.h
@@ -56,9 +56,10 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const /*dt*/, GlobalVector const& x,
-        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        const double t, double const /*dt*/,
+        std::vector<GlobalVector*> const& x, GlobalVector const& xdot,
+        const double dxdot_dx, const double dx_dx, int const process_id,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     HeatConductionProcessData _process_data;

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
@@ -159,7 +159,7 @@ void HeatTransportBHEProcess::initializeConcreteProcess(
 }
 
 void HeatTransportBHEProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble HeatTransportBHE process.");

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
@@ -176,10 +176,11 @@ void HeatTransportBHEProcess::assembleConcreteProcess(
 }
 
 void HeatTransportBHEProcess::assembleWithJacobianConcreteProcess(
-    const double /*t*/, double const /*dt*/, GlobalVector const& /*x*/,
-    GlobalVector const& /*xdot*/, const double /*dxdot_dx*/,
-    const double /*dx_dx*/, int const /*process_id*/, GlobalMatrix& /*M*/,
-    GlobalMatrix& /*K*/, GlobalVector& /*b*/, GlobalMatrix& /*Jac*/)
+    const double /*t*/, double const /*dt*/,
+    std::vector<GlobalVector*> const& /*x*/, GlobalVector const& /*xdot*/,
+    const double /*dxdot_dx*/, const double /*dx_dx*/, int const /*process_id*/,
+    GlobalMatrix& /*M*/, GlobalMatrix& /*K*/, GlobalVector& /*b*/,
+    GlobalMatrix& /*Jac*/)
 {
     OGS_FATAL(
         "HeatTransportBHE: analytical Jacobian assembly is not implemented");

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
@@ -55,9 +55,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
@@ -60,7 +60,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
@@ -368,7 +368,7 @@ void HydroMechanicsProcess<DisplacementDim>::initializeBoundaryConditions()
 
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble the equations for HydroMechanics");

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
@@ -388,7 +388,7 @@ void HydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac)

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -73,9 +73,9 @@ private:
     void initializeBoundaryConditions() override;
 
     void assembleConcreteProcess(const double t, double const /*dt*/,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const /*dt*/,

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -78,9 +78,10 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const /*dt*/, GlobalVector const& x,
-        GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
-        int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+        const double t, double const /*dt*/,
+        std::vector<GlobalVector*> const& x, GlobalVector const& xdot,
+        const double dxdot_dx, const double dx_dx, int const process_id,
+        GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
     void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -582,7 +582,7 @@ void HydroMechanicsProcess<GlobalDim>::assembleConcreteProcess(
 
 template <int GlobalDim>
 void HydroMechanicsProcess<GlobalDim>::assembleWithJacobianConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac)

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -567,7 +567,7 @@ bool HydroMechanicsProcess<GlobalDim>::isLinear() const
 
 template <int GlobalDim>
 void HydroMechanicsProcess<GlobalDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble HydroMechanicsProcess.");

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
@@ -66,9 +66,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
@@ -71,7 +71,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -560,7 +560,7 @@ void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac)

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -542,7 +542,7 @@ bool SmallDeformationProcess<DisplacementDim>::isLinear() const
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble SmallDeformationProcess.");

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
@@ -67,7 +67,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
@@ -62,9 +62,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -79,7 +79,7 @@ void LiquidFlowProcess::initializeConcreteProcess(
 }
 
 void LiquidFlowProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble LiquidFlowProcess.");

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -97,7 +97,7 @@ void LiquidFlowProcess::assembleConcreteProcess(
 }
 
 void LiquidFlowProcess::assembleWithJacobianConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac)

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -90,9 +90,9 @@ private:
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -95,7 +95,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/PhaseField/PhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.cpp
@@ -197,7 +197,7 @@ void PhaseFieldProcess<DisplacementDim>::assembleConcreteProcess(
 
 template <int DisplacementDim>
 void PhaseFieldProcess<DisplacementDim>::assembleWithJacobianConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac)

--- a/ProcessLib/PhaseField/PhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.cpp
@@ -162,7 +162,7 @@ void PhaseFieldProcess<DisplacementDim>::initializeBoundaryConditions()
 
 template <int DisplacementDim>
 void PhaseFieldProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble PhaseFieldProcess.");

--- a/ProcessLib/PhaseField/PhaseFieldProcess.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.h
@@ -88,9 +88,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/PhaseField/PhaseFieldProcess.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.h
@@ -93,7 +93,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -211,24 +211,25 @@ void Process::assemble(const double t, double const dt, GlobalVector const& x,
 }
 
 void Process::assembleWithJacobian(const double t, double const dt,
-                                   GlobalVector const& x,
+                                   std::vector<GlobalVector*> const& x,
                                    GlobalVector const& xdot,
                                    const double dxdot_dx, const double dx_dx,
                                    int const process_id, GlobalMatrix& M,
                                    GlobalMatrix& K, GlobalVector& b,
                                    GlobalMatrix& Jac)
 {
-    MathLib::LinAlg::setLocalAccessibleVector(x);
+    MathLib::LinAlg::setLocalAccessibleVector(*x[process_id]);
     MathLib::LinAlg::setLocalAccessibleVector(xdot);
 
     assembleWithJacobianConcreteProcess(t, dt, x, xdot, dxdot_dx, dx_dx,
                                         process_id, M, K, b, Jac);
 
     // TODO: apply BCs to Jacobian.
-    _boundary_conditions[process_id].applyNaturalBC(t, x, K, b, &Jac);
+    _boundary_conditions[process_id].applyNaturalBC(t, *x[process_id], K, b,
+                                                    &Jac);
 
     // the last argument is for the jacobian, nullptr is for a unused jacobian
-    _source_term_collections[process_id].integrate(t, x, b, &Jac);
+    _source_term_collections[process_id].integrate(t, *x[process_id], b, &Jac);
 }
 
 void Process::constructDofTable()

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -195,19 +195,22 @@ void Process::preAssemble(const double t, double const dt,
     preAssembleConcreteProcess(t, dt, x);
 }
 
-void Process::assemble(const double t, double const dt, GlobalVector const& x,
+void Process::assemble(const double t, double const dt,
+                       std::vector<GlobalVector*> const& x,
                        int const process_id, GlobalMatrix& M, GlobalMatrix& K,
                        GlobalVector& b)
 {
-    MathLib::LinAlg::setLocalAccessibleVector(x);
+    MathLib::LinAlg::setLocalAccessibleVector(*x[process_id]);
 
     assembleConcreteProcess(t, dt, x, process_id, M, K, b);
 
     // the last argument is for the jacobian, nullptr is for a unused jacobian
-    _boundary_conditions[process_id].applyNaturalBC(t, x, K, b, nullptr);
+    _boundary_conditions[process_id].applyNaturalBC(t, *x[process_id], K, b,
+                                                    nullptr);
 
     // the last argument is for the jacobian, nullptr is for a unused jacobian
-    _source_term_collections[process_id].integrate(t, x, b, nullptr);
+    _source_term_collections[process_id].integrate(t, *x[process_id], b,
+                                                   nullptr);
 }
 
 void Process::assembleWithJacobian(const double t, double const dt,

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -107,10 +107,10 @@ public:
                   GlobalVector& b) final;
 
     void assembleWithJacobian(const double t, double const dt,
-                              GlobalVector const& x, GlobalVector const& xdot,
-                              const double dxdot_dx, const double dx_dx,
-                              int const process_id, GlobalMatrix& M,
-                              GlobalMatrix& K, GlobalVector& b,
+                              std::vector<GlobalVector*> const& x,
+                              GlobalVector const& xdot, const double dxdot_dx,
+                              const double dx_dx, int const process_id,
+                              GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
                               GlobalMatrix& Jac) final;
 
     std::vector<NumLib::IndexValueVector<GlobalIndexType>> const*
@@ -201,7 +201,7 @@ private:
                                          GlobalMatrix& K, GlobalVector& b) = 0;
 
     virtual void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) = 0;

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -102,9 +102,9 @@ public:
     }
     void preAssemble(const double t, double const dt,
                      GlobalVector const& x) final;
-    void assemble(const double t, double const dt, GlobalVector const& x,
-                  int const process_id, GlobalMatrix& M, GlobalMatrix& K,
-                  GlobalVector& b) final;
+    void assemble(const double t, double const dt,
+                  std::vector<GlobalVector*> const& x, int const process_id,
+                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) final;
 
     void assembleWithJacobian(const double t, double const dt,
                               std::vector<GlobalVector*> const& x,
@@ -196,7 +196,7 @@ private:
     }
 
     virtual void assembleConcreteProcess(const double t, double const dt,
-                                         GlobalVector const& x,
+                                         std::vector<GlobalVector*> const& x,
                                          int const process_id, GlobalMatrix& M,
                                          GlobalMatrix& K, GlobalVector& b) = 0;
 

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
@@ -66,7 +66,7 @@ void RichardsComponentTransportProcess::initializeConcreteProcess(
 }
 
 void RichardsComponentTransportProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble RichardsComponentTransportProcess.");

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
@@ -83,7 +83,7 @@ void RichardsComponentTransportProcess::assembleConcreteProcess(
 }
 
 void RichardsComponentTransportProcess::assembleWithJacobianConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac)

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.h
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.h
@@ -135,7 +135,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.h
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.h
@@ -130,9 +130,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
@@ -66,7 +66,7 @@ void RichardsFlowProcess::initializeConcreteProcess(
 }
 
 void RichardsFlowProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble RichardsFlowProcess.");

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
@@ -83,7 +83,7 @@ void RichardsFlowProcess::assembleConcreteProcess(
 }
 
 void RichardsFlowProcess::assembleWithJacobianConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac)

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.h
@@ -59,7 +59,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.h
@@ -54,9 +54,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
@@ -257,7 +257,7 @@ void RichardsMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
 template <int DisplacementDim>
 void RichardsMechanicsProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac)

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
@@ -234,7 +234,7 @@ void RichardsMechanicsProcess<DisplacementDim>::initializeBoundaryConditions()
 
 template <int DisplacementDim>
 void RichardsMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble the equations for RichardsMechanics");

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
@@ -80,7 +80,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
@@ -75,9 +75,9 @@ private:
     void initializeBoundaryConditions() override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -260,7 +260,7 @@ void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac)

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -241,7 +241,7 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble SmallDeformationProcess.");

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -51,9 +51,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -56,7 +56,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
@@ -269,7 +269,7 @@ void SmallDeformationNonlocalProcess<
 template <int DisplacementDim>
 void SmallDeformationNonlocalProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac)

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
@@ -231,7 +231,7 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::
 
 template <int DisplacementDim>
 void SmallDeformationNonlocalProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble SmallDeformationNonlocalProcess.");

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
@@ -54,9 +54,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void preAssembleConcreteProcess(const double t, double const dt,
                                     GlobalVector const& x) override;

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
@@ -62,7 +62,7 @@ private:
                                     GlobalVector const& x) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -247,7 +247,7 @@ void TESProcess::assembleConcreteProcess(const double t, double const dt,
 }
 
 void TESProcess::assembleWithJacobianConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac)

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -229,7 +229,7 @@ void TESProcess::initializeSecondaryVariables()
 }
 
 void TESProcess::assembleConcreteProcess(const double t, double const dt,
-                                         GlobalVector const& x,
+                                         std::vector<GlobalVector*> const& x,
                                          int const process_id, GlobalMatrix& M,
                                          GlobalMatrix& K, GlobalVector& b)
 {

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -67,7 +67,7 @@ private:
     void initializeSecondaryVariables();
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -60,9 +60,9 @@ private:
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void initializeSecondaryVariables();
 

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
@@ -92,7 +92,7 @@ void ThermalTwoPhaseFlowWithPPProcess::assembleConcreteProcess(
 }
 
 void ThermalTwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac)

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
@@ -75,7 +75,7 @@ void ThermalTwoPhaseFlowWithPPProcess::initializeConcreteProcess(
 }
 
 void ThermalTwoPhaseFlowWithPPProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble ThermalTwoPhaseFlowWithPPProcess.");

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
@@ -67,7 +67,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
@@ -62,9 +62,9 @@ private:
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
@@ -240,7 +240,7 @@ void ThermoHydroMechanicsProcess<
 
 template <int DisplacementDim>
 void ThermoHydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble the equations for ThermoHydroMechanics");

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
@@ -260,7 +260,7 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
 template <int DisplacementDim>
 void ThermoHydroMechanicsProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac)

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
@@ -76,9 +76,9 @@ private:
     void initializeBoundaryConditions() override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
@@ -81,7 +81,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
@@ -212,7 +212,7 @@ void ThermoMechanicalPhaseFieldProcess<
 template <int DisplacementDim>
 void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac)

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
@@ -189,12 +189,11 @@ void ThermoMechanicalPhaseFieldProcess<
 }
 
 template <int DisplacementDim>
-void ThermoMechanicalPhaseFieldProcess<
-    DisplacementDim>::assembleConcreteProcess(const double t, double const dt,
-                                              GlobalVector const& x,
-                                              int const process_id,
-                                              GlobalMatrix& M, GlobalMatrix& K,
-                                              GlobalVector& b)
+void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
+    assembleConcreteProcess(const double t, double const dt,
+                            std::vector<GlobalVector*> const& x,
+                            int const process_id, GlobalMatrix& M,
+                            GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble the equations for ThermoMechanicalPhaseFieldProcess.");
 

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
@@ -93,9 +93,9 @@ private:
         unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
@@ -98,7 +98,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
@@ -277,7 +277,7 @@ void ThermoMechanicsProcess<DisplacementDim>::initializeBoundaryConditions()
 
 template <int DisplacementDim>
 void ThermoMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble ThermoMechanicsProcess.");

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
@@ -296,7 +296,7 @@ void ThermoMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
 template <int DisplacementDim>
 void ThermoMechanicsProcess<DisplacementDim>::
     assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac)

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
@@ -68,9 +68,9 @@ private:
     void initializeBoundaryConditions() override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
@@ -73,7 +73,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
@@ -89,7 +89,7 @@ void TwoPhaseFlowWithPPProcess::assembleConcreteProcess(
 }
 
 void TwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac)

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
@@ -72,7 +72,7 @@ void TwoPhaseFlowWithPPProcess::initializeConcreteProcess(
 }
 
 void TwoPhaseFlowWithPPProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble TwoPhaseFlowWithPPProcess.");

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
@@ -60,9 +60,9 @@ private:
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
@@ -65,7 +65,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
@@ -90,7 +90,7 @@ void TwoPhaseFlowWithPrhoProcess::assembleConcreteProcess(
 }
 
 void TwoPhaseFlowWithPrhoProcess::assembleWithJacobianConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac)

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
@@ -73,7 +73,7 @@ void TwoPhaseFlowWithPrhoProcess::initializeConcreteProcess(
 }
 
 void TwoPhaseFlowWithPrhoProcess::assembleConcreteProcess(
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble TwoPhaseFlowWithPrhoProcess.");

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
@@ -58,9 +58,9 @@ private:
         MeshLib::Mesh const& mesh, unsigned const integration_order) override;
 
     void assembleConcreteProcess(const double t, double const dt,
-                                 GlobalVector const& x, int const process_id,
-                                 GlobalMatrix& M, GlobalMatrix& K,
-                                 GlobalVector& b) override;
+                                 std::vector<GlobalVector*> const& x,
+                                 int const process_id, GlobalMatrix& M,
+                                 GlobalMatrix& K, GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
         const double t, double const dt, std::vector<GlobalVector*> const& x,

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
@@ -63,7 +63,7 @@ private:
                                  GlobalVector& b) override;
 
     void assembleWithJacobianConcreteProcess(
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;

--- a/ProcessLib/VectorMatrixAssembler.cpp
+++ b/ProcessLib/VectorMatrixAssembler.cpp
@@ -106,7 +106,7 @@ void VectorMatrixAssembler::assembleWithJacobian(
     std::size_t const mesh_item_id, LocalAssemblerInterface& local_assembler,
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>> const&
         dof_tables,
-    const double t, double const dt, GlobalVector const& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     GlobalMatrix& Jac, CoupledSolutionsForStaggeredScheme const* const cpl_xs)
@@ -129,7 +129,7 @@ void VectorMatrixAssembler::assembleWithJacobian(
 
     if (cpl_xs == nullptr)
     {
-        auto const local_x = x.get(indices);
+        auto const local_x = x[process_id]->get(indices);
         _jacobian_assembler->assembleWithJacobian(
             local_assembler, t, dt, local_x, local_xdot, dxdot_dx, dx_dx,
             _local_M_data, _local_K_data, _local_b_data, _local_Jac_data);
@@ -139,7 +139,7 @@ void VectorMatrixAssembler::assembleWithJacobian(
         auto local_coupled_xs0 = getCoupledLocalSolutions(cpl_xs->coupled_xs_t0,
                                                           indices_of_processes);
         auto local_coupled_xs =
-            getCoupledLocalSolutions(cpl_xs->coupled_xs, indices_of_processes);
+            getCoupledLocalSolutions(x, indices_of_processes);
 
         ProcessLib::LocalCoupledSolutions local_coupled_solutions(
             std::move(local_coupled_xs0), std::move(local_coupled_xs));

--- a/ProcessLib/VectorMatrixAssembler.cpp
+++ b/ProcessLib/VectorMatrixAssembler.cpp
@@ -43,7 +43,7 @@ void VectorMatrixAssembler::assemble(
     const std::size_t mesh_item_id, LocalAssemblerInterface& local_assembler,
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>> const&
         dof_tables,
-    const double t, double const dt, const GlobalVector& x,
+    const double t, double const dt, std::vector<GlobalVector*> const& x,
     int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     CoupledSolutionsForStaggeredScheme const* const cpl_xs)
 {
@@ -62,7 +62,7 @@ void VectorMatrixAssembler::assemble(
 
     if (cpl_xs == nullptr)
     {
-        auto const local_x = x.get(indices);
+        auto const local_x = x[process_id]->get(indices);
         local_assembler.assemble(t, dt, local_x, _local_M_data, _local_K_data,
                                  _local_b_data);
     }
@@ -71,7 +71,7 @@ void VectorMatrixAssembler::assemble(
         auto local_coupled_xs0 = getCoupledLocalSolutions(cpl_xs->coupled_xs_t0,
                                                           indices_of_processes);
         auto local_coupled_xs =
-            getCoupledLocalSolutions(cpl_xs->coupled_xs, indices_of_processes);
+            getCoupledLocalSolutions(x, indices_of_processes);
 
         ProcessLib::LocalCoupledSolutions local_coupled_solutions(
             std::move(local_coupled_xs0), std::move(local_coupled_xs));

--- a/ProcessLib/VectorMatrixAssembler.h
+++ b/ProcessLib/VectorMatrixAssembler.h
@@ -47,9 +47,9 @@ public:
                   LocalAssemblerInterface& local_assembler,
                   std::vector<std::reference_wrapper<
                       NumLib::LocalToGlobalIndexMap>> const& dof_tables,
-                  double const t, double const dt, GlobalVector const& x,
-                  int const process_id, GlobalMatrix& M, GlobalMatrix& K,
-                  GlobalVector& b,
+                  double const t, double const dt,
+                  std::vector<GlobalVector*> const& x, int const process_id,
+                  GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
                   CoupledSolutionsForStaggeredScheme const* const cpl_xs);
 
     //! Assembles \c M, \c K, \c b, and the Jacobian \c Jac of the residual.

--- a/ProcessLib/VectorMatrixAssembler.h
+++ b/ProcessLib/VectorMatrixAssembler.h
@@ -60,7 +60,7 @@ public:
         std::vector<
             std::reference_wrapper<NumLib::LocalToGlobalIndexMap>> const&
             dof_tables,
-        const double t, double const dt, GlobalVector const& x,
+        const double t, double const dt, std::vector<GlobalVector*> const& x,
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac,

--- a/Tests/NumLib/TimeLoopSingleODE.h
+++ b/Tests/NumLib/TimeLoopSingleODE.h
@@ -86,7 +86,9 @@ NumLib::NonlinearSolverStatus TimeLoopSingleODE<NLTag>::loop(
     const double delta_t, Callback& post_timestep)
 {
     // solution vector
-    GlobalVector& x = NumLib::GlobalVectorProvider::provider.getVector(x0);
+    std::vector<GlobalVector*> xs;
+    xs.push_back(&NumLib::GlobalVectorProvider::provider.getVector(x0));
+    GlobalVector& x = *xs.back();
 
     auto& time_disc = _ode_sys.getTimeDiscretization();
 
@@ -98,7 +100,7 @@ NumLib::NonlinearSolverStatus TimeLoopSingleODE<NLTag>::loop(
     {
         int const process_id = 0;
         MathLib::LinAlg::setLocalAccessibleVector(x);
-        _nonlinear_solver->assemble(x, process_id);
+        _nonlinear_solver->assemble(xs, process_id);
         time_disc.pushState(t0, x0,
                             _ode_sys);  // TODO: that might do duplicate work
     }
@@ -116,7 +118,7 @@ NumLib::NonlinearSolverStatus TimeLoopSingleODE<NLTag>::loop(
 
         int const process_id = 0;
         nonlinear_solver_status =
-            _nonlinear_solver->solve(x, nullptr, process_id);
+            _nonlinear_solver->solve(xs, nullptr, process_id);
         if (!nonlinear_solver_status.error_norms_met)
         {
             break;


### PR DESCRIPTION
Avoid different ways of passing current solution for monolithic and staggered schemes.

Removing of the `CoupledSolutionsForStaggeredScheme` will take some more time, so don't search for it here.