### PR TITLE
[PL] Add option to skip a staggered process.

### DIFF
--- a/Documentation/ProjectFile/prj/time_loop/processes/process/t_skip_process_computation.md
+++ b/Documentation/ProjectFile/prj/time_loop/processes/process/t_skip_process_computation.md
@@ -1,0 +1,3 @@
+This is for staggered scheme only.
+If this is true, the specific process computation will be skipped throughout
+the simulation and retains the initial value.

--- a/ProcessLib/ProcessData.h
+++ b/ProcessLib/ProcessData.h
@@ -27,8 +27,8 @@ struct ProcessData
                 NumLib::NonlinearSolver<NLTag>& nonlinear_solver,
                 std::unique_ptr<NumLib::ConvergenceCriterion>&& conv_crit_,
                 std::unique_ptr<NumLib::TimeDiscretization>&& time_disc_,
-                int const process_id_,
-                Process& process_)
+                int const process_id_, Process& process_,
+                bool const skip_process_computation_)
         : timestepper(std::move(timestepper_)),
           nonlinear_solver_tag(NLTag),
           nonlinear_solver(nonlinear_solver),
@@ -36,7 +36,8 @@ struct ProcessData
           conv_crit(std::move(conv_crit_)),
           time_disc(std::move(time_disc_)),
           process_id(process_id_),
-          process(process_)
+          process(process_),
+          skip_process_computation(skip_process_computation_)
     {
     }
 
@@ -50,7 +51,8 @@ struct ProcessData
           tdisc_ode_sys(std::move(pd.tdisc_ode_sys)),
           mat_strg(pd.mat_strg),
           process_id(pd.process_id),
-          process(pd.process)
+          process(pd.process),
+          skip_process_computation(pd.skip_process_computation)
     {
         pd.mat_strg = nullptr;
     }
@@ -73,5 +75,6 @@ struct ProcessData
     int const process_id;
 
     Process& process;
+    bool const skip_process_computation = false;
 };
 }  // namespace ProcessLib

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -691,6 +691,9 @@ TimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
         int const last_process_id = _per_process_data.size() - 1;
         for (auto& process_data : _per_process_data)
         {
+            if (process_data->skip_process_computation)
+                continue;
+
             auto const process_id = process_data->process_id;
             BaseLib::RunTime time_timestep_process;
             time_timestep_process.start();


### PR DESCRIPTION
Adding a new optional configuration parameter, skip_process_computation.
The value is used in staggered scheme and if set true, the particular
process computation is skipped throughout the simulation and the initial
value remains.

1. [ ] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.2)
2. [ ] Tests covering your feature were added?
3. [x] Any new feature or behavior change was documented?
