### PR TITLE
GMSH2OGS: check mesh integration

### DIFF
--- a/Applications/Utils/FileConverter/GMSH2OGS.cpp
+++ b/Applications/Utils/FileConverter/GMSH2OGS.cpp
@@ -117,15 +117,17 @@ int main (int argc, char* argv[])
         }
     }
     // *** print meshinformation
+
     INFO("Please check your mesh carefully!");
     INFO(
         "Degenerated or redundant mesh elements can cause OGS to stop or "
         "misbehave.");
     INFO("Use the -e option to delete redundant line elements.");
+
     // Geometric information
-    const GeoLib::AABB aabb(MeshLib::MeshInformation::getBoundingBox(*mesh));
-    auto minPt(aabb.getMinPoint());
-    auto maxPt(aabb.getMaxPoint());
+    const GeoLib::AABB aabb = MeshLib::MeshInformation::getBoundingBox(*mesh);
+    auto const minPt(aabb.getMinPoint());
+    auto const maxPt(aabb.getMaxPoint());
     INFO("Node coordinates:");
     INFO("\tx [%g, %g] (extent %g)", minPt[0], maxPt[0], maxPt[0] - minPt[0]);
     INFO("\ty [%g, %g] (extent %g)", minPt[1], maxPt[1], maxPt[1] - minPt[1]);
@@ -135,79 +137,13 @@ int main (int argc, char* argv[])
          mesh->getMaxEdgeLength());
 
     // Element information
-    const std::array<unsigned, 7> nr_ele_types(
-        MeshLib::MeshInformation::getNumberOfElementTypes(*mesh));
-    INFO("Element types:");
-    unsigned etype = 0;
-    if (nr_ele_types[etype] > 0)
-    {
-        INFO("\t%d lines", nr_ele_types[etype]);
-    }
-    if (nr_ele_types[++etype] > 0)
-    {
-        INFO("\t%d triangles", nr_ele_types[etype]);
-    }
-    if (nr_ele_types[++etype] > 0)
-    {
-        INFO("\t%d quads", nr_ele_types[etype]);
-    }
-    if (nr_ele_types[++etype] > 0)
-    {
-        INFO("\t%d tetrahedra", nr_ele_types[etype]);
-    }
-    if (nr_ele_types[++etype] > 0)
-    {
-        INFO("\t%d hexahedra", nr_ele_types[etype]);
-    }
-    if (nr_ele_types[++etype] > 0)
-    {
-        INFO("\t%d pyramids", nr_ele_types[etype]);
-    }
-    if (nr_ele_types[++etype] > 0)
-    {
-        INFO("\t%d prisms", nr_ele_types[etype]);
-    }
+    MeshLib::MeshInformation::writeAllNumbersOfElementTypes(*mesh);
 
-    std::vector<std::string> const& vec_names(
-        mesh->getProperties().getPropertyVectorNames());
-    INFO("There are %d properties in the mesh:", vec_names.size());
-    for (const auto& vec_name : vec_names)
-    {
-        if (auto const vec_bounds =
-                MeshLib::MeshInformation::getValueBounds<int>(*mesh, vec_name))
-        {
-            INFO("\t%s: [%d, %d]", vec_name.c_str(), vec_bounds->first,
-                 vec_bounds->second);
-        }
-        else if (auto const vec_bounds =
-                     MeshLib::MeshInformation::getValueBounds<double>(*mesh,
-                                                                      vec_name))
-        {
-            INFO("\t%s: [%g, %g]", vec_name.c_str(), vec_bounds->first,
-                 vec_bounds->second);
-        }
-        else
-        {
-            INFO("\t%s: Could not get value bounds for property vector.",
-                 vec_name.c_str());
-        }
-    }
+    MeshLib::MeshInformation::writePropertyVectorInformation(*mesh);
 
     if (valid_arg.isSet())
     {
-        // MeshValidation outputs error messages
-        // Remark: MeshValidation can modify the original mesh
-        MeshLib::MeshValidation validation(*mesh);
-
-        unsigned const n_holes(MeshLib::MeshValidation::detectHoles(*mesh));
-        if (n_holes > 0)
-        {
-            INFO("%d hole(s) detected within the mesh", n_holes);
-        }
-        else
-        {
-            INFO("No holes found within the mesh.");
-        }
+        MeshLib::MeshInformation::writeMeshValidationResults(*mesh);
     }
 
     // *** write mesh in new format

