### PR TITLE
Van Genuchten capillary pressure saturation

### DIFF
--- a/Documentation/ProjectFile/properties/property/SaturationVanGenuchten/t_entry_pressure.md
+++ b/Documentation/ProjectFile/properties/property/SaturationVanGenuchten/t_entry_pressure.md
@@ -1,1 +1,0 @@
-The required pressure for a non-wetting fluid to enter a porous medium (the capillary pressure at full saturation).

--- a/Documentation/ProjectFile/properties/property/SaturationVanGenuchten/t_p_b.md
+++ b/Documentation/ProjectFile/properties/property/SaturationVanGenuchten/t_p_b.md
@@ -1,0 +1,9 @@
+Pressure scaling parameter with units of pressure.
+
+Corresponds to van Genuchten parameter \f$\rho g / alpha\f$. The inverse of
+\f$\alpha\f$ "corresponds to the water contents lower then saturation" [1].
+
+[1] van Lier, Quirijn de Jong, and Everton Alves Rodrigues Pinheiro. "An alert
+regarding a common misinterpretation of the van Genuchten α parameter." Revista
+Brasileira de Ciência do Solo 42 (2018).
+

--- a/Documentation/bibliography.bib
+++ b/Documentation/bibliography.bib
@@ -33,6 +33,15 @@
   ISBN                     = {1558607323}
 }
 
