### PR TITLE
Added a member of inverse_value to MPL::Property

### DIFF
--- a/Documentation/ProjectFile/properties/property/SaturationBrooksCorey/t_maximum_capillary_pressure.md
+++ b/Documentation/ProjectFile/properties/property/SaturationBrooksCorey/t_maximum_capillary_pressure.md
@@ -1,0 +1,1 @@
+The maximum capillary pressure, which is an optional input.

--- a/Documentation/ProjectFile/properties/property/SaturationVanGenuchten/t_maximum_capillary_pressure.md
+++ b/Documentation/ProjectFile/properties/property/SaturationVanGenuchten/t_maximum_capillary_pressure.md
@@ -1,0 +1,1 @@
+The maximum capillary pressure, which is an optional input.

--- a/MaterialLib/MPL/Properties/CreateSaturationBrooksCorey.cpp
+++ b/MaterialLib/MPL/Properties/CreateSaturationBrooksCorey.cpp
@@ -34,8 +34,14 @@ std::unique_ptr<SaturationBrooksCorey> createSaturationBrooksCorey(
         //! \ogs_file_param{properties__property__SaturationBrooksCorey__entry_pressure}
         config.getConfigParameter<double>("entry_pressure");
 
-    return std::make_unique<SaturationBrooksCorey>(residual_liquid_saturation,
-                                                   residual_gas_saturation,
-                                                   exponent, entry_pressure);
+    // Optional input to get the maximum capillary pressure.
+    auto pc_max =
+        //! \ogs_file_param{properties__property__SaturationBrooksCorey__maximum_capillary_pressure}
+        config.getConfigParameter<double>("maximum_capillary_pressure",
+                                          std::numeric_limits<double>::max());
+
+    return std::make_unique<SaturationBrooksCorey>(
+        residual_liquid_saturation, residual_gas_saturation, exponent,
+        entry_pressure, pc_max);
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateSaturationVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CreateSaturationVanGenuchten.cpp
@@ -34,8 +34,14 @@ std::unique_ptr<SaturationVanGenuchten> createSaturationVanGenuchten(
         //! \ogs_file_param{properties__property__SaturationVanGenuchten__entry_pressure}
         config.getConfigParameter<double>("entry_pressure");
 
-    return std::make_unique<SaturationVanGenuchten>(residual_liquid_saturation,
-                                                    residual_gas_saturation,
-                                                    exponent, entry_pressure);
+    // Optional input to get the maximum capillary pressure.
+    auto pc_max =
+        //! \ogs_file_param{properties__property__SaturationVanGenuchten__maximum_capillary_pressure}
+        config.getConfigParameter<double>("maximum_capillary_pressure",
+                                          std::numeric_limits<double>::max());
+
+    return std::make_unique<SaturationVanGenuchten>(
+        residual_liquid_saturation, residual_gas_saturation, exponent,
+        entry_pressure, pc_max);
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/SaturationBrooksCorey.h
+++ b/MaterialLib/MPL/Properties/SaturationBrooksCorey.h
@@ -35,12 +35,13 @@ private:
     const double _residual_gas_saturation;
     const double _exponent;
     const double _entry_pressure;
+    double const _pc_max;  ///< Maximum capillary pressiure
 
 public:
     SaturationBrooksCorey(const double residual_liquid_saturation,
                           const double residual_gas_saturation,
-                          const double exponent,
-                          const double entry_pressure);
+                          const double exponent, const double entry_pressure,
+                          double const max_capillary_pressure);
 
     void setScale(
         std::variant<Medium*, Phase*, Component*> scale_pointer) override
@@ -70,5 +71,11 @@ public:
                              ParameterLib::SpatialPosition const& /*pos*/,
                              double const /*t*/,
                              double const /*dt*/) const override;
