### PR TITLE
Pass current solutions to BC's

### DIFF
--- a/ProcessLib/BoundaryCondition/BoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/BoundaryCondition.h
@@ -37,9 +37,10 @@ class BoundaryCondition
 public:
     //! Applies natural BCs (i.e. non-Dirichlet BCs) to the stiffness matrix
     //! \c K and the vector \c b.
-    virtual void applyNaturalBC(const double /*t*/, GlobalVector const& /*x*/,
-                                GlobalMatrix& /*K*/, GlobalVector& /*b*/,
-                                GlobalMatrix* /*Jac*/)
+    virtual void applyNaturalBC(const double /*t*/,
+                                std::vector<GlobalVector*> const& /*x*/,
+                                int const /*process_id*/, GlobalMatrix& /*K*/,
+                                GlobalVector& /*b*/, GlobalMatrix* /*Jac*/)
     {
         // By default it is assumed that the BC is not a natural BC. Therefore
         // there is nothing to do here.

--- a/ProcessLib/BoundaryCondition/BoundaryConditionCollection.cpp
+++ b/ProcessLib/BoundaryCondition/BoundaryConditionCollection.cpp
@@ -12,15 +12,13 @@
 
 namespace ProcessLib
 {
-void BoundaryConditionCollection::applyNaturalBC(const double t,
-                                                 GlobalVector const& x,
-                                                 GlobalMatrix& K,
-                                                 GlobalVector& b,
-                                                 GlobalMatrix* Jac)
+void BoundaryConditionCollection::applyNaturalBC(
+    const double t, std::vector<GlobalVector*> const& x, int const process_id,
+    GlobalMatrix& K, GlobalVector& b, GlobalMatrix* Jac)
 {
     for (auto const& bc : _boundary_conditions)
     {
-        bc->applyNaturalBC(t, x, K, b, Jac);
+        bc->applyNaturalBC(t, x, process_id, K, b, Jac);
     }
 }
 

--- a/ProcessLib/BoundaryCondition/BoundaryConditionCollection.h
+++ b/ProcessLib/BoundaryCondition/BoundaryConditionCollection.h
@@ -27,8 +27,9 @@ public:
     {
     }
 
-    void applyNaturalBC(const double t, GlobalVector const& x, GlobalMatrix& K,
-                        GlobalVector& b, GlobalMatrix* Jac);
+    void applyNaturalBC(const double t, std::vector<GlobalVector*> const& x,
+                        int const process_id, GlobalMatrix& K, GlobalVector& b,
+                        GlobalMatrix* Jac);
 
     std::vector<NumLib::IndexValueVector<GlobalIndexType>> const*
     getKnownSolutions(double const t, GlobalVector const& x) const

--- a/ProcessLib/BoundaryCondition/ConstraintDirichletBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/ConstraintDirichletBoundaryCondition.h
@@ -58,10 +58,10 @@ public:
         bool const lower,
         std::function<Eigen::Vector3d(std::size_t const,
                                       MathLib::Point3d const&, double const,
-                                      GlobalVector const&)>
+                                      std::vector<GlobalVector*> const&)>
             getFlux);
 
