### PR TITLE
Add output of fluxes to LiquidFlow process

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -519,7 +519,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
             process = ProcessLib::LiquidFlow::createLiquidFlowProcess(
                 name, *_mesh_vec[0], std::move(jacobian_assembler),
                 _process_variables, _parameters, integration_order,
-                process_config);
+                process_config, _mesh_vec, output_directory);
         }
         else
 #endif

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.h
@@ -26,6 +26,8 @@ std::unique_ptr<Process> createLiquidFlowProcess(
     std::vector<ProcessVariable> const& variables,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
     unsigned const integration_order,
-    BaseLib::ConfigTree const& config);
+    BaseLib::ConfigTree const& config,
+    std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,
+    std::string const& output_directory);
 }  // namespace LiquidFlow
 }  // namespace ProcessLib

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
@@ -87,7 +87,7 @@ LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::getFlux(
     const double mu =
         _material_properties.getViscosity(pressure, _reference_temperature);
 
-    Eigen::Vector3d flux;
+    Eigen::Vector3d flux(0.0, 0.0, 0.0);
     flux.head<GlobalDim>() =
         -permeability / mu * shape_matrices.dNdx *
         Eigen::Map<const NodalVectorType>(local_x.data(), local_x.size());

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
@@ -56,6 +56,47 @@ void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
 
 template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
+Eigen::Vector3d
+LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::getFlux(
+    MathLib::Point3d const& p_local_coords, double const t,
+    std::vector<double> const& local_x) const
+{
+    // eval dNdx and invJ at p
+    auto const fe =
+        NumLib::createIsoparametricFiniteElement<ShapeFunction,
+                                                 ShapeMatricesType>(_element);
+
+    typename ShapeMatricesType::ShapeMatrices shape_matrices(
+        ShapeFunction::DIM, GlobalDim, ShapeFunction::NPOINTS);
+
+    // Note: Axial symmetry is set to false here, because we only need dNdx
+    // here, which is not affected by axial symmetry.
+    fe.computeShapeFunctions(p_local_coords.getCoords(), shape_matrices,
+                             GlobalDim, false);
+
+    // create pos object to access the correct media property
+    ParameterLib::SpatialPosition pos;
+    pos.setElementID(_element.getID());
+    const int material_id = _material_properties.getMaterialID(pos);
+
+    double pressure = 0.0;
+    NumLib::shapeFunctionInterpolate(local_x, shape_matrices.N, pressure);
+    const Eigen::MatrixXd& permeability = _material_properties.getPermeability(
+        material_id, t, pos, _element.getDimension(), pressure,
+        _reference_temperature);
+    const double mu =
+        _material_properties.getViscosity(pressure, _reference_temperature);
+
+    Eigen::Vector3d flux;
+    flux.head<GlobalDim>() =
+        -permeability / mu * shape_matrices.dNdx *
+        Eigen::Map<const NodalVectorType>(local_x.data(), local_x.size());
+
+    return flux;
+}
+
+template <typename ShapeFunction, typename IntegrationMethod,
+          unsigned GlobalDim>
 template <typename LaplacianGravityVelocityCalculator>
 void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
     assembleMatrixAndVector(const int material_id, double const t,

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -128,6 +128,12 @@ public:
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;
 
+    /// Computes the flux in the point \c p_local_coords that is given in local
+    /// coordinates using the values from \c local_x.
+    Eigen::Vector3d getFlux(MathLib::Point3d const& p_local_coords,
+                            double const t,
+                            std::vector<double> const& local_x) const override;
+
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         const unsigned integration_point) const override
     {

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -141,5 +141,23 @@ Eigen::Vector3d LiquidFlowProcess::getFlux(
     return _local_assemblers[element_id]->getFlux(p, t, local_x);
 }
 
+// this is almost a copy of the implementation in the GroundwaterFlow
+void LiquidFlowProcess::postTimestepConcreteProcess(
+    std::vector<GlobalVector*> const& x,
+    const double t,
+    const double /*dt*/,
+    int const process_id)
+{
+    if (!_surfaceflux)  // computing the surfaceflux is optional
+    {
+        return;
+    }
+
+    ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
+    _surfaceflux->integrate(x, t, *this, process_id, _integration_order, _mesh,
+                            pv.getActiveElementIDs());
+    _surfaceflux->save(t);
+}
+
 }  // namespace LiquidFlow
 }  // namespace ProcessLib

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -125,5 +125,21 @@ void LiquidFlowProcess::computeSecondaryVariableConcrete(const double t,
         x, _coupled_solutions);
 }
 