+
+    /// This method gets capillary pressure via saturation.
+    PropertyDataType inverse_value(VariableArray const& variable_array,
+                                   ParameterLib::SpatialPosition const& pos,
+                                   double const t,
+                                   double const dt) const override;
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/SaturationLiakopoulos.cpp
+++ b/MaterialLib/MPL/Properties/SaturationLiakopoulos.cpp
@@ -83,4 +83,19 @@ PropertyDataType SaturationLiakopoulos::d2Value(
            std::pow(p_cap_restricted, _parameter_b - 2.);
 }
 
+PropertyDataType SaturationLiakopoulos::inverse_value(
+    VariableArray const& variable_array,
+    ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
+    double const /*dt*/) const
+{
+    const double saturation = std::get<double>(
+        variable_array[static_cast<int>(Variable::liquid_saturation)]);
+
+    const double S_L_max = 1.0;
+    const double S =
+        std::clamp(saturation, _residual_liquid_saturation, S_L_max);
+
+    return std::pow((1.0 - S) / _parameter_a, 1.0 / _parameter_b);
+}
+
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/SaturationLiakopoulos.h
+++ b/MaterialLib/MPL/Properties/SaturationLiakopoulos.h
@@ -86,6 +86,12 @@ public:
                              ParameterLib::SpatialPosition const& /*pos*/,
                              double const /*t*/,
                              double const /*dt*/) const override;
+
+    /// This method gets capillary pressure via saturation.
+    PropertyDataType inverse_value(VariableArray const& variable_array,
+                                   ParameterLib::SpatialPosition const& pos,
+                                   double const t,
+                                   double const dt) const override;
 };
 
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/SaturationVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/SaturationVanGenuchten.h
@@ -8,6 +8,9 @@
  */
 #pragma once
 
+#include <cmath>
+#include <limits>
+
 #include "MaterialLib/MPL/Property.h"
 
 namespace MaterialPropertyLib
@@ -28,12 +31,14 @@ private:
     double const _S_L_max;
     double const _m;
     double const _p_b;
+    double const _pc_max; ///< Maximum capillary pressiure
 
 public:
     SaturationVanGenuchten(double const residual_liquid_saturation,
                            double const residual_gas_saturation,
                            double const exponent,
-                           double const entry_pressure);
+                           double const entry_pressure,
+                           double const max_capillary_pressure);
 
     void setScale(
         std::variant<Medium*, Phase*, Component*> scale_pointer) override
@@ -63,5 +68,11 @@ public:
                              ParameterLib::SpatialPosition const& /*pos*/,
                              double const /*t*/,
                              double const /*dt*/) const override;
+
+    /// This method gets capillary pressure via saturation.
+    PropertyDataType inverse_value(VariableArray const& variable_array,
+                                   ParameterLib::SpatialPosition const& pos,
+                                   double const t,
+                                   double const dt) const override;
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/SaturationVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/SaturationVanGenuchten.h
@@ -19,10 +19,31 @@ class Medium;
 class Phase;
 class Component;
 
-/// The van Genuchten soil characteristics function.
-///
-/// This property must be a medium property, it computes the saturation of the
-/// wetting phase as function of capillary pressure.
+/**
+ *   \brief van Genuchten water retention model
+ *
+ *   \f[p_c=p_b (S_e^{-1/m}-1)^{1-m}\f]
+ *   with
+ *   \f[S_e=\frac{S-S_r}{S_{\mbox{max}}-S_r}\f]
+ *   where
+ *    \f{eqnarray*}{
+ *       &p_b&            \mbox{ entry pressure,}\\
+ *       &S_r&            \mbox{ residual saturation,}\\
+ *       &S_{\mbox{max}}& \mbox{ maximum saturation,}\\
+ *       &m(<=1) &        \mbox{ exponent.}\\
+ *    \f}
+ *
+ *    Note:
+ *     \f[m=1/(1-n)\f].
+ *
+ *    If \f$\alpha\f$ instead of \f$p_b\f$ is available, \f$p_b\f$ can
+ * be calculated
+ * as
+ *    \f[p_b=\rho g/\alpha\f]
+ *
+ * This property must be a medium property, it computes the saturation
+ *  of the wetting phase as function of capillary pressure.
+ */
 class SaturationVanGenuchten final : public Property
 {
 private:
@@ -58,11 +79,15 @@ public:
                            ParameterLib::SpatialPosition const& /*pos*/,
                            double const /*t*/,
                            double const /*dt*/) const override;
