### PR TITLE
Add prism element type to structure mesh generator tool.

### DIFF
--- a/Applications/Utils/SimpleMeshCreation/generateStructuredMesh.cpp
+++ b/Applications/Utils/SimpleMeshCreation/generateStructuredMesh.cpp
@@ -77,10 +77,13 @@ int main (int argc, char* argv[])
     allowed_ele_types.emplace_back("tri");
     allowed_ele_types.emplace_back("quad");
     allowed_ele_types.emplace_back("hex");
+    allowed_ele_types.emplace_back("prism");
     allowed_ele_types.emplace_back("tet");
     TCLAP::ValuesConstraint<std::string> allowedVals(allowed_ele_types);
-    TCLAP::ValueArg<std::string> eleTypeArg("e", "element-type",
-                                          "element type to be created: line | tri | quad | hex | tet", true, "line", &allowedVals);
+    TCLAP::ValueArg<std::string> eleTypeArg(
+        "e", "element-type",
+        "element type to be created: line | tri | quad | hex | prism | tet",
+        true, "line", &allowedVals);
     cmd.add(eleTypeArg);
     TCLAP::ValueArg<std::string> mesh_out("o", "mesh-output-file",
                                           "the name of the file the mesh will be written to", true,
@@ -220,6 +223,11 @@ int main (int argc, char* argv[])
         break;
     case MeshLib::MeshElemType::HEXAHEDRON:
         mesh.reset(MeshLib::MeshGenerator::generateRegularHexMesh(*vec_div[0], *vec_div[1], *vec_div[2]));
+        break;
+    case MeshLib::MeshElemType::PRISM:
+        mesh.reset(MeshLib::MeshGenerator::generateRegularPrismMesh(
+            length[0], length[1], length[2], n_subdivision[0], n_subdivision[1],
+            n_subdivision[2]));
         break;
     case MeshLib::MeshElemType::TETRAHEDRON:
         mesh.reset(MeshLib::MeshGenerator::generateRegularTetMesh(*vec_div[0], *vec_div[1], *vec_div[2]));

--- a/MeshLib/MeshEnums.cpp
+++ b/MeshLib/MeshEnums.cpp
@@ -14,6 +14,8 @@
 
 #include "MeshEnums.h"
 
+#include <boost/algorithm/string/predicate.hpp>
+
 namespace MeshLib {
 std::string MeshElemType2String(const MeshElemType t)
 {
@@ -91,35 +93,35 @@ std::string MeshElemType2StringShort(const MeshElemType t)
 
 MeshElemType String2MeshElemType(const std::string &s)
 {
-    if (s == "point" || s == "Point")
+    if (boost::iequals(s, "point"))
     {
         return MeshElemType::POINT;
     }
-    if (s == "line" || s == "Line")
+    if (boost::iequals(s, "line"))
     {
         return MeshElemType::LINE;
     }
-    if (s == "quad" || s == "Quadrilateral")
+    if (boost::iequals(s, "quad") || boost::iequals(s, "Quadrilateral"))
     {
         return MeshElemType::QUAD;
     }
-    if (s == "hex" || s == "Hexahedron")
+    if (boost::iequals(s, "hex") || boost::iequals(s, "Hexahedron"))
     {
         return MeshElemType::HEXAHEDRON;
     }
-    if (s == "tri" || s == "Triangle")
+    if (boost::iequals(s, "tri") || boost::iequals(s, "Triangle"))
     {
         return MeshElemType::TRIANGLE;
     }
-    if (s == "tet" || s == "Tetrahedron")
+    if (boost::iequals(s, "tet") || boost::iequals(s, "Tetrahedron"))
     {
         return MeshElemType::TETRAHEDRON;
     }
-    if (s == "pris" || s == "Prism")
+    if (boost::iequals(s, "pris") || boost::iequals(s, "Prism"))
     {
         return MeshElemType::PRISM;
     }
-    if (s == "pyra" || s == "Pyramid")
+    if (boost::iequals(s, "pyra") || boost::iequals(s, "Pyramid"))
     {
         return MeshElemType::PYRAMID;
     }

--- a/MeshLib/MeshGenerators/MeshGenerator.h
+++ b/MeshLib/MeshGenerators/MeshGenerator.h
@@ -396,7 +396,7 @@ Mesh* generateRegularPrismMesh(const double x_length,
                                std::string   const& mesh_name = "mesh");
 
 /**
- * Generate a regular 2D Triangle-Element mesh.
+ * Generate a regular 3D Prism-Element mesh.
  *
  * \param n_x_cells Number of cells in x-direction.
  * \param n_y_cells Number of cells in y-direction.
@@ -413,7 +413,7 @@ Mesh* generateRegularPrismMesh(const unsigned n_x_cells,
                                std::string   const& mesh_name = "mesh");
 
 /**
- * Generate a regular 2D Triangle-Element mesh.
+ * Generate a regular 3D Prism-Element mesh.
  *
  * \param n_x_cells    Number of cells in x-direction.
  * \param n_y_cells    Number of cells in y-direction.


### PR DESCRIPTION
This allows to generate tests for the prism element.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.1)
2. [x] Tests covering your feature were added?
  The feature is tested already in `Tests/MeshLib/TestMeshGenerator.cpp`
3. [x] Any new feature or behavior change was documented?
  Command line help is updated.
