### PR TITLE
Capillary pressure - van Genuchten model.

### DIFF
--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/c_CapillaryPressureVanGenuchten.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/c_CapillaryPressureVanGenuchten.md
@@ -1,0 +1,1 @@
+\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_exponent.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_exponent.md
@@ -1,0 +1,1 @@
+\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::_m

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_maximum_capillary_pressure.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_maximum_capillary_pressure.md
@@ -1,0 +1,1 @@
+\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::_pc_max

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_maximum_capillary_pressure.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_maximum_capillary_pressure.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::_pc_max
+\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::_p_cap_max

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_maximum_liquid_saturation.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_maximum_liquid_saturation.md
@@ -1,0 +1,1 @@
+The maximum saturation of liquid phase.

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_maximum_liquid_saturation.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_maximum_liquid_saturation.md
@@ -1,1 +1,0 @@
-The maximum saturation of liquid phase.

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_p_b.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_p_b.md
@@ -1,0 +1,1 @@
+\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::_p_b

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_residual_gas_saturation.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_residual_gas_saturation.md
@@ -1,0 +1,3 @@
+The smallest degree of saturation of the gas (or non-wetting) phase in the medium.
+The maximum saturation of the liquid (wetting) phase is
+\f$S_{L,\text{res}} = 1-S_{G,\text{res}}\f$.

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_residual_liquid_saturation.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_residual_liquid_saturation.md
@@ -1,0 +1,1 @@
+The residual saturation of liquid phase.

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_residual_liquid_saturation.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_residual_liquid_saturation.md
@@ -1,1 +1,1 @@
-The residual saturation of liquid phase.
+\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::_S_L_res

--- a/MaterialLib/MPL/CreateProperty.cpp
+++ b/MaterialLib/MPL/CreateProperty.cpp
@@ -113,6 +113,11 @@ std::unique_ptr<MaterialPropertyLib::Property> createProperty(
         return createSaturationVanGenuchten(config);
     }
 
