### PR TITLE
Repeat time step on assembly error

### DIFF
--- a/MaterialLib/SolidModels/MFront/MFront.cpp
+++ b/MaterialLib/SolidModels/MFront/MFront.cpp
@@ -11,6 +11,8 @@
 
 #include <MGIS/Behaviour/Integrate.hxx>
 
+#include "NumLib/Exceptions.h"
+
 namespace
 {
 /// Converts between OGSes and MFront's Kelvin vector indices.
@@ -313,7 +315,8 @@ MFront<DisplacementDim>::integrateStress(
     auto const status = mgis::behaviour::integrate(v, _behaviour);
     if (status != 1)
     {
-        OGS_FATAL("Integration failed with status %i.", status);
+        throw NumLib::AssemblyException("MFront: integration failed with status"
+                + std::to_string(status) + ".");
     }
 
     KelvinVector sigma;

--- a/NumLib/Exceptions.h
+++ b/NumLib/Exceptions.h
@@ -1,0 +1,23 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace NumLib
+{
+struct AssemblyException : public std::runtime_error
+{
+    AssemblyException(std::string const& reason)
+        : std::runtime_error{"Error in process' assembly: " + reason} {};
+};
+}  // namespace NumLib

--- a/ProcessLib/SmallDeformation/Tests.cmake
+++ b/ProcessLib/SmallDeformation/Tests.cmake
@@ -49,6 +49,7 @@ endif()
 
 if (OGS_USE_MFRONT)
     OgsTest(PROJECTFILE Mechanics/MohrCoulombAbboSloan/load_test_mc.prj)
+    OgsTest(PROJECTFILE Mechanics/MohrCoulombAbboSloan/oedometer.prj RUNTIME 80)
 
 # Linear elastic, no internal state variables, no external state variables.
 AddTest(

--- a/ProcessLib/SmallDeformation/Tests.cmake
+++ b/ProcessLib/SmallDeformation/Tests.cmake
@@ -49,7 +49,8 @@ endif()
 
 if (OGS_USE_MFRONT)
     OgsTest(PROJECTFILE Mechanics/MohrCoulombAbboSloan/load_test_mc.prj)
-    OgsTest(PROJECTFILE Mechanics/MohrCoulombAbboSloan/oedometer.prj RUNTIME 80)
+    #TODO (naumov) enable when output file format can be specified
+    #OgsTest(PROJECTFILE Mechanics/MohrCoulombAbboSloan/oedometer.prj RUNTIME 80)
 
 # Linear elastic, no internal state variables, no external state variables.
 AddTest(

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer.gml
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer.gml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c7d591cf85e502a4d99a16fa6db574f606567a955cd1fc2b7fe51178040b7cc
+size 702

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer.prj
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer.prj
@@ -32,10 +32,10 @@
                 <process_variable>displacement</process_variable>
             </process_variables>
             <secondary_variables>
-                <secondary_variable type="static" internal_name="ElasticStrain" output_name="ElasticStrain"/>
-                <secondary_variable type="static" internal_name="EquivalentPlasticStrain" output_name="EquivalentPlasticStrain"/>
-                <secondary_variable type="static" internal_name="sigma" output_name="sigma"/>
-                <secondary_variable type="static" internal_name="epsilon" output_name="epsilon"/>
+                <secondary_variable internal_name="ElasticStrain" output_name="ElasticStrain"/>
+                <secondary_variable internal_name="EquivalentPlasticStrain" output_name="EquivalentPlasticStrain"/>
+                <secondary_variable internal_name="sigma" output_name="sigma"/>
+                <secondary_variable internal_name="epsilon" output_name="epsilon"/>
             </secondary_variables>
         </process>
     </processes>

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer.prj
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer.prj
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<OpenGeoSysProject>
+    <meshes>
+        <mesh axially_symmetric="true">oedometer.vtu</mesh>
+        <mesh axially_symmetric="true">oedometer_top.vtu</mesh>
+        <mesh axially_symmetric="true">oedometer_bottom.vtu</mesh>
+        <mesh axially_symmetric="true">oedometer_left.vtu</mesh>
+        <mesh axially_symmetric="true">oedometer_right.vtu</mesh>
+    </meshes>
+    <processes>
+        <process>
+            <name>SD</name>
+            <type>SMALL_DEFORMATION</type>
+            <integration_order>2</integration_order>
+            <constitutive_relation>
+                <type>MFront</type>
+                <behaviour>MohrCoulombAbboSloan</behaviour>
+                <material_properties>
+                    <material_property name="YoungModulus" parameter="YoungModulus"/>
+                    <material_property name="PoissonRatio" parameter="PoissonRatio"/>
+                    <material_property name="Cohesion" parameter="Cohesion"/>
+                    <material_property name="FrictionAngle" parameter="FrictionAngle"/>
+                    <material_property name="DilatancyAngle" parameter="DilatancyAngle"/>
+                    <material_property name="TransitionAngle" parameter="TransitionAngle"/>
+                    <material_property name="TensionCutOffParameter" parameter="TensionCutOffParameter"/>
+                </material_properties>
+            </constitutive_relation>
+            <solid_density>rho_sr</solid_density>
+            <specific_body_force>0 0</specific_body_force>
+            <reference_temperature>293.15</reference_temperature>
+            <process_variables>
+                <process_variable>displacement</process_variable>
+            </process_variables>
+            <secondary_variables>
+                <secondary_variable type="static" internal_name="ElasticStrain" output_name="ElasticStrain"/>
+                <secondary_variable type="static" internal_name="EquivalentPlasticStrain" output_name="EquivalentPlasticStrain"/>
+                <secondary_variable type="static" internal_name="sigma" output_name="sigma"/>
+                <secondary_variable type="static" internal_name="epsilon" output_name="epsilon"/>
+            </secondary_variables>
+        </process>
+    </processes>
+    <time_loop>
+        <processes>
+            <process ref="SD">
+                <nonlinear_solver>basic_newton</nonlinear_solver>
+                <convergence_criterion>
+                    <type>PerComponentDeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <abstols>1e-12 1e-12</abstols>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>IterationNumberBasedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>240e3</t_end>
+                    <initial_dt>30000</initial_dt>
+                    <minimum_dt>1e-4</minimum_dt>
+                    <maximum_dt>1e5</maximum_dt>
+                    <number_iterations>1   10  20 </number_iterations>
+                    <multiplier>       1.1 0.9 0.5</multiplier>
+                </time_stepping>
+            </process>
+        </processes>
+        <output>
+            <type>VTK</type>
+            <prefix>oedometer</prefix>
+            <timesteps>
+                <pair>
+                    <repeat>100000</repeat>
+                    <each_steps>1</each_steps>
+                </pair>
+            </timesteps>
+            <variables>
+                <variable>displacement</variable>
+            </variables>
+        </output>
+    </time_loop>
+    <parameters>
+        <parameter>
+            <name>YoungModulus</name>
+            <type>Constant</type>
+            <value>150e6</value>
+        </parameter>
+        <parameter>
+            <name>PoissonRatio</name>
+            <type>Constant</type>
+            <value>0.2</value>
+        </parameter>
+        <parameter>
+            <name>Cohesion</name>
+            <type>Constant</type>
+            <value>1.4e3</value>
+        </parameter>
+        <parameter>
+            <name>FrictionAngle</name>
+            <type>Constant</type>
+            <value>20</value>
+        </parameter>
+        <parameter>
+            <name>DilatancyAngle</name>
+            <type>Constant</type>
+            <value>5</value>
+        </parameter>
+        <parameter>
+            <name>TransitionAngle</name>
+            <!--TransitionAngle=25.0, according to Abbo & Sloan, 1995, Computers and Structures -->
+            <type>Constant</type>
+            <value>28</value>
+        </parameter>
+        <parameter>
+            <name>TensionCutOffParameter</name>
+            <type>Constant</type>
+            <value>0.5e3</value>
+        </parameter>
+        <parameter>
+            <name>rho_sr</name>
+            <type>Constant</type>
+            <value>2780.0</value>
+        </parameter>
+        <parameter>
+            <name>displacement0</name>
+            <type>Constant</type>
+            <values>0 0</values>
+        </parameter>
+        <parameter>
+            <name>dirichlet0</name>
+            <type>Constant</type>
+            <value>0</value>
+        </parameter>
+        <parameter>
+            <name>load</name>
+            <type>CurveScaled</type>
+            <curve>linear_load</curve>
+            <parameter>displacement_top</parameter>
+        </parameter>
+        <parameter>
+            <name>displacement_top</name>
+            <type>Constant</type>
+            <values>-0.0001</values>
+        </parameter>
+    </parameters>
+    <curves>
+        <curve>
+            <name>linear_load</name>
+            <coords>0 40000 80000 120000  240000</coords>
+            <values>0 1     1     0       0</values>
+        </curve>
+    </curves>
+    <process_variables>
+        <process_variable>
+            <name>displacement</name>
+            <components>2</components>
+            <order>1</order>
+            <initial_condition>displacement0</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <mesh>oedometer_left</mesh>
+                    <type>Dirichlet</type>
+                    <component>0</component>
+                    <parameter>dirichlet0</parameter>
+                </boundary_condition>
+                <boundary_condition>
+                    <mesh>oedometer_right</mesh>
+                    <type>Dirichlet</type>
+                    <component>0</component>
+                    <parameter>dirichlet0</parameter>
+                </boundary_condition>
+                <boundary_condition>
+                    <mesh>oedometer_bottom</mesh>
+                    <type>Dirichlet</type>
+                    <component>1</component>
+                    <parameter>dirichlet0</parameter>
+                </boundary_condition>
+                <boundary_condition>
+                    <mesh>oedometer_top</mesh>
+                    <type>Dirichlet</type>
+                    <component>1</component>
+                    <parameter>load</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+    </process_variables>
+    <nonlinear_solvers>
+        <nonlinear_solver>
+            <name>basic_newton</name>
+            <type>Newton</type>
+            <max_iter>20</max_iter>
+            <linear_solver>general_linear_solver</linear_solver>
+        </nonlinear_solver>
+    </nonlinear_solvers>
+    <linear_solvers>
+        <linear_solver>
+            <name>general_linear_solver</name>
+            <eigen>
+                <solver_type>SparseLU</solver_type>
+                <scaling>true</scaling>
+            </eigen>
+        </linear_solver>
+    </linear_solvers>
+    <test_definition>
+        <vtkdiff>
+            <file>oedometer_pcs_0_ts_5_t_79811.437500.vtu</file>
+            <field>displacement</field>
+            <absolute_tolerance>1e-13</absolute_tolerance>
+            <relative_tolerance>1e-14</relative_tolerance>
+        </vtkdiff>
+        <vtkdiff>
+            <file>oedometer_pcs_0_ts_5_t_79811.437500.vtu</file>
+            <field>NodalForces</field>
+            <absolute_tolerance>1e-4</absolute_tolerance>
+            <relative_tolerance>1e-11</relative_tolerance>
+        </vtkdiff>
+        <vtkdiff>
+            <file>oedometer_pcs_0_ts_5_t_79811.437500.vtu</file>
+            <field>sigma</field>
+            <absolute_tolerance>1e-12</absolute_tolerance>
+            <relative_tolerance>1e-12</relative_tolerance>
+        </vtkdiff>
+        <vtkdiff>
+            <file>oedometer_pcs_0_ts_5_t_79811.437500.vtu</file>
+            <field>epsilon</field>
+            <absolute_tolerance>1e-14</absolute_tolerance>
+            <relative_tolerance>1e-15</relative_tolerance>
+        </vtkdiff>
+        <vtkdiff>
+            <file>oedometer_pcs_0_ts_5_t_79811.437500.vtu</file>
+            <field>ElasticStrain</field>
+            <absolute_tolerance>1e-14</absolute_tolerance>
+            <relative_tolerance>1e-15</relative_tolerance>
+        </vtkdiff>
+        <vtkdiff>
+            <file>oedometer_pcs_0_ts_5_t_79811.437500.vtu</file>
+            <field>EquivalentPlasticStrain</field>
+            <absolute_tolerance>1e-14</absolute_tolerance>
+            <relative_tolerance>1e-15</relative_tolerance>
+        </vtkdiff>
+
+        <vtkdiff>
+            <file>oedometer_pcs_0_ts_376_t_240000.000000.vtu</file>
+            <field>displacement</field>
+            <absolute_tolerance>1e-13</absolute_tolerance>
+            <relative_tolerance>1e-13</relative_tolerance>
+        </vtkdiff>
+        <vtkdiff>
+            <file>oedometer_pcs_0_ts_376_t_240000.000000.vtu</file>
+            <field>NodalForces</field>
+            <absolute_tolerance>2e-5</absolute_tolerance>
+            <relative_tolerance>1e-9</relative_tolerance>
+        </vtkdiff>
+        <vtkdiff>
+            <file>oedometer_pcs_0_ts_376_t_240000.000000.vtu</file>
+            <field>sigma</field>
+            <absolute_tolerance>1e-11</absolute_tolerance>
+            <relative_tolerance>1e-11</relative_tolerance>
+        </vtkdiff>
+        <vtkdiff>
+            <file>oedometer_pcs_0_ts_376_t_240000.000000.vtu</file>
+            <field>epsilon</field>
+            <absolute_tolerance>1e-14</absolute_tolerance>
+            <relative_tolerance>1e-15</relative_tolerance>
+        </vtkdiff>
+        <vtkdiff>
+            <file>oedometer_pcs_0_ts_376_t_240000.000000.vtu</file>
+            <field>ElasticStrain</field>
+            <absolute_tolerance>1e-14</absolute_tolerance>
+            <relative_tolerance>1e-15</relative_tolerance>
+        </vtkdiff>
+        <vtkdiff>
+            <file>oedometer_pcs_0_ts_376_t_240000.000000.vtu</file>
+            <field>EquivalentPlasticStrain</field>
+            <absolute_tolerance>1e-14</absolute_tolerance>
+            <relative_tolerance>1e-15</relative_tolerance>
+        </vtkdiff>
+    </test_definition>
+</OpenGeoSysProject>

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer.vtu
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:009560f86dc088f455d69588b97c74a5dbca3c59b439d548a77a897c43b6d969
+size 178163

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_bottom.vtu
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_bottom.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:031521e551e24d6fdd2ead439bf132b00badff81659bb698aff32a57778185d8
+size 3287

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_fixed_timestepping.prj
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_fixed_timestepping.prj
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<OpenGeoSysProject>
+    <meshes>
+        <mesh axially_symmetric="true">oedometer.vtu</mesh>
+        <mesh axially_symmetric="true">oedometer_top.vtu</mesh>
+        <mesh axially_symmetric="true">oedometer_bottom.vtu</mesh>
+        <mesh axially_symmetric="true">oedometer_left.vtu</mesh>
+        <mesh axially_symmetric="true">oedometer_right.vtu</mesh>
+    </meshes>
+    <processes>
+        <process>
+            <name>SD</name>
+            <type>SMALL_DEFORMATION</type>
+            <integration_order>2</integration_order>
+            <constitutive_relation>
+                <type>MFront</type>
+                <behaviour>MohrCoulombAbboSloan</behaviour>
+                <material_properties>
+                    <material_property name="YoungModulus" parameter="YoungModulus"/>
+                    <material_property name="PoissonRatio" parameter="PoissonRatio"/>
+                    <material_property name="Cohesion" parameter="Cohesion"/>
+                    <material_property name="FrictionAngle" parameter="FrictionAngle"/>
+                    <material_property name="DilatancyAngle" parameter="DilatancyAngle"/>
+                    <material_property name="TransitionAngle" parameter="TransitionAngle"/>
+                    <material_property name="TensionCutOffParameter" parameter="TensionCutOffParameter"/>
+                </material_properties>
+            </constitutive_relation>
+            <solid_density>rho_sr</solid_density>
+            <specific_body_force>0 0</specific_body_force>
+            <reference_temperature>293.15</reference_temperature>
+            <process_variables>
+                <process_variable>displacement</process_variable>
+            </process_variables>
+            <secondary_variables>
+                <secondary_variable type="static" internal_name="ElasticStrain" output_name="ElasticStrain"/>
+                <secondary_variable type="static" internal_name="EquivalentPlasticStrain" output_name="EquivalentPlasticStrain"/>
+                <secondary_variable type="static" internal_name="sigma" output_name="sigma"/>
+                <secondary_variable type="static" internal_name="epsilon" output_name="epsilon"/>
+            </secondary_variables>
+        </process>
+    </processes>
+    <time_loop>
+        <processes>
+            <process ref="SD">
+                <nonlinear_solver>basic_newton</nonlinear_solver>
+                <convergence_criterion>
+                    <type>PerComponentDeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <abstols>1e-12 1e-12</abstols>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial>0.0</t_initial>
+                    <t_end>240e3</t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>10</repeat>
+                        <delta_t>8000</delta_t>
+                        </pair>
+                        <pair>
+                            <repeat>200014</repeat>
+                        <delta_t>10</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+        </processes>
+        <output>
+            <type>VTK</type>
+            <prefix>oedometer_fixed_timestepping</prefix>
+            <timesteps>
+                <pair>
+                    <repeat>100000</repeat>
+                    <each_steps>1</each_steps>
+                </pair>
+            </timesteps>
+            <variables>
+                <variable>displacement</variable>
+            </variables>
+        </output>
+    </time_loop>
+    <parameters>
+        <parameter>
+            <name>YoungModulus</name>
+            <type>Constant</type>
+            <value>150e6</value>
+        </parameter>
+        <parameter>
+            <name>PoissonRatio</name>
+            <type>Constant</type>
+            <value>0.2</value>
+        </parameter>
+        <parameter>
+            <name>Cohesion</name>
+            <type>Constant</type>
+            <value>1.4e3</value>
+        </parameter>
+        <parameter>
+            <name>FrictionAngle</name>
+            <type>Constant</type>
+            <value>20</value>
+        </parameter>
+        <parameter>
+            <name>DilatancyAngle</name>
+            <type>Constant</type>
+            <value>5</value>
+        </parameter>
+        <parameter>
+            <name>TransitionAngle</name>
+            <!--TransitionAngle=25.0, according to Abbo & Sloan, 1995, Computers and Structures -->
+            <type>Constant</type>
+            <value>28</value>
+        </parameter>
+        <parameter>
+            <name>TensionCutOffParameter</name>
+            <type>Constant</type>
+            <value>0.5e3</value>
+        </parameter>
+        <parameter>
+            <name>rho_sr</name>
+            <type>Constant</type>
+            <value>2780.0</value>
+        </parameter>
+        <parameter>
+            <name>displacement0</name>
+            <type>Constant</type>
+            <values>0 0</values>
+        </parameter>
+        <parameter>
+            <name>dirichlet0</name>
+            <type>Constant</type>
+            <value>0</value>
+        </parameter>
+        <parameter>
+            <name>load</name>
+            <type>CurveScaled</type>
+            <curve>linear_load</curve>
+            <parameter>displacement_top</parameter>
+        </parameter>
+        <parameter>
+            <name>displacement_top</name>
+            <type>Constant</type>
+            <values>-0.0001</values>
+        </parameter>
+    </parameters>
+    <curves>
+        <curve>
+            <name>linear_load</name>
+            <coords>0 40000 80000 120000  240000</coords>
+            <values>0 1     1     0       0</values>
+        </curve>
+    </curves>
+    <process_variables>
+        <process_variable>
+            <name>displacement</name>
+            <components>2</components>
+            <order>1</order>
+            <initial_condition>displacement0</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <mesh>oedometer_left</mesh>
+                    <type>Dirichlet</type>
+                    <component>0</component>
+                    <parameter>dirichlet0</parameter>
+                </boundary_condition>
+                <boundary_condition>
+                    <mesh>oedometer_right</mesh>
+                    <type>Dirichlet</type>
+                    <component>0</component>
+                    <parameter>dirichlet0</parameter>
+                </boundary_condition>
+                <boundary_condition>
+                    <mesh>oedometer_bottom</mesh>
+                    <type>Dirichlet</type>
+                    <component>1</component>
+                    <parameter>dirichlet0</parameter>
+                </boundary_condition>
+                <boundary_condition>
+                    <mesh>oedometer_top</mesh>
+                    <type>Dirichlet</type>
+                    <component>1</component>
+                    <parameter>load</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+    </process_variables>
+    <nonlinear_solvers>
+        <nonlinear_solver>
+            <name>basic_newton</name>
+            <type>Newton</type>
+            <max_iter>20</max_iter>
+            <linear_solver>general_linear_solver</linear_solver>
+        </nonlinear_solver>
+    </nonlinear_solvers>
+    <linear_solvers>
+        <linear_solver>
+            <name>general_linear_solver</name>
+            <eigen>
+                <solver_type>SparseLU</solver_type>
+                <scaling>true</scaling>
+            </eigen>
+        </linear_solver>
+    </linear_solvers>
+</OpenGeoSysProject>

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_fixed_timestepping.prj
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_fixed_timestepping.prj
@@ -32,10 +32,10 @@
                 <process_variable>displacement</process_variable>
             </process_variables>
             <secondary_variables>
-                <secondary_variable type="static" internal_name="ElasticStrain" output_name="ElasticStrain"/>
-                <secondary_variable type="static" internal_name="EquivalentPlasticStrain" output_name="EquivalentPlasticStrain"/>
-                <secondary_variable type="static" internal_name="sigma" output_name="sigma"/>
-                <secondary_variable type="static" internal_name="epsilon" output_name="epsilon"/>
+                <secondary_variable internal_name="ElasticStrain" output_name="ElasticStrain"/>
+                <secondary_variable internal_name="EquivalentPlasticStrain" output_name="EquivalentPlasticStrain"/>
+                <secondary_variable internal_name="sigma" output_name="sigma"/>
+                <secondary_variable internal_name="epsilon" output_name="epsilon"/>
             </secondary_variables>
         </process>
     </processes>

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_left.vtu
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_left.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e128d7e3397b14cd0737c62568d6c6e4c18dfe41d89c336ca2e2c736840a9c5d
+size 10219

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_pcs_0_ts_376_t_240000.000000.vtu
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_pcs_0_ts_376_t_240000.000000.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e3ae7f561c86ea48ed7e509281596c3c7bc810a7c35a34a722e8d50989a36fb
+size 539075

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_pcs_0_ts_5_t_79811.437500.vtu
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_pcs_0_ts_5_t_79811.437500.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95d0f41fefc45644acd719731c91fed509ee8f4e67e128a2f87d7384630e23e0
+size 483879

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_right.vtu
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_right.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd1d66ba74e32b38eccd77a21c19eebbb6d77c2ce48ceddc64302c7ab8895cf4
+size 10219

--- a/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_top.vtu
+++ b/Tests/Data/Mechanics/MohrCoulombAbboSloan/oedometer_top.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50829c11c53ba4f57e17afb0835f627f1f378d2f8f762465b5a9f523c24148b6
+size 3287


### PR DESCRIPTION
Introduce explicit exception handling in the time loop/nonlinear-solver for failed assembly. In case of exception the time step will be repeated (if adaptive time stepping is used) with smaller time step size.
The exception is thrown in MFront material model when local integration fails.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.2)
2. [x] Tests covering your feature were added?
3. [x] Any new feature or behavior change was documented? Not needed.
