### PR TITLE
Introduced common functions to remove code duplication in mechanics related processes

### DIFF
--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -745,24 +745,8 @@ std::size_t HydroMechanicsLocalAssembler<
     ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
     DisplacementDim>::setSigma(double const* values)
 {
-    auto const kelvin_vector_size =
-        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
-    unsigned const n_integration_points =
-        _integration_method.getNumberOfPoints();
-
-    auto sigma_values =
-        Eigen::Map<Eigen::Matrix<double, kelvin_vector_size, Eigen::Dynamic,
-                                 Eigen::ColMajor> const>(
-            values, kelvin_vector_size, n_integration_points);
-
-    for (unsigned ip = 0; ip < n_integration_points; ++ip)
-    {
-        _ip_data[ip].sigma_eff =
-            MathLib::KelvinVector::symmetricTensorToKelvinVector(
-                sigma_values.col(ip));
-    }
-
-    return n_integration_points;
+    return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+        values, _ip_data, &IpData::sigma_eff);
 }
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
@@ -781,23 +765,8 @@ std::size_t HydroMechanicsLocalAssembler<
     ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
     DisplacementDim>::setEpsilon(double const* values)
 {
-    auto const kelvin_vector_size =
-        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
-    unsigned const n_integration_points =
-        _integration_method.getNumberOfPoints();
-
-    auto epsilon_values =
-        Eigen::Map<Eigen::Matrix<double, kelvin_vector_size, Eigen::Dynamic,
-                                 Eigen::ColMajor> const>(
-            values, kelvin_vector_size, n_integration_points);
-
-    for (unsigned ip = 0; ip < n_integration_points; ++ip)
-    {
-        _ip_data[ip].eps = MathLib::KelvinVector::symmetricTensorToKelvinVector(
-            epsilon_values.col(ip));
-    }
-
-    return n_integration_points;
+    return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+        values, _ip_data, &IpData::eps);
 }
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -745,7 +745,7 @@ std::size_t HydroMechanicsLocalAssembler<
     ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
     DisplacementDim>::setSigma(double const* values)
 {
-    return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+    return ProcessLib::setIntegrationPointKelvinVectorData<DisplacementDim>(
         values, _ip_data, &IpData::sigma_eff);
 }
 
@@ -755,7 +755,7 @@ std::vector<double> HydroMechanicsLocalAssembler<
     ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
     DisplacementDim>::getSigma() const
 {
-    return ProcessLib::getIntegrationPointKelvinVector<DisplacementDim>(
+    return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
         _ip_data, &IpData::sigma_eff);
 }
 
@@ -765,7 +765,7 @@ std::size_t HydroMechanicsLocalAssembler<
     ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
     DisplacementDim>::setEpsilon(double const* values)
 {
-    return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+    return ProcessLib::setIntegrationPointKelvinVectorData<DisplacementDim>(
         values, _ip_data, &IpData::eps);
 }
 

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "HydroMechanicsFEM.h"
-
 #include "MaterialLib/MPL/Medium.h"
 #include "MaterialLib/MPL/Property.h"
 #include "MaterialLib/MPL/Utils/FormEigenTensor.h"
@@ -21,6 +20,7 @@
 #include "MathLib/KelvinVector.h"
 #include "NumLib/Function/Interpolation.h"
 #include "ProcessLib/CoupledSolutionsForStaggeredScheme.h"
+#include "ProcessLib/Utils/SetOrGetIntegrationPointData.h"
 
 namespace ProcessLib
 {
@@ -771,24 +771,8 @@ std::vector<double> HydroMechanicsLocalAssembler<
     ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
     DisplacementDim>::getSigma() const
 {
-    auto const kelvin_vector_size =
-        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
-    unsigned const n_integration_points =
-        _integration_method.getNumberOfPoints();
-
-    std::vector<double> ip_sigma_values;
-    auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-        double, Eigen::Dynamic, kelvin_vector_size, Eigen::RowMajor>>(
-        ip_sigma_values, n_integration_points, kelvin_vector_size);
-
-    for (unsigned ip = 0; ip < n_integration_points; ++ip)
-    {
-        auto const& sigma = _ip_data[ip].sigma_eff;
-        cache_mat.row(ip) =
-            MathLib::KelvinVector::kelvinVectorToSymmetricTensor(sigma);
-    }
-
-    return ip_sigma_values;
+    return ProcessLib::getIntegrationPointKelvinVector<DisplacementDim>(
+        _ip_data, &IpData::sigma_eff);
 }
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
@@ -13,12 +13,14 @@
 
 #include <cassert>
 
+#include "IntegrationPointData.h"
 #include "MaterialLib/MPL/Medium.h"
 #include "MaterialLib/MPL/Utils/FormEigenTensor.h"
 #include "MaterialLib/SolidModels/SelectSolidConstitutiveRelation.h"
 #include "MathLib/KelvinVector.h"
 #include "NumLib/Function/Interpolation.h"
 #include "ProcessLib/CoupledSolutionsForStaggeredScheme.h"
+#include "ProcessLib/Utils/SetOrGetIntegrationPointData.h"
 
 namespace ProcessLib
 {
@@ -1002,23 +1004,8 @@ std::vector<double> const& RichardsMechanicsLocalAssembler<
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const
 {
-    constexpr int kelvin_vector_size =
-        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
-    auto const num_intpts = _ip_data.size();
-
-    cache.clear();
-    auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-        double, kelvin_vector_size, Eigen::Dynamic, Eigen::RowMajor>>(
-        cache, kelvin_vector_size, num_intpts);
-
-    for (unsigned ip = 0; ip < num_intpts; ++ip)
-    {
-        auto const& sigma = _ip_data[ip].sigma_eff;
-        cache_mat.col(ip) =
-            MathLib::KelvinVector::kelvinVectorToSymmetricTensor(sigma);
-    }
-
-    return cache;
+    return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
+        _ip_data, &IpData::sigma_eff, cache);
 }
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
@@ -1092,23 +1079,8 @@ std::vector<double> const& RichardsMechanicsLocalAssembler<
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const
 {
-    constexpr int kelvin_vector_size =
-        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
-    auto const num_intpts = _ip_data.size();
-
-    cache.clear();
-    auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-        double, kelvin_vector_size, Eigen::Dynamic, Eigen::RowMajor>>(
-        cache, kelvin_vector_size, num_intpts);
-
-    for (unsigned ip = 0; ip < num_intpts; ++ip)
-    {
-        auto const& eps = _ip_data[ip].eps;
-        cache_mat.col(ip) =
-            MathLib::KelvinVector::kelvinVectorToSymmetricTensor(eps);
-    }
-
-    return cache;
+    return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
+        _ip_data, &IpData::eps, cache);
 }
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
@@ -153,15 +153,18 @@ std::size_t RichardsMechanicsLocalAssembler<
 
     if (name == "saturation_ip")
     {
-        return setScalar(values, &IpData::saturation);
+        return ProcessLib::setIntegrationPointScalarData(values, _ip_data,
+                                                         &IpData::saturation);
     }
     if (name == "porosity_ip")
     {
-        return setScalar(values, &IpData::porosity);
+        return ProcessLib::setIntegrationPointScalarData(values, _ip_data,
+                                                         &IpData::porosity);
     }
     if (name == "transport_porosity_ip")
     {
-        return setScalar(values, &IpData::transport_porosity);
+        return ProcessLib::setIntegrationPointScalarData(
+            values, _ip_data, &IpData::transport_porosity);
     }
     if (name == "swelling_stress_ip")
     {
@@ -1087,21 +1090,6 @@ std::vector<double> const& RichardsMechanicsLocalAssembler<
     }
 
     return cache;