+    if (boost::iequals(property_type, "CapillaryPressureVanGenuchten"))
+    {
+        return createCapillaryPressureVanGenuchten(config);
+    }
+
     if (boost::iequals(property_type, "RelativePermeabilityVanGenuchten"))
     {
         return createRelPermVanGenuchten(config);

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.cpp
@@ -1,0 +1,105 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on March 20, 2020, 9:59 AM
+ */
+
+#include "CapillaryPressureVanGenuchten.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "MaterialLib/MPL/Medium.h"
+
+namespace MaterialPropertyLib
+{
+CapillaryPressureVanGenuchten::CapillaryPressureVanGenuchten(
+    double const residual_liquid_saturation,
+    double const maximum_liquid_saturation, double const exponent,
+    double const p_b, double const max_capillary_pressure)
+    : _residual_saturation(residual_liquid_saturation),
+      _maximuml_saturation(maximum_liquid_saturation),
+      _m(exponent),
+      _p_b(p_b),
+      _pc_max(max_capillary_pressure)
+{
+    if (!(_m > 0 && _m < 1))
+    {
+        OGS_FATAL(
+            "The exponent value m = %g of van Genuchten saturation model, is "
+            "out of its range of (0, 1)",
+            _m);
+    }
+}
+
+PropertyDataType CapillaryPressureVanGenuchten::value(
+    VariableArray const& variable_array,
+    ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
+    double const /*dt*/) const
+{
+    const double saturation = std::get<double>(
+        variable_array[static_cast<int>(Variable::liquid_saturation)]);
+
+    const double S =
+        std::clamp(saturation, _residual_saturation, _maximuml_saturation);
+    const double Se = (S - _residual_saturation) /
+                      (_maximuml_saturation - _residual_saturation);
+    const double pc =
+        (Se < 1.0) ? _p_b * std::pow(std::pow(Se, (-1.0 / _m)) - 1.0, 1.0 - _m)
+                   : 0.0;
+    return std::clamp(pc, 0.0, _pc_max);
+}
+
+PropertyDataType CapillaryPressureVanGenuchten::dValue(
+    VariableArray const& variable_array, Variable const /*primary_variable*/,
+    ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
+    double const /*dt*/) const
+{
+    const double saturation = std::get<double>(
+        variable_array[static_cast<int>(Variable::liquid_saturation)]);
+
+    const double S =
+        std::clamp(saturation, _residual_saturation, _maximuml_saturation);
+    const double Se = (S - _residual_saturation) /
+                      (_maximuml_saturation - _residual_saturation);
+
+    if (!(Se < 1.0))
+    {
+        return 0.0;
+    }
+    const double val1 = std::pow(Se, -1.0 / _m);
+    const double val2 = std::pow(val1 - 1.0, -_m);
+    return _p_b * (_m - 1.0) * val1 * val2 / (_m * (S - _residual_saturation));
+}
+
+PropertyDataType CapillaryPressureVanGenuchten::d2Value(
+    VariableArray const& variable_array, Variable const /*primary_variable1*/,
+    Variable const /*primary_variable2*/,
+    ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
+    double const /*dt*/) const
+{
+    const double saturation = std::get<double>(
+        variable_array[static_cast<int>(Variable::liquid_saturation)]);
+
+    const double S =
+        std::clamp(saturation, _residual_saturation, _maximuml_saturation);
+    const double Se = (S - _residual_saturation) /
+                      (_maximuml_saturation - _residual_saturation);
+    if (!(Se < 1.0))
+    {
+        return 0.0;
+    }
+
+    const double val1 = std::pow(Se, 1.0 / _m);
+    return -_p_b /
+           (_m * _m * (S - _residual_saturation) * (S - _residual_saturation)) *
+           std::pow(1 - val1, -_m - 1) * std::pow(val1, _m - 1) *
+           ((1 - _m * _m) * val1 + _m - 1);
+}
+
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.cpp
@@ -30,12 +30,51 @@ CapillaryPressureVanGenuchten::CapillaryPressureVanGenuchten(
       _p_b(p_b),
       _p_cap_max(maximum_capillary_pressure)
 {
+    if (_S_L_res < 0 || _S_L_res > 1)
+    {
+        OGS_FATAL(
+            "Van Genuchten capillary pressure model: "
+            "The residual liquid saturation value S_L_res = {:g} is out of "
+            "admissible range [0, 1].",
+            _S_L_res);
+    }
+    if (_S_L_max < 0 || _S_L_max > 1)
+    {
+        OGS_FATAL(
+            "Van Genuchten capillary pressure model: "
+            "The maximum liquid saturation value S_L_max = {:g} is out of "
+            "admissible range [0, 1].",
+            _S_L_max);
+    }
+    if (_S_L_res >= _S_L_max)
+    {
+        OGS_FATAL(
+            "Van Genuchten capillary pressure model: "
+            "The maximum liquid saturation S_L_max = {:g} must not be less or "
+            "equal to the residual liquid saturion S_L_res = { : g}.",
+            _S_L_max, _S_L_res);
+    }
     if (!(_m > 0 && _m < 1))
     {
         OGS_FATAL(
-            "The exponent value m = {:g} of van Genuchten capillary pressure "
-            "model, is out of its range of (0, 1)",
+            "Van Genuchten capillary pressure model: "
+            "The exponent value m = {:g} is out of of admissible range (0, 1).",
             _m);
+    }
+    if (_p_b <= 0)
+    {
+        OGS_FATAL(
+            "Van Genuchten capillary pressure model: "
+            "The pressure scaling value p_b = {:g} must be positive.",
+            _p_b);
+    }
+    if (_p_cap_max < 0)
+    {
+        OGS_FATAL(
+            "Van Genuchten capillary pressure model: "
+            "The maximum capillary pressure value p_cap_max = {:g} must be "
+            "non-negative.",
+            _p_cap_max);
     }
 }
 

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.cpp
@@ -103,46 +103,4 @@ PropertyDataType CapillaryPressureVanGenuchten::dValue(
     double const val2 = std::pow(val1 - 1.0, -_m);
     return _p_b * (_m - 1.0) * val1 * val2 / (_m * (S_L - _S_L_res));
 }
-
-PropertyDataType CapillaryPressureVanGenuchten::d2Value(
-    VariableArray const& variable_array, Variable const primary_variable1,
-    Variable const primary_variable2,
-    ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
-    double const /*dt*/) const
-{
-    (void)primary_variable1;
-    (void)primary_variable2;
-    assert((primary_variable1 == Variable::liquid_saturation) &&
-           (primary_variable2 == Variable::liquid_saturation) &&
-           "CapillaryPressureVanGenuchten::d2Value is implemented for "
-           "derivatives with respect to liquid saturation only.");
-
-    double const S_L = std::get<double>(
-        variable_array[static_cast<int>(Variable::liquid_saturation)]);
-
-    if (S_L <= _S_L_res)
-    {
-        return 0;
-    }
-
-    if (S_L >= _S_L_max)
-    {
-        return 0;
-    }
-    double const delta_S_L_res = S_L - _S_L_res;
-    double const S_eff = delta_S_L_res / (_S_L_max - _S_L_res);
-
-    assert(0 < S_eff && S_eff < 1.0);
-
-    double const val1 = std::pow(S_eff, -1.0 / _m);
-    double const p_cap = _p_b * std::pow(val1 - 1.0, 1.0 - _m);
-    if (p_cap >= _p_cap_max)
-    {
-        return 0;
-    }
-
-    return -_p_b / (_m * _m * delta_S_L_res * delta_S_L_res) * val1 * val1 *
-           std::pow(val1 - 1, -_m - 1) * ((1 - _m * _m) / val1 + _m - 1);
-}
-
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.cpp
@@ -20,19 +20,21 @@ namespace MaterialPropertyLib
 {
 CapillaryPressureVanGenuchten::CapillaryPressureVanGenuchten(
     double const residual_liquid_saturation,
-    double const maximum_liquid_saturation, double const exponent,
-    double const p_b, double const max_capillary_pressure)
-    : _residual_saturation(residual_liquid_saturation),
-      _maximuml_saturation(maximum_liquid_saturation),
+    double const residual_gas_saturation,
+    double const exponent,
+    double const p_b,
+    double const maximum_capillary_pressure)
+    : _S_L_res(residual_liquid_saturation),
+      _S_L_max(1. - residual_gas_saturation),
       _m(exponent),
       _p_b(p_b),
-      _pc_max(max_capillary_pressure)
+      _p_cap_max(maximum_capillary_pressure)
 {
     if (!(_m > 0 && _m < 1))
     {
         OGS_FATAL(
-            "The exponent value m = %g of van Genuchten saturation model, is "
-            "out of its range of (0, 1)",
+            "The exponent value m = {:g} of van Genuchten capillary pressure "
+            "model, is out of its range of (0, 1)",
             _m);
     }
 }
@@ -42,64 +44,105 @@ PropertyDataType CapillaryPressureVanGenuchten::value(
     ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
     double const /*dt*/) const
 {
-    const double saturation = std::get<double>(
+    double const S_L = std::get<double>(
         variable_array[static_cast<int>(Variable::liquid_saturation)]);
 
-    const double S =
-        std::clamp(saturation, _residual_saturation, _maximuml_saturation);
-    const double Se = (S - _residual_saturation) /
-                      (_maximuml_saturation - _residual_saturation);
-    const double pc =
-        (Se < 1.0) ? _p_b * std::pow(std::pow(Se, (-1.0 / _m)) - 1.0, 1.0 - _m)
-                   : 0.0;
-    return std::clamp(pc, 0.0, _pc_max);
+    if (S_L <= _S_L_res)
+    {
+        return _p_cap_max;
+    }
+
+    if (S_L >= _S_L_max)
+    {
+        return 0;
+    }
+
+    double const S_eff = (S_L - _S_L_res) / (_S_L_max - _S_L_res);
+    assert(0 <= S_eff && S_eff <= 1);
+
+    double const p_cap =
+        _p_b * std::pow(std::pow(S_eff, -1.0 / _m) - 1.0, 1.0 - _m);
+    assert(p_cap > 0);
+    return std::min(p_cap, _p_cap_max);
 }
 
 PropertyDataType CapillaryPressureVanGenuchten::dValue(
-    VariableArray const& variable_array, Variable const /*primary_variable*/,
+    VariableArray const& variable_array, Variable const primary_variable,
     ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
     double const /*dt*/) const
 {
-    const double saturation = std::get<double>(
+    (void)primary_variable;
+    assert((primary_variable == Variable::liquid_saturation) &&
+           "CapillaryPressureVanGenuchten::dValue is implemented for "
+           "derivatives with respect to liquid saturation only.");
+
+    double const S_L = std::get<double>(
         variable_array[static_cast<int>(Variable::liquid_saturation)]);
 
-    const double S =
-        std::clamp(saturation, _residual_saturation, _maximuml_saturation);
-    const double Se = (S - _residual_saturation) /
-                      (_maximuml_saturation - _residual_saturation);
-
-    if (!(Se < 1.0))
+    if (S_L <= _S_L_res)
     {
-        return 0.0;
+        return 0;
     }
-    const double val1 = std::pow(Se, -1.0 / _m);
-    const double val2 = std::pow(val1 - 1.0, -_m);
-    return _p_b * (_m - 1.0) * val1 * val2 / (_m * (S - _residual_saturation));
+
+    if (S_L >= _S_L_max)
+    {
+        return 0;
+    }
+
+    double const S_eff = (S_L - _S_L_res) / (_S_L_max - _S_L_res);
+
+    assert(0 < S_eff && S_eff < 1.0);
+
+    double const val1 = std::pow(S_eff, -1.0 / _m);
+    double const p_cap = _p_b * std::pow(val1 - 1.0, 1.0 - _m);
+    if (p_cap >= _p_cap_max)
+    {
+        return 0;
+    }
+
+    double const val2 = std::pow(val1 - 1.0, -_m);
+    return _p_b * (_m - 1.0) * val1 * val2 / (_m * (S_L - _S_L_res));
 }
 
 PropertyDataType CapillaryPressureVanGenuchten::d2Value(
-    VariableArray const& variable_array, Variable const /*primary_variable1*/,
-    Variable const /*primary_variable2*/,
+    VariableArray const& variable_array, Variable const primary_variable1,
+    Variable const primary_variable2,
     ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
     double const /*dt*/) const
 {
-    const double saturation = std::get<double>(
+    (void)primary_variable1;
+    (void)primary_variable2;
+    assert((primary_variable1 == Variable::liquid_saturation) &&
+           (primary_variable2 == Variable::liquid_saturation) &&
+           "CapillaryPressureVanGenuchten::d2Value is implemented for "
+           "derivatives with respect to liquid saturation only.");
+
+    double const S_L = std::get<double>(
         variable_array[static_cast<int>(Variable::liquid_saturation)]);
 
-    const double S =
-        std::clamp(saturation, _residual_saturation, _maximuml_saturation);
-    const double Se = (S - _residual_saturation) /
-                      (_maximuml_saturation - _residual_saturation);
-    if (!(Se < 1.0))
+    if (S_L <= _S_L_res)
     {
-        return 0.0;
+        return 0;
     }
 
-    const double val1 = std::pow(Se, 1.0 / _m);
-    return -_p_b /
-           (_m * _m * (S - _residual_saturation) * (S - _residual_saturation)) *
-           std::pow(1 - val1, -_m - 1) * std::pow(val1, _m - 1) *
-           ((1 - _m * _m) * val1 + _m - 1);
+    if (S_L >= _S_L_max)
+    {
+        return 0;
+    }
+    double const delta_S_L_res = S_L - _S_L_res;
+    double const S_eff = delta_S_L_res / (_S_L_max - _S_L_res);
+
+    assert(0 < S_eff && S_eff < 1.0);
+
+    double const val1 = std::pow(S_eff, -1.0 / _m);
+    double const p_cap = _p_b * std::pow(val1 - 1.0, 1.0 - _m);
+    if (p_cap >= _p_cap_max)
+    {
+        return 0;
+    }
+
+    return -_p_b / (_m * _m * delta_S_L_res * delta_S_L_res) * val1 * val1 *
+           std::pow(val1 - 1, -_m - 1) * ((1 - _m * _m) / val1 + _m - 1);
 }
 
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.h
@@ -1,0 +1,74 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on March 20, 2020, 9:59 AM
+ */
+
+#pragma once
+
+#include "MaterialLib/MPL/Property.h"
+
+namespace MaterialPropertyLib
+{
+class Medium;
+class Phase;
+class Component;
+
+/// \copydoc MaterialPropertyLib::SaturationVanGenuchten
+class CapillaryPressureVanGenuchten : public Property
+{
+public:
+    CapillaryPressureVanGenuchten(double const residual_liquid_saturation,
+                                  double const maximum_liquid_saturation,
+                                  double const exponent,
+                                  double const p_b,
+                                  double const max_capillary_pressure);
+
+    void setScale(
+        std::variant<Medium*, Phase*, Component*> scale_pointer) override
+    {
+        if (!std::holds_alternative<Medium*>(scale_pointer))
+        {
+            OGS_FATAL(
+                "The property 'CapillaryVanGenuchten' is implemented on the "
+                "'media' scale only.");
+        }
+        _medium = std::get<Medium*>(scale_pointer);
+    }
+
+    /// It returns \f$ p_c(S) \f$.
+    PropertyDataType value(VariableArray const& variable_array,
+                           ParameterLib::SpatialPosition const& pos,
+                           double const t,
+                           double const dt) const override;
+
+    /// It returns \f$ \frac{\partial p_c(S)}{\partial  S} \f$
+    PropertyDataType dValue(VariableArray const& variable_array,
+                            Variable const variable,
+                            ParameterLib::SpatialPosition const& pos,
+                            double const t,
+                            double const dt) const override;
+
+    /// It returns \f$ \frac{\partial^2 p_c(S)}{\partial  S^2} \f$
+    PropertyDataType d2Value(VariableArray const& variable_array,
+                             Variable const variable1, Variable const variable2,
+                             ParameterLib::SpatialPosition const& pos,
+                             double const t, double const dt) const override;
+
+private:
+    Medium* _medium = nullptr;
+    /// Residual saturation of liquid phase.
+    double const _residual_saturation;
+    double const _maximuml_saturation;  ///< Maximum saturation of liquid phase.
+    double const _m;                    ///< Exponent.
+    /// Capillary pressure scaling factor. Sometimes, it is called apparent gas
+    /// entry pressure.
+    double const _p_b;
+    double const _pc_max;  ///< Maximum capillary pressure.
+};
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.h
@@ -73,12 +73,6 @@ public:
                             double const t,
                             double const dt) const override;
 
-    /// \returns \f$ \frac{\partial^2 p_c(S)}{\partial  S^2} \f$
-    PropertyDataType d2Value(VariableArray const& variable_array,
-                             Variable const variable1, Variable const variable2,
-                             ParameterLib::SpatialPosition const& pos,
-                             double const t, double const dt) const override;
-
 private:
     Medium* _medium = nullptr;
     double const _S_L_res;    ///< Residual saturation of liquid phase.

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateCapillaryPressureVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateCapillaryPressureVanGenuchten.cpp
@@ -1,0 +1,48 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on March 20, 2020, 1:31 PM
+ */
+
+#include "CreateCapillaryPressureVanGenuchten.h"
+
+#include "BaseLib/ConfigTree.h"
+#include "CapillaryPressureVanGenuchten.h"
+#include "MaterialLib/MPL/Property.h"
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<Property> createCapillaryPressureVanGenuchten(
+    BaseLib::ConfigTree const& config)
+{
+    //! \ogs_file_param{properties__property__type}
+    config.checkConfigParameter("type", "CapillaryPressureVanGenuchten");
+
+    DBUG("Create CapillaryPressureVanGenuchten medium property");
+
+    auto const residual_liquid_saturation =
+        //! \ogs_file_param{properties__property__CapillaryPressureVanGenuchten__residual_liquid_saturation}
+        config.getConfigParameter<double>("residual_liquid_saturation");
+    auto const maximum_liquid_saturation =
+        //! \ogs_file_param{properties__property__CapillaryPressureVanGenuchten__maximum_liquid_saturation}
+        config.getConfigParameter<double>("maximum_liquid_saturation");
+    auto const exponent =
+        //! \ogs_file_param{properties__property__CapillaryPressureVanGenuchten__exponent}
+        config.getConfigParameter<double>("exponent");
+    auto const p_b =
+        //! \ogs_file_param{properties__property__CapillaryPressureVanGenuchten__p_b}
+        config.getConfigParameter<double>("p_b");
+    auto const maximum_capillary_pressure =
+        //! \ogs_file_param{properties__property__CapillaryPressureVanGenuchten__maximum_capillary_pressure}
+        config.getConfigParameter<double>("maximum_capillary_pressure");
+
+    return std::make_unique<CapillaryPressureVanGenuchten>(
+        residual_liquid_saturation, maximum_liquid_saturation, exponent, p_b,
+        maximum_capillary_pressure);
+}
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateCapillaryPressureVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateCapillaryPressureVanGenuchten.cpp
@@ -28,9 +28,9 @@ std::unique_ptr<Property> createCapillaryPressureVanGenuchten(
     auto const residual_liquid_saturation =
         //! \ogs_file_param{properties__property__CapillaryPressureVanGenuchten__residual_liquid_saturation}
         config.getConfigParameter<double>("residual_liquid_saturation");
-    auto const maximum_liquid_saturation =
-        //! \ogs_file_param{properties__property__CapillaryPressureVanGenuchten__maximum_liquid_saturation}
-        config.getConfigParameter<double>("maximum_liquid_saturation");
+    auto const residual_gas_saturation =
+        //! \ogs_file_param{properties__property__CapillaryPressureVanGenuchten__residual_gas_saturation}
+        config.getConfigParameter<double>("residual_gas_saturation");
     auto const exponent =
         //! \ogs_file_param{properties__property__CapillaryPressureVanGenuchten__exponent}
         config.getConfigParameter<double>("exponent");
@@ -42,7 +42,7 @@ std::unique_ptr<Property> createCapillaryPressureVanGenuchten(
         config.getConfigParameter<double>("maximum_capillary_pressure");
 
     return std::make_unique<CapillaryPressureVanGenuchten>(
-        residual_liquid_saturation, maximum_liquid_saturation, exponent, p_b,
+        residual_liquid_saturation, residual_gas_saturation, exponent, p_b,
         maximum_capillary_pressure);
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateCapillaryPressureVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateCapillaryPressureVanGenuchten.h
@@ -1,0 +1,26 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on March 20, 2020, 1:31 PM
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace MaterialPropertyLib
+{
+class Property;
+std::unique_ptr<Property> createCapillaryPressureVanGenuchten(
+    BaseLib::ConfigTree const& config);
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateProperties.h
+++ b/MaterialLib/MPL/Properties/CreateProperties.h
@@ -11,6 +11,7 @@
  */
 #pragma once
 
+#include "CapillaryPressureSaturation/CreateCapillaryPressureVanGenuchten.h"
 #include "CapillaryPressureSaturation/CreateSaturationBrooksCorey.h"
 #include "CapillaryPressureSaturation/CreateSaturationLiakopoulos.h"
 #include "CapillaryPressureSaturation/CreateSaturationVanGenuchten.h"
@@ -26,10 +27,7 @@
 #include "CreateParameterProperty.h"
 #include "CreatePermeabilityOrthotropicPowerLaw.h"
 #include "CreatePorosityFromMassBalance.h"
-#include "CapillaryPressureSaturation/CreateSaturationBrooksCorey.h"
 #include "CreateSaturationDependentSwelling.h"
-#include "CapillaryPressureSaturation/CreateSaturationLiakopoulos.h"
-#include "CapillaryPressureSaturation/CreateSaturationVanGenuchten.h"
 #include "CreateTransportPorosityFromMassBalance.h"
 #include "RelativePermeability/CreateRelPermBrooksCorey.h"
 #include "RelativePermeability/CreateRelPermLiakopoulos.h"

--- a/MaterialLib/MPL/Properties/CreateProperties.h
+++ b/MaterialLib/MPL/Properties/CreateProperties.h
@@ -15,7 +15,6 @@
 #include "CapillaryPressureSaturation/CreateSaturationBrooksCorey.h"
 #include "CapillaryPressureSaturation/CreateSaturationLiakopoulos.h"
 #include "CapillaryPressureSaturation/CreateSaturationVanGenuchten.h"
-
 #include "CreateBishopsPowerLaw.h"
 #include "CreateBishopsSaturationCutoff.h"
 #include "CreateConstant.h"

--- a/MaterialLib/MPL/PropertyType.h
+++ b/MaterialLib/MPL/PropertyType.h
@@ -39,6 +39,7 @@ enum PropertyType : int
     bishops_effective_stress,
     brooks_corey_exponent,
     bulk_modulus,
+    capillary_pressure,
     critical_density,
     critical_pressure,
     critical_temperature,
@@ -115,6 +116,10 @@ inline PropertyType convertStringToProperty(std::string const& inString)
     if (boost::iequals(inString, "bulk_modulus"))
     {
         return PropertyType::bulk_modulus;
+    }
+    if (boost::iequals(inString, "capillary_pressure"))
+    {
+        return PropertyType::capillary_pressure;
     }
     if (boost::iequals(inString, "critical_density"))
     {
@@ -284,6 +289,7 @@ static const std::array<std::string, PropertyType::number_of_properties>
                              "bishops_effective_stress",
                              "brooks_corey_exponent",
                              "bulk_modulus",
+                             "capillary_pressure",
                              "critical_density",
                              "critical_pressure",
                              "critical_temperature",

--- a/Tests/MaterialLib/TestMPLCapillaryPressureVanGenuchten.cpp
+++ b/Tests/MaterialLib/TestMPLCapillaryPressureVanGenuchten.cpp
@@ -84,9 +84,6 @@ TEST(MaterialPropertyLib, CapillaryPressureVanGenuchten)
 
         double const dp_cap = pressure.template dValue<double>(
             variable_array, MPL::Variable::liquid_saturation, pos, t, dt);
-        double const dp_cap2 = pressure.template d2Value<double>(
-            variable_array, MPL::Variable::liquid_saturation,
-            MPL::Variable::liquid_saturation, pos, t, dt);
 
         double const eps = 1e-6;
         variable_array[static_cast<int>(MPL::Variable::liquid_saturation)] =
@@ -99,8 +96,6 @@ TEST(MaterialPropertyLib, CapillaryPressureVanGenuchten)
             pressure.template value<double>(variable_array, pos, t, dt);
 
         double const Dp_cap = (p_cap_plus - p_cap_minus) / 2 / eps;
-        double const Dp_cap2 =
-            (p_cap_plus - 2 * p_cap + p_cap_minus) / (eps * eps);
 
         //
         // First order derivative tests
@@ -130,36 +125,6 @@ TEST(MaterialPropertyLib, CapillaryPressureVanGenuchten)
                 << "for liquid saturation " << S_L << ", capillary pressure "
                 << p_cap << ", dp_cap/dS_L " << dp_cap << " and Dp_cap/DS_L "
                 << Dp_cap;
-        }
-
-        //
-        // Second order derivative tests
-        //
-
-        // Testing relative error up to the S_L_max with different tolerances as
-        // d^2p_cap/dS_L^2 approaches -infinity.
-        if (S_L < 1 - 2 * residual_gas_saturation)
-        {
-            ASSERT_LE(std::abs(dp_cap2 - Dp_cap2) / p_cap, 2e-3)
-                << "for liquid saturation " << S_L << " and capillary pressure "
-                << p_cap << ", d^2p_cap/dS_L^2 " << dp_cap2
-                << " and D^2p_cap/DS_L^2 " << Dp_cap2;
-        }
-        else if (S_L < 1 - residual_gas_saturation * 1.35)
-        {
-            ASSERT_LE(std::abs(dp_cap2 - Dp_cap2) / p_cap, 4e-3)
-                << "for liquid saturation " << S_L << " and capillary pressure "
-                << p_cap << ", d^2p_cap/dS_L^2 " << dp_cap2
-                << " and D^2p_cap/DS_L^2 " << Dp_cap2;
-        }
-        // Skip the range up to maximum liquid saturation, continue after that
-        // with absolute error.
-        else if (S_L > 1 - residual_gas_saturation)
-        {
-            ASSERT_EQ(dp_cap2, Dp_cap2)
-                << "for liquid saturation " << S_L << " and capillary pressure "
-                << p_cap << ", d^2p_cap/dS_L^2 " << dp_cap2
-                << " and D^2p_cap/DS_L^2 " << Dp_cap2;
         }
     }
 }

--- a/Tests/MaterialLib/TestMPLCapillaryPressureVanGenuchten.cpp
+++ b/Tests/MaterialLib/TestMPLCapillaryPressureVanGenuchten.cpp
@@ -1,0 +1,165 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ */
+
+#include <gtest/gtest.h>
+
+#include "MaterialLib/MPL/Medium.h"
+#include "MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.h"
+#include "MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationVanGenuchten.h"
+#include "TestMPL.h"
+#include "Tests/TestTools.h"
+
+namespace MPL = MaterialPropertyLib;
+
+TEST(MaterialPropertyLib, CapillaryPressureVanGenuchten)
+{
+    double const residual_liquid_saturation = 0.1;
+    double const residual_gas_saturation = 0.05;
+    double const exponent = 0.79;
+    double const p_b = 10000;
+    double const maximum_capillary_pressure = 20000;
+
+    MPL::Property const& pressure = MPL::CapillaryPressureVanGenuchten{
+        residual_liquid_saturation, residual_gas_saturation, exponent, p_b,
+        maximum_capillary_pressure};
+
+    MPL::Property const& saturation = MPL::SaturationVanGenuchten{
+        residual_liquid_saturation, residual_gas_saturation, exponent, p_b};
+
+    MPL::VariableArray variable_array;
+    fill(begin(variable_array), end(variable_array),
+         std::numeric_limits<double>::quiet_NaN());
+    ParameterLib::SpatialPosition const pos;
+    double const t = std::numeric_limits<double>::quiet_NaN();
+    double const dt = std::numeric_limits<double>::quiet_NaN();
+
+    double const S_0 = -0.01;
+    double const S_max = 1.01;
+    int const n_steps = 10000;
+    for (int i = 0; i <= n_steps; ++i)
+    {
+        double const S_L = S_0 + i * (S_max - S_0) / n_steps;
+        variable_array[static_cast<int>(MPL::Variable::liquid_saturation)] =
+            S_L;
+
+        double const p_cap =
+            pressure.template value<double>(variable_array, pos, t, dt);
+        ASSERT_LE(p_cap, maximum_capillary_pressure);
+        ASSERT_GE(p_cap, 0);
+
+        variable_array[static_cast<int>(MPL::Variable::capillary_pressure)] =
+            p_cap;
+
+        double const S_L_roundtrip =
+            saturation.template value<double>(variable_array, pos, t, dt);
+
+        if (S_L < residual_liquid_saturation)
+        {
+            EXPECT_GE(S_L_roundtrip, S_L)
+                << "for liquid saturation " << S_L << " and capillary pressure "
+                << p_cap;
+        }
+
+        if (residual_liquid_saturation <= S_L &&
+            S_L <= 1. - residual_gas_saturation &&
+            p_cap < maximum_capillary_pressure)
+        {
+            ASSERT_LE(std::abs(S_L - S_L_roundtrip), 1e-15)
+                << "for liquid saturation " << S_L << " and capillary pressure "
+                << p_cap;
+        }
+
+        if (1. - residual_gas_saturation < S_L)
+        {
+            ASSERT_EQ(S_L_roundtrip, 1. - residual_gas_saturation)
+                << "for liquid saturation " << S_L << " and capillary pressure "
+                << p_cap;
+        }
+
+        double const dp_cap = pressure.template dValue<double>(
+            variable_array, MPL::Variable::liquid_saturation, pos, t, dt);
+        double const dp_cap2 = pressure.template d2Value<double>(
+            variable_array, MPL::Variable::liquid_saturation,
+            MPL::Variable::liquid_saturation, pos, t, dt);
+
+        double const eps = 1e-6;
+        variable_array[static_cast<int>(MPL::Variable::liquid_saturation)] =
+            S_L - eps;
+        double const p_cap_minus =
+            pressure.template value<double>(variable_array, pos, t, dt);
+        variable_array[static_cast<int>(MPL::Variable::liquid_saturation)] =
+            S_L + eps;
+        double const p_cap_plus =
+            pressure.template value<double>(variable_array, pos, t, dt);
+
+        double const Dp_cap = (p_cap_plus - p_cap_minus) / 2 / eps;
+        double const Dp_cap2 =
+            (p_cap_plus - 2 * p_cap + p_cap_minus) / (eps * eps);
+
+        //
+        // First order derivative tests
+        //
+
+        // Testing relative error up to the S_L_max with different tolerances as
+        // dp_cap/dS_L approaches -infinity.
+        if (S_L < 1 - 2 * residual_gas_saturation)
+        {
+            ASSERT_LE(std::abs(dp_cap - Dp_cap) / p_cap, 1e-9)
+                << "for liquid saturation " << S_L << ", capillary pressure "
+                << p_cap << ", dp_cap/dS_L " << dp_cap << " and Dp_cap/DS_L "
+                << Dp_cap;
+        }
+        else if (S_L < 1 - residual_gas_saturation * 1.35)
+        {
+            ASSERT_LE(std::abs(dp_cap - Dp_cap) / p_cap, 1e-8)
+                << "for liquid saturation " << S_L << ", capillary pressure "
+                << p_cap << ", dp_cap/dS_L " << dp_cap << " and Dp_cap/DS_L "
+                << Dp_cap;
+        }
+        // Skip the range up to maximum liquid saturation, continue after that
+        // with absolute error.
+        else if (S_L > 1 - residual_gas_saturation)
+        {
+            ASSERT_EQ(dp_cap, Dp_cap)
+                << "for liquid saturation " << S_L << ", capillary pressure "
+                << p_cap << ", dp_cap/dS_L " << dp_cap << " and Dp_cap/DS_L "
+                << Dp_cap;
+        }
+
+        //
+        // Second order derivative tests
+        //
+
+        // Testing relative error up to the S_L_max with different tolerances as
+        // d^2p_cap/dS_L^2 approaches -infinity.
+        if (S_L < 1 - 2 * residual_gas_saturation)
+        {
+            ASSERT_LE(std::abs(dp_cap2 - Dp_cap2) / p_cap, 2e-3)
+                << "for liquid saturation " << S_L << " and capillary pressure "
+                << p_cap << ", d^2p_cap/dS_L^2 " << dp_cap2
+                << " and D^2p_cap/DS_L^2 " << Dp_cap2;
+        }
+        else if (S_L < 1 - residual_gas_saturation * 1.35)
+        {
+            ASSERT_LE(std::abs(dp_cap2 - Dp_cap2) / p_cap, 4e-3)
+                << "for liquid saturation " << S_L << " and capillary pressure "
+                << p_cap << ", d^2p_cap/dS_L^2 " << dp_cap2
+                << " and D^2p_cap/DS_L^2 " << Dp_cap2;
+        }
+        // Skip the range up to maximum liquid saturation, continue after that
+        // with absolute error.
+        else if (S_L > 1 - residual_gas_saturation)
+        {
+            ASSERT_EQ(dp_cap2, Dp_cap2)
+                << "for liquid saturation " << S_L << " and capillary pressure "
+                << p_cap << ", d^2p_cap/dS_L^2 " << dp_cap2
+                << " and D^2p_cap/DS_L^2 " << Dp_cap2;
+        }
+    }
+}


### PR DESCRIPTION
An implementation of capillary pressure calculation from liquid saturation. This is not an inverse of the
SaturationVanGenuchten model, because the resulting capillary pressure is cut off at some maximum value.

1. [ ] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.1)
2. [x] Tests covering your feature were added?
3. [x] Any new feature or behavior change was documented?
