### PR TITLE
Correct Lubby2 equations in the pdf file in web content folder

### DIFF
--- a/web/content/docs/benchmarks/small-deformations/lubby2.pdf
+++ b/web/content/docs/benchmarks/small-deformations/lubby2.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4331d46503547ac35d6ded78a4e66a7117fc6f5653db807cb543f18bf5c89b09
-size 198023
+oid sha256:a2af2689afad0b9b890514e7e6266f2c186da8f45cf366c4130a30e05b28a418
+size 198025

--- a/web/content/docs/benchmarks/small-deformations/lubby2.pdf
+++ b/web/content/docs/benchmarks/small-deformations/lubby2.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a463af14824fb14018cd53b3b01664ab34288c53a46cd50fb22fb73eeabf66cd
-size 198168
+oid sha256:4331d46503547ac35d6ded78a4e66a7117fc6f5653db807cb543f18bf5c89b09
+size 198023


### PR DESCRIPTION
Correct Lubby2 eq 6, eq8 and eq 9:

1. [ ] Eq6: switch the \eta_M and G_M
2. [ ] Eq9: add an identity tensor symbol
