### PR TITLE
Class of the van Genuchten relative permeability of the non-wetting phase 

### DIFF
--- a/Documentation/ProjectFile/properties/property/RelativePermeabilityNonWettingPhaseVanGenuchtenMualem/c_RelativePermeabilityNonWettingVanGenuchten.md
+++ b/Documentation/ProjectFile/properties/property/RelativePermeabilityNonWettingPhaseVanGenuchtenMualem/c_RelativePermeabilityNonWettingVanGenuchten.md
@@ -1,0 +1,2 @@
+The van Genuchten Maulem relative permeability model for the
+ non-wetting phase.

--- a/Documentation/ProjectFile/properties/property/RelativePermeabilityNonWettingPhaseVanGenuchtenMualem/t_exponent.md
+++ b/Documentation/ProjectFile/properties/property/RelativePermeabilityNonWettingPhaseVanGenuchtenMualem/t_exponent.md
@@ -1,0 +1,1 @@
+The exponent.

--- a/Documentation/ProjectFile/properties/property/RelativePermeabilityNonWettingPhaseVanGenuchtenMualem/t_maximum_saturation.md
+++ b/Documentation/ProjectFile/properties/property/RelativePermeabilityNonWettingPhaseVanGenuchtenMualem/t_maximum_saturation.md
@@ -1,0 +1,1 @@
+The maximum saturation of the non-wetting phase.

--- a/Documentation/ProjectFile/properties/property/RelativePermeabilityNonWettingPhaseVanGenuchtenMualem/t_minimum_relative_permeability.md
+++ b/Documentation/ProjectFile/properties/property/RelativePermeabilityNonWettingPhaseVanGenuchtenMualem/t_minimum_relative_permeability.md
@@ -1,0 +1,2 @@
+The minimum relative permeability of the non-wetting phase.
+

--- a/Documentation/ProjectFile/properties/property/RelativePermeabilityNonWettingPhaseVanGenuchtenMualem/t_residual_saturation.md
+++ b/Documentation/ProjectFile/properties/property/RelativePermeabilityNonWettingPhaseVanGenuchtenMualem/t_residual_saturation.md
@@ -1,0 +1,1 @@
+The residual saturation of the non-wetting phase.

--- a/Documentation/bibliography.bib
+++ b/Documentation/bibliography.bib
@@ -308,3 +308,14 @@
   year={2015},
   publisher={Springer}
 }
+
+@article{lenhard1987model,
+  title={A model for hysteretic constitutive relations governing multiphase flow: 2. Permeability-saturation relations},
+  author={Lenhard, RJ and Parker, JC},
+  journal={Water Resources Research},
+  volume={23},
+  number={12},
+  pages={2197--2206},
+  year={1987},
+  publisher={Wiley Online Library}
+}

--- a/MaterialLib/MPL/CreateProperty.cpp
+++ b/MaterialLib/MPL/CreateProperty.cpp
@@ -129,6 +129,12 @@ std::unique_ptr<MaterialPropertyLib::Property> createProperty(
         return createRelPermVanGenuchten(config);
     }
 