+
+    /// Gets \f$ \frac{\partial S}{\partial p_c} \f$
     PropertyDataType dValue(VariableArray const& variable_array,
                             Variable const variable,
                             ParameterLib::SpatialPosition const& /*pos*/,
                             double const /*t*/,
                             double const /*dt*/) const override;
+
+    /// Gets \f$ \frac{\partial^2 S}{\partial p_c^2} \f$
     PropertyDataType d2Value(VariableArray const& variable_array,
                              Variable const variable1, Variable const variable2,
                              ParameterLib::SpatialPosition const& /*pos*/,

--- a/MaterialLib/MPL/Property.cpp
+++ b/MaterialLib/MPL/Property.cpp
@@ -79,6 +79,14 @@ PropertyDataType Property::value(VariableArray const& /*variable_array*/,
     return _value;
 }
 
+PropertyDataType Property::inverse_value(
+    VariableArray const& /*variable_array*/,
+    ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
+    double const /*dt*/) const
+{
+    return 0.0;
+}
+
 /// The default implementation of this method only returns the
 /// property value derivative without altering it.
 PropertyDataType Property::dValue(VariableArray const& /*variable_array*/,

--- a/MaterialLib/MPL/Property.h
+++ b/MaterialLib/MPL/Property.h
@@ -71,6 +71,14 @@ public:
                                      Variable const variable2,
                                      ParameterLib::SpatialPosition const& pos,
                                      double const t, double const dt) const;
+
+    /// This virtual method will compute the inverse value of the property
+    /// based on the primary variables that are passed as arguments.
+    virtual PropertyDataType inverse_value(
+        VariableArray const& variable_array,
+        ParameterLib::SpatialPosition const& pos, double const t,
+        double const dt) const;
+
     virtual void setScale(
         std::variant<Medium*, Phase*, Component*> /*scale_pointer*/){};
 
@@ -93,6 +101,14 @@ public:
             double const dt) const
     {
         return std::get<T>(value(variable_array, pos, t, dt));
+    }
+
+    template <typename T>
+    T inverse_value(VariableArray const& variable_array,
+                    ParameterLib::SpatialPosition const& pos, double const t,
+                    double const dt) const
+    {
+        return std::get<T>(inverse_value(variable_array, pos, t, dt));
     }
 
     template <typename T>

--- a/Tests/MaterialLib/TestMPLSaturationVanGenuchten.cpp
+++ b/Tests/MaterialLib/TestMPLSaturationVanGenuchten.cpp
@@ -22,10 +22,11 @@ TEST(MaterialPropertyLib, SaturationVanGenuchten)
     double const residual_gas_saturation = 0.05;
     double const exponent = 0.79;
     double const entry_pressure = 5000;
+    double const max_capillary_pressure = std::numeric_limits<double>::max();
 
     MPL::Property const& pressure_saturation = MPL::SaturationVanGenuchten{
         residual_liquid_saturation, residual_gas_saturation, exponent,
-        entry_pressure};
+        entry_pressure, max_capillary_pressure};
 
     MPL::VariableArray variable_array;
     ParameterLib::SpatialPosition const pos;


### PR DESCRIPTION
For capillary saturation models, the newly added member function of `inverse_value` gets capillary pressure via saturation. In the existing classes for capillary saturation models, the member function of `value` represents function of S(p_c). This is not adequate to the conventional definition of such models. Here are suggestions for future changes for  capillary pressure model classes:
```
Property::value:  Pc(S)
Property::inverse_value:  S(Pc)
```

1. [ ] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.0)
2. [x] Tests covering your feature were added? Yes
3. [x] Any new feature or behavior change was documented? yes