-    void preTimestep(double t, std::vector<GlobalVector*> const& x,
+    void preTimestep(double const t, std::vector<GlobalVector*> const& x,
                      int const process_id) override;
 
     void getEssentialBCValues(
@@ -113,9 +113,10 @@ private:
     MeshLib::Mesh const& _bulk_mesh;
 
     /// The function _getFlux calculates the flux through the boundary element.
-    std::function<Eigen::Vector3d(
-            std::size_t const, MathLib::Point3d const&, double const,
-            GlobalVector const&)> _getFlux;
+    std::function<Eigen::Vector3d(std::size_t const, MathLib::Point3d const&,
+                                  double const,
+                                  std::vector<GlobalVector*> const&)>
+        _getFlux;
 };
 
 /// The function parses the config tree and creates a

--- a/ProcessLib/BoundaryCondition/ConstraintDirichletBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/ConstraintDirichletBoundaryConditionLocalAssembler.h
@@ -50,10 +50,10 @@ public:
         default;
 
     virtual double integrate(
-        GlobalVector const& x, double const t,
-        std::function<Eigen::Vector3d(std::size_t const,
-                                      MathLib::Point3d const&, double const,
-                                      GlobalVector const&)> const& getFlux) = 0;
+        std::vector<GlobalVector*> const& x, double const t,
+        std::function<Eigen::Vector3d(
+            std::size_t const, MathLib::Point3d const&, double const,
+            std::vector<GlobalVector*> const&)> const& getFlux) = 0;
 };
 
 template <typename ShapeFunction, typename IntegrationMethod,
@@ -124,10 +124,10 @@ public:
     /// @param getFlux The function of the constraining process used to
     /// calculate the flux.
     double integrate(
-        GlobalVector const& x, double const t,
+        std::vector<GlobalVector*> const& x, double const t,
         std::function<Eigen::Vector3d(
             std::size_t const, MathLib::Point3d const&, double const,
-            GlobalVector const&)> const& getFlux) override
+            std::vector<GlobalVector*> const&)> const& getFlux) override
     {
         auto const n_integration_points =
             _integration_method.getNumberOfPoints();

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition-impl.h
@@ -80,17 +80,18 @@ GenericNaturalBoundaryCondition<BoundaryConditionData,
 template <typename BoundaryConditionData,
           template <typename, typename, unsigned>
           class LocalAssemblerImplementation>
-void GenericNaturalBoundaryCondition<
-    BoundaryConditionData,
-    LocalAssemblerImplementation>::applyNaturalBC(const double t,
-                                                  const GlobalVector& x,
-                                                  GlobalMatrix& K,
-                                                  GlobalVector& b,
-                                                  GlobalMatrix* Jac)
+void GenericNaturalBoundaryCondition<BoundaryConditionData,
+                                     LocalAssemblerImplementation>::
+    applyNaturalBC(const double t,
+                   std::vector<GlobalVector*> const& x,
+                   int const process_id,
+                   GlobalMatrix& K,
+                   GlobalVector& b,
+                   GlobalMatrix* Jac)
 {
     GlobalExecutor::executeMemberOnDereferenced(
         &GenericNaturalBoundaryConditionLocalAssemblerInterface::assemble,
-        _local_assemblers, *_dof_table_boundary, t, x, K, b, Jac);
+        _local_assemblers, *_dof_table_boundary, t, x, process_id, K, b, Jac);
 }
 
 }  // namespace ProcessLib

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryCondition.h
@@ -35,8 +35,9 @@ public:
 
     /// Calls local assemblers which calculate their contributions to the global
     /// matrix and the right-hand-side.
-    void applyNaturalBC(const double t, GlobalVector const& x, GlobalMatrix& K,
-                        GlobalVector& b, GlobalMatrix* Jac) override;
+    void applyNaturalBC(const double t, std::vector<GlobalVector*> const& x,
+                        int const process_id, GlobalMatrix& K, GlobalVector& b,
+                        GlobalMatrix* Jac) override;
 
 private:
     /// Data used in the assembly of the specific boundary condition.

--- a/ProcessLib/BoundaryCondition/GenericNaturalBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/GenericNaturalBoundaryConditionLocalAssembler.h
@@ -25,8 +25,8 @@ public:
     virtual void assemble(
         std::size_t const id,
         NumLib::LocalToGlobalIndexMap const& dof_table_boundary, double const t,
-        const GlobalVector& x, GlobalMatrix& K, GlobalVector& b,
-        GlobalMatrix* Jac) = 0;
+        std::vector<GlobalVector*> const& x, int const process_id,
+        GlobalMatrix& K, GlobalVector& b, GlobalMatrix* Jac) = 0;
 };
 
 template <typename ShapeFunction, typename IntegrationMethod,

