### PR TITLE
add GMRES restart option

### DIFF
--- a/Documentation/ProjectFile/prj/linear_solvers/linear_solver/eigen/t_restart.md
+++ b/Documentation/ProjectFile/prj/linear_solvers/linear_solver/eigen/t_restart.md
@@ -1,0 +1,7 @@
+Sets the number of iterations after which a restart of the GMRES method is performed.
+Default value is 30.
+This option is only available for the GMRES solver which is part of the unsupported Eigen modules that are available
+through OGS_USE_EIGEN_UNSUPPORTED cmake option.
+
+See following links for detail description:
+ - "Detailed Description" in https://eigen.tuxfamily.org/dox/unsupported/classEigen_1_1GMRES.html

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -124,16 +124,20 @@ private:
     }
 };
 
-template <> 
-void EigenIterativeLinearSolver<Eigen::GMRES<EigenMatrix::RawMatrixType, Eigen::IdentityPreconditioner>>::setRestart(int const restart)
+template <>
+void EigenIterativeLinearSolver<
+    Eigen::GMRES<EigenMatrix::RawMatrixType,
+                 Eigen::IdentityPreconditioner>>::setRestart(int const restart)
 {
     _solver.set_restart(restart);
     INFO("-> set restart value: {:d}", _solver.get_restart());
 }
 
-template <> 
-void EigenIterativeLinearSolver<Eigen::GMRES<EigenMatrix::RawMatrixType, Eigen::DiagonalPreconditioner<double>>>::setRestart(int const restart)
-{   
+template <>
+void EigenIterativeLinearSolver<Eigen::GMRES<
+    EigenMatrix::RawMatrixType,
+    Eigen::DiagonalPreconditioner<double>>>::setRestart(int const restart)
+{
     _solver.set_restart(restart);
     INFO("-> set restart value: {:d}", _solver.get_restart());
 }
@@ -297,7 +301,7 @@ void EigenLinearSolver::setOption(BaseLib::ConfigTree const& option)
 #else
         OGS_FATAL(
             "The code is not compiled with the Eigen unsupported modules. "
-            "GMRES option restart is not available.");
+            "GMRES/GMRES option restart is not available.");
 #endif
     }
 

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -124,6 +124,7 @@ private:
     }
 };
 
+/// Specialization for (all) three preconditioners separately
 template <>
 void EigenIterativeLinearSolver<
     Eigen::GMRES<EigenMatrix::RawMatrixType,

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.cpp
@@ -92,6 +92,7 @@ public:
              EigenOption::getPreconName(opt.precon_type));
         _solver.setTolerance(opt.error_tolerance);
         _solver.setMaxIterations(opt.max_iterations);
+        MathLib::details::EigenIterativeLinearSolver<T_SOLVER>::setRestart(opt.restart);
 
         if (!A.isCompressed())
         {
@@ -119,7 +120,30 @@ public:
 
 private:
     T_SOLVER _solver;
+    void setRestart(int const /*restart*/) {
+    }
 };
+
+template <> 
+void EigenIterativeLinearSolver<Eigen::GMRES<EigenMatrix::RawMatrixType, Eigen::IdentityPreconditioner>>::setRestart(int const restart)
+{
+    _solver.set_restart(restart);
+    INFO("-> set restart value: {:d}", _solver.get_restart());
+}
+
+template <> 
+void EigenIterativeLinearSolver<Eigen::GMRES<EigenMatrix::RawMatrixType, Eigen::DiagonalPreconditioner<double>>>::setRestart(int const restart)
+{   
+    _solver.set_restart(restart);
+    INFO("-> set restart value: {:d}", _solver.get_restart());
+}
+
+template <>
+void EigenIterativeLinearSolver<Eigen::GMRES<EigenMatrix::RawMatrixType, Eigen::IncompleteLUT<double>>>::setRestart(int const restart)
+{
+    _solver.set_restart(restart);
+    INFO("-> set restart value: {:d}", _solver.get_restart());
+}
 
 template <template <typename, typename> class Solver, typename Precon>
 std::unique_ptr<EigenLinearSolverBase> createIterativeSolver()
@@ -265,6 +289,18 @@ void EigenLinearSolver::setOption(BaseLib::ConfigTree const& option)
             "scaling is not available.");
 #endif
     }
+    if (auto restart =
+            //! \ogs_file_param{prj__linear_solvers__linear_solver__eigen__restart}
+            ptSolver->getConfigParameterOptional<int>("restart")) {
+#ifdef USE_EIGEN_UNSUPPORTED
+        _option.restart = *restart;
+#else
+        OGS_FATAL(
+            "The code is not compiled with the Eigen unsupported modules. "
+            "GMRES option restart is not available.");
+#endif
+    }
+
 }
 
 bool EigenLinearSolver::solve(EigenMatrix &A, EigenVector& b, EigenVector &x)

--- a/MathLib/LinAlg/Eigen/EigenLinearSolver.h
+++ b/MathLib/LinAlg/Eigen/EigenLinearSolver.h
@@ -59,6 +59,7 @@ public:
 protected:
     EigenOption _option;
     std::unique_ptr<EigenLinearSolverBase> _solver;
+    void setRestart();
 };
 
 }  // namespace MathLib

--- a/MathLib/LinAlg/Eigen/EigenOption.cpp
+++ b/MathLib/LinAlg/Eigen/EigenOption.cpp
@@ -22,6 +22,7 @@ EigenOption::EigenOption()
     error_tolerance = 1.e-16;
 #ifdef USE_EIGEN_UNSUPPORTED
     scaling = false;
+    restart = 30;
 #endif
 }
 

--- a/MathLib/LinAlg/Eigen/EigenOption.h
+++ b/MathLib/LinAlg/Eigen/EigenOption.h
@@ -47,6 +47,7 @@ struct EigenOption final
 #ifdef USE_EIGEN_UNSUPPORTED
     /// Scaling the coefficient matrix and the RHS bector
     bool scaling;
+    int restart;
 #endif
 
     /// Constructor

--- a/MathLib/LinAlg/Eigen/EigenOption.h
+++ b/MathLib/LinAlg/Eigen/EigenOption.h
@@ -47,6 +47,7 @@ struct EigenOption final
 #ifdef USE_EIGEN_UNSUPPORTED
     /// Scaling the coefficient matrix and the RHS bector
     bool scaling;
+    /// Restart value for the GMRES solver
     int restart;
 #endif
 


### PR DESCRIPTION
add restart option for the GMRES solver (Eigen-unsupported). 
It sets the number of iterations before a restart is conducted. It can improve the convergence behavior. However, increasing the value comes with a tradeoff in time and memory. First tests suggest that the default value (30) is already quite optimal in most cases.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.1)
2. [ ] Tests covering your feature were added?
3. [x] Any new feature or behavior change was documented?