--- a/Applications/Utils/FileConverter/GMSH2OGS.cpp
+++ b/Applications/Utils/FileConverter/GMSH2OGS.cpp
@@ -29,16 +29,14 @@
 #include "BaseLib/MemWatch.h"
 #endif
 
-#include "GeoLib/AABB.h"
-
 #include "Applications/FileIO/Gmsh/GmshReader.h"
-
+#include "GeoLib/AABB.h"
 #include "MeshLib/IO/writeMeshToFile.h"
-#include "MeshLib/MeshSearch/ElementSearch.h"
 #include "MeshLib/Mesh.h"
 #include "MeshLib/MeshEditing/RemoveMeshComponents.h"
 #include "MeshLib/MeshInformation.h"
 #include "MeshLib/MeshQuality/MeshValidation.h"
+#include "MeshLib/MeshSearch/ElementSearch.h"
 
 int main (int argc, char* argv[])
 {
@@ -73,8 +71,8 @@ int main (int argc, char* argv[])
         "filename as string");
     cmd.add(gmsh_mesh_arg);
 
-    TCLAP::SwitchArg valid_arg("v","validation","validate the mesh");
-    cmd.add( valid_arg );
+    TCLAP::SwitchArg valid_arg("v", "validation", "validate the mesh");
+    cmd.add(valid_arg);
 
     TCLAP::SwitchArg exclude_lines_arg("e", "exclude-lines",
         "if set, lines will not be written to the ogs mesh");
@@ -120,21 +118,25 @@ int main (int argc, char* argv[])
     }
     // *** print meshinformation
     INFO("Please check your mesh carefully!");
-    INFO("Degenerated or redundant mesh elements can cause OGS to stop or misbehave.");
+    INFO(
+        "Degenerated or redundant mesh elements can cause OGS to stop or "
+        "misbehave.");
     INFO("Use the -e option to delete redundant line elements.");
     // Geometric information
     const GeoLib::AABB aabb(MeshLib::MeshInformation::getBoundingBox(*mesh));
     auto minPt(aabb.getMinPoint());
     auto maxPt(aabb.getMaxPoint());
     INFO("Node coordinates:");
-    INFO("\tx [%g, %g] (extent %g)", minPt[0], maxPt[0], maxPt[0]-minPt[0]);
-    INFO("\ty [%g, %g] (extent %g)", minPt[1], maxPt[1], maxPt[1]-minPt[1]);
-    INFO("\tz [%g, %g] (extent %g)", minPt[2], maxPt[2], maxPt[2]-minPt[2]);
+    INFO("\tx [%g, %g] (extent %g)", minPt[0], maxPt[0], maxPt[0] - minPt[0]);
+    INFO("\ty [%g, %g] (extent %g)", minPt[1], maxPt[1], maxPt[1] - minPt[1]);
+    INFO("\tz [%g, %g] (extent %g)", minPt[2], maxPt[2], maxPt[2] - minPt[2]);
 
-    INFO("Edge length: [%g, %g]", mesh->getMinEdgeLength(), mesh->getMaxEdgeLength());
+    INFO("Edge length: [%g, %g]", mesh->getMinEdgeLength(),
+         mesh->getMaxEdgeLength());
 
     // Element information
-    const std::array<unsigned, 7> nr_ele_types(MeshLib::MeshInformation::getNumberOfElementTypes(*mesh));
+    const std::array<unsigned, 7> nr_ele_types(
+        MeshLib::MeshInformation::getNumberOfElementTypes(*mesh));
     INFO("Element types:");
     unsigned etype = 0;
     if (nr_ele_types[etype] > 0)
@@ -166,7 +168,8 @@ int main (int argc, char* argv[])
         INFO("\t%d prisms", nr_ele_types[etype]);
     }
 
-    std::vector<std::string> const& vec_names (mesh->getProperties().getPropertyVectorNames());
+    std::vector<std::string> const& vec_names(
+        mesh->getProperties().getPropertyVectorNames());
     INFO("There are %d properties in the mesh:", vec_names.size());
     for (const auto& vec_name : vec_names)
     {
@@ -190,22 +193,22 @@ int main (int argc, char* argv[])
         }
     }
 
