### PR TITLE
[CMake] Fix segmentation fault in ThirdParty/IPhreeqc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ include(PreFind)
 include(SubmoduleSetup)
 include(ProcessesSetup)
 include(ProjectSetup)
-add_subdirectory(ThirdParty)
 include(Versions)
 include(CheckTypeSizes)
 include(CheckArchitecture)
@@ -279,6 +278,7 @@ if(OGS_INSITU)
     add_definitions(-DUSE_INSITU)
 endif()
 
+add_subdirectory(ThirdParty)
 include_directories(
     SYSTEM
     ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,6 @@ add_subdirectory(NumLib)
 
 if(OGS_BUILD_PROCESS_ComponentTransport
    OR OGS_BUILD_PROCESS_RichardsComponentTransport
-   OR OGS_BUILD_PROCESS_RichardsComponentTransport
    OR OGS_BUILD_PROCESS_HeatTransportBHE)
     add_subdirectory(ChemistryLib)
 endif()


### PR DESCRIPTION
As titled. 

In order to fix the issue mentioned in #2861,  the syntax `add_subdirectory(ThirdParty)` is reverted back to the place where it was.