### PR TITLE
Clang-tidy cleanups.

### DIFF
--- a/Applications/FileIO/CsvInterface.cpp
+++ b/Applications/FileIO/CsvInterface.cpp
@@ -88,7 +88,7 @@ int CsvInterface::readPoints(std::string const& fname, char delim,
             continue;
         }
         it = fields.begin();
-        std::array<double, 3> point;
+        std::array<double, 3> point{};
         try {
             point[0] = std::stod(*it);
             point[1] = std::stod(*(++it));
@@ -189,7 +189,7 @@ int CsvInterface::readPoints(std::ifstream &in, char delim,
             continue;
         }
 
-        std::array<double, 3> point;
+        std::array<double, 3> point{};
         it = fields.begin();
         try {
             std::advance(it, column_advance[0]);

--- a/Applications/FileIO/GMSInterface.cpp
+++ b/Applications/FileIO/GMSInterface.cpp
@@ -90,10 +90,12 @@ int GMSInterface::readBoreholesFromGMS(std::vector<GeoLib::Point*>* boreholes,
                     depth = pnt[2];
                 }
                 else
+                {
                     WARN(
                         "GMSInterface::readBoreholeFromGMS(): Skipped layer "
                         "'{:s}' in borehole '{:s}' because of thickness 0.0.",
                         sName, cName);
+                }
             }
             else  // add new borehole
             {
@@ -317,8 +319,10 @@ MeshLib::Mesh* GMSInterface::readGMS3DMMesh(const std::string& filename)
                   std::back_inserter(*opt_pv));
     }
     else
+    {
         ERR("Ignoring Material IDs information (does not match number of "
             "elements).");
+    }
     return new MeshLib::Mesh(mesh_name, nodes, elements, properties);
 }
 

--- a/Applications/FileIO/GocadIO/CoordinateSystem.cpp
+++ b/Applications/FileIO/GocadIO/CoordinateSystem.cpp
@@ -100,8 +100,10 @@ bool CoordinateSystem::parse(std::istream& in)
             return true;
         }
         else
+        {
             WARN("CoordinateSystem::parse() - Unknown keyword found: {:s}",
                  line);
+        }
     }
     ERR ("Error: Unexpected end of file.");
     return false;

--- a/Applications/FileIO/GocadIO/CoordinateSystem.h
+++ b/Applications/FileIO/GocadIO/CoordinateSystem.h
@@ -30,7 +30,7 @@ public:
     std::string datum;
     std::string axis_name_u, axis_name_v, axis_name_w;
     std::string axis_unit_u, axis_unit_v, axis_unit_w;
-    ZPOSITIVE z_positive;
+    ZPOSITIVE z_positive = ZPOSITIVE::Elevation;
 };
 
 std::ostream& operator<<(std::ostream& os, CoordinateSystem const& c);

--- a/Applications/FileIO/GocadIO/GocadAsciiReader.cpp
+++ b/Applications/FileIO/GocadIO/GocadAsciiReader.cpp
@@ -245,7 +245,7 @@ MeshLib::Node* createNode(std::stringstream& sstr)
 {
     std::string keyword;
     std::size_t id;
-    std::array<double, 3> data;
+    std::array<double, 3> data{};
     sstr >> keyword >> id >> data[0] >> data[1] >> data[2];
     return new MeshLib::Node(data, id);
 }