+    if (boost::iequals(property_type,
+                       "RelativePermeabilityNonWettingPhaseVanGenuchtenMualem"))
+    {
+        return createRelPermNonWettingPhaseVanGenuchtenMualem(config);
+    }
+
     if (boost::iequals(property_type, "SaturationDependentSwelling"))
     {
         return createSaturationDependentSwelling(config,

--- a/MaterialLib/MPL/Properties/CreateProperties.h
+++ b/MaterialLib/MPL/Properties/CreateProperties.h
@@ -33,3 +33,4 @@
 #include "RelativePermeability/CreateRelPermBrooksCorey.h"
 #include "RelativePermeability/CreateRelPermLiakopoulos.h"
 #include "RelativePermeability/CreateRelPermVanGenuchten.h"
+#include "RelativePermeability/CreateRelPermNonWettingPhaseVanGenuchtenMualem.h"

--- a/MaterialLib/MPL/Properties/RelativePermeability/CreateRelPermNonWettingPhaseVanGenuchtenMualem.cpp
+++ b/MaterialLib/MPL/Properties/RelativePermeability/CreateRelPermNonWettingPhaseVanGenuchtenMualem.cpp
@@ -1,0 +1,47 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on April 14, 2020, 3:50 PM
+ */
+
+#include "CreateRelPermNonWettingPhaseVanGenuchtenMualem.h"
+
+#include "BaseLib/ConfigTree.h"
+#include "MaterialLib/MPL/Property.h"
+#include "RelPermNonWettingPhaseVanGenuchtenMualem.h"
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<Property> createRelPermNonWettingPhaseVanGenuchtenMualem(
+    BaseLib::ConfigTree const& config)
+{
+    //! \ogs_file_param{properties__property__type}
+    config.checkConfigParameter(
+        "type", "RelativePermeabilityNonWettingPhaseVanGenuchtenMualem");
+    DBUG("Create RelPermNonWettingPhaseVanGenuchtenMualem medium property");
+
+    auto const residual_saturation =
+        //! \ogs_file_param{properties__property__RelativePermeabilityNonWettingPhaseVanGenuchtenMualem__residual_saturation}
+        config.getConfigParameter<double>("residual_saturation");
+    auto const maximum_saturation =
+        //! \ogs_file_param{properties__property__RelativePermeabilityNonWettingPhaseVanGenuchtenMualem__maximum_saturation}
+        config.getConfigParameter<double>("maximum_saturation");
+
+    auto const exponent =
+        //! \ogs_file_param{properties__property__RelativePermeabilityNonWettingPhaseVanGenuchtenMualem__exponent}
+        config.getConfigParameter<double>("exponent");
+
+    auto const min_relative_permeability =
+        //! \ogs_file_param{properties__property__RelativePermeabilityNonWettingPhaseVanGenuchtenMualem__minimum_relative_permeability}
+        config.getConfigParameter<double>("minimum_relative_permeability");
+
+    return std::make_unique<RelPermNonWettingPhaseVanGenuchtenMualem>(
+        residual_saturation, maximum_saturation, exponent,
+        min_relative_permeability);
+}
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/RelativePermeability/CreateRelPermNonWettingPhaseVanGenuchtenMualem.h
+++ b/MaterialLib/MPL/Properties/RelativePermeability/CreateRelPermNonWettingPhaseVanGenuchtenMualem.h
@@ -1,0 +1,26 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on April 14, 2020, 3:50 PM
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace MaterialPropertyLib
+{
+class Property;
+std::unique_ptr<Property> createRelPermNonWettingPhaseVanGenuchtenMualem(
+    BaseLib::ConfigTree const& config);
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/RelativePermeability/RelPermBrooksCorey.h
+++ b/MaterialLib/MPL/Properties/RelativePermeability/RelPermBrooksCorey.h
@@ -20,7 +20,6 @@ namespace MaterialPropertyLib
 {
 class Medium;
 class Phase;
-class Component;
 /**
  * \class RelPermBrooksCorey
  * \brief Relative permeability function proposed by Brooks&Corey
@@ -48,11 +47,12 @@ public:
 
     void checkScale() const override
     {
-        if (!std::holds_alternative<Medium*>(scale_))
+        if (!std::holds_alternative<Medium*>(scale_) ||
+            !std::holds_alternative<Phase*>(scale_))
         {
             OGS_FATAL(
                 "The property 'RelPermBrooksCorey' is implemented on the "
-                "'media' scale only.");
+                "'media' or 'phase' scale only.");
         }
     }
 

--- a/MaterialLib/MPL/Properties/RelativePermeability/RelPermLiakopoulos.h
+++ b/MaterialLib/MPL/Properties/RelativePermeability/RelPermLiakopoulos.h
@@ -19,7 +19,6 @@ namespace MaterialPropertyLib
 {
 class Medium;
 class Phase;
-class Component;
 /**
  * \class RelPermLiakopoulos
  * \brief Relative permeability function for Liakopoulos Benchmark
@@ -70,11 +69,12 @@ public:
 
     void checkScale() const override
     {
-        if (!std::holds_alternative<Medium*>(scale_))
+        if (!std::holds_alternative<Medium*>(scale_) ||
+            !std::holds_alternative<Phase*>(scale_))
         {
             OGS_FATAL(
                 "The property 'RelPermLiakopoulos' is implemented on the "
-                "'media' scale only.");
+                "'media' or 'phase' scale only.");
         }
     }
 

--- a/MaterialLib/MPL/Properties/RelativePermeability/RelPermNonWettingPhaseVanGenuchtenMualem.cpp
+++ b/MaterialLib/MPL/Properties/RelativePermeability/RelPermNonWettingPhaseVanGenuchtenMualem.cpp
@@ -1,0 +1,74 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on April 1, 2020, 2:15 PM
+ */
+
+#include "RelPermNonWettingPhaseVanGenuchtenMualem.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "MaterialLib/MPL/Medium.h"
+#include "MaterialLib/MPL/Utils/CheckVanGenuchtenExponentRange.h"
+
+namespace MaterialPropertyLib
+{
+RelPermNonWettingPhaseVanGenuchtenMualem::
+    RelPermNonWettingPhaseVanGenuchtenMualem(const double Snr,
+                                             const double Snmax, const double m,
+                                             const double krel_min)
+    : S_L_res_(1. - Snmax), S_L_max(1. - Snr), m_(m), krel_min_(krel_min)
+{
+    checkVanGenuchtenExponentRange(m_);
+}
+
+PropertyDataType RelPermNonWettingPhaseVanGenuchtenMualem::value(
+    VariableArray const& variable_array,
+    ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
+    double const /*dt*/) const
+{
+    const double S_L = std::clamp(
+        std::get<double>(
+            variable_array[static_cast<int>(Variable::liquid_saturation)]),
+        S_L_res_ + minor_offset_, S_L_max - minor_offset_);
+
+    const double Se = (S_L - S_L_res_) / (S_L_max - S_L_res_);
+    const double krel =
+        std::sqrt(1.0 - Se) * std::pow(1.0 - std::pow(Se, 1.0 / m_), 2.0 * m_);
+    return std::max(krel_min_, krel);
+}
+
+PropertyDataType RelPermNonWettingPhaseVanGenuchtenMualem::dValue(
+    VariableArray const& variable_array, Variable const primary_variable,
+    ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
+    double const /*dt*/) const
+{
+    (void)primary_variable;
+    assert(
+        (primary_variable == Variable::liquid_saturation) &&
+        "RelPermNonWettingPhaseVanGenuchtenMualem::dValue is implemented for "
+        "derivatives with respect to liquid saturation only.");
+
+    const double S_L = std::get<double>(
+        variable_array[static_cast<int>(Variable::liquid_saturation)]);
+    if (S_L < S_L_res_ + minor_offset_ || S_L > S_L_max - minor_offset_)
+    {
+        return 0.0;
+    }
+
+    const double Se = (S_L - S_L_res_) / (S_L_max - S_L_res_);
+    const double val1 = std::sqrt(1.0 - Se);
+    const double val2 = 1.0 - std::pow(Se, 1.0 / m_);
+    return (-0.5 * std::pow(val2, 2.0 * m_) / val1 -
+            2.0 * std::pow(Se, -1.0 + 1.0 / m_) * val1 *
+                std::pow(val2, 2.0 * m_ - 1.0)) /
+           (S_L_max - S_L_res_);
+}
+
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/RelativePermeability/RelPermNonWettingPhaseVanGenuchtenMualem.h
+++ b/MaterialLib/MPL/Properties/RelativePermeability/RelPermNonWettingPhaseVanGenuchtenMualem.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on April 1, 2020, 2:15 PM
+ */
+
+#pragma once
+
+#include <limits>
+
+#include "BaseLib/ConfigTree.h"
+#include "MaterialLib/MPL/Property.h"
+
+namespace MaterialPropertyLib
+{
+class Phase;
+
+/**
+ *  van Genuchten-Mualem relative permeability function for non-wetting phase
+ *   \cite lenhard1987model
+ *
+ *   \f[k_{rel}^n= (1 - S_e)^{1/2} (1 - S_e^{1/m})^{2m}\f]
+ *   with
+ *   \f[S_e=\frac{S^w-S_r}{S^w_{\mbox{max}}-S^w_r}\f]
+ *   where
+ *    \f{eqnarray*}{
+ *       &S^w_r&            \mbox{residual saturation of wetting phase,}\\
+ *       &S^w_{\mbox{max}}& \mbox{maximum saturation of wetting phase,}\\
+ *       &m\, \in (0, 1) &    \mbox{ exponent.}\\
+ *    \f}
+ */
+class RelPermNonWettingPhaseVanGenuchtenMualem final : public Property
+{
+public:
+    /**
+    * @param Snr       Residual saturation of the non-wetting phase,
+    *                  \f$ S^n_r \f$
+    * @param Snmax     Maximum saturation  of the non-wetting phase,
+    *                  \f$ S^n_{\mbox{max}} \f$
+    * @param m         Exponent, \f$ m \in [0,1]\f$
+    * @param krel_min  Minimum relative permeability,
+    *                  \f$ k_{rel}^{\mbox{min}}\f$
+    */
+    RelPermNonWettingPhaseVanGenuchtenMualem(const double Snr,
+                                             const double Snmax, const double m,
+                                             const double krel_min);
+
+    void checkScale() const override
+    {
+        if (!std::holds_alternative<Phase*>(scale_))
+        {
+            OGS_FATAL(
+                "The property 'RelPermNonWettingPhaseVanGenuchtenMualem' is "
+                "implemented on the 'media' or 'Phase' scale only.");
+        }
+    }
+
+    /// \return \f$k_{rel}^n \f$.
+    PropertyDataType value(VariableArray const& variable_array,
+                           ParameterLib::SpatialPosition const& pos,
+                           double const t, double const dt) const override;
+
+    /// \return \f$ \dfrac{\partial k_{rel}^n}{\partial S^w} \f$.
+    PropertyDataType dValue(VariableArray const& variable_array,
+                            Variable const variable,
+                            ParameterLib::SpatialPosition const& pos,
+                            double const t, double const dt) const override;
+
+private:
+    /// A small number for an offset to set the bound of S, the saturation, such
+    /// that S in  [Sr+minor_offset_, Smax-minor_offset_].
+    const double minor_offset_ = 1.e-9;
+
+    const double S_L_res_;   ///< Residual saturation of wetting phase.
+    const double S_L_max;    ///< Maximum saturation of wetting phase.
+    const double m_;         ///< Exponent \f$ m \f$.
+    const double krel_min_;  ///< Minimum relative permeability
+};
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/RelativePermeability/RelPermVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/RelativePermeability/RelPermVanGenuchten.h
@@ -16,7 +16,6 @@ namespace MaterialPropertyLib
 {
 class Medium;
 class Phase;
-class Component;
 
 /// Van Genuchten relative permeability function.
 ///
@@ -39,11 +38,12 @@ public:
 
     void checkScale() const override
     {
-        if (!std::holds_alternative<Medium*>(scale_))
+        if (!std::holds_alternative<Medium*>(scale_) ||
+            !std::holds_alternative<Phase*>(scale_))
         {
             OGS_FATAL(
                 "The property 'RelativePermeabilityVanGenuchten' is "
-                "implemented on the 'media' scale only.");
+                "implemented on the 'media' or 'phase' scale only.");
         }
     }
 

--- a/MeshLib/Elements/TemplateElement-impl.h
+++ b/MeshLib/Elements/TemplateElement-impl.h
@@ -52,7 +52,7 @@ TemplateElement<ELEMENT_RULE>::TemplateElement(const TemplateElement &e)
 }
 
 
-namespace detail
+namespace details
 {
 
 template<unsigned N>
@@ -76,7 +76,7 @@ isEdge(unsigned const (&/*edge_nodes*/)[1], unsigned /*idx1*/, unsigned /*idx2*/
     return false;
 }
 
-} // namespace detail
+} // namespace details
 
 
 template <class ELEMENT_RULE>
@@ -84,7 +84,7 @@ bool TemplateElement<ELEMENT_RULE>::isEdge(unsigned idx1, unsigned idx2) const
 {
     for (unsigned i(0); i<getNumberOfEdges(); i++)
     {
-        if (detail::isEdge(ELEMENT_RULE::edge_nodes[i], idx1, idx2))
+        if (details::isEdge(ELEMENT_RULE::edge_nodes[i], idx1, idx2))
         {
             return true;
         }

--- a/Tests/BaseLib/TestConfigTree.cpp
+++ b/Tests/BaseLib/TestConfigTree.cpp
@@ -120,7 +120,7 @@ TEST(BaseLibConfigTree, Get)
             "<vector_bad1>x 1 2a</vector_bad1>"
             "<vector_bad2>0 1 2a</vector_bad2>"
             ;
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     Callbacks cbs;
     {
@@ -256,7 +256,7 @@ TEST(BaseLibConfigTree, IncompleteParse)
             "<pt x=\"0.5\">1</pt>"
             "<pt2 x=\"0.5\" y=\"1.0\" z=\"2.0\" />"
             ;
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     Callbacks cbs;
     {
@@ -297,7 +297,7 @@ TEST(BaseLibConfigTree, CheckRange)
             "<int>0</int>"
             "<int>1</int>"
             "<int>2</int>";
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     Callbacks cbs;
     {
@@ -336,7 +336,7 @@ TEST(BaseLibConfigTree, GetSubtreeList)
             "<val><int>0</int></val>"
             "<val><int>1</int></val>"
             "<val><int>2</int></val>";
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     Callbacks cbs;
     {
@@ -368,7 +368,7 @@ TEST(BaseLibConfigTree, GetParamList)
             "<int>2</int>"
             "<int2 a=\"b\">3</int2>"
             "<int3>4<error/></int3>";
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     Callbacks cbs;
     {
@@ -419,7 +419,7 @@ TEST(BaseLibConfigTree, GetValueList)
             "<int>0</int>"
             "<int>1</int>"
             "<int>2</int>";
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     Callbacks cbs;
     {
@@ -454,7 +454,7 @@ TEST(BaseLibConfigTree, NoConversion)
             "<ign/>"
             "<ign2/><ign2/><ign2/>"
             ;
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     Callbacks cbs;
     {
@@ -506,7 +506,7 @@ TEST(BaseLibConfigTree, NoConversion)
 TEST(BaseLibConfigTree, BadKeynames)
 {
     const char xml[] = "";
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     Callbacks cbs;
     {
@@ -550,7 +550,7 @@ TEST(BaseLibConfigTree, StringLiterals)
     const char xml[] =
             "<s>test</s>"
             "<t>Test</t>";
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     Callbacks cbs;
     {
@@ -576,7 +576,7 @@ TEST(BaseLibConfigTree, MoveConstruct)
             "<s>test</s>"
             "<t>Test</t>"
             "<u>data</u>";
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     Callbacks cbs;
     {
@@ -620,7 +620,7 @@ TEST(BaseLibConfigTree, MoveAssign)
             "<s>test</s>"
             "<t>Test</t>"
             "<u>data</u>";
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     Callbacks cbs;
     {

--- a/Tests/MaterialLib/TestCapillaryPressureSaturationModel.cpp
+++ b/Tests/MaterialLib/TestCapillaryPressureSaturationModel.cpp
@@ -28,7 +28,7 @@ using namespace MaterialLib::PorousMedium;
 std::unique_ptr<CapillaryPressureSaturation> createCapillaryPressureModel(
     const char xml[])
 {
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
                              BaseLib::ConfigTree::onwarning);
     auto const& sub_config = conf.getConfigSubtree("capillary_pressure");

--- a/Tests/MaterialLib/TestFluidDensity.cpp
+++ b/Tests/MaterialLib/TestFluidDensity.cpp
@@ -28,7 +28,7 @@ using ArrayType = MaterialLib::Fluid::FluidProperty::ArrayType;
 // Test density models.
 std::unique_ptr<FluidProperty> createTestFluidDensityModel(const char xml[])
 {
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
                              BaseLib::ConfigTree::onwarning);
     auto const& sub_config = conf.getConfigSubtree("density");

--- a/Tests/MaterialLib/TestFluidProperties.cpp
+++ b/Tests/MaterialLib/TestFluidProperties.cpp
@@ -30,7 +30,7 @@ using ArrayType = MaterialLib::Fluid::FluidProperty::ArrayType;
 
 std::unique_ptr<FluidProperties> createTestFluidProperties(const char xml[])
 {
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
                              BaseLib::ConfigTree::onwarning);
     auto const& sub_config = conf.getConfigSubtree("fluid");

--- a/Tests/MaterialLib/TestFluidSpecificHeatCapacityModel.cpp
+++ b/Tests/MaterialLib/TestFluidSpecificHeatCapacityModel.cpp
@@ -30,7 +30,7 @@ using ArrayType = MaterialLib::Fluid::FluidProperty::ArrayType;
 std::unique_ptr<FluidProperty> createSpecificFluidHeatCapacityModel(
     const char xml[])
 {
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
                              BaseLib::ConfigTree::onwarning);
     auto const& sub_config = conf.getConfigSubtree("specific_heat_capacity");

--- a/Tests/MaterialLib/TestFluidThermalConductivityModel.cpp
+++ b/Tests/MaterialLib/TestFluidThermalConductivityModel.cpp
@@ -31,7 +31,7 @@ using ArrayType = MaterialLib::Fluid::FluidProperty::ArrayType;
 std::unique_ptr<FluidProperty> createFluidThermalConductivityModel(
     const char xml[])
 {
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
                              BaseLib::ConfigTree::onwarning);
     auto const& sub_config = conf.getConfigSubtree("thermal_conductivity");

--- a/Tests/MaterialLib/TestFluidViscosity.cpp
+++ b/Tests/MaterialLib/TestFluidViscosity.cpp
@@ -27,7 +27,7 @@ using ArrayType = MaterialLib::Fluid::FluidProperty::ArrayType;
 
 std::unique_ptr<FluidProperty> createTestViscosityModel(const char xml[])
 {
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
                              BaseLib::ConfigTree::onwarning);
     auto const& sub_config = conf.getConfigSubtree("viscosity");

--- a/Tests/MaterialLib/TestMPL.cpp
+++ b/Tests/MaterialLib/TestMPL.cpp
@@ -32,3 +32,24 @@ std::unique_ptr<MPL::Medium> createTestMaterial(std::string const& xml)
 
     return MPL::createMedium(config, parameters, nullptr, curves);
 }
+
+namespace Tests
+{
+std::unique_ptr<MaterialPropertyLib::Property> createTestProperty(
+    const char xml[],
+    std::function<std::unique_ptr<MaterialPropertyLib::Property>(
+        BaseLib::ConfigTree const& config)>
+        createProperty)
+{
+    auto const ptree = readXml(xml);
+    BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
+                             BaseLib::ConfigTree::onwarning);
+    auto const& sub_config = conf.getConfigSubtree("property");
+    // Parsing the property name:
+    auto const property_name =
+        sub_config.getConfigParameter<std::string>("name");
+
+    return createProperty(sub_config);
+}
+
+}  // namespace Tests

--- a/Tests/MaterialLib/TestMPL.cpp
+++ b/Tests/MaterialLib/TestMPL.cpp
@@ -18,12 +18,13 @@
 #include "MaterialLib/MPL/CreateMedium.h"
 #include "MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h"
 #include "ParameterLib/Parameter.h"
+#include "Tests/TestTools.h"
 
 namespace Tests
 {
 std::unique_ptr<MPL::Medium> createTestMaterial(std::string const& xml)
 {
-    auto const ptree = readXml(xml.c_str());
+    auto const ptree = Tests::readXml(xml.c_str());
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
                              BaseLib::ConfigTree::onwarning);
     auto const& config = conf.getConfigSubtree("medium");
@@ -41,7 +42,7 @@ std::unique_ptr<MaterialPropertyLib::Property> createTestProperty(
         BaseLib::ConfigTree const& config)>
         createProperty)
 {
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
                              BaseLib::ConfigTree::onwarning);
     auto const& sub_config = conf.getConfigSubtree("property");

--- a/Tests/MaterialLib/TestMPL.cpp
+++ b/Tests/MaterialLib/TestMPL.cpp
@@ -19,6 +19,8 @@
 #include "MathLib/InterpolationAlgorithms/PiecewiseLinearInterpolation.h"
 #include "ParameterLib/Parameter.h"
 
+namespace Tests
+{
 std::unique_ptr<MPL::Medium> createTestMaterial(std::string const& xml)
 {
     auto const ptree = readXml(xml.c_str());
@@ -33,8 +35,6 @@ std::unique_ptr<MPL::Medium> createTestMaterial(std::string const& xml)
     return MPL::createMedium(config, parameters, nullptr, curves);
 }
 
-namespace Tests
-{
 std::unique_ptr<MaterialPropertyLib::Property> createTestProperty(
     const char xml[],
     std::function<std::unique_ptr<MaterialPropertyLib::Property>(

--- a/Tests/MaterialLib/TestMPL.h
+++ b/Tests/MaterialLib/TestMPL.h
@@ -13,9 +13,31 @@
 
 #pragma once
 
-#include "Tests/TestTools.h"
+#include <functional>
+#include <memory>
 
 #include "MaterialLib/MPL/Medium.h"
+
 namespace MPL = MaterialPropertyLib;
 
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace MaterialPropertyLib
+{
+class Property;
+}
+
 std::unique_ptr<MPL::Medium> createTestMaterial(std::string const& xml);
+
+namespace Tests
+{
+std::unique_ptr<MaterialPropertyLib::Property> createTestProperty(
+    const char xml[],
+    std::function<std::unique_ptr<MaterialPropertyLib::Property>(
+        BaseLib::ConfigTree const& config)>
+        createProperty);
+
+}  // namespace Tests

--- a/Tests/MaterialLib/TestMPL.h
+++ b/Tests/MaterialLib/TestMPL.h
@@ -30,10 +30,10 @@ namespace MaterialPropertyLib
 class Property;
 }
 
-std::unique_ptr<MPL::Medium> createTestMaterial(std::string const& xml);
-
 namespace Tests
 {
+std::unique_ptr<MPL::Medium> createTestMaterial(std::string const& xml);
+
 std::unique_ptr<MaterialPropertyLib::Property> createTestProperty(
     const char xml[],
     std::function<std::unique_ptr<MaterialPropertyLib::Property>(

--- a/Tests/MaterialLib/TestMPLCapillaryPressureRegularizedVanGenuchten.cpp
+++ b/Tests/MaterialLib/TestMPLCapillaryPressureRegularizedVanGenuchten.cpp
@@ -27,23 +27,6 @@
 
 namespace MPL = MaterialPropertyLib;
 
-std::unique_ptr<MaterialPropertyLib::Property> createTestProperty(
-    const char xml[],
-    std::function<std::unique_ptr<MaterialPropertyLib::Property>(
-        BaseLib::ConfigTree const& config)>
-        createProperty)
-{
-    auto const ptree = readXml(xml);
-    BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
-                             BaseLib::ConfigTree::onwarning);
-    auto const& sub_config = conf.getConfigSubtree("property");
-    // Parsing the property name:
-    auto const property_name =
-        sub_config.getConfigParameter<std::string>("name");
-
-    return createProperty(sub_config);
-}
-
 TEST(MaterialPropertyLib, CapillaryPressureRegularizedVanGenuchten)
 {
     const char xml_pc_S[] =
@@ -55,7 +38,7 @@ TEST(MaterialPropertyLib, CapillaryPressureRegularizedVanGenuchten)
         "   <exponent>0.6</exponent>"
         "   <p_b>1.e+4</p_b>"
         "</property>";
-    auto const capillary_pressure_property_ptr = createTestProperty(
+    auto const capillary_pressure_property_ptr = Tests::createTestProperty(
         xml_pc_S, MPL::createCapillaryPressureRegularizedVanGenuchten);
 
     MPL::Property const& capillary_pressure_property =

--- a/Tests/MaterialLib/TestMPLIdealGasLaw.cpp
+++ b/Tests/MaterialLib/TestMPLIdealGasLaw.cpp
@@ -56,7 +56,7 @@ TEST(MaterialPropertyLib, IdealGasLawOfPurePhase)
     m << "<properties></properties>\n";
     m << "</medium>\n";
 
-    auto const& medium = createTestMaterial(m.str());
+    auto const& medium = Tests::createTestMaterial(m.str());
     auto const& gas_phase = medium->phase("Gas");
 
     MaterialPropertyLib::VariableArray variable_array;

--- a/Tests/MaterialLib/TestMPLParseMaterial.cpp
+++ b/Tests/MaterialLib/TestMPLParseMaterial.cpp
@@ -243,7 +243,7 @@ TEST(Material, parseMaterials)
     medium.property[MPL::permeability] = "1.0e-12";
 
     // create an actual MaterialProperty-Medium out of the specifier object
-    auto const m = createTestMaterial(makeMedium(medium));
+    auto const m = Tests::createTestMaterial(makeMedium(medium));
 
     // those two vectors will actually be compared
     std::vector<std::string> expected;

--- a/Tests/MaterialLib/TestMPLRelPermBrooksCorey.cpp
+++ b/Tests/MaterialLib/TestMPLRelPermBrooksCorey.cpp
@@ -90,7 +90,7 @@ TEST(MaterialPropertyLib, RelPermBrooksCorey)
         std::stringstream m;
         m << m_beg.str() << m_sat.str() << m_end.str();
 
-        auto const& medium = createTestMaterial(m.str());
+        auto const& medium = Tests::createTestMaterial(m.str());
         MaterialPropertyLib::VariableArray variable_array;
         ParameterLib::SpatialPosition const pos;
         double const time = std::numeric_limits<double>::quiet_NaN();

--- a/Tests/MaterialLib/TestMPLRelPermLiakopoulos.cpp
+++ b/Tests/MaterialLib/TestMPLRelPermLiakopoulos.cpp
@@ -77,7 +77,7 @@ TEST(MaterialPropertyLib, RelPermLiakopoulos)
         std::stringstream m;
         m << m_beg.str() << m_sat.str() << m_end.str();
 
-        auto const& medium = createTestMaterial(m.str());
+        auto const& medium = Tests::createTestMaterial(m.str());
         MaterialPropertyLib::VariableArray variable_array;
         ParameterLib::SpatialPosition const pos;
         double const time = std::numeric_limits<double>::quiet_NaN();

--- a/Tests/MaterialLib/TestMPLRelPermNonWettingPhaseVanGenuchtenMualem.cpp
+++ b/Tests/MaterialLib/TestMPLRelPermNonWettingPhaseVanGenuchtenMualem.cpp
@@ -1,0 +1,81 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ *  Created on March 27, 2020, 4:01 PM
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <functional>
+#include <limits>
+#include <random>
+
+#include "BaseLib/ConfigTree.h"
+
+#include "MaterialLib/MPL/Medium.h"
+#include "MaterialLib/MPL/Properties/RelativePermeability/CreateRelPermNonWettingPhaseVanGenuchtenMualem.h"
+#include "MaterialLib/MPL/Properties/RelativePermeability/RelPermNonWettingPhaseVanGenuchtenMualem.h"
+
+#include "TestMPL.h"
+#include "Tests/TestTools.h"
+
+TEST(MaterialPropertyLib, RelPermNonWettingPhaseVanGenuchtenMualem)
+{
+    const char xml[] =
+        "<property>"
+        "   <name>relative_permeability</name>"
+        "   <type>RelativePermeabilityNonWettingPhaseVanGenuchtenMualem</type>"
+        "   <residual_saturation>0.1</residual_saturation>"
+        "   <maximum_saturation>1.0</maximum_saturation>"
+        "   <exponent>0.5</exponent>"
+        "<minimum_relative_permeability>1.e-9</minimum_relative_permeability>"
+        "</property>";
+
+    std::unique_ptr<MPL::Property> const perm_ptr = Tests::createTestProperty(
+        xml, MPL::createRelPermNonWettingPhaseVanGenuchtenMualem);
+    MPL::Property const& perm_model = *perm_ptr;
+
+    std::vector<double> const S = {0.2, 0.33, 0.45, 0.52, 0.6, 0.85};
+    std::vector<double> const expected_krel = {
+        8.38365641777669e-01, 6.88828521847265e-01, 5.30330085889911e-01,
+        4.32869977650940e-01, 3.20750149549792e-01, 2.54616639316144e-02};
+
+    const double perturbation = 1.e-8;
+    for (std::size_t i = 0; i < S.size(); i++)
+    {
+        MPL::VariableArray variable_array;
+        ParameterLib::SpatialPosition const pos;
+        double const t = std::numeric_limits<double>::quiet_NaN();
+        double const dt = std::numeric_limits<double>::quiet_NaN();
+        variable_array[static_cast<int>(MPL::Variable::liquid_saturation)] =
+            S[i];
+
+        const double k_rel_i =
+            perm_model.template value<double>(variable_array, pos, t, dt);
+
+        ASSERT_NEAR(expected_krel[i], k_rel_i, 1.e-9);
+
+        const double dkrel_dS = perm_model.template dValue<double>(
+            variable_array, MaterialPropertyLib::Variable::liquid_saturation,
+            pos, t, dt);
+        variable_array[static_cast<int>(MPL::Variable::liquid_saturation)] =
+            S[i] - perturbation;
+        const double k_rel_i_0 =
+            perm_model.template value<double>(variable_array, pos, t, dt);
+        variable_array[static_cast<int>(MPL::Variable::liquid_saturation)] =
+            S[i] + perturbation;
+        const double k_rel_i_1 =
+            perm_model.template value<double>(variable_array, pos, t, dt);
+
+        // Compare the derivative with numerical one.
+        ASSERT_NEAR(dkrel_dS, 0.5 * (k_rel_i_1 - k_rel_i_0) / perturbation,
+                    1.e-8);
+    }
+}

--- a/Tests/MaterialLib/TestMPLSaturationBrooksCorey.cpp
+++ b/Tests/MaterialLib/TestMPLSaturationBrooksCorey.cpp
@@ -43,7 +43,7 @@ TEST(MaterialPropertyLib, SaturationBrooksCorey)
     m << "</properties>\n";
     m << "</medium>\n";
 
-    auto const& medium = createTestMaterial(m.str());
+    auto const& medium = Tests::createTestMaterial(m.str());
 
     MaterialPropertyLib::VariableArray variable_array;
     ParameterLib::SpatialPosition const pos;

--- a/Tests/MaterialLib/TestMPLSaturationLiakopoulos.cpp
+++ b/Tests/MaterialLib/TestMPLSaturationLiakopoulos.cpp
@@ -30,7 +30,7 @@ TEST(MaterialPropertyLib, SaturationLiakopoulos)
     m << "</properties>\n";
     m << "</medium>\n";
 
-    auto const& medium = createTestMaterial(m.str());
+    auto const& medium = Tests::createTestMaterial(m.str());
 
     MaterialPropertyLib::VariableArray variable_array;
     ParameterLib::SpatialPosition const pos;

--- a/Tests/MaterialLib/TestPorousMediumStorage.cpp
+++ b/Tests/MaterialLib/TestPorousMediumStorage.cpp
@@ -24,7 +24,7 @@ using namespace MaterialLib::PorousMedium;
 
 std::unique_ptr<Storage> createTestStorageModel(const char xml[])
 {
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
                              BaseLib::ConfigTree::onwarning);
     auto const& sub_config = conf.getConfigSubtree("storage");

--- a/Tests/MaterialLib/TestRelativePermeabilityModel.cpp
+++ b/Tests/MaterialLib/TestRelativePermeabilityModel.cpp
@@ -28,7 +28,7 @@ using namespace MaterialLib::PorousMedium;
 std::unique_ptr<RelativePermeability> createRelativePermeabilityModel(
     const char xml[])
 {
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
                              BaseLib::ConfigTree::onwarning);
     auto const& sub_config = conf.getConfigSubtree("relative_permeability");

--- a/Tests/MathLib/TestLinearSolver.cpp
+++ b/Tests/MathLib/TestLinearSolver.cpp
@@ -283,7 +283,7 @@ TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_basic)
             "  </parameters>"
             "  <prefix>ptest1</prefix>"
             "</petsc>";
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     checkLinearSolverInterface<MathLib::PETScMatrix,
                                MathLib::PETScVector,
@@ -317,7 +317,7 @@ TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_chebyshev_sor)
             "  </parameters>"
             "  <prefix>ptest2</prefix>"
             "</petsc>";
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     checkLinearSolverInterface<MathLib::PETScMatrix,
                                MathLib::PETScVector,
@@ -353,7 +353,7 @@ TEST(MPITest_Math, CheckInterface_PETSc_Linear_Solver_gmres_amg)
             "  </parameters>"
             "  <prefix>ptest3</prefix>"
             "</petsc>";
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
 
     checkLinearSolverInterface<MathLib::PETScMatrix,
                                MathLib::PETScVector,

--- a/Tests/MathLib/TestPiecewiseLinearCurve.cpp
+++ b/Tests/MathLib/TestPiecewiseLinearCurve.cpp
@@ -24,7 +24,7 @@
 template <typename CurveType>
 std::unique_ptr<CurveType> createPiecewiseLinearCurve(const char xml[])
 {
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
                              BaseLib::ConfigTree::onwarning);
     auto const& sub_config = conf.getConfigSubtree("curve");

--- a/Tests/NumLib/TestODEInt.cpp
+++ b/Tests/NumLib/TestODEInt.cpp
@@ -41,7 +41,7 @@ createLinearSolver()
         "<petsc><parameters>"
         "-ksp_type bcgs -pc_type sor -ksp_rtol 1e-24 -ksp_max_it 100 -ksp_initial_guess_nonzero false"
         "</parameters></petsc>";
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
     BaseLib::ConfigTree config(ptree, "", BaseLib::ConfigTree::onerror,
                                BaseLib::ConfigTree::onwarning);
     return std::make_unique<GlobalLinearSolver>("", &config);

--- a/Tests/NumLib/TestTimeSteppingEvolutionaryPIDcontroller.cpp
+++ b/Tests/NumLib/TestTimeSteppingEvolutionaryPIDcontroller.cpp
@@ -25,7 +25,7 @@
 std::unique_ptr<NumLib::TimeStepAlgorithm> createTestTimeStepper(
     const char xml[])
 {
-    auto const ptree = readXml(xml);
+    auto const ptree = Tests::readXml(xml);
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
                              BaseLib::ConfigTree::onwarning);
     auto const& sub_config = conf.getConfigSubtree("time_stepping");

--- a/Tests/ParameterLib/Parameter.cpp
+++ b/Tests/ParameterLib/Parameter.cpp
@@ -35,7 +35,7 @@ std::unique_ptr<Parameter<double>> constructParameterFromString(
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>> const&
         curves = {})
 {
-    auto const xml_ptree = readXml(xml.c_str());
+    auto const xml_ptree = Tests::readXml(xml.c_str());
     BaseLib::ConfigTree config_tree(xml_ptree, "", BaseLib::ConfigTree::onerror,
                                     BaseLib::ConfigTree::onwarning);
     auto parameter_base = createParameter(config_tree, meshes, curves);

--- a/Tests/TestTools.cpp
+++ b/Tests/TestTools.cpp
@@ -11,14 +11,16 @@
 
 #include "Tests/TestTools.h"
 
-boost::property_tree::ptree
-readXml(const char xml[])
+namespace Tests
+{
+boost::property_tree::ptree readXml(const char xml[])
 {
     boost::property_tree::ptree ptree;
     std::istringstream xml_str(xml);
     boost::property_tree::read_xml(
-        xml_str, ptree,
-        boost::property_tree::xml_parser::no_comments |
-        boost::property_tree::xml_parser::trim_whitespace);
+        xml_str, ptree, boost::property_tree::xml_parser::no_comments |
+                            boost::property_tree::xml_parser::trim_whitespace);
     return ptree;
 }
+
+}  // namespace Tests

--- a/Tests/TestTools.h
+++ b/Tests/TestTools.h
@@ -24,6 +24,7 @@
 #define ASSERT_ARRAY_EQ(E,A,N)\
     for (std::size_t i=0; i<(unsigned)(N); i++) \
         ASSERT_EQ((E)[i], (A)[i]);
-
-boost::property_tree::ptree
-readXml(const char xml[]);
+namespace Tests
+{
+boost::property_tree::ptree readXml(const char xml[]);
+}  // namespace Tests


### PR DESCRIPTION
As titled, the PR presents the van Genuchten Maulem model for the relative permeability of wetting phase.

Besides,  this PR allows use  `relative_permeability` as  phase property (see issue  #2904).

1. [ ] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.1)? not yet
2. [x] Tests covering your feature were added? Yes, there is an unit test.
![k_rel_vanGenuchtenMaulem](https://user-images.githubusercontent.com/1343839/83623741-01123480-a592-11ea-96ea-39d6b7f38c2f.png)


3. [x] Any new feature or behavior change was documented? Yes, it was.
