### PR TITLE
Pass solutions to pre and post

### DIFF
--- a/ProcessLib/BoundaryCondition/BoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/BoundaryCondition.h
@@ -54,7 +54,9 @@ public:
         // Therefore there is nothing to do here.
     }
 
-    virtual void preTimestep(const double /*t*/, GlobalVector const& /*x*/)
+    virtual void preTimestep(const double /*t*/,
+                             std::vector<GlobalVector*> const& /*x*/,
+                             int const /*process_id*/)
     {
         // A hook added for solution dependent dirichlet
     }

--- a/ProcessLib/BoundaryCondition/BoundaryConditionCollection.h
+++ b/ProcessLib/BoundaryCondition/BoundaryConditionCollection.h
@@ -53,11 +53,12 @@ public:
         _boundary_conditions.push_back(std::move(bc));
     }
 
-    void preTimestep(const double t, GlobalVector const& x)
+    void preTimestep(const double t, std::vector<GlobalVector*> const& x,
+                     int const process_id)
     {
         for (auto const& bc_ptr : _boundary_conditions)
         {
-            bc_ptr->preTimestep(t, x);
+            bc_ptr->preTimestep(t, x, process_id);
         }
     }
 

--- a/ProcessLib/BoundaryCondition/ConstraintDirichletBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/ConstraintDirichletBoundaryCondition.cpp
@@ -106,17 +106,18 @@ ConstraintDirichletBoundaryCondition::ConstraintDirichletBoundaryCondition(
         _integration_order, bulk_mesh, _bulk_ids);
 }
 
