### PR TITLE
Elemtypes map

### DIFF
--- a/Applications/DataExplorer/DataView/ElementTreeModel.cpp
+++ b/Applications/DataExplorer/DataView/ElementTreeModel.cpp
@@ -128,17 +128,20 @@ void ElementTreeModel::setMesh(MeshLib::Mesh const& mesh)
     auto* elements_item = new TreeItem(elements_number, _rootItem);
     _rootItem->appendChild(elements_item);
 
-    const std::array<QString, 7> n_element_names = {{ "Lines:", "Triangles:", "Quads:", "Tetrahedra:", "Hexahedra:", "Pyramids:", "Prisms:" }};
-    const std::array<unsigned, 7>& n_element_types (MeshLib::MeshInformation::getNumberOfElementTypes(mesh));
-    for (std::size_t i=0; i<n_element_types.size(); ++i)
+    auto const& n_element_types =
+        MeshLib::MeshInformation::getNumberOfElementTypes(mesh);
+    for (auto entry : n_element_types)
     {
-        if (n_element_types[i])
-        {
-            QList<QVariant> elements_number;
-            elements_number << n_element_names[i] << QString::number(n_element_types[i]) << "" << "";
-            auto* type_item = new TreeItem(elements_number, elements_item);
-            elements_item->appendChild(type_item);
-        }
+        QList<QVariant> elements_number;
+        elements_number << QString::fromStdString(
+                               MeshLib::MeshElemType2String(
+                                   static_cast<MeshLib::MeshElemType>(
+                                       entry.first)) +
+                               "s:")
+                        << QString::number(entry.second) << ""
+                        << "";
+        auto* type_item = new TreeItem(elements_number, elements_item);
+        elements_item->appendChild(type_item);
     }
 
     QList<QVariant> bounding_box;

