### PR TITLE
[PL/ST/Python] bulk dof table and bulk mesh id passed

### DIFF
--- a/ProcessLib/SourceTerms/CreateSourceTerm.cpp
+++ b/ProcessLib/SourceTerms/CreateSourceTerm.cpp
@@ -113,9 +113,12 @@ std::unique_ptr<SourceTerm> createSourceTerm(
 
         return ProcessLib::createPythonSourceTerm(
             config.config, config.mesh, std::move(dof_table_source_term),
-            source_term_mesh.getID(), variable_id, *config.component_id,
-            integration_order, shapefunction_order,
-            source_term_mesh.getDimension());
+            dof_table_bulk,
+            dof_table_bulk.getMeshSubset(variable_id, *config.component_id)
+                .getMesh()
+                .getID(),
+            variable_id, *config.component_id, integration_order,
+            shapefunction_order, source_term_mesh.getDimension());
 #else
         OGS_FATAL("OpenGeoSys has not been built with Python support.");
 #endif

--- a/ProcessLib/SourceTerms/Python/CreatePythonSourceTerm.cpp
+++ b/ProcessLib/SourceTerms/Python/CreatePythonSourceTerm.cpp
@@ -22,7 +22,8 @@ namespace ProcessLib
 {
 std::unique_ptr<SourceTerm> createPythonSourceTerm(
     BaseLib::ConfigTree const& config, MeshLib::Mesh const& source_term_mesh,
-    std::unique_ptr<NumLib::LocalToGlobalIndexMap> dof_table,
+    std::unique_ptr<NumLib::LocalToGlobalIndexMap> source_dof_table,
+    const NumLib::LocalToGlobalIndexMap& bulk_dof_table,
     std::size_t const bulk_mesh_id, int const variable_id,
     int const component_id, unsigned const integration_order,
     unsigned const shapefunction_order, unsigned const global_dim)
@@ -69,11 +70,12 @@ std::unique_ptr<SourceTerm> createPythonSourceTerm(
 #endif  // USE_PETSC
 
     auto const global_component_id =
-        dof_table->getGlobalComponent(variable_id, component_id);
+        source_dof_table->getGlobalComponent(variable_id, component_id);
     return std::make_unique<ProcessLib::SourceTerms::Python::PythonSourceTerm>(
-        std::move(dof_table),
+        std::move(source_dof_table),
         ProcessLib::SourceTerms::Python::PythonSourceTermData{
-            source_term, bulk_mesh_id, global_component_id, source_term_mesh},
+            bulk_dof_table, source_term, bulk_mesh_id, global_component_id,
+            source_term_mesh},
         integration_order, shapefunction_order, global_dim, flush_stdout);
 }
 

--- a/ProcessLib/SourceTerms/Python/CreatePythonSourceTerm.h
+++ b/ProcessLib/SourceTerms/Python/CreatePythonSourceTerm.h
@@ -31,7 +31,8 @@ class SourceTerm;
 
 std::unique_ptr<SourceTerm> createPythonSourceTerm(
     BaseLib::ConfigTree const& config, MeshLib::Mesh const& source_term_mesh,
-    std::unique_ptr<NumLib::LocalToGlobalIndexMap> dof_table,
+    std::unique_ptr<NumLib::LocalToGlobalIndexMap> source_dof_table,
+    const NumLib::LocalToGlobalIndexMap& bulk_dof_table,
     std::size_t const bulk_mesh_id, int const variable_id,
     int const component_id, unsigned const integration_order,
     unsigned const shapefunction_order, unsigned const global_dim);

--- a/ProcessLib/SourceTerms/Python/PythonSourceTerm.h
+++ b/ProcessLib/SourceTerms/Python/PythonSourceTerm.h
@@ -28,6 +28,8 @@ namespace Python
 //! Groups data used by source terms, in particular by the local assemblers.
 struct PythonSourceTermData final
 {
+    //! DOF table of the entire domain.
+    NumLib::LocalToGlobalIndexMap const& dof_table_bulk;
     //! Python object computing source term values.
     PythonSourceTermPythonSideInterface* source_term_object;
 

--- a/ProcessLib/SourceTerms/Python/PythonSourceTermLocalAssembler.h
+++ b/ProcessLib/SourceTerms/Python/PythonSourceTermLocalAssembler.h
@@ -131,7 +131,7 @@ public:
                                           MeshLib::MeshItemType::Node,
                                           bulk_node_id};
                     auto const dof_idx =
-                        dof_table_source_term.getGlobalIndex(loc, var, comp);
+                        _data.dof_table_bulk.getGlobalIndex(loc, var, comp);
                     if (dof_idx == NumLib::MeshComponentMap::nop)
                     {
                         // TODO extend Python BC to mixed FEM ansatz functions


### PR DESCRIPTION
Before this fix, python source terms were only applicable, if the bulk mesh and the source mesh were of identical. To find the correct dof_idx, a location with the bulk_mesh_id seems to need to be passed to the bulk_dof_table.