-void ConstraintDirichletBoundaryCondition::preTimestep(double t,
-                                                       GlobalVector const& x)
+void ConstraintDirichletBoundaryCondition::preTimestep(
+    double t, std::vector<GlobalVector*> const& x, int const process_id)
 {
     DBUG(
         "ConstraintDirichletBoundaryCondition::preTimestep: computing flux "
         "constraints");
+    auto const& solution = *x[process_id];
     for (auto const* boundary_element : _bc_mesh.getElements())
     {
         _flux_values[boundary_element->getID()] =
             _local_assemblers[boundary_element->getID()]->integrate(
-                x, t,
+                solution, t,
                 [this](std::size_t const element_id,
                        MathLib::Point3d const& pnt, double const t,
                        GlobalVector const& x) {

--- a/ProcessLib/BoundaryCondition/ConstraintDirichletBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/ConstraintDirichletBoundaryCondition.h
@@ -61,7 +61,8 @@ public:
                                       GlobalVector const&)>
             getFlux);
 
-    void preTimestep(double t, GlobalVector const& x) override;
+    void preTimestep(double t, std::vector<GlobalVector*> const& x,
+                     int const process_id) override;
 
     void getEssentialBCValues(
         const double t, const GlobalVector& x,

--- a/ProcessLib/BoundaryCondition/PhaseFieldIrreversibleDamageOracleBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/PhaseFieldIrreversibleDamageOracleBoundaryCondition.cpp
@@ -38,7 +38,8 @@ void PhaseFieldIrreversibleDamageOracleBoundaryCondition::getEssentialBCValues(
 
 // update new values and corresponding indices.
 void PhaseFieldIrreversibleDamageOracleBoundaryCondition::preTimestep(
-    const double /*t*/, const GlobalVector& x)
+    const double /*t*/, std::vector<GlobalVector*> const& x,
+    int const process_id)
 {
     // phase-field variable is considered irreversible if it loses more than 95%
     // of the stiffness, which is a widely used threshold.
@@ -56,7 +57,7 @@ void PhaseFieldIrreversibleDamageOracleBoundaryCondition::preTimestep(
         const auto g_idx =
             _dof_table.getGlobalIndex(l, _variable_id, _component_id);
 
-        if (x[node_id] <= irreversibleDamage)
+        if ((*x[process_id])[node_id] <= irreversibleDamage)
         {
             _bc_values.ids.emplace_back(g_idx);
             _bc_values.values.emplace_back(0.0);

--- a/ProcessLib/BoundaryCondition/PhaseFieldIrreversibleDamageOracleBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/PhaseFieldIrreversibleDamageOracleBoundaryCondition.h
@@ -47,7 +47,8 @@ public:
         const double t, const GlobalVector& x,
         NumLib::IndexValueVector<GlobalIndexType>& bc_values) const override;
 
-    void preTimestep(const double t, const GlobalVector& x) override;
+    void preTimestep(const double t, std::vector<GlobalVector*> const& x,
+                     int const process_id) override;
 
 private:
     NumLib::LocalToGlobalIndexMap const& _dof_table;

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
@@ -186,8 +186,8 @@ void ComponentTransportProcess::
 }
 
 void ComponentTransportProcess::preTimestepConcreteProcess(
-    GlobalVector const& x, const double /*t*/, const double /*delta_t*/,
-    int const process_id)
+    std::vector<GlobalVector*> const& x, const double /*t*/,
+    const double /*delta_t*/, int const process_id)
 {
     if (_use_monolithic_scheme)
     {
@@ -197,17 +197,18 @@ void ComponentTransportProcess::preTimestepConcreteProcess(
     if (!_xs_previous_timestep[process_id])
     {
         _xs_previous_timestep[process_id] =
-            MathLib::MatrixVectorTraits<GlobalVector>::newInstance(x);
+            MathLib::MatrixVectorTraits<GlobalVector>::newInstance(
+                *x[process_id]);
     }
     else
     {
         auto& x0 = *_xs_previous_timestep[process_id];
-        MathLib::LinAlg::copy(x, x0);
+        MathLib::LinAlg::copy(*x[process_id], x0);
     }
 }
 
 void ComponentTransportProcess::postTimestepConcreteProcess(
-    GlobalVector const& x,
+    std::vector<GlobalVector*> const& x,
     const double t,
     const double /*delta_t*/,
     int const process_id)
@@ -233,8 +234,9 @@ void ComponentTransportProcess::postTimestepConcreteProcess(
 
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
-    _surfaceflux->integrate(x, t, *this, process_id, _integration_order,
-                            _mesh, pv.getActiveElementIDs());
+    _surfaceflux->integrate(*x[process_id], t, *this, process_id,
+                            _integration_order, _mesh,
+                            pv.getActiveElementIDs());
     _surfaceflux->save(t);
 }
 

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.h
@@ -126,11 +126,12 @@ public:
     void setCoupledTermForTheStaggeredSchemeToLocalAssemblers(
         int const process_id) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, const double /*t*/,
+    void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                    const double /*t*/,
                                     const double /*delta_t*/,
                                     int const process_id) override;
 
-    void postTimestepConcreteProcess(GlobalVector const& x,
+    void postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
                                      const double t,
                                      const double delta_t,
                                      int const process_id) override;

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -61,7 +61,7 @@ public:
         return _local_assemblers[element_id]->getFlux(p, t, local_x);
     }
 
-    void postTimestepConcreteProcess(GlobalVector const& x,
+    void postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
                                      const double t,
                                      const double /*delta_t*/,
                                      int const process_id) override
@@ -79,8 +79,9 @@ public:
 
         ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
-        _surfaceflux->integrate(x, t, *this, process_id, _integration_order,
-                                _mesh, pv.getActiveElementIDs());
+        _surfaceflux->integrate(*x[process_id], t, *this, process_id,
+                                _integration_order, _mesh,
+                                pv.getActiveElementIDs());
         _surfaceflux->save(t);
     }
 

--- a/ProcessLib/HT/HTProcess.h
+++ b/ProcessLib/HT/HTProcess.h
@@ -81,7 +81,7 @@ public:
     void setCoupledTermForTheStaggeredSchemeToLocalAssemblers(
         int const process_id) override;
 
-    void postTimestepConcreteProcess(GlobalVector const& x,
+    void postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
                                      const double t,
                                      const double delta_t,
                                      int const process_id) override;
@@ -103,8 +103,8 @@ private:
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt,
+    void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                    double const t, double const dt,
                                     const int process_id) override;
 
     void setCoupledSolutionsOfPreviousTimeStepPerProcess(const int process_id);

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
@@ -455,7 +455,7 @@ void HydroMechanicsProcess<DisplacementDim>::
 
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt,
+    std::vector<GlobalVector*> const& x, double const t, double const dt,
     const int process_id)
 {
     DBUG("PreTimestep HydroMechanicsProcess.");
@@ -466,21 +466,22 @@ void HydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
             getProcessVariables(process_id)[0];
         GlobalExecutor::executeSelectedMemberOnDereferenced(
             &LocalAssemblerInterface::preTimestep, _local_assemblers,
-            pv.getActiveElementIDs(), *_local_to_global_index_map, x, t,
-            dt);
+            pv.getActiveElementIDs(), *_local_to_global_index_map,
+            *x[process_id], t, dt);
     }
 }
 
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::postTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt,
+    std::vector<GlobalVector*> const& x, double const t, double const dt,
     const int process_id)
 {
     DBUG("PostTimestep HydroMechanicsProcess.");
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerInterface::postTimestep, _local_assemblers,
-        pv.getActiveElementIDs(), getDOFTable(process_id), x, t, dt);
+        pv.getActiveElementIDs(), getDOFTable(process_id), *x[process_id], t,
+        dt);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -83,12 +83,12 @@ private:
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt,
+    void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                    double const t, double const dt,
                                     const int process_id) override;
 
