### PR TITLE
Fix bug in groundwater advection feature of HeatTransportBHE process

### DIFF
--- a/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerSoil-impl.h
+++ b/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerSoil-impl.h
@@ -139,7 +139,7 @@ void HeatTransportBHELocalAssemblerSoil<ShapeFunction, IntegrationMethod>::
                 .property(MaterialPropertyLib::PropertyType::phase_velocity)
                 .value(vars, pos, t);
         auto const velocity = Eigen::Map<Eigen::Vector3d const>(
-            std::get<MaterialPropertyLib::Vector>(velocity_arr).data(), 1, 3);
+            std::get<MaterialPropertyLib::Vector>(velocity_arr).data());
 
         // calculate the hydrodynamic thermodispersion tensor
         auto const thermal_conductivity =


### PR DESCRIPTION
In the original PR#2711, when running in debug mode, there will be assertion failures since Eigen::Map performs an internal check of the row and cols. Now they are corrected as the same with Vector3d.