### PR TITLE
Remove extension of MFront Library for other system, MGIS could autom…

### DIFF
--- a/MaterialLib/SolidModels/MFront/CreateMFront.cpp
+++ b/MaterialLib/SolidModels/MFront/CreateMFront.cpp
@@ -70,7 +70,7 @@ std::unique_ptr<MechanicsBase<DisplacementDim>> createMFront(
     auto const lib_path =
         library_name
             ? BaseLib::joinPaths(BaseLib::getProjectDirectory(), *library_name)
-            : "libOgsMFrontBehaviour.so";
+            : "libOgsMFrontBehaviour";
 
     auto const behaviour_name =
         //! \ogs_file_param{material__solid__constitutive_relation__MFront__behaviour}


### PR DESCRIPTION
I think that no need for extension, the MGIS automaticly check the system and find an extension...add that extension will only make it work for linux...