@@ -352,9 +352,9 @@ bool parseLineSegments(std::ifstream& in,
         {
             std::stringstream sstr(line);
             std::string keyword;
-            std::array<std::size_t, 2> data;
+            std::array<std::size_t, 2> data{};
             sstr >> keyword >> data[0] >> data[1];
-            std::array<MeshLib::Node*, 2> elem_nodes;
+            std::array<MeshLib::Node*, 2> elem_nodes{};
             for (std::size_t i = 0; i < 2; ++i)
             {
                 auto const it = node_id_map.find(data[i]);
@@ -443,9 +443,9 @@ bool parseElements(std::ifstream& in,
         {
             std::stringstream sstr(line);
             std::string keyword;
-            std::array<std::size_t, 3> data;
+            std::array<std::size_t, 3> data{};
             sstr >> keyword >> data[0] >> data[1] >> data[2];
-            std::array<MeshLib::Node*, 3> elem_nodes;
+            std::array<MeshLib::Node*, 3> elem_nodes{};
             for (std::size_t i = 0; i < 3; ++i)
             {
                 auto const it = node_id_map.find(data[i]);

--- a/Applications/FileIO/GocadIO/GocadSGridReader.cpp
+++ b/Applications/FileIO/GocadIO/GocadSGridReader.cpp
@@ -346,11 +346,17 @@ void GocadSGridReader::parseFaceSet(std::string& line, std::istream& in)
                 std::array<std::size_t, 3> const c(
                     _index_calculator.getCoordsForID(id));
                 if (c[0] >= _index_calculator._x_dim - 1)
+                {
                     ERR("****** i coord {:d} to big for id {:d}.", c[0], id);
+                }
                 if (c[1] >= _index_calculator._y_dim - 1)
+                {
                     ERR("****** j coord {:d} to big for id {:d}.", c[1], id);
+                }
                 if (c[2] >= _index_calculator._z_dim - 1)
+                {
                     ERR("****** k coord {:d} to big for id {:d}.", c[2], id);
+                }
                 std::size_t const cell_id(
                     _index_calculator.getCellIdx(c[0], c[1], c[2]));
                 face_set_property._property_data[cell_id] =
@@ -435,9 +441,11 @@ void GocadSGridReader::readNodesBinary()
         k++;
     }
     if (k != n * 3 && !in.eof())
+    {
         ERR("Read different number of points. Expected {:d} floats, got "
             "{:d}.\n",
             n * 3, k);
+    }
 }
 
 void GocadSGridReader::mapRegionFlagsToCellProperties(
@@ -540,9 +548,10 @@ std::vector<Bitset> GocadSGridReader::readRegionFlagsBinary() const
         result[k++] = readBits(in, regions.size());
     }
     if (k != n && !in.eof())
+    {
         ERR("Read different number of values. Expected {:d}, got {:d}.\n", n,
             k);
-
+    }
     return result;
 }
 std::vector<MeshLib::Element*> GocadSGridReader::createElements(

--- a/Applications/FileIO/Legacy/OGSIOVer4.cpp
+++ b/Applications/FileIO/Legacy/OGSIOVer4.cpp
@@ -101,10 +101,12 @@ std::string readPoints(std::istream &in, std::vector<GeoLib::Point*>* pnt_vec,
 
             std::size_t id_pos (line.find("$ID"));
             if (id_pos != std::string::npos)
+            {
                 WARN(
                     "readPoints(): found tag $ID - please use tag $NAME for "
                     "reading point names in point {:d}.",
                     cnt);
+            }
             cnt++;
         }
         getline(in, line);
@@ -541,7 +543,9 @@ bool readGLIFileV4(const std::string& fname,
              ply_vec->size());
     }
     else
+    {
         INFO("GeoLib::readGLIFile(): tag #POLYLINE not found.");
+    }
 
     if (!ply_vec->empty())
     {

--- a/Applications/FileIO/Legacy/createSurface.cpp
+++ b/Applications/FileIO/Legacy/createSurface.cpp
@@ -106,7 +106,9 @@ bool createSurface(GeoLib::Polyline const& ply,
         return false;
     }
     if (!(fs::remove(geo_file) && fs::remove(msh_file)))
+    {
         WARN("Could not remove temporary files in createSurface.");
+    }
 
     // convert the surface mesh into a geometric surface
     if (!MeshLib::convertMeshToGeo(*surface_mesh, geometries,

--- a/Applications/FileIO/PetrelInterface.cpp
+++ b/Applications/FileIO/PetrelInterface.cpp
@@ -45,10 +45,12 @@ PetrelInterface::PetrelInterface(std::list<std::string> &sfc_fnames,
             in.close();
         }
         else
+        {
             WARN(
                 "PetrelInterface::PetrelInterface(): \tCould not open file "
                 "{:s}.",
                 it->c_str());
+        }
     }
 
     for (std::list<std::string>::const_iterator it(well_path_fnames.begin()); it
@@ -63,10 +65,12 @@ PetrelInterface::PetrelInterface(std::list<std::string> &sfc_fnames,
             in.close();
         }
         else
+        {
             WARN(
                 "PetrelInterface::PetrelInterface(): \tCould not open well "
                 "path file {:s}.",
                 it->c_str());
+        }
     }
 
     // store data in GEOObject
@@ -124,11 +128,14 @@ void PetrelInterface::readPetrelSurface(std::istream &in)
                 idx++;
             }
         }
-    } else
+    }
+    else
+    {
         WARN(
             "PetrelInterface::readPetrelSurface(): problem reading petrel "
             "points from line\n'{:s}'.",
             line);
+    }
 }
 
 void PetrelInterface::readPetrelWellTrace(std::istream &in)

--- a/Applications/FileIO/TetGenInterface.cpp
+++ b/Applications/FileIO/TetGenInterface.cpp
@@ -215,11 +215,15 @@ MeshLib::Mesh* TetGenInterface::readTetGenMesh (std::string const& nodes_fname,
     if (!ins_nodes || !ins_ele)
     {
         if (!ins_nodes)
+        {
             ERR("TetGenInterface::readTetGenMesh failed to open {:s}",
                 nodes_fname);
+        }
         if (!ins_ele)
+        {
             ERR("TetGenInterface::readTetGenMesh failed to open {:s}",
                 ele_fname);
+        }
         return nullptr;
     }
 
@@ -591,8 +595,10 @@ bool TetGenInterface::writeTetGenSmesh(const std::string &file_name,
         return false;
     }
     if (surfaces==nullptr)
+    {
         WARN("No surfaces found for geometry {:s}. Writing points only.",
              geo_name);
+    }
 
     std::ofstream out( file_name.c_str(), std::ios::out );
     out.precision(std::numeric_limits<double>::digits10);

--- a/BaseLib/DateTools.cpp
+++ b/BaseLib/DateTools.cpp
@@ -75,11 +75,15 @@ std::string date2string(double ddate)
     rest = rest % (y * 10000);
     auto m = static_cast<int>(std::floor(rest / 100.0));
     if (m < 1 || m > 12)
+    {
         WARN("date2String(): month not in [1:12].");
+    }
     rest = rest % (m * 100);
     int d = rest;
     if (d < 1 || d > 31)
+    {
         WARN("date2String(): day not in [1:31].");
+    }
 
     std::string day = std::to_string(d);
     if (d < 10)
@@ -116,10 +120,14 @@ int xmlDate2int(const std::string &s)
     {
         int d = atoi(s.substr(8,2).c_str());
         if (d < 1 || d > 31)
+        {
             WARN("xmlDate2double(): day not in [1:31].");
+        }
         int m = atoi(s.substr(5,2).c_str());
         if (m < 1 || m > 12)
+        {
             WARN("xmlDate2double(): month not in [1:12].");
+        }
         int y = atoi(s.substr(0,4).c_str());
         return date2int(y, m, d);
     }

--- a/BaseLib/FileTools.h
+++ b/BaseLib/FileTools.h
@@ -101,7 +101,9 @@ std::vector<T> readBinaryArray(std::string const& filename, std::size_t const n)
         result.size());
 
     if (!in.eof())