+Eigen::Vector3d LiquidFlowProcess::getFlux(
+    std::size_t const element_id,
+    MathLib::Point3d const& p,
+    double const t,
+    std::vector<GlobalVector*> const& x) const
+{
+    // fetch local_x from primary variable
+    std::vector<GlobalIndexType> indices_cache;
+    auto const r_c_indices = NumLib::getRowColumnIndices(
+        element_id, *_local_to_global_index_map, indices_cache);
+    constexpr int process_id = 0;  // monolithic scheme.
+    std::vector<double> local_x(x[process_id]->get(r_c_indices.rows));
+
+    return _local_assemblers[element_id]->getFlux(p, t, local_x);
+}
+
 }  // namespace LiquidFlow
 }  // namespace ProcessLib

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -18,6 +18,8 @@
 #include "LiquidFlowLocalAssembler.h"
 #include "LiquidFlowMaterialProperties.h"
 #include "MeshLib/PropertyVector.h"
+// TODO(TF) used for output of flux, if output classes are ready this has to be changed
+#include "MeshLib/IO/writeMeshToFile.h"
 #include "ProcessLib/Utils/CreateLocalAssemblers.h"
 
 namespace ProcessLib
@@ -37,7 +39,8 @@ LiquidFlowProcess::LiquidFlowProcess(
     int const gravitational_axis_id,
     double const gravitational_acceleration,
     double const reference_temperature,
-    BaseLib::ConfigTree const& config)
+    BaseLib::ConfigTree const& config,
+    std::unique_ptr<ProcessLib::SurfaceFluxData>&& surfaceflux)
     : Process(std::move(name), mesh, std::move(jacobian_assembler), parameters,
               integration_order, std::move(process_variables),
               std::move(secondary_variables)),
@@ -45,7 +48,8 @@ LiquidFlowProcess::LiquidFlowProcess(
       _gravitational_acceleration(gravitational_acceleration),
       _reference_temperature(reference_temperature),
       _material_properties(
-          createLiquidFlowMaterialProperties(config, parameters, material_ids))
+          createLiquidFlowMaterialProperties(config, parameters, material_ids)),
+      _surfaceflux(std::move(surfaceflux))
 {
     DBUG("Create Liquid flow process.");
 }

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -78,6 +78,12 @@ public:
                                           int const process_id) override;
 
     bool isLinear() const override { return true; }
+
+    Eigen::Vector3d getFlux(std::size_t const element_id,
+                            MathLib::Point3d const& p,
+                            double const t,
+                            std::vector<GlobalVector*> const& x) const override;
+
     int getGravitationalAxisID() const { return _gravitational_axis_id; }
     double getGravitationalAcceleration() const
     {

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -19,6 +19,7 @@
 #include "MaterialLib/Fluid/FluidProperties/FluidProperties.h"
 #include "NumLib/DOF/LocalToGlobalIndexMap.h"
 #include "ProcessLib/Process.h"
+#include "ProcessLib/SurfaceFlux/SurfaceFluxData.h"
 
 namespace MeshLib
 {
@@ -69,7 +70,8 @@ public:
         int const gravitational_axis_id,
         double const gravitational_acceleration,
         double const reference_temperature,
-        BaseLib::ConfigTree const& config);
+        BaseLib::ConfigTree const& config,
+        std::unique_ptr<ProcessLib::SurfaceFluxData>&& surfaceflux);
 
     void computeSecondaryVariableConcrete(double const t,
                                           GlobalVector const& x,
@@ -105,6 +107,8 @@ private:
 
     std::vector<std::unique_ptr<LiquidFlowLocalAssemblerInterface>>
         _local_assemblers;
+
+    std::unique_ptr<ProcessLib::SurfaceFluxData> _surfaceflux;
 };
 
 }  // namespace LiquidFlow

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -90,6 +90,11 @@ public:
         return _gravitational_acceleration;
     }
 
