### PR TITLE
RichardsM: Add element averaged stress output

### DIFF
--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
@@ -864,9 +864,8 @@ void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
 
     double saturation_avg = 0;
 
-    typename BMatricesType::KelvinVectorType sigma_avg;
-    sigma_avg.setZero(
-        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value);
+    using KV = typename BMatricesType::KelvinVectorType;
+    KV sigma_avg = KV::Zero();
 
     for (unsigned ip = 0; ip < n_integration_points; ip++)
     {
@@ -886,14 +885,10 @@ void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
     sigma_avg /= n_integration_points;
 
     (*_process_data.element_saturation)[_element.getID()] = saturation_avg;
-    auto const sym_stress_tensor =
+
+    Eigen::Map<KV>(&(*_process_data.element_stresses)[_element.getID() *
+                                                      KV::RowsAtCompileTime]) =
         MathLib::KelvinVector::kelvinVectorToSymmetricTensor(sigma_avg);
-    auto& stress_outputs = (*_process_data.element_stresses);
-    for (int comp = 0; comp != stress_outputs.getNumberOfComponents(); comp++)
-    {
-        stress_outputs.getComponent(_element.getID(), comp) =
-            sym_stress_tensor[comp];
-    }
 
     NumLib::interpolateToHigherOrderNodes<
         ShapeFunctionPressure, typename ShapeFunctionDisplacement::MeshElement,

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
@@ -864,7 +864,7 @@ void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
 
     double saturation_avg = 0;
 
-    using KV = typename BMatricesType::KelvinVectorType;
+    using KV = MathLib::KelvinVector::KelvinVectorType<DisplacementDim>;
     KV sigma_avg = KV::Zero();
 
     for (unsigned ip = 0; ip < n_integration_points; ip++)

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
@@ -206,6 +206,12 @@ void RichardsMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
         const_cast<MeshLib::Mesh&>(mesh), "saturation_avg",
         MeshLib::MeshItemType::Cell, 1);
 
+    _process_data.element_stresses = MeshLib::getOrCreateMeshProperty<double>(
+        const_cast<MeshLib::Mesh&>(mesh), "stress_avg",
+        MeshLib::MeshItemType::Cell,
+        MathLib::KelvinVector::KelvinVectorType<
+            DisplacementDim>::RowsAtCompileTime);
+
     _process_data.pressure_interpolated =
         MeshLib::getOrCreateMeshProperty<double>(
             const_cast<MeshLib::Mesh&>(mesh), "pressure_interpolated",

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcessData.h
@@ -71,6 +71,7 @@ struct RichardsMechanicsProcessData
     bool const apply_mass_lumping;
 
     MeshLib::PropertyVector<double>* element_saturation = nullptr;
+    MeshLib::PropertyVector<double>* element_stresses = nullptr;
     MeshLib::PropertyVector<double>* pressure_interpolated = nullptr;
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;


### PR DESCRIPTION
Added additional output of averaged integration point stresses for each cell similar to existing saturation output.
Allows to visualize stress values on tri-meshes.
- Hard coded for RichardsM process and not configurable in project file.

1. [ ] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.0)
2. [ ] Tests covering your feature were added?
3. [ ] Any new feature or behavior change was documented?
