### PR TITLE
MPL; use trailing underscores for private members

### DIFF
--- a/Documentation/ProjectFile/properties/property/BishopsPowerLaw/t_exponent.md
+++ b/Documentation/ProjectFile/properties/property/BishopsPowerLaw/t_exponent.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::BishopsPowerLaw::_m
+\copydoc MaterialPropertyLib::BishopsPowerLaw::m_

--- a/Documentation/ProjectFile/properties/property/BishopsSaturationCutoff/t_cutoff_value.md
+++ b/Documentation/ProjectFile/properties/property/BishopsSaturationCutoff/t_cutoff_value.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::BishopsSaturationCutoff::_S_L_max
+\copydoc MaterialPropertyLib::BishopsSaturationCutoff::S_L_max_

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_exponent.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_exponent.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::_m
+\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::m_

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_maximum_capillary_pressure.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_maximum_capillary_pressure.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::_p_cap_max
+\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::p_cap_max_

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_p_b.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_p_b.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::_p_b
+\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::p_b_

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_residual_liquid_saturation.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_residual_liquid_saturation.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::_S_L_res
+\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::S_L_res_

--- a/Documentation/ProjectFile/properties/property/Curve/t_independent_variable.md
+++ b/Documentation/ProjectFile/properties/property/Curve/t_independent_variable.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::CurveProperty::_independent_variable
+\copydoc MaterialPropertyLib::CurveProperty::independent_variable_

--- a/Documentation/ProjectFile/properties/property/PermeabilityOrthotropicPowerLaw/t_exponents.md
+++ b/Documentation/ProjectFile/properties/property/PermeabilityOrthotropicPowerLaw/t_exponents.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::PermeabilityOrthotropicPowerLaw::_lambda
+\copydoc MaterialPropertyLib::PermeabilityOrthotropicPowerLaw::lambda_

--- a/Documentation/ProjectFile/properties/property/PermeabilityOrthotropicPowerLaw/t_intrinsic_permeabilities.md
+++ b/Documentation/ProjectFile/properties/property/PermeabilityOrthotropicPowerLaw/t_intrinsic_permeabilities.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::PermeabilityOrthotropicPowerLaw::_k
+\copydoc MaterialPropertyLib::PermeabilityOrthotropicPowerLaw::k_

--- a/Documentation/ProjectFile/properties/property/PorosityFromMassBalance/t_initial_porosity.md
+++ b/Documentation/ProjectFile/properties/property/PorosityFromMassBalance/t_initial_porosity.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::PorosityFromMassBalance::_phi0
+\copydoc MaterialPropertyLib::PorosityFromMassBalance::phi0_

--- a/Documentation/ProjectFile/properties/property/PorosityFromMassBalance/t_maximal_porosity.md
+++ b/Documentation/ProjectFile/properties/property/PorosityFromMassBalance/t_maximal_porosity.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::PorosityFromMassBalance::_phi_max
+\copydoc MaterialPropertyLib::PorosityFromMassBalance::phi_max_

--- a/Documentation/ProjectFile/properties/property/PorosityFromMassBalance/t_minimal_porosity.md
+++ b/Documentation/ProjectFile/properties/property/PorosityFromMassBalance/t_minimal_porosity.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::PorosityFromMassBalance::_phi_min
+\copydoc MaterialPropertyLib::PorosityFromMassBalance::phi_min_

--- a/Documentation/ProjectFile/properties/property/SaturationDependentSwelling/t_exponents.md
+++ b/Documentation/ProjectFile/properties/property/SaturationDependentSwelling/t_exponents.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::SaturationDependentSwelling::_lambda
+\copydoc MaterialPropertyLib::SaturationDependentSwelling::lambda_

--- a/Documentation/ProjectFile/properties/property/SaturationDependentSwelling/t_lower_saturation_limit.md
+++ b/Documentation/ProjectFile/properties/property/SaturationDependentSwelling/t_lower_saturation_limit.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::SaturationDependentSwelling::_S_min
+\copydoc MaterialPropertyLib::SaturationDependentSwelling::S_min_

--- a/Documentation/ProjectFile/properties/property/SaturationDependentSwelling/t_swelling_pressures.md
+++ b/Documentation/ProjectFile/properties/property/SaturationDependentSwelling/t_swelling_pressures.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::SaturationDependentSwelling::_p
+\copydoc MaterialPropertyLib::SaturationDependentSwelling::p_

--- a/Documentation/ProjectFile/properties/property/SaturationDependentSwelling/t_upper_saturation_limit.md
+++ b/Documentation/ProjectFile/properties/property/SaturationDependentSwelling/t_upper_saturation_limit.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::SaturationDependentSwelling::_S_max
+\copydoc MaterialPropertyLib::SaturationDependentSwelling::S_max_

--- a/Documentation/ProjectFile/properties/property/TransportPorosityFromMassBalance/t_initial_porosity.md
+++ b/Documentation/ProjectFile/properties/property/TransportPorosityFromMassBalance/t_initial_porosity.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::TransportPorosityFromMassBalance::_phi0
+\copydoc MaterialPropertyLib::TransportPorosityFromMassBalance::phi0_

--- a/Documentation/ProjectFile/properties/property/TransportPorosityFromMassBalance/t_maximal_porosity.md
+++ b/Documentation/ProjectFile/properties/property/TransportPorosityFromMassBalance/t_maximal_porosity.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::TransportPorosityFromMassBalance::_phi_max
+\copydoc MaterialPropertyLib::TransportPorosityFromMassBalance::phi_max_

--- a/Documentation/ProjectFile/properties/property/TransportPorosityFromMassBalance/t_minimal_porosity.md
+++ b/Documentation/ProjectFile/properties/property/TransportPorosityFromMassBalance/t_minimal_porosity.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::TransportPorosityFromMassBalance::_phi_min
+\copydoc MaterialPropertyLib::TransportPorosityFromMassBalance::phi_min_