+    void postTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
+                                     const double t,
+                                     const double dt,
+                                     int const process_id) override;
+
 private:
     void initializeConcreteProcess(
         NumLib::LocalToGlobalIndexMap const& dof_table,

--- a/ProcessLib/LiquidFlow/Tests.cmake
+++ b/ProcessLib/LiquidFlow/Tests.cmake
@@ -364,3 +364,18 @@ AddTest(
     time_dependent_heterogeneous_source_term_pcs_0_ts_120_t_1200.000000.vtu time_dependent_heterogeneous_source_term_pcs_0_ts_120_t_1200.000000.vtu pressure pressure 1e-7 1e-13
     time_dependent_heterogeneous_source_term_pcs_0_ts_200_t_2000.000000.vtu time_dependent_heterogeneous_source_term_pcs_0_ts_200_t_2000.000000.vtu pressure pressure 1e-7 1e-13
 )
+
+AddTest(
+    NAME LiquidFlow_Flux
+    PATH Parabolic/LiquidFlow/Flux
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS cube_1e3_calculatesurfaceflux.prj
+    WRAPPER time
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    DIFF_DATA
+    cube_1x1x1_hex_1e3_complete_surface_left_right_dirichlet_specific_flux_t_0.432000_expected.vtu cube_1x1x1_hex_1e3_complete_surface_left_right_dirichlet_specific_flux_t_0.432000.vtu specific_flux specific_flux 1e-7 1e-13
+    cube_1x1x1_hex_1e3_complete_surface_left_right_dirichlet_specific_flux_t_0.864000_expected.vtu cube_1x1x1_hex_1e3_complete_surface_left_right_dirichlet_specific_flux_t_0.864000.vtu specific_flux specific_flux 1e-7 1e-13
+    LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_1_t_0.432000_expected.vtu LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_1_t_0.432000.vtu pressure pressure 1e-7 1e-13
+    LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_2_t_0.864000_expected.vtu LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_2_t_0.864000.vtu pressure pressure 1e-7 1e-13
+)

--- a/ProcessLib/LiquidFlow/Tests.cmake
+++ b/ProcessLib/LiquidFlow/Tests.cmake
@@ -366,7 +366,7 @@ AddTest(
 )
 
 AddTest(
-    NAME LiquidFlow_Flux
+    NAME LiquidFlow_Flux_3D
     PATH Parabolic/LiquidFlow/Flux
     EXECUTABLE ogs
     EXECUTABLE_ARGS cube_1e3_calculatesurfaceflux.prj
@@ -378,4 +378,19 @@ AddTest(
     cube_1x1x1_hex_1e3_complete_surface_left_right_dirichlet_specific_flux_t_0.864000_expected.vtu cube_1x1x1_hex_1e3_complete_surface_left_right_dirichlet_specific_flux_t_0.864000.vtu specific_flux specific_flux 1e-7 1e-13
     LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_1_t_0.432000_expected.vtu LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_1_t_0.432000.vtu pressure pressure 1e-7 1e-13
     LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_2_t_0.864000_expected.vtu LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_2_t_0.864000.vtu pressure pressure 1e-7 1e-13
+)
+
+AddTest(
+    NAME LiquidFlow_Flux_2D
+    PATH Parabolic/LiquidFlow/Flux/2D
+    EXECUTABLE ogs
+    EXECUTABLE_ARGS square_1e1_calculatesurfaceflux.prj
+    WRAPPER time
+    TESTER vtkdiff
+    REQUIREMENTS NOT OGS_USE_MPI
+    DIFF_DATA
+    square_1x1_quad_1e1_complete_surface_left_right_dirichlet_specific_flux_t_0.432000_expected.vtu square_1x1_quad_1e1_complete_surface_left_right_dirichlet_specific_flux_t_0.432000.vtu specific_flux specific_flux 1e-7 1e-13
+    square_1x1_quad_1e1_complete_surface_left_right_dirichlet_specific_flux_t_0.864000_expected.vtu square_1x1_quad_1e1_complete_surface_left_right_dirichlet_specific_flux_t_0.864000.vtu specific_flux specific_flux 1e-7 1e-13
+    LF_square_1e1_surfaceflux_pcs_0_ts_1_t_0.432000_expected.vtu LF_square_1e1_surfaceflux_pcs_0_ts_1_t_0.432000.vtu pressure pressure 1e-7 1e-13
+    LF_square_1e1_surfaceflux_pcs_0_ts_2_t_0.864000_expected.vtu LF_square_1e1_surfaceflux_pcs_0_ts_2_t_0.864000.vtu pressure pressure 1e-7 1e-13
 )

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/2D/LF_square_1e1_surfaceflux_pcs_0_ts_1_t_0.432000_expected.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/2D/LF_square_1e1_surfaceflux_pcs_0_ts_1_t_0.432000_expected.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a09fca3e1cf6cc900db49ed46c6bb874a291a41cead6e334b24f35504003510b
+size 3284

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/2D/LF_square_1e1_surfaceflux_pcs_0_ts_2_t_0.864000_expected.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/2D/LF_square_1e1_surfaceflux_pcs_0_ts_2_t_0.864000_expected.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:960089f24280fbce95e7f376a4fb9a1caa3da98457fcc83ed4b3736e19c3df54
+size 3256

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1e1_calculatesurfaceflux.prj
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1e1_calculatesurfaceflux.prj
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<OpenGeoSysProject>
+    <meshes>
+        <mesh>square_1x1_quad_1e1.vtu</mesh>
+        <mesh>square_1x1_quad_1e1_complete_surface.vtu</mesh>
+        <mesh>square_1x1_quad_1e1_left.vtu</mesh>
+        <mesh>square_1x1_quad_1e1_right.vtu</mesh>
+    </meshes>
+    <processes>
+        <process>
+            <name>LiquidFlow</name>
+            <type>LIQUID_FLOW</type>
+            <integration_order>2</integration_order>
+            <darcy_gravity>
+                <!-- axis_id: 0, 1, or the dimension of space minus one -->
+                <axis_id>0</axis_id>
+                <!-- g>=0. g=0: non gravity term -->
+                <g>0.</g>
+            </darcy_gravity>
+            <process_variables>
+                <process_variable>pressure</process_variable>
+            </process_variables>
+            <secondary_variables>
+                <secondary_variable internal_name="darcy_velocity" output_name="v"/>
+            </secondary_variables>
+            <calculatesurfaceflux>
+                <mesh>square_1x1_quad_1e1_complete_surface</mesh>
+                <property_name>specific_flux</property_name>
+                <output_mesh>square_1x1_quad_1e1_complete_surface_left_right_dirichlet_specific_flux.vtu</output_mesh>
+            </calculatesurfaceflux>
+            <material_property>
+                <fluid>
+                    <density>
+                        <type>Constant</type>
+                        <value> 78.68 </value>
+                    </density>
+                    <viscosity>
+                        <type>Constant</type>
+                        <value> 1.295e-4 </value>
+                    </viscosity>
+                </fluid>
+                <porous_medium>
+                    <porous_medium id="0">
+                        <permeability>
+                            <permeability_tensor_entries>kappa1</permeability_tensor_entries>
+                            <type>Constant</type>
+                        </permeability>
+                        <porosity>
+                            <type>Constant</type>
+                            <porosity_parameter>constant_porosity_parameter</porosity_parameter>
+                        </porosity>
+                        <storage>
+                            <type>Constant</type>
+                            <value> 8.05e-10 </value>
+                        </storage>
+                    </porous_medium>
+                </porous_medium>
+            </material_property>
+        </process>
+    </processes>
+    <time_loop>
+        <processes>
+            <process ref="LiquidFlow">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <abstol>1.e-10</abstol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial> 0.0 </t_initial>
+                    <t_end> 0.864 </t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>2</repeat>
+                            <delta_t>0.432</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+        </processes>
+        <output>
+            <type>VTK</type>
+            <prefix>LF_square_1e1_surfaceflux</prefix>
+            <timesteps>
+                <pair>
+                    <repeat> 1 </repeat>
+                    <each_steps> 1 </each_steps>
+                </pair>
+            </timesteps>
+            <variables>
+                <variable> pressure </variable>
+                <variable> v </variable>
+            </variables>
+        </output>
+    </time_loop>
+    <parameters>
+        <parameter>
+            <name>p0</name>
+            <type>Constant</type>
+            <value>5e6</value>
+        </parameter>
+        <parameter>
+            <name>p_Dirichlet_left</name>
+            <type>Constant</type>
+            <value>1e7</value>
+        </parameter>
+        <parameter>
+            <name>p_Dirichlet_right</name>
+            <type>Constant</type>
+            <value>1e6</value>
+        </parameter>
+        <parameter>
+            <name>constant_porosity_parameter</name>
+            <type>Constant</type>
+            <value>1</value>
+        </parameter>
+        <parameter>
+            <name>kappa1</name>
+            <type>Constant</type>
+            <values>9.2e-12 0 0 9.2e-12</values>
+        </parameter>
+        <parameter>
+            <name>p_spatial</name>
+            <type>Constant</type>
+            <value>1</value>
+        </parameter>
+    </parameters>
+    <process_variables>
+        <process_variable>
+            <name>pressure</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>p0</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <mesh>square_1x1_quad_1e1_left</mesh>
+                    <type>Dirichlet</type>
+                    <parameter>p_Dirichlet_left</parameter>
+                </boundary_condition>
+                <boundary_condition>
+                    <mesh>square_1x1_quad_1e1_right</mesh>
+                    <type>Dirichlet</type>
+                    <parameter>p_Dirichlet_right</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+    </process_variables>
+    <nonlinear_solvers>
+        <nonlinear_solver>
+            <name>basic_picard</name>
+            <type>Picard</type>
+            <max_iter>10</max_iter>
+            <linear_solver>general_linear_solver</linear_solver>
+        </nonlinear_solver>
+    </nonlinear_solvers>
+    <linear_solvers>
+        <linear_solver>
+            <name>general_linear_solver</name>
+            <lis>-i cg -p jacobi -tol 1e-16 -maxiter 10000</lis>
+            <eigen>
+                <solver_type>CG</solver_type>
+                <precon_type>DIAGONAL</precon_type>
+                <max_iteration_step>10000</max_iteration_step>
+                <error_tolerance>1e-16</error_tolerance>
+            </eigen>
+            <petsc>
+                <prefix>lf</prefix>
+                <parameters>-lf_ksp_type cg -lf_pc_type bjacobi -lf_ksp_rtol 1e-16 -lf_ksp_max_it 10000</parameters>
+            </petsc>
+        </linear_solver>
+    </linear_solvers>
+</OpenGeoSysProject>

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1x1_quad_1e1.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1x1_quad_1e1.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16b826f3e01dafe34f447332b39a2a01cfa9e330c9ff7706190d0f420570c364
+size 2276

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1x1_quad_1e1_complete_surface.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1x1_quad_1e1_complete_surface.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17da3e834d5c3aa33c7bcd5f69eeffe45226d10070ec1efde9d0b1d515f6c892
+size 3535

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1x1_quad_1e1_complete_surface_left_right_dirichlet_specific_flux_t_0.432000_expected.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1x1_quad_1e1_complete_surface_left_right_dirichlet_specific_flux_t_0.432000_expected.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf38c54df6739ac7ab831bf2605ed356f0519e3d382a31dfb49d08bddffea466
+size 4030

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1x1_quad_1e1_complete_surface_left_right_dirichlet_specific_flux_t_0.864000_expected.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1x1_quad_1e1_complete_surface_left_right_dirichlet_specific_flux_t_0.864000_expected.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c2583ec787a3ee56c18217b09b34bdda1de66008c9f4ecd9e0c653dd187cb8a
+size 4030

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1x1_quad_1e1_left.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1x1_quad_1e1_left.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb3a7aa685ad561fdf455dd462467cab1e124fedc44e6c0f14befe33d83e6cd5
+size 3637

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1x1_quad_1e1_right.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/2D/square_1x1_quad_1e1_right.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e39f78e2cabffd2f4f1313b774ca9464b8ffdf7fc97aa94b66bae80d162c850
+size 3659

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_0_t_0.000000_expected.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_0_t_0.000000_expected.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3928650be26b5dc4a48e0a635fdfc20eaa912e48c32d6d8c6533c87fee70622b
+size 39859

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_1_t_0.432000_expected.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_1_t_0.432000_expected.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4b22d3aa39091be0e2b9a1759f9824855175de911f58344b6686f59e43cd6f2
+size 46835

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_2_t_0.864000_expected.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/LF_cube_1e3_calculatesurfaceflux_pcs_0_ts_2_t_0.864000_expected.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01b5c7d2ce1ccedbb1a4fbe5a544ad502bf36ef47772db4cec78afc3c8e4f182
+size 46755

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1e3_calculatesurfaceflux.prj
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1e3_calculatesurfaceflux.prj
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<OpenGeoSysProject>
+    <meshes>
+        <mesh>cube_1x1x1_hex_1e3.vtu</mesh>
+        <mesh>cube_1x1x1_hex_1e3_complete_surface.vtu</mesh>
+        <mesh>cube_1x1x1_hex_1e3_left.vtu</mesh>
+        <mesh>cube_1x1x1_hex_1e3_right.vtu</mesh>
+    </meshes>
+    <processes>
+        <process>
+            <name>LiquidFlow</name>
+            <type>LIQUID_FLOW</type>
+            <integration_order>2</integration_order>
+            <darcy_gravity>
+                <!-- axis_id: 0, 1, or the dimension of space minus one -->
+                <axis_id>0</axis_id>
+                <!-- g>=0. g=0: non gravity term -->
+                <g>0.</g>
+            </darcy_gravity>
+            <process_variables>
+                <process_variable>pressure</process_variable>
+            </process_variables>
+            <secondary_variables>
+                <secondary_variable internal_name="darcy_velocity" output_name="v"/>
+            </secondary_variables>
+            <calculatesurfaceflux>
+                <mesh>cube_1x1x1_hex_1e3_complete_surface</mesh>
+                <property_name>specific_flux</property_name>
+                <output_mesh>cube_1x1x1_hex_1e3_complete_surface_left_right_dirichlet_specific_flux.vtu</output_mesh>
+            </calculatesurfaceflux>
+            <material_property>
+                <fluid>
+                    <density>
+                        <type>Constant</type>
+                        <value> 78.68 </value>
+                    </density>
+                    <viscosity>
+                        <type>Constant</type>
+                        <value> 1.295e-4 </value>
+                    </viscosity>
+                </fluid>
+                <porous_medium>
+                    <porous_medium id="0">
+                        <permeability>
+                            <permeability_tensor_entries>kappa1</permeability_tensor_entries>
+                            <type>Constant</type>
+                        </permeability>
+                        <porosity>
+                            <type>Constant</type>
+                            <porosity_parameter>constant_porosity_parameter</porosity_parameter>
+                        </porosity>
+                        <storage>
+                            <type>Constant</type>
+                            <value> 8.05e-10 </value>
+                        </storage>
+                    </porous_medium>
+                </porous_medium>
+            </material_property>
+        </process>
+    </processes>
+    <time_loop>
+        <processes>
+            <process ref="LiquidFlow">
+                <nonlinear_solver>basic_picard</nonlinear_solver>
+                <convergence_criterion>
+                    <type>DeltaX</type>
+                    <norm_type>NORM2</norm_type>
+                    <abstol>1.e-10</abstol>
+                </convergence_criterion>
+                <time_discretization>
+                    <type>BackwardEuler</type>
+                </time_discretization>
+                <time_stepping>
+                    <type>FixedTimeStepping</type>
+                    <t_initial> 0.0 </t_initial>
+                    <t_end> 0.864 </t_end>
+                    <timesteps>
+                        <pair>
+                            <repeat>2</repeat>
+                            <delta_t>0.432</delta_t>
+                        </pair>
+                    </timesteps>
+                </time_stepping>
+            </process>
+        </processes>
+        <output>
+            <type>VTK</type>
+            <prefix>LF_cube_1e3_calculatesurfaceflux</prefix>
+            <timesteps>
+                <pair>
+                    <repeat> 1 </repeat>
+                    <each_steps> 1 </each_steps>
+                </pair>
+            </timesteps>
+            <variables>
+                <variable> pressure </variable>
+                <variable> v </variable>
+            </variables>
+        </output>
+    </time_loop>
+    <parameters>
+        <parameter>
+            <name>p0</name>
+            <type>Constant</type>
+            <value>5e6</value>
+        </parameter>
+        <parameter>
+            <name>p_Dirichlet_left</name>
+            <type>Constant</type>
+            <value>1e7</value>
+        </parameter>
+        <parameter>
+            <name>p_Dirichlet_right</name>
+            <type>Constant</type>
+            <value>1e6</value>
+        </parameter>
+        <parameter>
+            <name>constant_porosity_parameter</name>
+            <type>Constant</type>
+            <value>1</value>
+        </parameter>
+        <parameter>
+            <name>kappa1</name>
+            <type>Constant</type>
+            <values>9.2e-12 0 0 0 9.2e-12 0 0 0 9.2e-12</values>
+        </parameter>
+        <parameter>
+            <name>p_spatial</name>
+            <type>Constant</type>
+            <value>1</value>
+        </parameter>
+    </parameters>
+    <process_variables>
+        <process_variable>
+            <name>pressure</name>
+            <components>1</components>
+            <order>1</order>
+            <initial_condition>p0</initial_condition>
+            <boundary_conditions>
+                <boundary_condition>
+                    <mesh>cube_1x1x1_hex_1e3_left</mesh>
+                    <type>Dirichlet</type>
+                    <parameter>p_Dirichlet_left</parameter>
+                </boundary_condition>
+                <boundary_condition>
+                    <mesh>cube_1x1x1_hex_1e3_right</mesh>
+                    <type>Dirichlet</type>
+                    <parameter>p_Dirichlet_right</parameter>
+                </boundary_condition>
+            </boundary_conditions>
+        </process_variable>
+    </process_variables>
+    <nonlinear_solvers>
+        <nonlinear_solver>
+            <name>basic_picard</name>
+            <type>Picard</type>
+            <max_iter>10</max_iter>
+            <linear_solver>general_linear_solver</linear_solver>
+        </nonlinear_solver>
+    </nonlinear_solvers>
+    <linear_solvers>
+        <linear_solver>
+            <name>general_linear_solver</name>
+            <lis>-i cg -p jacobi -tol 1e-16 -maxiter 10000</lis>
+            <eigen>
+                <solver_type>CG</solver_type>
+                <precon_type>DIAGONAL</precon_type>
+                <max_iteration_step>10000</max_iteration_step>
+                <error_tolerance>1e-16</error_tolerance>
+            </eigen>
+            <petsc>
+                <prefix>lf</prefix>
+                <parameters>-lf_ksp_type cg -lf_pc_type bjacobi -lf_ksp_rtol 1e-16 -lf_ksp_max_it 10000</parameters>
+            </petsc>
+        </linear_solver>
+    </linear_solvers>
+</OpenGeoSysProject>

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1x1x1_hex_1e3.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1x1x1_hex_1e3.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3e77b980dc0a4cefc19ba02eca4ad07ded3dc97497a01f169c719fc738a6bc9
+size 23197

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1x1x1_hex_1e3_complete_surface.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1x1x1_hex_1e3_complete_surface.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f405c070ea2cab30321345825eff7421fb1a5401cc2887a68da26e4e04d0b70
+size 65673

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1x1x1_hex_1e3_complete_surface_left_right_dirichlet_specific_flux_t_0.432000_expected.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1x1x1_hex_1e3_complete_surface_left_right_dirichlet_specific_flux_t_0.432000_expected.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c40d5de97b2704c8260f3afec3d5d381b6614b3b6121518535a90ec738764cac
+size 79556

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1x1x1_hex_1e3_complete_surface_left_right_dirichlet_specific_flux_t_0.864000_expected.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1x1x1_hex_1e3_complete_surface_left_right_dirichlet_specific_flux_t_0.864000_expected.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e2fb642aa3ca416db53112da6cbceed72e2a74369297c48bd26964ee95dcdb6
+size 79556

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1x1x1_hex_1e3_left.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1x1x1_hex_1e3_left.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b76bf4e7791dcd0431554367369cd2c49fd24c6d0784b73d55333667b73d1bc
+size 12897

--- a/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1x1x1_hex_1e3_right.vtu
+++ b/Tests/Data/Parabolic/LiquidFlow/Flux/cube_1x1x1_hex_1e3_right.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efcc5a635b6616ee00d7f8df481c3dfedbab2984a2e5ffb317386095681d19e4
+size 12898


### PR DESCRIPTION
1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.0)
2. [x] Tests covering your feature were added?
3. [x] Any new feature or behavior change was documented?:
        The flux calculation is now available for the LiquidFlow process. This works analogously to the other implementations in the HT-Process, HC-Process and groundwater flow process. Documentation already exists for this.
