### PR TITLE
Improve error message in MeshNodeSearcher

### DIFF
--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -11,6 +11,7 @@
 #include "MeshNodeSearcher.h"
 
 #include <typeinfo>
+#include <sstream>
 
 #include "HeuristicSearchLength.h"
 #include "MeshNodesAlongPolyline.h"
@@ -109,12 +110,21 @@ std::vector<std::size_t> MeshNodeSearcher::getMeshNodeIDs(
         }
         if (ids.size() != 1)
         {
+            std::stringstream ss;
+            auto const& bulk_nodes = _mesh.getNodes();
+            for (auto const id : ids)
+            {
+                ss << "- bulk node: " << (*bulk_nodes[id]) << ", distance: "
+                   << std::sqrt(MathLib::sqrDist(bulk_nodes[id]->getCoords(),
+                                                 p.getCoords()))
+                   << "\n";
+            }
             OGS_FATAL(
                 "Found %d nodes in the mesh for point %d : (%g, %g, %g) in %g "
                 "epsilon radius in the mesh '%s'. Expected to find exactly one "
-                "node.",
+                "node.\n%s",
                 ids.size(), p.getID(), p[0], p[1], p[2], epsilon_radius,
-                _mesh.getName().c_str());
+                _mesh.getName().c_str(), ss.str().c_str());
         }
         node_ids.push_back(ids.front());
     }

--- a/MeshGeoToolsLib/MeshNodeSearcher.cpp
+++ b/MeshGeoToolsLib/MeshNodeSearcher.cpp
@@ -238,9 +238,4 @@ MeshNodeSearcher const& MeshNodeSearcher::getMeshNodeSearcher(
     return *_mesh_node_searchers[mesh_id];
 }
 
-std::size_t MeshNodeSearcher::getMeshId() const
-{
-    return _mesh.getID();
-}
-
 }  // end namespace MeshGeoToolsLib

--- a/MeshGeoToolsLib/MeshNodeSearcher.h
+++ b/MeshGeoToolsLib/MeshNodeSearcher.h
@@ -141,11 +141,6 @@ public:
         GeoLib::Surface const& sfc) const;
 
     /**
-     * Get the mesh this searcher operates on.
-     */
-    std::size_t getMeshId() const;
-
-    /**
      * Returns a (possibly new) mesh node searcher for the mesh.
      * A new one will be created, if it does not already exists.
      */


### PR DESCRIPTION
It is expected that exactly one MeshLib::Node has to be found. In the case more than one MeshLib::Node is found, the coordinates and the distances of the corresponding nodes  are written as output.