### PR TITLE
Time stepping infinite loop fix

### DIFF
--- a/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.cpp
+++ b/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.cpp
@@ -173,4 +173,11 @@ void EvolutionaryPIDcontroller::addFixedOutputTimes(
     // Remove possible duplicated elements and sort in descending order.
     BaseLib::makeVectorUnique(_fixed_output_times, std::greater<double>());
 }
+
+bool EvolutionaryPIDcontroller::canReduceTimestepSize() const
+{
+    // If current and previous dt are both at minimum dt, then cannot reduce
+    // further.
+    return !(_ts_current.dt() == _h_min && _ts_prev.dt() == _h_min);
+}
 }  // namespace NumLib

--- a/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.h
+++ b/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.h
@@ -80,7 +80,7 @@ public:
         _is_accepted = accepted;
     }
 
-    bool isSolutionErrorComputationNeeded() override { return true; }
+    bool isSolutionErrorComputationNeeded() const override { return true; }
 
     virtual bool canReduceTimestepSize() const override;
 

--- a/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.h
+++ b/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.h
@@ -82,6 +82,8 @@ public:
 
     bool isSolutionErrorComputationNeeded() override { return true; }
 
+    virtual bool canReduceTimestepSize() const override;
+
     void addFixedOutputTimes(
         std::vector<double> const& extra_fixed_output_times) override;
 

--- a/NumLib/TimeStepping/Algorithms/IterationNumberBasedTimeStepping.cpp
+++ b/NumLib/TimeStepping/Algorithms/IterationNumberBasedTimeStepping.cpp
@@ -123,4 +123,12 @@ bool IterationNumberBasedTimeStepping::accepted() const
 {
     return _accepted;
 }
+
+bool IterationNumberBasedTimeStepping::canReduceTimestepSize() const
+{
+    // If current and previous dt are both at minimum dt, then cannot reduce
+    // further.
+    return !(_ts_current.dt() == _min_dt && _ts_prev.dt() == _min_dt);
+}
+
 }  // namespace NumLib

--- a/NumLib/TimeStepping/Algorithms/IterationNumberBasedTimeStepping.h
+++ b/NumLib/TimeStepping/Algorithms/IterationNumberBasedTimeStepping.h
@@ -99,6 +99,8 @@ public:
 
     bool isSolutionErrorComputationNeeded() override { return true; }
 
+    bool canReduceTimestepSize() const override;
+
     /// Return the number of repeated steps.
     int getNumberOfRepeatedSteps() const { return _n_rejected_steps; }
 

--- a/NumLib/TimeStepping/Algorithms/IterationNumberBasedTimeStepping.h
+++ b/NumLib/TimeStepping/Algorithms/IterationNumberBasedTimeStepping.h
@@ -97,7 +97,7 @@ public:
     bool accepted() const override;
     void setAcceptedOrNot(bool accepted) override { _accepted = accepted; };
 
-    bool isSolutionErrorComputationNeeded() override { return true; }
+    bool isSolutionErrorComputationNeeded() const override { return true; }
 
     bool canReduceTimestepSize() const override;
 

--- a/NumLib/TimeStepping/Algorithms/TimeStepAlgorithm.h
+++ b/NumLib/TimeStepping/Algorithms/TimeStepAlgorithm.h
@@ -111,7 +111,7 @@ public:
 
     /// Get a flag to indicate whether this algorithm needs to compute
     /// solution error. The default return value is false.
-    virtual bool isSolutionErrorComputationNeeded() { return false; }
+    virtual bool isSolutionErrorComputationNeeded() const { return false; }
 
     /// Query the timestepper if further time step size reduction is possible.
     virtual bool canReduceTimestepSize() const { return false; }

--- a/NumLib/TimeStepping/Algorithms/TimeStepAlgorithm.h
+++ b/NumLib/TimeStepping/Algorithms/TimeStepAlgorithm.h
@@ -113,6 +113,9 @@ public:
     /// solution error. The default return value is false.
     virtual bool isSolutionErrorComputationNeeded() { return false; }
 
+    /// Query the timestepper if further time step size reduction is possible.
+    virtual bool canReduceTimestepSize() const { return false; }
+
     /// Add specified times to the existing vector of the specified times.
     /// If there are specified times, they will be used as constraints in the
     /// computing of time step size such that the time step can exactly reach at

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -592,9 +592,8 @@ static NumLib::NonlinearSolverStatus solveMonolithicProcess(
     return nonlinear_solver_status;
 }
 
-static std::string const nonlinear_fixed_dt_fails_info =
-    "Nonlinear solver fails. Because the time stepper FixedTimeStepping is "
-    "used, the program has to be terminated.";
+static constexpr std::string_view timestepper_cannot_reduce_dt =
+    "Time stepper cannot reduce the time step size further.";
 
 void postTimestepForAllProcesses(
     double const t, double const dt,
@@ -646,7 +645,7 @@ NumLib::NonlinearSolverStatus TimeLoop::solveUncoupledEquationSystems(
                 // save unsuccessful solution
                 _output->doOutputAlways(process_data->process, process_id,
                                         timestep_id, t, _process_solutions);
-                OGS_FATAL(nonlinear_fixed_dt_fails_info.data());
+                OGS_FATAL(timestepper_cannot_reduce_dt.data());
             }
 
             return nonlinear_solver_status;
@@ -723,7 +722,7 @@ TimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
                     // save unsuccessful solution
                     _output->doOutputAlways(process_data->process, process_id,
                                             timestep_id, t, _process_solutions);
-                    OGS_FATAL(nonlinear_fixed_dt_fails_info.data());
+                    OGS_FATAL(timestepper_cannot_reduce_dt.data());
                 }
                 break;
             }

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -641,7 +641,7 @@ NumLib::NonlinearSolverStatus TimeLoop::solveUncoupledEquationSystems(
                 "process #%u.",
                 timestep_id, t, process_id);
 
-            if (!process_data->timestepper->isSolutionErrorComputationNeeded())
+            if (!process_data->timestepper->canReduceTimestepSize())
             {
                 // save unsuccessful solution
                 _output->doOutputAlways(process_data->process, process_id,
@@ -718,8 +718,7 @@ TimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
                     "for process #%u.",
                     timestep_id, t, process_id);
 
-                if (!process_data->timestepper
-                         ->isSolutionErrorComputationNeeded())
+                if (!process_data->timestepper->canReduceTimestepSize())
                 {
                     // save unsuccessful solution
                     _output->doOutputAlways(process_data->process, process_id,


### PR DESCRIPTION
Iteration number based time stepping scheme ended in an infinite loop when the minimum time step size was reached.

 - Add a new function (similar to `isSolutionErrorComputationNeeded`) but with different logic for the adaptive timesteppers, `canReduceTimestepSize()`.
 - Update (generalize) error message.
