### PR TITLE
Two corrections in MPI and vtk stuffs.

### DIFF
--- a/Applications/ApplicationsLib/LinearSolverLibrarySetup.h
+++ b/Applications/ApplicationsLib/LinearSolverLibrarySetup.h
@@ -32,6 +32,7 @@ struct LinearSolverLibrarySetup final
         MPI_Init(&argc, &argv);
         char help[] = "ogs6 with PETSc \n";
         PetscInitialize(&argc, &argv, nullptr, help);
+        MPI_Comm_set_errhandler(PETSC_COMM_WORLD, MPI_ERRORS_RETURN);
     }
 
     ~LinearSolverLibrarySetup()

--- a/MeshLib/Vtk/VtkMappedMeshSource.cpp
+++ b/MeshLib/Vtk/VtkMappedMeshSource.cpp
@@ -144,35 +144,43 @@ int VtkMappedMeshSource::RequestData(vtkInformation* /*request*/,
     std::vector<std::string> const& propertyNames =
         properties.getPropertyVectorNames();
 
-    for (auto name = propertyNames.cbegin(); name != propertyNames.cend();
-         ++name)
+    for (auto const& name : propertyNames)
     {
-        if (addProperty<double>(properties, *name))
+        if (addProperty<double>(properties, name))
         {
             continue;
         }
-        if (addProperty<float>(properties, *name))
+        if (addProperty<float>(properties, name))
         {
             continue;
         }
-        if (addProperty<int>(properties, *name))
+        if (addProperty<int>(properties, name))
         {
             continue;
         }
-        if (addProperty<unsigned>(properties, *name))
+        if (addProperty<unsigned>(properties, name))
         {
             continue;
         }
-        if (addProperty<std::size_t>(properties, *name))
+        if (addProperty<std::size_t>(properties, name))
         {
             continue;
         }
-        if (addProperty<char>(properties, *name))
+        if (addProperty<char>(properties, name))
         {
             continue;
         }
 
-        DBUG("Mesh property '%s' with unknown data type.", *name->c_str());
+        OGS_FATAL(
+            "Mesh property '%s' with unknown data type. Please check the data "
+            "type of the mesh properties. The available data types are:"
+            "\n\t double,"
+            "\n\t float,"
+            "\n\t int,"
+            "\n\t unsigned,"
+            "\n\t size_t,"
+            "\n\t char.",
+            name.data());
     }
 
     output->GetPointData()->ShallowCopy(this->PointData.GetPointer());


### PR DESCRIPTION
Two corrections:
1. DBUG message (`*name->c_str()`) in `VtkMappedMeshSource::RequestData`,
2. Enabled MPI to work with `std::runtime_error` properly.
