### PR TITLE
Pass xdot to assemble

### DIFF
--- a/NumLib/ODESolver/ODESystem.h
+++ b/NumLib/ODESolver/ODESystem.h
@@ -52,6 +52,7 @@ public:
     //! Assemble \c M, \c K and \c b at the provided state (\c t, \c x).
     virtual void assemble(const double t, double const dt,
                           std::vector<GlobalVector*> const& x,
+                          std::vector<GlobalVector*> const& xdot,
                           int const process_id, GlobalMatrix& M,
                           GlobalMatrix& K, GlobalVector& b) = 0;
 

--- a/ProcessLib/CentralDifferencesJacobianAssembler.cpp
+++ b/ProcessLib/CentralDifferencesJacobianAssembler.cpp
@@ -71,12 +71,14 @@ void CentralDifferencesJacobianAssembler::assembleWithJacobian(
         auto const eps = _absolute_epsilons[component];
 
         _local_x_perturbed_data[i] += eps;
-        local_assembler.assemble(t, dt, _local_x_perturbed_data, local_M_data,
-                                 local_K_data, local_b_data);
+        local_assembler.assemble(t, dt, _local_x_perturbed_data,
+                                 local_xdot_data, local_M_data, local_K_data,
+                                 local_b_data);
 
         _local_x_perturbed_data[i] = local_x_data[i] - eps;
-        local_assembler.assemble(t, dt, _local_x_perturbed_data, _local_M_data,
-                                 _local_K_data, _local_b_data);
+        local_assembler.assemble(t, dt, _local_x_perturbed_data,
+                                 local_xdot_data, _local_M_data, _local_K_data,
+                                 _local_b_data);
 
         _local_x_perturbed_data[i] = local_x_data[i];
 
@@ -116,8 +118,8 @@ void CentralDifferencesJacobianAssembler::assembleWithJacobian(
     }
 
     // Assemble with unperturbed local x.
-    local_assembler.assemble(t, dt, local_x_data, local_M_data, local_K_data,
-                             local_b_data);
+    local_assembler.assemble(t, dt, local_x_data, local_xdot_data, local_M_data,
+                             local_K_data, local_b_data);
 
     // Compute remaining terms of the Jacobian.
     if (dxdot_dx != 0.0 && !local_M_data.empty()) {

--- a/ProcessLib/ComponentTransport/ComponentTransportFEM.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportFEM.h
@@ -155,6 +155,7 @@ public:
 
     void assemble(double const t, double const /*dt*/,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
@@ -89,7 +89,8 @@ void ComponentTransportProcess::initializeConcreteProcess(
 
 void ComponentTransportProcess::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble ComponentTransportProcess.");
 
@@ -111,8 +112,8 @@ void ComponentTransportProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_tables, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_tables, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 void ComponentTransportProcess::setCoupledSolutionsOfPreviousTimeStep()

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.h
@@ -143,6 +143,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowFEM.h
@@ -102,6 +102,7 @@ public:
 
     void assemble(double const t, double const /*dt*/,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& local_K_data,
                   std::vector<double>& /*local_b_data*/) override

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -58,7 +58,8 @@ void GroundwaterFlowProcess::initializeConcreteProcess(
 
 void GroundwaterFlowProcess::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble GroundwaterFlowProcess.");
 
@@ -68,8 +69,8 @@ void GroundwaterFlowProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 void GroundwaterFlowProcess::assembleWithJacobianConcreteProcess(

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.h
@@ -92,6 +92,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -123,6 +123,7 @@ void HTProcess::initializeConcreteProcess(
 
 void HTProcess::assembleConcreteProcess(const double t, double const dt,
                                         std::vector<GlobalVector*> const& x,
+                                        std::vector<GlobalVector*> const& xdot,
                                         int const process_id, GlobalMatrix& M,
                                         GlobalMatrix& K, GlobalVector& b)
 {
@@ -156,8 +157,8 @@ void HTProcess::assembleConcreteProcess(const double t, double const dt,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_tables, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_tables, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 void HTProcess::assembleWithJacobianConcreteProcess(

--- a/ProcessLib/HT/HTProcess.h
+++ b/ProcessLib/HT/HTProcess.h
@@ -96,6 +96,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/HT/MonolithicHTFEM.h
+++ b/ProcessLib/HT/MonolithicHTFEM.h
@@ -68,6 +68,7 @@ public:
 
     void assemble(double const t, double const /*dt*/,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override

--- a/ProcessLib/HeatConduction/HeatConductionFEM.h
+++ b/ProcessLib/HeatConduction/HeatConductionFEM.h
@@ -92,6 +92,7 @@ public:
 
     void assemble(double const t, double const /*dt*/,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& /*local_b_data*/) override

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -73,7 +73,8 @@ void HeatConductionProcess::initializeConcreteProcess(
 
 void HeatConductionProcess::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble HeatConductionProcess.");
 
@@ -84,8 +85,8 @@ void HeatConductionProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 void HeatConductionProcess::assembleWithJacobianConcreteProcess(

--- a/ProcessLib/HeatConduction/HeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.h
@@ -51,6 +51,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const /*dt*/,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
@@ -159,7 +159,8 @@ void HeatTransportBHEProcess::initializeConcreteProcess(
 
 void HeatTransportBHEProcess::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble HeatTransportBHE process.");
 
@@ -170,8 +171,8 @@ void HeatTransportBHEProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 void HeatTransportBHEProcess::assembleWithJacobianConcreteProcess(

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
@@ -55,6 +55,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerBHE-impl.h
+++ b/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerBHE-impl.h
@@ -117,6 +117,7 @@ void HeatTransportBHELocalAssemblerBHE<ShapeFunction, IntegrationMethod,
     assemble(
         double const /*t*/, double const /*dt*/,
         std::vector<double> const& /*local_x*/,
+        std::vector<double> const& /*local_xdot*/,
         std::vector<double>& local_M_data, std::vector<double>& local_K_data,
         std::vector<double>& /*local_b_data*/)  // local b vector is not touched
 {

--- a/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerBHE.h
+++ b/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerBHE.h
@@ -61,6 +61,7 @@ public:
 
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override;

--- a/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerSoil-impl.h
+++ b/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerSoil-impl.h
@@ -71,6 +71,7 @@ template <typename ShapeFunction, typename IntegrationMethod>
 void HeatTransportBHELocalAssemblerSoil<ShapeFunction, IntegrationMethod>::
     assemble(double const t, double const /*dt*/,
              std::vector<double> const& local_x,
+             std::vector<double> const& /*local_xdot*/,
              std::vector<double>& local_M_data,
              std::vector<double>& local_K_data,
              std::vector<double>& /*local_b_data*/)

--- a/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerSoil.h
+++ b/ProcessLib/HeatTransportBHE/LocalAssemblers/HeatTransportBHELocalAssemblerSoil.h
@@ -55,6 +55,7 @@ public:
 
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override;

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -139,6 +139,7 @@ public:
 
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_rhs_data*/) override

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
@@ -377,7 +377,8 @@ void HydroMechanicsProcess<DisplacementDim>::initializeBoundaryConditions()
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble the equations for HydroMechanics");
 
@@ -390,7 +391,7 @@ void HydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        dof_table, t, dt, x, process_id, M, K, b, _coupled_solutions);
+        dof_table, t, dt, x, xdot, process_id, M, K, b, _coupled_solutions);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -75,6 +75,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const /*dt*/,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.cpp
@@ -569,7 +569,8 @@ bool HydroMechanicsProcess<GlobalDim>::isLinear() const
 template <int GlobalDim>
 void HydroMechanicsProcess<GlobalDim>::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble HydroMechanicsProcess.");
 
@@ -578,7 +579,7 @@ void HydroMechanicsProcess<GlobalDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        dof_table, t, dt, x, process_id, M, K, b, _coupled_solutions);
+        dof_table, t, dt, x, xdot, process_id, M, K, b, _coupled_solutions);
 }
 
 template <int GlobalDim>

--- a/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/LIE/HydroMechanics/HydroMechanicsProcess.h
@@ -66,6 +66,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerInterface.h
+++ b/ProcessLib/LIE/HydroMechanics/LocalAssembler/HydroMechanicsLocalAssemblerInterface.h
@@ -48,6 +48,7 @@ public:
 
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_rhs_data*/) override

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerFracture.h
@@ -66,6 +66,7 @@ public:
 
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrix.h
@@ -61,6 +61,7 @@ public:
 
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerMatrixNearFracture.h
@@ -68,6 +68,7 @@ public:
 
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -545,7 +545,8 @@ bool SmallDeformationProcess<DisplacementDim>::isLinear() const
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble SmallDeformationProcess.");
 
@@ -556,8 +557,8 @@ void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
@@ -62,6 +62,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler-impl.h
@@ -25,6 +25,7 @@ template <typename ShapeFunction, typename IntegrationMethod,
 void LiquidFlowLocalAssembler<ShapeFunction, IntegrationMethod, GlobalDim>::
     assemble(double const t, double const /*dt*/,
              std::vector<double> const& local_x,
+             std::vector<double> const& /*local_xdot*/,
              std::vector<double>& local_M_data,
              std::vector<double>& local_K_data,
              std::vector<double>& local_b_data)

--- a/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowLocalAssembler.h
@@ -124,6 +124,7 @@ public:
 
     void assemble(double const t, double const dt,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -77,7 +77,8 @@ void LiquidFlowProcess::initializeConcreteProcess(
 
 void LiquidFlowProcess::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble LiquidFlowProcess.");
 
@@ -89,8 +90,8 @@ void LiquidFlowProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 void LiquidFlowProcess::assembleWithJacobianConcreteProcess(

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -102,6 +102,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -16,12 +16,14 @@
 
 namespace ProcessLib
 {
-void LocalAssemblerInterface::assemble(double const /*t*/,
-                                       double const /*dt*/,
-                                       std::vector<double> const& /*local_x*/,
-                                       std::vector<double>& /*local_M_data*/,
-                                       std::vector<double>& /*local_K_data*/,
-                                       std::vector<double>& /*local_b_data*/)
+void LocalAssemblerInterface::assemble(
+    double const /*t*/,
+    double const /*dt*/,
+    std::vector<double> const& /*local_x*/,
+    std::vector<double> const& /*local_xdot*/,
+    std::vector<double>& /*local_M_data*/,
+    std::vector<double>& /*local_K_data*/,
+    std::vector<double>& /*local_b_data*/)
 {
     OGS_FATAL(
         "The assemble() function is not implemented in the local assembler.");

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -48,6 +48,7 @@ public:
 
     virtual void assemble(double const t, double const dt,
                           std::vector<double> const& local_x,
+                          std::vector<double> const& local_xdot,
                           std::vector<double>& local_M_data,
                           std::vector<double>& local_K_data,
                           std::vector<double>& local_b_data);

--- a/ProcessLib/PhaseField/PhaseFieldFEM.h
+++ b/ProcessLib/PhaseField/PhaseFieldFEM.h
@@ -209,6 +209,7 @@ public:
 
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_rhs_data*/) override

--- a/ProcessLib/PhaseField/PhaseFieldProcess.cpp
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.cpp
@@ -161,7 +161,8 @@ void PhaseFieldProcess<DisplacementDim>::initializeBoundaryConditions()
 template <int DisplacementDim>
 void PhaseFieldProcess<DisplacementDim>::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble PhaseFieldProcess.");
 
@@ -189,8 +190,8 @@ void PhaseFieldProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_tables, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_tables, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/PhaseField/PhaseFieldProcess.h
+++ b/ProcessLib/PhaseField/PhaseFieldProcess.h
@@ -88,6 +88,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -196,6 +196,7 @@ void Process::assemble(const double t, double const dt,
                        GlobalVector& b)
 {
     MathLib::LinAlg::setLocalAccessibleVector(*x[process_id]);
+    MathLib::LinAlg::setLocalAccessibleVector(*xdot[process_id]);
 
     assembleConcreteProcess(t, dt, x, xdot, process_id, M, K, b);
 

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -191,12 +191,13 @@ void Process::preAssemble(const double t, double const dt,
 
 void Process::assemble(const double t, double const dt,
                        std::vector<GlobalVector*> const& x,
+                       std::vector<GlobalVector*> const& xdot,
                        int const process_id, GlobalMatrix& M, GlobalMatrix& K,
                        GlobalVector& b)
 {
     MathLib::LinAlg::setLocalAccessibleVector(*x[process_id]);
 
-    assembleConcreteProcess(t, dt, x, process_id, M, K, b);
+    assembleConcreteProcess(t, dt, x, xdot, process_id, M, K, b);
 
     // the last argument is for the jacobian, nullptr is for a unused jacobian
     _boundary_conditions[process_id].applyNaturalBC(t, x, process_id, K, b,

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -100,7 +100,8 @@ public:
     void preAssemble(const double t, double const dt,
                      GlobalVector const& x) final;
     void assemble(const double t, double const dt,
-                  std::vector<GlobalVector*> const& x, int const process_id,
+                  std::vector<GlobalVector*> const& x,
+                  std::vector<GlobalVector*> const& xdot, int const process_id,
                   GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b) final;
 
     void assembleWithJacobian(const double t, double const dt,
@@ -195,6 +196,7 @@ private:
 
     virtual void assembleConcreteProcess(const double t, double const dt,
                                          std::vector<GlobalVector*> const& x,
+                                         std::vector<GlobalVector*> const& xdot,
                                          int const process_id, GlobalMatrix& M,
                                          GlobalMatrix& K, GlobalVector& b) = 0;
 

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportFEM-impl.h
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportFEM-impl.h
@@ -58,6 +58,7 @@ template <typename ShapeFunction, typename IntegrationMethod,
           unsigned GlobalDim>
 void LocalAssemblerData<ShapeFunction, IntegrationMethod, GlobalDim>::assemble(
     double const t, double const /*dt*/, std::vector<double> const& local_x,
+    std::vector<double> const& /*local_xdot*/,
     std::vector<double>& local_M_data, std::vector<double>& local_K_data,
     std::vector<double>& local_b_data)
 {

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportFEM.h
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportFEM.h
@@ -106,6 +106,7 @@ public:
 
     void assemble(double const t, double const dt,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& local_xdot,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.cpp
@@ -65,7 +65,8 @@ void RichardsComponentTransportProcess::initializeConcreteProcess(
 
 void RichardsComponentTransportProcess::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble RichardsComponentTransportProcess.");
 
@@ -76,8 +77,8 @@ void RichardsComponentTransportProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 void RichardsComponentTransportProcess::assembleWithJacobianConcreteProcess(

--- a/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.h
+++ b/ProcessLib/RichardsComponentTransport/RichardsComponentTransportProcess.h
@@ -130,6 +130,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/RichardsFlow/RichardsFlowFEM.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowFEM.h
@@ -130,6 +130,7 @@ public:
 
     void assemble(double const t, double const /*dt*/,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.cpp
@@ -66,7 +66,8 @@ void RichardsFlowProcess::initializeConcreteProcess(
 
 void RichardsFlowProcess::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble RichardsFlowProcess.");
 
@@ -77,8 +78,8 @@ void RichardsFlowProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 void RichardsFlowProcess::assembleWithJacobianConcreteProcess(

--- a/ProcessLib/RichardsFlow/RichardsFlowProcess.h
+++ b/ProcessLib/RichardsFlow/RichardsFlowProcess.h
@@ -54,6 +54,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
@@ -98,6 +98,7 @@ void RichardsMechanicsLocalAssembler<
     ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
     DisplacementDim>::assemble(double const t, double const dt,
                                std::vector<double> const& local_x,
+                               std::vector<double> const& /*local_xdot*/,
                                std::vector<double>& local_M_data,
                                std::vector<double>& local_K_data,
                                std::vector<double>& local_rhs_data)

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
@@ -73,6 +73,7 @@ public:
 
     void assemble(double const t, double const dt,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& local_xdot,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_rhs_data) override;

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
@@ -249,7 +249,8 @@ void RichardsMechanicsProcess<DisplacementDim>::initializeBoundaryConditions()
 template <int DisplacementDim>
 void RichardsMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble the equations for RichardsMechanics");
 
@@ -264,8 +265,8 @@ void RichardsMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
@@ -75,6 +75,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -222,6 +222,7 @@ public:
 
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -178,7 +178,8 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble SmallDeformationProcess.");
 
@@ -189,8 +190,8 @@ void SmallDeformationProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -51,6 +51,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
@@ -306,6 +306,7 @@ public:
 
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.cpp
@@ -231,7 +231,8 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::
 template <int DisplacementDim>
 void SmallDeformationNonlocalProcess<DisplacementDim>::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble SmallDeformationNonlocalProcess.");
 
@@ -243,8 +244,8 @@ void SmallDeformationNonlocalProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalProcess.h
@@ -53,6 +53,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/TES/TESLocalAssembler-impl.h
+++ b/ProcessLib/TES/TESLocalAssembler-impl.h
@@ -137,6 +137,7 @@ template <typename ShapeFunction_, typename IntegrationMethod_,
           unsigned GlobalDim>
 void TESLocalAssembler<ShapeFunction_, IntegrationMethod_, GlobalDim>::assemble(
     double const /*t*/, double const /*dt*/, std::vector<double> const& local_x,
+    std::vector<double> const& /*local_xdot*/,
     std::vector<double>& local_M_data, std::vector<double>& local_K_data,
     std::vector<double>& local_b_data)
 {

--- a/ProcessLib/TES/TESLocalAssembler.h
+++ b/ProcessLib/TES/TESLocalAssembler.h
@@ -82,6 +82,7 @@ public:
 
     void assemble(double const t, double const dt,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& local_xdot,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;

--- a/ProcessLib/TES/TESProcess.cpp
+++ b/ProcessLib/TES/TESProcess.cpp
@@ -211,6 +211,7 @@ void TESProcess::initializeSecondaryVariables()
 
 void TESProcess::assembleConcreteProcess(const double t, double const dt,
                                          std::vector<GlobalVector*> const& x,
+                                         std::vector<GlobalVector*> const& xdot,
                                          int const process_id, GlobalMatrix& M,
                                          GlobalMatrix& K, GlobalVector& b)
 {
@@ -223,8 +224,8 @@ void TESProcess::assembleConcreteProcess(const double t, double const dt,
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 void TESProcess::assembleWithJacobianConcreteProcess(

--- a/ProcessLib/TES/TESProcess.h
+++ b/ProcessLib/TES/TESProcess.h
@@ -60,6 +60,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPLocalAssembler-impl.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPLocalAssembler-impl.h
@@ -60,6 +60,7 @@ void ThermalTwoPhaseFlowWithPPLocalAssembler<
     ShapeFunction, IntegrationMethod,
     GlobalDim>::assemble(double const t, double const /*dt*/,
                          std::vector<double> const& local_x,
+                         std::vector<double> const& /*local_xdot*/,
                          std::vector<double>& local_M_data,
                          std::vector<double>& local_K_data,
                          std::vector<double>& local_b_data)

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPLocalAssembler.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPLocalAssembler.h
@@ -134,6 +134,7 @@ public:
 
     void assemble(double const t, double const dt,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& local_xdot,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.cpp
@@ -75,7 +75,8 @@ void ThermalTwoPhaseFlowWithPPProcess::initializeConcreteProcess(
 
 void ThermalTwoPhaseFlowWithPPProcess::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble ThermalTwoPhaseFlowWithPPProcess.");
 
@@ -86,8 +87,8 @@ void ThermalTwoPhaseFlowWithPPProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 void ThermalTwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/ThermalTwoPhaseFlowWithPPProcess.h
@@ -62,6 +62,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
@@ -77,6 +77,7 @@ public:
 
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_rhs_data*/) override

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
@@ -239,7 +239,8 @@ void ThermoHydroMechanicsProcess<
 template <int DisplacementDim>
 void ThermoHydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble the equations for ThermoHydroMechanics");
 
@@ -252,7 +253,7 @@ void ThermoHydroMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        dof_table, t, dt, x, process_id, M, K, b, _coupled_solutions);
+        dof_table, t, dt, x, xdot, process_id, M, K, b, _coupled_solutions);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
@@ -76,6 +76,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
@@ -224,6 +224,7 @@ public:
 
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_rhs_data*/) override

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.cpp
@@ -190,6 +190,7 @@ template <int DisplacementDim>
 void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
     assembleConcreteProcess(const double t, double const dt,
                             std::vector<GlobalVector*> const& x,
+                            std::vector<GlobalVector*> const& xdot,
                             int const process_id, GlobalMatrix& M,
                             GlobalMatrix& K, GlobalVector& b)
 {
@@ -202,8 +203,8 @@ void ThermoMechanicalPhaseFieldProcess<DisplacementDim>::
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldProcess.h
@@ -93,6 +93,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
@@ -124,6 +124,7 @@ public:
 
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& /*local_x*/,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_rhs_data*/) override

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.cpp
@@ -286,7 +286,8 @@ void ThermoMechanicsProcess<DisplacementDim>::initializeBoundaryConditions()
 template <int DisplacementDim>
 void ThermoMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble ThermoMechanicsProcess.");
 
@@ -297,8 +298,8 @@ void ThermoMechanicsProcess<DisplacementDim>::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsProcess.h
@@ -69,6 +69,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler-impl.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler-impl.h
@@ -48,6 +48,7 @@ void TwoPhaseFlowWithPPLocalAssembler<
     ShapeFunction, IntegrationMethod,
     GlobalDim>::assemble(double const t, double const /*dt*/,
                          std::vector<double> const& local_x,
+                         std::vector<double> const& /*local_xdot*/,
                          std::vector<double>& local_M_data,
                          std::vector<double>& local_K_data,
                          std::vector<double>& local_b_data)

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPLocalAssembler.h
@@ -126,6 +126,7 @@ public:
 
     void assemble(double const t, double const dt,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& local_xdot,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.cpp
@@ -65,7 +65,8 @@ void TwoPhaseFlowWithPPProcess::initializeConcreteProcess(
 
 void TwoPhaseFlowWithPPProcess::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble TwoPhaseFlowWithPPProcess.");
 
@@ -76,8 +77,8 @@ void TwoPhaseFlowWithPPProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 void TwoPhaseFlowWithPPProcess::assembleWithJacobianConcreteProcess(

--- a/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPP/TwoPhaseFlowWithPPProcess.h
@@ -63,6 +63,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler-impl.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler-impl.h
@@ -26,6 +26,7 @@ void TwoPhaseFlowWithPrhoLocalAssembler<
     ShapeFunction, IntegrationMethod,
     GlobalDim>::assemble(double const t, double const /*dt*/,
                          std::vector<double> const& local_x,
+                         std::vector<double> const& /*local_xdot*/,
                          std::vector<double>& local_M_data,
                          std::vector<double>& local_K_data,
                          std::vector<double>& local_b_data)

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoLocalAssembler.h
@@ -135,9 +135,11 @@ public:
 
     void assemble(double const t, double const /*dt*/,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& local_xdot,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override;
+
     Eigen::Map<const Eigen::RowVectorXd> getShapeMatrix(
         const unsigned integration_point) const override
     {

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.cpp
@@ -66,7 +66,8 @@ void TwoPhaseFlowWithPrhoProcess::initializeConcreteProcess(
 
 void TwoPhaseFlowWithPrhoProcess::assembleConcreteProcess(
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b)
 {
     DBUG("Assemble TwoPhaseFlowWithPrhoProcess.");
 
@@ -77,8 +78,8 @@ void TwoPhaseFlowWithPrhoProcess::assembleConcreteProcess(
     // Call global assembler for each local assembly item.
     GlobalExecutor::executeSelectedMemberDereferenced(
         _global_assembler, &VectorMatrixAssembler::assemble, _local_assemblers,
-        pv.getActiveElementIDs(), dof_table, t, dt, x, process_id, M, K, b,
-        _coupled_solutions);
+        pv.getActiveElementIDs(), dof_table, t, dt, x, xdot, process_id, M, K,
+        b, _coupled_solutions);
 }
 
 void TwoPhaseFlowWithPrhoProcess::assembleWithJacobianConcreteProcess(

--- a/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
+++ b/ProcessLib/TwoPhaseFlowWithPrho/TwoPhaseFlowWithPrhoProcess.h
@@ -61,6 +61,7 @@ private:
 
     void assembleConcreteProcess(const double t, double const dt,
                                  std::vector<GlobalVector*> const& x,
+                                 std::vector<GlobalVector*> const& xdot,
                                  int const process_id, GlobalMatrix& M,
                                  GlobalMatrix& K, GlobalVector& b) override;
 

--- a/ProcessLib/VectorMatrixAssembler.cpp
+++ b/ProcessLib/VectorMatrixAssembler.cpp
@@ -44,7 +44,8 @@ void VectorMatrixAssembler::assemble(
     std::vector<std::reference_wrapper<NumLib::LocalToGlobalIndexMap>> const&
         dof_tables,
     const double t, double const dt, std::vector<GlobalVector*> const& x,
-    int const process_id, GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
+    std::vector<GlobalVector*> const& xdot, int const process_id,
+    GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
     CoupledSolutionsForStaggeredScheme const* const cpl_xs)
 {
     std::vector<std::vector<GlobalIndexType>> indices_of_processes;
@@ -63,8 +64,9 @@ void VectorMatrixAssembler::assemble(
     if (cpl_xs == nullptr)
     {
         auto const local_x = x[process_id]->get(indices);
-        local_assembler.assemble(t, dt, local_x, _local_M_data, _local_K_data,
-                                 _local_b_data);
+        auto const local_xdot = xdot[process_id]->get(indices);
+        local_assembler.assemble(t, dt, local_x, local_xdot, _local_M_data,
+                                 _local_K_data, _local_b_data);
     }
     else
     {

--- a/ProcessLib/VectorMatrixAssembler.h
+++ b/ProcessLib/VectorMatrixAssembler.h
@@ -48,7 +48,8 @@ public:
                   std::vector<std::reference_wrapper<
                       NumLib::LocalToGlobalIndexMap>> const& dof_tables,
                   double const t, double const dt,
-                  std::vector<GlobalVector*> const& x, int const process_id,
+                  std::vector<GlobalVector*> const& x,
+                  std::vector<GlobalVector*> const& xdot, int const process_id,
                   GlobalMatrix& M, GlobalMatrix& K, GlobalVector& b,
                   CoupledSolutionsForStaggeredScheme const* const cpl_xs);
 

--- a/Tests/ProcessLib/TestJacobianAssembler.cpp
+++ b/Tests/ProcessLib/TestJacobianAssembler.cpp
@@ -295,6 +295,7 @@ class LocalAssemblerM final : public ProcessLib::LocalAssemblerInterface
 public:
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& local_M_data,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& /*local_b_data*/) override
@@ -311,7 +312,8 @@ public:
                               std::vector<double>& local_b_data,
                               std::vector<double>& local_Jac_data) override
     {
-        assemble(t, dt, local_x, local_M_data, local_K_data, local_b_data);
+        assemble(t, dt, local_x, local_xdot, local_M_data, local_K_data,
+                 local_b_data);
 
         // dM/dx * xdot
         MatVec::Mat::getDMatDxTimesY(local_x, local_xdot, local_Jac_data);
@@ -336,6 +338,7 @@ class LocalAssemblerK final : public ProcessLib::LocalAssemblerInterface
 public:
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& local_K_data,
                   std::vector<double>& /*local_b_data*/) override
@@ -345,14 +348,15 @@ public:
 
     void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x,
-                              std::vector<double> const& /*local_xdot*/,
+                              std::vector<double> const& local_xdot,
                               const double /*dxdot_dx*/, const double dx_dx,
                               std::vector<double>& local_M_data,
                               std::vector<double>& local_K_data,
                               std::vector<double>& local_b_data,
                               std::vector<double>& local_Jac_data) override
     {
-        assemble(t, dt, local_x, local_M_data, local_K_data, local_b_data);
+        assemble(t, dt, local_x, local_xdot, local_M_data, local_K_data,
+                 local_b_data);
 
         // dK/dx * x
         MatVec::Mat::getDMatDxTimesY(local_x, local_x, local_Jac_data);
@@ -377,6 +381,7 @@ class LocalAssemblerB final : public ProcessLib::LocalAssemblerInterface
 public:
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& /*local_M_data*/,
                   std::vector<double>& /*local_K_data*/,
                   std::vector<double>& local_b_data) override
@@ -386,14 +391,15 @@ public:
 
     void assembleWithJacobian(double const t, double const dt,
                               std::vector<double> const& local_x,
-                              std::vector<double> const& /*local_xdot*/,
+                              std::vector<double> const& local_xdot,
                               const double /*dxdot_dx*/, const double /*dx_dx*/,
                               std::vector<double>& local_M_data,
                               std::vector<double>& local_K_data,
                               std::vector<double>& local_b_data,
                               std::vector<double>& local_Jac_data) override
     {
-        assemble(t, dt, local_x, local_M_data, local_K_data, local_b_data);
+        assemble(t, dt, local_x, local_xdot, local_M_data, local_K_data,
+                 local_b_data);
 
         // db/dx
         MatVec::Vec::getDVecDx(local_x, local_Jac_data);
@@ -417,6 +423,7 @@ class LocalAssemblerMKb final : public ProcessLib::LocalAssemblerInterface
 public:
     void assemble(double const /*t*/, double const /*dt*/,
                   std::vector<double> const& local_x,
+                  std::vector<double> const& /*local_xdot*/,
                   std::vector<double>& local_M_data,
                   std::vector<double>& local_K_data,
                   std::vector<double>& local_b_data) override
@@ -435,7 +442,8 @@ public:
                               std::vector<double>& local_b_data,
                               std::vector<double>& local_Jac_data) override
     {
-        assemble(t, dt, local_x, local_M_data, local_K_data, local_b_data);
+        assemble(t, dt, local_x, local_xdot, local_M_data, local_K_data,
+                 local_b_data);
 
         std::vector<double> local_JacM_data;
         // dM/dx * xdot


### PR DESCRIPTION
This is part of #2688 .

Needed now for implementation of rate-dependent material models.

Review commit-wise.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.0)
2. [x] Tests covering your feature were added? Upcoming material model will use xdot, otherwise assemblers are tested.
3. [x] Any new feature or behavior change was documented? No project file changes.