-    if (valid_arg.isSet()) {
+    if (valid_arg.isSet())
+    {
         // MeshValidation outputs error messages
         // Remark: MeshValidation can modify the original mesh
         MeshLib::MeshValidation validation(*mesh);
 
-        unsigned const n_holes (MeshLib::MeshValidation::detectHoles(*mesh));
+        unsigned const n_holes(MeshLib::MeshValidation::detectHoles(*mesh));
         if (n_holes > 0)
         {
             INFO("%d hole(s) detected within the mesh", n_holes);
         }
         else
         {
-            INFO ("No holes found within the mesh.");
+            INFO("No holes found within the mesh.");
         }
     }
-
 
     // *** write mesh in new format
     MeshLib::IO::writeMeshToFile(*mesh, ogs_mesh_arg.getValue());

--- a/Applications/Utils/FileConverter/GMSH2OGS.cpp
+++ b/Applications/Utils/FileConverter/GMSH2OGS.cpp
@@ -29,12 +29,16 @@
 #include "BaseLib/MemWatch.h"
 #endif
 
+#include "GeoLib/AABB.h"
+
 #include "Applications/FileIO/Gmsh/GmshReader.h"
 
 #include "MeshLib/IO/writeMeshToFile.h"
 #include "MeshLib/MeshSearch/ElementSearch.h"
 #include "MeshLib/Mesh.h"
 #include "MeshLib/MeshEditing/RemoveMeshComponents.h"
+#include "MeshLib/MeshInformation.h"
+#include "MeshLib/MeshQuality/MeshValidation.h"
 
 int main (int argc, char* argv[])
 {
@@ -68,6 +72,9 @@ int main (int argc, char* argv[])
         "",
         "filename as string");
     cmd.add(gmsh_mesh_arg);
+
+    TCLAP::SwitchArg valid_arg("v","validation","validate the mesh");
+    cmd.add( valid_arg );
 
     TCLAP::SwitchArg exclude_lines_arg("e", "exclude-lines",
         "if set, lines will not be written to the ogs mesh");
@@ -111,6 +118,94 @@ int main (int argc, char* argv[])
             INFO("Mesh does not contain any lines.");
         }
     }
+    // *** print meshinformation
+    INFO("Please check your mesh carefully!");
+    INFO("Degenerated or redundant mesh elements can cause OGS to stop or misbehave.");
+    INFO("Use the -e option to delete redundant line elements.");
+    // Geometric information
+    const GeoLib::AABB aabb(MeshLib::MeshInformation::getBoundingBox(*mesh));
+    auto minPt(aabb.getMinPoint());
+    auto maxPt(aabb.getMaxPoint());
+    INFO("Node coordinates:");
+    INFO("\tx [%g, %g] (extent %g)", minPt[0], maxPt[0], maxPt[0]-minPt[0]);
+    INFO("\ty [%g, %g] (extent %g)", minPt[1], maxPt[1], maxPt[1]-minPt[1]);
+    INFO("\tz [%g, %g] (extent %g)", minPt[2], maxPt[2], maxPt[2]-minPt[2]);
+
+    INFO("Edge length: [%g, %g]", mesh->getMinEdgeLength(), mesh->getMaxEdgeLength());
+
+    // Element information
+    const std::array<unsigned, 7> nr_ele_types(MeshLib::MeshInformation::getNumberOfElementTypes(*mesh));
+    INFO("Element types:");
+    unsigned etype = 0;
+    if (nr_ele_types[etype] > 0)
+    {
+        INFO("\t%d lines", nr_ele_types[etype]);
+    }
+    if (nr_ele_types[++etype] > 0)
+    {
+        INFO("\t%d triangles", nr_ele_types[etype]);
+    }
+    if (nr_ele_types[++etype] > 0)
+    {
+        INFO("\t%d quads", nr_ele_types[etype]);
+    }
+    if (nr_ele_types[++etype] > 0)
+    {
+        INFO("\t%d tetrahedra", nr_ele_types[etype]);
+    }
+    if (nr_ele_types[++etype] > 0)
+    {
+        INFO("\t%d hexahedra", nr_ele_types[etype]);
+    }
+    if (nr_ele_types[++etype] > 0)
+    {
+        INFO("\t%d pyramids", nr_ele_types[etype]);
+    }
+    if (nr_ele_types[++etype] > 0)
+    {
+        INFO("\t%d prisms", nr_ele_types[etype]);
+    }
+
+    std::vector<std::string> const& vec_names (mesh->getProperties().getPropertyVectorNames());
+    INFO("There are %d properties in the mesh:", vec_names.size());
+    for (const auto& vec_name : vec_names)
+    {
+        if (auto const vec_bounds =
+                MeshLib::MeshInformation::getValueBounds<int>(*mesh, vec_name))
+        {
+            INFO("\t%s: [%d, %d]", vec_name.c_str(), vec_bounds->first,
+                 vec_bounds->second);
+        }
+        else if (auto const vec_bounds =
+                     MeshLib::MeshInformation::getValueBounds<double>(*mesh,
+                                                                      vec_name))
+        {
+            INFO("\t%s: [%g, %g]", vec_name.c_str(), vec_bounds->first,
+                 vec_bounds->second);
+        }
+        else
+        {
+            INFO("\t%s: Could not get value bounds for property vector.",
+                 vec_name.c_str());
+        }
+    }
+
+    if (valid_arg.isSet()) {
+        // MeshValidation outputs error messages
+        // Remark: MeshValidation can modify the original mesh
+        MeshLib::MeshValidation validation(*mesh);
+
+        unsigned const n_holes (MeshLib::MeshValidation::detectHoles(*mesh));
+        if (n_holes > 0)
+        {
+            INFO("%d hole(s) detected within the mesh", n_holes);
+        }
+        else
+        {
+            INFO ("No holes found within the mesh.");
+        }
+    }
+
 
     // *** write mesh in new format
     MeshLib::IO::writeMeshToFile(*mesh, ogs_mesh_arg.getValue());

