### PR TITLE
[MPL] Compressibility Ideal Gas Law

### DIFF
--- a/Documentation/ProjectFile/properties/property/t_CompressibilityIdealGasLaw.md
+++ b/Documentation/ProjectFile/properties/property/t_CompressibilityIdealGasLaw.md
@@ -1,0 +1,1 @@
+Compressibiliy function corresponding to the ideal gas law.

--- a/Documentation/ProjectFile/properties/property/t_DensityIdealGasLaw.md
+++ b/Documentation/ProjectFile/properties/property/t_DensityIdealGasLaw.md
@@ -1,0 +1,1 @@
+Density function corresponding to the ideal gas law.

--- a/MaterialLib/MPL/CreateProperty.cpp
+++ b/MaterialLib/MPL/CreateProperty.cpp
@@ -54,9 +54,14 @@ std::unique_ptr<MaterialPropertyLib::Property> createProperty(
         return createParameterProperty(config, parameters);
     }
 
-    if (boost::iequals(property_type, "IdealGasLaw"))
+    if (boost::iequals(property_type, "DensityIdealGasLaw"))
     {
-        return createIdealGasLaw(config);
+        return createDensityIdealGasLaw(config);
+    }
+
+    if (boost::iequals(property_type, "CompressibilityIdealGasLaw"))
+    {
+        return createCompressibilityIdealGasLaw(config);
     }
 
     if (boost::iequals(property_type, "SaturationBrooksCorey"))