--- a/ProcessLib/BoundaryCondition/HCNonAdvectiveFreeComponentFlowBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/HCNonAdvectiveFreeComponentFlowBoundaryConditionLocalAssembler.h
@@ -69,8 +69,9 @@ public:
 
     void assemble(std::size_t const mesh_item_id,
                   NumLib::LocalToGlobalIndexMap const& dof_table_boundary,
-                  double const t, const GlobalVector& x, GlobalMatrix& /*K*/,
-                  GlobalVector& b, GlobalMatrix* /*Jac*/) override
+                  double const t, std::vector<GlobalVector*> const& x,
+                  int const process_id, GlobalMatrix& /*K*/, GlobalVector& b,
+                  GlobalMatrix* /*Jac*/) override
     {
         NodalVectorType _local_rhs = NodalVectorType::Zero(_local_matrix_size);
         // Get element nodes for the interpolation from nodes to
@@ -83,7 +84,7 @@ public:
 
         auto const indices =
             NumLib::getIndices(mesh_item_id, dof_table_boundary);
-        std::vector<double> const local_values = x.get(indices);
+        std::vector<double> const local_values = x[process_id]->get(indices);
         std::size_t const bulk_element_id =
             _data.bulk_element_ids[Base::_element.getID()];
         std::size_t const bulk_face_id =

--- a/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/NeumannBoundaryConditionLocalAssembler.h
@@ -46,9 +46,9 @@ public:
 
     void assemble(std::size_t const id,
                   NumLib::LocalToGlobalIndexMap const& dof_table_boundary,
-                  double const t, const GlobalVector& /*x*/,
-                  GlobalMatrix& /*K*/, GlobalVector& b,
-                  GlobalMatrix* /*Jac*/) override
+                  double const t, std::vector<GlobalVector*> const& /*x*/,
+                  int const /*process_id*/, GlobalMatrix& /*K*/,
+                  GlobalVector& b, GlobalMatrix* /*Jac*/) override
     {
         _local_rhs.setZero();
 

--- a/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition-impl.h
+++ b/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition-impl.h
@@ -61,12 +61,10 @@ NormalTractionBoundaryCondition<LocalAssemblerImplementation>::
 
 template <template <typename, typename, unsigned>
           class LocalAssemblerImplementation>
-void NormalTractionBoundaryCondition<
-    LocalAssemblerImplementation>::applyNaturalBC(const double t,
-                                                  const GlobalVector& x,
-                                                  GlobalMatrix& K,
-                                                  GlobalVector& b,
-                                                  GlobalMatrix* Jac)
+void NormalTractionBoundaryCondition<LocalAssemblerImplementation>::
+    applyNaturalBC(const double t, std::vector<GlobalVector*> const& x,
+                   int const /*process_id*/, GlobalMatrix& K, GlobalVector& b,
+                   GlobalMatrix* Jac)
 {
     GlobalExecutor::executeMemberOnDereferenced(
         &NormalTractionBoundaryConditionLocalAssemblerInterface::assemble,

--- a/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/NormalTractionBoundaryCondition.h
@@ -44,8 +44,9 @@ public:
 
     /// Calls local assemblers which calculate their contributions to the global
     /// matrix and the right-hand-side.
-    void applyNaturalBC(const double t, GlobalVector const& x, GlobalMatrix& K,
-                        GlobalVector& b, GlobalMatrix* Jac) override;
+    void applyNaturalBC(const double t, std::vector<GlobalVector*> const& x,
+                        int const process_id, GlobalMatrix& K, GlobalVector& b,
+                        GlobalMatrix* Jac) override;
 
 private:
     MeshLib::Mesh const& _bc_mesh;

--- a/ProcessLib/BoundaryCondition/NormalTractionBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/NormalTractionBoundaryConditionLocalAssembler.h
@@ -43,8 +43,8 @@ public:
     virtual void assemble(
         std::size_t const id,
         NumLib::LocalToGlobalIndexMap const& dof_table_boundary, double const t,
-        const GlobalVector& /*x*/, GlobalMatrix& /*K*/, GlobalVector& b,
-        GlobalMatrix* /*Jac*/) = 0;
+        std::vector<GlobalVector*> const& /*x*/, GlobalMatrix& /*K*/,
+        GlobalVector& b, GlobalMatrix* /*Jac*/) = 0;
     virtual ~NormalTractionBoundaryConditionLocalAssemblerInterface() = default;
 };
 
@@ -115,7 +115,7 @@ public:
 
     void assemble(std::size_t const id,
                   NumLib::LocalToGlobalIndexMap const& dof_table_boundary,
-                  double const t, const GlobalVector& /*x*/,
+                  double const t, std::vector<GlobalVector*> const& /*x*/,
                   GlobalMatrix& /*K*/, GlobalVector& local_rhs,
                   GlobalMatrix* /*Jac*/) override
     {

--- a/ProcessLib/BoundaryCondition/Python/PythonBoundaryCondition.cpp
+++ b/ProcessLib/BoundaryCondition/Python/PythonBoundaryCondition.cpp
@@ -179,10 +179,9 @@ void PythonBoundaryCondition::getEssentialBCValues(
     }
 }
 
-void PythonBoundaryCondition::applyNaturalBC(const double t,
-                                             const GlobalVector& x,
-                                             GlobalMatrix& K, GlobalVector& b,
-                                             GlobalMatrix* Jac)
+void PythonBoundaryCondition::applyNaturalBC(
+    const double t, std::vector<GlobalVector*> const& x, int const process_id,
+    GlobalMatrix& K, GlobalVector& b, GlobalMatrix* Jac)
 {
     FlushStdoutGuard guard(_flush_stdout);
 
@@ -190,7 +189,8 @@ void PythonBoundaryCondition::applyNaturalBC(const double t,
     {
         GlobalExecutor::executeMemberOnDereferenced(
             &GenericNaturalBoundaryConditionLocalAssemblerInterface::assemble,
-            _local_assemblers, *_dof_table_boundary, t, x, K, b, Jac);
+            _local_assemblers, *_dof_table_boundary, t, x, process_id, K, b,
+            Jac);
     }
     catch (MethodNotOverriddenInDerivedClassException const& /*e*/)
     {

--- a/ProcessLib/BoundaryCondition/Python/PythonBoundaryCondition.h
+++ b/ProcessLib/BoundaryCondition/Python/PythonBoundaryCondition.h
@@ -54,8 +54,9 @@ public:
         const double t, const GlobalVector& x,
         NumLib::IndexValueVector<GlobalIndexType>& bc_values) const override;
 
-    void applyNaturalBC(const double t, const GlobalVector& x, GlobalMatrix& K,
-                        GlobalVector& b, GlobalMatrix* Jac) override;
+    void applyNaturalBC(const double t, std::vector<GlobalVector*> const& x,
+                        int const process_id, GlobalMatrix& K, GlobalVector& b,
+                        GlobalMatrix* Jac) override;
 
 private:
     //! Auxiliary data.

--- a/ProcessLib/BoundaryCondition/Python/PythonBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/Python/PythonBoundaryConditionLocalAssembler.h
@@ -48,8 +48,9 @@ public:
 
     void assemble(std::size_t const boundary_element_id,
                   NumLib::LocalToGlobalIndexMap const& dof_table_boundary,
-                  double const t, const GlobalVector& x, GlobalMatrix& /*K*/,
-                  GlobalVector& b, GlobalMatrix* Jac) override
+                  double const t, std::vector<GlobalVector*> const& x,
+                  int const process_id, GlobalMatrix& /*K*/, GlobalVector& b,
+                  GlobalMatrix* Jac) override
     {
         using ShapeMatricesType =
             ShapeMatrixPolicyType<ShapeFunction, GlobalDim>;
@@ -104,7 +105,7 @@ public:
                             bulk_node_id, var, comp);
                     }
                     primary_variables_mat(element_node_id, global_component) =
