### PR TITLE
[CMake] Unity builds

### DIFF
--- a/Applications/CLI/CMakeLists.txt
+++ b/Applications/CLI/CMakeLists.txt
@@ -71,10 +71,6 @@ if(OGS_INSITU)
     target_link_libraries(ogs PRIVATE InSituLib)
 endif()
 
-if(OGS_USE_PCH)
-    cotire(ogs)
-endif()
-
 # ---- Tests ----
 add_test(NAME ogs_no_args COMMAND ogs)
 set_tests_properties(ogs_no_args PROPERTIES WILL_FAIL TRUE)

--- a/Applications/DataExplorer/DataExplorer.cmake
+++ b/Applications/DataExplorer/DataExplorer.cmake
@@ -81,10 +81,6 @@ endif()
 
 set_property(TARGET DataExplorer PROPERTY FOLDER "DataExplorer")
 
-if(OGS_USE_PCH)
-    cotire(DataExplorer)
-endif()
-
 # ---- Installation ----
 install(TARGETS DataExplorer RUNTIME DESTINATION bin COMPONENT ogs_gui)
 

--- a/Applications/DataExplorer/DataView/DiagramView/GetDateTime.h
+++ b/Applications/DataExplorer/DataView/DiagramView/GetDateTime.h
@@ -8,6 +8,8 @@
  *
  */
 
+#pragma once
+
 #include <QDateTime>
 #include <QString>
 #include <string>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ endif()
 option(OGS_USE_CONAN "Should Conan package manager be used?" ON)
 set(OGS_CONAN_BUILD "missing" CACHE STRING "Possible values: all, missing, \
     never or list of libs to build")
+option(OGS_DISABLE_CCACHE "Disables ccache compiler cache." OFF)
 
 # Third-party libraries, names come from Conan package names
 set(OGS_LIBS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ option(OGS_USE_CONAN "Should Conan package manager be used?" ON)
 set(OGS_CONAN_BUILD "missing" CACHE STRING "Possible values: all, missing, \
     never or list of libs to build")
 option(OGS_DISABLE_CCACHE "Disables ccache compiler cache." OFF)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.16)
