### PR TITLE
[HM] MPL Linkage

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -574,7 +574,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                                std::move(jacobian_assembler),
                                _process_variables, _parameters,
                                _local_coordinate_system, integration_order,
-                               process_config);
+                               process_config, _media);
                     break;
                 case 3:
                     process =
@@ -583,7 +583,7 @@ void ProjectData::parseProcesses(BaseLib::ConfigTree const& processes_config,
                                std::move(jacobian_assembler),
                                _process_variables, _parameters,
                                _local_coordinate_system, integration_order,
-                               process_config);
+                               process_config, _media);
                     break;
                 default:
                     OGS_FATAL(

--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/t_fluid_viscosity.md
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/t_fluid_viscosity.md
@@ -1,1 +1,0 @@
-\copydoc ProcessLib::HydroMechanics::HydroMechanicsProcessData::fluid_viscosity

--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/t_porosity.md
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/t_porosity.md
@@ -1,1 +1,0 @@
-\copydoc ProcessLib::HydroMechanics::HydroMechanicsProcessData::porosity

--- a/MaterialLib/MPL/Phase.cpp
+++ b/MaterialLib/MPL/Phase.cpp
@@ -65,4 +65,5 @@ std::string Phase::name() const
 {
     return std::get<std::string>(_properties[PropertyType::name]->value());
 }
+
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Phase.h
+++ b/MaterialLib/MPL/Phase.h
@@ -52,6 +52,20 @@ public:
 
     std::string name() const;
 
+    template <size_t N>
+    void checkRequiredProperties(
+        std::array<PropertyType, N> const& required_properties) const
+    {
+        for (auto const& p : required_properties)
+        {
+            if (!hasProperty(p))
+            {
+                OGS_FATAL("The property '%s' is missing in the %s phase.",
+                          property_enum_to_string[p].c_str(), name().c_str());
+            }
+        }
+    }
+
 private:
     std::vector<std::unique_ptr<Component>> const _components;
 

--- a/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.cpp
@@ -14,6 +14,7 @@
 
 #include "MaterialLib/MPL/CreateMaterialSpatialDistributionMap.h"
 #include "MaterialLib/MPL/MaterialSpatialDistributionMap.h"
+#include "MaterialLib/MPL/Medium.h"
 
 #include "MaterialLib/SolidModels/CreateConstitutiveRelation.h"
 #include "MaterialLib/SolidModels/MechanicsBase.h"
@@ -163,6 +164,15 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
 
     auto media_map =
         MaterialPropertyLib::createMaterialSpatialDistributionMap(media, mesh);
+
+    std::array const requiredGasProperties = {MaterialPropertyLib::viscosity};
+    std::array const requiredSolidProperties = {MaterialPropertyLib::porosity};
+    for (auto const& m : media)
+    {
+        m.second->phase("Gas").checkRequiredProperties(requiredGasProperties);
+        m.second->phase("Solid").checkRequiredProperties(
+            requiredSolidProperties);
+    }
 
     // Initial stress conditions
     auto const initial_stress = ParameterLib::findOptionalTagParameter<double>(

--- a/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.h
@@ -11,12 +11,17 @@
 #pragma once
 
 #include <boost/optional.hpp>
+#include <map>
 #include <memory>
 #include <vector>
 
 namespace BaseLib
 {
 class ConfigTree;
+}
+namespace MaterialPropertyLib
+{
+class Medium;
 }
 namespace MeshLib
 {
@@ -48,7 +53,8 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     boost::optional<ParameterLib::CoordinateSystem> const&
         local_coordinate_system,
     unsigned const integration_order,
-    BaseLib::ConfigTree const& config);
+    BaseLib::ConfigTree const& config,
+    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
 
 extern template std::unique_ptr<Process> createHydroMechanicsProcess<2>(
     std::string name,
@@ -59,7 +65,8 @@ extern template std::unique_ptr<Process> createHydroMechanicsProcess<2>(
     boost::optional<ParameterLib::CoordinateSystem> const&
         local_coordinate_system,
     unsigned const integration_order,
-    BaseLib::ConfigTree const& config);
+    BaseLib::ConfigTree const& config,
+    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
 
 extern template std::unique_ptr<Process> createHydroMechanicsProcess<3>(
     std::string name,
@@ -70,6 +77,7 @@ extern template std::unique_ptr<Process> createHydroMechanicsProcess<3>(
     boost::optional<ParameterLib::CoordinateSystem> const&
         local_coordinate_system,
     unsigned const integration_order,
-    BaseLib::ConfigTree const& config);
+    BaseLib::ConfigTree const& config,
+    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
 }  // namespace HydroMechanics
 }  // namespace ProcessLib

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -66,7 +66,7 @@ HydroMechanicsLocalAssembler<ShapeFunctionDisplacement, ShapeFunctionPressure,
         _ip_data.emplace_back(solid_material);
         auto& ip_data = _ip_data[ip];
         auto const& sm_u = shape_matrices_u[ip];
-        _ip_data[ip].integration_weight =
+       ip_data.integration_weight =
             _integration_method.getWeightedPoint(ip).getWeight() *
             sm_u.integralMeasure * sm_u.detJ;
 
@@ -228,7 +228,8 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
             (_process_data.fluid_type == FluidType::Fluid_Type::IDEAL_GAS)
                 ? N_p.dot(p)
                 : std::numeric_limits<double>::quiet_NaN();
-        double const rho_fr = _process_data.getFluidDensity(t, x_position, p_fr);
+        double const rho_fr =
+            _process_data.getFluidDensity(t, x_position, p_fr);
         double const beta_p = _process_data.getFluidCompressibility(p_fr);
         auto const porosity =
             solid_phase.property(MaterialPropertyLib::PropertyType::porosity)
@@ -242,8 +243,8 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
         //
         eps.noalias() = B * u;
 
-        auto C =
-            _ip_data[ip].updateConstitutiveRelation(t, x_position, dt, u, T_ref);
+        auto C = _ip_data[ip].updateConstitutiveRelation(t, x_position, dt, u,
+                                                         T_ref);
 
         local_Jac
             .template block<displacement_size, displacement_size>(
@@ -271,7 +272,8 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
             ((alpha - porosity) * (1.0 - alpha) / K_S + porosity * beta_p);
 
         add_p_derivative.noalias() += rho_fr * beta_p * dNdx_p.transpose() *
-            K_over_mu * (dNdx_p * p - 2.0 * rho_fr * b) * N_p * w;
+                                      K_over_mu *
+                                      (dNdx_p * p - 2.0 * rho_fr * b) * N_p * w;
 
         local_rhs.template segment<pressure_size>(pressure_index).noalias() +=
             dNdx_p.transpose() * rho_fr * rho_fr * K_over_mu * b * w;
@@ -442,7 +444,8 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
             (_process_data.fluid_type == FluidType::Fluid_Type::IDEAL_GAS)
                 ? N_p.dot(p)
                 : std::numeric_limits<double>::quiet_NaN();
-        double const rho_fr = _process_data.getFluidDensity(t, x_position, p_fr);
+        double const rho_fr =
+            _process_data.getFluidDensity(t, x_position, p_fr);
         double const beta_p = _process_data.getFluidCompressibility(p_fr);
         auto const porosity =
             solid_phase.property(MaterialPropertyLib::PropertyType::porosity)

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
@@ -18,6 +18,8 @@
 
 #include <Eigen/Dense>
 
+#include "MaterialLib/MPL/MaterialSpatialDistributionMap.h"
+
 namespace MaterialLib
 {
 namespace Solids
@@ -35,6 +37,9 @@ struct HydroMechanicsProcessData
 {
     MeshLib::PropertyVector<int> const* const material_ids = nullptr;
 
+    std::unique_ptr<MaterialPropertyLib::MaterialSpatialDistributionMap>
+        media_map = nullptr;
+
     /// The constitutive relation for the mechanical part.
     /// \note Linear elasticity is the only supported one in the moment.
     std::map<
@@ -49,15 +54,10 @@ struct HydroMechanicsProcessData
     /// Permeability of the solid. A scalar quantity,
     /// ParameterLib::Parameter<double>.
     ParameterLib::Parameter<double> const& intrinsic_permeability;
-    /// Fluid's viscosity. A scalar quantity, ParameterLib::Parameter<double>.
-    ParameterLib::Parameter<double> const& fluid_viscosity;
     /// Fluid's density. A scalar quantity, ParameterLib::Parameter<double>.
     ParameterLib::Parameter<double> const& fluid_density;
     /// Biot coefficient. A scalar quantity, ParameterLib::Parameter<double>.
     ParameterLib::Parameter<double> const& biot_coefficient;
-    /// Porosity of the solid. A scalar quantity,
-    /// ParameterLib::Parameter<double>.
-    ParameterLib::Parameter<double> const& porosity;
     /// Solid's density. A scalar quantity, ParameterLib::Parameter<double>.
     ParameterLib::Parameter<double> const& solid_density;
     /// Specific body forces applied to solid and fluid.

--- a/Tests/Data/HydroMechanics/IdealGas/flow_free_expansion/flow_free_expansion.prj
+++ b/Tests/Data/HydroMechanics/IdealGas/flow_free_expansion/flow_free_expansion.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_fr</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -40,6 +38,32 @@
             <specific_gas_constant>287.058</specific_gas_constant>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-5</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0.3</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -108,19 +132,9 @@
             <value>1e-5</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-5</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>0.6</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0.3</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>

--- a/Tests/Data/HydroMechanics/IdealGas/flow_no_strain/flow_no_strain.prj
+++ b/Tests/Data/HydroMechanics/IdealGas/flow_no_strain/flow_no_strain.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_fr</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -40,6 +38,32 @@
             <specific_gas_constant>287.058</specific_gas_constant>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-5</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0.03</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -108,19 +132,9 @@
             <value>1e-4</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-5</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>0.6</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0.03</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>

--- a/Tests/Data/HydroMechanics/IdealGas/flow_pressure_boundary/flow_pressure_boundary.prj
+++ b/Tests/Data/HydroMechanics/IdealGas/flow_pressure_boundary/flow_pressure_boundary.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_fr</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -40,6 +38,32 @@
             <specific_gas_constant>287.058</specific_gas_constant>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-5</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0.1</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -108,19 +132,9 @@
             <value>1e-12</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-5</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>1.0</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0.1</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>
@@ -147,7 +161,7 @@
             <type>Constant</type>
             <value>0</value>
         </parameter>
-		<parameter>
+        <parameter>
             <name>flux_in</name>
             <type>Constant</type>
             <value>1e-2</value>

--- a/Tests/Data/HydroMechanics/Linear/Confined_Compression/cube_1e3.prj
+++ b/Tests/Data/HydroMechanics/Linear/Confined_Compression/cube_1e3.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_fr</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -29,6 +27,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-9</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0.8</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -88,19 +112,9 @@
             <value>1e-12</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-9</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>1</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0.8</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>

--- a/Tests/Data/HydroMechanics/Linear/Confined_Compression/square_1e2.prj
+++ b/Tests/Data/HydroMechanics/Linear/Confined_Compression/square_1e2.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_fr</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -38,6 +36,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-9</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0.8</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -122,19 +146,9 @@
             <value>1e-12</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-9</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>1</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0.8</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>

--- a/Tests/Data/HydroMechanics/Linear/Confined_Compression/square_1e2_quad9.prj
+++ b/Tests/Data/HydroMechanics/Linear/Confined_Compression/square_1e2_quad9.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_fr</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -29,6 +27,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-9</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0.8</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -88,19 +112,9 @@
             <value>1e-12</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-9</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>1</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0.8</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>

--- a/Tests/Data/HydroMechanics/Linear/Confined_Compression/square_1e2_tri.prj
+++ b/Tests/Data/HydroMechanics/Linear/Confined_Compression/square_1e2_tri.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_fr</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -29,6 +27,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-9</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0.8</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -88,19 +112,9 @@
             <value>1e-12</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-9</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>1</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0.8</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>

--- a/Tests/Data/HydroMechanics/Linear/Gravity/flow_gravity.prj
+++ b/Tests/Data/HydroMechanics/Linear/Gravity/flow_gravity.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_fr</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -38,6 +36,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0.1</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -59,11 +83,11 @@
                             <repeat>10</repeat>
                             <delta_t>5</delta_t>
                         </pair>
-						<pair>
+                        <pair>
                             <repeat>2</repeat>
                             <delta_t>1e4</delta_t>
                         </pair>
-						<pair>
+                        <pair>
                             <repeat>10</repeat>
                             <delta_t>1e7</delta_t>
                         </pair>
@@ -114,19 +138,9 @@
             <value>1e-12</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>1</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0.1</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>
@@ -148,7 +162,7 @@
             <type>Constant</type>
             <value>0</value>
         </parameter>
-		<parameter>
+        <parameter>
             <name>flux_in</name>
             <type>Constant</type>
             <value>1e-2</value>

--- a/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_early/square_1e2_UC_early.prj
+++ b/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_early/square_1e2_UC_early.prj
@@ -14,9 +14,7 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <fluid_density>rho_fr</fluid_density>
             <process_variables>
@@ -29,6 +27,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -88,19 +112,9 @@
             <value>1e-10</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>1</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>

--- a/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_early/square_1e4_UC_early.prj
+++ b/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_early/square_1e4_UC_early.prj
@@ -14,9 +14,7 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <fluid_density>rho_fr</fluid_density>
             <process_variables>
@@ -29,6 +27,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -88,19 +112,9 @@
             <value>1e-10</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>1</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>

--- a/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_late/square_1e2_UC_late.prj
+++ b/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_late/square_1e2_UC_late.prj
@@ -14,9 +14,7 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <fluid_density>rho_fr</fluid_density>
             <process_variables>
@@ -29,6 +27,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -88,19 +112,9 @@
             <value>1e-10</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>1</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>

--- a/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_late/square_1e4_UC_late.prj
+++ b/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_late/square_1e4_UC_late.prj
@@ -14,9 +14,7 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <fluid_density>rho_fr</fluid_density>
             <process_variables>
@@ -29,6 +27,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -88,19 +112,9 @@
             <value>1e-10</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>1</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>

--- a/Tests/Data/HydroMechanics/Principal_Stress/Hollow_Sphere/sphere.prj
+++ b/Tests/Data/HydroMechanics/Principal_Stress/Hollow_Sphere/sphere.prj
@@ -19,10 +19,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_fr</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -92,6 +90,32 @@
             </variables>
         </output>
     </time_loop>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <parameters>
         <!-- Mechanics -->
         <parameter>
@@ -111,19 +135,9 @@
             <value>1e-16</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>0</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0.0</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>

--- a/Tests/Data/HydroMechanics/Principal_Stress/Tube/tube.prj
+++ b/Tests/Data/HydroMechanics/Principal_Stress/Tube/tube.prj
@@ -19,10 +19,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_fr</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -92,6 +90,32 @@
             </variables>
         </output>
     </time_loop>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <parameters>
         <!-- Mechanics -->
         <parameter>
@@ -111,19 +135,9 @@
             <value>1e-16</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>0</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0.0</value>
         </parameter>
         <parameter>
             <name>rho_sr</name>

--- a/Tests/Data/HydroMechanics/StaggeredScheme/InjectionProduction1D/InjectionProduction1D.prj
+++ b/Tests/Data/HydroMechanics/StaggeredScheme/InjectionProduction1D/InjectionProduction1D.prj
@@ -15,10 +15,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_f</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_s</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
@@ -41,6 +39,32 @@
             <fluid_compressibility>3.33333333333e-5</fluid_compressibility>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0.3</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <global_process_coupling>
             <max_iter> 6 </max_iter>
@@ -158,19 +182,9 @@
             <value>4.9346165e-11</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>1</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0.3</value>
         </parameter>
         <parameter>
             <name>rho_s</name>

--- a/Tests/Data/HydroMechanics/StaggeredScheme/InjectionProduction1D/RerefenceSolutionByMonolithicScheme/InjectionProduction1DMono.prj
+++ b/Tests/Data/HydroMechanics/StaggeredScheme/InjectionProduction1D/RerefenceSolutionByMonolithicScheme/InjectionProduction1DMono.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_f</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_s</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
@@ -40,6 +38,32 @@
             <fluid_compressibility>3.33333333333e-5</fluid_compressibility>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0.3</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <!--For the equations of deformation-->
@@ -117,19 +141,9 @@
             <value>4.9346165e-11</value>
         </parameter>
         <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
-        </parameter>
-        <parameter>
             <name>alpha</name>
             <type>Constant</type>
             <value>1</value>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Constant</type>
-            <value>0.3</value>
         </parameter>
         <parameter>
             <name>rho_s</name>

--- a/Tests/Data/HydroMechanics/Verification/hm1_1Dbeam.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm1_1Dbeam.prj
@@ -15,10 +15,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_liquid</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
@@ -43,6 +41,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Parameter</type>
+                            <parameter_name>phi</parameter_name>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <global_process_coupling>
             <max_iter> 1 </max_iter>
@@ -57,7 +81,7 @@
                     <!-- convergence criterion for the second process -->
                     <type>DeltaX</type>
                     <norm_type>NORM2</norm_type>
-                    <reltol> 1.0e-15  </reltol>
+                    <reltol> 1.0e-15 </reltol>
                 </convergence_criterion>
             </convergence_criteria>
         </global_process_coupling>
@@ -123,7 +147,6 @@
                     <each_steps> 1 </each_steps>
                 </pair>
             </timesteps>
-
             <variables>
                 <variable>pressure</variable>
                 <variable>displacement</variable>
@@ -193,11 +216,6 @@
                 <index>0</index>
                 <value>1</value>
             </index_values>
-        </parameter>
-        <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
         </parameter>
         <parameter>
             <name>rho_liquid</name>

--- a/Tests/Data/HydroMechanics/Verification/hm1_2Dsquare.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm1_2Dsquare.prj
@@ -15,10 +15,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_liquid</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
@@ -43,6 +41,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Parameter</type>
+                            <parameter_name>phi</parameter_name>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <global_process_coupling>
             <max_iter> 1 </max_iter>
@@ -57,7 +81,7 @@
                     <!-- convergence criterion for the second process -->
                     <type>DeltaX</type>
                     <norm_type>NORM2</norm_type>
-                    <reltol> 1.0e-15  </reltol>
+                    <reltol> 1.0e-15 </reltol>
                 </convergence_criterion>
             </convergence_criteria>
         </global_process_coupling>
@@ -192,11 +216,6 @@
                 <index>0</index>
                 <value>1</value>
             </index_values>
-        </parameter>
-        <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
         </parameter>
         <parameter>
             <name>rho_liquid</name>

--- a/Tests/Data/HydroMechanics/Verification/hm1_3Dcube.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm1_3Dcube.prj
@@ -15,10 +15,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_liquid</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
@@ -43,6 +41,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Parameter</type>
+                            <parameter_name>phi</parameter_name>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <global_process_coupling>
             <max_iter> 1 </max_iter>
@@ -57,7 +81,7 @@
                     <!-- convergence criterion for the second process -->
                     <type>DeltaX</type>
                     <norm_type>NORM2</norm_type>
-                    <reltol> 1.0e-15  </reltol>
+                    <reltol> 1.0e-15 </reltol>
                 </convergence_criterion>
             </convergence_criteria>
         </global_process_coupling>
@@ -192,11 +216,6 @@
                 <index>0</index>
                 <value>1</value>
             </index_values>
-        </parameter>
-        <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
         </parameter>
         <parameter>
             <name>rho_liquid</name>

--- a/Tests/Data/HydroMechanics/Verification/hm1_3Dgravity.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm1_3Dgravity.prj
@@ -15,10 +15,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_liquid</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
@@ -43,6 +41,104 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium id="0">
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+        <medium id="1">
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+        <medium id="2">
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+        <medium id="3">
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Constant</type>
+                            <value>0</value>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <global_process_coupling>
             <max_iter> 1 </max_iter>
@@ -57,7 +153,7 @@
                     <!-- convergence criterion for the second process -->
                     <type>DeltaX</type>
                     <norm_type>NORM2</norm_type>
-                    <reltol> 1.0e-15  </reltol>
+                    <reltol> 1.0e-15 </reltol>
                 </convergence_criterion>
             </convergence_criteria>
         </global_process_coupling>
@@ -70,7 +166,7 @@
                 <convergence_criterion>
                     <type>DeltaX</type>
                     <norm_type>NORM2</norm_type>
-		    <reltol>1.0e-15</reltol>
+                    <reltol>1.0e-15</reltol>
                 </convergence_criterion>
                 <time_discretization>
                     <type>BackwardEuler</type>
@@ -203,27 +299,6 @@
             </index_values>
         </parameter>
         <parameter>
-            <name>phi</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>0</value>
-            </index_values>
-            <index_values>
-                <index>1</index>
-                <value>0</value>
-            </index_values>
-            <index_values>
-                <index>2</index>
-                <value>0</value>
-            </index_values>
-            <index_values>
-                <index>3</index>
-                <value>0</value>
-            </index_values>
-        </parameter>
-        <parameter>
             <name>rho_solid</name>
             <type>Group</type>
             <group_id_property>MaterialIDs</group_id_property>
@@ -264,11 +339,6 @@
                 <index>3</index>
                 <value>1</value>
             </index_values>
-        </parameter>
-        <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
         </parameter>
         <parameter>
             <name>rho_liquid</name>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1D1bt.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1D1bt.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_liquid</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
@@ -34,14 +32,40 @@
                 <secondary_variable internal_name="epsilon_xx" output_name="epsilon_xx"/>
                 <secondary_variable internal_name="epsilon_yy" output_name="epsilon_yy"/>
                 <secondary_variable internal_name="epsilon_zz" output_name="epsilon_zz"/>
-               <secondary_variable internal_name="epsilon_xy" output_name="epsilon_xy"/>
-               <secondary_variable internal_name="epsilon_xz" output_name="epsilon_xz"/>
-               <secondary_variable internal_name="epsilon_yz" output_name="epsilon_yz"/>
+                <secondary_variable internal_name="epsilon_xy" output_name="epsilon_xy"/>
+                <secondary_variable internal_name="epsilon_xz" output_name="epsilon_xz"/>
+                <secondary_variable internal_name="epsilon_yz" output_name="epsilon_yz"/>
             </secondary_variables>
             <specific_body_force>0 0 0</specific_body_force>
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Parameter</type>
+                            <parameter_name>phi</parameter_name>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -146,11 +170,6 @@
                 <index>0</index>
                 <value>1</value>
             </index_values>
-        </parameter>
-        <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
         </parameter>
         <parameter>
             <name>rho_liquid</name>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1D2bt.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1D2bt.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_liquid</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
@@ -42,6 +40,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Parameter</type>
+                            <parameter_name>phi</parameter_name>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -146,11 +170,6 @@
                 <index>0</index>
                 <value>1</value>
             </index_values>
-        </parameter>
-        <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
         </parameter>
         <parameter>
             <name>rho_liquid</name>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1Dbiot.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1Dbiot.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_liquid</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
@@ -42,6 +40,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Parameter</type>
+                            <parameter_name>phi</parameter_name>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -146,11 +170,6 @@
                 <index>0</index>
                 <value>1</value>
             </index_values>
-        </parameter>
-        <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
         </parameter>
         <parameter>
             <name>rho_liquid</name>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1Dcolumn1.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1Dcolumn1.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_liquid</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
@@ -42,6 +40,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Parameter</type>
+                            <parameter_name>phi</parameter_name>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -146,11 +170,6 @@
                 <index>0</index>
                 <value>1</value>
             </index_values>
-        </parameter>
-        <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
         </parameter>
         <parameter>
             <name>rho_liquid</name>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1Dcolumn2.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1Dcolumn2.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_liquid</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
@@ -42,6 +40,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Parameter</type>
+                            <parameter_name>phi</parameter_name>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -150,11 +174,6 @@
                 <index>0</index>
                 <value>1</value>
             </index_values>
-        </parameter>
-        <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
         </parameter>
         <parameter>
             <name>rho_liquid</name>

--- a/Tests/Data/HydroMechanics/Verification/hm2_2Dmandel.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_2Dmandel.prj
@@ -14,10 +14,8 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <fluid_viscosity>mu</fluid_viscosity>
             <fluid_density>rho_liquid</fluid_density>
             <biot_coefficient>alpha</biot_coefficient>
-            <porosity>phi</porosity>
             <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
@@ -42,6 +40,32 @@
             <fluid_type>incompressible_fluid</fluid_type>
         </process>
     </processes>
+    <media>
+        <medium>
+            <phases>
+                <phase>
+                    <type>Gas</type>
+                    <properties>
+                        <property>
+                            <name>viscosity</name>
+                            <type>Constant</type>
+                            <value>1e-3</value>
+                        </property>
+                    </properties>
+                </phase>
+                <phase>
+                    <type>Solid</type>
+                    <properties>
+                        <property>
+                            <name>porosity</name>
+                            <type>Parameter</type>
+                            <parameter_name>phi</parameter_name>
+                        </property>
+                    </properties>
+                </phase>
+            </phases>
+        </medium>
+    </media>
     <time_loop>
         <processes>
             <process ref="HM">
@@ -150,11 +174,6 @@
                 <index>0</index>
                 <value>1</value>
             </index_values>
-        </parameter>
-        <parameter>
-            <name>mu</name>
-            <type>Constant</type>
-            <value>1e-3</value>
         </parameter>
         <parameter>
             <name>rho_liquid</name>


### PR DESCRIPTION
Added Linkage to MPL with only porosity and viscosity being included for now.

The remaining parameters will follow in future PRs.
This is a preliminary step for properly introducing a new permeability model for HM
Also, the specific distinction of FluidTypes in HM will be removed and instead make use of MPL

Here is the Python Script I used for updating the benchmark files (one had to be adjusted manually):
[ConvertToMPL.txt](https://github.com/ufz/ogs/files/4103434/ConvertToMPL.txt)
