### PR TITLE
Improve checkMPLProperties

### DIFF
--- a/MaterialLib/MPL/CheckMaterialSpatialDistributionMap.h
+++ b/MaterialLib/MPL/CheckMaterialSpatialDistributionMap.h
@@ -1,0 +1,52 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "MaterialSpatialDistributionMap.h"
+#include "Medium.h"
+#include "MeshLib/Mesh.h"
+#include "Phase.h"
+
+namespace MaterialPropertyLib
+{
+template <typename ContainerMedium,
+          typename ContainerSolid,
+          typename ContainerLiquid>
+void checkMaterialSpatialDistributionMap(
+    MeshLib::Mesh const& mesh,
+    MaterialPropertyLib::MaterialSpatialDistributionMap const& media_map,
+    ContainerMedium const& required_properties_medium,
+    ContainerSolid const& required_properties_solid_phase,
+    ContainerLiquid const& required_properties_liquid_phase)
+{
+    for (auto const& element : mesh.getElements())
+    {
+        auto const element_id = element->getID();
+
+        auto const& medium = *media_map.getMedium(element_id);
+        if (!required_properties_medium.empty())
+        {
+            MaterialPropertyLib::checkRequiredProperties(
+                medium, required_properties_medium);
+        }
+        if (!required_properties_liquid_phase.empty())
+        {
+            MaterialPropertyLib::checkRequiredProperties(
+                medium.phase("AqueousLiquid"),
+                required_properties_liquid_phase);
+        }
+        if (!required_properties_solid_phase.empty())
+        {
+            MaterialPropertyLib::checkRequiredProperties(
+                medium.phase("Solid"), required_properties_solid_phase);
+        }
+    }
+}
+
+}  // namespace MaterialPropertyLib

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
@@ -20,9 +20,9 @@ namespace ProcessLib
 {
 namespace ComponentTransport
 {
-
-void checkMPLProperties(MeshLib::Mesh const& mesh,
-                        ComponentTransportProcessData const& process_data)
+void checkMPLProperties(
+    MeshLib::Mesh const& mesh,
+    MaterialPropertyLib::MaterialSpatialDistributionMap const& media_map)
 {
     DBUG("Check the media properties of ComponentTransport process ...");
 
@@ -48,7 +48,7 @@ void checkMPLProperties(MeshLib::Mesh const& mesh,
     {
         auto const element_id = element->getID();
 
-        auto const& medium = *process_data.media_map->getMedium(element_id);
+        auto const& medium = *media_map.getMedium(element_id);
         checkRequiredProperties(medium, required_properties_medium);
 
         // check if liquid phase definition and the corresponding properties
@@ -103,7 +103,7 @@ void ComponentTransportProcess::initializeConcreteProcess(
     MeshLib::Mesh const& mesh,
     unsigned const integration_order)
 {
-    checkMPLProperties(mesh, _process_data);
+    checkMPLProperties(mesh, *_process_data.media_map.get());
 
     const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.cpp
@@ -20,61 +20,6 @@ namespace ProcessLib
 {
 namespace ComponentTransport
 {
-void checkMPLProperties(
-    MeshLib::Mesh const& mesh,
-    MaterialPropertyLib::MaterialSpatialDistributionMap const& media_map)
-{
-    DBUG("Check the media properties of ComponentTransport process ...");
-
-    std::array<MaterialPropertyLib::PropertyType, 4> const
-        required_properties_medium = {
-            MaterialPropertyLib::PropertyType::porosity,
-            MaterialPropertyLib::PropertyType::transversal_dispersivity,
-            MaterialPropertyLib::PropertyType::longitudinal_dispersivity,
-            MaterialPropertyLib::PropertyType::permeability};
-
-    std::array<MaterialPropertyLib::PropertyType, 2> const
-        required_properties_liquid_phase = {
-            MaterialPropertyLib::PropertyType::density,
-            MaterialPropertyLib::PropertyType::viscosity};
-
-    std::array<MaterialPropertyLib::PropertyType, 3> const
-        required_properties_components = {
-            MaterialPropertyLib::PropertyType::retardation_factor,
-            MaterialPropertyLib::PropertyType::decay_rate,
-            MaterialPropertyLib::PropertyType::molecular_diffusion};
-
-    for (auto const& element : mesh.getElements())
-    {
-        auto const element_id = element->getID();
-
-        auto const& medium = *media_map.getMedium(element_id);
-        checkRequiredProperties(medium, required_properties_medium);
-
-        // check if liquid phase definition and the corresponding properties
-        // exists
-        auto const& liquid_phase = medium.phase("AqueousLiquid");
-        checkRequiredProperties(liquid_phase, required_properties_liquid_phase);
-
-        // check if components and the corresponding properties exists
-        auto const number_of_components = liquid_phase.numberOfComponents();
-        for (std::size_t component_id = 0; component_id < number_of_components;
-             ++component_id)
-        {
-            if (!liquid_phase.hasComponent(component_id))
-            {
-                OGS_FATAL(
-                    "The component %u in the AqueousLiquid phase isn't "
-                    "specified.",
-                    component_id);
-            }
-            auto const& component = liquid_phase.component(component_id);
-            checkRequiredProperties(component, required_properties_components);
-        }
-    }
-    DBUG("Media properties verified.");
-}
-
 ComponentTransportProcess::ComponentTransportProcess(
     std::string name,
     MeshLib::Mesh& mesh,
@@ -103,8 +48,6 @@ void ComponentTransportProcess::initializeConcreteProcess(
     MeshLib::Mesh const& mesh,
     unsigned const integration_order)
 {
-    checkMPLProperties(mesh, *_process_data.media_map.get());
-
     const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 

--- a/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
@@ -22,6 +22,55 @@ namespace ProcessLib
 {
 namespace ComponentTransport
 {
+void checkMPLProperties(
+    MeshLib::Mesh const& mesh,
+    MaterialPropertyLib::MaterialSpatialDistributionMap const& media_map)
+{
+    std::array const required_properties_medium = {
+        MaterialPropertyLib::PropertyType::porosity,
+        MaterialPropertyLib::PropertyType::transversal_dispersivity,
+        MaterialPropertyLib::PropertyType::longitudinal_dispersivity,
+        MaterialPropertyLib::PropertyType::permeability};
+
+    std::array const required_properties_liquid_phase = {
+        MaterialPropertyLib::PropertyType::density,
+        MaterialPropertyLib::PropertyType::viscosity};
+
+    std::array const required_properties_components = {
+        MaterialPropertyLib::PropertyType::retardation_factor,
+        MaterialPropertyLib::PropertyType::decay_rate,
+        MaterialPropertyLib::PropertyType::molecular_diffusion};
+
+    for (auto const& element : mesh.getElements())
+    {
+        auto const element_id = element->getID();
+
+        auto const& medium = *media_map.getMedium(element_id);
+        checkRequiredProperties(medium, required_properties_medium);
+
+        // check if liquid phase definition and the corresponding properties
+        // exist
+        auto const& liquid_phase = medium.phase("AqueousLiquid");
+        checkRequiredProperties(liquid_phase, required_properties_liquid_phase);
+
+        // check if components and the corresponding properties exist
+        auto const number_of_components = liquid_phase.numberOfComponents();
+        for (std::size_t component_id = 0; component_id < number_of_components;
+             ++component_id)
+        {
+            if (!liquid_phase.hasComponent(component_id))
+            {
+                OGS_FATAL(
+                    "The component %u in the AqueousLiquid phase isn't "
+                    "specified.",
+                    component_id);
+            }
+            auto const& component = liquid_phase.component(component_id);
+            checkRequiredProperties(component, required_properties_components);
+        }
+    }
+}
+
 std::unique_ptr<Process> createComponentTransportProcess(
     std::string name,
     MeshLib::Mesh& mesh,
@@ -133,6 +182,10 @@ std::unique_ptr<Process> createComponentTransportProcess(
 
     auto media_map =
         MaterialPropertyLib::createMaterialSpatialDistributionMap(media, mesh);
+
+    DBUG("Check the media properties of ComponentTransport process ...");
+    checkMPLProperties(mesh, *media_map);
+    DBUG("Media properties verified.");
 
     ComponentTransportProcessData process_data{
         std::move(media_map),

--- a/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
@@ -13,6 +13,7 @@
 #include "BaseLib/FileTools.h"
 #include "GroundwaterFlowProcess.h"
 #include "GroundwaterFlowProcessData.h"
+#include "MaterialLib/MPL/CheckMaterialSpatialDistributionMap.h"
 #include "MaterialLib/MPL/CreateMaterialSpatialDistributionMap.h"
 #include "MaterialLib/MPL/MaterialSpatialDistributionMap.h"
 #include "MeshLib/IO/readMeshFromFile.h"
@@ -28,18 +29,13 @@ void checkMPLProperties(
     MeshLib::Mesh const& mesh,
     MaterialPropertyLib::MaterialSpatialDistributionMap const& media_map)
 {
-    std::array const requiredPropertyMedium = {
+    std::array const required_medium_properties = {
         MaterialPropertyLib::PropertyType::reference_temperature,
         MaterialPropertyLib::PropertyType::diffusion};
+    std::array<MaterialPropertyLib::PropertyType, 0> const empty{};
 
-    for (auto const& element : mesh.getElements())
-    {
-        auto const element_id = element->getID();
-
-        auto const& medium = *media_map.getMedium(element_id);
-        MaterialPropertyLib::checkRequiredProperties(
-            medium, requiredPropertyMedium);
-    }
+    MaterialPropertyLib::checkMaterialSpatialDistributionMap(
+        mesh, media_map, required_medium_properties, empty, empty);
 }
 
 std::unique_ptr<Process> createGroundwaterFlowProcess(

--- a/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/CreateGroundwaterFlowProcess.cpp
@@ -24,6 +24,24 @@ namespace ProcessLib
 {
 namespace GroundwaterFlow
 {
+void checkMPLProperties(
+    MeshLib::Mesh const& mesh,
+    MaterialPropertyLib::MaterialSpatialDistributionMap const& media_map)
+{
+    std::array const requiredPropertyMedium = {
+        MaterialPropertyLib::PropertyType::reference_temperature,
+        MaterialPropertyLib::PropertyType::diffusion};
+
+    for (auto const& element : mesh.getElements())
+    {
+        auto const element_id = element->getID();
+
+        auto const& medium = *media_map.getMedium(element_id);
+        MaterialPropertyLib::checkRequiredProperties(
+            medium, requiredPropertyMedium);
+    }
+}
+
 std::unique_ptr<Process> createGroundwaterFlowProcess(
     std::string name,
     MeshLib::Mesh& mesh,
@@ -56,6 +74,10 @@ std::unique_ptr<Process> createGroundwaterFlowProcess(
 
     auto media_map =
         MaterialPropertyLib::createMaterialSpatialDistributionMap(media, mesh);
+
+    DBUG("Check the media properties of GroundwaterFlow process ...");
+    checkMPLProperties(mesh, *media_map);
+    DBUG("Media properties verified.");
 
     GroundwaterFlowProcessData process_data{std::move(media_map)};
 

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -18,9 +18,9 @@ namespace ProcessLib
 {
 namespace GroundwaterFlow
 {
-
-void checkMPLProperties(MeshLib::Mesh const& mesh,
-                        GroundwaterFlowProcessData const& process_data)
+void checkMPLProperties(
+    MeshLib::Mesh const& mesh,
+    MaterialPropertyLib::MaterialSpatialDistributionMap const& media_map)
 {
     DBUG("Check the media properties of HT process ...");
 
@@ -32,7 +32,7 @@ void checkMPLProperties(MeshLib::Mesh const& mesh,
     {
         auto const element_id = element->getID();
 
-        auto const& medium = *process_data.media_map->getMedium(element_id);
+        auto const& medium = *media_map.getMedium(element_id);
         MaterialPropertyLib::checkRequiredProperties(
             medium, requiredPropertyMedium);
     }
@@ -63,7 +63,7 @@ void GroundwaterFlowProcess::initializeConcreteProcess(
     MeshLib::Mesh const& mesh,
     unsigned const integration_order)
 {
-    checkMPLProperties(mesh, _process_data);
+    checkMPLProperties(mesh, *_process_data.media_map.get());
     const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     ProcessLib::createLocalAssemblers<LocalAssemblerData>(

--- a/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
+++ b/ProcessLib/GroundwaterFlow/GroundwaterFlowProcess.cpp
@@ -18,27 +18,6 @@ namespace ProcessLib
 {
 namespace GroundwaterFlow
 {
-void checkMPLProperties(
-    MeshLib::Mesh const& mesh,
-    MaterialPropertyLib::MaterialSpatialDistributionMap const& media_map)
-{
-    DBUG("Check the media properties of HT process ...");
-
-    std::array const requiredPropertyMedium = {
-        MaterialPropertyLib::PropertyType::reference_temperature,
-        MaterialPropertyLib::PropertyType::diffusion};
-
-    for (auto const& element : mesh.getElements())
-    {
-        auto const element_id = element->getID();
-
-        auto const& medium = *media_map.getMedium(element_id);
-        MaterialPropertyLib::checkRequiredProperties(
-            medium, requiredPropertyMedium);
-    }
-    DBUG("Media properties verified.");
-}
-
 GroundwaterFlowProcess::GroundwaterFlowProcess(
     std::string name,
     MeshLib::Mesh& mesh,
@@ -63,7 +42,6 @@ void GroundwaterFlowProcess::initializeConcreteProcess(
     MeshLib::Mesh const& mesh,
     unsigned const integration_order)
 {
-    checkMPLProperties(mesh, *_process_data.media_map.get());
     const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     ProcessLib::createLocalAssemblers<LocalAssemblerData>(

--- a/ProcessLib/HT/CreateHTProcess.cpp
+++ b/ProcessLib/HT/CreateHTProcess.cpp
@@ -10,6 +10,7 @@
 
 #include "CreateHTProcess.h"
 
+#include "MaterialLib/MPL/CheckMaterialSpatialDistributionMap.h"
 #include "MaterialLib/MPL/CreateMaterialSpatialDistributionMap.h"
 #include "MeshLib/IO/readMeshFromFile.h"
 #include "ParameterLib/ConstantParameter.h"
@@ -26,6 +27,29 @@ namespace ProcessLib
 {
 namespace HT
 {
+void checkMPLProperties(
+    MeshLib::Mesh const& mesh,
+    MaterialPropertyLib::MaterialSpatialDistributionMap const& media_map)
+{
+    std::array const requiredPropertyMedium = {
+        MaterialPropertyLib::PropertyType::porosity,
+        MaterialPropertyLib::PropertyType::permeability};
+
+    std::array const requiredPropertyLiquidPhase = {
+        MaterialPropertyLib::PropertyType::viscosity,
+        MaterialPropertyLib::PropertyType::density,
+        MaterialPropertyLib::PropertyType::specific_heat_capacity};
+
+    std::array const requiredPropertySolidPhase = {
+        MaterialPropertyLib::PropertyType::specific_heat_capacity,
+        MaterialPropertyLib::PropertyType::density,
+        MaterialPropertyLib::PropertyType::storage};
+
+    MaterialPropertyLib::checkMaterialSpatialDistributionMap(
+        mesh, media_map, requiredPropertyMedium, requiredPropertySolidPhase,
+        requiredPropertyLiquidPhase);
+}
+
 std::unique_ptr<Process> createHTProcess(
     std::string name,
     MeshLib::Mesh& mesh,
@@ -139,6 +163,10 @@ std::unique_ptr<Process> createHTProcess(
 
     auto media_map =
         MaterialPropertyLib::createMaterialSpatialDistributionMap(media, mesh);
+
+    DBUG("Check the media properties of HT process ...");
+    checkMPLProperties(mesh, *media_map);
+    DBUG("Media properties verified.");
 
     HTProcessData process_data{
         std::move(media_map),     has_fluid_thermal_expansion,

--- a/ProcessLib/HT/HTProcess.cpp
+++ b/ProcessLib/HT/HTProcess.cpp
@@ -24,42 +24,6 @@ namespace ProcessLib
 {
 namespace HT
 {
-void checkMPLProperties(MeshLib::Mesh const& mesh,
-                        HTProcessData const& process_data)
-{
-    DBUG("Check the media properties of HT process ...");
-
-    std::array const requiredPropertyMedium = {
-        MaterialPropertyLib::PropertyType::porosity,
-        MaterialPropertyLib::PropertyType::permeability};
-
-    std::array const requiredPropertyLiquidPhase = {
-        MaterialPropertyLib::PropertyType::viscosity,
-        MaterialPropertyLib::PropertyType::density,
-        MaterialPropertyLib::PropertyType::specific_heat_capacity};
-
-    std::array const requiredPropertySolidPhase = {
-        MaterialPropertyLib::PropertyType::specific_heat_capacity,
-        MaterialPropertyLib::PropertyType::density,
-        MaterialPropertyLib::PropertyType::storage};
-
-    for (auto const& element : mesh.getElements())
-    {
-        auto const element_id = element->getID();
-
-        auto const& medium = *process_data.media_map->getMedium(element_id);
-        MaterialPropertyLib::checkRequiredProperties(
-            medium, requiredPropertyMedium);
-
-        MaterialPropertyLib::checkRequiredProperties(
-            medium.phase("AqueousLiquid"), requiredPropertyLiquidPhase);
-
-        MaterialPropertyLib::checkRequiredProperties(
-            medium.phase("Solid"), requiredPropertySolidPhase);
-    }
-    DBUG("Media properties verified.");
-}
-
 HTProcess::HTProcess(
     std::string name,
     MeshLib::Mesh& mesh,
@@ -89,8 +53,6 @@ void HTProcess::initializeConcreteProcess(
     MeshLib::Mesh const& mesh,
     unsigned const integration_order)
 {
-    checkMPLProperties(mesh, _process_data);
-
     // For the staggered scheme, both processes are assumed to use the same
     // element order. Therefore the order of shape function can be fetched from
     // any set of the sets of process variables of the coupled processes. Here,

--- a/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/CreateLiquidFlowProcess.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 
+#include "MaterialLib/MPL/CheckMaterialSpatialDistributionMap.h"
 #include "MaterialLib/MPL/CreateMaterialSpatialDistributionMap.h"
 #include "MaterialLib/PhysicalConstant.h"
 #include "ParameterLib/Utils.h"
@@ -29,32 +30,21 @@ void checkMPLProperties(
     MeshLib::Mesh const& mesh,
     MaterialPropertyLib::MaterialSpatialDistributionMap const& media_map)
 {
-    std::array const requiredPropertyMedium = {
+    std::array const required_medium_properties = {
         MaterialPropertyLib::reference_temperature,
-        MaterialPropertyLib::PropertyType::porosity,
         MaterialPropertyLib::PropertyType::permeability};
 
-    std::array const requiredPropertyLiquidPhase = {
+    std::array const required_liquid_properties = {
         MaterialPropertyLib::PropertyType::viscosity,
         MaterialPropertyLib::PropertyType::density};
 
-    std::array const requiredPropertySolidPhase = {
+    std::array const required_solid_properties = {
+        MaterialPropertyLib::PropertyType::porosity,
         MaterialPropertyLib::PropertyType::storage};
 
-    for (auto const& element : mesh.getElements())
-    {
-        auto const element_id = element->getID();
-
-        auto const& medium = *media_map.getMedium(element_id);
-        MaterialPropertyLib::checkRequiredProperties(
-            medium, requiredPropertyMedium);
-
-        MaterialPropertyLib::checkRequiredProperties(
-            medium.phase("AqueousLiquid"), requiredPropertyLiquidPhase);
-
-        MaterialPropertyLib::checkRequiredProperties(
-            medium.phase("Solid"), requiredPropertySolidPhase);
-    }
+    MaterialPropertyLib::checkMaterialSpatialDistributionMap(
+        mesh, media_map, required_medium_properties, required_solid_properties,
+        required_liquid_properties);
 }
 
 std::unique_ptr<Process> createLiquidFlowProcess(

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -24,41 +24,6 @@ namespace ProcessLib
 {
 namespace LiquidFlow
 {
-void checkMPLProperties(
-    MeshLib::Mesh const& mesh,
-    MaterialPropertyLib::MaterialSpatialDistributionMap const& media_map)
-{
-    DBUG("Check the media properties of LiquidFlow process ...");
-
-    std::array const requiredPropertyMedium = {
-        MaterialPropertyLib::reference_temperature,
-        MaterialPropertyLib::PropertyType::permeability};
-
-    std::array const requiredPropertyLiquidPhase = {
-        MaterialPropertyLib::PropertyType::viscosity,
-        MaterialPropertyLib::PropertyType::density};
-
-    std::array const requiredPropertySolidPhase = {
-        MaterialPropertyLib::PropertyType::porosity,
-        MaterialPropertyLib::PropertyType::storage};
-
-    for (auto const& element : mesh.getElements())
-    {
-        auto const element_id = element->getID();
-
-        auto const& medium = *media_map.getMedium(element_id);
-        MaterialPropertyLib::checkRequiredProperties(
-            medium, requiredPropertyMedium);
-
-        MaterialPropertyLib::checkRequiredProperties(
-            medium.phase("AqueousLiquid"), requiredPropertyLiquidPhase);
-
-        MaterialPropertyLib::checkRequiredProperties(
-            medium.phase("Solid"), requiredPropertySolidPhase);
-    }
-    DBUG("Media properties verified.");
-}
-
 LiquidFlowProcess::LiquidFlowProcess(
     std::string name,
     MeshLib::Mesh& mesh,
@@ -84,8 +49,6 @@ void LiquidFlowProcess::initializeConcreteProcess(
     MeshLib::Mesh const& mesh,
     unsigned const integration_order)
 {
-    checkMPLProperties(mesh, *_process_data.media_map.get());
-
     const int process_id = 0;
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     ProcessLib::createLocalAssemblers<LiquidFlowLocalAssembler>(

--- a/ProcessLib/RichardsFlow/CreateRichardsFlowProcess.cpp
+++ b/ProcessLib/RichardsFlow/CreateRichardsFlowProcess.cpp
@@ -10,6 +10,7 @@
 
 #include "CreateRichardsFlowProcess.h"
 
+#include "MaterialLib/MPL/CheckMaterialSpatialDistributionMap.h"
 #include "MaterialLib/MPL/CreateMaterialSpatialDistributionMap.h"
 #include "ParameterLib/ConstantParameter.h"
 #include "ParameterLib/Utils.h"
@@ -27,34 +28,23 @@ void checkMPLProperties(
     MeshLib::Mesh const& mesh,
     MaterialPropertyLib::MaterialSpatialDistributionMap const& media_map)
 {
-    std::array const requiredPropertyMedium = {
+    std::array const required_medium_properties = {
         MaterialPropertyLib::PropertyType::reference_temperature,
         MaterialPropertyLib::PropertyType::saturation,
         MaterialPropertyLib::PropertyType::relative_permeability};
 
-    std::array const requiredPropertyLiquidPhase = {
+    std::array const required_liquid_properties = {
         MaterialPropertyLib::PropertyType::viscosity,
         MaterialPropertyLib::PropertyType::density};
 
-    std::array const requiredPropertySolidPhase = {
+    std::array const required_solid_properties = {
         MaterialPropertyLib::PropertyType::porosity,
         MaterialPropertyLib::PropertyType::storage,
         MaterialPropertyLib::PropertyType::permeability};
 
-    for (auto const& element : mesh.getElements())
-    {
-        auto const element_id = element->getID();
-
-        auto const& medium = *media_map.getMedium(element_id);
-        MaterialPropertyLib::checkRequiredProperties(
-            medium, requiredPropertyMedium);
-
-        MaterialPropertyLib::checkRequiredProperties(
-            medium.phase("AqueousLiquid"), requiredPropertyLiquidPhase);
-
-        MaterialPropertyLib::checkRequiredProperties(
-            medium.phase("Solid"), requiredPropertySolidPhase);
-    }
+    MaterialPropertyLib::checkMaterialSpatialDistributionMap(
+        mesh, media_map, required_medium_properties, required_solid_properties,
+        required_liquid_properties);
 }
 
 std::unique_ptr<Process> createRichardsFlowProcess(
@@ -112,7 +102,7 @@ std::unique_ptr<Process> createRichardsFlowProcess(
         MaterialPropertyLib::createMaterialSpatialDistributionMap(media, mesh);
 
     DBUG("Check the media properties of RichardsFlow process ...");
-    checkMPLProperties(mesh, *media_map.get());
+    checkMPLProperties(mesh, *media_map);
     DBUG("Media properties verified.");
 
     RichardsFlowProcessData process_data{


### PR DESCRIPTION
This PR
 - moves the function `checkMPLProperties` from the respective processes to the corresponding CreateProcess implementations and 
 - uses a newly implemented function `checkMaterialSpatialDistributionMap` in the respective function `checkMPLProperties`.