--- a/Applications/Utils/MeshEdit/checkMesh.cpp
+++ b/Applications/Utils/MeshEdit/checkMesh.cpp
@@ -82,75 +82,14 @@ int main(int argc, char *argv[])
     INFO("Edge length: [%g, %g]", mesh->getMinEdgeLength(), mesh->getMaxEdgeLength());
 
     // Element information
-    const std::array<unsigned, 7> nr_ele_types(MeshLib::MeshInformation::getNumberOfElementTypes(*mesh));
-    INFO("Element types:");
-    unsigned etype = 0;
-    if (nr_ele_types[etype] > 0)
-    {
-        INFO("\t%d lines", nr_ele_types[etype]);
-    }
-    if (nr_ele_types[++etype] > 0)
-    {
-        INFO("\t%d triangles", nr_ele_types[etype]);
-    }
-    if (nr_ele_types[++etype] > 0)
-    {
-        INFO("\t%d quads", nr_ele_types[etype]);
-    }
-    if (nr_ele_types[++etype] > 0)
-    {
-        INFO("\t%d tetrahedra", nr_ele_types[etype]);
-    }
-    if (nr_ele_types[++etype] > 0)
-    {
-        INFO("\t%d hexahedra", nr_ele_types[etype]);
-    }
-    if (nr_ele_types[++etype] > 0)
-    {
-        INFO("\t%d pyramids", nr_ele_types[etype]);
-    }
-    if (nr_ele_types[++etype] > 0)
-    {
-        INFO("\t%d prisms", nr_ele_types[etype]);
-    }
 
-    std::vector<std::string> const& vec_names (mesh->getProperties().getPropertyVectorNames());
-    INFO("There are %d properties in the mesh:", vec_names.size());
-    for (const auto& vec_name : vec_names)
-    {
-        if (auto const vec_bounds =
-                MeshLib::MeshInformation::getValueBounds<int>(*mesh, vec_name))
-        {
-            INFO("\t%s: [%d, %d]", vec_name.c_str(), vec_bounds->first,
-                 vec_bounds->second);
-        }
-        else if (auto const vec_bounds =
-                     MeshLib::MeshInformation::getValueBounds<double>(*mesh,
-                                                                      vec_name))
-        {
-            INFO("\t%s: [%g, %g]", vec_name.c_str(), vec_bounds->first,
-                 vec_bounds->second);
-        }
-        else
-        {
-            INFO("\t%s: Could not get value bounds for property vector.",
-                 vec_name.c_str());
-        }
-    }
+    MeshLib::MeshInformation::writeAllNumbersOfElementTypes(*mesh);
+
+    MeshLib::MeshInformation::writePropertyVectorInformation(*mesh);
 
     if (valid_arg.isSet()) {
         // MeshValidation outputs error messages
         // Remark: MeshValidation can modify the original mesh
-        MeshLib::MeshValidation validation(*mesh);
-
-        unsigned const n_holes (MeshLib::MeshValidation::detectHoles(*mesh));
-        if (n_holes > 0)
-        {
-            INFO("%d hole(s) detected within the mesh", n_holes);
-        }
-        else
-        {
-            INFO ("No holes found within the mesh.");
-        }
+        MeshLib::MeshInformation::writeMeshValidationResults(*mesh);
     }
 }