-}
-
-template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
-          typename IntegrationMethod, int DisplacementDim>
-std::size_t RichardsMechanicsLocalAssembler<
-    ShapeFunctionDisplacement, ShapeFunctionPressure, IntegrationMethod,
-    DisplacementDim>::setScalar(double const* values, double IpData::*member)
-{
-    auto const n_integration_points = _integration_method.getNumberOfPoints();
-
-    for (unsigned ip = 0; ip < n_integration_points; ++ip)
-    {
-        _ip_data[ip].*member = values[ip];
-    }
-    return n_integration_points;
 }
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
@@ -1126,19 +1126,8 @@ std::vector<double> const& RichardsMechanicsLocalAssembler<
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const
 {
-    auto const num_intpts = _ip_data.size();
-
-    cache.clear();
-    auto cache_mat = MathLib::createZeroedMatrix<
-        Eigen::Matrix<double, 1, Eigen::Dynamic, Eigen::RowMajor>>(cache, 1,
-                                                                   num_intpts);
-
-    for (unsigned ip = 0; ip < num_intpts; ++ip)
-    {
-        cache_mat[ip] = _ip_data[ip].saturation;
-    }
-
-    return cache;
+    return ProcessLib::getIntegrationPointScalarData(
+        _ip_data, &IpData::saturation, cache);
 }
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
@@ -1163,19 +1152,8 @@ std::vector<double> const& RichardsMechanicsLocalAssembler<
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const
 {
-    auto const num_intpts = _ip_data.size();
-
-    cache.clear();
-    auto cache_mat = MathLib::createZeroedMatrix<
-        Eigen::Matrix<double, 1, Eigen::Dynamic, Eigen::RowMajor>>(cache, 1,
-                                                                   num_intpts);
-
-    for (unsigned ip = 0; ip < num_intpts; ++ip)
-    {
-        cache_mat[ip] = _ip_data[ip].porosity;
-    }
-
-    return cache;
+    return ProcessLib::getIntegrationPointScalarData(_ip_data,
+                                                     &IpData::porosity, cache);
 }
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
@@ -1200,19 +1178,8 @@ std::vector<double> const& RichardsMechanicsLocalAssembler<
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const
 {
-    auto const num_intpts = _ip_data.size();
-
-    cache.clear();
-    auto cache_mat = MathLib::createZeroedMatrix<
-        Eigen::Matrix<double, 1, Eigen::Dynamic, Eigen::RowMajor>>(cache, 1,
-                                                                   num_intpts);
-
-    for (unsigned ip = 0; ip < num_intpts; ++ip)
-    {
-        cache_mat[ip] = _ip_data[ip].transport_porosity;
-    }
-
-    return cache;
+    return ProcessLib::getIntegrationPointScalarData(
+        _ip_data, &IpData::transport_porosity, cache);
 }
 
 template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
@@ -147,7 +147,7 @@ std::size_t RichardsMechanicsLocalAssembler<
                 "simultaneously.",
                 _process_data.initial_stress->name);
         }
-        return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+        return ProcessLib::setIntegrationPointKelvinVectorData<DisplacementDim>(
             values, _ip_data, &IpData::sigma_eff);
     }
 
@@ -168,12 +168,12 @@ std::size_t RichardsMechanicsLocalAssembler<
     }
     if (name == "swelling_stress_ip")
     {
-        return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+        return ProcessLib::setIntegrationPointKelvinVectorData<DisplacementDim>(
             values, _ip_data, &IpData::sigma_sw);
     }
     if (name == "epsilon_ip")
     {
-        return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+        return ProcessLib::setIntegrationPointKelvinVectorData<DisplacementDim>(
             values, _ip_data, &IpData::eps);
     }
     return 0;

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
@@ -174,8 +174,6 @@ public:
         return Eigen::Map<const Eigen::RowVectorXd>(N_u.data(), N_u.size());
     }
 
-    std::size_t setScalar(double const* values, double IpData::*member);
-
     std::vector<double> getSigma() const override;
 
     std::vector<double> const& getIntPtDarcyVelocity(

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
@@ -175,8 +175,6 @@ public:
     }
 
     std::size_t setScalar(double const* values, double IpData::*member);
