### PR TITLE
Updated eve modules

### DIFF
--- a/scripts/env/eve/cli.sh
+++ b/scripts/env/eve/cli.sh
@@ -7,16 +7,15 @@ fi
 
 module use /global/apps/modulefiles
 
-module load cmake
 module load foss/2018b
-module load ninja/1.9.0
-module load git/2.20.1
+module load cmake
+module load ninja
+module load git-lfs
 
 # Libraries
-module load boost/1.62.0-1
+module load Boost/1.67.0
 module load eigen/3.3.4-1-cmake
 module load vtk/8.2.0/foss2018b/serial
 
 # Tools
-module load coreutils/8.21-1
 module load ccache/3.3.3


### PR DESCRIPTION
Newer Boost module does not depend on deprecated modules.