-    void postTimestepConcreteProcess(GlobalVector const& x, const double t,
-                                     const double delta_t,
+    void postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                     const double t, const double delta_t,
                                      int const process_id) override;
 
     void postNonLinearSolverConcreteProcess(GlobalVector const& x,

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
@@ -51,8 +51,8 @@ public:
     bool isLinear() const override;
     //! @}
 
-    void postTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                     double const dt,
+    void postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                     double const t, double const dt,
                                      int const process_id) override;
 
 private:
@@ -75,9 +75,9 @@ private:
         GlobalVector const& xdot, const double dxdot_dx, const double dx_dx,
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt,
-                                    const int /*process_id*/) override;
+    void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                    double const t, double const dt,
+                                    int const process_id) override;
 
 private:
     HydroMechanicsProcessData<GlobalDim> _process_data;

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -579,7 +579,7 @@ void SmallDeformationProcess<DisplacementDim>::
 }
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt,
+    std::vector<GlobalVector*> const& x, double const t, double const dt,
     const int process_id)
 {
     DBUG("PreTimestep SmallDeformationProcess.");
@@ -588,7 +588,7 @@ void SmallDeformationProcess<DisplacementDim>::preTimestepConcreteProcess(
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &SmallDeformationLocalAssemblerInterface::preTimestep,
         _local_assemblers, pv.getActiveElementIDs(),
-        *_local_to_global_index_map, x, t, dt);
+        *_local_to_global_index_map, *x[process_id], t, dt);
 }
 // ------------------------------------------------------------------------------------
 // template instantiation

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
@@ -72,9 +72,9 @@ private:
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt,
-                                    const int /*process_id*/) override;
+    void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                    double const t, double const dt,
+                                    const int process_id) override;
 
 private:
     SmallDeformationProcessData<DisplacementDim> _process_data;