-    std::size_t setKelvinVector(double const* values,
-                                KelvinVectorType IpData::*member);
 
     std::vector<double> getSigma() const override;
 

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -386,7 +386,7 @@ public:
 
     std::size_t setSigma(double const* values)
     {
-        return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+        return ProcessLib::setIntegrationPointKelvinVectorData<DisplacementDim>(
             values, _ip_data, &IpData::sigma);
     }
 
@@ -395,7 +395,7 @@ public:
     // There should be only one.
     std::vector<double> getSigma() const override
     {
-        return ProcessLib::getIntegrationPointKelvinVector<DisplacementDim>(
+        return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
             _ip_data, &IpData::sigma);
     }
 

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -386,24 +386,8 @@ public:
 
     std::size_t setSigma(double const* values)
     {
-        auto const kelvin_vector_size =
-            MathLib::KelvinVector::KelvinVectorDimensions<
-                DisplacementDim>::value;
-        auto const n_integration_points = _ip_data.size();
-
-        auto sigma_values =
-            Eigen::Map<Eigen::Matrix<double, kelvin_vector_size, Eigen::Dynamic,
-                                     Eigen::ColMajor> const>(
-                values, kelvin_vector_size, n_integration_points);
-
-        for (unsigned ip = 0; ip < n_integration_points; ++ip)
-        {
-            _ip_data[ip].sigma =
-                MathLib::KelvinVector::symmetricTensorToKelvinVector(
-                    sigma_values.col(ip));
-        }
-
-        return n_integration_points;
+        return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+            values, _ip_data, &IpData::sigma);
     }
 
     // TODO (naumov) This method is same as getIntPtSigma but for arguments and

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -411,24 +411,8 @@ public:
     // There should be only one.
     std::vector<double> getSigma() const override
     {
-        auto const kelvin_vector_size =
-            MathLib::KelvinVector::KelvinVectorDimensions<
-                DisplacementDim>::value;
-        auto const n_integration_points = _ip_data.size();
-
-        std::vector<double> ip_sigma_values;
-        auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-            double, Eigen::Dynamic, kelvin_vector_size, Eigen::RowMajor>>(
-            ip_sigma_values, n_integration_points, kelvin_vector_size);
-
-        for (unsigned ip = 0; ip < n_integration_points; ++ip)
-        {
-            auto const& sigma = _ip_data[ip].sigma;
-            cache_mat.row(ip) =
-                MathLib::KelvinVector::kelvinVectorToSymmetricTensor(sigma);
-        }
-
-        return ip_sigma_values;
+        return ProcessLib::getIntegrationPointKelvinVector<DisplacementDim>(
+            _ip_data, &IpData::sigma);
     }
 
     std::vector<double> const& getIntPtSigma(

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <vector>
 
+#include "LocalAssemblerInterface.h"
 #include "MaterialLib/PhysicalConstant.h"
 #include "MaterialLib/SolidModels/SelectSolidConstitutiveRelation.h"
 #include "MathLib/LinAlg/Eigen/EigenMapTools.h"
@@ -26,8 +27,7 @@
 #include "ProcessLib/LocalAssemblerInterface.h"
 #include "ProcessLib/LocalAssemblerTraits.h"
 #include "ProcessLib/Utils/InitShapeMatrices.h"
-
-#include "LocalAssemblerInterface.h"
+#include "ProcessLib/Utils/SetOrGetIntegrationPointData.h"
 #include "SmallDeformationProcessData.h"
 
 namespace ProcessLib
@@ -100,6 +100,8 @@ public:
     using GMatricesType = GMatrixPolicyType<ShapeFunction, DisplacementDim>;
     using GradientVectorType = typename GMatricesType::GradientVectorType;
     using GradientMatrixType = typename GMatricesType::GradientMatrixType;
+    using IpData =
+        IntegrationPointData<BMatricesType, ShapeMatricesType, DisplacementDim>;
 
     SmallDeformationLocalAssembler(SmallDeformationLocalAssembler const&) =
         delete;
@@ -435,24 +437,8 @@ public:
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
-        static const int kelvin_vector_size =
-            MathLib::KelvinVector::KelvinVectorDimensions<
-                DisplacementDim>::value;
-        auto const num_intpts = _ip_data.size();
-
-        cache.clear();
-        auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-            double, kelvin_vector_size, Eigen::Dynamic, Eigen::RowMajor>>(
-            cache, kelvin_vector_size, num_intpts);
-
-        for (unsigned ip = 0; ip < num_intpts; ++ip)
-        {
-            auto const& sigma = _ip_data[ip].sigma;
-            cache_mat.col(ip) =
-                MathLib::KelvinVector::kelvinVectorToSymmetricTensor(sigma);
-        }
-
-        return cache;
+        return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
+            _ip_data, &IpData::sigma, cache);
     }
 
     std::vector<double> const& getIntPtEpsilon(
@@ -461,24 +447,8 @@ public:
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
-        auto const kelvin_vector_size =
-            MathLib::KelvinVector::KelvinVectorDimensions<
-                DisplacementDim>::value;
-        auto const num_intpts = _ip_data.size();
-
-        cache.clear();
-        auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-            double, kelvin_vector_size, Eigen::Dynamic, Eigen::RowMajor>>(
-            cache, kelvin_vector_size, num_intpts);
-
-        for (unsigned ip = 0; ip < num_intpts; ++ip)
-        {
-            auto const& eps = _ip_data[ip].eps;
-            cache_mat.col(ip) =
-                MathLib::KelvinVector::kelvinVectorToSymmetricTensor(eps);
-        }
-
-        return cache;
+        return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
+            _ip_data, &IpData::eps, cache);
     }
 
     unsigned getNumberOfIntegrationPoints() const override
@@ -538,11 +508,7 @@ public:
 private:
     SmallDeformationProcessData<DisplacementDim>& _process_data;
 