+@Article{Genuchten1980,
+    author = "van Genuchten, M. Th.",
+    title = "A closed for equation for predicting the hydraulic conductivity of unsaturated soils",
+    journal = "Soil Sci. Soc.",
+    volume = "44",
+    pages = "892--898",
+    year = "1980"
+}
+
 @Article{Kolditz2001,
   Title                    = {{Non-linear flow in fractured rock}},
   Author                   = {Kolditz , Olaf},

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateSaturationVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateSaturationVanGenuchten.cpp
@@ -30,12 +30,10 @@ std::unique_ptr<SaturationVanGenuchten> createSaturationVanGenuchten(
     auto const exponent =
         //! \ogs_file_param{properties__property__SaturationVanGenuchten__exponent}
         config.getConfigParameter<double>("exponent");
-    auto const entry_pressure =
-        //! \ogs_file_param{properties__property__SaturationVanGenuchten__entry_pressure}
-        config.getConfigParameter<double>("entry_pressure");
+    //! \ogs_file_param{properties__property__SaturationVanGenuchten__p_b}
+    auto const p_b = config.getConfigParameter<double>("p_b");
 
-    return std::make_unique<SaturationVanGenuchten>(residual_liquid_saturation,
-                                                    residual_gas_saturation,
-                                                    exponent, entry_pressure);
+    return std::make_unique<SaturationVanGenuchten>(
+        residual_liquid_saturation, residual_gas_saturation, exponent, p_b);
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationVanGenuchten.cpp
@@ -21,11 +21,11 @@ SaturationVanGenuchten::SaturationVanGenuchten(
     double const residual_liquid_saturation,
     double const residual_gas_saturation,
     double const exponent,
-    double const entry_pressure)
+    double const p_b)
     : _S_L_res(residual_liquid_saturation),
       _S_L_max(1. - residual_gas_saturation),
       _m(exponent),
-      _p_b(entry_pressure)
+      _p_b(p_b)
 {
     if (!(_m > 0 && _m < 1))
     {

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationVanGenuchten.h
@@ -24,10 +24,13 @@ class Component;
  * \f[S_\text{eff}=\frac{S-S_r}{S_{\text{max}}-S_r}.\f]
  * Above, \f$S_r\f$ and \f$S_{\text{max}}\f$ are the residual and the maximum
  * saturations.
- * The exponent \f$m \in (0,1)\f$ and the parameter \f$p_b\f$ (it is equal to
- * \f$\rho g/\alpha\f$ in original publication) are given by the user.
+ * The exponent \f$m \in (0,1)\f$ and the pressure scaling parameter \f$p_b\f$
+ * (it is equal to \f$\rho g/\alpha\f$ in original publication) are given by the
+ * user.
+ * The scaling parameter \f$p_b\f$ is given in same units as pressure.
  *
- * Sometimes a formulation with \f$n = 1 / (1 - m) > 1\f$ is used.
+ * In the original work another exponent \f$n\f$ is used, but usually set to
+ * \f$n = 1 / (1 - m)\f$, and also in this implementation.
  *
  * The saturation is computed from the capillary pressure as follows:
  * \f[S(p_c)=
@@ -46,7 +49,7 @@ public:
     SaturationVanGenuchten(double const residual_liquid_saturation,
                            double const residual_gas_saturation,
                            double const exponent,
-                           double const entry_pressure);
+                           double const p_b);
 
     void setScale(
         std::variant<Medium*, Phase*, Component*> scale_pointer) override

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationVanGenuchten.h
@@ -16,40 +16,29 @@ class Medium;
 class Phase;
 class Component;
 /**
- *   \brief The van Genuchten capillary pressure model:
+ * \brief The van Genuchten capillary pressure model.
  *
- *   \f[p_c(S)=p_b (S_e^{-1/m}-1)^{1-m}\f]
- *   with
- *   \f[S_e=\frac{S-S_r}{S_{\mbox{max}}-S_r}\f]
- *   where
- *    \f{eqnarray*}{
- *       &p_b&            \mbox{ entry pressure,}\\
- *       &S_r&            \mbox{ residual saturation,}\\
- *       &S_{\mbox{max}}& \mbox{ maximum saturation,}\\
- *       &m \in [0,1) &        \mbox{ exponent.}\\
- *    \f}
+ * The van Genuchten capillary pressure model (\cite Genuchten1980) is:
+ * \f[p_c(S)=p_b (S_\text{eff}^{-1/m}-1)^{1-m}\f]
+ * with effective saturation defined as
+ * \f[S_\text{eff}=\frac{S-S_r}{S_{\text{max}}-S_r}.\f]
+ * Above, \f$S_r\f$ and \f$S_{\text{max}}\f$ are the residual and the maximum
+ * saturations.
+ * The exponent \f$m \in (0,1)\f$ and the parameter \f$p_b\f$ (it is equal to
+ * \f$\rho g/\alpha\f$ in original publication) are given by the user.
  *
- *    Note in some expressions, a parameter of \f$n\f$ is introduced, where
- *     \f[n=1/(1-m)\f].
+ * Sometimes a formulation with \f$n = 1 / (1 - m) > 1\f$ is used.
  *
- *    If \f$\alpha\f$ instead of \f$p_b\f$ is available, \f$p_b\f$ can
- * be calculated
- * as
- *    \f[p_b=\rho g/\alpha\f].
- *
- *  If the capillary pressure is known, the saturation can be
- *  obtained by this model with
- *  \f[S(p_c)=\left \{
- *  \begin{array}{1}
- *   S_{\mbox{max}},\, p_c < 0,\\
- *    \left( \left(\dfrac{p_c}{p_b}\right)^{\frac{1}{1-m}} +1\right)^{-m}
- *     (S_{\mbox{max}}-S_r) +S_r,\, p_c  \geq 0
-      \end{array}
- *   \right.
- * \f].
- *
- *   class SaturationVanGenuchten handles the computations associated
- *    with  \f$S(p_c)\f$.
+ * The saturation is computed from the capillary pressure as follows:
+ * \f[S(p_c)=
+ * \begin{cases}
+ *  S_{\text{max}} & \text{for $p_c \leq 0$, and}\\
+ *   \left( \left(\frac{p_c}{p_b}\right)^{\frac{1}{1-m}} +1\right)^{-m}
+ *    (S_{\text{max}}-S_r) +S_r& \text{for $p_c > 0$.}
+ * \end{cases}
+ * \f]
+ * The result is then clamped between the residual and maximum liquid
+ * saturations.
  */
 class SaturationVanGenuchten final : public Property
 {

--- a/Tests/Data/RichardsMechanics/RichardsFlow_2d_quasinewton.prj
+++ b/Tests/Data/RichardsMechanics/RichardsFlow_2d_quasinewton.prj
@@ -102,7 +102,7 @@
                     <residual_liquid_saturation>0.1689</residual_liquid_saturation>
                     <residual_gas_saturation>0.05</residual_gas_saturation>
                     <exponent>0.789029535864979</exponent>
-                    <entry_pressure>3633.33</entry_pressure>
+                    <p_b>3633.33</p_b>
                 </property>
                 <property>
                     <name>relative_permeability</name>

--- a/Tests/Data/RichardsMechanics/RichardsFlow_2d_richardsflow.prj
+++ b/Tests/Data/RichardsMechanics/RichardsFlow_2d_richardsflow.prj
@@ -74,7 +74,7 @@
                     <residual_liquid_saturation>0.1689</residual_liquid_saturation>
                     <residual_gas_saturation>0.05</residual_gas_saturation>
                     <exponent>0.789029535864979</exponent>
-                    <entry_pressure>3633.33</entry_pressure>
+                    <p_b>3633.33</p_b>
                 </property>
                 <property>
                     <name>relative_permeability</name>

--- a/Tests/Data/RichardsMechanics/RichardsFlow_2d_small.prj
+++ b/Tests/Data/RichardsMechanics/RichardsFlow_2d_small.prj
@@ -97,7 +97,7 @@
                     <residual_liquid_saturation>0.1689</residual_liquid_saturation>
                     <residual_gas_saturation>0.05</residual_gas_saturation>
                     <exponent>0.789029535864979</exponent>
-                    <entry_pressure>3633.33</entry_pressure>
+                    <p_b>3633.33</p_b>
                 </property>
                 <property>
                     <name>relative_permeability</name>

--- a/Tests/Data/RichardsMechanics/RichardsFlow_2d_small_masslumping.prj
+++ b/Tests/Data/RichardsMechanics/RichardsFlow_2d_small_masslumping.prj
@@ -98,7 +98,7 @@
                     <residual_liquid_saturation>0.1689</residual_liquid_saturation>
                     <residual_gas_saturation>0.05</residual_gas_saturation>
                     <exponent>0.789029535864979</exponent>
-                    <entry_pressure>3633.33</entry_pressure>
+                    <p_b>3633.33</p_b>
                 </property>
                 <property>
                     <name>relative_permeability</name>

--- a/Tests/Data/RichardsMechanics/bishops_effective_stress_power_law.prj
+++ b/Tests/Data/RichardsMechanics/bishops_effective_stress_power_law.prj
@@ -100,7 +100,7 @@
                     <residual_liquid_saturation>0.1</residual_liquid_saturation>
                     <residual_gas_saturation>0.05</residual_gas_saturation>
                     <exponent>0.8</exponent>
-                    <entry_pressure>0.5</entry_pressure>
+                    <p_b>0.5</p_b>
                 </property>
                 <property>
                     <name>relative_permeability</name>

--- a/Tests/Data/RichardsMechanics/bishops_effective_stress_saturation_cutoff.prj
+++ b/Tests/Data/RichardsMechanics/bishops_effective_stress_saturation_cutoff.prj
@@ -100,7 +100,7 @@
                     <residual_liquid_saturation>0.1</residual_liquid_saturation>
                     <residual_gas_saturation>0.05</residual_gas_saturation>
                     <exponent>0.8</exponent>
-                    <entry_pressure>0.5</entry_pressure>
+                    <p_b>0.5</p_b>
                 </property>
                 <property>
                     <name>relative_permeability</name>

--- a/Tests/Data/RichardsMechanics/deformation_dependent_porosity_swelling.prj
+++ b/Tests/Data/RichardsMechanics/deformation_dependent_porosity_swelling.prj
@@ -117,7 +117,7 @@
                     <residual_liquid_saturation>0.1</residual_liquid_saturation>
                     <residual_gas_saturation>0.05</residual_gas_saturation>
                     <exponent>0.8</exponent>
-                    <entry_pressure>0.5</entry_pressure>
+                    <p_b>0.5</p_b>
                 </property>
                 <property>
                     <name>relative_permeability</name>

--- a/Tests/Data/RichardsMechanics/gravity.prj
+++ b/Tests/Data/RichardsMechanics/gravity.prj
@@ -104,7 +104,7 @@
                     <residual_liquid_saturation>0.01</residual_liquid_saturation>
                     <residual_gas_saturation>0.01</residual_gas_saturation>
                     <exponent>0.789029535864979</exponent>
-                    <entry_pressure>3633.33</entry_pressure>
+                    <p_b>3633.33</p_b>
                 </property>
                 <property>
                     <name>relative_permeability</name>

--- a/Tests/Data/RichardsMechanics/orthotropic_swelling_xy.prj
+++ b/Tests/Data/RichardsMechanics/orthotropic_swelling_xy.prj
@@ -109,7 +109,7 @@
                     <residual_liquid_saturation>0.1</residual_liquid_saturation>
                     <residual_gas_saturation>0.05</residual_gas_saturation>
                     <exponent>0.8</exponent>
-                    <entry_pressure>0.5</entry_pressure>
+                    <p_b>0.5</p_b>
                 </property>
                 <property>
                     <name>relative_permeability</name>

--- a/Tests/Data/RichardsMechanics/orthotropic_swelling_xyz.prj
+++ b/Tests/Data/RichardsMechanics/orthotropic_swelling_xyz.prj
@@ -109,7 +109,7 @@
                     <residual_liquid_saturation>0.1</residual_liquid_saturation>
                     <residual_gas_saturation>0.05</residual_gas_saturation>
                     <exponent>0.8</exponent>
-                    <entry_pressure>0.5</entry_pressure>
+                    <p_b>0.5</p_b>
                 </property>
                 <property>
                     <name>relative_permeability</name>

--- a/Tests/MaterialLib/TestMPLSaturationVanGenuchten.cpp
+++ b/Tests/MaterialLib/TestMPLSaturationVanGenuchten.cpp
@@ -21,11 +21,10 @@ TEST(MaterialPropertyLib, SaturationVanGenuchten)
     double const residual_liquid_saturation = 0.1;
     double const residual_gas_saturation = 0.05;
     double const exponent = 0.79;
-    double const entry_pressure = 5000;
+    double const p_b = 5000;
 
     MPL::Property const& pressure_saturation = MPL::SaturationVanGenuchten{
-        residual_liquid_saturation, residual_gas_saturation, exponent,
-        entry_pressure};
+        residual_liquid_saturation, residual_gas_saturation, exponent, p_b};
 
     MPL::VariableArray variable_array;
     ParameterLib::SpatialPosition const pos;


### PR DESCRIPTION
Mainly fixing the documentation. See individual commits for details.
Change input parameter `<entry_pressure>` to `<p_b>` and `<exponent>` to `<m>`.