-                        x[dof_idx];
+                        (*x[process_id])[dof_idx];
                 }
             }
         }

--- a/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/RobinBoundaryConditionLocalAssembler.h
@@ -47,8 +47,9 @@ public:
     // TODO also implement derivative for Jacobian in Newton scheme.
     void assemble(std::size_t const id,
                   NumLib::LocalToGlobalIndexMap const& dof_table_boundary,
-                  double const t, const GlobalVector& /*x*/, GlobalMatrix& K,
-                  GlobalVector& b, GlobalMatrix* /*Jac*/) override
+                  double const t, std::vector<GlobalVector*> const& /*x*/,
+                  int const /*process_id*/, GlobalMatrix& K, GlobalVector& b,
+                  GlobalMatrix* /*Jac*/) override
     {
         _local_K.setZero();
         _local_rhs.setZero();

--- a/ProcessLib/BoundaryCondition/VariableDependentNeumannBoundaryConditionLocalAssembler.h
+++ b/ProcessLib/BoundaryCondition/VariableDependentNeumannBoundaryConditionLocalAssembler.h
@@ -57,8 +57,9 @@ public:
 
     void assemble(std::size_t const mesh_item_id,
                   NumLib::LocalToGlobalIndexMap const& dof_table_boundary,
-                  double const t, const GlobalVector& x, GlobalMatrix& /*K*/,
-                  GlobalVector& b, GlobalMatrix* /*Jac*/) override
+                  double const t, std::vector<GlobalVector*> const& x,
+                  int const process_id, GlobalMatrix& /*K*/, GlobalVector& b,
+                  GlobalMatrix* /*Jac*/) override
     {
         NodalVectorType _local_rhs(_local_matrix_size);
         _local_rhs.setZero();
@@ -87,9 +88,9 @@ public:
         auto const indices_other_variable = NumLib::getIndices(
             mesh_item_id, _data.dof_table_boundary_other_variable);
         std::vector<double> const local_current_variable =
-            x.get(indices_current_variable);
+            x[process_id]->get(indices_current_variable);
         std::vector<double> const local_other_variable =
-            x.get(indices_other_variable);
+            x[process_id]->get(indices_other_variable);
 
         for (unsigned ip = 0; ip < n_integration_points; ip++)
         {

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.h
@@ -115,7 +115,7 @@ public:
 
     Eigen::Vector3d getFlux(std::size_t const element_id,
                             MathLib::Point3d const& p, double const t,
-                            GlobalVector const& x) const override;
+                            std::vector<GlobalVector*> const& x) const override;
 
     std::vector<std::pair<int, std::string>> const&
     getProcessIDToComponentNameMap() const

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -50,13 +50,13 @@ public:
     Eigen::Vector3d getFlux(std::size_t element_id,
                             MathLib::Point3d const& p,
                             double const t,
-                            GlobalVector const& x) const override
+                            std::vector<GlobalVector*> const& x) const override
     {
         // fetch local_x from primary variable
         std::vector<GlobalIndexType> indices_cache;
         auto const r_c_indices = NumLib::getRowColumnIndices(
             element_id, *_local_to_global_index_map, indices_cache);
-        std::vector<double> local_x(x.get(r_c_indices.rows));
+        std::vector<double> local_x(x[0]->get(r_c_indices.rows));
 
         return _local_assemblers[element_id]->getFlux(p, t, local_x);
     }
