### PR TITLE
[MPL] Shared Media

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -447,8 +447,8 @@ void ProjectData::parseMedia(
          //! \ogs_file_param{prj__media__medium}
          media_config->getConfigSubtreeList("medium"))
     {
-        //! \ogs_file_attr{prj__media__medium__id}
         auto material_id_string =
+            //! \ogs_file_attr{prj__media__medium__id}
             medium_config.getConfigAttribute<std::string>("id", "0");
         material_id_string.erase(
             remove_if(begin(material_id_string), end(material_id_string),

--- a/Applications/ApplicationsLib/ProjectData.h
+++ b/Applications/ApplicationsLib/ProjectData.h
@@ -125,7 +125,7 @@ private:
 
     boost::optional<ParameterLib::CoordinateSystem> _local_coordinate_system;
 
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> _media;
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> _media;
 
     /// The time loop used to solve this project's processes.
     std::unique_ptr<ProcessLib::TimeLoop> _time_loop;

--- a/MaterialLib/MPL/CreateMaterialSpatialDistributionMap.cpp
+++ b/MaterialLib/MPL/CreateMaterialSpatialDistributionMap.cpp
@@ -16,7 +16,7 @@ namespace MaterialPropertyLib
 {
 std::unique_ptr<MaterialSpatialDistributionMap>
 createMaterialSpatialDistributionMap(
-    std::map<int, std::unique_ptr<Medium>> const& media,
+    std::map<int, std::shared_ptr<Medium>> const& media,
     MeshLib::Mesh const& mesh)
 {
     auto const material_ids = materialIDs(mesh);

--- a/MaterialLib/MPL/CreateMaterialSpatialDistributionMap.h
+++ b/MaterialLib/MPL/CreateMaterialSpatialDistributionMap.h
@@ -26,6 +26,6 @@ class Medium;
 
 std::unique_ptr<MaterialSpatialDistributionMap>
 createMaterialSpatialDistributionMap(
-    std::map<int, std::unique_ptr<Medium>> const& media,
+    std::map<int, std::shared_ptr<Medium>> const& media,
     MeshLib::Mesh const& mesh);
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/MaterialSpatialDistributionMap.h
+++ b/MaterialLib/MPL/MaterialSpatialDistributionMap.h
@@ -29,7 +29,7 @@ class MaterialSpatialDistributionMap
 {
 public:
     MaterialSpatialDistributionMap(
-        std::map<int, std::unique_ptr<Medium>> const& media,
+        std::map<int, std::shared_ptr<Medium>> const& media,
         MeshLib::PropertyVector<int> const* const material_ids)
         : _media(media), _material_ids(material_ids)
     {
@@ -38,7 +38,7 @@ public:
     Medium* getMedium(std::size_t element_id);
 
 private:
-    std::map<int, std::unique_ptr<Medium>> const& _media;
+    std::map<int, std::shared_ptr<Medium>> const& _media;
     MeshLib::PropertyVector<int> const* const _material_ids;
 };
 }  // namespace MaterialPropertyLib

--- a/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
@@ -32,7 +32,7 @@ std::unique_ptr<Process> createComponentTransportProcess(
     BaseLib::ConfigTree const& config,
     std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,
     std::string const& output_directory,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media)
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media)
 {
     //! \ogs_file_param{prj__processes__process__type}
     config.checkConfigParameter("type", "ComponentTransport");

--- a/ProcessLib/ComponentTransport/CreateComponentTransportProcess.h
+++ b/ProcessLib/ComponentTransport/CreateComponentTransportProcess.h
@@ -32,7 +32,7 @@ std::unique_ptr<Process> createComponentTransportProcess(
     BaseLib::ConfigTree const& config,
     std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,
     std::string const& output_directory,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 
 }  // namespace ComponentTransport
 }  // namespace ProcessLib

--- a/ProcessLib/HT/CreateHTProcess.cpp
+++ b/ProcessLib/HT/CreateHTProcess.cpp
@@ -36,7 +36,7 @@ std::unique_ptr<Process> createHTProcess(
     BaseLib::ConfigTree const& config,
     std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,
     std::string const& output_directory,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media)
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media)
 {
     //! \ogs_file_param{prj__processes__process__type}
     config.checkConfigParameter("type", "HT");

--- a/ProcessLib/HT/CreateHTProcess.h
+++ b/ProcessLib/HT/CreateHTProcess.h
@@ -33,7 +33,7 @@ std::unique_ptr<Process> createHTProcess(
     BaseLib::ConfigTree const& config,
     std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,
     std::string const& output_directory,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 
 }  // namespace HT
 }  // namespace ProcessLib

--- a/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.cpp
+++ b/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.cpp
@@ -39,7 +39,7 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
         curves,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media)
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media)
 {
     //! \ogs_file_param{prj__processes__process__type}
     config.checkConfigParameter("type", "HEAT_TRANSPORT_BHE");

--- a/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.h
+++ b/ProcessLib/HeatTransportBHE/CreateHeatTransportBHEProcess.h
@@ -30,6 +30,6 @@ std::unique_ptr<Process> createHeatTransportBHEProcess(
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
         curves,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 }  // namespace HeatTransportBHE
 }  // namespace ProcessLib

--- a/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     boost::optional<ParameterLib::CoordinateSystem> const&
         local_coordinate_system,
     unsigned const integration_order, BaseLib::ConfigTree const& config,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media)
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media)
 {
     //! \ogs_file_param{prj__processes__process__type}
     config.checkConfigParameter("type", "HYDRO_MECHANICS");
@@ -232,7 +232,7 @@ template std::unique_ptr<Process> createHydroMechanicsProcess<2>(
         local_coordinate_system,
     unsigned const integration_order,
     BaseLib::ConfigTree const& config,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 
 template std::unique_ptr<Process> createHydroMechanicsProcess<3>(
     std::string name,
@@ -244,7 +244,7 @@ template std::unique_ptr<Process> createHydroMechanicsProcess<3>(
         local_coordinate_system,
     unsigned const integration_order,
     BaseLib::ConfigTree const& config,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 
 }  // namespace HydroMechanics
 }  // namespace ProcessLib

--- a/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.h
@@ -54,7 +54,7 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
         local_coordinate_system,
     unsigned const integration_order,
     BaseLib::ConfigTree const& config,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 
 extern template std::unique_ptr<Process> createHydroMechanicsProcess<2>(
     std::string name,
@@ -66,7 +66,7 @@ extern template std::unique_ptr<Process> createHydroMechanicsProcess<2>(
         local_coordinate_system,
     unsigned const integration_order,
     BaseLib::ConfigTree const& config,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 
 extern template std::unique_ptr<Process> createHydroMechanicsProcess<3>(
     std::string name,
@@ -78,6 +78,6 @@ extern template std::unique_ptr<Process> createHydroMechanicsProcess<3>(
         local_coordinate_system,
     unsigned const integration_order,
     BaseLib::ConfigTree const& config,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 }  // namespace HydroMechanics
 }  // namespace ProcessLib

--- a/ProcessLib/ThermoHydroMechanics/CreateThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/CreateThermoHydroMechanicsProcess.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
     boost::optional<ParameterLib::CoordinateSystem> const&
         local_coordinate_system,
     unsigned const integration_order, BaseLib::ConfigTree const& config,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media)
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media)
 {
     //! \ogs_file_param{prj__processes__process__type}
     config.checkConfigParameter("type", "THERMO_HYDRO_MECHANICS");
@@ -186,7 +186,7 @@ template std::unique_ptr<Process> createThermoHydroMechanicsProcess<2>(
         local_coordinate_system,
     unsigned const integration_order,
     BaseLib::ConfigTree const& config,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 
 template std::unique_ptr<Process> createThermoHydroMechanicsProcess<3>(
     std::string name,
@@ -198,6 +198,6 @@ template std::unique_ptr<Process> createThermoHydroMechanicsProcess<3>(
         local_coordinate_system,
     unsigned const integration_order,
     BaseLib::ConfigTree const& config,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 }  // namespace ThermoHydroMechanics
 }  // namespace ProcessLib

--- a/ProcessLib/ThermoHydroMechanics/CreateThermoHydroMechanicsProcess.h
+++ b/ProcessLib/ThermoHydroMechanics/CreateThermoHydroMechanicsProcess.h
@@ -57,7 +57,7 @@ std::unique_ptr<Process> createThermoHydroMechanicsProcess(
         local_coordinate_system,
     unsigned const integration_order,
     BaseLib::ConfigTree const& config,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 
 extern template std::unique_ptr<Process> createThermoHydroMechanicsProcess<2>(
     std::string name, MeshLib::Mesh& mesh,
@@ -67,7 +67,7 @@ extern template std::unique_ptr<Process> createThermoHydroMechanicsProcess<2>(
     boost::optional<ParameterLib::CoordinateSystem> const&
         local_coordinate_system,
     unsigned const integration_order, BaseLib::ConfigTree const& config,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 
 extern template std::unique_ptr<Process> createThermoHydroMechanicsProcess<3>(
     std::string name,
@@ -79,6 +79,6 @@ extern template std::unique_ptr<Process> createThermoHydroMechanicsProcess<3>(
         local_coordinate_system,
     unsigned const integration_order,
     BaseLib::ConfigTree const& config,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 }  // namespace ThermoHydroMechanics
 }  // namespace ProcessLib

--- a/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.cpp
@@ -34,7 +34,7 @@ std::unique_ptr<Process> createTwoPhaseFlowWithPPProcess(
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
         curves,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media)
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media)
 {
     //! \ogs_file_param{prj__processes__process__type}
     config.checkConfigParameter("type", "TWOPHASE_FLOW_PP");

--- a/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/CreateTwoPhaseFlowWithPPProcess.h
@@ -63,6 +63,6 @@ std::unique_ptr<Process> createTwoPhaseFlowWithPPProcess(
     std::map<std::string,
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
         curves,
-    std::map<int, std::unique_ptr<MaterialPropertyLib::Medium>> const& media);
+    std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media);
 }  // namespace TwoPhaseFlowWithPP
 }  // namespace ProcessLib


### PR DESCRIPTION
Changed the media map definition to shared_pointer, so that one medium definition can be assigned to multiple material ID's. This can be useful when a mesh has multiple material ID's defined, but they have the same properties. Or if they only differ in one property, this can be easier written by refering this property to a Group-Parameter.
PR #2779 will contain a benchmark benefitting from this.
This is how a .prj-file would look like, which benefits from it: 
[hm1_3Dgravity.prj.txt](https://github.com/ufz/ogs/files/4152636/hm1_3Dgravity.prj.txt)


1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.0)
