### PR TITLE
[HM] enable mass lumping

### DIFF
--- a/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/t_mass_lumping.md
+++ b/Documentation/ProjectFile/prj/processes/process/HYDRO_MECHANICS/t_mass_lumping.md
@@ -1,0 +1,1 @@
+\copydoc ProcessLib::HydroMechanics::HydroMechanicsProcessData::mass_lumping

--- a/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/CreateHydroMechanicsProcess.cpp
@@ -131,6 +131,9 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
         std::copy_n(b.data(), b.size(), specific_body_force.data());
     }
 
+    //! \ogs_file_param{prj__processes__process__HYDRO_MECHANICS__mass_lumping}
+    auto mass_lumping = config.getConfigParameter<bool>("mass_lumping", false);
+
     auto media_map =
         MaterialPropertyLib::createMaterialSpatialDistributionMap(media, mesh);
 
@@ -165,7 +168,8 @@ std::unique_ptr<Process> createHydroMechanicsProcess(
     HydroMechanicsProcessData<DisplacementDim> process_data{
         materialIDs(mesh),     std::move(media_map),
         std::move(solid_constitutive_relations),
-        initial_stress,        specific_body_force};
+        initial_stress,        specific_body_force,
+        mass_lumping};
 
     SecondaryVariableCollection secondary_variables;
 

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -303,6 +303,11 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                                           pressure_index)
         .noalias() = -Kup;
 
+    if (_process_data.mass_lumping)
+    {
+        storage_p = storage_p.colwise().sum().eval().asDiagonal();
+    }
+
     // pressure equation, pressure part.
     local_Jac
         .template block<pressure_size, pressure_size>(pressure_index,

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
@@ -55,6 +55,8 @@ struct HydroMechanicsProcessData
     /// A vector of displacement dimension's length.
     Eigen::Matrix<double, DisplacementDim, 1> const specific_body_force;
 
+    bool const mass_lumping;
+
     MeshLib::PropertyVector<double>* pressure_interpolated = nullptr;
     std::array<MeshLib::PropertyVector<double>*, 3> principal_stress_vector = {
         nullptr, nullptr, nullptr};


### PR DESCRIPTION
Gives the option to use mass lumping in HM which can help with oscillation problems

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.0)