--- a/MaterialLib/MPL/Component.cpp
+++ b/MaterialLib/MPL/Component.cpp
@@ -26,17 +26,17 @@ Component::Component(std::string const& component_name,
 {
     if (properties)
     {
-        overwriteExistingProperties(_properties, *properties, this);
+        overwriteExistingProperties(properties_, *properties, this);
     }
 }
 
 Property const& Component::property(PropertyType const& p) const
 {
-    return *_properties[p];
+    return *properties_[p];
 }
 
 bool Component::hasProperty(PropertyType const& p) const
 {
-    return _properties[p] != nullptr;
+    return properties_[p] != nullptr;
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Component.h
+++ b/MaterialLib/MPL/Component.h
@@ -71,7 +71,7 @@ public:
 
 protected:
     /// The property array of the component.
-    PropertyArray _properties;
+    PropertyArray properties_;
 };
 
 /// Method for creating a new component based on the specified component name.

--- a/MaterialLib/MPL/CreatePhase.h
+++ b/MaterialLib/MPL/CreatePhase.h
@@ -36,7 +36,7 @@ class PiecewiseLinearInterpolation;
 namespace MaterialPropertyLib
 {
 /// A method that parses the phase details and stores them in the private
-/// _phases member.
+/// phases_ member.
 ///
 /// This method creates the phases of the medium. Unlike a medium, a phase may
 /// have a name. However, this is silly at the moment since this name still has

--- a/MaterialLib/MPL/MaterialSpatialDistributionMap.cpp
+++ b/MaterialLib/MPL/MaterialSpatialDistributionMap.cpp
@@ -25,17 +25,17 @@ Medium const* MaterialSpatialDistributionMap::getMedium(
     std::size_t const element_id) const
 {
     auto const material_id =
-        _material_ids == nullptr ? 0 : (*_material_ids)[element_id];
+        material_ids_ == nullptr ? 0 : (*material_ids_)[element_id];
 
-    return _media.at(material_id).get();
+    return media_.at(material_id).get();
 }
 
 
 void MaterialSpatialDistributionMap::checkElementHasMedium(std::size_t const element_id)
 {
     auto const material_id =
-            _material_ids == nullptr ? 0 : (*_material_ids)[element_id];
-    if (_media.find(material_id) == _media.end())
+        material_ids_ == nullptr ? 0 : (*material_ids_)[element_id];
+    if (media_.find(material_id) == media_.end())
     {
         OGS_FATAL(
             "There is no medium definition for element {:d} with material "

--- a/MaterialLib/MPL/MaterialSpatialDistributionMap.h
+++ b/MaterialLib/MPL/MaterialSpatialDistributionMap.h
@@ -31,7 +31,7 @@ public:
     MaterialSpatialDistributionMap(
         std::map<int, std::shared_ptr<Medium>> const& media,
         MeshLib::PropertyVector<int> const* const material_ids)
-        : _media(media), _material_ids(material_ids)
+        : media_(media), material_ids_(material_ids)
     {
     }
 
@@ -40,7 +40,7 @@ public:
     void checkElementHasMedium(std::size_t const element_id);
 
 private:
-    std::map<int, std::shared_ptr<Medium>> const& _media;
-    MeshLib::PropertyVector<int> const* const _material_ids;
+    std::map<int, std::shared_ptr<Medium>> const& media_;
+    MeshLib::PropertyVector<int> const* const material_ids_;
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Medium.cpp
+++ b/MaterialLib/MPL/Medium.cpp
@@ -19,23 +19,23 @@ namespace MaterialPropertyLib
 {
 Medium::Medium(std::vector<std::unique_ptr<Phase>>&& phases,
                std::unique_ptr<PropertyArray>&& properties)
-    : _phases(std::move(phases))
+    : phases_(std::move(phases))
 {
     if (properties)
     {
-        overwriteExistingProperties(_properties, *properties, this);
+        overwriteExistingProperties(properties_, *properties, this);
     }
 }
 
 Phase const& Medium::phase(std::size_t const index) const
 {
-    return *_phases[index];
+    return *phases_[index];
 }
 
 Phase const& Medium::phase(std::string const& name) const
 {
     return *BaseLib::findElementOrError(
-        _phases.begin(), _phases.end(),
+        phases_.begin(), phases_.end(),
         [&name](std::unique_ptr<MaterialPropertyLib::Phase> const& phase) {
             return phase->name == name;
         },
@@ -44,16 +44,16 @@ Phase const& Medium::phase(std::string const& name) const
 
 Property const& Medium::property(PropertyType const& p) const
 {
-    return *_properties[p];
+    return *properties_[p];
 }
 
 bool Medium::hasProperty(PropertyType const& p) const
 {
-    return _properties[p] != nullptr;
+    return properties_[p] != nullptr;
 }
 
 std::size_t Medium::numberOfPhases() const
 {
-    return _phases.size();
+    return phases_.size();
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Medium.h
+++ b/MaterialLib/MPL/Medium.h
@@ -34,7 +34,7 @@ public:
            std::unique_ptr<PropertyArray>&& properties);
 
     /// A get-function for a particular phase. The ul argument specifies the
-    /// index within the _phases vector.
+    /// index within the phases_ vector.
     Phase const& phase(std::size_t index) const;
     /// A get-function for a particular phase by phase name.
     Phase const& phase(std::string const& phase_name) const;
@@ -79,14 +79,14 @@ public:
 
 private:
     /// The vector that holds the phases.
-    std::vector<std::unique_ptr<Phase>> const _phases;
+    std::vector<std::unique_ptr<Phase>> const phases_;
     /// The array that holds the medium properties.
     ///
     /// Currently, these defaults is the volume fraction average.
     ///
     /// Most properties are fine with the volume fraction average, but
     /// special-defaults are allowed as well...
-    PropertyArray _properties;
+    PropertyArray properties_;
 };
 
 template <typename Container>

--- a/MaterialLib/MPL/Phase.cpp
+++ b/MaterialLib/MPL/Phase.cpp
@@ -21,28 +21,28 @@ namespace MaterialPropertyLib
 Phase::Phase(std::string&& phase_name,
              std::vector<std::unique_ptr<Component>>&& components,
              std::unique_ptr<PropertyArray>&& properties)
-    : name(std::move(phase_name)), _components(std::move(components))
+    : name(std::move(phase_name)), components_(std::move(components))
 {
     if (properties)
     {
-        overwriteExistingProperties(_properties, *properties, this);
+        overwriteExistingProperties(properties_, *properties, this);
     }
 }
 
 Component const& Phase::component(const std::size_t& index) const
 {
-    return *_components[index];
+    return *components_[index];
 }
 
 bool Phase::hasComponent(std::size_t const& index) const
 {
-    return _components[index] != nullptr;
+    return components_[index] != nullptr;
 }
 
 Component const& Phase::component(std::string const& name) const
 {
     return *BaseLib::findElementOrError(
-        _components.begin(), _components.end(),
+        components_.begin(), components_.end(),
         [&name](std::unique_ptr<Component> const& component) {
             return component->name == name;
         },
@@ -51,17 +51,17 @@ Component const& Phase::component(std::string const& name) const
 
 Property const& Phase::property(PropertyType const& p) const
 {
-    return *_properties[p];
+    return *properties_[p];
 }
 
 bool Phase::hasProperty(PropertyType const& p) const
 {
-    return _properties[p] != nullptr;
+    return properties_[p] != nullptr;
 }
 
 std::size_t Phase::numberOfComponents() const
 {
-    return _components.size();
+    return components_.size();
 }
 
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Phase.h
+++ b/MaterialLib/MPL/Phase.h
@@ -55,14 +55,14 @@ public:
     std::string const name;
 
 private:
-    std::vector<std::unique_ptr<Component>> const _components;
+    std::vector<std::unique_ptr<Component>> const components_;
 
     /// Here, all for all properties listed in the Properties enumerator are
     /// initialized by mole average functions of value zero. However,
     /// 'special-default' properties are allowed to be set.
     ///
     /// After this, other special properties can be set as exceptional defaults.
-    PropertyArray _properties;
+    PropertyArray properties_;
 };
 
 template <typename Container>

--- a/MaterialLib/MPL/Properties/BishopsPowerLaw.cpp
+++ b/MaterialLib/MPL/Properties/BishopsPowerLaw.cpp
@@ -11,7 +11,7 @@
 
 namespace MaterialPropertyLib
 {
-BishopsPowerLaw::BishopsPowerLaw(double const exponent) : _m(exponent) {}
+BishopsPowerLaw::BishopsPowerLaw(double const exponent) : m_(exponent) {}
 
 void BishopsPowerLaw::setScale(
     std::variant<Medium*, Phase*, Component*> scale_pointer)
@@ -22,7 +22,7 @@ void BishopsPowerLaw::setScale(
             "The property 'BishopsPowerLaw' is implemented on the 'media' "
             "scale only.");
     }
-    _medium = std::get<Medium*>(scale_pointer);
+    medium_ = std::get<Medium*>(scale_pointer);
 }
 
 PropertyDataType BishopsPowerLaw::value(
@@ -33,7 +33,7 @@ PropertyDataType BishopsPowerLaw::value(
     auto const S_L = std::get<double>(
         variable_array[static_cast<int>(Variable::liquid_saturation)]);
 
-    return std::pow(S_L, _m);
+    return std::pow(S_L, m_);
 }
 
 PropertyDataType BishopsPowerLaw::dValue(
@@ -49,6 +49,6 @@ PropertyDataType BishopsPowerLaw::dValue(
     auto const S_L = std::get<double>(
         variable_array[static_cast<int>(Variable::liquid_saturation)]);
 
-    return _m * std::pow(S_L, _m - 1.);
+    return m_ * std::pow(S_L, m_ - 1.);
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/BishopsPowerLaw.h
+++ b/MaterialLib/MPL/Properties/BishopsPowerLaw.h
@@ -32,7 +32,7 @@ public:
                             double const /*dt*/) const override;
 
 private:
-    Medium* _medium = nullptr;
-    double const _m;  //< Exponent.
+    Medium* medium_ = nullptr;
+    double const m_;  //< Exponent.
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/BishopsSaturationCutoff.cpp
+++ b/MaterialLib/MPL/Properties/BishopsSaturationCutoff.cpp
@@ -12,7 +12,7 @@
 namespace MaterialPropertyLib
 {
 BishopsSaturationCutoff::BishopsSaturationCutoff(double const cutoff_value)
-    : _S_L_max(cutoff_value)
+    : S_L_max_(cutoff_value)
 {
 }
 
@@ -25,7 +25,7 @@ void BishopsSaturationCutoff::setScale(
             "The property 'BishopsSaturationCutoff' is implemented on the "
             "'media' scale only.");
     }
-    _medium = std::get<Medium*>(scale_pointer);
+    medium_ = std::get<Medium*>(scale_pointer);
 }
 
 PropertyDataType BishopsSaturationCutoff::value(
@@ -36,7 +36,7 @@ PropertyDataType BishopsSaturationCutoff::value(
     auto const S_L = std::get<double>(
         variable_array[static_cast<int>(Variable::liquid_saturation)]);
 
-    return S_L < _S_L_max ? 0. : 1.;
+    return S_L < S_L_max_ ? 0. : 1.;
 }
 
 PropertyDataType BishopsSaturationCutoff::dValue(

--- a/MaterialLib/MPL/Properties/BishopsSaturationCutoff.h
+++ b/MaterialLib/MPL/Properties/BishopsSaturationCutoff.h
@@ -34,7 +34,7 @@ public:
                             double const /*dt*/) const override;
 
 private:
-    Medium* _medium = nullptr;
-    double const _S_L_max;  //< Maximum saturation cutoff value.
+    Medium* medium_ = nullptr;
+    double const S_L_max_;  //< Maximum saturation cutoff value.
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.cpp
@@ -24,57 +24,57 @@ CapillaryPressureVanGenuchten::CapillaryPressureVanGenuchten(
     double const exponent,
     double const p_b,
     double const maximum_capillary_pressure)
-    : _S_L_res(residual_liquid_saturation),
-      _S_L_max(1. - residual_gas_saturation),
-      _m(exponent),
-      _p_b(p_b),
-      _p_cap_max(maximum_capillary_pressure)
+    : S_L_res_(residual_liquid_saturation),
+      S_L_max_(1. - residual_gas_saturation),
+      m_(exponent),
+      p_b_(p_b),
+      p_cap_max_(maximum_capillary_pressure)
 {
-    if (_S_L_res < 0 || _S_L_res > 1)
+    if (S_L_res_ < 0 || S_L_res_ > 1)
     {
         OGS_FATAL(
             "Van Genuchten capillary pressure model: "
             "The residual liquid saturation value S_L_res = {:g} is out of "
             "admissible range [0, 1].",
-            _S_L_res);
+            S_L_res_);
     }
-    if (_S_L_max < 0 || _S_L_max > 1)
+    if (S_L_max_ < 0 || S_L_max_ > 1)
     {
         OGS_FATAL(
             "Van Genuchten capillary pressure model: "
             "The maximum liquid saturation value S_L_max = {:g} is out of "
             "admissible range [0, 1].",
-            _S_L_max);
+            S_L_max_);
     }
-    if (_S_L_res >= _S_L_max)
+    if (S_L_res_ >= S_L_max_)
     {
         OGS_FATAL(
             "Van Genuchten capillary pressure model: "
             "The maximum liquid saturation S_L_max = {:g} must not be less or "
             "equal to the residual liquid saturion S_L_res = { : g}.",
-            _S_L_max, _S_L_res);
+            S_L_max_, S_L_res_);
     }
-    if (!(_m > 0 && _m < 1))
+    if (!(m_ > 0 && m_ < 1))
     {
         OGS_FATAL(
             "Van Genuchten capillary pressure model: "
             "The exponent value m = {:g} is out of of admissible range (0, 1).",
-            _m);
+            m_);
     }
-    if (_p_b <= 0)
+    if (p_b_ <= 0)
     {
         OGS_FATAL(
             "Van Genuchten capillary pressure model: "
             "The pressure scaling value p_b = {:g} must be positive.",
-            _p_b);
+            p_b_);
     }
-    if (_p_cap_max < 0)
+    if (p_cap_max_ < 0)
     {
         OGS_FATAL(
             "Van Genuchten capillary pressure model: "
             "The maximum capillary pressure value p_cap_max = {:g} must be "
             "non-negative.",
-            _p_cap_max);
+            p_cap_max_);
     }
 }
 
@@ -86,23 +86,23 @@ PropertyDataType CapillaryPressureVanGenuchten::value(
     double const S_L = std::get<double>(
         variable_array[static_cast<int>(Variable::liquid_saturation)]);
 
-    if (S_L <= _S_L_res)
+    if (S_L <= S_L_res_)
     {
-        return _p_cap_max;
+        return p_cap_max_;
     }
 
-    if (S_L >= _S_L_max)
+    if (S_L >= S_L_max_)
     {
         return 0;
     }
 
-    double const S_eff = (S_L - _S_L_res) / (_S_L_max - _S_L_res);
+    double const S_eff = (S_L - S_L_res_) / (S_L_max_ - S_L_res_);
     assert(0 <= S_eff && S_eff <= 1);
 
     double const p_cap =
-        _p_b * std::pow(std::pow(S_eff, -1.0 / _m) - 1.0, 1.0 - _m);
+        p_b_ * std::pow(std::pow(S_eff, -1.0 / m_) - 1.0, 1.0 - m_);
     assert(p_cap > 0);
-    return std::min(p_cap, _p_cap_max);
+    return std::min(p_cap, p_cap_max_);
 }
 
 PropertyDataType CapillaryPressureVanGenuchten::dValue(
@@ -118,28 +118,28 @@ PropertyDataType CapillaryPressureVanGenuchten::dValue(
     double const S_L = std::get<double>(
         variable_array[static_cast<int>(Variable::liquid_saturation)]);
 
-    if (S_L <= _S_L_res)
+    if (S_L <= S_L_res_)
     {
         return 0;
     }
 
-    if (S_L >= _S_L_max)
+    if (S_L >= S_L_max_)
     {
         return 0;
     }
 
-    double const S_eff = (S_L - _S_L_res) / (_S_L_max - _S_L_res);
+    double const S_eff = (S_L - S_L_res_) / (S_L_max_ - S_L_res_);
 
     assert(0 < S_eff && S_eff < 1.0);
 
-    double const val1 = std::pow(S_eff, -1.0 / _m);
-    double const p_cap = _p_b * std::pow(val1 - 1.0, 1.0 - _m);
-    if (p_cap >= _p_cap_max)
+    double const val1 = std::pow(S_eff, -1.0 / m_);
+    double const p_cap = p_b_ * std::pow(val1 - 1.0, 1.0 - m_);
+    if (p_cap >= p_cap_max_)
     {
         return 0;
     }
 
-    double const val2 = std::pow(val1 - 1.0, -_m);
-    return _p_b * (_m - 1.0) * val1 * val2 / (_m * (S_L - _S_L_res));
+    double const val2 = std::pow(val1 - 1.0, -m_);
+    return p_b_ * (m_ - 1.0) * val1 * val2 / (m_ * (S_L - S_L_res_));
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.h
@@ -57,7 +57,7 @@ public:
                 "The property 'CapillaryPressureVanGenuchten' is implemented "
                 "on the 'media' scale only.");
         }
-        _medium = std::get<Medium*>(scale_pointer);
+        medium_ = std::get<Medium*>(scale_pointer);
     }
 
     /// \returns \f$ p_c(S) \f$.
@@ -74,11 +74,11 @@ public:
                             double const dt) const override;
 
 private:
-    Medium* _medium = nullptr;
-    double const _S_L_res;    ///< Residual saturation of liquid phase.
-    double const _S_L_max;    ///< Maximum saturation of liquid phase.
-    double const _m;          ///< Exponent.
-    double const _p_b;        ///< Pressure scaling factor.
-    double const _p_cap_max;  ///< Maximum capillary pressure.
+    Medium* medium_ = nullptr;
+    double const S_L_res_;    ///< Residual saturation of liquid phase.
+    double const S_L_max_;    ///< Maximum saturation of liquid phase.
+    double const m_;          ///< Exponent.
+    double const p_b_;        ///< Pressure scaling factor.
+    double const p_cap_max_;  ///< Maximum capillary pressure.
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationBrooksCorey.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationBrooksCorey.cpp
@@ -27,10 +27,10 @@ SaturationBrooksCorey::SaturationBrooksCorey(
     const double residual_gas_saturation,
     const double exponent,
     const double entry_pressure)
-    : _residual_liquid_saturation(residual_liquid_saturation),
-      _residual_gas_saturation(residual_gas_saturation),
-      _exponent(exponent),
-      _entry_pressure(entry_pressure){};
+    : residual_liquid_saturation_(residual_liquid_saturation),
+      residual_gas_saturation_(residual_gas_saturation),
+      exponent_(exponent),
+      entry_pressure_(entry_pressure){};
 
 PropertyDataType SaturationBrooksCorey::value(
     VariableArray const& variable_array,
@@ -40,10 +40,10 @@ PropertyDataType SaturationBrooksCorey::value(
     const double p_cap = std::get<double>(
         variable_array[static_cast<int>(Variable::capillary_pressure)]);
 
-    const double s_L_res = _residual_liquid_saturation;
-    const double s_L_max = 1.0 - _residual_gas_saturation;
-    const double lambda = _exponent;
-    const double p_b = _entry_pressure;
+    const double s_L_res = residual_liquid_saturation_;
+    const double s_L_max = 1.0 - residual_gas_saturation_;
+    const double lambda = exponent_;
+    const double p_b = entry_pressure_;
 
     if (p_cap <= p_b)
         return s_L_max;
@@ -62,18 +62,18 @@ PropertyDataType SaturationBrooksCorey::dValue(
            "SaturationBrooksCorey::dValue is implemented for "
            " derivatives with respect to capillary pressure only.");
 
-    const double s_L_res = _residual_liquid_saturation;
-    const double s_L_max = 1.0 - _residual_gas_saturation;
-    const double p_b = _entry_pressure;
+    const double s_L_res = residual_liquid_saturation_;
+    const double s_L_max = 1.0 - residual_gas_saturation_;
+    const double p_b = entry_pressure_;
     const double p_cap = std::max(
         p_b,
         std::get<double>(
             variable_array[static_cast<int>(Variable::capillary_pressure)]));
 
-    auto const s_L = _medium->property(PropertyType::saturation)
+    auto const s_L = medium_->property(PropertyType::saturation)
                          .template value<double>(variable_array, pos, t, dt);
 
-    const double lambda = _exponent;
+    const double lambda = exponent_;
     const double ds_L_d_s_eff = 1. / (s_L_max - s_L_res);
 
     return -lambda / p_cap * s_L * ds_L_d_s_eff;
@@ -92,16 +92,16 @@ PropertyDataType SaturationBrooksCorey::d2Value(
            "SaturationBrooksCorey::d2Value is implemented for "
            " derivatives with respect to capillary pressure only.");
 
-    const double p_b = _entry_pressure;
+    const double p_b = entry_pressure_;
     const double p_cap = std::max(
         p_b,
         std::get<double>(
             variable_array[static_cast<int>(Variable::capillary_pressure)]));
 
-    const double s_L_res = _residual_liquid_saturation;
-    const double s_L_max = 1.0 - _residual_gas_saturation;
+    const double s_L_res = residual_liquid_saturation_;
+    const double s_L_max = 1.0 - residual_gas_saturation_;
 
-    const double lambda = _exponent;
+    const double lambda = exponent_;
 
     return lambda * (lambda + 1) * std::pow(p_b / p_cap, lambda) /
            (p_cap * p_cap) * (s_L_max - s_L_res);

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationBrooksCorey.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationBrooksCorey.h
@@ -30,11 +30,11 @@ class Component;
 class SaturationBrooksCorey final : public Property
 {
 private:
-    Medium* _medium = nullptr;
-    const double _residual_liquid_saturation;
-    const double _residual_gas_saturation;
-    const double _exponent;
-    const double _entry_pressure;
+    Medium* medium_ = nullptr;
+    const double residual_liquid_saturation_;
+    const double residual_gas_saturation_;
+    const double exponent_;
+    const double entry_pressure_;
 
 public:
     SaturationBrooksCorey(const double residual_liquid_saturation,
@@ -51,11 +51,11 @@ public:
                 "The property 'SaturationBrooksCorey' is implemented on the "
                 "'media' scale only.");
         }
-        _medium = std::get<Medium*>(scale_pointer);
+        medium_ = std::get<Medium*>(scale_pointer);
     }
 
     /// Those methods override the base class implementations and
-    /// actually compute and set the property _values and _dValues.
+    /// actually compute and set the property values_ and dValues_.
     PropertyDataType value(VariableArray const& variable_array,
                            ParameterLib::SpatialPosition const& /*pos*/,
                            double const /*t*/,

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationLiakopoulos.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationLiakopoulos.cpp
@@ -33,8 +33,8 @@ PropertyDataType SaturationLiakopoulos::value(
     if (p_cap < 0.)
         return 1.;
 
-    return std::max(_residual_liquid_saturation,
-                    1. - _parameter_a * std::pow(p_cap, _parameter_b));
+    return std::max(residual_liquid_saturation_,
+                    1. - parameter_a_ * std::pow(p_cap, parameter_b_));
 }
 
 PropertyDataType SaturationLiakopoulos::dValue(
@@ -53,10 +53,10 @@ PropertyDataType SaturationLiakopoulos::dValue(
     {
         return 0.;
     }
-    const double p_cap_restricted = std::min(p_cap, _p_cap_max);
+    const double p_cap_restricted = std::min(p_cap, p_cap_max_);
 
-    return -_parameter_a * _parameter_b *
-           std::pow(p_cap_restricted, _parameter_b - 1.);
+    return -parameter_a_ * parameter_b_ *
+           std::pow(p_cap_restricted, parameter_b_ - 1.);
 }
 
 PropertyDataType SaturationLiakopoulos::d2Value(
@@ -79,9 +79,9 @@ PropertyDataType SaturationLiakopoulos::d2Value(
     {
         return 0.;
     }
-    const double p_cap_restricted = std::min(p_cap, _p_cap_max);
-    return -_parameter_a * (_parameter_b - 1.) * _parameter_b *
-           std::pow(p_cap_restricted, _parameter_b - 2.);
+    const double p_cap_restricted = std::min(p_cap, p_cap_max_);
+    return -parameter_a_ * (parameter_b_ - 1.) * parameter_b_ *
+           std::pow(p_cap_restricted, parameter_b_ - 2.);
 }
 
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationLiakopoulos.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationLiakopoulos.h
@@ -36,7 +36,7 @@ class Component;
 class SaturationLiakopoulos final : public Property
 {
 private:
-    Medium* _medium = nullptr;
+    Medium* medium_ = nullptr;
     /**
       Parameters for Liakopoulos saturation curve taken from:
       Asadi, R., Ataie-Ashtiani, B. (2015): A Comparison of finite volume
@@ -46,11 +46,11 @@ private:
       Those parameters are fixed for that particular model, no need to change
       them.
     */
-    const double _residual_liquid_saturation = 0.2;
-    const double _parameter_a = 1.9722e-11;
-    const double _parameter_b = 2.4279;
-    const double _p_cap_max = std::pow(
-        (1. - _residual_liquid_saturation) / _parameter_a, (1. / _parameter_b));
+    const double residual_liquid_saturation_ = 0.2;
+    const double parameter_a_ = 1.9722e-11;
+    const double parameter_b_ = 2.4279;
+    const double p_cap_max_ = std::pow(
+        (1. - residual_liquid_saturation_) / parameter_a_, (1. / parameter_b_));
 
 public:
     /// This method assigns a pointer to the material object that is the owner
@@ -60,7 +60,7 @@ public:
     {
         if (std::holds_alternative<Medium*>(scale_pointer))
         {
-            _medium = std::get<Medium*>(scale_pointer);
+            medium_ = std::get<Medium*>(scale_pointer);
         }
         else
         {
@@ -71,7 +71,7 @@ public:
     }
 
     /// Those methods override the base class implementations and
-    /// actually compute and set the property _values and _dValues.
+    /// actually compute and set the property values_ and dValues_.
     PropertyDataType value(VariableArray const& variable_array,
                            ParameterLib::SpatialPosition const& /*pos*/,
                            double const /*t*/,

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationVanGenuchten.cpp
@@ -22,17 +22,17 @@ SaturationVanGenuchten::SaturationVanGenuchten(
     double const residual_gas_saturation,
     double const exponent,
     double const p_b)
-    : _S_L_res(residual_liquid_saturation),
-      _S_L_max(1. - residual_gas_saturation),
-      _m(exponent),
-      _p_b(p_b)
+    : S_L_res_(residual_liquid_saturation),
+      S_L_max_(1. - residual_gas_saturation),
+      m_(exponent),
+      p_b_(p_b)
 {
-    if (!(_m > 0 && _m < 1))
+    if (!(m_ > 0 && m_ < 1))
     {
         OGS_FATAL(
             "The exponent value m = {:g} of van Genuchten saturation model, is "
             "out of its range of (0, 1)",
-            _m);
+            m_);
     }
 }
 
@@ -46,16 +46,16 @@ PropertyDataType SaturationVanGenuchten::value(
 
     if (p_cap <= 0)
     {
-        return _S_L_max;
+        return S_L_max_;
     }
 
-    double const p = p_cap / _p_b;
-    double const n = 1. / (1. - _m);
+    double const p = p_cap / p_b_;
+    double const n = 1. / (1. - m_);
     double const p_to_n = std::pow(p, n);
 
-    double const S_eff = std::pow(p_to_n + 1., -_m);
-    double const S = S_eff * _S_L_max - S_eff * _S_L_res + _S_L_res;
-    return std::clamp(S, _S_L_res, _S_L_max);
+    double const S_eff = std::pow(p_to_n + 1., -m_);
+    double const S = S_eff * S_L_max_ - S_eff * S_L_res_ + S_L_res_;
+    return std::clamp(S, S_L_res_, S_L_max_);
 }
 
 PropertyDataType SaturationVanGenuchten::dValue(
@@ -76,22 +76,22 @@ PropertyDataType SaturationVanGenuchten::dValue(
         return 0;
     }
 
-    double const p = p_cap / _p_b;
-    double const n = 1. / (1. - _m);
+    double const p = p_cap / p_b_;
+    double const n = 1. / (1. - m_);
     double const p_to_n = std::pow(p, n);
 
-    double const S_eff = std::pow(p_to_n + 1., -_m);
-    double const S = S_eff * _S_L_max - S_eff * _S_L_res + _S_L_res;
+    double const S_eff = std::pow(p_to_n + 1., -m_);
+    double const S = S_eff * S_L_max_ - S_eff * S_L_res_ + S_L_res_;
 
-    if (S < _S_L_res || S > _S_L_max)
+    if (S < S_L_res_ || S > S_L_max_)
     {
         return 0;
     }
 
-    double const dS_eff_dp_cap = -_m * std::pow(p_cap / _p_b, n - 1) *
-                                 std::pow(1 + p_to_n, -1. - _m) /
-                                 (_p_b * (1. - _m));
-    return dS_eff_dp_cap * (_S_L_max - _S_L_res);
+    double const dS_eff_dp_cap = -m_ * std::pow(p_cap / p_b_, n - 1) *
+                                 std::pow(1 + p_to_n, -1. - m_) /
+                                 (p_b_ * (1. - m_));
+    return dS_eff_dp_cap * (S_L_max_ - S_L_res_);
 }
 
 PropertyDataType SaturationVanGenuchten::d2Value(
@@ -115,21 +115,21 @@ PropertyDataType SaturationVanGenuchten::d2Value(
         return 0;
     }
 
-    double const p = p_cap / _p_b;
-    double const n = 1. / (1. - _m);
+    double const p = p_cap / p_b_;
+    double const n = 1. / (1. - m_);
     double const p_to_n = std::pow(p, n);
 
-    double const S_eff = std::pow(p_to_n + 1., -_m);
-    double const S = S_eff * _S_L_max - S_eff * _S_L_res + _S_L_res;
+    double const S_eff = std::pow(p_to_n + 1., -m_);
+    double const S = S_eff * S_L_max_ - S_eff * S_L_res_ + S_L_res_;
 
-    if (S < _S_L_res || S > _S_L_max)
+    if (S < S_L_res_ || S > S_L_max_)
     {
         return 0;
     }
 
     double const d2S_eff_dp_cap2 =
-        _m * p_to_n * std::pow(p_to_n + 1., -_m - 2.) * (p_to_n - _m) /
-        (p_cap * p_cap * (_m - 1.) * (_m - 1.));
-    return d2S_eff_dp_cap2 * (_S_L_max - _S_L_res);
+        m_ * p_to_n * std::pow(p_to_n + 1., -m_ - 2.) * (p_to_n - m_) /
+        (p_cap * p_cap * (m_ - 1.) * (m_ - 1.));
+    return d2S_eff_dp_cap2 * (S_L_max_ - S_L_res_);
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationVanGenuchten.h
@@ -60,11 +60,11 @@ public:
                 "The property 'SaturationVanGenuchten' is implemented on the "
                 "'media' scale only.");
         }
-        _medium = std::get<Medium*>(scale_pointer);
+        medium_ = std::get<Medium*>(scale_pointer);
     }
 
     /// Those methods override the base class implementations and
-    /// actually compute and set the property _values and _dValues.
+    /// actually compute and set the property values_ and dValues_.
     PropertyDataType value(VariableArray const& variable_array,
                            ParameterLib::SpatialPosition const& /*pos*/,
                            double const /*t*/,
@@ -81,10 +81,10 @@ public:
                              double const /*dt*/) const override;
 
 private:
-    Medium* _medium = nullptr;
-    double const _S_L_res;
-    double const _S_L_max;
-    double const _m;
-    double const _p_b;
+    Medium* medium_ = nullptr;
+    double const S_L_res_;
+    double const S_L_max_;
+    double const m_;
+    double const p_b_;
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/Constant.cpp
+++ b/MaterialLib/MPL/Properties/Constant.cpp
@@ -16,8 +16,8 @@ namespace MaterialPropertyLib
 {
 Constant::Constant(PropertyDataType const& v)
 {
-    _value = v;
-    _dvalue = std::visit(
+    value_ = v;
+    dvalue_ = std::visit(
         [](auto const& value) -> PropertyDataType { return decltype(value){}; },
         v);
 };

--- a/MaterialLib/MPL/Properties/Constant.h
+++ b/MaterialLib/MPL/Properties/Constant.h
@@ -22,7 +22,7 @@ class Constant final : public Property
 {
 public:
     /// This constructor accepts single values of any data type defined in the
-    /// PropertyDataType definition and sets the protected attribute _value of
+    /// PropertyDataType definition and sets the protected attribute value_ of
     /// the base class Property to that value.
     explicit Constant(PropertyDataType const& v);
 };

--- a/MaterialLib/MPL/Properties/CurveProperty.cpp
+++ b/MaterialLib/MPL/Properties/CurveProperty.cpp
@@ -14,7 +14,7 @@ namespace MaterialPropertyLib
 {
 CurveProperty::CurveProperty(Variable const independent_variable,
                              MathLib::PiecewiseLinearInterpolation const& curve)
-    : _independent_variable(independent_variable), _curve(curve)
+    : independent_variable_(independent_variable), curve_(curve)
 {
 }
 
@@ -24,8 +24,8 @@ PropertyDataType CurveProperty::value(
     double const /*dt*/) const
 {
     auto const x = std::get<double>(
-        variable_array[static_cast<int>(_independent_variable)]);
-    return _curve.getValue(x);
+        variable_array[static_cast<int>(independent_variable_)]);
+    return curve_.getValue(x);
 }
 
 PropertyDataType CurveProperty::dValue(
@@ -35,7 +35,7 @@ PropertyDataType CurveProperty::dValue(
     double const /*dt*/) const
 {
     auto const x = std::get<double>(
-        variable_array[static_cast<int>(_independent_variable)]);
-    return _curve.getDerivative(x);
+        variable_array[static_cast<int>(independent_variable_)]);
+    return curve_.getDerivative(x);
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CurveProperty.h
+++ b/MaterialLib/MPL/Properties/CurveProperty.h
@@ -44,8 +44,8 @@ public:
 
 private:
     /// The variable type that the curve property depends on.
-    Variable const _independent_variable;
+    Variable const independent_variable_;
     /// The curve used by the property.
-    MathLib::PiecewiseLinearInterpolation const& _curve;
+    MathLib::PiecewiseLinearInterpolation const& curve_;
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/DupuitPermeability.cpp
+++ b/MaterialLib/MPL/Properties/DupuitPermeability.cpp
@@ -14,7 +14,7 @@ namespace MaterialPropertyLib
 {
 DupuitPermeability::DupuitPermeability(
     ParameterLib::Parameter<double> const& parameter)
-    : _parameter(parameter)
+    : parameter_(parameter)
 {
 }
 
@@ -25,7 +25,7 @@ PropertyDataType DupuitPermeability::value(
 {
     double const pressure = std::get<double>(variable_array[static_cast<int>(
         MaterialPropertyLib::Variable::phase_pressure)]);
-    auto const& permeability_values = _parameter(t, pos);
+    auto const& permeability_values = parameter_(t, pos);
 
     auto const& permeability_variant = fromVector(permeability_values);
     PropertyDataType dupuit_permeability = std::visit(

--- a/MaterialLib/MPL/Properties/DupuitPermeability.h
+++ b/MaterialLib/MPL/Properties/DupuitPermeability.h
@@ -31,6 +31,6 @@ public:
         double const dt) const override;
 
 private:
-    ParameterLib::Parameter<double> const& _parameter;
+    ParameterLib::Parameter<double> const& parameter_;
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/ExponentialProperty.cpp
+++ b/MaterialLib/MPL/Properties/ExponentialProperty.cpp
@@ -17,9 +17,9 @@ namespace MaterialPropertyLib
 {
 ExponentialProperty::ExponentialProperty(
     PropertyDataType const& property_reference_value, ExponentData const& v)
-    : _exponent_data(v)
+    : exponent_data_(v)
 {
-    _value = property_reference_value;
+    value_ = property_reference_value;
 }
 
 PropertyDataType ExponentialProperty::value(
@@ -27,12 +27,12 @@ PropertyDataType ExponentialProperty::value(
     ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
     double const /*dt*/) const
 {
-    return std::get<double>(_value) *
+    return std::get<double>(value_) *
            std::exp(
-               -std::get<double>(_exponent_data.factor) *
+               -std::get<double>(exponent_data_.factor) *
                (std::get<double>(
-                    variable_array[static_cast<int>(_exponent_data.type)]) -
-                std::get<double>(_exponent_data.reference_condition)));
+                    variable_array[static_cast<int>(exponent_data_.type)]) -
+                std::get<double>(exponent_data_.reference_condition)));
 }
 
 PropertyDataType ExponentialProperty::dValue(
@@ -40,15 +40,15 @@ PropertyDataType ExponentialProperty::dValue(
     ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
     double const /*dt*/) const
 {
-    return _exponent_data.type == primary_variable
-               ? -std::get<double>(_value) *
-                     std::get<double>(_exponent_data.factor) *
+    return exponent_data_.type == primary_variable
+               ? -std::get<double>(value_) *
+                     std::get<double>(exponent_data_.factor) *
                      std::exp(
-                         -std::get<double>(_exponent_data.factor) *
+                         -std::get<double>(exponent_data_.factor) *
                          (std::get<double>(variable_array[static_cast<int>(
-                              _exponent_data.type)]) -
-                          std::get<double>(_exponent_data.reference_condition)))
-               : decltype(_value){};
+                              exponent_data_.type)]) -
+                          std::get<double>(exponent_data_.reference_condition)))
+               : decltype(value_){};
 }
 
 PropertyDataType ExponentialProperty::d2Value(
@@ -56,16 +56,16 @@ PropertyDataType ExponentialProperty::d2Value(
     ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
     double const /*dt*/) const
 {
-    return _exponent_data.type == pv1 && _exponent_data.type == pv2
-               ? std::get<double>(_value) *
+    return exponent_data_.type == pv1 && exponent_data_.type == pv2
+               ? std::get<double>(value_) *
                      boost::math::pow<2>(
-                         std::get<double>(_exponent_data.factor)) *
+                         std::get<double>(exponent_data_.factor)) *
                      std::exp(
-                         -std::get<double>(_exponent_data.factor) *
+                         -std::get<double>(exponent_data_.factor) *
                          (std::get<double>(variable_array[static_cast<int>(
-                              _exponent_data.type)]) -
-                          std::get<double>(_exponent_data.reference_condition)))
-               : decltype(_value){};
+                              exponent_data_.type)]) -
+                          std::get<double>(exponent_data_.reference_condition)))
+               : decltype(value_){};
 }
 
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/ExponentialProperty.h
+++ b/MaterialLib/MPL/Properties/ExponentialProperty.h
@@ -30,7 +30,7 @@ class ExponentialProperty final : public Property
 {
 public:
     /// This constructor accepts single values of double data type defined in
-    /// the PropertyDataType definition and sets the protected attribute _value
+    /// the PropertyDataType definition and sets the protected attribute value_
     /// of the base class Property to that value.
     ExponentialProperty(PropertyDataType const& property_reference_value,
                         ExponentData const& v);
@@ -55,6 +55,6 @@ public:
                              double const /*dt*/) const override;
 
 private:
-    ExponentData const _exponent_data;
+    ExponentData const exponent_data_;
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/IdealGasLaw.cpp
+++ b/MaterialLib/MPL/Properties/IdealGasLaw.cpp
@@ -19,19 +19,19 @@
 
 namespace MaterialPropertyLib
 {
-double molarMass(Phase* _phase, Component* _component,
+double molarMass(Phase* phase_, Component* component_,
                  VariableArray const& variable_array,
                  ParameterLib::SpatialPosition const& pos, double const t,
                  double const dt)
 {
-    if (_phase)  // IdealGasLaw of an entire phase
+    if (phase_)  // IdealGasLaw of an entire phase
     {
-        return _phase->property(PropertyType::molar_mass)
+        return phase_->property(PropertyType::molar_mass)
             .template value<double>(variable_array, pos, t, dt);
     }
-    if (_component)  // IdealGasLaw of a single component
+    if (component_)  // IdealGasLaw of a single component
     {
-        return _component->property(PropertyType::molar_mass)
+        return component_->property(PropertyType::molar_mass)
             .template value<double>(variable_array, pos, t, dt);
     }
     OGS_FATAL(
@@ -51,7 +51,7 @@ PropertyDataType IdealGasLaw::value(VariableArray const& variable_array,
     const double temperature = std::get<double>(
         variable_array[static_cast<int>(Variable::temperature)]);
     double molar_mass =
-        molarMass(_phase, _component, variable_array, pos, t, dt);
+        molarMass(phase_, component_, variable_array, pos, t, dt);
 
     const double density = pressure * molar_mass / gas_constant / temperature;
 
@@ -69,7 +69,7 @@ PropertyDataType IdealGasLaw::dValue(VariableArray const& variable_array,
     const double temperature = std::get<double>(
         variable_array[static_cast<int>(Variable::temperature)]);
     double molar_mass =
-        molarMass(_phase, _component, variable_array, pos, t, dt);
+        molarMass(phase_, component_, variable_array, pos, t, dt);
 
     if (primary_variable == Variable::temperature)
     {
@@ -101,7 +101,7 @@ PropertyDataType IdealGasLaw::d2Value(VariableArray const& variable_array,
     const double temperature = std::get<double>(
         variable_array[static_cast<int>(Variable::temperature)]);
     double molar_mass =
-        molarMass(_phase, _component, variable_array, pos, t, dt);
+        molarMass(phase_, component_, variable_array, pos, t, dt);
 
     if ((primary_variable1 == Variable::phase_pressure) &&
         (primary_variable2 == Variable::phase_pressure))

--- a/MaterialLib/MPL/Properties/IdealGasLaw.h
+++ b/MaterialLib/MPL/Properties/IdealGasLaw.h
@@ -39,11 +39,11 @@ public:
     {
         if (std::holds_alternative<Phase*>(scale_pointer))
         {
-            _phase = std::get<Phase*>(scale_pointer);
+            phase_ = std::get<Phase*>(scale_pointer);
         }
         else if (std::holds_alternative<Component*>(scale_pointer))
         {
-            _component = std::get<Component*>(scale_pointer);
+            component_ = std::get<Component*>(scale_pointer);
         }
         else
         {
@@ -54,7 +54,7 @@ public:
     }
 
     /// Those methods override the base class implementations and
-    /// actually compute and set the property _values and _dValues.
+    /// actually compute and set the property values_ and dValues_.
     PropertyDataType value(VariableArray const& variable_array,
                            ParameterLib::SpatialPosition const& /*pos*/,
                            double const /*t*/,
@@ -70,8 +70,8 @@ public:
                              double const t, double const dt) const override;
 
 private:
-    Phase* _phase = nullptr;
-    Component* _component = nullptr;
+    Phase* phase_ = nullptr;
+    Component* component_ = nullptr;
 };
 
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/LinearProperty.cpp
+++ b/MaterialLib/MPL/Properties/LinearProperty.cpp
@@ -16,9 +16,9 @@ namespace MaterialPropertyLib
 {
 LinearProperty::LinearProperty(PropertyDataType const& property_reference_value,
                                std::vector<IndependentVariable> const& vs)
-    : _independent_variables(vs)
+    : independent_variables_(vs)
 {
-    _value = property_reference_value;
+    value_ = property_reference_value;
 }
 
 PropertyDataType LinearProperty::value(
@@ -37,12 +37,12 @@ PropertyDataType LinearProperty::value(
     };
 
     double const linearized_ratio_to_reference_value =
-        std::accumulate(_independent_variables.begin(),
-                        _independent_variables.end(),
+        std::accumulate(independent_variables_.begin(),
+                        independent_variables_.end(),
                         1.0,
                         calculate_linearized_ratio);
 
-    return std::get<double>(_value) * linearized_ratio_to_reference_value;
+    return std::get<double>(value_) * linearized_ratio_to_reference_value;
 }
 
 PropertyDataType LinearProperty::dValue(
@@ -51,16 +51,16 @@ PropertyDataType LinearProperty::dValue(
     double const /*dt*/) const
 {
     auto const independent_variable =
-        std::find_if(_independent_variables.begin(),
-                     _independent_variables.end(),
+        std::find_if(independent_variables_.begin(),
+                     independent_variables_.end(),
                      [&primary_variable](auto const& iv) -> bool {
                          return iv.type == primary_variable;
                      });
 
-    return independent_variable != _independent_variables.end()
-               ? std::get<double>(_value) *
+    return independent_variable != independent_variables_.end()
+               ? std::get<double>(value_) *
                      std::get<double>(independent_variable->slope)
-               : decltype(_value){};
+               : decltype(value_){};
 }
 
 PropertyDataType LinearProperty::d2Value(
@@ -68,7 +68,7 @@ PropertyDataType LinearProperty::d2Value(
     Variable const /*pv2*/, ParameterLib::SpatialPosition const& /*pos*/,
     double const /*t*/, double const /*dt*/) const
 {
-    return decltype(_value){};
+    return decltype(value_){};
 }
 
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/LinearProperty.h
+++ b/MaterialLib/MPL/Properties/LinearProperty.h
@@ -28,7 +28,7 @@ class LinearProperty final : public Property
 {
 public:
     /// This constructor accepts single values of double data type defined in
-    /// the PropertyDataType definition and sets the protected attribute _value
+    /// the PropertyDataType definition and sets the protected attribute value_
     /// of the base class Property to that value.
     LinearProperty(PropertyDataType const& property_reference_value,
                    std::vector<IndependentVariable> const& vs);
@@ -57,6 +57,6 @@ public:
                              double const /*dt*/) const override;
 
 private:
-    std::vector<IndependentVariable> const _independent_variables;
+    std::vector<IndependentVariable> const independent_variables_;
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/ParameterProperty.cpp
+++ b/MaterialLib/MPL/Properties/ParameterProperty.cpp
@@ -14,7 +14,7 @@ namespace MaterialPropertyLib
 {
 ParameterProperty::ParameterProperty(
     ParameterLib::Parameter<double> const& parameter)
-    : _parameter(parameter)
+    : parameter_(parameter)
 {
 }
 
@@ -23,7 +23,7 @@ PropertyDataType ParameterProperty::value(
     ParameterLib::SpatialPosition const& pos, double const t,
     double const /*dt*/) const
 {
-    return fromVector(_parameter(t, pos));
+    return fromVector(parameter_(t, pos));
 }
 
 PropertyDataType ParameterProperty::dValue(

--- a/MaterialLib/MPL/Properties/ParameterProperty.h
+++ b/MaterialLib/MPL/Properties/ParameterProperty.h
@@ -48,6 +48,6 @@ public:
                              double const /*dt*/) const override;
 
 private:
-    ParameterLib::Parameter<double> const& _parameter;
+    ParameterLib::Parameter<double> const& parameter_;
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/PermeabilityOrthotropicPowerLaw.h
+++ b/MaterialLib/MPL/Properties/PermeabilityOrthotropicPowerLaw.h
@@ -35,12 +35,12 @@ template <int DisplacementDim>
 class PermeabilityOrthotropicPowerLaw final : public Property
 {
 private:
-    Phase* _phase = nullptr;
+    Phase* phase_ = nullptr;
     /// Intrinsic permeabilities, one for each spatial dimension.
-    std::array<double, DisplacementDim> const _k;
+    std::array<double, DisplacementDim> const k_;
     /// Exponents, one for each spatial dimension.
-    std::array<double, DisplacementDim> const _lambda;
-    ParameterLib::CoordinateSystem const* const _local_coordinate_system;
+    std::array<double, DisplacementDim> const lambda_;
+    ParameterLib::CoordinateSystem const* const local_coordinate_system_;
 
 public:
     PermeabilityOrthotropicPowerLaw(

--- a/MaterialLib/MPL/Properties/PorosityFromMassBalance.cpp
+++ b/MaterialLib/MPL/Properties/PorosityFromMassBalance.cpp
@@ -21,13 +21,13 @@ void PorosityFromMassBalance::setScale(
 {
     if (std::holds_alternative<Phase*>(scale_pointer))
     {
-        _phase = std::get<Phase*>(scale_pointer);
-        if (_phase->name != "Solid")
+        phase_ = std::get<Phase*>(scale_pointer);
+        if (phase_->name != "Solid")
         {
             OGS_FATAL(
                 "The property 'PorosityFromMassBalance' must be "
                 "given in the 'Solid' phase, not in '{:s}' phase.",
-                _phase->name);
+                phase_->name);
         }
     }
     else
@@ -43,10 +43,10 @@ PropertyDataType PorosityFromMassBalance::value(
     ParameterLib::SpatialPosition const& pos,
     double const t, double const dt) const
 {
-    double const K_SR = _phase->property(PropertyType::bulk_modulus)
+    double const K_SR = phase_->property(PropertyType::bulk_modulus)
                             .template value<double>(variable_array, pos, t, dt);
     auto const alpha_b =
-        _phase->property(PropertyType::biot_coefficient)
+        phase_->property(PropertyType::biot_coefficient)
             .template value<double>(variable_array, pos, t, dt);
 
     double const e_dot = std::get<double>(
@@ -59,7 +59,7 @@ PropertyDataType PorosityFromMassBalance::value(
         variable_array[static_cast<int>(Variable::porosity)]);
 
     double const w = dt * (e_dot + p_eff_dot / K_SR);
-    return std::clamp((phi + alpha_b * w) / (1 + w), _phi_min, _phi_max);
+    return std::clamp((phi + alpha_b * w) / (1 + w), phi_min_, phi_max_);
 }
 
 PropertyDataType PorosityFromMassBalance::dValue(

--- a/MaterialLib/MPL/Properties/PorosityFromMassBalance.h
+++ b/MaterialLib/MPL/Properties/PorosityFromMassBalance.h
@@ -25,18 +25,18 @@ class Component;
 class PorosityFromMassBalance final : public Property
 {
 private:
-    Phase* _phase = nullptr;
+    Phase* phase_ = nullptr;
 
     /// Parameter, which is used by FEM to set the initial porosity value.
-    ParameterLib::Parameter<double> const& _phi0;
-    double const _phi_min;  //< Lower limit for the porosity.
-    double const _phi_max;  //< Upper limit for the porosity.
+    ParameterLib::Parameter<double> const& phi0_;
+    double const phi_min_;  //< Lower limit for the porosity.
+    double const phi_max_;  //< Upper limit for the porosity.
 
 public:
     PorosityFromMassBalance(
         ParameterLib::Parameter<double> const& initial_porosity,
         double const phi_min, double const phi_max)
-        : _phi0(initial_porosity), _phi_min(phi_min), _phi_max(phi_max)
+        : phi0_(initial_porosity), phi_min_(phi_min), phi_max_(phi_max)
     {
     }
 
@@ -46,7 +46,7 @@ public:
     PropertyDataType initialValue(ParameterLib::SpatialPosition const& pos,
                                   double const t) const override
     {
-        return fromVector(_phi0(t, pos));
+        return fromVector(phi0_(t, pos));
     }
 
     PropertyDataType value(VariableArray const& variable_array,

--- a/MaterialLib/MPL/Properties/RelativePermeability/RelPermBrooksCorey.h
+++ b/MaterialLib/MPL/Properties/RelativePermeability/RelPermBrooksCorey.h
@@ -31,18 +31,18 @@ class Component;
 class RelPermBrooksCorey final : public Property
 {
 private:
-    Medium* _medium = nullptr;
-    const double _residual_liquid_saturation;
-    const double _residual_gas_saturation;
-    const double _min_relative_permeability_liquid;
-    const double _min_relative_permeability_gas;
-    const double _exponent;
+    Medium* medium_ = nullptr;
+    const double residual_liquid_saturation_;
+    const double residual_gas_saturation_;
+    const double min_relative_permeability_liquid_;
+    const double min_relative_permeability_gas_;
+    const double exponent_;
 
 public:
     RelPermBrooksCorey(const double /*residual_liquid_saturation*/,
                        const double /*residual_gas_saturation*/,
-                       const double /*_min_relative_permeability_liquid*/,
-                       const double /*_min_relative_permeability_gas*/,
+                       const double /*min_relative_permeability_liquid_*/,
+                       const double /*min_relative_permeability_gas_*/,
                        const double /*exponent*/
     );
     /// This method assigns a pointer to the material object that is the owner
@@ -52,7 +52,7 @@ public:
     {
         if (std::holds_alternative<Medium*>(scale_pointer))
         {
-            _medium = std::get<Medium*>(scale_pointer);
+            medium_ = std::get<Medium*>(scale_pointer);
         }
         else
         {
@@ -63,7 +63,7 @@ public:
     }
 
     /// Those methods override the base class implementations and
-    /// actually compute and set the property _values and _dValues.
+    /// actually compute and set the property values_ and dValues_.
     PropertyDataType value(VariableArray const& variable_array,
                            ParameterLib::SpatialPosition const& pos,
                            double const t, double const dt) const override;

--- a/MaterialLib/MPL/Properties/RelativePermeability/RelPermLiakopoulos.h
+++ b/MaterialLib/MPL/Properties/RelativePermeability/RelPermLiakopoulos.h
@@ -47,7 +47,7 @@ s^{\mathrm{r}}_{\mathrm{L}}}\f]
 class RelPermLiakopoulos final : public Property
 {
 private:
-    Medium* _medium = nullptr;
+    Medium* medium_ = nullptr;
     /**
     Parameters for Liakopoulos relative permeability:
     Asadi, R., Ataie-Ashtiani, B. (2015): A Comparison of finite volume
@@ -57,14 +57,14 @@ private:
     Those parameters are fixed for that particular model, no need to change
     them.
     */
-    const double _residual_liquid_saturation = 0.2;
-    const double _maximal_liquid_saturation = 1.;
-    const double _parameter_a = 2.207;
-    const double _parameter_b = 1.0121;
-    const double _exponent = 3.;
-    const double _min_relative_permeability_gas = 1.0e-4;
-    const double _dse_dsL =
-        1. / (_maximal_liquid_saturation - _residual_liquid_saturation);
+    const double residual_liquid_saturation_ = 0.2;
+    const double maximal_liquid_saturation_ = 1.;
+    const double parameter_a_ = 2.207;
+    const double parameter_b_ = 1.0121;
+    const double exponent_ = 3.;
+    const double min_relative_permeability_gas_ = 1.0e-4;
+    const double dse_dsL_ =
+        1. / (maximal_liquid_saturation_ - residual_liquid_saturation_);
 
 public:
     /// This method assigns a pointer to the meterial object that is the owner
@@ -74,7 +74,7 @@ public:
     {
         if (std::holds_alternative<Medium*>(scale_pointer))
         {
-            _medium = std::get<Medium*>(scale_pointer);
+            medium_ = std::get<Medium*>(scale_pointer);
         }
         else
         {
@@ -85,7 +85,7 @@ public:
     }
 
     /// Those methods override the base class implementations and
-    /// actually compute and set the property _values and _dValues.
+    /// actually compute and set the property values_ and dValues_.
     PropertyDataType value(VariableArray const& variable_array,
                            ParameterLib::SpatialPosition const& pos,
                            double const t, double const dt) const override;

--- a/MaterialLib/MPL/Properties/RelativePermeability/RelPermVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/RelativePermeability/RelPermVanGenuchten.h
@@ -25,11 +25,11 @@ class Component;
 class RelPermVanGenuchten final : public Property
 {
 private:
-    double const _S_L_res;
-    double const _S_L_max;
-    double const _k_rel_min;
-    double const _m;
-    Medium* _medium = nullptr;
+    double const S_L_res_;
+    double const S_L_max_;
+    double const k_rel_min_;
+    double const m_;
+    Medium* medium_ = nullptr;
 
 public:
     RelPermVanGenuchten(double const residual_liquid_saturation,
@@ -43,7 +43,7 @@ public:
     {
         if (std::holds_alternative<Medium*>(scale_pointer))
         {
-            _medium = std::get<Medium*>(scale_pointer);
+            medium_ = std::get<Medium*>(scale_pointer);
         }
         else
         {
@@ -54,7 +54,7 @@ public:
     }
 
     /// Those methods override the base class implementations and
-    /// actually compute and set the property _values and _dValues.
+    /// actually compute and set the property values_ and dValues_.
     PropertyDataType value(VariableArray const& variable_array,
                            ParameterLib::SpatialPosition const& pos,
                            double const t, double const dt) const override;

--- a/MaterialLib/MPL/Properties/SaturationDependentSwelling.h
+++ b/MaterialLib/MPL/Properties/SaturationDependentSwelling.h
@@ -34,14 +34,14 @@ class Component;
 class SaturationDependentSwelling final : public Property
 {
 private:
-    Phase* _phase = nullptr;
+    Phase* phase_ = nullptr;
     /// Maximum swelling pressures, one for each spatial dimension.
-    std::array<double, 3> const _p;
+    std::array<double, 3> const p_;
     /// Exponents, one for each spatial dimension.
-    std::array<double, 3> const _lambda;
-    double const _S_min;  //< Lower saturation limit.
-    double const _S_max;  //< Upper saturation limit.
-    ParameterLib::CoordinateSystem const* const _local_coordinate_system;
+    std::array<double, 3> const lambda_;
+    double const S_min_;  //< Lower saturation limit.
+    double const S_max_;  //< Upper saturation limit.
+    ParameterLib::CoordinateSystem const* const local_coordinate_system_;
 
 public:
     SaturationDependentSwelling(

--- a/MaterialLib/MPL/Properties/TransportPorosityFromMassBalance.cpp
+++ b/MaterialLib/MPL/Properties/TransportPorosityFromMassBalance.cpp
@@ -21,13 +21,13 @@ void TransportPorosityFromMassBalance::setScale(
 {
     if (std::holds_alternative<Phase*>(scale_pointer))
     {
-        _phase = std::get<Phase*>(scale_pointer);
-        if (_phase->name != "Solid")
+        phase_ = std::get<Phase*>(scale_pointer);
+        if (phase_->name != "Solid")
         {
             OGS_FATAL(
                 "The property 'TransportPorosityFromMassBalance' must be "
                 "given in the 'Solid' phase, not in '{:s}' phase.",
-                _phase->name);
+                phase_->name);
         }
     }
     else
@@ -43,10 +43,10 @@ PropertyDataType TransportPorosityFromMassBalance::value(
     ParameterLib::SpatialPosition const& pos, double const t,
     double const dt) const
 {
-    double const K_SR = _phase->property(PropertyType::bulk_modulus)
+    double const K_SR = phase_->property(PropertyType::bulk_modulus)
                             .template value<double>(variable_array, pos, t, dt);
     auto const alpha_b =
-        _phase->property(PropertyType::biot_coefficient)
+        phase_->property(PropertyType::biot_coefficient)
             .template value<double>(variable_array, pos, t, dt);
 
     double const e_dot = std::get<double>(
@@ -62,7 +62,7 @@ PropertyDataType TransportPorosityFromMassBalance::value(
         variable_array[static_cast<int>(Variable::transport_porosity)]);
 
     double const w = dt * (e_dot + p_eff_dot / K_SR);
-    return std::clamp(phi_tr_prev + (alpha_b - phi) * w, _phi_min, _phi_max);
+    return std::clamp(phi_tr_prev + (alpha_b - phi) * w, phi_min_, phi_max_);
 }
 
 PropertyDataType TransportPorosityFromMassBalance::dValue(

--- a/MaterialLib/MPL/Properties/TransportPorosityFromMassBalance.h
+++ b/MaterialLib/MPL/Properties/TransportPorosityFromMassBalance.h
@@ -24,18 +24,18 @@ class Component;
 class TransportPorosityFromMassBalance final : public Property
 {
 private:
-    Phase* _phase = nullptr;
+    Phase* phase_ = nullptr;
 
     /// Parameter, which is used by FEM to set the initial porosity value.
-    ParameterLib::Parameter<double> const& _phi0;
-    double const _phi_min;  //< Lower limit for the porosity.
-    double const _phi_max;  //< Upper limit for the porosity.
+    ParameterLib::Parameter<double> const& phi0_;
+    double const phi_min_;  //< Lower limit for the porosity.
+    double const phi_max_;  //< Upper limit for the porosity.
 
 public:
     TransportPorosityFromMassBalance(
         ParameterLib::Parameter<double> const& initial_porosity,
         double const phi_min, double const phi_max)
-        : _phi0(initial_porosity), _phi_min(phi_min), _phi_max(phi_max)
+        : phi0_(initial_porosity), phi_min_(phi_min), phi_max_(phi_max)
     {
     }
 
@@ -45,7 +45,7 @@ public:
     PropertyDataType initialValue(ParameterLib::SpatialPosition const& pos,
                                   double const t) const override
     {
-        return fromVector(_phi0(t, pos));
+        return fromVector(phi0_(t, pos));
     }
 
     PropertyDataType value(VariableArray const& variable_array,

--- a/MaterialLib/MPL/Property.cpp
+++ b/MaterialLib/MPL/Property.cpp
@@ -67,7 +67,7 @@ PropertyDataType Property::initialValue(
 
 PropertyDataType Property::value() const
 {
-    return _value;
+    return value_;
 }
 
 /// The default implementation of this method only returns the property value
@@ -76,7 +76,7 @@ PropertyDataType Property::value(VariableArray const& /*variable_array*/,
                                  ParameterLib::SpatialPosition const& /*pos*/,
                                  double const /*t*/, double const /*dt*/) const
 {
-    return _value;
+    return value_;
 }
 
 /// The default implementation of this method only returns the
@@ -86,7 +86,7 @@ PropertyDataType Property::dValue(VariableArray const& /*variable_array*/,
                                   ParameterLib::SpatialPosition const& /*pos*/,
                                   double const /*t*/, double const /*dt*/) const
 {
-    return _dvalue;
+    return dvalue_;
 }
 
 /// Default implementation: 2nd derivative of any constant property is zero.

--- a/MaterialLib/MPL/Property.h
+++ b/MaterialLib/MPL/Property.h
@@ -50,7 +50,7 @@ public:
     virtual PropertyDataType initialValue(
         ParameterLib::SpatialPosition const& pos, double const t) const;
 
-    /// This virtual method simply returns the private _value attribute without
+    /// This virtual method simply returns the private value_ attribute without
     /// changing it.
     virtual PropertyDataType value() const;
     /// This virtual method will compute the property value based on the primary
@@ -114,8 +114,8 @@ public:
 
 protected:
     /// The single value of a property.
-    PropertyDataType _value;
-    PropertyDataType _dvalue;
+    PropertyDataType value_;
+    PropertyDataType dvalue_;
 };
 
 inline void overwriteExistingProperties(


### PR DESCRIPTION
As pointed out by @wenqing this fixes possible issue when using underscores in front of an identifier.

Review after #2919 