-    std::vector<
-        IntegrationPointData<BMatricesType, ShapeMatricesType, DisplacementDim>,
-        Eigen::aligned_allocator<IntegrationPointData<
-            BMatricesType, ShapeMatricesType, DisplacementDim>>>
-        _ip_data;
+    std::vector<IpData, Eigen::aligned_allocator<IpData>> _ip_data;
 
     IntegrationMethod _integration_method;
     MeshLib::Element const& _element;

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
@@ -682,7 +682,7 @@ public:
 
     std::size_t setSigma(double const* values)
     {
-        return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+        return ProcessLib::setIntegrationPointKelvinVectorData<DisplacementDim>(
             values, _ip_data, &IpData::sigma);
     }
 
@@ -691,7 +691,7 @@ public:
     // There should be only one.
     std::vector<double> getSigma() const override
     {
-        return ProcessLib::getIntegrationPointKelvinVector<DisplacementDim>(
+        return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
             _ip_data, &IpData::sigma);
     }
 

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
@@ -164,7 +164,8 @@ public:
 
         if (name == "kappa_d_ip")
         {
-            return setKappaD(values);
+            return ProcessLib::setIntegrationPointScalarData(values, _ip_data,
+                                                             &IpData::kappa_d);
         }
 
         return 0;
@@ -692,18 +693,6 @@ public:
     {
         return ProcessLib::getIntegrationPointKelvinVector<DisplacementDim>(
             _ip_data, &IpData::sigma);
-    }
-
-    std::size_t setKappaD(double const* values)
-    {
-        unsigned const n_integration_points =
-            _integration_method.getNumberOfPoints();
-
-        for (unsigned ip = 0; ip < n_integration_points; ++ip)
-        {
-            _ip_data[ip].kappa_d = values[ip];
-        }
-        return n_integration_points;
     }
 
     void setKappaD(double value)

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
@@ -681,24 +681,8 @@ public:
 
     std::size_t setSigma(double const* values)
     {
-        auto const kelvin_vector_size =
-            MathLib::KelvinVector::KelvinVectorDimensions<
-                DisplacementDim>::value;
-        auto const n_integration_points = _ip_data.size();
-
-        auto sigma_values =
-            Eigen::Map<Eigen::Matrix<double, kelvin_vector_size, Eigen::Dynamic,
-                                     Eigen::ColMajor> const>(
-                values, kelvin_vector_size, n_integration_points);
-
-        for (unsigned ip = 0; ip < n_integration_points; ++ip)
-        {
-            _ip_data[ip].sigma =
-                MathLib::KelvinVector::symmetricTensorToKelvinVector(
-                    sigma_values.col(ip));
-        }
-
-        return n_integration_points;
+        return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+            values, _ip_data, &IpData::sigma);
     }
 
     // TODO (naumov) This method is same as getIntPtSigma but for arguments and

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
@@ -706,24 +706,8 @@ public:
     // There should be only one.
     std::vector<double> getSigma() const override
     {
-        auto const kelvin_vector_size =
-            MathLib::KelvinVector::KelvinVectorDimensions<
-                DisplacementDim>::value;
-        auto const n_integration_points = _ip_data.size();
-
-        std::vector<double> ip_sigma_values;
-        auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-            double, Eigen::Dynamic, kelvin_vector_size, Eigen::RowMajor>>(
-            ip_sigma_values, n_integration_points, kelvin_vector_size);
-
-        for (unsigned ip = 0; ip < n_integration_points; ++ip)
-        {
-            auto const& sigma = _ip_data[ip].sigma;
-            cache_mat.row(ip) =
-                MathLib::KelvinVector::kelvinVectorToSymmetricTensor(sigma);
-        }
-
-        return ip_sigma_values;
+        return ProcessLib::getIntegrationPointKelvinVector<DisplacementDim>(
+            _ip_data, &IpData::sigma);
     }
 
     std::size_t setKappaD(double const* values)

--- a/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
+++ b/ProcessLib/SmallDeformationNonlocal/SmallDeformationNonlocalFEM.h
@@ -735,15 +735,8 @@ public:
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
-        cache.clear();
-        cache.reserve(_ip_data.size());
-
-        for (auto const& ip_data : _ip_data)
-        {
-            cache.push_back(ip_data.damage);
-        }
-
-        return cache;
+        return ProcessLib::getIntegrationPointScalarData(
+            _ip_data, &IpData::damage, cache);
     }
 
     unsigned getNumberOfIntegrationPoints() const override

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
@@ -146,7 +146,7 @@ public:
 private:
     std::size_t setSigma(double const* values)
     {
-        return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+        return ProcessLib::setIntegrationPointKelvinVectorData<DisplacementDim>(
             values, _ip_data, &IpData::sigma_eff);
     }
 
