### PR TITLE
Biot effect LIE/HM

### DIFF
--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -356,9 +356,12 @@ void HydroMechanicsProcess<GlobalDim>::initializeConcreteProcess(
             {
                 continue;
             }
-            ParameterLib::SpatialPosition x;
-            x.setElementID(e->getID());
-            (*mesh_prop_b)[e->getID()] = frac->aperture0(0, x)[0];
+            // Mean value for the element. This allows usage of node based
+            // properties for aperture.
+            (*mesh_prop_b)[e->getID()] =
+                frac->aperture0
+                    .getNodalValuesOnElement(*e, /*time independent*/ 0)
+                    .mean();
         }
         _process_data.mesh_prop_b = mesh_prop_b;
 

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
@@ -249,16 +249,14 @@ void HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
         rhs_u.noalias() -= -H_u.transpose() * rho * gravity_vec * ip_w;
 
         //
-        // displacement equation, pressure part
-        //
-        Kup.noalias() += B.transpose() * alpha * identity2 * N_p * ip_w;
-
-        //
-        // pressure equation, pressure part.
+        // pressure equation, pressure part and displacement equation, pressure
+        // part
         //
         if (!_process_data.deactivate_matrix_in_flow)  // Only for hydraulically
                                                        // active matrix
         {
+            Kup.noalias() += B.transpose() * alpha * identity2 * N_p * ip_w;
+
             double const k_over_mu =
                 _process_data.intrinsic_permeability(t, x_position)[0] /
                 _process_data.fluid_viscosity(t, x_position)[0];

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerMatrix-impl.h
@@ -79,6 +79,7 @@ HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
         ip_data.integration_weight =
             sm_u.detJ * sm_u.integralMeasure *
             integration_method.getWeightedPoint(ip).getWeight();
+        ip_data.darcy_velocity.setZero();
 
         ip_data.N_u = sm_u.N;
         ip_data.dNdx_u = sm_u.dNdx;
@@ -218,8 +219,6 @@ void HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
         auto& eps = ip_data.eps;
         auto& state = ip_data.material_state_variables;
 
-        auto q = ip_data.darcy_velocity.head(GlobalDim);
-
         auto const alpha = _process_data.biot_coefficient(t, x_position)[0];
         auto const rho_sr = _process_data.solid_density(t, x_position)[0];
         auto const rho_fr = _process_data.fluid_density(t, x_position)[0];
@@ -262,6 +261,7 @@ void HydroMechanicsLocalAssemblerMatrix<ShapeFunctionDisplacement,
                 _process_data.fluid_viscosity(t, x_position)[0];
             double const S = _process_data.specific_storage(t, x_position)[0];
 
+            auto q = ip_data.darcy_velocity.head(GlobalDim);
             q.noalias() = -k_over_mu * (dNdx_p * p + rho_fr * gravity_vec);
 
             laplace_p.noalias() +=

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -496,9 +496,12 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
             {
                 continue;
             }
-            ParameterLib::SpatialPosition x;
-            x.setElementID(e->getID());
-            (*mesh_prop_b)[e->getID()] = fracture_prop.aperture0(0, x)[0];
+            // Mean value for the element. This allows usage of node based
+            // properties for aperture.
+            (*mesh_prop_b)[e->getID()] =
+                fracture_prop.aperture0
+                    .getNodalValuesOnElement(*e, /*time independent*/ 0)
+                    .mean();
         }
     }
     _process_data._mesh_prop_b = mesh_prop_b;

--- a/Tests/Data/LIE/HydroMechanics/expected_single_fracture_3compartments_flow_linear_aperture0_e_pcs_0_ts_1108_t_10000.000000.vtu
+++ b/Tests/Data/LIE/HydroMechanics/expected_single_fracture_3compartments_flow_linear_aperture0_e_pcs_0_ts_1108_t_10000.000000.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc9671fd9fd91f1898a38f230786b605e5cc73130cfb2d505775235c3687d996
-size 19625
+oid sha256:59ee1b647ac10bed7fb3ca7e09fe4b39405dbe45b3b64a8f5b6f04a4c2cba1c1
+size 21046

--- a/Tests/Data/LIE/HydroMechanics/expected_single_fracture_3compartments_flow_linear_aperture0_pcs_0_ts_1108_t_10000.000000.vtu
+++ b/Tests/Data/LIE/HydroMechanics/expected_single_fracture_3compartments_flow_linear_aperture0_pcs_0_ts_1108_t_10000.000000.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:796baa6991d7962e97f9a3ea7cf1d7ca72fe57cdf9ae3d27f10bc584887fd0f5
-size 19901
+oid sha256:c28583089f38f3a322d7d843a7bc8af5e7cc3b75870ccc4f768de902ea1acfd7
+size 21366

--- a/Tests/Data/LIE/HydroMechanics/expected_single_fracture_3compartments_flow_pcs_0_ts_1108_t_10000.000000.vtu
+++ b/Tests/Data/LIE/HydroMechanics/expected_single_fracture_3compartments_flow_pcs_0_ts_1108_t_10000.000000.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b44389299aa15cb656430ed1659ab6f0c69ff5670304221d8c8b9cbe37f9f5b8
-size 19568
+oid sha256:d1684d63a96c0727fb28adbea99616ebe80b10e7aa13769c0eb5281e83acc9ce
+size 20734