+    option(OGS_USE_UNITY_BUILDS "Enables Unity builds for faster compilation." OFF)
+endif()
 
 # Third-party libraries, names come from Conan package names
 set(OGS_LIBS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,6 @@ set(CMAKE_LIBRARY_SEARCH_PATH
 set(OGS_CPU_ARCHITECTURE "native" CACHE STRING "Processor architecture, \
     defaults to native (*nix) / blend (MSVC).")
 option(OGS_ENABLE_AVX2 "Enable the use of AVX2 instructions" OFF)
-option(OGS_USE_PCH "Should pre-compiled headers be used?" ON)
-if(DEFINED CMAKE_CXX_CLANG_TIDY)
-    set(OGS_USE_PCH OFF CACHE INTERNAL "")
-endif()
 option(OGS_USE_CONAN "Should Conan package manager be used?" ON)
 set(OGS_CONAN_BUILD "missing" CACHE STRING "Possible values: all, missing, \
     never or list of libs to build")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,8 @@ if(BUILD_TESTING AND NOT IS_SUBPROJECT)
     add_subdirectory(Tests)
 endif()
 
+include(UnityBuildSettings)
+
 file(WRITE ${PROJECT_BINARY_DIR}/disabled-tests.log "${DISABLED_TESTS_LOG}")
 unset(DISABLED_TESTS_LOG CACHE) # Don't write to CMakeCache.txt
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set(OGS_CONAN_BUILD "missing" CACHE STRING "Possible values: all, missing, \
     never or list of libs to build")
 option(OGS_DISABLE_CCACHE "Disables ccache compiler cache." OFF)
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.16)
-    option(OGS_USE_UNITY_BUILDS "Enables Unity builds for faster compilation." OFF)
+    option(OGS_USE_UNITY_BUILDS "Enables Unity builds for faster compilation." ON)
 endif()
 
 # Third-party libraries, names come from Conan package names

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,7 +116,8 @@ pipeline {
                   '-DOGS_USE_CVODE=ON ' +
                   '-DOGS_USE_MFRONT=ON ' +
                   '-DOGS_USE_PYTHON=ON ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON '
+                  '-DOGS_USE_UNITY_BUILDS=ON ' +
+                  '-DOGS_USE_PCH=OFF '
               }
               // Workaround some MGIS CMake logic flaws
               configure {
@@ -203,7 +204,8 @@ pipeline {
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_BUILD_TESTS=OFF ' +
                   '-DOGS_USE_NETCDF=ON ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON '
+                  '-DOGS_USE_UNITY_BUILDS=ON ' +
+                  '-DOGS_USE_PCH=OFF '
               }
               build {
                 target="package"
@@ -260,7 +262,8 @@ pipeline {
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_CONAN_BUILD_TYPE=Release ' +
                   '-DOGS_CPU_ARCHITECTURE=generic ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON '
+                  '-DOGS_USE_UNITY_BUILDS=ON ' +
+                  '-DOGS_USE_PCH=OFF '
                 config = 'Debug'
               }
               build { }
@@ -294,7 +297,8 @@ pipeline {
                   '-DOGS_CPU_ARCHITECTURE=sandybridge ' +
                   '-DCMAKE_INSTALL_PREFIX=/global/apps/ogs/head/standard ' +
                   '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/standard ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON '
+                  '-DOGS_USE_UNITY_BUILDS=ON ' +
+                  '-DOGS_USE_PCH=OFF '
                 env = 'eve/cli.sh'
               }
               build {
@@ -351,7 +355,8 @@ pipeline {
                   '-DOGS_CPU_ARCHITECTURE=sandybridge ' +
                   '-DCMAKE_INSTALL_PREFIX=/global/apps/ogs/head/petsc ' +
                   '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/petsc ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON '
+                  '-DOGS_USE_UNITY_BUILDS=ON ' +
+                  '-DOGS_USE_PCH=OFF '
                 env = 'eve/petsc.sh'
               }
               build {
@@ -415,7 +420,8 @@ pipeline {
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_BUILD_SWMM=ON ' +
                   '-DOGS_USE_NETCDF=ON ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON '
+                  '-DOGS_USE_UNITY_BUILDS=ON ' +
+                  '-DOGS_USE_PCH=OFF '
               }
               build {
                 target="package"
@@ -471,7 +477,8 @@ pipeline {
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON '
+                  '-DOGS_USE_UNITY_BUILDS=ON ' +
+                  '-DOGS_USE_PCH=OFF '
               }
               build {
                 target="package"
@@ -520,7 +527,8 @@ pipeline {
                   '-DOGS_USE_CONAN=OFF ' +
                   '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" ' +
                   '-DOGS_USE_NETCDF=ON ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON '
+                  '-DOGS_USE_UNITY_BUILDS=ON ' +
+                  '-DOGS_USE_PCH=OFF '
               }
               build {
                 target="package"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -297,7 +297,7 @@ pipeline {
                   '-DOGS_CPU_ARCHITECTURE=sandybridge ' +
                   '-DCMAKE_INSTALL_PREFIX=/global/apps/ogs/head/standard ' +
                   '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/standard ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON ' +
+                  '-DOGS_USE_UNITY_BUILDS=ON ' + // no effect as cmake too old
                   '-DOGS_USE_PCH=OFF '
                 env = 'eve/cli.sh'
               }
@@ -355,7 +355,7 @@ pipeline {
                   '-DOGS_CPU_ARCHITECTURE=sandybridge ' +
                   '-DCMAKE_INSTALL_PREFIX=/global/apps/ogs/head/petsc ' +
                   '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/petsc ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON ' +
+                  '-DOGS_USE_UNITY_BUILDS=ON ' + // no effect as cmake too old
                   '-DOGS_USE_PCH=OFF '
                 env = 'eve/petsc.sh'
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,7 +116,6 @@ pipeline {
                   '-DOGS_USE_CVODE=ON ' +
                   '-DOGS_USE_MFRONT=ON ' +
                   '-DOGS_USE_PYTHON=ON ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON ' +
                   '-DOGS_USE_PCH=OFF '
               }
               // Workaround some MGIS CMake logic flaws
@@ -204,7 +203,6 @@ pipeline {
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_BUILD_TESTS=OFF ' +
                   '-DOGS_USE_NETCDF=ON ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON ' +
                   '-DOGS_USE_PCH=OFF '
               }
               build {
@@ -262,7 +260,6 @@ pipeline {
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_CONAN_BUILD_TYPE=Release ' +
                   '-DOGS_CPU_ARCHITECTURE=generic ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON ' +
                   '-DOGS_USE_PCH=OFF '
                 config = 'Debug'
               }
@@ -297,7 +294,6 @@ pipeline {
                   '-DOGS_CPU_ARCHITECTURE=sandybridge ' +
                   '-DCMAKE_INSTALL_PREFIX=/global/apps/ogs/head/standard ' +
                   '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/standard ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON ' + // no effect as cmake too old
                   '-DOGS_USE_PCH=OFF '
                 env = 'eve/cli.sh'
               }
@@ -355,7 +351,6 @@ pipeline {
                   '-DOGS_CPU_ARCHITECTURE=sandybridge ' +
                   '-DCMAKE_INSTALL_PREFIX=/global/apps/ogs/head/petsc ' +
                   '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/petsc ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON ' + // no effect as cmake too old
                   '-DOGS_USE_PCH=OFF '
                 env = 'eve/petsc.sh'
               }
@@ -420,7 +415,6 @@ pipeline {
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_BUILD_SWMM=ON ' +
                   '-DOGS_USE_NETCDF=ON ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON ' +
                   '-DOGS_USE_PCH=OFF '
               }
               build {
@@ -477,7 +471,6 @@ pipeline {
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON ' +
                   '-DOGS_USE_PCH=OFF '
               }
               build {
@@ -527,7 +520,6 @@ pipeline {
                   '-DOGS_USE_CONAN=OFF ' +
                   '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" ' +
                   '-DOGS_USE_NETCDF=ON ' +
-                  '-DOGS_USE_UNITY_BUILDS=ON ' +
                   '-DOGS_USE_PCH=OFF '
               }
               build {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,8 +115,7 @@ pipeline {
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_USE_CVODE=ON ' +
                   '-DOGS_USE_MFRONT=ON ' +
-                  '-DOGS_USE_PYTHON=ON ' +
-                  '-DOGS_USE_PCH=OFF '
+                  '-DOGS_USE_PYTHON=ON '
               }
               // Workaround some MGIS CMake logic flaws
               configure {
@@ -197,13 +196,11 @@ pipeline {
                 cmakeOptions =
                   "-DBUILD_SHARED_LIBS=${build_shared} " +
                   '-DOGS_CPU_ARCHITECTURE=generic ' +
-                  '-DOGS_USE_PCH=OFF ' +     // see #1992
                   '-DOGS_BUILD_GUI=ON ' +
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_BUILD_TESTS=OFF ' +
-                  '-DOGS_USE_NETCDF=ON ' +
-                  '-DOGS_USE_PCH=OFF '
+                  '-DOGS_USE_NETCDF=ON '
               }
               build {
                 target="package"
@@ -259,8 +256,7 @@ pipeline {
                   "-DBUILD_SHARED_LIBS=${build_shared} " +
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_CONAN_BUILD_TYPE=Release ' +
-                  '-DOGS_CPU_ARCHITECTURE=generic ' +
-                  '-DOGS_USE_PCH=OFF '
+                  '-DOGS_CPU_ARCHITECTURE=generic '
                 config = 'Debug'
               }
               build { }
@@ -293,8 +289,7 @@ pipeline {
                   '-DBUILD_SHARED_LIBS=ON ' +
                   '-DOGS_CPU_ARCHITECTURE=sandybridge ' +
                   '-DCMAKE_INSTALL_PREFIX=/global/apps/ogs/head/standard ' +
-                  '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/standard ' +
-                  '-DOGS_USE_PCH=OFF '
+                  '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/standard '
                 env = 'eve/cli.sh'
               }
               build {
@@ -350,8 +345,7 @@ pipeline {
                   '-DBUILD_SHARED_LIBS=ON ' +
                   '-DOGS_CPU_ARCHITECTURE=sandybridge ' +
                   '-DCMAKE_INSTALL_PREFIX=/global/apps/ogs/head/petsc ' +
-                  '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/petsc ' +
-                  '-DOGS_USE_PCH=OFF '
+                  '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/petsc '
                 env = 'eve/petsc.sh'
               }
               build {
@@ -414,8 +408,7 @@ pipeline {
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_BUILD_SWMM=ON ' +
-                  '-DOGS_USE_NETCDF=ON ' +
-                  '-DOGS_USE_PCH=OFF '
+                  '-DOGS_USE_NETCDF=ON '
               }
               build {
                 target="package"
@@ -470,8 +463,7 @@ pipeline {
                   '-DOGS_CPU_ARCHITECTURE=core2 ' +
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_CONAN_BUILD=missing ' +
-                  '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" ' +
-                  '-DOGS_USE_PCH=OFF '
+                  '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" '
               }
               build {
                 target="package"
@@ -519,8 +511,7 @@ pipeline {
                   '-DOGS_BUILD_GUI=ON ' +
                   '-DOGS_USE_CONAN=OFF ' +
                   '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" ' +
-                  '-DOGS_USE_NETCDF=ON ' +
-                  '-DOGS_USE_PCH=OFF '
+                  '-DOGS_USE_NETCDF=ON '
               }
               build {
                 target="package"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,8 @@ pipeline {
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_USE_CVODE=ON ' +
                   '-DOGS_USE_MFRONT=ON ' +
-                  '-DOGS_USE_PYTHON=ON '
+                  '-DOGS_USE_PYTHON=ON ' +
+                  '-DOGS_USE_UNITY_BUILDS=ON '
               }
               // Workaround some MGIS CMake logic flaws
               configure {
@@ -201,7 +202,8 @@ pipeline {
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_BUILD_TESTS=OFF ' +
-                  '-DOGS_USE_NETCDF=ON '
+                  '-DOGS_USE_NETCDF=ON ' +
+                  '-DOGS_USE_UNITY_BUILDS=ON '
               }
               build {
                 target="package"
@@ -257,7 +259,8 @@ pipeline {
                   "-DBUILD_SHARED_LIBS=${build_shared} " +
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_CONAN_BUILD_TYPE=Release ' +
-                  '-DOGS_CPU_ARCHITECTURE=generic '
+                  '-DOGS_CPU_ARCHITECTURE=generic ' +
+                  '-DOGS_USE_UNITY_BUILDS=ON '
                 config = 'Debug'
               }
               build { }
@@ -290,7 +293,8 @@ pipeline {
                   '-DBUILD_SHARED_LIBS=ON ' +
                   '-DOGS_CPU_ARCHITECTURE=sandybridge ' +
                   '-DCMAKE_INSTALL_PREFIX=/global/apps/ogs/head/standard ' +
-                  '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/standard '
+                  '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/standard ' +
+                  '-DOGS_USE_UNITY_BUILDS=ON '
                 env = 'eve/cli.sh'
               }
               build {
@@ -346,7 +350,8 @@ pipeline {
                   '-DBUILD_SHARED_LIBS=ON ' +
                   '-DOGS_CPU_ARCHITECTURE=sandybridge ' +
                   '-DCMAKE_INSTALL_PREFIX=/global/apps/ogs/head/petsc ' +
-                  '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/petsc '
+                  '-DOGS_MODULEFILE=/global/apps/modulefiles/ogs/head/petsc ' +
+                  '-DOGS_USE_UNITY_BUILDS=ON '
                 env = 'eve/petsc.sh'
               }
               build {
@@ -409,7 +414,8 @@ pipeline {
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_CONAN_BUILD=missing ' +
                   '-DOGS_BUILD_SWMM=ON ' +
-                  '-DOGS_USE_NETCDF=ON '
+                  '-DOGS_USE_NETCDF=ON ' +
+                  '-DOGS_USE_UNITY_BUILDS=ON '
               }
               build {
                 target="package"
@@ -464,7 +470,8 @@ pipeline {
                   '-DOGS_CPU_ARCHITECTURE=core2 ' +
                   '-DOGS_BUILD_UTILS=ON ' +
                   '-DOGS_CONAN_BUILD=missing ' +
-                  '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" '
+                  '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" ' +
+                  '-DOGS_USE_UNITY_BUILDS=ON '
               }
               build {
                 target="package"
@@ -512,7 +519,8 @@ pipeline {
                   '-DOGS_BUILD_GUI=ON ' +
                   '-DOGS_USE_CONAN=OFF ' +
                   '-DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" ' +
-                  '-DOGS_USE_NETCDF=ON '
+                  '-DOGS_USE_NETCDF=ON ' +
+                  '-DOGS_USE_UNITY_BUILDS=ON '
               }
               build {
                 target="package"

--- a/MathLib/KelvinVector-impl.h
+++ b/MathLib/KelvinVector-impl.h
@@ -69,7 +69,7 @@ double Invariants<KelvinVectorSize>::trace(
 // Initialization of static Invariant variables.
 //
 
-namespace detail
+namespace KelvinVector_detail
 {
 template <int KelvinVectorSize>
 Eigen::Matrix<double, KelvinVectorSize, KelvinVectorSize>
@@ -108,17 +108,17 @@ Eigen::Matrix<double, KelvinVectorSize, 1> initIdentity2()
 template <int KelvinVectorSize>
 const Eigen::Matrix<double, KelvinVectorSize, KelvinVectorSize>
     Invariants<KelvinVectorSize>::deviatoric_projection =
-        detail::initDeviatoricProjection<KelvinVectorSize>();
+        KelvinVector_detail::initDeviatoricProjection<KelvinVectorSize>();
 
 template <int KelvinVectorSize>
 Eigen::Matrix<double, KelvinVectorSize, KelvinVectorSize> const
     Invariants<KelvinVectorSize>::spherical_projection =
-        detail::initSphericalProjection<KelvinVectorSize>();
+        KelvinVector_detail::initSphericalProjection<KelvinVectorSize>();
 
 template <int KelvinVectorSize>
 const Eigen::Matrix<double, KelvinVectorSize, 1>
     Invariants<KelvinVectorSize>::identity2 =
-        detail::initIdentity2<KelvinVectorSize>();
+        KelvinVector_detail::initIdentity2<KelvinVectorSize>();
 
 }  // namespace KelvinVector
 }  // namespace MathLib

--- a/Tests/BaseLib/TestFilePathStringManipulation.cpp
+++ b/Tests/BaseLib/TestFilePathStringManipulation.cpp
@@ -15,33 +15,6 @@
 
 #include "BaseLib/FileTools.h"
 
-// For testing of some internal functions used inside FileTools.cpp.
-#include "BaseLib/FileTools.cpp"
-
-TEST(BaseLib, FindLastPathSeparatorWin)
-{
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("file"), std::string::npos );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("\\file"), 0U );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("path\\"), 4U );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("\\path\\"), 5U );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("path\\file"), 4U );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("\\path\\file"), 5U );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("\\path\\path\\file"), 10U );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("\\path\\path\\path\\"), 15U );
-}
-
-TEST(BaseLib, FindLastPathSeparatorUnix)
-{
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("file"), std::string::npos );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("/file"), 0U );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("path/"), 4U );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("/path/"), 5U );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("path/file"), 4U );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("/path/file"), 5U );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("/path/path/file"), 10U );
-    ASSERT_EQ ( BaseLib::findLastPathSeparator("/path/path/path/"), 15U );
-}
-
 TEST(BaseLib, DropFileExtensionWin)
 {
     ASSERT_EQ ( BaseLib::dropFileExtension("file"), "file" );

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -85,10 +85,6 @@ if(OGS_BUILD_GUI)
     endif()
 endif()
 
-if(OGS_USE_PCH)
-    cotire(testrunner)
-endif()
-
 # cmake-format: off
 # Add make-target tests which runs the testrunner
 if(IS_CI AND NOT OGS_COVERAGE)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -15,7 +15,11 @@ append_source_files(TEST_SOURCES MaterialLib)
 append_source_files(TEST_SOURCES MathLib)
 append_source_files(TEST_SOURCES MeshLib)
 append_source_files(TEST_SOURCES MeshGeoToolsLib)
-append_source_files(TEST_SOURCES NumLib)
+append_source_files(TEST_SOURCES_NUMLIB NumLib)
+# Disable Unity build for NumLib tests
+set_source_files_properties(${TEST_SOURCES_NUMLIB} PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+# Keep order of source files, otherwise PETSc non-MPI tests fail
+set(TEST_SOURCES ${TEST_SOURCES} ${TEST_SOURCES_NUMLIB})
 append_source_files(TEST_SOURCES ParameterLib)
 append_source_files(TEST_SOURCES ProcessLib)
 

--- a/Tests/MathLib/TestODESolver.cpp
+++ b/Tests/MathLib/TestODESolver.cpp
@@ -13,6 +13,8 @@
 #include "BaseLib/ConfigTree.h"
 #include "MathLib/ODE/ODESolverBuilder.h"
 
+namespace TestODESolver {
+
 const double abs_tol = 1e-8;
 const double rel_tol = 1e-8;
 
@@ -315,3 +317,5 @@ TEST(MathLibCVodeTest, ExponentialWithJacobianNewton)
         check(time_reached, y[0], y_dot[0], time, y_ana, y_dot_ana);
     }
 }
+
+} // end namespace

--- a/Tests/NumLib/TestODEInt.cpp
+++ b/Tests/NumLib/TestODEInt.cpp
@@ -25,6 +25,8 @@
 
 #include "TimeLoopSingleODE.h"
 
+namespace TestODEInt {
+
 #ifndef USE_PETSC
 std::unique_ptr<GlobalLinearSolver>
 createLinearSolver()
@@ -298,3 +300,5 @@ TYPED_TEST(NumLibODEIntTyped, DISABLED_T1)
  * * check that the order of time discretization scales correctly
  *   with the timestep size
  */
+
+} // end namespace

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,6 @@ jobs:
       mkdir build
       cd build
       call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\vsdevcmd" -arch=x64
-      cmake .. -G Ninja -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DOGS_EIGEN_DYNAMIC_SHAPE_MATRICES=ON -DOGS_USE_PCH=OFF
+      cmake .. -G Ninja -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DOGS_EIGEN_DYNAMIC_SHAPE_MATRICES=ON
       ninja -j 2
       ninja -j 2 tests

--- a/scripts/cmake/CCacheSetup.cmake
+++ b/scripts/cmake/CCacheSetup.cmake
@@ -1,4 +1,4 @@
-if(NOT CCACHE_TOOL_PATH)
+if(NOT CCACHE_TOOL_PATH OR OGS_DISABLE_CCACHE)
     return()
 endif()
 

--- a/scripts/cmake/CompilerSetup.cmake
+++ b/scripts/cmake/CompilerSetup.cmake
@@ -3,13 +3,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-if(${CMAKE_CXX_COMPILER} MATCHES "clcache")
-    set(OGS_USE_PCH OFF CACHE INTERNAL "")
-endif()
-if(OGS_USE_PCH)
-    include(cotire) # compile time reducer
-endif()
-
 if(${CMAKE_CXX_COMPILER} MATCHES "clcache" AND CMAKE_BUILD_TYPE STREQUAL "Debug")
     message(WARNING "clcache does not cache in Debug config!")
 endif()

--- a/scripts/cmake/Functions.cmake
+++ b/scripts/cmake/Functions.cmake
@@ -98,10 +98,6 @@ function(ogs_add_library targetName)
     generate_export_header(${targetName})
     target_include_directories(${targetName} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
-    if(OGS_USE_PCH AND NOT ${targetName} STREQUAL "ChemistryLib")
-        cotire(${targetName})
-    endif()
-
     if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.16)
         set_target_properties(${targetName} PROPERTIES
             UNITY_BUILD ${OGS_USE_UNITY_BUILDS})

--- a/scripts/cmake/Functions.cmake
+++ b/scripts/cmake/Functions.cmake
@@ -101,4 +101,9 @@ function(ogs_add_library targetName)
     if(OGS_USE_PCH AND NOT ${targetName} STREQUAL "ChemistryLib")
         cotire(${targetName})
     endif()
+
+    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.16)
+        set_target_properties(${targetName} PROPERTIES
+            UNITY_BUILD ${OGS_USE_UNITY_BUILDS})
+    endif()
 endfunction()

--- a/scripts/cmake/UnityBuildSettings.cmake
+++ b/scripts/cmake/UnityBuildSettings.cmake
@@ -1,8 +1,16 @@
-set_target_properties(BaseLib PROPERTIES UNITY_BUILD ON
-    UNITY_BUILD_BATCH_SIZE 8)
-set_target_properties(GeoLib PROPERTIES UNITY_BUILD ON
-    UNITY_BUILD_BATCH_SIZE 40)
-set_target_properties(MathLib PROPERTIES UNITY_BUILD ON
-    UNITY_BUILD_BATCH_SIZE 10)
-set_target_properties(MeshLib PROPERTIES UNITY_BUILD ON
-    UNITY_BUILD_BATCH_SIZE 40)
+if(NOT OGS_USE_UNITY_BUILDS OR ${CMAKE_VERSION} VERSION_LESS 3.16)
+    return()
+endif()
+
+set_target_properties(BaseLib PROPERTIES UNITY_BUILD_BATCH_SIZE 8)
+set_target_properties(GeoLib PROPERTIES UNITY_BUILD_BATCH_SIZE 40)
+set_target_properties(MaterialLib PROPERTIES UNITY_BUILD_BATCH_SIZE 20)
+set_target_properties(MathLib PROPERTIES UNITY_BUILD_BATCH_SIZE 10)
+set_target_properties(MeshLib PROPERTIES UNITY_BUILD_BATCH_SIZE 20)
+# set_target_properties(ProcessLib PROPERTIES UNITY_BUILD_BATCH_SIZE 80) # breaks!
+
+if(TARGET testrunner)
+    # breaks!
+    # set_target_properties(testrunner PROPERTIES UNITY_BUILD ON)
+    # set_target_properties(testrunner PROPERTIES UNITY_BUILD_BATCH_SIZE 2)
+endif()

--- a/scripts/cmake/UnityBuildSettings.cmake
+++ b/scripts/cmake/UnityBuildSettings.cmake
@@ -10,7 +10,5 @@ set_target_properties(MeshLib PROPERTIES UNITY_BUILD_BATCH_SIZE 20)
 # set_target_properties(ProcessLib PROPERTIES UNITY_BUILD_BATCH_SIZE 80) # breaks!
 
 if(TARGET testrunner)
-    # breaks!
-    # set_target_properties(testrunner PROPERTIES UNITY_BUILD ON)
-    # set_target_properties(testrunner PROPERTIES UNITY_BUILD_BATCH_SIZE 2)
+    set_target_properties(testrunner PROPERTIES UNITY_BUILD ON)
 endif()

--- a/scripts/cmake/UnityBuildSettings.cmake
+++ b/scripts/cmake/UnityBuildSettings.cmake
@@ -1,0 +1,8 @@
+set_target_properties(BaseLib PROPERTIES UNITY_BUILD ON
+    UNITY_BUILD_BATCH_SIZE 8)
+set_target_properties(GeoLib PROPERTIES UNITY_BUILD ON
+    UNITY_BUILD_BATCH_SIZE 40)
+set_target_properties(MathLib PROPERTIES UNITY_BUILD ON
+    UNITY_BUILD_BATCH_SIZE 10)
+set_target_properties(MeshLib PROPERTIES UNITY_BUILD ON
+    UNITY_BUILD_BATCH_SIZE 40)

--- a/scripts/docker/Dockerfile.clang.full
+++ b/scripts/docker/Dockerfile.clang.full
@@ -65,16 +65,16 @@ RUN apt-get update && \
     git lfs install && \
     mkdir -p /apps /scratch /lustre /work /projects /data
 
-# CMake version 3.14.7
+# CMake version 3.16.6
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.7-Linux-x86_64.sh && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.16/cmake-3.16.6-Linux-x86_64.sh && \
     mkdir -p /usr/local && \
-    /bin/sh /var/tmp/cmake-3.14.7-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
-    rm -rf /var/tmp/cmake-3.14.7-Linux-x86_64.sh
+    /bin/sh /var/tmp/cmake-3.16.6-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
+    rm -rf /var/tmp/cmake-3.16.6-Linux-x86_64.sh
 ENV PATH=/usr/local/bin:$PATH
 
 # Package manager Conan building block

--- a/scripts/docker/Dockerfile.gcc.full
+++ b/scripts/docker/Dockerfile.gcc.full
@@ -59,16 +59,16 @@ RUN apt-get update && \
     git lfs install && \
     mkdir -p /apps /scratch /lustre /work /projects /data
 
-# CMake version 3.14.7
+# CMake version 3.16.6
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.7-Linux-x86_64.sh && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.16/cmake-3.16.6-Linux-x86_64.sh && \
     mkdir -p /usr/local && \
-    /bin/sh /var/tmp/cmake-3.14.7-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
-    rm -rf /var/tmp/cmake-3.14.7-Linux-x86_64.sh
+    /bin/sh /var/tmp/cmake-3.16.6-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
+    rm -rf /var/tmp/cmake-3.16.6-Linux-x86_64.sh
 ENV PATH=/usr/local/bin:$PATH
 
 # Package manager Conan building block

--- a/scripts/docker/Dockerfile.gcc.gui
+++ b/scripts/docker/Dockerfile.gcc.gui
@@ -67,16 +67,16 @@ RUN apt-get update -y && \
         mesa-common-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# CMake version 3.14.7
+# CMake version 3.16.6
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.7-Linux-x86_64.sh && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.16/cmake-3.16.6-Linux-x86_64.sh && \
     mkdir -p /usr/local && \
-    /bin/sh /var/tmp/cmake-3.14.7-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
-    rm -rf /var/tmp/cmake-3.14.7-Linux-x86_64.sh
+    /bin/sh /var/tmp/cmake-3.16.6-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
+    rm -rf /var/tmp/cmake-3.16.6-Linux-x86_64.sh
 ENV PATH=/usr/local/bin:$PATH
 
 # Package manager Conan building block

--- a/web/content/docs/devguide/troubleshooting/build.pandoc
+++ b/web/content/docs/devguide/troubleshooting/build.pandoc
@@ -29,13 +29,3 @@ If this still fails you can disable building of the failing processes, e.g.:
 ```
 cmake . -DOGS_BUILD_PROCESS_HT=OFF
 cmake --build . --config Release -j 1
-
-## Cotire-related (pre-compiled headers)
-
-If you get some error during build which mentions `cotire` or `*.prefix.hxx.gch` you can try to clean the pre-compiled headers with:
-
-```bash
-make clean_cotire
-```
-
-This may occur after updating the compiler or system libraries. Related to configurations with `OGS_USE_PCH=ON` only.


### PR DESCRIPTION
Introduces CMake-option `OGS_USE_UNITY_BUILDS` to enable [unity builds](https://onqtam.com/programming/2019-12-20-pch-unity-cmake-3-16/) to speed up compilation significantly (defaults to `ON`).

Compilation tests show speed-ups for different targets between 25 % and 75 %.

When using at least CMake 3.16 then `OGS_USE_UNITY_BUILDS` is set to `ON` (requires CMake 3.16, as a soft dependency) and all libs added with `ogs_add_library()` will build as Unity builds.

Removed CMake-option `OGS_USE_PCH`.

Also introduced CMake-variable `OGS_DISABLE_CCACHE`.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.1)
2. [x] Tests covering your feature were added?

TODO:

- [x] testrunner