@@ -155,7 +155,7 @@ private:
     // There should be only one.
     std::vector<double> getSigma() const override
     {
-        return ProcessLib::getIntegrationPointKelvinVector<DisplacementDim>(
+        return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
             _ip_data, &IpData::sigma_eff);
     }
 

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
@@ -146,25 +146,8 @@ public:
 private:
     std::size_t setSigma(double const* values)
     {
-        auto const kelvin_vector_size =
-            MathLib::KelvinVector::KelvinVectorDimensions<
-                DisplacementDim>::value;
-        unsigned const n_integration_points =
-            _integration_method.getNumberOfPoints();
-
-        auto sigma_values =
-            Eigen::Map<Eigen::Matrix<double, kelvin_vector_size, Eigen::Dynamic,
-                                     Eigen::ColMajor> const>(
-                values, kelvin_vector_size, n_integration_points);
-
-        for (unsigned ip = 0; ip < n_integration_points; ++ip)
-        {
-            _ip_data[ip].sigma =
-                MathLib::KelvinVector::symmetricTensorToKelvinVector(
-                    sigma_values.col(ip));
-        }
-
-        return n_integration_points;
+        return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+            values, _ip_data, &IpData::sigma_eff);
     }
 
     // TODO (naumov) This method is same as getIntPtSigma but for arguments and

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
@@ -172,25 +172,8 @@ private:
     // There should be only one.
     std::vector<double> getSigma() const override
     {
-        auto const kelvin_vector_size =
-            MathLib::KelvinVector::KelvinVectorDimensions<
-                DisplacementDim>::value;
-        unsigned const n_integration_points =
-            _integration_method.getNumberOfPoints();
-
-        std::vector<double> ip_sigma_values;
-        auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-            double, Eigen::Dynamic, kelvin_vector_size, Eigen::RowMajor>>(
-            ip_sigma_values, n_integration_points, kelvin_vector_size);
-
-        for (unsigned ip = 0; ip < n_integration_points; ++ip)
-        {
-            auto const& sigma = _ip_data[ip].sigma_eff;
-            cache_mat.row(ip) =
-                MathLib::KelvinVector::kelvinVectorToSymmetricTensor(sigma);
-        }
-
-        return ip_sigma_values;
+        return ProcessLib::getIntegrationPointKelvinVector<DisplacementDim>(
+            _ip_data, &IpData::sigma_eff);
     }
 
     std::vector<double> const& getIntPtSigma(

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
@@ -13,6 +13,8 @@
 #include <memory>
 #include <vector>
 
+#include "IntegrationPointData.h"
+#include "LocalAssemblerInterface.h"
 #include "MaterialLib/PhysicalConstant.h"
 #include "MaterialLib/SolidModels/LinearElasticIsotropic.h"
 #include "MathLib/KelvinVector.h"
@@ -24,9 +26,7 @@
 #include "ProcessLib/Deformation/LinearBMatrix.h"
 #include "ProcessLib/LocalAssemblerTraits.h"
 #include "ProcessLib/Utils/InitShapeMatrices.h"
-
-#include "IntegrationPointData.h"
-#include "LocalAssemblerInterface.h"
+#include "ProcessLib/Utils/SetOrGetIntegrationPointData.h"
 #include "ThermoHydroMechanicsProcessData.h"
 
 namespace ProcessLib
@@ -199,25 +199,8 @@ private:
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
-        static const int kelvin_vector_size =
-            MathLib::KelvinVector::KelvinVectorDimensions<
-                DisplacementDim>::value;
-        unsigned const n_integration_points =
-            _integration_method.getNumberOfPoints();
-
-        cache.clear();
-        auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-            double, kelvin_vector_size, Eigen::Dynamic, Eigen::RowMajor>>(
-            cache, kelvin_vector_size, n_integration_points);
-
-        for (unsigned ip = 0; ip < n_integration_points; ++ip)
-        {
-            auto const& sigma = _ip_data[ip].sigma_eff;
-            cache_mat.col(ip) =
-                MathLib::KelvinVector::kelvinVectorToSymmetricTensor(sigma);
-        }
-
-        return cache;
+        return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
+            _ip_data, &IpData::sigma_eff, cache);
     }
 
     virtual std::vector<double> const& getIntPtEpsilon(
@@ -226,25 +209,8 @@ private:
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
-        auto const kelvin_vector_size =
-            MathLib::KelvinVector::KelvinVectorDimensions<
-                DisplacementDim>::value;
-        unsigned const n_integration_points =
-            _integration_method.getNumberOfPoints();
-
-        cache.clear();
-        auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-            double, kelvin_vector_size, Eigen::Dynamic, Eigen::RowMajor>>(
-            cache, kelvin_vector_size, n_integration_points);
-
-        for (unsigned ip = 0; ip < n_integration_points; ++ip)
-        {
-            auto const& eps = _ip_data[ip].eps;
-            cache_mat.col(ip) =
-                MathLib::KelvinVector::kelvinVectorToSymmetricTensor(eps);
-        }
-
-        return cache;
+        return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
+            _ip_data, &IpData::eps, cache);
     }
 
 private:

--- a/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
+++ b/ProcessLib/ThermoMechanicalPhaseField/ThermoMechanicalPhaseFieldFEM.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <vector>
 
+#include "LocalAssemblerInterface.h"
 #include "MaterialLib/SolidModels/LinearElasticIsotropic.h"
 #include "MaterialLib/SolidModels/LinearElasticIsotropicPhaseField.h"
 #include "MaterialLib/SolidModels/SelectSolidConstitutiveRelation.h"
@@ -23,8 +24,7 @@
 #include "ProcessLib/Deformation/BMatrixPolicy.h"
 #include "ProcessLib/Deformation/LinearBMatrix.h"
 #include "ProcessLib/Utils/InitShapeMatrices.h"
-
-#include "LocalAssemblerInterface.h"
+#include "ProcessLib/Utils/SetOrGetIntegrationPointData.h"
 #include "ThermoMechanicalPhaseFieldProcessData.h"
 
 namespace ProcessLib
@@ -140,6 +140,8 @@ public:
         typename ShapeMatricesType::template VectorType<displacement_size>;
     using PhaseFieldVector =
         typename ShapeMatricesType::template VectorType<phasefield_size>;
+    using IpData =
+        IntegrationPointData<BMatricesType, ShapeMatricesType, DisplacementDim>;
 
     ThermoMechanicalPhaseFieldLocalAssembler(
         ThermoMechanicalPhaseFieldLocalAssembler const&) = delete;