--- a/Applications/FileIO/TetGenInterface.cpp
+++ b/Applications/FileIO/TetGenInterface.cpp
@@ -715,8 +715,10 @@ void TetGenInterface::write2dElements(std::ofstream &out,
                                       const MeshLib::Mesh &mesh) const
 {
     // the surfaces header
-    const std::array<unsigned,7> types = MeshLib::MeshInformation::getNumberOfElementTypes(mesh);
-    const unsigned nTotalTriangles (types[1] + (2*types[2]));
+    auto const& types = MeshLib::MeshInformation::getNumberOfElementTypes(mesh);
+    const unsigned nTotalTriangles =
+        (types.at(MeshLib::MeshElemType::TRIANGLE) +
+         (2 * types.at(MeshLib::MeshElemType::QUAD)));
     out << nTotalTriangles << " 1\n";
 
     const std::vector<MeshLib::Element*> &elements = mesh.getElements();

--- a/Applications/Utils/MeshEdit/UnityPreprocessing.cpp
+++ b/Applications/Utils/MeshEdit/UnityPreprocessing.cpp
@@ -210,15 +210,16 @@ int main (int argc, char* argv[])
     INFO("done.\n");
 
     INFO("Checking for line elements...");
-    std::array<unsigned, 7> const& n_element_types =
+    auto const& n_element_types =
         MeshLib::MeshInformation::getNumberOfElementTypes(*mesh);
     std::unique_ptr<MeshLib::Mesh> result;
-    if (n_element_types[0] == 0)
+    if (n_element_types.at(MeshLib::MeshElemType::LINE) == 0)
     {
         INFO ("No line elements found.\n");
         result = std::move(mesh);
     }
-    else if (n_element_types[0] == mesh->getNumberOfElements())
+    else if (n_element_types.at(MeshLib::MeshElemType::LINE) ==
+             mesh->getNumberOfElements())
     {
         INFO ("Keeping line mesh.\n");
         result = std::move(mesh);

--- a/MeshLib/MeshInformation.cpp
+++ b/MeshLib/MeshInformation.cpp
@@ -25,42 +25,15 @@ GeoLib::AABB MeshInformation::getBoundingBox(const MeshLib::Mesh& mesh)
     return GeoLib::AABB(nodes.begin(), nodes.end());
 }
 
-std::array<unsigned, 7> MeshInformation::getNumberOfElementTypes(
+std::map<MeshElemType, unsigned> MeshInformation::getNumberOfElementTypes(
     const MeshLib::Mesh& mesh)
 {
-    std::array<unsigned, 7> n_element_types = {{0, 0, 0, 0, 0, 0, 0}};
+    std::map<MeshElemType, unsigned> n_element_types;
     const std::vector<MeshLib::Element*>& elements(mesh.getElements());
     for (auto element : elements)
     {
         MeshElemType t = element->getGeomType();
-        if (t == MeshElemType::LINE)
-        {
-            n_element_types[0]++;
-        }
-        if (t == MeshElemType::TRIANGLE)
-        {
-            n_element_types[1]++;
-        }
-        if (t == MeshElemType::QUAD)
-        {
-            n_element_types[2]++;
-        }
-        if (t == MeshElemType::TETRAHEDRON)
-        {
-            n_element_types[3]++;
-        }
-        if (t == MeshElemType::HEXAHEDRON)
-        {
-            n_element_types[4]++;
-        }
-        if (t == MeshElemType::PYRAMID)
-        {
-            n_element_types[5]++;
-        }
-        if (t == MeshElemType::PRISM)
-        {
-            n_element_types[6]++;
-        }
+        n_element_types[t]++;
     }
     return n_element_types;
 }
@@ -69,14 +42,14 @@ void MeshInformation::writeAllNumbersOfElementTypes(const MeshLib::Mesh& mesh)
 {
     auto const& nr_ele_types =
         MeshLib::MeshInformation::getNumberOfElementTypes(mesh);
-    const std::array<std::string, 7> element_names{
-        "lines",     "triangles", "quads", "tetrahedra",
-        "hexahedra", "pyramids",  "prisms"};
-    for (unsigned int element_type = 0; element_type < nr_ele_types.size();
-         element_type++)
+
+    INFO("Number of elements in the mesh:");
+    for (auto entry : nr_ele_types)
     {
-        INFO("\t{:d} {:s} ", nr_ele_types[element_type],
-             element_names[element_type].c_str());
+        INFO("\t{:s}s: {:d}",
+             MeshLib::MeshElemType2String(
+                 static_cast<MeshLib::MeshElemType>(entry.first)),
+             entry.second);
     }
 }
 

--- a/MeshLib/MeshInformation.h
+++ b/MeshLib/MeshInformation.h
@@ -16,6 +16,7 @@
 
 #include <array>
 #include <limits>
+#include <map>
 #include <string>
 
 #include "GeoLib/AABB.h"
@@ -68,7 +69,7 @@ public:
      *        5: \#pyramids
      *        6: \#prisms
      */
-    static std::array<unsigned, 7> getNumberOfElementTypes(
+    static std::map<MeshElemType, unsigned> getNumberOfElementTypes(
         const MeshLib::Mesh& mesh);
 
     /// writes all numbers of element types

--- a/Tests/FileIO/TestGmsInterface.cpp
+++ b/Tests/FileIO/TestGmsInterface.cpp
@@ -25,10 +25,11 @@ TEST(FileIO, TestGmsInterface)
     ASSERT_EQ(11795, mesh->getNumberOfNodes());
     ASSERT_EQ(19885, mesh->getNumberOfElements());
 
-    std::array<unsigned, 7> types (MeshLib::MeshInformation::getNumberOfElementTypes(*mesh));
-    ASSERT_EQ(1456,  types[3]);    // tets
-    ASSERT_EQ(1355,  types[5]);    // pyramids
-    ASSERT_EQ(17074, types[6]);    // prism
+    auto const& types =
+        MeshLib::MeshInformation::getNumberOfElementTypes(*mesh);
+    ASSERT_EQ(1456, types.at(MeshLib::MeshElemType::TETRAHEDRON));  // tets
+    ASSERT_EQ(1355, types.at(MeshLib::MeshElemType::PYRAMID));      // pyramids
+    ASSERT_EQ(17074, types.at(MeshLib::MeshElemType::PRISM));       // prism
     auto const& bounds =
         MeshLib::MeshInformation::getValueBounds<int>(*mesh, "MaterialIDs");
     ASSERT_TRUE(boost::none != bounds);

--- a/Tests/FileIO_SWMM/TestSwmmInterface.cpp
+++ b/Tests/FileIO_SWMM/TestSwmmInterface.cpp
@@ -66,8 +66,9 @@ TEST(FileIO, TestSwmmInterface)
     for (std::size_t i=3; i<n_nodes; ++i)
         ASSERT_NEAR(0, (*depth)[i], std::numeric_limits<double>::epsilon());
 
-    std::array<unsigned, 7> types (MeshLib::MeshInformation::getNumberOfElementTypes(mesh));
-    ASSERT_EQ(n_elems, types[0]); // all elems are lines
+    auto const& types = MeshLib::MeshInformation::getNumberOfElementTypes(mesh);
+    ASSERT_EQ(n_elems,
+              types.at(MeshLib::MeshElemType::LINE));  // all elems are lines
     auto const bounds =
         MeshLib::MeshInformation::getValueBounds<int>(mesh, "MaterialIDs");
     ASSERT_TRUE(boost::none != bounds);

--- a/Tests/MeshLib/TestAddLayerToMesh.cpp
+++ b/Tests/MeshLib/TestAddLayerToMesh.cpp
@@ -70,9 +70,10 @@ TEST(MeshLib, AddTopLayerToLineMesh)
     ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
     ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
 
-    std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
-    ASSERT_EQ(5, n_elems[0]); // tests if 5 lines are present
-    ASSERT_EQ(5, n_elems[2]); // tests if 5 quads are present
+    auto const& n_elems =
+        MeshLib::MeshInformation::getNumberOfElementTypes(*result);
+    ASSERT_EQ(5, n_elems.at(MeshLib::MeshElemType::LINE));
+    ASSERT_EQ(5, n_elems.at(MeshLib::MeshElemType::QUAD));
 
     AddLayerValidation::testZCoords2D(*mesh, *result, height);
     AddLayerValidation::validate(*result, false);
@@ -87,9 +88,10 @@ TEST(MeshLib, AddBottomLayerToLineMesh)
     ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
     ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
 
-    std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
-    ASSERT_EQ(5, n_elems[0]); // tests if 5 lines are present
-    ASSERT_EQ(5, n_elems[2]); // tests if 5 quads are present
+    auto const& n_elems =
+        MeshLib::MeshInformation::getNumberOfElementTypes(*result);
+    ASSERT_EQ(5, n_elems.at(MeshLib::MeshElemType::LINE));
+    ASSERT_EQ(5, n_elems.at(MeshLib::MeshElemType::QUAD));
 
     AddLayerValidation::testZCoords2D(*mesh, *result, -1 * height);
     AddLayerValidation::validate(*result, false);
@@ -118,9 +120,12 @@ TEST(MeshLib, AddTopLayerToTriMesh)
     ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
     ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
 
-    std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
-    ASSERT_EQ(mesh->getNumberOfElements(), n_elems[1]); // tests if 50 tris are present
-    ASSERT_EQ(mesh->getNumberOfElements(), n_elems[6]); // tests if 50 prisms are present
+    auto const& n_elems =
+        MeshLib::MeshInformation::getNumberOfElementTypes(*result);
+    ASSERT_EQ(mesh->getNumberOfElements(),
+              n_elems.at(MeshLib::MeshElemType::TRIANGLE));
+    ASSERT_EQ(mesh->getNumberOfElements(),
+              n_elems.at(MeshLib::MeshElemType::PRISM));
 
     ASSERT_EQ(1, result->getProperties().getPropertyVectorNames().size());
     auto const* const new_mats =
@@ -141,9 +146,10 @@ TEST(MeshLib, AddBottomLayerToTriMesh)
     ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
     ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
 
-    std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
-    ASSERT_EQ(50, n_elems[1]); // tests if 50 tris are present
-    ASSERT_EQ(50, n_elems[6]); // tests if 50 prisms are present
+    auto const& n_elems =
+        MeshLib::MeshInformation::getNumberOfElementTypes(*result);
+    ASSERT_EQ(50, n_elems.at(MeshLib::MeshElemType::TRIANGLE));
+    ASSERT_EQ(50, n_elems.at(MeshLib::MeshElemType::PRISM));
 
     AddLayerValidation::testZCoords2D(*mesh, *result, -1 * height);
     AddLayerValidation::validate(*result, true);
@@ -158,9 +164,10 @@ TEST(MeshLib, AddTopLayerToQuadMesh)
     ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
     ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
 
-    std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
-    ASSERT_EQ(25, n_elems[2]); // tests if 25 quads are present
-    ASSERT_EQ(25, n_elems[4]); // tests if 25 hexes are present
+    auto const& n_elems =
+        MeshLib::MeshInformation::getNumberOfElementTypes(*result);
+    ASSERT_EQ(25, n_elems.at(MeshLib::MeshElemType::QUAD));
+    ASSERT_EQ(25, n_elems.at(MeshLib::MeshElemType::HEXAHEDRON));
 
     AddLayerValidation::testZCoords2D(*mesh, *result, height);
     AddLayerValidation::validate(*result, true);
@@ -175,9 +182,10 @@ TEST(MeshLib, AddBottomLayerToQuadMesh)
     ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
     ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
 
-    std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
-    ASSERT_EQ(25, n_elems[2]); // tests if 25 quads are present
-    ASSERT_EQ(25, n_elems[4]); // tests if 25 hexes are present
+    auto const& n_elems =
+        MeshLib::MeshInformation::getNumberOfElementTypes(*result);
+    ASSERT_EQ(25, n_elems.at(MeshLib::MeshElemType::QUAD));
+    ASSERT_EQ(25, n_elems.at(MeshLib::MeshElemType::HEXAHEDRON));
 
     AddLayerValidation::testZCoords2D(*mesh, *result, -1 * height);
     AddLayerValidation::validate(*result, true);
@@ -192,8 +200,9 @@ TEST(MeshLib, AddTopLayerToHexMesh)
     ASSERT_EQ(mesh->getNumberOfNodes(), result->getNumberOfNodes()-36);
     ASSERT_EQ(mesh->getNumberOfElements(), result->getNumberOfElements()-25);
 
-    std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
-    ASSERT_EQ(150, n_elems[4]); // tests if 150 hexes are present
+    auto const& n_elems =
+        MeshLib::MeshInformation::getNumberOfElementTypes(*result);
+    ASSERT_EQ(150, n_elems.at(MeshLib::MeshElemType::HEXAHEDRON));
 
     MathLib::Vector3 const dir(0, 0, -1);
     std::unique_ptr<MeshLib::Mesh> const test_input (
@@ -213,8 +222,9 @@ TEST(MeshLib, AddBottomLayerToHexMesh)
     ASSERT_EQ(mesh->getNumberOfNodes(), result->getNumberOfNodes()-36);
     ASSERT_EQ(mesh->getNumberOfElements(), result->getNumberOfElements()-25);
 
-    std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
-    ASSERT_EQ(150, n_elems[4]); // tests if 150 hexes are present
+    auto const& n_elems =
+        MeshLib::MeshInformation::getNumberOfElementTypes(*result);
+    ASSERT_EQ(150, n_elems.at(MeshLib::MeshElemType::HEXAHEDRON));
 
     MathLib::Vector3 const dir(0, 0, 1);
     std::unique_ptr<MeshLib::Mesh> const test_input (
@@ -235,9 +245,10 @@ TEST(MeshLib, AddTopLayerToPrismMesh)
     ASSERT_EQ(mesh2->getNumberOfNodes()/2.0 * 3, result->getNumberOfNodes());
     ASSERT_EQ(mesh2->getNumberOfElements()/2.0 * 3, result->getNumberOfElements());
 
-    std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
-    ASSERT_EQ(50, n_elems[1]); // tests if 50 tris are present
-    ASSERT_EQ(100, n_elems[6]); // tests if 50 prisms are present
+    auto const& n_elems =
+        MeshLib::MeshInformation::getNumberOfElementTypes(*result);
+    ASSERT_EQ(50, n_elems.at(MeshLib::MeshElemType::TRIANGLE));
+    ASSERT_EQ(100, n_elems.at(MeshLib::MeshElemType::PRISM));
 
     MathLib::Vector3 const dir(0, 0, -1);
     std::unique_ptr<MeshLib::Mesh> test_input (
@@ -265,9 +276,12 @@ TEST(MeshLib, AddBottomLayerToPrismMesh)
     ASSERT_EQ(mesh2->getNumberOfNodes()/2.0 * 3, result->getNumberOfNodes());
     ASSERT_EQ(mesh2->getNumberOfElements()/2.0 * 3, result->getNumberOfElements());
 
-    std::array<unsigned, 7> const n_elems (MeshLib::MeshInformation::getNumberOfElementTypes(*result));
-    ASSERT_EQ(mesh->getNumberOfElements(), n_elems[1]); // tests if 50 tris are present
-    ASSERT_EQ(2 * mesh->getNumberOfElements(), n_elems[6]); // tests if 50 prisms are present
+    auto const& n_elems =
+        MeshLib::MeshInformation::getNumberOfElementTypes(*result);
+    ASSERT_EQ(mesh->getNumberOfElements(),
+              n_elems.at(MeshLib::MeshElemType::TRIANGLE));
+    ASSERT_EQ(2 * mesh->getNumberOfElements(),
+              n_elems.at(MeshLib::MeshElemType::PRISM));
     ASSERT_EQ(1, result->getProperties().getPropertyVectorNames().size());
     auto const* const new_mats =
         result->getProperties().getPropertyVector<int>(mat_name);

--- a/Tests/MeshLib/TestRasterToMesh.cpp
+++ b/Tests/MeshLib/TestRasterToMesh.cpp
@@ -61,9 +61,9 @@ TEST_F(RasterToMeshTest, convertRasterToTriMeshElevation)
         mesh->getProperties().getPropertyVectorNames();
     ASSERT_TRUE(names.empty());
 
-    std::array<unsigned, 7> n_types =
+    auto const& n_types =
         MeshLib::MeshInformation::getNumberOfElementTypes(*mesh);
-    ASSERT_EQ(2 * _n_pix, n_types[1]);
+    ASSERT_EQ(2 * _n_pix, n_types.at(MeshLib::MeshElemType::TRIANGLE));
 
     GeoLib::AABB aabb = MeshLib::MeshInformation::getBoundingBox(*mesh);
     ASSERT_NEAR(aabb.getMinPoint()[2], 0,
@@ -83,9 +83,9 @@ TEST_F(RasterToMeshTest, convertRasterToQuadMeshElevation)
     std::vector<std::string> names = mesh->getProperties().getPropertyVectorNames();
     ASSERT_TRUE(names.empty());
 
-    std::array<unsigned, 7> n_types =
+    auto const& n_types =
         MeshLib::MeshInformation::getNumberOfElementTypes(*mesh);
-    ASSERT_EQ(_n_pix, n_types[2]);
+    ASSERT_EQ(_n_pix, n_types.at(MeshLib::MeshElemType::QUAD));
 
     GeoLib::AABB aabb = MeshLib::MeshInformation::getBoundingBox(*mesh);
     ASSERT_NEAR(aabb.getMinPoint()[2], 0,
@@ -136,9 +136,9 @@ TEST_F(RasterToMeshTest, convertRasterToTriMeshValue)
         ASSERT_NEAR(0, (*n)[2], std::numeric_limits<double>::epsilon());
     }
 
-    std::array<unsigned, 7> n_types =
+    auto const& n_types =
         MeshLib::MeshInformation::getNumberOfElementTypes(*mesh);
-    ASSERT_EQ(2 * _n_pix, n_types[1]);
+    ASSERT_EQ(2 * _n_pix, n_types.at(MeshLib::MeshElemType::TRIANGLE));
 }
 
 TEST_F(RasterToMeshTest, convertRasterToQuadMeshValue)
@@ -170,9 +170,9 @@ TEST_F(RasterToMeshTest, convertRasterToQuadMeshValue)
         ASSERT_TRUE((*n)[2] == 0);
     }
 
-    std::array<unsigned, 7> n_types =
+    auto const& n_types =
         MeshLib::MeshInformation::getNumberOfElementTypes(*mesh);
-    ASSERT_EQ(_n_pix, n_types[2]);
+    ASSERT_EQ(_n_pix, n_types.at(MeshLib::MeshElemType::QUAD));
 }
 
 TEST_F(RasterToMeshTest, convertRasterToPrismMeshValue)
@@ -204,9 +204,9 @@ TEST_F(RasterToMeshTest, convertRasterToPrismMeshValue)
         ASSERT_TRUE(((*n)[2] == 0) || ((*n)[2] == _spacing));
     }
 
-    std::array<unsigned, 7> n_types =
+    auto const& n_types =
         MeshLib::MeshInformation::getNumberOfElementTypes(*mesh);
-    ASSERT_EQ(2 * _n_pix, n_types[6]);
+    ASSERT_EQ(2 * _n_pix, n_types.at(MeshLib::MeshElemType::PRISM));
 }
 
 TEST_F(RasterToMeshTest, convertRasterToHexMeshValue)
@@ -238,9 +238,9 @@ TEST_F(RasterToMeshTest, convertRasterToHexMeshValue)
         ASSERT_TRUE(((*n)[2] == 0) || ((*n)[2] == _spacing));
     }
 
-    std::array<unsigned, 7> n_types =
+    auto const& n_types =
         MeshLib::MeshInformation::getNumberOfElementTypes(*mesh);
-    ASSERT_EQ(_n_pix, n_types[4]);
+    ASSERT_EQ(_n_pix, n_types.at(MeshLib::MeshElemType::HEXAHEDRON));
 }
 
 TEST_F(RasterToMeshTest, convertRasterToQuadMeshNone)