+    {
         ERR("EOF reached.\n");
+    }
 
     return std::vector<T>();
 }

--- a/BaseLib/Histogram.h
+++ b/BaseLib/Histogram.h
@@ -49,7 +49,7 @@ public:
     template <typename InputIterator>
     Histogram(InputIterator first, InputIterator last, const int nr_bins = 16,
               const bool computeHistogram = true )
-        : _data(first, last), _nr_bins(nr_bins)
+        : _data(first, last), _nr_bins(nr_bins), _dirty(true)
     {
         init(computeHistogram);
     }
@@ -62,7 +62,7 @@ public:
      */
     explicit Histogram(std::vector<T> data, const unsigned int nr_bins = 16,
                        const bool computeHistogram = true)
-        : _data(std::move(data)), _nr_bins(nr_bins)
+        : _data(std::move(data)), _nr_bins(nr_bins), _dirty(true)
     {
         init(computeHistogram);
     }

--- a/BaseLib/IO/XmlIO/Qt/XMLQtInterface.cpp
+++ b/BaseLib/IO/XmlIO/Qt/XMLQtInterface.cpp
@@ -125,7 +125,9 @@ bool XMLQtInterface::checkHash() const
         INFO("File is valid, hashfile written.");
     }
     else
+    {
         WARN("File is valid but could not write hashfile!");
+    }
     return true;
 }
 }  // namespace IO

--- a/GeoLib/Grid.h
+++ b/GeoLib/Grid.h
@@ -377,7 +377,7 @@ template <typename POINT>
 template <typename T>
 std::array<std::size_t,3> Grid<POINT>::getGridCoords(T const& pnt) const
 {
-    std::array<std::size_t,3> coords;
+    std::array<std::size_t,3> coords{};
     for (std::size_t k(0); k < 3; k++)
     {
         if (pnt[k] < _min_pnt[k])
@@ -407,7 +407,7 @@ template <typename P>
 std::array<double,6> Grid<POINT>::getPointCellBorderDistances(P const& p,
     std::array<std::size_t,3> const& coords) const
 {
-    std::array<double,6> dists;
+    std::array<double,6> dists{};
     dists[0] = std::abs(p[2]-_min_pnt[2] + coords[2]*_step_sizes[2]); // bottom
     dists[5] = std::abs(p[2]-_min_pnt[2] + (coords[2]+1)*_step_sizes[2]); // top
 

--- a/GeoLib/Grid.h
+++ b/GeoLib/Grid.h
@@ -200,8 +200,10 @@ Grid<POINT>::Grid(InputIterator first, InputIterator last,
                                     _max_pnt[2] - _min_pnt[2]}};
 
     // enlarge delta
-    for (auto & d : delta)
+    for (auto& d : delta)
+    {
         d = std::nextafter(d, std::numeric_limits<double>::max());
+    }
 
     assert(n_pnts > 0);
     initNumberOfSteps(max_num_per_grid_cell, static_cast<std::size_t>(n_pnts), delta);

--- a/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlGmlInterface.cpp
@@ -431,12 +431,15 @@ bool XmlGmlInterface::write()
                 }
             }
             else
+            {
                 INFO("XmlGmlInterface::write(): Polyline vector is empty, no polylines written to file.");
+            }
         }
     }
     else
+    {
         INFO("XmlGmlInterface::write(): Polyline vector is empty, no polylines written to file.");
-
+    }
 
     // SURFACES
     const GeoLib::SurfaceVec* sfc_vec (_geo_objs.getSurfaceVecObj(_exportName));
@@ -478,12 +481,15 @@ bool XmlGmlInterface::write()
                 }
             }
             else
+            {
                 INFO("XmlGmlInterface::write(): Surface vector is empty, no surfaces written to file.");
+            }
         }
     }
     else
+    {
         INFO("XmlGmlInterface::write(): Surface vector is empty, no surfaces written to file.");
-
+    }
 
     std::string xml = doc.toString().toStdString();
     _out << xml;