@@ -281,24 +283,8 @@ private:
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
-        static const int kelvin_vector_size =
-            MathLib::KelvinVector::KelvinVectorDimensions<
-                DisplacementDim>::value;
-        auto const num_intpts = _ip_data.size();
-
-        cache.clear();
-        auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-            double, kelvin_vector_size, Eigen::Dynamic, Eigen::RowMajor>>(
-            cache, kelvin_vector_size, num_intpts);
-
-        for (unsigned ip = 0; ip < num_intpts; ++ip)
-        {
-            auto const& sigma = _ip_data[ip].sigma;
-            cache_mat.col(ip) =
-                MathLib::KelvinVector::kelvinVectorToSymmetricTensor(sigma);
-        }
-
-        return cache;
+        return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
+            _ip_data, &IpData::sigma, cache);
     }
 
     std::vector<double> const& getIntPtEpsilon(
@@ -307,24 +293,8 @@ private:
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const override
     {
-        auto const kelvin_vector_size =
-            MathLib::KelvinVector::KelvinVectorDimensions<
-                DisplacementDim>::value;
-        auto const num_intpts = _ip_data.size();
-
-        cache.clear();
-        auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-            double, kelvin_vector_size, Eigen::Dynamic, Eigen::RowMajor>>(
-            cache, kelvin_vector_size, num_intpts);
-
-        for (unsigned ip = 0; ip < num_intpts; ++ip)
-        {
-            auto const& eps = _ip_data[ip].eps;
-            cache_mat.col(ip) =
-                MathLib::KelvinVector::kelvinVectorToSymmetricTensor(eps);
-        }
-
-        return cache;
+        return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
+            _ip_data, &IpData::eps, cache);
     }
 
     std::vector<double> const& getIntPtHeatFlux(
@@ -380,11 +350,7 @@ private:
 
     ThermoMechanicalPhaseFieldProcessData<DisplacementDim>& _process_data;
 
-    std::vector<
-        IntegrationPointData<BMatricesType, ShapeMatricesType, DisplacementDim>,
-        Eigen::aligned_allocator<IntegrationPointData<
-            BMatricesType, ShapeMatricesType, DisplacementDim>>>
-        _ip_data;
+    std::vector<IpData, Eigen::aligned_allocator<IpData>> _ip_data;
 
     IntegrationMethod _integration_method;
     MeshLib::Element const& _element;

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
@@ -567,24 +567,8 @@ template <typename ShapeFunction, typename IntegrationMethod,
 std::vector<double> ThermoMechanicsLocalAssembler<
     ShapeFunction, IntegrationMethod, DisplacementDim>::getSigma() const
 {
-    auto const kelvin_vector_size =
-        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
-    unsigned const n_integration_points =
-        _integration_method.getNumberOfPoints();
-
-    std::vector<double> ip_sigma_values;
-    auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-        double, Eigen::Dynamic, kelvin_vector_size, Eigen::RowMajor>>(
-        ip_sigma_values, n_integration_points, kelvin_vector_size);
-
-    for (unsigned ip = 0; ip < n_integration_points; ++ip)
-    {
-        auto const& sigma = _ip_data[ip].sigma;
-        cache_mat.row(ip) =
-            MathLib::KelvinVector::kelvinVectorToSymmetricTensor(sigma);
-    }
-
-    return ip_sigma_values;
+    return ProcessLib::getIntegrationPointKelvinVector<DisplacementDim>(
+        _ip_data, &IpData::sigma);
 }
 
 template <typename ShapeFunction, typename IntegrationMethod,
@@ -631,24 +615,8 @@ template <typename ShapeFunction, typename IntegrationMethod,
 std::vector<double> ThermoMechanicsLocalAssembler<
     ShapeFunction, IntegrationMethod, DisplacementDim>::getEpsilon() const
 {
-    auto const kelvin_vector_size =
-        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
-    unsigned const n_integration_points =
-        _integration_method.getNumberOfPoints();
-
-    std::vector<double> ip_epsilon_values;
-    auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-        double, Eigen::Dynamic, kelvin_vector_size, Eigen::RowMajor>>(
-        ip_epsilon_values, n_integration_points, kelvin_vector_size);
-
-    for (unsigned ip = 0; ip < n_integration_points; ++ip)
-    {
-        auto const& eps = _ip_data[ip].eps;
-        cache_mat.row(ip) =
-            MathLib::KelvinVector::kelvinVectorToSymmetricTensor(eps);
-    }
-
-    return ip_epsilon_values;
+    return ProcessLib::getIntegrationPointKelvinVector<DisplacementDim>(
+        _ip_data, &IpData::eps);
 }
 
 template <typename ShapeFunction, typename IntegrationMethod,

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
@@ -542,24 +542,8 @@ std::size_t
 ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
                               DisplacementDim>::setSigma(double const* values)
 {
-    auto const kelvin_vector_size =
-        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
-    unsigned const n_integration_points =
-        _integration_method.getNumberOfPoints();
-
-    auto sigma_values =
-        Eigen::Map<Eigen::Matrix<double, kelvin_vector_size, Eigen::Dynamic,
-                                 Eigen::ColMajor> const>(
-            values, kelvin_vector_size, n_integration_points);
-
-    for (unsigned ip = 0; ip < n_integration_points; ++ip)
-    {
-        _ip_data[ip].sigma =
-            MathLib::KelvinVector::symmetricTensorToKelvinVector(
-                sigma_values.col(ip));
-    }
-
-    return n_integration_points;
+    return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+        values, _ip_data, &IpData::sigma);
 }
 
 template <typename ShapeFunction, typename IntegrationMethod,
@@ -591,23 +575,8 @@ std::size_t
 ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
                               DisplacementDim>::setEpsilon(double const* values)
 {
-    auto const kelvin_vector_size =
-        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
-    unsigned const n_integration_points =
-        _integration_method.getNumberOfPoints();
-
-    auto epsilon_values =
-        Eigen::Map<Eigen::Matrix<double, kelvin_vector_size, Eigen::Dynamic,
-                                 Eigen::ColMajor> const>(
-            values, kelvin_vector_size, n_integration_points);
-
-    for (unsigned ip = 0; ip < n_integration_points; ++ip)
-    {
-        _ip_data[ip].eps = MathLib::KelvinVector::symmetricTensorToKelvinVector(
-            epsilon_values.col(ip));
-    }
-
-    return n_integration_points;
+    return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+        values, _ip_data, &IpData::eps);
 }
 
 template <typename ShapeFunction, typename IntegrationMethod,

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
@@ -542,7 +542,7 @@ std::size_t
 ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
                               DisplacementDim>::setSigma(double const* values)
 {
-    return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+    return ProcessLib::setIntegrationPointKelvinVectorData<DisplacementDim>(
         values, _ip_data, &IpData::sigma);
 }
 