--- a/ProcessLib/PhaseField/PhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.cpp
@@ -239,7 +239,7 @@ void PhaseFieldProcess<DisplacementDim>::assembleWithJacobianConcreteProcess(
 
 template <int DisplacementDim>
 void PhaseFieldProcess<DisplacementDim>::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt,
+    std::vector<GlobalVector*> const& x, double const t, double const dt,
     const int process_id)
 {
     DBUG("PreTimestep PhaseFieldProcess %d.", process_id);
@@ -250,13 +250,14 @@ void PhaseFieldProcess<DisplacementDim>::preTimestepConcreteProcess(
 
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerInterface::preTimestep, _local_assemblers,
-        pv.getActiveElementIDs(), getDOFTable(process_id), x, t, dt);
+        pv.getActiveElementIDs(), getDOFTable(process_id), *x[process_id], t,
+        dt);
 }
 
 template <int DisplacementDim>
 void PhaseFieldProcess<DisplacementDim>::postTimestepConcreteProcess(
-    GlobalVector const& x, const double t, const double /*delta_t*/,
-    int const process_id)
+    std::vector<GlobalVector*> const& x, const double t,
+    const double /*delta_t*/, int const process_id)
 {
     if (isPhaseFieldProcess(process_id))
     {
@@ -277,7 +278,7 @@ void PhaseFieldProcess<DisplacementDim>::postTimestepConcreteProcess(
 
         GlobalExecutor::executeSelectedMemberOnDereferenced(
             &LocalAssemblerInterface::computeEnergy, _local_assemblers,
-            pv.getActiveElementIDs(), dof_tables, x, t,
+            pv.getActiveElementIDs(), dof_tables, *x[process_id], t,
             _process_data.elastic_energy, _process_data.surface_energy,
             _process_data.pressure_work, _coupled_solutions);
 

--- a/ProcessLib/PhaseField/PhaseFieldProcess.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.h
@@ -98,12 +98,12 @@ private:
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt,
+    void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                    double const t, double const dt,
                                     const int process_id) override;
 
-    void postTimestepConcreteProcess(GlobalVector const& x, const double t,
-                                     const double delta_t,
+    void postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                     const double t, const double delta_t,
                                      int const process_id) override;
 
     void postNonLinearSolverConcreteProcess(GlobalVector const& x,

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -378,7 +378,7 @@ void Process::computeSparsityPattern()
         NumLib::computeSparsityPattern(*_local_to_global_index_map, _mesh);
 }
 
-void Process::preTimestep(GlobalVector const& x, const double t,
+void Process::preTimestep(std::vector<GlobalVector*> const& x, const double t,
                           const double delta_t, const int process_id)
 {
     for (auto& cached_var : _cached_secondary_variables)
@@ -386,16 +386,18 @@ void Process::preTimestep(GlobalVector const& x, const double t,
         cached_var->setTime(t);
     }
 
-    MathLib::LinAlg::setLocalAccessibleVector(x);
+    for (auto* const solution : x)
+        MathLib::LinAlg::setLocalAccessibleVector(*solution);
     preTimestepConcreteProcess(x, t, delta_t, process_id);
 
-    _boundary_conditions[process_id].preTimestep(t, x);
+    _boundary_conditions[process_id].preTimestep(t, x, process_id);
 }
 
-void Process::postTimestep(GlobalVector const& x, const double t,
+void Process::postTimestep(std::vector<GlobalVector*> const& x, const double t,
                            const double delta_t, int const process_id)
 {
-    MathLib::LinAlg::setLocalAccessibleVector(x);
+    for (auto* const solution : x)
+        MathLib::LinAlg::setLocalAccessibleVector(*solution);
     postTimestepConcreteProcess(x, t, delta_t, process_id);
 }
 

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -59,11 +59,11 @@ public:
             const bool use_monolithic_scheme = true);
 
     /// Preprocessing before starting assembly for new timestep.
-    void preTimestep(GlobalVector const& x, const double t,
+    void preTimestep(std::vector<GlobalVector*> const& x, const double t,
                      const double delta_t, const int process_id);
 
     /// Postprocessing after a complete timestep.
-    void postTimestep(GlobalVector const& x, const double t,
+    void postTimestep(std::vector<GlobalVector*> const& x, const double t,
                       const double delta_t, int const process_id);
 
     /// Calculates secondary variables, e.g. stress and strain for deformation
@@ -206,17 +206,19 @@ private:
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) = 0;
 
-    virtual void preTimestepConcreteProcess(GlobalVector const& /*x*/,
-                                            const double /*t*/,
-                                            const double /*delta_t*/,
-                                            const int /*process_id*/)
+    virtual void preTimestepConcreteProcess(
+        std::vector<GlobalVector*> const& /*x*/,
+        const double /*t*/,
+        const double /*delta_t*/,
+        const int /*process_id*/)
     {
     }
 
-    virtual void postTimestepConcreteProcess(GlobalVector const& /*x*/,
-                                             const double /*t*/,
-                                             const double /*delta_t*/,
-                                             int const /*process_id*/)
+    virtual void postTimestepConcreteProcess(
+        std::vector<GlobalVector*> const& /*x*/,
+        const double /*t*/,
+        const double /*delta_t*/,
+        int const /*process_id*/)
     {
     }
 

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
@@ -324,7 +324,7 @@ void RichardsMechanicsProcess<DisplacementDim>::
 
 template <int DisplacementDim>
 void RichardsMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt,
+    std::vector<GlobalVector*> const& x, double const t, double const dt,
     const int process_id)
 {
     DBUG("PreTimestep RichardsMechanicsProcess.");
@@ -335,8 +335,8 @@ void RichardsMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
             getProcessVariables(process_id)[0];
         GlobalExecutor::executeSelectedMemberOnDereferenced(
             &LocalAssemblerInterface::preTimestep, _local_assemblers,
-            pv.getActiveElementIDs(), *_local_to_global_index_map, x,
-            t, dt);
+            pv.getActiveElementIDs(), *_local_to_global_index_map,
+            *x[process_id], t, dt);
     }
 }
 

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
@@ -85,8 +85,8 @@ private:
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt,
+    void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                    double const t, double const dt,
                                     const int process_id) override;
 
     void postNonLinearSolverConcreteProcess(GlobalVector const& x,

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -283,7 +283,7 @@ void SmallDeformationProcess<DisplacementDim>::
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::postTimestepConcreteProcess(
-    GlobalVector const& x, const double t, const double dt,
+    std::vector<GlobalVector*> const& x, const double t, const double dt,
     int const process_id)
 {
     DBUG("PostTimestep SmallDeformationProcess.");
@@ -292,11 +292,13 @@ void SmallDeformationProcess<DisplacementDim>::postTimestepConcreteProcess(
 
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerInterface::postTimestep, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map, x, t, dt);
+        pv.getActiveElementIDs(), *_local_to_global_index_map, *x[process_id],
+        t, dt);
 
     std::unique_ptr<GlobalVector> material_forces;
     ProcessLib::SmallDeformation::writeMaterialForces(
-        material_forces, _local_assemblers, *_local_to_global_index_map, x);
+        material_forces, _local_assemblers, *_local_to_global_index_map,
+        *x[process_id]);
 
     material_forces->copyValues(*_material_forces);
 }

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -61,8 +61,8 @@ private:
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
-    void postTimestepConcreteProcess(GlobalVector const& x, const double t,
-                                     const double dt,
+    void postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                     const double t, const double dt,
                                      int const process_id) override;
 
 private:

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
@@ -293,11 +293,11 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::
 }
 
 template <int DisplacementDim>
