### PR TITLE
[HM] MPL Link 2

### DIFF
--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/t_biot_coefficient.md
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/t_biot_coefficient.md
@@ -1,1 +1,0 @@
-\copydoc ProcessLib::HydroMechanics::HydroMechanicsProcessData::biot_coefficient

--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/t_solid_density.md
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/t_solid_density.md
@@ -1,1 +1,0 @@
-\copydoc ProcessLib::HydroMechanics::HydroMechanicsProcessData::solid_density

--- a/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.cpp
@@ -128,21 +128,6 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
         "fluid_density", parameters, 1, &mesh);
     DBUG("Use '%s' as fluid density parameter.", fluid_density.name.c_str());
 
-    // Biot coefficient
-    auto& biot_coefficient = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS__biot_coefficient}
-        "biot_coefficient", parameters, 1, &mesh);
-    DBUG("Use '%s' as Biot coefficient parameter.",
-         biot_coefficient.name.c_str());
-
-    // Solid density
-    auto& solid_density = ParameterLib::findParameter<double>(
-        config,
-        //! \ogs_file_param_special{prj__processes__process__HYDRO_MECHANICS__solid_density}
-        "solid_density", parameters, 1, &mesh);
-    DBUG("Use '%s' as solid density parameter.", solid_density.name.c_str());
-
     // Specific body force
     Eigen::Matrix<double, DisplacementDim, 1> specific_body_force;
     {
@@ -166,7 +151,9 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
         MaterialPropertyLib::createMaterialSpatialDistributionMap(media, mesh);
 
     std::array const requiredGasProperties = {MaterialPropertyLib::viscosity};
-    std::array const requiredSolidProperties = {MaterialPropertyLib::porosity};
+    std::array const requiredSolidProperties = {
+        MaterialPropertyLib::porosity, MaterialPropertyLib::biot_coefficient,
+        MaterialPropertyLib::density};
     for (auto const& m : media)
     {
         m.second->phase("Gas").checkRequiredProperties(requiredGasProperties);
@@ -220,8 +207,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
         materialIDs(mesh),     std::move(media_map),
         std::move(solid_constitutive_relations),
         initial_stress,        intrinsic_permeability,
-        fluid_density,         biot_coefficient,
-        solid_density,         specific_body_force,
+        fluid_density,         specific_body_force,
         fluid_compressibility, reference_temperature,
         specific_gas_constant, fluid_type};
 

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -24,6 +24,8 @@ namespace ProcessLib
 {
 namespace HydroMechanics
 {
+namespace MPL = MaterialPropertyLib;
+
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
           typename IntegrationMethod, int DisplacementDim>
 HydroMechanicsLocalAssembler<ShapeFunctionDisplacement, ShapeFunctionPressure,
@@ -186,7 +188,7 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
     auto const& medium = _process_data.media_map->getMedium(_element.getID());
     auto const& gas_phase = medium->phase("Gas");
     auto const& solid_phase = medium->phase("Solid");
-    MaterialPropertyLib::VariableArray vars;
+    MPL::VariableArray vars;
     for (unsigned ip = 0; ip < n_integration_points; ip++)
     {
         x_position.setIntegrationPoint(ip);
@@ -213,21 +215,18 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
         auto& eps = _ip_data[ip].eps;
         auto const& sigma_eff = _ip_data[ip].sigma_eff;
 
-        auto const mu =
-            gas_phase.property(MaterialPropertyLib::PropertyType::viscosity)
-                .template value<double>(vars, x_position, t);
+        auto const mu = gas_phase.property(MPL::PropertyType::viscosity)
+                            .template value<double>(vars, x_position, t);
 
         double const K_over_mu =
             _process_data.intrinsic_permeability(t, x_position)[0] / mu;
 
         auto const alpha =
-            solid_phase
-                .property(MaterialPropertyLib::PropertyType::biot_coefficient)
+            solid_phase.property(MPL::PropertyType::biot_coefficient)
                 .template value<double>(vars, x_position, t);
         auto const K_S = solid_material.getBulkModulus(t, x_position);
-        auto const rho_sr =
-            solid_phase.property(MaterialPropertyLib::PropertyType::density)
-                .template value<double>(vars, x_position, t);
+        auto const rho_sr = solid_phase.property(MPL::PropertyType::density)
+                                .template value<double>(vars, x_position, t);
         // TODO (FZill) get fluid properties from GPML
         double const p_fr =
             (_process_data.fluid_type == FluidType::Fluid_Type::IDEAL_GAS)
@@ -236,9 +235,8 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
         double const rho_fr =
             _process_data.getFluidDensity(t, x_position, p_fr);
         double const beta_p = _process_data.getFluidCompressibility(p_fr);
-        auto const porosity =
-            solid_phase.property(MaterialPropertyLib::PropertyType::porosity)
-                .template value<double>(vars, x_position, t);
+        auto const porosity = solid_phase.property(MPL::PropertyType::porosity)
+                                  .template value<double>(vars, x_position, t);
         auto const& identity2 = MathLib::KelvinVector::Invariants<
             MathLib::KelvinVector::KelvinVectorDimensions<
                 DisplacementDim>::value>::identity2;
@@ -349,15 +347,14 @@ HydroMechanicsLocalAssembler<ShapeFunctionDisplacement, ShapeFunctionPressure,
 
     auto const& medium = _process_data.media_map->getMedium(_element.getID());
     auto const& gas_phase = medium->phase("Gas");
-    MaterialPropertyLib::VariableArray vars;
+    MPL::VariableArray vars;
 
     for (unsigned ip = 0; ip < n_integration_points; ip++)
     {
         x_position.setIntegrationPoint(ip);
 
-        auto const mu =
-            gas_phase.property(MaterialPropertyLib::PropertyType::viscosity)
-                .template value<double>(vars, x_position, t);
+        auto const mu = gas_phase.property(MPL::PropertyType::viscosity)
+                            .template value<double>(vars, x_position, t);
 
         double const K_over_mu =
             _process_data.intrinsic_permeability(t, x_position)[0] / mu;
@@ -423,7 +420,7 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
     auto const& medium = _process_data.media_map->getMedium(_element.getID());
     auto const& gas_phase = medium->phase("Gas");
     auto const& solid_phase = medium->phase("Solid");
-    MaterialPropertyLib::VariableArray vars;
+    MPL::VariableArray vars;
 
     int const n_integration_points = _integration_method.getNumberOfPoints();
     for (int ip = 0; ip < n_integration_points; ip++)
@@ -437,15 +434,13 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
         auto const& N_p = _ip_data[ip].N_p;
         auto const& dNdx_p = _ip_data[ip].dNdx_p;
 
-        auto const mu =
-            gas_phase.property(MaterialPropertyLib::PropertyType::viscosity)
-                .template value<double>(vars, x_position, t);
+        auto const mu = gas_phase.property(MPL::PropertyType::viscosity)
+                            .template value<double>(vars, x_position, t);
 
         double const K_over_mu =
             _process_data.intrinsic_permeability(t, x_position)[0] / mu;
         auto const alpha_b =
-            solid_phase
-                .property(MaterialPropertyLib::PropertyType::biot_coefficient)
+            solid_phase.property(MPL::PropertyType::biot_coefficient)
                 .template value<double>(vars, x_position, t);
         // TODO (FZill) get fluid properties from GPML
         double const p_fr =
@@ -455,9 +450,8 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
         double const rho_fr =
             _process_data.getFluidDensity(t, x_position, p_fr);
         double const beta_p = _process_data.getFluidCompressibility(p_fr);
-        auto const porosity =
-            solid_phase.property(MaterialPropertyLib::PropertyType::porosity)
-                .template value<double>(vars, x_position, t);
+        auto const porosity = solid_phase.property(MPL::PropertyType::porosity)
+                                  .template value<double>(vars, x_position, t);
         auto const K_S = solid_material.getBulkModulus(t, x_position);
 
         laplace.noalias() += dNdx_p.transpose() * K_over_mu * dNdx_p * w;
@@ -522,7 +516,7 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
 
     auto const& medium = _process_data.media_map->getMedium(_element.getID());
     auto const& solid_phase = medium->phase("Solid");
-    MaterialPropertyLib::VariableArray vars;
+    MPL::VariableArray vars;
 
     int const n_integration_points = _integration_method.getNumberOfPoints();
     for (int ip = 0; ip < n_integration_points; ip++)
@@ -551,16 +545,13 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
         auto const& sigma_eff = _ip_data[ip].sigma_eff;
 
         auto const alpha =
-            solid_phase
-                .property(MaterialPropertyLib::PropertyType::biot_coefficient)
+            solid_phase.property(MPL::PropertyType::biot_coefficient)
                 .template value<double>(vars, x_position, t);
-        auto const rho_sr =
-            solid_phase.property(MaterialPropertyLib::PropertyType::density)
-                .template value<double>(vars, x_position, t);
+        auto const rho_sr = solid_phase.property(MPL::PropertyType::density)
+                                .template value<double>(vars, x_position, t);
         auto const rho_fr = _process_data.fluid_density(t, x_position)[0];
-        auto const porosity =
-            solid_phase.property(MaterialPropertyLib::PropertyType::porosity)
-                .template value<double>(vars, x_position, t);
+        auto const porosity = solid_phase.property(MPL::PropertyType::porosity)
+                                  .template value<double>(vars, x_position, t);
         auto const& b = _process_data.specific_body_force;
         auto const& identity2 = MathLib::KelvinVector::Invariants<
             MathLib::KelvinVector::KelvinVectorDimensions<

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -220,9 +220,14 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
         double const K_over_mu =
             _process_data.intrinsic_permeability(t, x_position)[0] / mu;
 
-        auto const alpha = _process_data.biot_coefficient(t, x_position)[0];
+        auto const alpha =
+            solid_phase
+                .property(MaterialPropertyLib::PropertyType::biot_coefficient)
+                .template value<double>(vars, x_position, t);
         auto const K_S = solid_material.getBulkModulus(t, x_position);
-        auto const rho_sr = _process_data.solid_density(t, x_position)[0];
+        auto const rho_sr =
+            solid_phase.property(MaterialPropertyLib::PropertyType::density)
+                .template value<double>(vars, x_position, t);
         // TODO (FZill) get fluid properties from GPML
         double const p_fr =
             (_process_data.fluid_type == FluidType::Fluid_Type::IDEAL_GAS)
@@ -438,7 +443,10 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
 
         double const K_over_mu =
             _process_data.intrinsic_permeability(t, x_position)[0] / mu;
-        auto const alpha_b = _process_data.biot_coefficient(t, x_position)[0];
+        auto const alpha_b =
+            solid_phase
+                .property(MaterialPropertyLib::PropertyType::biot_coefficient)
+                .template value<double>(vars, x_position, t);
         // TODO (FZill) get fluid properties from GPML
         double const p_fr =
             (_process_data.fluid_type == FluidType::Fluid_Type::IDEAL_GAS)
@@ -542,8 +550,13 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
         auto& eps = _ip_data[ip].eps;
         auto const& sigma_eff = _ip_data[ip].sigma_eff;
 
-        auto const alpha = _process_data.biot_coefficient(t, x_position)[0];
-        auto const rho_sr = _process_data.solid_density(t, x_position)[0];
+        auto const alpha =
+            solid_phase
+                .property(MaterialPropertyLib::PropertyType::biot_coefficient)
+                .template value<double>(vars, x_position, t);
+        auto const rho_sr =
+            solid_phase.property(MaterialPropertyLib::PropertyType::density)
+                .template value<double>(vars, x_position, t);
         auto const rho_fr = _process_data.fluid_density(t, x_position)[0];
         auto const porosity =
             solid_phase.property(MaterialPropertyLib::PropertyType::porosity)

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
@@ -56,10 +56,6 @@ struct HydroMechanicsProcessData
     ParameterLib::Parameter<double> const& intrinsic_permeability;
     /// Fluid's density. A scalar quantity, ParameterLib::Parameter<double>.
     ParameterLib::Parameter<double> const& fluid_density;
-    /// Biot coefficient. A scalar quantity, ParameterLib::Parameter<double>.
-    ParameterLib::Parameter<double> const& biot_coefficient;
-    /// Solid's density. A scalar quantity, ParameterLib::Parameter<double>.
-    ParameterLib::Parameter<double> const& solid_density;
     /// Specific body forces applied to solid and fluid.
     /// It is usually used to apply gravitational forces.
     /// A vector of displacement dimension's length.

--- a/Tests/Data/HydroMechanics/IdealGas/flow_free_expansion/flow_free_expansion.prj
+++ b/Tests/Data/HydroMechanics/IdealGas/flow_free_expansion/flow_free_expansion.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_fr</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
                 <pressure>pressure</pressure>
@@ -58,6 +56,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0.3</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1.43e3</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>0.6</value>
                         </property>
                     </properties>
                 </phase>
@@ -130,16 +138,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-5</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>0.6</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>1.43e3</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/IdealGas/flow_no_strain/flow_no_strain.prj
+++ b/Tests/Data/HydroMechanics/IdealGas/flow_no_strain/flow_no_strain.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_fr</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
                 <pressure>pressure</pressure>
@@ -58,6 +56,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0.03</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>2.17e3</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>0.6</value>
                         </property>
                     </properties>
                 </phase>
@@ -130,16 +138,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-4</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>0.6</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>2.17e3</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/IdealGas/flow_pressure_boundary/flow_pressure_boundary.prj
+++ b/Tests/Data/HydroMechanics/IdealGas/flow_pressure_boundary/flow_pressure_boundary.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_fr</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
                 <pressure>pressure</pressure>
@@ -58,6 +56,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0.1</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>2.2e3</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1.0</value>
                         </property>
                     </properties>
                 </phase>
@@ -130,16 +138,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-12</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>1.0</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>2.2e3</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/Linear/Confined_Compression/cube_1e3.prj
+++ b/Tests/Data/HydroMechanics/Linear/Confined_Compression/cube_1e3.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_fr</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
                 <pressure>pressure</pressure>
@@ -47,6 +45,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0.8</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1.2e-6</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -110,16 +118,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-12</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>1</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>1.2e-6</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/Linear/Confined_Compression/square_1e2.prj
+++ b/Tests/Data/HydroMechanics/Linear/Confined_Compression/square_1e2.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_fr</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
                 <pressure>pressure</pressure>
@@ -56,6 +54,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0.8</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1.2e-6</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -144,16 +152,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-12</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>1</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>1.2e-6</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/Linear/Confined_Compression/square_1e2_quad9.prj
+++ b/Tests/Data/HydroMechanics/Linear/Confined_Compression/square_1e2_quad9.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_fr</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
                 <pressure>pressure</pressure>
@@ -47,6 +45,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0.8</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1.2e-6</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -110,16 +118,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-12</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>1</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>1.2e-6</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/Linear/Confined_Compression/square_1e2_tri.prj
+++ b/Tests/Data/HydroMechanics/Linear/Confined_Compression/square_1e2_tri.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_fr</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
                 <pressure>pressure</pressure>
@@ -47,6 +45,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0.8</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1.2e-6</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -110,16 +118,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-12</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>1</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>1.2e-6</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/Linear/Gravity/flow_gravity.prj
+++ b/Tests/Data/HydroMechanics/Linear/Gravity/flow_gravity.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_fr</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
                 <pressure>pressure</pressure>
@@ -56,6 +54,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0.1</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>2.0e3</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -136,16 +144,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-12</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>1</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>2.0e3</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_early/square_1e2_UC_early.prj
+++ b/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_early/square_1e2_UC_early.prj
@@ -14,8 +14,6 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <fluid_density>rho_fr</fluid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -47,6 +45,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1.2e-6</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -110,16 +118,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-10</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>1</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>1.2e-6</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_early/square_1e4_UC_early.prj
+++ b/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_early/square_1e4_UC_early.prj
@@ -14,8 +14,6 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <fluid_density>rho_fr</fluid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -47,6 +45,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1.2e-6</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -110,16 +118,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-10</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>1</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>1.2e-6</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_late/square_1e2_UC_late.prj
+++ b/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_late/square_1e2_UC_late.prj
@@ -14,8 +14,6 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <fluid_density>rho_fr</fluid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -47,6 +45,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1.2e-6</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -110,16 +118,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-10</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>1</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>1.2e-6</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_late/square_1e4_UC_late.prj
+++ b/Tests/Data/HydroMechanics/Linear/Unconfined_Compression_late/square_1e4_UC_late.prj
@@ -14,8 +14,6 @@
                 <poissons_ratio>nu</poissons_ratio>
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <fluid_density>rho_fr</fluid_density>
             <process_variables>
                 <displacement>displacement</displacement>
@@ -47,6 +45,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1.2e-6</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -110,16 +118,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-10</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>1</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>1.2e-6</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/Principal_Stress/Hollow_Sphere/sphere.prj
+++ b/Tests/Data/HydroMechanics/Principal_Stress/Hollow_Sphere/sphere.prj
@@ -20,8 +20,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_fr</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
                 <pressure>pressure</pressure>
@@ -111,6 +109,16 @@
                             <type>Constant</type>
                             <value>0.0</value>
                         </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>8.96e3</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>0</value>
+                        </property>
                     </properties>
                 </phase>
             </phases>
@@ -133,16 +141,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-16</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>0</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>8.96e3</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/Principal_Stress/Tube/tube.prj
+++ b/Tests/Data/HydroMechanics/Principal_Stress/Tube/tube.prj
@@ -20,8 +20,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_fr</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_sr</solid_density>
             <process_variables>
                 <displacement>displacement</displacement>
                 <pressure>pressure</pressure>
@@ -111,6 +109,16 @@
                             <type>Constant</type>
                             <value>0.0</value>
                         </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>0</value>
+                        </property>
                     </properties>
                 </phase>
             </phases>
@@ -133,16 +141,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>1e-16</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>0</value>
-        </parameter>
-        <parameter>
-            <name>rho_sr</name>
-            <type>Constant</type>
-            <value>1</value>
         </parameter>
         <parameter>
             <name>rho_fr</name>

--- a/Tests/Data/HydroMechanics/StaggeredScheme/InjectionProduction1D/InjectionProduction1D.prj
+++ b/Tests/Data/HydroMechanics/StaggeredScheme/InjectionProduction1D/InjectionProduction1D.prj
@@ -16,8 +16,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_f</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_s</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
                 <displacement>displacement</displacement>
@@ -59,6 +57,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0.3</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -180,16 +188,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>4.9346165e-11</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>1</value>
-        </parameter>
-        <parameter>
-            <name>rho_s</name>
-            <type>Constant</type>
-            <value>0.0</value>
         </parameter>
         <parameter>
             <name>rho_f</name>

--- a/Tests/Data/HydroMechanics/StaggeredScheme/InjectionProduction1D/RerefenceSolutionByMonolithicScheme/InjectionProduction1DMono.prj
+++ b/Tests/Data/HydroMechanics/StaggeredScheme/InjectionProduction1D/RerefenceSolutionByMonolithicScheme/InjectionProduction1DMono.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_f</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_s</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
                 <displacement>displacement</displacement>
@@ -58,6 +56,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0.3</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>0.0</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -139,16 +147,6 @@
             <name>k</name>
             <type>Constant</type>
             <value>4.9346165e-11</value>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Constant</type>
-            <value>1</value>
-        </parameter>
-        <parameter>
-            <name>rho_s</name>
-            <type>Constant</type>
-            <value>0.0</value>
         </parameter>
         <parameter>
             <name>rho_f</name>

--- a/Tests/Data/HydroMechanics/Verification/hm1_1Dbeam.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm1_1Dbeam.prj
@@ -16,8 +16,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_liquid</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
                 <displacement>displacement</displacement>
@@ -61,6 +59,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -188,24 +196,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-12</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>rho_solid</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm1_1Dbeam.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm1_1Dbeam.prj
@@ -59,8 +59,8 @@
                     <properties>
                         <property>
                             <name>porosity</name>
-                            <type>Parameter</type>
-                            <parameter_name>phi</parameter_name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -188,15 +188,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-12</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>0</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm1_2Dsquare.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm1_2Dsquare.prj
@@ -59,8 +59,8 @@
                     <properties>
                         <property>
                             <name>porosity</name>
-                            <type>Parameter</type>
-                            <parameter_name>phi</parameter_name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -188,15 +188,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-11</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>0</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm1_2Dsquare.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm1_2Dsquare.prj
@@ -16,8 +16,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_liquid</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
                 <displacement>displacement</displacement>
@@ -61,6 +59,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -188,24 +196,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-11</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>rho_solid</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm1_3Dcube.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm1_3Dcube.prj
@@ -59,8 +59,8 @@
                     <properties>
                         <property>
                             <name>porosity</name>
-                            <type>Parameter</type>
-                            <parameter_name>phi</parameter_name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -188,15 +188,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>0</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm1_3Dcube.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm1_3Dcube.prj
@@ -16,8 +16,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_liquid</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
                 <displacement>displacement</displacement>
@@ -61,6 +59,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -188,24 +196,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>rho_solid</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm1_3Dgravity.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm1_3Dgravity.prj
@@ -16,8 +16,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_liquid</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
                 <displacement>displacement</displacement>
@@ -62,6 +60,16 @@
                             <type>Constant</type>
                             <value>0</value>
                         </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>3.058104e+03</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
+                        </property>
                     </properties>
                 </phase>
             </phases>
@@ -85,6 +93,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>3.058104e+03</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -110,6 +128,16 @@
                             <type>Constant</type>
                             <value>0</value>
                         </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>3.058104e+03</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
+                        </property>
                     </properties>
                 </phase>
             </phases>
@@ -133,6 +161,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>3.058104e+03</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -296,48 +334,6 @@
             <index_values>
                 <index>3</index>
                 <value>1e-12</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>rho_solid</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>3.058104e+03</value>
-            </index_values>
-            <index_values>
-                <index>1</index>
-                <value>3.058104e+03</value>
-            </index_values>
-            <index_values>
-                <index>2</index>
-                <value>3.058104e+03</value>
-            </index_values>
-            <index_values>
-                <index>3</index>
-                <value>3.058104e+03</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
-            </index_values>
-            <index_values>
-                <index>1</index>
-                <value>1</value>
-            </index_values>
-            <index_values>
-                <index>2</index>
-                <value>1</value>
-            </index_values>
-            <index_values>
-                <index>3</index>
-                <value>1</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1D1bt.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1D1bt.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_liquid</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
                 <displacement>displacement</displacement>
@@ -60,6 +58,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -142,24 +150,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>rho_solid</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1D1bt.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1D1bt.prj
@@ -58,8 +58,8 @@
                     <properties>
                         <property>
                             <name>porosity</name>
-                            <type>Parameter</type>
-                            <parameter_name>phi</parameter_name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -142,15 +142,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>0</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1D2bt.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1D2bt.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_liquid</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
                 <displacement>displacement</displacement>
@@ -60,6 +58,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -142,24 +150,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>rho_solid</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1D2bt.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1D2bt.prj
@@ -58,8 +58,8 @@
                     <properties>
                         <property>
                             <name>porosity</name>
-                            <type>Parameter</type>
-                            <parameter_name>phi</parameter_name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -142,15 +142,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>0</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1Dbiot.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1Dbiot.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_liquid</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
                 <displacement>displacement</displacement>
@@ -60,6 +58,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -142,24 +150,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>rho_solid</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1Dbiot.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1Dbiot.prj
@@ -58,8 +58,8 @@
                     <properties>
                         <property>
                             <name>porosity</name>
-                            <type>Parameter</type>
-                            <parameter_name>phi</parameter_name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -142,15 +142,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>0</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1Dcolumn1.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1Dcolumn1.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_liquid</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
                 <displacement>displacement</displacement>
@@ -60,6 +58,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -142,24 +150,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>rho_solid</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1Dcolumn1.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1Dcolumn1.prj
@@ -58,8 +58,8 @@
                     <properties>
                         <property>
                             <name>porosity</name>
-                            <type>Parameter</type>
-                            <parameter_name>phi</parameter_name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -142,15 +142,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>0</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1Dcolumn2.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1Dcolumn2.prj
@@ -58,8 +58,8 @@
                     <properties>
                         <property>
                             <name>porosity</name>
-                            <type>Parameter</type>
-                            <parameter_name>phi</parameter_name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -146,15 +146,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>0</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm2_1Dcolumn2.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_1Dcolumn2.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_liquid</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
                 <displacement>displacement</displacement>
@@ -60,6 +58,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -146,24 +154,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>rho_solid</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm2_2Dmandel.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_2Dmandel.prj
@@ -58,8 +58,8 @@
                     <properties>
                         <property>
                             <name>porosity</name>
-                            <type>Parameter</type>
-                            <parameter_name>phi</parameter_name>
+                            <type>Constant</type>
+                            <value>0</value>
                         </property>
                     </properties>
                 </phase>
@@ -146,15 +146,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>phi</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>0</value>
             </index_values>
         </parameter>
         <parameter>

--- a/Tests/Data/HydroMechanics/Verification/hm2_2Dmandel.prj
+++ b/Tests/Data/HydroMechanics/Verification/hm2_2Dmandel.prj
@@ -15,8 +15,6 @@
             </constitutive_relation>
             <intrinsic_permeability>k</intrinsic_permeability>
             <fluid_density>rho_liquid</fluid_density>
-            <biot_coefficient>alpha</biot_coefficient>
-            <solid_density>rho_solid</solid_density>
             <process_variables>
                 <pressure>pressure</pressure>
                 <displacement>displacement</displacement>
@@ -60,6 +58,16 @@
                             <name>porosity</name>
                             <type>Constant</type>
                             <value>0</value>
+                        </property>
+                        <property>
+                            <name>density</name>
+                            <type>Constant</type>
+                            <value>1</value>
+                        </property>
+                        <property>
+                            <name>biot_coefficient</name>
+                            <type>Constant</type>
+                            <value>1</value>
                         </property>
                     </properties>
                 </phase>
@@ -146,24 +154,6 @@
             <index_values>
                 <index>0</index>
                 <value>1e-10</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>rho_solid</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
-            </index_values>
-        </parameter>
-        <parameter>
-            <name>alpha</name>
-            <type>Group</type>
-            <group_id_property>MaterialIDs</group_id_property>
-            <index_values>
-                <index>0</index>
-                <value>1</value>
             </index_values>
         </parameter>
         <parameter>


### PR DESCRIPTION
Continuation of the Linkage of HM to MPL.
Solid density and biot coefficient were adapted.
Added a namespace alias for the MaterialPropertyLib, since previously it resulted in bulky statements when fetching the template values.

Also, I simplified the porosity specification in some benchmark files.

I used the same script as last time: 
[ConvertToMPL.txt](https://github.com/ufz/ogs/files/4121439/ConvertToMPL.txt)