@@ -551,7 +551,7 @@ template <typename ShapeFunction, typename IntegrationMethod,
 std::vector<double> ThermoMechanicsLocalAssembler<
     ShapeFunction, IntegrationMethod, DisplacementDim>::getSigma() const
 {
-    return ProcessLib::getIntegrationPointKelvinVector<DisplacementDim>(
+    return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
         _ip_data, &IpData::sigma);
 }
 
@@ -575,7 +575,7 @@ std::size_t
 ThermoMechanicsLocalAssembler<ShapeFunction, IntegrationMethod,
                               DisplacementDim>::setEpsilon(double const* values)
 {
-    return ProcessLib::setIntegrationPointKelvinVector<DisplacementDim>(
+    return ProcessLib::setIntegrationPointKelvinVectorData<DisplacementDim>(
         values, _ip_data, &IpData::eps);
 }
 
@@ -584,7 +584,7 @@ template <typename ShapeFunction, typename IntegrationMethod,
 std::vector<double> ThermoMechanicsLocalAssembler<
     ShapeFunction, IntegrationMethod, DisplacementDim>::getEpsilon() const
 {
-    return ProcessLib::getIntegrationPointKelvinVector<DisplacementDim>(
+    return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
         _ip_data, &IpData::eps);
 }
 

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM-impl.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include "ProcessLib/Utils/SetOrGetIntegrationPointData.h"
 #include "ThermoMechanicsFEM.h"
 
 namespace ProcessLib
@@ -596,24 +597,8 @@ std::vector<double> const& ThermoMechanicsLocalAssembler<
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const
 {
-    static const int kelvin_vector_size =
-        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
-    unsigned const n_integration_points =
-        _integration_method.getNumberOfPoints();
-
-    cache.clear();
-    auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-        double, kelvin_vector_size, Eigen::Dynamic, Eigen::RowMajor>>(
-        cache, kelvin_vector_size, n_integration_points);
-
-    for (unsigned ip = 0; ip < n_integration_points; ++ip)
-    {
-        auto const& sigma = _ip_data[ip].sigma;
-        cache_mat.col(ip) =
-            MathLib::KelvinVector::kelvinVectorToSymmetricTensor(sigma);
-    }
-
-    return cache;
+    return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
+        _ip_data, &IpData::sigma, cache);
 }
 
 template <typename ShapeFunction, typename IntegrationMethod,
@@ -676,24 +661,8 @@ std::vector<double> const& ThermoMechanicsLocalAssembler<
         std::vector<NumLib::LocalToGlobalIndexMap const*> const& /*dof_table*/,
         std::vector<double>& cache) const
 {
-    auto const kelvin_vector_size =
-        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
-    unsigned const n_integration_points =
-        _integration_method.getNumberOfPoints();
-
-    cache.clear();
-    auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
-        double, kelvin_vector_size, Eigen::Dynamic, Eigen::RowMajor>>(
-        cache, kelvin_vector_size, n_integration_points);
-
-    for (unsigned ip = 0; ip < n_integration_points; ++ip)
-    {
-        auto const& eps = _ip_data[ip].eps;
-        cache_mat.col(ip) =
-            MathLib::KelvinVector::kelvinVectorToSymmetricTensor(eps);
-    }
-
-    return cache;
+    return ProcessLib::getIntegrationPointKelvinVectorData<DisplacementDim>(
+        _ip_data, &IpData::eps, cache);
 }
 
 template <typename ShapeFunction, typename IntegrationMethod,

--- a/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
+++ b/ProcessLib/ThermoMechanics/ThermoMechanicsFEM.h
@@ -104,6 +104,8 @@ public:
     using JacobianMatrix = typename ShapeMatricesType::template MatrixType<
         ShapeFunction::NPOINTS + ShapeFunction::NPOINTS * DisplacementDim,
         ShapeFunction::NPOINTS + ShapeFunction::NPOINTS * DisplacementDim>;
+    using IpData =
+        IntegrationPointData<BMatricesType, ShapeMatricesType, DisplacementDim>;
 
     ThermoMechanicsLocalAssembler(ThermoMechanicsLocalAssembler const&) =
         delete;
@@ -311,11 +313,7 @@ private:
 
     ThermoMechanicsProcessData<DisplacementDim>& _process_data;
 
-    std::vector<
-        IntegrationPointData<BMatricesType, ShapeMatricesType, DisplacementDim>,
-        Eigen::aligned_allocator<IntegrationPointData<
-            BMatricesType, ShapeMatricesType, DisplacementDim>>>
-        _ip_data;
+    std::vector<IpData, Eigen::aligned_allocator<IpData>> _ip_data;
 
     IntegrationMethod _integration_method;
     MeshLib::Element const& _element;

--- a/ProcessLib/Utils/SetOrGetIntegrationPointData.h
+++ b/ProcessLib/Utils/SetOrGetIntegrationPointData.h
@@ -98,4 +98,25 @@ std::size_t setIntegrationPointKelvinVector(
     return num_intpts;
 }
 
+template <typename IntegrationPointData, typename MemberType>
+std::vector<double> const& getIntegrationPointScalarData(
+    std::vector<IntegrationPointData,
+                Eigen::aligned_allocator<IntegrationPointData>> const& ip_data,
+    MemberType member, std::vector<double>& cache)
+{
+    auto const num_intpts = ip_data.size();
+
+    cache.clear();
+    auto cache_mat = MathLib::createZeroedMatrix<
+        Eigen::Matrix<double, 1, Eigen::Dynamic, Eigen::RowMajor>>(cache, 1,
+                                                                   num_intpts);
+
+    for (unsigned ip = 0; ip < num_intpts; ++ip)
+    {
+        cache_mat[ip] = ip_data[ip].*member;
+    }
+
+    return cache;
+}
+
 }  // namespace ProcessLib

--- a/ProcessLib/Utils/SetOrGetIntegrationPointData.h
+++ b/ProcessLib/Utils/SetOrGetIntegrationPointData.h
@@ -45,4 +45,30 @@ std::vector<double> const& getIntegrationPointKelvinVectorData(
     return cache;
 }
 