--- a/MeshLib/MeshInformation.cpp
+++ b/MeshLib/MeshInformation.cpp
@@ -13,7 +13,9 @@
  */
 
 #include "MeshInformation.h"
+
 #include "Elements/Element.h"
+#include "MeshLib/MeshQuality/MeshValidation.h"
 
 namespace MeshLib
 {
@@ -61,6 +63,64 @@ std::array<unsigned, 7> MeshInformation::getNumberOfElementTypes(
         }
     }
     return n_element_types;
+}
+
+void MeshInformation::writeAllNumbersOfElementTypes(const MeshLib::Mesh& mesh)
+{
+    auto const& nr_ele_types =
+        MeshLib::MeshInformation::getNumberOfElementTypes(mesh);
+    const std::array<std::string, 7> element_names{
+        "lines",     "triangles", "quads", "tetrahedra",
+        "hexahedra", "pyramids",  "prisms"};
+    for (unsigned int element_type = 0; element_type < nr_ele_types.size();
+         element_type++)
+    {
+        INFO("\t%d %s ", nr_ele_types[element_type],
+             element_names[element_type].c_str());
+    }
+}
+
+void MeshInformation::writePropertyVectorInformation(const MeshLib::Mesh& mesh)
+{
+    std::vector<std::string> const& vec_names(
+        mesh.getProperties().getPropertyVectorNames());
+    INFO("There are %d properties in the mesh:", vec_names.size());
+    for (const auto& vec_name : vec_names)
+    {
+        if (auto const vec_bounds =
+                MeshLib::MeshInformation::getValueBounds<int>(mesh, vec_name))
+        {
+            INFO("\t%s: [%d, %d]", vec_name.c_str(), vec_bounds->first,
+                 vec_bounds->second);
+        }
+        else if (auto const vec_bounds =
+                     MeshLib::MeshInformation::getValueBounds<double>(mesh,
+                                                                      vec_name))
+        {
+            INFO("\t%s: [%g, %g]", vec_name.c_str(), vec_bounds->first,
+                 vec_bounds->second);
+        }
+        else
+        {
+            INFO("\t%s: Could not get value bounds for property vector.",
+                 vec_name.c_str());
+        }
+    }
+}
+
+void MeshInformation::writeMeshValidationResults(MeshLib::Mesh& mesh)
+{
+    MeshLib::MeshValidation validation(mesh);
+
+    unsigned const n_holes(MeshLib::MeshValidation::detectHoles(mesh));
+    if (n_holes > 0)
+    {
+        INFO("%d hole(s) detected within the mesh", n_holes);
+    }
+    else
+    {
+        INFO("No holes found within the mesh.");
+    }
 }
 
 }  // namespace MeshLib

--- a/MeshLib/MeshInformation.h
+++ b/MeshLib/MeshInformation.h
@@ -78,7 +78,7 @@ public:
     static void writePropertyVectorInformation(const MeshLib::Mesh& mesh);
 
     /// writes out mesh validation results
-    // Remark: MeshValidation can modify the original mesh
+    /// Remark: MeshValidation can modify the original mesh
     static void writeMeshValidationResults(MeshLib::Mesh& mesh);
 };
 

--- a/MeshLib/MeshInformation.h
+++ b/MeshLib/MeshInformation.h
@@ -70,6 +70,16 @@ public:
      */
     static std::array<unsigned, 7> getNumberOfElementTypes(
         const MeshLib::Mesh& mesh);
+
+    /// writes all numbers of element types
+    static void writeAllNumbersOfElementTypes(const MeshLib::Mesh& mesh);
+
+    /// writes out property vector information
+    static void writePropertyVectorInformation(const MeshLib::Mesh& mesh);
+
+    /// writes out mesh validation results
+    // Remark: MeshValidation can modify the original mesh
+    static void writeMeshValidationResults(MeshLib::Mesh& mesh);
 };
 
 }  // namespace MeshLib


### PR DESCRIPTION
Perform additional mesh checks (e.g. for element type) while converting.
This should facilitate troubleshooting as GMSH meshes nomally don't work out of the box.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Fixes #2841
1. [ ] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.1)
2. [ ] Tests covering your feature were added?
3. [ ] Any new feature or behavior change was documented?
