### PR TITLE
[MPL] User-provided limits for porosity.

### DIFF
--- a/Documentation/ProjectFile/properties/property/PorosityFromMassBalance/t_maximal_porosity.md
+++ b/Documentation/ProjectFile/properties/property/PorosityFromMassBalance/t_maximal_porosity.md
@@ -1,0 +1,1 @@
+\copydoc MaterialPropertyLib::PorosityFromMassBalance::_phi_max

--- a/Documentation/ProjectFile/properties/property/PorosityFromMassBalance/t_minimal_porosity.md
+++ b/Documentation/ProjectFile/properties/property/PorosityFromMassBalance/t_minimal_porosity.md
@@ -1,0 +1,1 @@
+\copydoc MaterialPropertyLib::PorosityFromMassBalance::_phi_min

--- a/MaterialLib/MPL/Properties/CreatePorosityFromMassBalance.cpp
+++ b/MaterialLib/MPL/Properties/CreatePorosityFromMassBalance.cpp
@@ -29,6 +29,13 @@ std::unique_ptr<PorosityFromMassBalance> createPorosityFromMassBalance(
     auto const& initial_porosity = ParameterLib::findParameter<double>(
         parameter_name, parameters, 0, nullptr);
 
-    return std::make_unique<PorosityFromMassBalance>(initial_porosity);
+    //! \ogs_file_param{properties__property__PorosityFromMassBalance__minimal_porosity}
+    auto const& phi_min = config.getConfigParameter<double>("minimal_porosity");
+
+    //! \ogs_file_param{properties__property__PorosityFromMassBalance__maximal_porosity}
+    auto const& phi_max = config.getConfigParameter<double>("maximal_porosity");
+
+    return std::make_unique<PorosityFromMassBalance>(
+        initial_porosity, phi_min, phi_max);
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/PorosityFromMassBalance.cpp
+++ b/MaterialLib/MPL/Properties/PorosityFromMassBalance.cpp
@@ -59,7 +59,7 @@ PropertyDataType PorosityFromMassBalance::value(
         variable_array[static_cast<int>(Variable::porosity)]);
 
     double const w = dt * (e_dot + p_eff_dot / K_SR);
-    return std::clamp((phi + alpha_b * w) / (1 + w), 0., 1.);
+    return std::clamp((phi + alpha_b * w) / (1 + w), _phi_min, _phi_max);
 }
 
 PropertyDataType PorosityFromMassBalance::dValue(

--- a/MaterialLib/MPL/Properties/PorosityFromMassBalance.h
+++ b/MaterialLib/MPL/Properties/PorosityFromMassBalance.h
@@ -29,11 +29,14 @@ private:
 
     /// Parameter, which is used by FEM to set the initial porosity value.
     ParameterLib::Parameter<double> const& _phi0;
+    double const _phi_min;  //< Lower limit for the porosity.
+    double const _phi_max;  //< Upper limit for the porosity.
 
 public:
     PorosityFromMassBalance(
-        ParameterLib::Parameter<double> const& initial_porosity)
-        : _phi0(initial_porosity)
+        ParameterLib::Parameter<double> const& initial_porosity,
+        double const phi_min, double const phi_max)
+        : _phi0(initial_porosity), _phi_min(phi_min), _phi_max(phi_max)
     {
     }
 

--- a/Tests/Data/RichardsMechanics/deformation_dependent_porosity.prj
+++ b/Tests/Data/RichardsMechanics/deformation_dependent_porosity.prj
@@ -79,6 +79,8 @@
                             <name>porosity</name>
                             <type>PorosityFromMassBalance</type>
                             <initial_porosity>phi0</initial_porosity>
+                            <minimal_porosity>0</minimal_porosity>
+                            <maximal_porosity>1</maximal_porosity>
                         </property>
                         <property>
                             <name>permeability</name>

--- a/Tests/Data/RichardsMechanics/orthotropic_power_law_permeability_xyz.prj
+++ b/Tests/Data/RichardsMechanics/orthotropic_power_law_permeability_xyz.prj
@@ -77,6 +77,8 @@
                             <name>porosity</name>
                             <type>PorosityFromMassBalance</type>
                             <initial_porosity>phi0</initial_porosity>
+                            <minimal_porosity>0</minimal_porosity>
+                            <maximal_porosity>1</maximal_porosity>
                         </property>
                         <property>
                             <name>permeability</name>


### PR DESCRIPTION
Currently the limits are hard coded to be 0 and 1.
In some cases these values could be higher and lower,
respectively.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.0)
2. [x] Tests covering your feature were added? Existing one is updated.
3. [x] Any new feature or behavior change was documented?