@@ -79,9 +79,8 @@ public:
 
         ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
-        _surfaceflux->integrate(*x[process_id], t, *this, process_id,
-                                _integration_order, _mesh,
-                                pv.getActiveElementIDs());
+        _surfaceflux->integrate(x, t, *this, process_id, _integration_order,
+                                _mesh, pv.getActiveElementIDs());
         _surfaceflux->save(t);
     }
 

--- a/ProcessLib/HT/HTProcess.h
+++ b/ProcessLib/HT/HTProcess.h
@@ -76,7 +76,7 @@ public:
     Eigen::Vector3d getFlux(std::size_t element_id,
                             MathLib::Point3d const& p,
                             double const t,
-                            GlobalVector const& x) const override;
+                            std::vector<GlobalVector*> const& x) const override;
 
     void setCoupledTermForTheStaggeredSchemeToLocalAssemblers(
         int const process_id) override;

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -205,7 +205,7 @@ void Process::assemble(const double t, double const dt,
     assembleConcreteProcess(t, dt, x, process_id, M, K, b);
 
     // the last argument is for the jacobian, nullptr is for a unused jacobian
-    _boundary_conditions[process_id].applyNaturalBC(t, *x[process_id], K, b,
+    _boundary_conditions[process_id].applyNaturalBC(t, x, process_id, K, b,
                                                     nullptr);
 
     // the last argument is for the jacobian, nullptr is for a unused jacobian
@@ -228,7 +228,7 @@ void Process::assembleWithJacobian(const double t, double const dt,
                                         process_id, M, K, b, Jac);
 
     // TODO: apply BCs to Jacobian.
-    _boundary_conditions[process_id].applyNaturalBC(t, *x[process_id], K, b,
+    _boundary_conditions[process_id].applyNaturalBC(t, x, process_id, K, b,
                                                     &Jac);
 
     // the last argument is for the jacobian, nullptr is for a unused jacobian

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -146,10 +146,11 @@ public:
 
     // Used as a call back for CalculateSurfaceFlux process.
 
-    virtual Eigen::Vector3d getFlux(std::size_t /*element_id*/,
-                                    MathLib::Point3d const& /*p*/,
-                                    double const /*t*/,
-                                    GlobalVector const& /*x*/) const
+    virtual Eigen::Vector3d getFlux(
+        std::size_t /*element_id*/,
+        MathLib::Point3d const& /*p*/,
+        double const /*t*/,
+        std::vector<GlobalVector*> const& /*x*/) const
     {
         return Eigen::Vector3d{};
     }

--- a/ProcessLib/SurfaceFlux/SurfaceFlux.cpp
+++ b/ProcessLib/SurfaceFlux/SurfaceFlux.cpp
@@ -54,14 +54,14 @@ SurfaceFlux::SurfaceFlux(
 }
 
 void SurfaceFlux::integrate(
-    GlobalVector const& x,
+    std::vector<GlobalVector*> const& x,
     MeshLib::PropertyVector<double>& balance,
     double const t,
     MeshLib::Mesh const& bulk_mesh,
     std::vector<std::size_t> const& active_element_ids,
-    std::function<Eigen::Vector3d(std::size_t const, MathLib::Point3d const&,
-                                  double const, GlobalVector const&)> const&
-        getFlux)
+    std::function<Eigen::Vector3d(
+        std::size_t const, MathLib::Point3d const&, double const,
+        std::vector<GlobalVector*> const&)> const& getFlux)
 {
     DBUG("Integrate SurfaceFlux.");
 

--- a/ProcessLib/SurfaceFlux/SurfaceFlux.h
+++ b/ProcessLib/SurfaceFlux/SurfaceFlux.h
@@ -40,14 +40,14 @@ public:
     /// @param getFlux function that calculates the flux in the integration
     /// points of the face elements of the bulk element that belongs to the
     /// surface.
-    void integrate(GlobalVector const& x,
+    void integrate(std::vector<GlobalVector*> const& x,
                    MeshLib::PropertyVector<double>& balance,
                    double const t,
                    MeshLib::Mesh const& bulk_mesh,
                    std::vector<std::size_t> const& active_element_ids,
                    std::function<Eigen::Vector3d(
                        std::size_t const, MathLib::Point3d const&, double const,
-                       GlobalVector const&)> const& getFlux);
+                       std::vector<GlobalVector*> const&)> const& getFlux);
 
 private:
     // the local assemblers for each element of the mesh

--- a/ProcessLib/SurfaceFlux/SurfaceFluxData.h
+++ b/ProcessLib/SurfaceFlux/SurfaceFluxData.h
@@ -76,9 +76,9 @@ struct SurfaceFluxData
             std::move(surfaceflux_out_fname));
     }
 