--- a/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow.prj
+++ b/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow.prj
@@ -267,9 +267,9 @@
                 <boundary_condition>
                     <geometrical_set>single_fracture</geometrical_set>
                     <geometry>PLY_EAST</geometry>
-                    <type>Neumann</type>
+                    <type>Dirichlet</type>
                     <component>0</component>
-                    <parameter>p_in</parameter>
+                    <parameter>zero_u</parameter>
                 </boundary_condition>
                 <boundary_condition>
                     <geometrical_set>single_fracture</geometrical_set>
@@ -286,6 +286,13 @@
             <order>2</order>
             <initial_condition>displacement0</initial_condition>
             <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>single_fracture</geometrical_set>
+                    <geometry>OutletPoint</geometry>
+                    <type>Dirichlet</type>
+                    <component>0</component>
+                    <parameter>zero_u</parameter>
+                </boundary_condition>
             </boundary_conditions>
         </process_variable>
     </process_variables>

--- a/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow.prj
+++ b/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow.prj
@@ -35,7 +35,7 @@
                 <tension_cutoff>1</tension_cutoff>
             </fracture_model>
             <fracture_properties>
-                <material_id>0</material_id>
+                <material_id>1</material_id>
                 <initial_aperture>aperture0</initial_aperture>
                 <specific_storage>S_f</specific_storage>
                 <biot_coefficient>biot_f</biot_coefficient>

--- a/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow_linear_aperture0.prj
+++ b/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow_linear_aperture0.prj
@@ -267,9 +267,9 @@
                 <boundary_condition>
                     <geometrical_set>single_fracture</geometrical_set>
                     <geometry>PLY_EAST</geometry>
-                    <type>Neumann</type>
+                    <type>Dirichlet</type>
                     <component>0</component>
-                    <parameter>p_in</parameter>
+                    <parameter>zero_u</parameter>
                 </boundary_condition>
                 <boundary_condition>
                     <geometrical_set>single_fracture</geometrical_set>
@@ -286,6 +286,13 @@
             <order>2</order>
             <initial_condition>displacement0</initial_condition>
             <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>single_fracture</geometrical_set>
+                    <geometry>OutletPoint</geometry>
+                    <type>Dirichlet</type>
+                    <component>0</component>
+                    <parameter>zero_u</parameter>
+                </boundary_condition>
             </boundary_conditions>
         </process_variable>
     </process_variables>

--- a/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow_linear_aperture0.prj
+++ b/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow_linear_aperture0.prj
@@ -35,7 +35,7 @@
                 <tension_cutoff>1</tension_cutoff>
             </fracture_model>
             <fracture_properties>
-                <material_id>0</material_id>
+                <material_id>1</material_id>
                 <initial_aperture>aperture0</initial_aperture>
                 <specific_storage>S_f</specific_storage>
                 <biot_coefficient>biot_f</biot_coefficient>

--- a/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow_linear_aperture0_e.prj
+++ b/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow_linear_aperture0_e.prj
@@ -267,9 +267,9 @@
                 <boundary_condition>
                     <geometrical_set>single_fracture</geometrical_set>
                     <geometry>PLY_EAST</geometry>
-                    <type>Neumann</type>
+                    <type>Dirichlet</type>
                     <component>0</component>
-                    <parameter>p_in</parameter>
+                    <parameter>zero_u</parameter>
                 </boundary_condition>
                 <boundary_condition>
                     <geometrical_set>single_fracture</geometrical_set>
@@ -286,6 +286,13 @@
             <order>2</order>
             <initial_condition>displacement0</initial_condition>
             <boundary_conditions>
+                <boundary_condition>
+                    <geometrical_set>single_fracture</geometrical_set>
+                    <geometry>OutletPoint</geometry>
+                    <type>Dirichlet</type>
+                    <component>0</component>
+                    <parameter>zero_u</parameter>
+                </boundary_condition>
             </boundary_conditions>
         </process_variable>
     </process_variables>

--- a/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow_linear_aperture0_e.prj
+++ b/Tests/Data/LIE/HydroMechanics/single_fracture_3compartments_flow_linear_aperture0_e.prj
@@ -35,7 +35,7 @@
                 <tension_cutoff>1</tension_cutoff>
             </fracture_model>
             <fracture_properties>
-                <material_id>0</material_id>
+                <material_id>1</material_id>
                 <initial_aperture>aperture0</initial_aperture>
                 <specific_storage>S_f</specific_storage>
                 <biot_coefficient>biot_f</biot_coefficient>


### PR DESCRIPTION
When flow is only in the fracture, p is still set in the adjacent matrix elements to avoid leak-off. This pressure had an impact mechanically which is now deactivated.

Secondly, some test cases had a missing boundary condition on the displacement jump which has now been added.