### PR TITLE
Fix conan gui builds

### DIFF
--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
@@ -294,7 +294,7 @@ void RichardsMechanicsLocalAssembler<
                                          MPL::Variable::capillary_pressure,
                                          x_position, t, dt);
 
-        auto const chi = [&](double const S_L) {
+        auto const chi = [medium, x_position, t, dt](double const S_L) {
             MPL::VariableArray variables;
             variables[static_cast<int>(MPL::Variable::liquid_saturation)] = S_L;
             return medium->property(MPL::PropertyType::bishops_effective_stress)
@@ -578,7 +578,7 @@ void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
                     variables, MPL::Variable::capillary_pressure,
                     MPL::Variable::capillary_pressure, x_position, t, dt);
 
-        auto const chi = [&](double const S_L) {
+        auto const chi = [medium, x_position, t, dt](double const S_L) {
             MPL::VariableArray variables;
             variables[static_cast<int>(MPL::Variable::liquid_saturation)] = S_L;
             return medium->property(MPL::PropertyType::bishops_effective_stress)

--- a/scripts/cmake/ConanSetup.cmake
+++ b/scripts/cmake/ConanSetup.cmake
@@ -68,7 +68,7 @@ endif()
 if(OGS_BUILD_GUI)
     set(CONAN_REQUIRES ${CONAN_REQUIRES}
         shapelib/1.3.0@bilke/stable
-        libgeotiff/1.4.2@bilke/stable
+        # libgeotiff/1.4.2@bilke/stable # TODO
         # Overrides for dependency mismatches
         bzip2/1.0.8
         zlib/1.2.11


### PR DESCRIPTION
Disabled geotiff when `OGS_USE_CONAN=ON` and `OGS_BUILD_GUI=ON`.