-void SmallDeformationNonlocalProcess<
-    DisplacementDim>::postTimestepConcreteProcess(GlobalVector const& x,
-                                                  double const t,
-                                                  double const dt,
-                                                  int const process_id)
+void SmallDeformationNonlocalProcess<DisplacementDim>::
+    postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                double const t,
+                                double const dt,
+                                int const process_id)
 {
     DBUG("PostTimestep SmallDeformationNonlocalProcess.");
 
@@ -305,7 +305,8 @@ void SmallDeformationNonlocalProcess<
 
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerInterface::postTimestep, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map, x, t, dt);
+        pv.getActiveElementIDs(), *_local_to_global_index_map, *x[process_id],
+        t, dt);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
@@ -67,8 +67,8 @@ private:
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
-    void postTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                     double const dt,
+    void postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                     double const t, double const dt,
                                      int const process_id) override;
 
     NumLib::IterationResult postIterationConcreteProcess(

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -263,10 +263,10 @@ void TESProcess::assembleWithJacobianConcreteProcess(
         dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 
-void TESProcess::preTimestepConcreteProcess(GlobalVector const& x,
+void TESProcess::preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
                                             const double t,
                                             const double delta_t,
-                                            const int /*process_id*/)
+                                            const int process_id)
 {
     DBUG("new timestep");
 
@@ -275,7 +275,7 @@ void TESProcess::preTimestepConcreteProcess(GlobalVector const& x,
     ++_assembly_params.timestep;  // TODO remove that
 
     _x_previous_timestep =
-        MathLib::MatrixVectorTraits<GlobalVector>::newInstance(x);
+        MathLib::MatrixVectorTraits<GlobalVector>::newInstance(*x[process_id]);
 }
 
 void TESProcess::preIterationConcreteProcess(const unsigned iter,

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -44,8 +44,8 @@ public:
         NumLib::NamedFunctionCaller&& named_function_caller,
         BaseLib::ConfigTree const& config);
 
-    void preTimestepConcreteProcess(GlobalVector const& x, const double t,
-                                    const double delta_t,
+    void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                    const double t, const double delta_t,
                                     const int process_id) override;
     void preIterationConcreteProcess(const unsigned iter,
                                      GlobalVector const& x) override;

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
@@ -110,7 +110,7 @@ void ThermalTwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(
         dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 void ThermalTwoPhaseFlowWithPPProcess::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const delta_t,
+    std::vector<GlobalVector*> const& x, double const t, double const delta_t,
     const int process_id)
 {
     DBUG("PreTimestep ThermalTwoPhaseFlowWithPPProcess.");
@@ -118,8 +118,8 @@ void ThermalTwoPhaseFlowWithPPProcess::preTimestepConcreteProcess(
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerInterface::preTimestep, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map, x, t,
-        delta_t);
+        pv.getActiveElementIDs(), *_local_to_global_index_map, *x[process_id],
+        t, delta_t);
 }
 
 }  // namespace ThermalTwoPhaseFlowWithPP

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
@@ -72,8 +72,8 @@ private:
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, const double t,
-                                    const double delta_t,
+    void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                    const double t, const double delta_t,
                                     const int process_id) override;
 
     ThermalTwoPhaseFlowWithPPProcessData _process_data;

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
@@ -332,7 +332,7 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::
 
 template <int DisplacementDim>
 void ThermoHydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt,
