### PR TITLE
HM permeability output

### DIFF
--- a/MaterialLib/MPL/Utils/GetSymmetricTensor.cpp
+++ b/MaterialLib/MPL/Utils/GetSymmetricTensor.cpp
@@ -1,0 +1,99 @@
+/*
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on March 04, 2020, 5:20 PM
+ */
+
+#include "GetSymmetricTensor.h"
+
+#include "MaterialLib/MPL/PropertyType.h"
+
+namespace MaterialPropertyLib
+{
+template <int GlobalDim>
+struct GetSymmetricTensor
+{
+    SymmetricTensor<GlobalDim> operator()(double const& value) const
+    {
+        SymmetricTensor<GlobalDim> result = SymmetricTensor<GlobalDim>::Zero();
+        result.template head<3>() = Eigen::Vector3d::Constant(value);
+        return result;
+    }
+
+    SymmetricTensor<GlobalDim> operator()(Eigen::Vector2d const& values) const
+    {
+        SymmetricTensor<GlobalDim> result = SymmetricTensor<GlobalDim>::Zero();
+        result.template head<2>() = values;
+        return result;
+    }
+
+    SymmetricTensor<GlobalDim> operator()(Eigen::Vector3d const& values) const
+    {
+        SymmetricTensor<GlobalDim> result = SymmetricTensor<GlobalDim>::Zero();
+        result.template head<3>() = values;
+        return result;
+    }
+
+    SymmetricTensor<GlobalDim> operator()(Eigen::Matrix2d const& values) const
+    {
+        if constexpr (GlobalDim == 2)
+        {
+            SymmetricTensor<GlobalDim> result;
+            result << values(0, 0), values(1, 1), 0., values(0, 1);
+            return result;
+        }
+        OGS_FATAL("Cannot convert 2d matrix to 3d symmetric Tensor.");
+    }
+
+    SymmetricTensor<GlobalDim> operator()(Eigen::Matrix3d const& values) const
+    {
+        if constexpr (GlobalDim == 3)
+        {
+            SymmetricTensor<GlobalDim> result;
+            result << values(0, 0), values(1, 1), values(2, 2),
+                      values(0, 1), values(1, 2), values(0, 2);
+            return result;
+        }
+        OGS_FATAL("Cannot convert 3d matrix to 2d symmetric Tensor.");
+    }
+
+    SymmetricTensor<GlobalDim> operator()(
+        SymmetricTensor<2> const& values) const
+    {
+        if constexpr (GlobalDim == 2)
+        {
+            return values;
+        }
+        OGS_FATAL("Cannot convert 3d symmetric tensor to 2d symmetric tensor.");
+    }
+
+    SymmetricTensor<GlobalDim> operator()(
+        SymmetricTensor<3> const& values) const
+    {
+        if constexpr (GlobalDim == 3)
+        {
+            return values;
+        }
+        OGS_FATAL("Cannot convert 2d symmetric tensor to 3d symmetric tensor.");
+    }
+};
+
+template <int GlobalDim>
+SymmetricTensor<GlobalDim> getSymmetricTensor(
+    MaterialPropertyLib::PropertyDataType const& values)
+{
+    return std::visit(GetSymmetricTensor<GlobalDim>(), values);
+}
+
+template Eigen::Matrix<double, 4, 1> getSymmetricTensor<2>(
+    MaterialPropertyLib::PropertyDataType const& values);
+
+template Eigen::Matrix<double, 6, 1> getSymmetricTensor<3>(
+    MaterialPropertyLib::PropertyDataType const& values);
+
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Utils/GetSymmetricTensor.h
+++ b/MaterialLib/MPL/Utils/GetSymmetricTensor.h
@@ -1,0 +1,32 @@
+/*
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on March 04, 2020, 5:20 PM
+ */
+
+#pragma once
+
+#include <Eigen/Dense>
+
+#include "MaterialLib/MPL/Property.h"
+#include "MathLib/KelvinVector.h"
+
+namespace MaterialPropertyLib
+{
+template <int GlobalDim>
+constexpr int symmetric_tensor_size =
+    MathLib::KelvinVector::KelvinVectorDimensions<GlobalDim>::value;
+
+template <int GlobalDim>
+using SymmetricTensor =
+    Eigen::Matrix<double, symmetric_tensor_size<GlobalDim>, 1>;
+
+template <int GlobalDim>
+SymmetricTensor<GlobalDim> getSymmetricTensor(
+    MaterialPropertyLib::PropertyDataType const& values);
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/VariableType.h
+++ b/MaterialLib/MPL/VariableType.h
@@ -53,6 +53,7 @@ enum class Variable : int
     porosity,
     displacement,
     strain,
+    stress,
     volumetric_strain_rate,
     number_of_variables
 };

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -13,11 +13,11 @@
 
 #include "HydroMechanicsFEM.h"
 
-#include "MaterialLib/SolidModels/SelectSolidConstitutiveRelation.h"
 #include "MaterialLib/MPL/Medium.h"
 #include "MaterialLib/MPL/Property.h"
 #include "MaterialLib/MPL/Utils/FormEigenTensor.h"
 #include "MaterialLib/MPL/Utils/GetSymmetricTensor.h"
+#include "MaterialLib/SolidModels/SelectSolidConstitutiveRelation.h"
 #include "MathLib/KelvinVector.h"
 #include "NumLib/Function/Interpolation.h"
 #include "ProcessLib/CoupledSolutionsForStaggeredScheme.h"
@@ -70,7 +70,7 @@ HydroMechanicsLocalAssembler<ShapeFunctionDisplacement, ShapeFunctionPressure,
         _ip_data.emplace_back(solid_material);
         auto& ip_data = _ip_data[ip];
         auto const& sm_u = shape_matrices_u[ip];
-       ip_data.integration_weight =
+        ip_data.integration_weight =
             _integration_method.getWeightedPoint(ip).getWeight() *
             sm_u.integralMeasure * sm_u.detJ;
 
@@ -616,8 +616,8 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
 
         eps.noalias() = B * u;
 
-        auto C = _ip_data[ip].updateConstitutiveRelation(
-            t, x_position, dt, u, T_ref);
+        auto C = _ip_data[ip].updateConstitutiveRelation(t, x_position, dt, u,
+                                                         T_ref);
 
         local_Jac.noalias() += B.transpose() * C * B * w;
 

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -17,6 +17,7 @@
 #include "MaterialLib/MPL/Medium.h"
 #include "MaterialLib/MPL/Property.h"
 #include "MaterialLib/MPL/Utils/FormEigenTensor.h"
+#include "MaterialLib/MPL/Utils/GetSymmetricTensor.h"
 #include "MathLib/KelvinVector.h"
 #include "NumLib/Function/Interpolation.h"
 #include "ProcessLib/CoupledSolutionsForStaggeredScheme.h"
@@ -846,7 +847,7 @@ template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
 void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                   ShapeFunctionPressure, IntegrationMethod,
                                   DisplacementDim>::
-    computeSecondaryVariableConcrete(double const /*t*/,
+    computeSecondaryVariableConcrete(double const t,
                                      std::vector<double> const& local_x)
 {
     auto p = Eigen::Map<typename ShapeMatricesTypePressure::template VectorType<
@@ -857,21 +858,55 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
         DisplacementDim>(_element, _is_axially_symmetric, p,
                          *_process_data.pressure_interpolated);
 
+    int const elem_id = _element.getID();
+    ParameterLib::SpatialPosition x_position;
+    x_position.setElementID(elem_id);
+    unsigned const n_integration_points =
+        _integration_method.getNumberOfPoints();
+
+    auto const& medium = _process_data.media_map->getMedium(elem_id);
+    MPL::VariableArray vars;
+
+    // TODO (naumov) Temporary value not used by current material models. Need
+    // extension of secondary variables interface.
+    double const dt = std::numeric_limits<double>::quiet_NaN();
+
+    constexpr int symmetric_tensor_size =
+        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
+    using SymmetricTensor = Eigen::Matrix<double, symmetric_tensor_size, 1>;
+
+    SymmetricTensor k_sum = SymmetricTensor::Zero(symmetric_tensor_size);
     auto sigma_eff_sum = MathLib::KelvinVector::tensorToKelvin<DisplacementDim>(
         Eigen::Matrix<double, 3, 3>::Zero());
 
-    for (auto const& ip_data : _ip_data)
+    for (unsigned ip = 0; ip < n_integration_points; ip++)
     {
-        sigma_eff_sum += ip_data.sigma_eff;
+        x_position.setIntegrationPoint(ip);
+
+        auto const& eps = _ip_data[ip].eps;
+        auto const& sigma_eff = _ip_data[ip].sigma_eff;
+        sigma_eff_sum += sigma_eff;
+
+        vars[static_cast<int>(MPL::Variable::strain)].emplace<SymmetricTensor>(
+            MathLib::KelvinVector::kelvinVectorToSymmetricTensor(eps));
+        vars[static_cast<int>(MPL::Variable::stress)].emplace<SymmetricTensor>(
+            MathLib::KelvinVector::kelvinVectorToSymmetricTensor(sigma_eff));
+        vars[static_cast<int>(MPL::Variable::phase_pressure)] =
+            _ip_data[ip].N_p.dot(p);
+        k_sum += MPL::getSymmetricTensor<DisplacementDim>(
+                    medium->property(MPL::PropertyType::permeability)
+                        .value(vars, x_position, t, dt));
     }
+
+    Eigen::Map<Eigen::VectorXd>(
+        &(*_process_data.permeability)[elem_id * symmetric_tensor_size],
+        symmetric_tensor_size) = k_sum / n_integration_points;
 
     Eigen::Matrix<double, 3, 3, 0, 3, 3> const sigma_avg =
         MathLib::KelvinVector::kelvinVectorToTensor(sigma_eff_sum) /
-        _integration_method.getNumberOfPoints();
+        n_integration_points;
 
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double, 3, 3>> e_s(sigma_avg);
-
-    int const elem_id = _element.getID();
 
     Eigen::Map<Eigen::Vector3d>(
         &(*_process_data.principal_stress_values)[elem_id * 3], 3) =

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -16,6 +16,7 @@
 #include "MaterialLib/SolidModels/SelectSolidConstitutiveRelation.h"
 #include "MaterialLib/MPL/Medium.h"
 #include "MaterialLib/MPL/Property.h"
+#include "MaterialLib/MPL/Utils/FormEigenTensor.h"
 #include "MathLib/KelvinVector.h"
 #include "NumLib/Function/Interpolation.h"
 #include "ProcessLib/CoupledSolutionsForStaggeredScheme.h"
@@ -223,8 +224,9 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
 
         auto const K_S = solid_material.getBulkModulus(t, x_position);
 
-        auto const K = medium->property(MPL::PropertyType::permeability)
-                           .template value<double>(vars, x_position, t, dt);
+        auto const K = MPL::formEigenTensor<DisplacementDim>(
+            medium->property(MPL::PropertyType::permeability)
+                .value(vars, x_position, t, dt));
         auto const alpha = solid.property(MPL::PropertyType::biot_coefficient)
                                .template value<double>(vars, x_position, t, dt);
         auto const rho_sr =
@@ -378,8 +380,9 @@ HydroMechanicsLocalAssembler<ShapeFunctionDisplacement, ShapeFunctionPressure,
         vars[static_cast<int>(MPL::Variable::phase_pressure)] =
             _ip_data[ip].N_p.dot(p);
 
-        auto const K = medium->property(MPL::PropertyType::permeability)
-                           .template value<double>(vars, x_position, t, dt);
+        auto const K = MPL::formEigenTensor<DisplacementDim>(
+            medium->property(MPL::PropertyType::permeability)
+                .value(vars, x_position, t, dt));
 
         auto const mu = gas.property(MPL::PropertyType::viscosity)
                             .template value<double>(vars, x_position, t, dt);
@@ -471,8 +474,9 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
 
         auto const K_S = solid_material.getBulkModulus(t, x_position);
 
-        auto const K = medium->property(MPL::PropertyType::permeability)
-                           .template value<double>(vars, x_position, t, dt);
+        auto const K = MPL::formEigenTensor<DisplacementDim>(
+            medium->property(MPL::PropertyType::permeability)
+                .value(vars, x_position, t, dt));
         auto const alpha_b =
             solid.property(MPL::PropertyType::biot_coefficient)
                 .template value<double>(vars, x_position, t, dt);

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
@@ -295,6 +295,11 @@ void HydroMechanicsProcess<DisplacementDim>::initializeConcreteProcess(
             const_cast<MeshLib::Mesh&>(mesh), "principal_stress_values",
             MeshLib::MeshItemType::Cell, 3);
 
+    _process_data.permeability = MeshLib::getOrCreateMeshProperty<double>(
+        const_cast<MeshLib::Mesh&>(mesh), "permeability",
+        MeshLib::MeshItemType::Cell,
+        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value);
+
     // Set initial conditions for integration point data.
     for (auto const& ip_writer : _integration_point_writer)
     {

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcessData.h
@@ -62,6 +62,10 @@ struct HydroMechanicsProcessData
         nullptr, nullptr, nullptr};
     MeshLib::PropertyVector<double>* principal_stress_values = nullptr;
 
+    /// Total permeability as a symmetric tensor of length 4 or 6
+    /// with elements in the order k_xx, k_yy, k_zz, k_xy, k_yz, k_xz
+    MeshLib::PropertyVector<double>* permeability = nullptr;
+
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 };
 


### PR DESCRIPTION
Made the permeability in HM a tensor which will be needed to use certain permeability models.
To analyze the results of the permeability models the k-output was added.
Therefore, the variant visitor was implemented.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.0)
