### PR TITLE
Remove compile time log level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,19 +150,6 @@ endif()
 
 option(OGS_USE_MKL "Use Intel MKL" OFF)
 
-# Logging
-set(OGS_LOG_LEVEL
-    "LOGOG_LEVEL_DEBUG"
-    CACHE STRING "Set logging level included in compilation.")
-set_property(CACHE OGS_LOG_LEVEL
-             PROPERTY STRINGS
-                      LOGOG_LEVEL_NONE
-                      LOGOG_LEVEL_ERROR
-                      LOGOG_LEVEL_WARN
-                      LOGOG_LEVEL_INFO
-                      LOGOG_LEVEL_DEBUG
-                      LOGOG_LEVEL_ALL)
-
 # Debug
 option(OGS_FATAL_ABORT "Abort in OGS_FATAL" OFF)
 
@@ -264,8 +251,6 @@ endif()
 if(OGS_FATAL_ABORT)
     add_definitions(-DOGS_FATAL_ABORT)
 endif()
-
-add_definitions(-DLOGOG_LEVEL=${OGS_LOG_LEVEL})
 
 # Packaging
 include(scripts/cmake/packaging/Pack.cmake)

--- a/web/content/docs/devguide/advanced/configuration-options.pandoc
+++ b/web/content/docs/devguide/advanced/configuration-options.pandoc
@@ -36,10 +36,6 @@ CMake switches to enable / disable parts of OGS.
 
 - `CMAKE_BUILD_TYPE` - Set to `Release` to build with optimization flags, set to `Debug` for debugging.
 
-#### Logging
-
-- `OGS_DISABLE_LOGGING` - Disables all logog output messages. This really strips out all logog-code (useful for performance testing).
-
 #### Testing
 
 - `OGS_COVERAGE` - Enables code coverage measurements with gcov/lcov. TODO

--- a/web/content/docs/devguide/advanced/log-and-debug-output.pandoc
+++ b/web/content/docs/devguide/advanced/log-and-debug-output.pandoc
@@ -30,4 +30,7 @@ if (foo > maxfoo)
 
 For more information see the [Logog documentation](http://johnwbyrd.github.com/logog/quickstart.html).
 
-On release builds the log level is `LOGOG_LEVEL_INFO`, on debug it is `LOGOG_LEVEL_DEBUG` and it can be overriden with the CMake option `OGS_LOG_LEVEL`. You can completely disable logging with the CMake-option `OGS_DISABLE_LOGGING` set to `ON`.
+
+On release builds the default log level is `INFO`, for debug builds it is
+`DEBUG`.
+The log level can be adjusted on the command line with `-l <LOG_LEVEL>` flag.


### PR DESCRIPTION
the log level can be adjusted in preprocessor. The default values are "debug" for all builds.
If someone actively uses/relies on this feature, now is good point to tell it ;)
This feature is removed in this pull request.

Reducing complexity a little.
Part of #2875 