+    std::vector<GlobalVector*> const& x, double const t, double const dt,
     const int process_id)
 {
     DBUG("PreTimestep ThermoHydroMechanicsProcess.");
@@ -341,19 +341,19 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
     {
         GlobalExecutor::executeMemberOnDereferenced(
             &LocalAssemblerInterface::preTimestep, _local_assemblers,
-            *_local_to_global_index_map, x, t, dt);
+            *_local_to_global_index_map, *x[process_id], t, dt);
     }
 }
 
 template <int DisplacementDim>
 void ThermoHydroMechanicsProcess<DisplacementDim>::postTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt,
+    std::vector<GlobalVector*> const& x, double const t, double const dt,
     const int process_id)
 {
     DBUG("PostTimestep ThermoHydroMechanicsProcess.");
     GlobalExecutor::executeMemberOnDereferenced(
         &LocalAssemblerInterface::postTimestep, _local_assemblers,
-        getDOFTable(process_id), x, t, dt);
+        getDOFTable(process_id), *x[process_id], t, dt);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
@@ -86,12 +86,12 @@ private:
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt,
+    void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                    double const t, double const dt,
                                     const int process_id) override;
 
-    void postTimestepConcreteProcess(GlobalVector const& x, const double t,
-                                     const double delta_t,
+    void postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                     const double t, const double delta_t,
                                      int const process_id) override;
 
     void postNonLinearSolverConcreteProcess(GlobalVector const& x,

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
@@ -260,11 +260,11 @@ void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
 }
 
 template <int DisplacementDim>