-    void integrate(GlobalVector const& x, double const t, Process const& p,
-                   int const process_id, int const integration_order,
-                   MeshLib::Mesh const& bulk_mesh,
+    void integrate(std::vector<GlobalVector*> const& x, double const t,
+                   Process const& p, int const process_id,
+                   int const integration_order, MeshLib::Mesh const& bulk_mesh,
                    std::vector<std::size_t> const& active_element_ids)
     {
         auto* const surfaceflux_pv = MeshLib::getOrCreateMeshProperty<double>(
@@ -93,7 +93,7 @@ struct SurfaceFluxData
         surfaceflux_process.integrate(
             x, *surfaceflux_pv, t, bulk_mesh, active_element_ids,
             [&p](std::size_t const element_id, MathLib::Point3d const& pnt,
-                 double const t, GlobalVector const& x) {
+                 double const t, std::vector<GlobalVector*> const& x) {
                 return p.getFlux(element_id, pnt, t, x);
             });
     }

--- a/ProcessLib/SurfaceFlux/SurfaceFluxLocalAssembler.h
+++ b/ProcessLib/SurfaceFlux/SurfaceFluxLocalAssembler.h
@@ -29,14 +29,15 @@ class SurfaceFluxLocalAssemblerInterface
 public:
     virtual ~SurfaceFluxLocalAssemblerInterface() = default;
 
-    virtual void integrate(std::size_t const element_id,
-                           GlobalVector const& x,
-                           MeshLib::PropertyVector<double>& specific_flux,
-                           double const t,
-                           MeshLib::Mesh const& bulk_mesh,
-                           std::function<Eigen::Vector3d(
-                               std::size_t const, MathLib::Point3d const&,
-                               double const, GlobalVector const&)>) = 0;
+    virtual void integrate(
+        std::size_t const element_id,
+        std::vector<GlobalVector*> const& x,
+        MeshLib::PropertyVector<double>& specific_flux,
+        double const t,
+        MeshLib::Mesh const& bulk_mesh,
+        std::function<Eigen::Vector3d(std::size_t const,
+                                      MathLib::Point3d const&, double const,
+                                      std::vector<GlobalVector*> const&)>) = 0;
 };
 
 template <typename ShapeFunction, typename IntegrationMethod,
@@ -110,13 +111,13 @@ public:
     /// points of the face elements of the bulk element that belongs to the
     /// surface.
     void integrate(std::size_t const element_id,
-                   GlobalVector const& x,
+                   std::vector<GlobalVector*> const& x,
                    MeshLib::PropertyVector<double>& specific_flux,
                    double const t,
                    MeshLib::Mesh const& bulk_mesh,
                    std::function<Eigen::Vector3d(
                        std::size_t const, MathLib::Point3d const&, double const,
-                       GlobalVector const&)>
+                       std::vector<GlobalVector*> const&)>
                        getFlux) override
     {
         auto surface_element_normal =


### PR DESCRIPTION
Main reason for modification is the getFlux function, which for
particular processes (ComponentTransport) relies on all solutions being
available.
This modification ripples through all of the code, especially through
the boundary conditions.
Modified `applyNaturalBC`, ~`preTimestep`~, `integrate`, and `assemble`
functions.
The `preTimestep` is now decoupled from the secondary vars/BCs since #2697 