### PR TITLE
[CMake] Added option to set OGS_BUILD_PROCESSES=OFF.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,17 +131,24 @@ endforeach()
 set(OGS_BUILD_PROCESSES
     ""
     CACHE STRING "Semicolon-separated list of processes to build")
+if(NOT OGS_BUILD_CLI)
+    set(OGS_BUILD_PROCESSES OFF "" CACHE INTERNAL "")
+endif()
 if(NOT "${OGS_BUILD_PROCESSES}" STREQUAL "")
-    foreach(process ${OGS_BUILD_PROCESSES})
-        if(NOT "${process}" IN_LIST ProcessesList)
-            message(
-                FATAL_ERROR
-                    "${process} given in OGS_BUILD_PROCESSES is "
-                    "not a valid process name! Valid names are ${ProcessesList}"
-                )
-        endif()
-    endforeach()
-    message(STATUS "Enabled processes:")
+    if(${OGS_BUILD_PROCESSES})
+        foreach(process ${OGS_BUILD_PROCESSES})
+            if(NOT "${process}" IN_LIST ProcessesList)
+                message(
+                    FATAL_ERROR
+                        "${process} given in OGS_BUILD_PROCESSES is "
+                        "not a valid process name! Valid names are ${ProcessesList}"
+                    )
+            endif()
+        endforeach()
+        message(STATUS "Enabled processes:")
+    else()
+        message(STATUS "All processes disabled.")
+    endif()
     foreach(process ${ProcessesList})
         if("${process}" IN_LIST OGS_BUILD_PROCESSES)
             set(OGS_BUILD_PROCESS_${process} ON CACHE BOOL "" FORCE)
@@ -150,7 +157,6 @@ if(NOT "${OGS_BUILD_PROCESSES}" STREQUAL "")
             set(OGS_BUILD_PROCESS_${process} OFF CACHE BOOL "" FORCE)
         endif()
     endforeach()
-
 endif()
 
 if(WIN32)

--- a/web/content/docs/devguide/advanced/configuration-options.pandoc
+++ b/web/content/docs/devguide/advanced/configuration-options.pandoc
@@ -17,14 +17,14 @@ Some of these options are enabled by default ("*Defaults* to *ON*") otherwise th
 
 CMake switches to enable / disable parts of OGS.
 
-- `OGS_BUILD_CLI` - Builds the simulator. *Defaults* to *ON*.
+- `OGS_BUILD_CLI` - Builds the simulator. *Defaults* to *ON*. If set to *OFF* all processes are also disabled.
 - `OGS_BUILD_GUI` - Builds the Data Explorer. *Defaults* to *OFF*.
 - `BUILD_TESTING` - Builds the test executables. *Defaults* to *ON*.
 - `OGS_BUILD_UTILS` - Builds several utilities.
 - `OGS_NO_EXTERNAL_LIBS` - Disables all external optional dependencies.
 - `OGS_BUILD_PROCESS_X` - For enabling/disabling compilation of process `X`.
   Run the CMake-Gui to see a list of processes.
-- `OGS_BUILD_PROCESSES` - A `;`-separated list specifying processes to build. *Defaults* to an *empty string*. This will alter the `OGS_BUILD_PROCESS_X`-options. For e.g. building just the two processes `HT` and `LIE`: `-DOGS_BUILD_PROCESSES="HT;LIE"`. Setting this variable back to an empty string **does not reset** the `OGS_BUILD_PROCESS_X`-options.
+- `OGS_BUILD_PROCESSES` - A `;`-separated list specifying processes to build. *Defaults* to an *empty string*. This will alter the `OGS_BUILD_PROCESS_X`-options. For e.g. building just the two processes `HT` and `LIE`: `-DOGS_BUILD_PROCESSES="HT;LIE"`. Setting this variable back to an empty string **does not reset** the `OGS_BUILD_PROCESS_X`-options. You can also set it to *OFF* to disable all processes.
 
 #### Debugging
 


### PR DESCRIPTION
This disables building of all processes, e.g. if you want to just
build the utils.

Setting `OGS_BUILD_CLI=OFF` also disables all processes.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.2.2)
3. [x] Any new feature or behavior change was documented?