@@ -262,9 +262,9 @@ TEST_F(RasterToMeshTest, convertRasterToQuadMeshNone)
         ASSERT_TRUE((*n)[2] == 0);
     }
 
-    std::array<unsigned, 7> n_types =
+    auto const& n_types =
         MeshLib::MeshInformation::getNumberOfElementTypes(*mesh);
-    ASSERT_EQ(_n_pix, n_types[2]);
+    ASSERT_EQ(_n_pix, n_types.at(MeshLib::MeshElemType::QUAD));
 }
 
 #ifdef OGS_BUILD_GUI
@@ -305,8 +305,8 @@ TEST_F(RasterToMeshTest, vtkImage)
         ASSERT_TRUE((*n)[2] == 0);
     }
 
-    std::array<unsigned, 7> n_types =
+    auto const& n_types =
         MeshLib::MeshInformation::getNumberOfElementTypes(*mesh);
-    ASSERT_EQ(2 * _n_pix, n_types[1]);
+    ASSERT_EQ(2 * _n_pix, n_types.at(MeshLib::MeshElemType::TRIANGLE));
 }
 #endif


### PR DESCRIPTION
Substitute getNumberOfElementTypes() array by std::map to avoid multiple different element type mappings.

I'm not able to check the output of the DataExplorer right now as the binary makes some throws some OpenGL/QT errors on my machine. But at least it compiles.