--- a/MaterialLib/MPL/Properties/CompressibilityIdealGasLaw.cpp
+++ b/MaterialLib/MPL/Properties/CompressibilityIdealGasLaw.cpp
@@ -1,0 +1,69 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ *  \file
+ *  Created on January 28, 2020, 16:05 PM
+ */
+
+#include "MaterialLib/MPL/Properties/CompressibilityIdealGasLaw.h"
+#include "MaterialLib/MPL/Medium.h"
+#include "MaterialLib/PhysicalConstant.h"
+
+namespace MaterialPropertyLib
+{
+
+PropertyDataType CompressibilityIdealGasLaw::value(VariableArray const& variable_array,
+                                    ParameterLib::SpatialPosition const& pos,
+                                    double const t) const
+{
+    return 1. / std::get<double>(
+        variable_array[static_cast<int>(Variable::phase_pressure)]);
+}
+
+PropertyDataType CompressibilityIdealGasLaw::dValue(VariableArray const& variable_array,
+                                     Variable const primary_variable,
+                                     ParameterLib::SpatialPosition const& pos,
+                                     double const t) const
+{
+    const double pressure = std::get<double>(
+        variable_array[static_cast<int>(Variable::phase_pressure)]);
+
+    if (primary_variable == Variable::phase_pressure)
+    {
+        return -1. / (pressure * pressure);
+    }
+
+    OGS_FATAL(
+        "CompressibilityIdealGasLaw::dValue is implemented for derivatives "
+        "with respect to phase pressure only.");
+
+    return 0.;
+}
+
+PropertyDataType CompressibilityIdealGasLaw::d2Value(VariableArray const& variable_array,
+                                      Variable const primary_variable1,
+                                      Variable const primary_variable2,
+                                      ParameterLib::SpatialPosition const& pos,
+                                      double const t) const
+{
+    const double pressure = std::get<double>(
+        variable_array[static_cast<int>(Variable::phase_pressure)]);
+
+    if ((primary_variable1 == Variable::phase_pressure) &&
+        (primary_variable2 == Variable::phase_pressure))
+    {
+        return 2. / (pressure * pressure * pressure);
+    }
+
+    OGS_FATAL(
+        "CompressibilityIdealGasLaw::d2Value is implemented for derivatives "
+        "with respect to phase pressure only.");
+
+    return 0.;
+}
+
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CompressibilityIdealGasLaw.h
+++ b/MaterialLib/MPL/Properties/CompressibilityIdealGasLaw.h
@@ -1,17 +1,14 @@
 /**
- * \file
- * \author Norbert Grunwald
- * \date   27.06.2018
- * \brief
- *
- * \file
  * \copyright
  * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
  *            Distributed under a Modified BSD License.
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
  *
+ *  \file
+ *  Created on January 28, 2020, 16:05 PM
  */
+
 #pragma once
 
 #include "BaseLib/ConfigTree.h"
@@ -23,13 +20,12 @@ class Medium;
 class Phase;
 class Component;
 /**
- * \class IdealGasLaw
- * \brief Density function for ideal gases
+ * \class CompressibilityIdealGasLaw
+ * \brief Compressibility function for ideal gases
  * \details This property must be either a phase or a component property, it
- * computes the density of an ideal gas as function of phase pressure and
- * temperature
+ * computes the compressibility of an ideal gas as function of phase pressure
  */
-class IdealGasLaw final : public Property
+class CompressibilityIdealGasLaw final : public Property
 {
 public:
     /// This method assigns a pointer to the material object that is the owner
@@ -48,7 +44,7 @@ public:
         else
         {
             OGS_FATAL(
-                "The property 'IdealGasLaw' is implemented on the "
+                "The property 'CompressibilityIdealGasLaw' is implemented on the "
                 "'phase' and 'component' scales only.");
         }
     }

--- a/MaterialLib/MPL/Properties/CreateCompressibilityIdealGasLaw.cpp
+++ b/MaterialLib/MPL/Properties/CreateCompressibilityIdealGasLaw.cpp
@@ -1,26 +1,25 @@
 /**
- * \file
- * \author Norbert Grunwald
- * \date   Sep 10, 2019
- *
  * \copyright
  * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
  *            Distributed under a Modified BSD License.
  *              See accompanying file LICENSE.txt or
  *              http://www.opengeosys.org/project/license
+ *
+ *  \file
+ *  Created on January 28, 2020, 16:05 PM
  */
 
 #include "BaseLib/ConfigTree.h"
-#include "IdealGasLaw.h"
+#include "CompressibilityIdealGasLaw.h"
 
 namespace MaterialPropertyLib
 {
-std::unique_ptr<IdealGasLaw> createIdealGasLaw(
+std::unique_ptr<CompressibilityIdealGasLaw> createCompressibilityIdealGasLaw(
     BaseLib::ConfigTree const& config)
 {
     //! \ogs_file_param{properties__property__type}
-    config.checkConfigParameter("type", "IdealGasLaw");
-    DBUG("Create IdealGasLaw medium property");
-    return std::make_unique<IdealGasLaw>();
+    config.checkConfigParameter("type", "CompressibilityIdealGasLaw");
+    DBUG("Create CompressibilityIdealGasLaw medium property");
+    return std::make_unique<CompressibilityIdealGasLaw>();
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateCompressibilityIdealGasLaw.h
+++ b/MaterialLib/MPL/Properties/CreateCompressibilityIdealGasLaw.h
@@ -1,0 +1,30 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ *  \file
+ *  Created on January 28, 2020, 16:05 PM
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace MaterialPropertyLib
+{
+class CompressibilityIdealGasLaw;
+}
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<CompressibilityIdealGasLaw> createCompressibilityIdealGasLaw(
+    BaseLib::ConfigTree const& config);
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateDensityIdealGasLaw.cpp
+++ b/MaterialLib/MPL/Properties/CreateDensityIdealGasLaw.cpp
@@ -10,22 +10,17 @@
  *              http://www.opengeosys.org/project/license
  */
 
-#pragma once
-
-#include <memory>
-
-namespace BaseLib
-{
-class ConfigTree;
-}
+#include "BaseLib/ConfigTree.h"
+#include "DensityIdealGasLaw.h"
 
 namespace MaterialPropertyLib
 {
-class IdealGasLaw;
-}
-
-namespace MaterialPropertyLib
+std::unique_ptr<DensityIdealGasLaw> createDensityIdealGasLaw(
+    BaseLib::ConfigTree const& config)
 {
-std::unique_ptr<IdealGasLaw> createIdealGasLaw(
-    BaseLib::ConfigTree const& config);
+    //! \ogs_file_param{properties__property__type}
+    config.checkConfigParameter("type", "DensityIdealGasLaw");
+    DBUG("Create DensityIdealGasLaw medium property");
+    return std::make_unique<DensityIdealGasLaw>();
+}
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateDensityIdealGasLaw.h
+++ b/MaterialLib/MPL/Properties/CreateDensityIdealGasLaw.h
@@ -1,0 +1,31 @@
+/**
+ * \file
+ * \author Norbert Grunwald
+ * \date   Sep 10, 2019
+ *
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace MaterialPropertyLib
+{
+class DensityIdealGasLaw;
+}
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<DensityIdealGasLaw> createDensityIdealGasLaw(
+    BaseLib::ConfigTree const& config);
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateProperties.h
+++ b/MaterialLib/MPL/Properties/CreateProperties.h
@@ -13,7 +13,8 @@
 
 #include "CreateConstant.h"
 #include "CreateExponentialProperty.h"
-#include "CreateIdealGasLaw.h"
+#include "CreateDensityIdealGasLaw.h"
+#include "CreateCompressibilityIdealGasLaw.h"
 #include "CreateLinearProperty.h"
 #include "CreateParameterProperty.h"
 #include "CreateRelPermBrooksCorey.h"

--- a/MaterialLib/MPL/Properties/DensityIdealGasLaw.cpp
+++ b/MaterialLib/MPL/Properties/DensityIdealGasLaw.cpp
@@ -13,7 +13,7 @@
  *
  */
 
-#include "MaterialLib/MPL/Properties/IdealGasLaw.h"
+#include "MaterialLib/MPL/Properties/DensityIdealGasLaw.h"
 #include "MaterialLib/MPL/Medium.h"
 #include "MaterialLib/PhysicalConstant.h"
 
@@ -40,7 +40,7 @@ double molarMass(Phase* _phase, Component* _component,
     return 0.;
 }
 
-PropertyDataType IdealGasLaw::value(VariableArray const& variable_array,
+PropertyDataType DensityIdealGasLaw::value(VariableArray const& variable_array,
                                     ParameterLib::SpatialPosition const& pos,
                                     double const t) const
 {
@@ -56,7 +56,7 @@ PropertyDataType IdealGasLaw::value(VariableArray const& variable_array,
     return density;
 }
 
-PropertyDataType IdealGasLaw::dValue(VariableArray const& variable_array,
+PropertyDataType DensityIdealGasLaw::dValue(VariableArray const& variable_array,
                                      Variable const primary_variable,
                                      ParameterLib::SpatialPosition const& pos,
                                      double const t) const
@@ -80,13 +80,13 @@ PropertyDataType IdealGasLaw::dValue(VariableArray const& variable_array,
     }
 
     OGS_FATAL(
-        "IdealGasLaw::dValue is implemented for derivatives "
+        "DensityIdealGasLaw::dValue is implemented for derivatives "
         "with respect to phase pressure or temperature only.");
 
     return 0.;
 }
 
-PropertyDataType IdealGasLaw::d2Value(VariableArray const& variable_array,
+PropertyDataType DensityIdealGasLaw::d2Value(VariableArray const& variable_array,
                                       Variable const primary_variable1,
                                       Variable const primary_variable2,
                                       ParameterLib::SpatialPosition const& pos,
@@ -122,7 +122,7 @@ PropertyDataType IdealGasLaw::d2Value(VariableArray const& variable_array,
     }
 
     OGS_FATAL(
-        "IdealGasLaw::d2Value is implemented for derivatives "
+        "DensityIdealGasLaw::d2Value is implemented for derivatives "
         "with respect to phase pressure and temperature only.");
 
     return 0.;

--- a/MaterialLib/MPL/Properties/DensityIdealGasLaw.h
+++ b/MaterialLib/MPL/Properties/DensityIdealGasLaw.h
@@ -1,0 +1,76 @@
+/**
+ * \file
+ * \author Norbert Grunwald
+ * \date   27.06.2018
+ * \brief
+ *
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+#pragma once
+
+#include "BaseLib/ConfigTree.h"
+#include "MaterialLib/MPL/Property.h"
+
+namespace MaterialPropertyLib
+{
+class Medium;
+class Phase;
+class Component;
+/**
+ * \class IdealGasLaw
+ * \brief Density function for ideal gases
+ * \details This property must be either a phase or a component property, it
+ * computes the density of an ideal gas as function of phase pressure and
+ * temperature
+ */
+class DensityIdealGasLaw final : public Property
+{
+public:
+    /// This method assigns a pointer to the material object that is the owner
+    /// of this property
+    void setScale(
+        std::variant<Medium*, Phase*, Component*> scale_pointer) override
+    {
+        if (std::holds_alternative<Phase*>(scale_pointer))
+        {
+            _phase = std::get<Phase*>(scale_pointer);
+        }
+        else if (std::holds_alternative<Component*>(scale_pointer))
+        {
+            _component = std::get<Component*>(scale_pointer);
+        }
+        else
+        {
+            OGS_FATAL(
+                "The property 'DensityIdealGasLaw' is implemented on the "
+                "'phase' and 'component' scales only.");
+        }
+    }
+
+    /// Those methods override the base class implementations and
+    /// actually compute and set the property _values and _dValues.
+    PropertyDataType value(VariableArray const& variable_array,
+                           ParameterLib::SpatialPosition const& /*pos*/,
+                           double const /*t*/) const override;
+    PropertyDataType dValue(VariableArray const& variable_array,
+                            Variable const variable,
+                            ParameterLib::SpatialPosition const& /*pos*/,
+                            double const /*t*/) const override;
+    PropertyDataType d2Value(VariableArray const& variable_array,
+                             Variable const variable1,
+                             Variable const variable2,
+                             ParameterLib::SpatialPosition const& pos,
+                             double const t) const override;
+
+private:
+    Phase* _phase = nullptr;
+    Component* _component = nullptr;
+};
+
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/Properties.h
+++ b/MaterialLib/MPL/Properties/Properties.h
@@ -13,7 +13,8 @@
 
 #include "Constant.h"
 #include "ExponentialProperty.h"
-#include "IdealGasLaw.h"
+#include "DensityIdealGasLaw.h"
+#include "CompressibilityIdealGasLaw.h"
 #include "LinearProperty.h"
 #include "ParameterProperty.h"
 #include "RelPermBrooksCorey.h"

--- a/Tests/Data/Parabolic/ThermalTwoPhaseFlowPP/HeatPipe/Twophase_HeatPipe_quad_curve_large.prj
+++ b/Tests/Data/Parabolic/ThermalTwoPhaseFlowPP/HeatPipe/Twophase_HeatPipe_quad_curve_large.prj
@@ -24,7 +24,7 @@
                         <value> 1.e3 </value>
                     </liquid_density>
                     <gas_density>
-                        <type>IdealGasLaw</type>
+                        <type>DensityIdealGasLaw</type>
                         <molar_mass> 0.029 </molar_mass>
                     </gas_density>
                     <liquid_viscosity>

--- a/Tests/Data/Parabolic/ThermalTwoPhaseFlowPP/HeatPipe/Twophase_HeatPipe_quad_curve_small.prj
+++ b/Tests/Data/Parabolic/ThermalTwoPhaseFlowPP/HeatPipe/Twophase_HeatPipe_quad_curve_small.prj
@@ -24,7 +24,7 @@
                         <value> 1.e3 </value>
                     </liquid_density>
                     <gas_density>
-                        <type>IdealGasLaw</type>
+                        <type>DensityIdealGasLaw</type>
                         <molar_mass> 0.029 </molar_mass>
                     </gas_density>
                     <liquid_viscosity>

--- a/Tests/Data/Parabolic/TwoPhaseFlowPP/Liakopoulos/TwoPhase_Lia_quad_large.prj
+++ b/Tests/Data/Parabolic/TwoPhaseFlowPP/Liakopoulos/TwoPhase_Lia_quad_large.prj
@@ -47,7 +47,7 @@
                <properties>
                   <property>
                      <name>density</name>
-                     <type>IdealGasLaw</type>
+                     <type>DensityIdealGasLaw</type>
                   </property>
                   <property>
                      <name>viscosity</name>

--- a/Tests/Data/Parabolic/TwoPhaseFlowPP/Liakopoulos/TwoPhase_Lia_quad_short.prj
+++ b/Tests/Data/Parabolic/TwoPhaseFlowPP/Liakopoulos/TwoPhase_Lia_quad_short.prj
@@ -47,7 +47,7 @@
                <properties>
                   <property>
                      <name>density</name>
-                     <type>IdealGasLaw</type>
+                     <type>DensityIdealGasLaw</type>
                   </property>
                   <property>
                      <name>viscosity</name>

--- a/Tests/Data/Parabolic/TwoPhaseFlowPrho/MoMaS/Twophase_MoMaS_quad.prj
+++ b/Tests/Data/Parabolic/TwoPhaseFlowPrho/MoMaS/Twophase_MoMaS_quad.prj
@@ -23,7 +23,7 @@
                         <value> 1.e3 </value>
                     </liquid_density>
                     <gas_density>
-                        <type>IdealGasLaw</type>
+                        <type>DensityIdealGasLaw</type>
                         <molar_mass> 0.002 </molar_mass>
                     </gas_density>
                     <liquid_viscosity>

--- a/Tests/Data/Parabolic/TwoPhaseFlowPrho/MoMaS/Twophase_MoMaS_quad_adaptive_dt.prj
+++ b/Tests/Data/Parabolic/TwoPhaseFlowPrho/MoMaS/Twophase_MoMaS_quad_adaptive_dt.prj
@@ -23,7 +23,7 @@
                         <value> 1.e3 </value>
                     </liquid_density>
                     <gas_density>
-                        <type>IdealGasLaw</type>
+                        <type>DensityIdealGasLaw</type>
                         <molar_mass> 0.002 </molar_mass>
                     </gas_density>
                     <liquid_viscosity>

--- a/Tests/Data/Parabolic/TwoPhaseFlowPrho/MoMaS/Twophase_MoMaS_small.prj
+++ b/Tests/Data/Parabolic/TwoPhaseFlowPrho/MoMaS/Twophase_MoMaS_small.prj
@@ -23,7 +23,7 @@
                         <value> 1.e3 </value>
                     </liquid_density>
                     <gas_density>
-                        <type>IdealGasLaw</type>
+                        <type>DensityIdealGasLaw</type>
                         <molar_mass> 0.002 </molar_mass>
                     </gas_density>
                     <liquid_viscosity>

--- a/Tests/MaterialLib/TestMPLCompressibilityIdealGasLaw.cpp
+++ b/Tests/MaterialLib/TestMPLCompressibilityIdealGasLaw.cpp
@@ -1,0 +1,74 @@
+/**
+ * \file
+ *
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+#include <gtest/gtest.h>
+#include <sstream>
+
+#include "TestMPL.h"
+#include "Tests/TestTools.h"
+
+#include "MaterialLib/MPL/Medium.h"
+#include "MaterialLib/MPL/Properties/CompressibilityIdealGasLaw.h"
+
+TEST(MaterialPropertyLib, CompressibilityIdealGasLaw)
+{
+    const double pressure_norm = 101325.0;    // Pa
+
+    const double compressibility_norm_air = 1.0 / pressure_norm;
+
+    const double d_beta_dp_air = compressibility_norm_air / pressure_norm;
+
+    const double d_beta_dp2_air = compressibility_norm_air /
+        (pressure_norm * pressure_norm);
+
+    std::stringstream m;
+    m << "<medium>\n";
+    m << "<phases><phase>\n";
+    m << "  <type>Gas</type>\n";
+    m << "  <properties>\n";
+    m << "    <property>\n";
+    m << "      <name>compressibility</name>\n";
+    m << "      <type>CompressibilityIdealGasLaw</type>\n";
+    m << "    </property>\n";
+    m << "  </properties>\n";
+    m << "</phase></phases>\n";
+    m << "<properties></properties>\n";
+    m << "</medium>\n";
+
+    auto const& medium = createTestMaterial(m.str());
+    auto const& gas_phase = medium->phase("Gas");
+
+    MaterialPropertyLib::VariableArray variable_array;
+    variable_array[static_cast<int>(
+        MaterialPropertyLib::Variable::phase_pressure)] = pressure_norm;
+
+    ParameterLib::SpatialPosition const pos;
+    double const time = std::numeric_limits<double>::quiet_NaN();
+
+    auto const beta =
+        gas_phase.property(MaterialPropertyLib::PropertyType::compressibility)
+            .template value<double>(variable_array, pos, time);
+
+    auto const d_beta_dp =
+        gas_phase.property(MaterialPropertyLib::PropertyType::compressibility)
+            .template dValue<double>(
+                variable_array, MaterialPropertyLib::Variable::phase_pressure,
+                pos, time);
+
+    auto const d_beta_dp2 =
+        gas_phase.property(MaterialPropertyLib::PropertyType::density)
+            .template d2Value<double>(
+                variable_array, MaterialPropertyLib::Variable::phase_pressure,
+                MaterialPropertyLib::Variable::phase_pressure, pos, time);
+
+    ASSERT_NEAR(compressibility_norm_air, beta, 1.e-10);
+    ASSERT_NEAR(d_beta_dp_air, d_beta_dp, 1.e-10);
+    ASSERT_NEAR(d_beta_dp2_air, d_beta_dp2, 1.e-10);
+}

--- a/Tests/MaterialLib/TestMPLDensityIdealGasLaw.cpp
+++ b/Tests/MaterialLib/TestMPLDensityIdealGasLaw.cpp
@@ -15,10 +15,10 @@
 #include "Tests/TestTools.h"
 
 #include "MaterialLib/MPL/Medium.h"
-#include "MaterialLib/MPL/Properties/IdealGasLaw.h"
+#include "MaterialLib/MPL/Properties/DensityIdealGasLaw.h"
 #include "MaterialLib/PhysicalConstant.h"
 
-TEST(MaterialPropertyLib, IdealGasLawOfPurePhase)
+TEST(MaterialPropertyLib, DensityIdealGasLaw)
 {
     const double pressure_norm = 101325.0;    // Pa
     const double temperature_norm = 273.15;   // K
@@ -44,7 +44,7 @@ TEST(MaterialPropertyLib, IdealGasLawOfPurePhase)
     m << "  <properties>\n";
     m << "    <property>\n";
     m << "      <name>density</name>\n";
-    m << "      <type>IdealGasLaw</type>\n";
+    m << "      <type>DensityIdealGasLaw</type>\n";
     m << "    </property>\n";
     m << "    <property>\n";
     m << "      <name>molar_mass</name>\n";


### PR DESCRIPTION
Preceeding the #2779.

Added an Ideal Gas Law for Fluid compressibility.
The Ideal Gas Law which already existed and returned the value for the density is renamed in accordance to the other models with multiple return variables (e.g. RelPermBrooksCorey, SaturationBrooksCorey) -> DensityIdealGasLaw
The new file is named accordingly CompressibilityIdealGasLaw

