### PR TITLE
Matched non-associated tension cut-off in MCAS.

### DIFF
--- a/MaterialLib/SolidModels/MFront/MohrCoulombAbboSloan.mfront
+++ b/MaterialLib/SolidModels/MFront/MohrCoulombAbboSloan.mfront
@@ -185,7 +185,7 @@ a.setEntryName("TensionCutOffParameter");
         const auto dev_s_squared = computeJ3Derivative(
             sig);  // replaces dev_s_squared = deviator(square(s));
         const auto dG_dI1 = sin_psi / 3.;
-        const auto root = max(sqrt(J2 * KG * KG + a * a * sin_psi * sin_psi),
+        const auto root = max(sqrt(J2 * KG * KG + a * a * tan(phi) * tan(phi) * cos(psi) * cos(psi)),
                               local_zero_tolerance);
         const auto dG_dJ2 = KG / (2. * root) * (KG - tan_3_lode * dKG_dlode);
         const auto dG_dJ3 = J2 * KG * tan_3_lode / (3. * J3 * root) * dKG_dlode;

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/load_test_mc.prj
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/load_test_mc.prj
@@ -346,7 +346,7 @@
             <file>load_test_mc_pcs_0_ts_40_t_40.000000.vtu</file>
             <field>sigma</field>
             <absolute_tolerance>1e-12</absolute_tolerance>
-            <relative_tolerance>1e-12</relative_tolerance>
+            <relative_tolerance>1e-11</relative_tolerance>
         </vtkdiff>
         <vtkdiff>
             <file>load_test_mc_pcs_0_ts_40_t_40.000000.vtu</file>

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/load_test_mc.prj
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/load_test_mc.prj
@@ -345,7 +345,7 @@
         <vtkdiff>
             <file>load_test_mc_pcs_0_ts_40_t_40.000000.vtu</file>
             <field>sigma</field>
-            <absolute_tolerance>1e-12</absolute_tolerance>
+            <absolute_tolerance>1e-11</absolute_tolerance>
             <relative_tolerance>1e-11</relative_tolerance>
         </vtkdiff>
         <vtkdiff>


### PR DESCRIPTION
Minor change in the Mohr-Coulomb Abbo-Sloan model for non-associated flow with apex smoothing.