--- a/GeoLib/IO/XmlIO/Qt/XmlStnInterface.cpp
+++ b/GeoLib/IO/XmlIO/Qt/XmlStnInterface.cpp
@@ -177,7 +177,9 @@ void XmlStnInterface::readStations( const QDomNode &stationsRoot,
             }
         }
         else
+        {
             WARN("XmlStnInterface::readStations(): Attribute missing in <station> tag.");
+        }
         station = station.nextSiblingElement();
     }
 }
@@ -216,13 +218,17 @@ void XmlStnInterface::readStratigraphy( const QDomNode &stratRoot,
                 depth_check = depth;
             }
             else
+            {
                 WARN(
                     "XmlStnInterface::readStratigraphy(): Skipped layer '{:s}' "
                     "in borehole '{:s}' because of thickness 0.0.",
                     horizonName, borehole->getName());
+            }
         }
         else
+        {
             WARN("XmlStnInterface::readStratigraphy(): Attribute missing in <horizon> tag.");
+        }
         horizon = horizon.nextSiblingElement();
     }
 }

--- a/GeoLib/PointVec.cpp
+++ b/GeoLib/PointVec.cpp
@@ -111,8 +111,10 @@ PointVec::PointVec(
     }
 
     if (number_of_all_input_pnts > _data_vec->size())
+    {
         WARN("PointVec::PointVec(): there are {:d} double points.",
              number_of_all_input_pnts - _data_vec->size());
+    }
 
     correctNameIDMapping();
     // create the inverse mapping

--- a/GeoLib/Polyline.cpp
+++ b/GeoLib/Polyline.cpp
@@ -378,7 +378,9 @@ Polyline* Polyline::constructPolylineFromSegments(const std::vector<Polyline*> &
                 }
             }
             else
+            {
                 ERR("Error in Polyline::contructPolylineFromSegments() - Line segments use different point vectors.");
+            }
         }
 
         if (!ply_found)

--- a/GeoLib/Raster.cpp
+++ b/GeoLib/Raster.cpp
@@ -99,7 +99,7 @@ double Raster::interpolateValueAtPoint(MathLib::Point3d const& pnt) const
     std::array<int,4> const y_nb = {{ 0, 0, yShiftIdx, yShiftIdx }};
 
     // get pixel values
-    std::array<double,4>  pix_val;
+    std::array<double,4>  pix_val{};
     unsigned no_data_count (0);
     for (unsigned j=0; j<4; ++j)
     {

--- a/GeoLib/SensorData.cpp
+++ b/GeoLib/SensorData.cpp
@@ -33,8 +33,10 @@ SensorData::SensorData(std::vector<std::size_t> time_steps)
 {
     for (std::size_t i=1; i<time_steps.size(); i++)
     {
-        if (time_steps[i-1]>=time_steps[i])
+        if (time_steps[i - 1] >= time_steps[i])
+        {
             ERR("Error in SensorData() - Time series has no order!");
+        }
     }
 }
 

--- a/GeoLib/SurfaceGrid.h
+++ b/GeoLib/SurfaceGrid.h
@@ -38,8 +38,8 @@ private:
     bool sortTriangleInGridCells(GeoLib::Triangle const*const triangle);
     boost::optional<std::array<std::size_t,3>>
         getGridCellCoordinates(MathLib::Point3d const& p) const;
-    std::array<double,3> _step_sizes;
-    std::array<double,3> _inverse_step_sizes;
+    std::array<double,3> _step_sizes{};
+    std::array<double,3> _inverse_step_sizes{};
     std::array<std::size_t,3> _n_steps;
     std::vector<std::vector<GeoLib::Triangle const*>> _triangles_in_grid_box;
 };

--- a/MeshLib/CoordinateSystem.h
+++ b/MeshLib/CoordinateSystem.h
@@ -55,9 +55,13 @@ public:
     /// get dimension size
     unsigned getDimension() const {
         if (hasZ())
+        {
             return 3;
+        }
         if (hasY())
+        {
             return 2;
+        }
 
         return 1;
     }

