### PR TITLE
[cmake] Move BUILD_TESTING condition up.

### DIFF
--- a/Applications/Utils/CMakeLists.txt
+++ b/Applications/Utils/CMakeLists.txt
@@ -14,4 +14,6 @@ if(OGS_BUILD_SWMM)
     add_subdirectory(SWMMConverter)
 endif()
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/ComponentTransport/CMakeLists.txt
+++ b/ProcessLib/ComponentTransport/CMakeLists.txt
@@ -8,4 +8,6 @@ endif()
 
 target_link_libraries(ComponentTransport PUBLIC ProcessLib PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/GroundwaterFlow/CMakeLists.txt
+++ b/ProcessLib/GroundwaterFlow/CMakeLists.txt
@@ -7,4 +7,6 @@ endif()
 
 target_link_libraries(GroundwaterFlow PUBLIC ProcessLib PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/HT/CMakeLists.txt
+++ b/ProcessLib/HT/CMakeLists.txt
@@ -6,4 +6,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 target_link_libraries(HT PUBLIC ProcessLib PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/HeatConduction/CMakeLists.txt
+++ b/ProcessLib/HeatConduction/CMakeLists.txt
@@ -6,4 +6,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 target_link_libraries(HeatConduction PUBLIC ProcessLib PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/HeatTransportBHE/CMakeLists.txt
+++ b/ProcessLib/HeatTransportBHE/CMakeLists.txt
@@ -16,4 +16,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 target_link_libraries(HeatTransportBHE PUBLIC ProcessLib PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/HydroMechanics/CMakeLists.txt
+++ b/ProcessLib/HydroMechanics/CMakeLists.txt
@@ -6,4 +6,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 target_link_libraries(HydroMechanics PUBLIC ProcessLib PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/LiquidFlow/CMakeLists.txt
+++ b/ProcessLib/LiquidFlow/CMakeLists.txt
@@ -6,4 +6,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 target_link_libraries(LiquidFlow PUBLIC ProcessLib PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/PhaseField/CMakeLists.txt
+++ b/ProcessLib/PhaseField/CMakeLists.txt
@@ -6,4 +6,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 target_link_libraries(PhaseField PUBLIC ProcessLib PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/RichardsComponentTransport/CMakeLists.txt
+++ b/ProcessLib/RichardsComponentTransport/CMakeLists.txt
@@ -9,4 +9,6 @@ target_link_libraries(RichardsComponentTransport
                       PUBLIC ProcessLib
                       PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/RichardsFlow/CMakeLists.txt
+++ b/ProcessLib/RichardsFlow/CMakeLists.txt
@@ -6,4 +6,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 target_link_libraries(RichardsFlow PUBLIC ProcessLib PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/RichardsMechanics/CMakeLists.txt
+++ b/ProcessLib/RichardsMechanics/CMakeLists.txt
@@ -10,4 +10,6 @@ target_link_libraries(
     PUBLIC ProcessLib
     PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/SmallDeformation/CMakeLists.txt
+++ b/ProcessLib/SmallDeformation/CMakeLists.txt
@@ -7,4 +7,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 target_link_libraries(SmallDeformation PUBLIC ProcessLib PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/SmallDeformationNonlocal/CMakeLists.txt
+++ b/ProcessLib/SmallDeformationNonlocal/CMakeLists.txt
@@ -9,4 +9,6 @@ if(BUILD_SHARED_LIBS)
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/TES/CMakeLists.txt
+++ b/ProcessLib/TES/CMakeLists.txt
@@ -6,4 +6,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 target_link_libraries(TES PUBLIC ProcessLib PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/ThermalTwoPhaseFlowWithPP/CMakeLists.txt
+++ b/ProcessLib/ThermalTwoPhaseFlowWithPP/CMakeLists.txt
@@ -9,4 +9,6 @@ target_link_libraries(ThermalTwoPhaseFlowWithPP
                       PUBLIC ProcessLib
                       PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/ThermoHydroMechanics/CMakeLists.txt
+++ b/ProcessLib/ThermoHydroMechanics/CMakeLists.txt
@@ -9,4 +9,6 @@ target_link_libraries(ThermoHydroMechanics
                       PUBLIC ProcessLib
                       PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/ThermoMechanicalPhaseField/CMakeLists.txt
+++ b/ProcessLib/ThermoMechanicalPhaseField/CMakeLists.txt
@@ -9,4 +9,6 @@ target_link_libraries(ThermoMechanicalPhaseField
                       PUBLIC ProcessLib
                       PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/ThermoMechanics/CMakeLists.txt
+++ b/ProcessLib/ThermoMechanics/CMakeLists.txt
@@ -6,4 +6,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 target_link_libraries(ThermoMechanics PUBLIC ProcessLib PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/TwoPhaseFlowWithPP/CMakeLists.txt
+++ b/ProcessLib/TwoPhaseFlowWithPP/CMakeLists.txt
@@ -7,4 +7,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 target_link_libraries(TwoPhaseFlowWithPP PUBLIC ProcessLib PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/ProcessLib/TwoPhaseFlowWithPrho/CMakeLists.txt
+++ b/ProcessLib/TwoPhaseFlowWithPrho/CMakeLists.txt
@@ -9,4 +9,6 @@ target_link_libraries(TwoPhaseFlowWithPrho
                       PUBLIC ProcessLib
                       PRIVATE ParameterLib)
 
-include(Tests.cmake)
+if(BUILD_TESTING)
+    include(Tests.cmake)
+endif()

--- a/scripts/cmake/test/AddTest.cmake
+++ b/scripts/cmake/test/AddTest.cmake
@@ -39,9 +39,6 @@
 #         the benchmark output directory.
 
 function (AddTest)
-    if(NOT BUILD_TESTING)
-        return()
-    endif()
     # parse arguments
     set(options NONE)
     set(oneValueArgs EXECUTABLE PATH NAME WRAPPER TESTER ABSTOL RELTOL RUNTIME DEPENDS)

--- a/scripts/cmake/test/OgsTest.cmake
+++ b/scripts/cmake/test/OgsTest.cmake
@@ -1,5 +1,5 @@
 function (OgsTest)
-    if(NOT BUILD_TESTING OR NOT OGS_BUILD_CLI)
+    if(NOT OGS_BUILD_CLI)
         return()
     endif()
     set(options LARGE)


### PR DESCRIPTION
The condition for adding a ctest is moved out of the `AddTest` and `OgsTest` cmake macros.

Small bugfix as reported by @ThieJan for the `ogs-Mechanics_slope_stability_mfront` test, which has a special conditions. Error happens with `BUILD_TESTING=OFF` configuration.
```
CMake Error at ProcessLib/SmallDeformation/Tests.cmake:121 (set_tests_properties):
> set_tests_properties Can not find test to add properties to:
> ogs-Mechanics_slope_stability_mfront
```