-void ThermoMechanicalPhaseFieldProcess<
-    DisplacementDim>::preTimestepConcreteProcess(GlobalVector const& x,
-                                                 double const t,
-                                                 double const dt,
-                                                 const int process_id)
+void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
+    preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                               double const t,
+                               double const dt,
+                               const int process_id)
 {
     DBUG("PreTimestep ThermoMechanicalPhaseFieldProcess.");
 
@@ -277,16 +277,16 @@ void ThermoMechanicalPhaseFieldProcess<
 
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &ThermoMechanicalPhaseFieldLocalAssemblerInterface::preTimestep,
-        _local_assemblers, pv.getActiveElementIDs(), getDOFTable(process_id), x,
-        t, dt);
+        _local_assemblers, pv.getActiveElementIDs(), getDOFTable(process_id),
+        *x[process_id], t, dt);
 }
 
 template <int DisplacementDim>
-void ThermoMechanicalPhaseFieldProcess<
-    DisplacementDim>::postTimestepConcreteProcess(GlobalVector const& x,
-                                                  double const t,
-                                                  double const dt,
-                                                  int const process_id)
+void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
+    postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                double const t,
+                                double const dt,
+                                int const process_id)
 {
     DBUG("PostTimestep ThermoMechanicalPhaseFieldProcess.");
 
@@ -294,8 +294,8 @@ void ThermoMechanicalPhaseFieldProcess<
 
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &ThermoMechanicalPhaseFieldLocalAssemblerInterface::postTimestep,
-        _local_assemblers, pv.getActiveElementIDs(), getDOFTable(process_id), x,
-        t, dt);
+        _local_assemblers, pv.getActiveElementIDs(), getDOFTable(process_id),
+        *x[process_id], t, dt);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
@@ -103,12 +103,12 @@ private:
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt,
+    void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                    double const t, double const dt,
                                     const int process_id) override;
 
-    void postTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                     double const dt,
+    void postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                     double const t, double const dt,
                                      int const process_id) override;
 
     void postNonLinearSolverConcreteProcess(GlobalVector const& x,

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
@@ -383,7 +383,7 @@ void ThermoMechanicsProcess<DisplacementDim>::
 
 template <int DisplacementDim>
 void ThermoMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt,
+    std::vector<GlobalVector*> const& x, double const t, double const dt,
     const int process_id)
 {
     DBUG("PreTimestep ThermoMechanicsProcess.");
@@ -397,19 +397,20 @@ void ThermoMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
         GlobalExecutor::executeSelectedMemberOnDereferenced(
             &ThermoMechanicsLocalAssemblerInterface::preTimestep,
             _local_assemblers, pv.getActiveElementIDs(),
-            *_local_to_global_index_map, x, t, dt);
+            *_local_to_global_index_map, *x[process_id], t, dt);
         return;
     }
 
     // For the staggered scheme.
     if (!_previous_T)
     {
-        _previous_T = MathLib::MatrixVectorTraits<GlobalVector>::newInstance(x);
+        _previous_T = MathLib::MatrixVectorTraits<GlobalVector>::newInstance(
+            *x[process_id]);
     }
     else
     {
         auto& x0 = *_previous_T;
-        MathLib::LinAlg::copy(x, x0);
+        MathLib::LinAlg::copy(*x[process_id], x0);
     }
 
     auto& x0 = *_previous_T;