--- a/MeshLib/Elements/HexRule20.cpp
+++ b/MeshLib/Elements/HexRule20.cpp
@@ -48,7 +48,7 @@ const Element* HexRule20::getFace(const Element* e, unsigned i)
 {
     if (i < n_faces)
     {
-        std::array<Node*, 8> nodes;
+        std::array<Node*, 8> nodes{};
         for (unsigned j = 0; j < 8; j++)
         {
             nodes[j] = const_cast<Node*>(e->getNode(face_nodes[i][j]));

--- a/MeshLib/Elements/HexRule8.cpp
+++ b/MeshLib/Elements/HexRule8.cpp
@@ -52,7 +52,7 @@ const Element* HexRule8::getFace(const Element* e, unsigned i)
 {
     if (i < n_faces)
     {
-        std::array<Node*, 4> nodes;
+        std::array<Node*, 4> nodes{};
         for (unsigned j = 0; j < 4; j++)
         {
             nodes[j] = const_cast<Node*>(e->getNode(face_nodes[i][j]));

--- a/MeshLib/Elements/TetRule10.cpp
+++ b/MeshLib/Elements/TetRule10.cpp
@@ -42,7 +42,7 @@ const Element* TetRule10::getFace(const Element* e, unsigned i)
 {
     if (i<n_faces)
     {
-        std::array<Node*,6> nodes;
+        std::array<Node*,6> nodes{};
         for (unsigned j = 0; j < 6; j++)
         {
             nodes[j] = const_cast<Node*>(e->getNode(face_nodes[i][j]));

--- a/MeshLib/Elements/TetRule4.cpp
+++ b/MeshLib/Elements/TetRule4.cpp
@@ -44,7 +44,7 @@ const Element* TetRule4::getFace(const Element* e, unsigned i)
 {
     if (i<n_faces)
     {
-        std::array<Node*,3> nodes;
+        std::array<Node*,3> nodes{};
         for (unsigned j = 0; j < 3; j++)
         {
             nodes[j] = const_cast<Node*>(e->getNode(face_nodes[i][j]));

--- a/MeshLib/IO/VtkIO/VtuInterface-impl.h
+++ b/MeshLib/IO/VtkIO/VtuInterface-impl.h
@@ -49,14 +49,20 @@ bool VtuInterface::writeVTU(std::string const& file_name,
     vtkSource->Update();
     vtuWriter->SetInputData(vtkSource->GetOutput());
 
-    if(_use_compressor)
+    if (_use_compressor)
+    {
         vtuWriter->SetCompressorTypeToZLib();
+    }
     else
+    {
         vtuWriter->SetCompressorTypeToNone();
+    }
 
     vtuWriter->SetDataMode(_data_mode);
     if (_data_mode == vtkXMLWriter::Appended)
+    {
         vtuWriter->SetEncodeAppendedData(1);
+    }
     if (_data_mode == vtkXMLWriter::Ascii)
     {
         vtkSource->Update();

--- a/MeshLib/IO/VtkIO/VtuInterface.cpp
+++ b/MeshLib/IO/VtkIO/VtuInterface.cpp
@@ -43,8 +43,10 @@ namespace IO
 VtuInterface::VtuInterface(const MeshLib::Mesh* mesh, int dataMode, bool compress) :
     _mesh(mesh), _data_mode(dataMode), _use_compressor(compress)
 {
-    if(_data_mode == vtkXMLWriter::Ascii && compress)
+    if (_data_mode == vtkXMLWriter::Ascii && compress)
+    {
         WARN("Ascii data cannot be compressed, ignoring compression flag.");
+    }
 }
 
 MeshLib::Mesh* VtuInterface::readVTUFile(std::string const &file_name)

--- a/MeshLib/MeshEditing/ElementValueModification.h
+++ b/MeshLib/MeshEditing/ElementValueModification.h
@@ -66,7 +66,9 @@ private:
                 }
             }
             if (!exists)
+            {
                 value_mapping.push_back(value);
+            }
         }
 
         std::sort(value_mapping.begin(), value_mapping.end());

--- a/MeshLib/MeshEditing/MeshRevision.cpp
+++ b/MeshLib/MeshEditing/MeshRevision.cpp
@@ -833,7 +833,7 @@ unsigned MeshRevision::lutHexDiametralNode(unsigned id) const
 std::array<unsigned, 4> MeshRevision::lutHexCuttingQuadNodes(unsigned id1,
                                                              unsigned id2) const
 {
-    std::array<unsigned,4> nodes;
+    std::array<unsigned,4> nodes{};
     if      (id1==0 && id2==1) { nodes[0]=3; nodes[1]=2; nodes[2]=5; nodes[3]=4; }
     else if (id1==1 && id2==2) { nodes[0]=0; nodes[1]=3; nodes[2]=6; nodes[3]=5; }
     else if (id1==2 && id2==3) { nodes[0]=1; nodes[1]=0; nodes[2]=7; nodes[3]=6; }

--- a/MeshLib/MeshEditing/MeshRevision.cpp
+++ b/MeshLib/MeshEditing/MeshRevision.cpp
@@ -117,8 +117,11 @@ MeshLib::Mesh* MeshRevision::simplifyMesh(const std::string &new_mesh_name,
             }
             new_material_vec->insert(new_material_vec->end(),
                 n_new_elements, (*material_vec)[k]);
-        } else
+        }
+        else
+        {
             ERR ("Something is wrong, more unique nodes than actual nodes");
+        }
     }
 
     this->resetNodeIDs();

--- a/MeshLib/MeshGenerators/MeshLayerMapper.cpp
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.cpp
@@ -42,8 +42,10 @@ MeshLib::Mesh* MeshLayerMapper::createStaticLayers(MeshLib::Mesh const& mesh, st
             thickness.push_back(layer_thickness_vector[i]);
         }
         else
+        {
             WARN("Ignoring layer {:d} with thickness {:f}.", i,
                  layer_thickness_vector[i]);
+        }
     }
 
     const std::size_t nLayers(thickness.size());

--- a/MeshLib/MeshGenerators/MeshLayerMapper.cpp
+++ b/MeshLib/MeshGenerators/MeshLayerMapper.cpp
@@ -219,7 +219,7 @@ void MeshLayerMapper::addLayerToMesh(const MeshLib::Mesh &dem_mesh, unsigned lay
         }
         unsigned node_counter(3);
         unsigned missing_idx(0);
-        std::array<MeshLib::Node*, 6> new_elem_nodes;
+        std::array<MeshLib::Node*, 6> new_elem_nodes{};
         for (unsigned j=0; j<3; ++j)
         {
             new_elem_nodes[j] = _nodes[_nodes[last_layer_node_offset + elem->getNodeIndex(j)]->getID()];
@@ -242,6 +242,7 @@ void MeshLayerMapper::addLayerToMesh(const MeshLib::Mesh &dem_mesh, unsigned lay
             _materials.push_back(layer_id);
             break;
         case 5:
+        {
             std::array<MeshLib::Node*, 5> pyramid_nodes;
             pyramid_nodes[0] = new_elem_nodes[pyramid_base[missing_idx][0]];
             pyramid_nodes[1] = new_elem_nodes[pyramid_base[missing_idx][1]];
@@ -251,12 +252,15 @@ void MeshLayerMapper::addLayerToMesh(const MeshLib::Mesh &dem_mesh, unsigned lay
             _elements.push_back(new MeshLib::Pyramid(pyramid_nodes));
             _materials.push_back(layer_id);
             break;
+        }
         case 4:
+        {
             std::array<MeshLib::Node*, 4> tet_nodes;
             std::copy(new_elem_nodes.begin(), new_elem_nodes.begin() + node_counter, tet_nodes.begin());
             _elements.push_back(new MeshLib::Tet(tet_nodes));
             _materials.push_back(layer_id);
             break;
+        }
         default:
             continue;
         }

--- a/MeshLib/MeshGenerators/QuadraticMeshGenerator.cpp
+++ b/MeshLib/MeshGenerators/QuadraticMeshGenerator.cpp
@@ -31,7 +31,7 @@ std::unique_ptr<QuadraticElement> convertLinearToQuadratic(
     assert(n_base_nodes == e.getNumberOfBaseNodes());
 
     // Copy base nodes of element to the quadratic element new nodes'.
-    std::array<MeshLib::Node*, n_all_nodes> nodes;
+    std::array<MeshLib::Node*, n_all_nodes> nodes{};
     for (int i = 0; i < n_base_nodes; i++)
     {
         nodes[i] = const_cast<MeshLib::Node*>(e.getNode(i));

--- a/MeshLib/MeshGenerators/RasterToMesh.h
+++ b/MeshLib/MeshGenerators/RasterToMesh.h
@@ -97,8 +97,11 @@ private:
                 {
                     auto val(static_cast<T>(img[idx + j]));
                     prop_vec.push_back(val);
-                    if (elem_type == MeshElemType::TRIANGLE || elem_type == MeshElemType::PRISM)
+                    if (elem_type == MeshElemType::TRIANGLE ||
+                        elem_type == MeshElemType::PRISM)
+                    {
                         prop_vec.push_back(val); // because each pixel is represented by two cells
+                    }
                 }
             }
         }

--- a/MeshLib/MeshGenerators/VtkMeshConverter.h
+++ b/MeshLib/MeshGenerators/VtkMeshConverter.h
@@ -79,7 +79,9 @@ private:
             for (std::size_t j = 0; j < imgWidth; j++)
             {
                 if (!pix_vis[i * imgWidth + j])
+                {
                     continue;
+                }
                 T val(static_cast<T>(pix_val[i * (imgWidth + 1) + j]));
                 if (elem_type == MeshElemType::TRIANGLE)
                 {
@@ -87,7 +89,9 @@ private:
                     prop_vec.push_back(val);
                 }
                 else if (elem_type == MeshElemType::QUAD)
+                {
                     prop_vec.push_back(val);
+                }
             }
         }
     }

--- a/MeshLib/MeshQuality/ElementSizeMetric.cpp
+++ b/MeshLib/MeshQuality/ElementSizeMetric.cpp
@@ -43,7 +43,9 @@ void ElementSizeMetric::calculateQuality()
         _min,
         _max);
     if (error_count > 0)
+    {
         WARN("Warning: {:d} elements with zero volume found.", error_count);
+    }
 }
 
 std::size_t ElementSizeMetric::calc1dQuality()

--- a/MeshLib/MeshQuality/MeshValidation.cpp
+++ b/MeshLib/MeshQuality/MeshValidation.cpp
@@ -104,13 +104,17 @@ std::vector<ElementErrorCode> MeshValidation::testElementGeometry(const MeshLib:
         for (std::size_t i = 0; i < nErrorCodes; ++i)
         {
             if (error_count[i])
+            {
                 INFO("{:d} elements found with {:s}.",
                      error_count[i],
                      ElementErrorCode::toString(flags[i]));
+            }
         }
     }
     else
+    {
         INFO ("No errors found.");
+    }
     return error_code_vector;
 }
 

--- a/MeshLib/MeshSearch/ElementSearch.h
+++ b/MeshLib/MeshSearch/ElementSearch.h
@@ -96,7 +96,9 @@ public:
             {
                 if ((*pv)[i] < min_property_value ||
                     (*pv)[i] > max_property_value)
+                {
                     matchedIDs.push_back(i);
+                }
             }
         }
         else
@@ -105,7 +107,9 @@ public:
             {
                 if ((*pv)[i] >= min_property_value &&
                     (*pv)[i] <= max_property_value)
+                {
                     matchedIDs.push_back(i);
+                }
             }
         }
         updateUnion(matchedIDs);

--- a/MeshLib/MeshSearch/MeshElementGrid.cpp
+++ b/MeshLib/MeshSearch/MeshElementGrid.cpp
@@ -123,8 +123,8 @@ void MeshElementGrid::sortElementsInGridCells(MeshLib::Mesh const& sfc_mesh)
 
 bool MeshElementGrid::sortElementInGridCells(MeshLib::Element const& element)
 {
-    std::array<std::size_t,3> min;
-    std::array<std::size_t,3> max;
+    std::array<std::size_t,3> min{};
+    std::array<std::size_t,3> max{};
     std::pair<bool, std::array<std::size_t, 3>> c(
         getGridCellCoordinates(*(static_cast<MathLib::Point3d const*>(element.getNode(0)))));
     if (c.first) {
@@ -183,7 +183,7 @@ std::pair<bool, std::array<std::size_t, 3>>
 MeshElementGrid::getGridCellCoordinates(MathLib::Point3d const& p) const
 {
     bool valid(true);
-    std::array<std::size_t, 3> coords;
+    std::array<std::size_t, 3> coords{};
 
     for (std::size_t k(0); k<3; ++k) {
         const double d(p[k]-_aabb.getMinPoint()[k]);

--- a/MeshLib/MeshSearch/MeshElementGrid.h
+++ b/MeshLib/MeshSearch/MeshElementGrid.h
@@ -84,8 +84,8 @@ private:
     /// false.
     std::pair<bool, std::array<std::size_t,3>>
         getGridCellCoordinates(MathLib::Point3d const& p) const;
-    std::array<double,3> _step_sizes;
-    std::array<double,3> _inverse_step_sizes;
+    std::array<double,3> _step_sizes{};
+    std::array<double,3> _inverse_step_sizes{};
     std::array<std::size_t,3> _n_steps;
     std::vector<std::vector<MeshLib::Element const*>> _elements_in_grid_box;
 };

--- a/MeshLib/MeshSurfaceExtraction.cpp
+++ b/MeshLib/MeshSurfaceExtraction.cpp
@@ -257,7 +257,9 @@ void MeshSurfaceExtraction::get2DSurfaceElements(
     const MathLib::Vector3& dir, double angle, unsigned mesh_dimension)
 {
     if (mesh_dimension < 2 || mesh_dimension > 3)
+    {
         ERR("Cannot handle meshes of dimension {:i}", mesh_dimension);
+    }
 
     bool const complete_surface = (MathLib::scalarProduct(dir, dir) == 0);
 

--- a/MeshLib/Vtk/VtkMappedMeshSource.cpp
+++ b/MeshLib/Vtk/VtkMappedMeshSource.cpp
@@ -113,7 +113,7 @@ int VtkMappedMeshSource::RequestData(vtkInformation* /*request*/,
         }
         else if (cellType == VTK_QUADRATIC_WEDGE)
         {
-            std::array<vtkIdType, 15> ogs_nodeIds;
+            std::array<vtkIdType, 15> ogs_nodeIds{};
             for (unsigned i = 0; i < 15; ++i)
             {
                 ogs_nodeIds[i] = ptIds->GetId(i);

--- a/MeshLib/Vtk/VtkMappedMeshSource.h
+++ b/MeshLib/Vtk/VtkMappedMeshSource.h
@@ -82,7 +82,7 @@ private:
     bool addProperty(MeshLib::Properties const& properties,
                      std::string const& prop_name) const;
 
-    const MeshLib::Mesh* _mesh;
+    const MeshLib::Mesh* _mesh{};
 
     int NumberOfDimensions{0};
     int NumberOfNodes{0};

--- a/Tests/MeshLib/TestElementConstants.cpp
+++ b/Tests/MeshLib/TestElementConstants.cpp
@@ -20,7 +20,7 @@ TEST(MeshLib, ElementConstantsQuad4)
     ASSERT_EQ(4u, Quad::n_all_nodes);
     ASSERT_EQ(4u, Quad::n_base_nodes);
 
-    std::array<Node*, 4> nodes;
+    std::array<Node*, 4> nodes{};
     nodes[0] = new Node(0.0, 0.0, 0.0);
     nodes[1] = new Node(0.0, 1.0, 0.0);
     nodes[2] = new Node(1.0, 1.0, 0.0);
@@ -43,7 +43,7 @@ TEST(MeshLib, ElementConstantsQuad8)
     ASSERT_EQ(8u, Quad8::n_all_nodes);
     ASSERT_EQ(4u, Quad8::n_base_nodes);
 
-    std::array<Node*, 8> nodes;
+    std::array<Node*, 8> nodes{};
     nodes[0] = new Node(0.0, 0.0, 0.0);
     nodes[1] = new Node(0.0, 1.0, 0.0);
     nodes[2] = new Node(1.0, 1.0, 0.0);
@@ -72,7 +72,7 @@ TEST(MeshLib, ElementConstantsQuad9)
     ASSERT_EQ(9u, Quad9::n_all_nodes);
     ASSERT_EQ(4u, Quad9::n_base_nodes);
 
-    std::array<Node*, 9> nodes;
+    std::array<Node*, 9> nodes{};
     nodes[0] = new Node(0.0, 0.0, 0.0);
     nodes[1] = new Node(0.0, 1.0, 0.0);
     nodes[2] = new Node(1.0, 1.0, 0.0);
@@ -102,7 +102,7 @@ TEST(MeshLib, ElementConstantsHex8)
     ASSERT_EQ(8u, Hex::n_all_nodes);
     ASSERT_EQ(8u, Hex::n_base_nodes);
 
-    std::array<Node*, 8> nodes;
+    std::array<Node*, 8> nodes{};
     nodes[0] = new Node(0.0, 0.0, 0.0);
     nodes[1] = new Node(0.0, 1.0, 0.0);
     nodes[2] = new Node(1.0, 1.0, 0.0);
@@ -129,7 +129,7 @@ TEST(MeshLib, ElementConstantsHex20)
     ASSERT_EQ(20u, Hex20::n_all_nodes);
     ASSERT_EQ( 8u, Hex20::n_base_nodes);
 
-    std::array<Node*, 20> nodes;
+    std::array<Node*, 20> nodes{};
     nodes[0] = new Node(0.0, 0.0, 0.0);
     nodes[1] = new Node(1.0, 0.0, 0.0);
     nodes[2] = new Node(1.0, 1.0, 0.0);
@@ -168,7 +168,7 @@ TEST(MeshLib, ElementConstantsTet4)
     ASSERT_EQ(4u, Tet::n_all_nodes);
     ASSERT_EQ(4u, Tet::n_base_nodes);
 
-    std::array<Node*, 4> nodes;
+    std::array<Node*, 4> nodes{};
     nodes[0] = new Node(0.0, 0.0, 0.0);
     nodes[1] = new Node(1.0, 0.0, 0.0);
     nodes[2] = new Node(0.0, 1.0, 0.0);
@@ -191,7 +191,7 @@ TEST(MeshLib, ElementConstantsTet10)
     ASSERT_EQ(10u, Tet10::n_all_nodes);
     ASSERT_EQ( 4u, Tet10::n_base_nodes);
 
-    std::array<Node*, 10> nodes;
+    std::array<Node*, 10> nodes{};
     nodes[0] = new Node(0.0, 0.0, 0.0);
     nodes[1] = new Node(1.0, 0.0, 0.0);
     nodes[2] = new Node(0.0, 1.0, 0.0);

--- a/Tests/MeshLib/TestPntInElement.cpp
+++ b/Tests/MeshLib/TestPntInElement.cpp
@@ -109,7 +109,7 @@ TEST(IsPntInElement, Pyramid)
 {
     GeoLib::Point pnt;
     std::vector<MeshLib::Node*> nodes (createNodes());
-    std::array<MeshLib::Node*, 5> pyr_nodes;
+    std::array<MeshLib::Node*, 5> pyr_nodes{};
     std::copy(nodes.begin(), nodes.begin()+5, pyr_nodes.begin());
     MeshLib::Pyramid pyr(pyr_nodes);
 
@@ -144,7 +144,7 @@ TEST(IsPntInElement, Hex)
 {
     GeoLib::Point pnt;
     std::vector<MeshLib::Node*> nodes (createNodes());
-    std::array<MeshLib::Node*, 8> hex_nodes;
+    std::array<MeshLib::Node*, 8> hex_nodes{};
     std::copy(nodes.begin(), nodes.end(), hex_nodes.begin());
     MeshLib::Hex hex(hex_nodes);
 

--- a/Tests/MeshLib/TestTriLineMesh.cpp
+++ b/Tests/MeshLib/TestTriLineMesh.cpp
@@ -25,7 +25,7 @@ class MeshLibTriLineMesh : public ::testing::Test
         nodes.push_back(new MeshLib::Node(0, 1, 0));
         nodes.push_back(new MeshLib::Node(1, 1, 0));
 
-        std::array<MeshLib::Node*, 3> t_nodes;
+        std::array<MeshLib::Node*, 3> t_nodes{};
         t_nodes[0] = nodes[0];
         t_nodes[1] = nodes[1];
         t_nodes[2] = nodes[2];
@@ -36,7 +36,7 @@ class MeshLibTriLineMesh : public ::testing::Test
         t_nodes[2] = nodes[2];
         elements.push_back(new MeshLib::Tri(t_nodes));
 
-        std::array<MeshLib::Node*, 2> l_nodes;
+        std::array<MeshLib::Node*, 2> l_nodes{};
         l_nodes[0] = nodes[1];
         l_nodes[1] = nodes[2];
         elements.push_back(new MeshLib::Line(l_nodes));


### PR DESCRIPTION
Cleanups in BaseLib, Applications/FileIO, and MeshLib.
Fixed warnings are
- google-readability-braces-around-statements
- cppcoreguidelines-pro-type-member-init