+template <int DisplacementDim, typename IntegrationPointData,
+          typename MemberType>
+std::vector<double> getIntegrationPointKelvinVector(
+    std::vector<IntegrationPointData,
+                Eigen::aligned_allocator<IntegrationPointData>> const& ip_data,
+    MemberType member)
+{
+    constexpr int kelvin_vector_size =
+        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
+    auto const num_intpts = ip_data.size();
+
+    std::vector<double> ip_kelvin_vector_values;
+    auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
+        double, Eigen::Dynamic, kelvin_vector_size, Eigen::RowMajor>>(
+        ip_kelvin_vector_values, num_intpts, kelvin_vector_size);
+
+    for (unsigned ip = 0; ip < num_intpts; ++ip)
+    {
+        auto const& ip_member = ip_data[ip].*member;
+        cache_mat.row(ip) =
+            MathLib::KelvinVector::kelvinVectorToSymmetricTensor(ip_member);
+    }
+
+    return ip_kelvin_vector_values;
+}
+
 }  // namespace ProcessLib

--- a/ProcessLib/Utils/SetOrGetIntegrationPointData.h
+++ b/ProcessLib/Utils/SetOrGetIntegrationPointData.h
@@ -71,4 +71,31 @@ std::vector<double> getIntegrationPointKelvinVector(
     return ip_kelvin_vector_values;
 }
 
+template <int DisplacementDim, typename IntegrationPointData,
+          typename MemberType>
+std::size_t setIntegrationPointKelvinVector(
+    double const* values,
+    std::vector<IntegrationPointData,
+                Eigen::aligned_allocator<IntegrationPointData>>& ip_data,
+    MemberType member)
+{
+    constexpr int kelvin_vector_size =
+        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
+    auto const num_intpts = ip_data.size();
+
+    auto kelvin_vector_values =
+        Eigen::Map<Eigen::Matrix<double, kelvin_vector_size, Eigen::Dynamic,
+                                 Eigen::ColMajor> const>(
+            values, kelvin_vector_size, num_intpts);
+
+    for (unsigned ip = 0; ip < num_intpts; ++ip)
+    {
+        ip_data[ip].*member =
+            MathLib::KelvinVector::symmetricTensorToKelvinVector(
+                kelvin_vector_values.col(ip));
+    }
+
+    return num_intpts;
+}
+
 }  // namespace ProcessLib

--- a/ProcessLib/Utils/SetOrGetIntegrationPointData.h
+++ b/ProcessLib/Utils/SetOrGetIntegrationPointData.h
@@ -1,0 +1,48 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on May 4, 2020, 10:27 AM
+ */
+
+#pragma once
+
+#include <Eigen/Eigen>
+#include <vector>
+
+#include "MathLib/KelvinVector.h"
+#include "NumLib/Function/Interpolation.h"
+
+namespace ProcessLib
+{
+template <int DisplacementDim, typename IntegrationPointData,
+          typename MemberType>
+std::vector<double> const& getIntegrationPointKelvinVectorData(
+    std::vector<IntegrationPointData,
+                Eigen::aligned_allocator<IntegrationPointData>> const& ip_data,
+    MemberType member, std::vector<double>& cache)
+{
+    constexpr int kelvin_vector_size =
+        MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;
+    auto const num_intpts = ip_data.size();
+
+    cache.clear();
+    auto cache_mat = MathLib::createZeroedMatrix<Eigen::Matrix<
+        double, kelvin_vector_size, Eigen::Dynamic, Eigen::RowMajor>>(
+        cache, kelvin_vector_size, num_intpts);
+
+    for (unsigned ip = 0; ip < num_intpts; ++ip)
+    {
+        auto const& kelvin_vector = ip_data[ip].*member;
+        cache_mat.col(ip) =
+            MathLib::KelvinVector::kelvinVectorToSymmetricTensor(kelvin_vector);
+    }
+
+    return cache;
+}
+
+}  // namespace ProcessLib

--- a/ProcessLib/Utils/SetOrGetIntegrationPointData.h
+++ b/ProcessLib/Utils/SetOrGetIntegrationPointData.h
@@ -119,4 +119,20 @@ std::vector<double> const& getIntegrationPointScalarData(
     return cache;
 }
 
+template <typename IntegrationPointData, typename MemberType>
+std::size_t setIntegrationPointScalarData(
+    double const* values,
+    std::vector<IntegrationPointData,
+                Eigen::aligned_allocator<IntegrationPointData>>& ip_data,
+    MemberType member)
+{
+    auto const num_intpts = ip_data.size();
+
+    for (unsigned ip = 0; ip < num_intpts; ++ip)
+    {
+        ip_data[ip].*member = values[ip];
+    }
+    return num_intpts;
+}
+
 }  // namespace ProcessLib

--- a/ProcessLib/Utils/SetOrGetIntegrationPointData.h
+++ b/ProcessLib/Utils/SetOrGetIntegrationPointData.h
@@ -47,7 +47,7 @@ std::vector<double> const& getIntegrationPointKelvinVectorData(
 
 template <int DisplacementDim, typename IntegrationPointData,
           typename MemberType>
-std::vector<double> getIntegrationPointKelvinVector(
+std::vector<double> getIntegrationPointKelvinVectorData(
     std::vector<IntegrationPointData,
                 Eigen::aligned_allocator<IntegrationPointData>> const& ip_data,
     MemberType member)
@@ -73,7 +73,7 @@ std::vector<double> getIntegrationPointKelvinVector(
 
 template <int DisplacementDim, typename IntegrationPointData,
           typename MemberType>
-std::size_t setIntegrationPointKelvinVector(
+std::size_t setIntegrationPointKelvinVectorData(
     double const* values,
     std::vector<IntegrationPointData,
                 Eigen::aligned_allocator<IntegrationPointData>>& ip_data,


### PR DESCRIPTION
As titled.
The introduced common functions are included in a new file: 
`ProcessLib/Utils/SetOrGetIntegrationPointData.h`.