@@ -418,7 +419,7 @@ void ThermoMechanicsProcess<DisplacementDim>::preTimestepConcreteProcess(
 
 template <int DisplacementDim>
 void ThermoMechanicsProcess<DisplacementDim>::postTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt,
+    std::vector<GlobalVector*> const& x, double const t, double const dt,
     int const process_id)
 {
     if (process_id != _process_data.mechanics_process_id)
@@ -433,7 +434,7 @@ void ThermoMechanicsProcess<DisplacementDim>::postTimestepConcreteProcess(
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &ThermoMechanicsLocalAssemblerInterface::postTimestep,
         _local_assemblers, pv.getActiveElementIDs(),
-        *_local_to_global_index_map, x, t, dt);
+        *_local_to_global_index_map, *x[process_id], t, dt);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
@@ -78,12 +78,12 @@ private:
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, double const t,
-                                    double const dt,
+    void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                    double const t, double const dt,
                                     const int process_id) override;
 
-    void postTimestepConcreteProcess(GlobalVector const& x, const double t,
-                                     const double delta_t,
+    void postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                     const double t, const double delta_t,
                                      int const process_id) override;
 
     NumLib::LocalToGlobalIndexMap const& getDOFTable(

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -528,9 +528,8 @@ void preTimestepForAllProcesses(
     for (auto& process_data : per_process_data)
     {
         auto const process_id = process_data->process_id;
-        auto& x = *_process_solutions[process_id];
         auto& pcs = process_data->process;
-        pcs.preTimestep(x, t, dt, process_id);
+        pcs.preTimestep(_process_solutions, t, dt, process_id);
     }
 }
 
@@ -575,7 +574,7 @@ void postTimestepForAllProcesses(
             pcs.setCoupledSolutionsForStaggeredScheme(&coupled_solutions);
         }
         auto& x = *process_solutions[process_id];
-        pcs.postTimestep(x, t, dt, process_id);
+        pcs.postTimestep(process_solutions, t, dt, process_id);
         pcs.computeSecondaryVariable(t, x, process_id);
     }
 }
@@ -772,7 +771,7 @@ void TimeLoop::outputSolutions(bool const output_initial_condition,
 
         if (output_initial_condition)
         {
-            pcs.preTimestep(x, _start_time,
+            pcs.preTimestep(_process_solutions, _start_time,
                             process_data->timestepper->getTimeStep().dt(),
                             process_id);
             // Update secondary variables, which might be uninitialized, before

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
@@ -108,7 +108,7 @@ void TwoPhaseFlowWithPrhoProcess::assembleWithJacobianConcreteProcess(
         dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 void TwoPhaseFlowWithPrhoProcess::preTimestepConcreteProcess(
-    GlobalVector const& x, double const t, double const dt,
+    std::vector<GlobalVector*> const& x, double const t, double const dt,
     const int process_id)
 {
     DBUG("PreTimestep TwoPhaseFlowWithPrhoProcess.");
@@ -117,8 +117,8 @@ void TwoPhaseFlowWithPrhoProcess::preTimestepConcreteProcess(
 
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerInterface::preTimestep, _local_assemblers,
-        pv.getActiveElementIDs(), *_local_to_global_index_map, x, t,
-        dt);
+        pv.getActiveElementIDs(), *_local_to_global_index_map, *x[process_id],
+        t, dt);
 }
 
 }  // namespace TwoPhaseFlowWithPrho

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
@@ -68,8 +68,8 @@ private:
         int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
         GlobalMatrix& Jac) override;
 
-    void preTimestepConcreteProcess(GlobalVector const& x, const double t,
-                                    const double dt,
+    void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                    const double t, const double dt,
                                     const int process_id) override;
 
     TwoPhaseFlowWithPrhoProcessData _process_data;


### PR DESCRIPTION
`preTimestep` now accepts a vector of solution together with a `process_id`.
In `postTimestep` only the vector of solutions has been changed.
