### PR TITLE
refactoring the MPL verification of HT process

### DIFF
--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -291,21 +291,19 @@ void checkMPLProperties(MeshLib::Mesh const& mesh,
 {
     DBUG("Check the media properties of HT process ...");
 
-    std::vector<MaterialPropertyLib::PropertyType> const requiredPropertyMedium =
-        {MaterialPropertyLib::PropertyType::porosity,
-         MaterialPropertyLib::PropertyType::permeability};
+    std::array const requiredPropertyMedium = {
+        MaterialPropertyLib::PropertyType::porosity,
+        MaterialPropertyLib::PropertyType::permeability};
 
-    std::vector<MaterialPropertyLib::PropertyType> const
-        requiredPropertyLiquidPhase = {
-            MaterialPropertyLib::PropertyType::viscosity,
-            MaterialPropertyLib::PropertyType::density,
-            MaterialPropertyLib::PropertyType::specific_heat_capacity};
+    std::array const requiredPropertyLiquidPhase = {
+        MaterialPropertyLib::PropertyType::viscosity,
+        MaterialPropertyLib::PropertyType::density,
+        MaterialPropertyLib::PropertyType::specific_heat_capacity};
 
-    std::vector<MaterialPropertyLib::PropertyType> const
-        requiredPropertySolidPhase = {
-            MaterialPropertyLib::PropertyType::specific_heat_capacity,
-            MaterialPropertyLib::PropertyType::density,
-            MaterialPropertyLib::PropertyType::storage};
+    std::array const requiredPropertySolidPhase = {
+        MaterialPropertyLib::PropertyType::specific_heat_capacity,
+        MaterialPropertyLib::PropertyType::density,
+        MaterialPropertyLib::PropertyType::storage};
 
     for (auto const& element : mesh.getElements())
     {

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -291,18 +291,18 @@ void checkMPLProperties(MeshLib::Mesh const& mesh,
 {
     DBUG("Check the media properties of HT process ...");
 
-    std::vector<MaterialPropertyLib::PropertyType> const reqiredPropertyMedium =
+    std::vector<MaterialPropertyLib::PropertyType> const requiredPropertyMedium =
         {MaterialPropertyLib::PropertyType::porosity,
          MaterialPropertyLib::PropertyType::permeability};
 
     std::vector<MaterialPropertyLib::PropertyType> const
-        reqiredPropertyLiquidPhase = {
+        requiredPropertyLiquidPhase = {
             MaterialPropertyLib::PropertyType::viscosity,
             MaterialPropertyLib::PropertyType::density,
             MaterialPropertyLib::PropertyType::specific_heat_capacity};
 
     std::vector<MaterialPropertyLib::PropertyType> const
-        reqiredPropertySolidPhase = {
+        requiredPropertySolidPhase = {
             MaterialPropertyLib::PropertyType::specific_heat_capacity,
             MaterialPropertyLib::PropertyType::density,
             MaterialPropertyLib::PropertyType::storage};
@@ -314,7 +314,7 @@ void checkMPLProperties(MeshLib::Mesh const& mesh,
         // check if a definition of the porous media exists
         auto const& medium = *process_data.media_map->getMedium(element_id);
 
-        for (auto const property : reqiredPropertyMedium)
+        for (auto const property : requiredPropertyMedium)
         {
             if (!medium.hasProperty(property))
             {
@@ -327,7 +327,7 @@ void checkMPLProperties(MeshLib::Mesh const& mesh,
         // check if liquid phase definition and the corresponding properties
         // exists
         auto const& liquid_phase = medium.phase("AqueousLiquid");
-        for (auto const property : reqiredPropertyLiquidPhase)
+        for (auto const property : requiredPropertyLiquidPhase)
         {
             if (!liquid_phase.hasProperty(property))
             {
@@ -341,7 +341,7 @@ void checkMPLProperties(MeshLib::Mesh const& mesh,
         // check if solid phase definition and the corresponding properties
         // exists
         auto const& solid_phase = medium.phase("Solid");
-        for (auto const property : reqiredPropertySolidPhase)
+        for (auto const property : requiredPropertySolidPhase)
         {
             if (!solid_phase.hasProperty(property))
             {


### PR DESCRIPTION
A more elegant way (IMHO) to verify the correct configuration of material properties. No new features, and in this process there is actually the same number of code lines, but it will be very useful in complex processes such as th2m where 18+ properties have to be checked.

1. [ ] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.0)
2. [ ] Tests covering your feature were added?
3. [ ] Any new feature or behavior change was documented?
