### PR TITLE
[DE] Raster translation fix

### DIFF
--- a/Applications/DataExplorer/VtkVis/NetCdfConfigureDialog.cpp
+++ b/Applications/DataExplorer/VtkVis/NetCdfConfigureDialog.cpp
@@ -329,7 +329,7 @@ void NetCdfConfigureDialog::createDataObject()
     {
         vtkImageImport* image = VtkRaster::loadImageFromArray(data_array.data(), header);
         _currentRaster = VtkGeoImageSource::New();
-        _currentRaster->setImage(image, QString::fromStdString(this->getName()), origin[0], origin[1], resolution);
+        _currentRaster->setImage(image, QString::fromStdString(this->getName()));
     }
 }
 

--- a/Applications/DataExplorer/VtkVis/VtkCompositeTextureOnSurfaceFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeTextureOnSurfaceFilter.cpp
@@ -84,7 +84,7 @@ void VtkCompositeTextureOnSurfaceFilter::init()
         double scalingFactor(1);
         std::string name = fileName.toStdString();
         vtkImageAlgorithm* image = VtkRaster::loadImage(name, x0, y0, scalingFactor);
-        surface->SetRaster(image, x0, y0, scalingFactor);
+        surface->SetRaster(image);
         surface->Update();
 
         QDir dir = QDir(fileName);
@@ -98,11 +98,7 @@ void VtkCompositeTextureOnSurfaceFilter::init()
         if (dlg.getRaster() != nullptr)
         {
             VtkGeoImageSource* image = dlg.getRaster();
-            double origin[3];
-            image->GetOutput()->GetOrigin(origin);
-            double spacing[3];
-            image->GetOutput()->GetSpacing(spacing);
-            surface->SetRaster(image, origin[0], origin[1], spacing[0]);
+            surface->SetRaster(image);
             surface->Update();
         }
     }

--- a/Applications/DataExplorer/VtkVis/VtkCompositeTextureOnSurfaceFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkCompositeTextureOnSurfaceFilter.cpp
@@ -79,11 +79,8 @@ void VtkCompositeTextureOnSurfaceFilter::init()
         (fi.suffix().toLower() == "png") || (fi.suffix().toLower() == "grd") ||
         (fi.suffix().toLower() == "jpg") || (fi.suffix().toLower() == "bmp"))
     {
-        double x0(0);
-        double y0(0);
-        double scalingFactor(1);
         std::string name = fileName.toStdString();
-        vtkImageAlgorithm* image = VtkRaster::loadImage(name, x0, y0, scalingFactor);
+        vtkImageAlgorithm* image = VtkRaster::loadImage(name);
         surface->SetRaster(image);
         surface->Update();
 

--- a/Applications/DataExplorer/VtkVis/VtkGeoImageSource.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkGeoImageSource.cpp
@@ -74,47 +74,25 @@ void VtkGeoImageSource::PrintSelf(ostream& os, vtkIndent indent)
 
 bool VtkGeoImageSource::readImage(const QString &filename)
 {
-    vtkImageAlgorithm* img (VtkRaster::loadImage(filename.toStdString(), _x0, _y0, _spacing));
+    vtkImageAlgorithm* img (VtkRaster::loadImage(filename.toStdString()));
     if (img == nullptr)
     {
         return false;
     }
-    this->setImage(img, filename, _x0, _y0, _spacing);
+    this->setImage(img, filename);
     return true;
 }
 
-void VtkGeoImageSource::setImage(vtkImageAlgorithm* image, const QString &name, double x0, double y0, double spacing)
+void VtkGeoImageSource::setImage(vtkImageAlgorithm* image, const QString &name)
 {
     this->_imageSource = image;
     this->SetInputConnection(_imageSource->GetOutputPort());
     this->SetName(name);
-    _x0 = x0; _y0 = y0; _z0 = -10; _spacing = spacing;
-
-    this->GetOutput()->SetOrigin(_x0, _y0, _z0);
-    this->GetOutput()->SetSpacing(_spacing, _spacing, _spacing);
 }
 
 vtkImageData* VtkGeoImageSource::getImageData()
 {
     return this->_imageSource->GetImageDataInput(0);
-}
-
-void VtkGeoImageSource::getOrigin(double origin[3]) const
-{
-    origin[0] = this->_x0;
-    origin[1] = this->_y0;
-    origin[2] = this->_z0;
-}
-
-double VtkGeoImageSource::getSpacing() const
-{
-    return this->_spacing;
-}
-
-void VtkGeoImageSource::getRange(double range[2])
-{
-    this->_imageSource->Update();
-    _imageSource->GetOutput()->GetPointData()->GetArray(0)->GetRange(range);
 }
 
 void VtkGeoImageSource::SimpleExecute(vtkImageData* input, vtkImageData* output)

--- a/Applications/DataExplorer/VtkVis/VtkGeoImageSource.h
+++ b/Applications/DataExplorer/VtkVis/VtkGeoImageSource.h
@@ -48,17 +48,7 @@ public:
     bool readImage(const QString &filename);
 
     /// @brief Imports an existing image object.
-    void setImage(vtkImageAlgorithm* image, const QString& name, double x0,
-                  double y0, double spacing);
-
-    /// @brief Returns the origin in world coordinates.
-    void getOrigin(double origin[3]) const;
-
-    /// @brief Returns the scalar data range.
-    void getRange(double range[2]);
-
-    /// @brief Returns the spacing between two pixels.
-    double getSpacing() const;
+    void setImage(vtkImageAlgorithm* image, const QString& name);
 
     void SetUserProperty(QString name, QVariant value) override;
 
@@ -74,6 +64,4 @@ protected:
 
 private:
     vtkImageAlgorithm* _imageSource{nullptr};
-
-    double _x0{0}, _y0{0}, _z0{0}, _spacing{1};
 };

--- a/Applications/DataExplorer/VtkVis/VtkRaster.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkRaster.cpp
@@ -120,7 +120,6 @@ vtkImageAlgorithm* VtkRaster::loadImageFromTIFF(const std::string& fileName)
 
         int version[3];
         int count (0);
-        double x0, double y0, cellsize;
         GTIFDirectoryInfo(geoTiff, version, &count);
 
         if (count == 0)
@@ -128,6 +127,9 @@ vtkImageAlgorithm* VtkRaster::loadImageFromTIFF(const std::string& fileName)
 
         if (geoTiff)
         {
+            double x0 = 0.0;
+            double y0 = 0.0;
+            double cellsize = 1.0;
             int imgWidth = 0;
             int imgHeight = 0;
             int nImages = 0;

--- a/Applications/DataExplorer/VtkVis/VtkRaster.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkRaster.cpp
@@ -41,8 +41,7 @@
 #include "BaseLib/StringTools.h"
 #include "GeoLib/Raster.h"
 
-vtkImageAlgorithm* VtkRaster::loadImage(const std::string &fileName,
-                                        double& x0, double& y0, double& delta)
+vtkImageAlgorithm* VtkRaster::loadImage(const std::string &fileName)
 {
     QFileInfo fileInfo(QString::fromStdString(fileName));
 
@@ -65,11 +64,8 @@ vtkImageAlgorithm* VtkRaster::loadImage(const std::string &fileName,
         (fileInfo.suffix().toLower() == "tiff"))
     {
 #ifdef GEOTIFF_FOUND
-        return loadImageFromTIFF(fileName, x0, y0, delta);
+        return loadImageFromTIFF(fileName);
 #else
-        (void)x0;
-        (void)y0;
-        (void)delta;
         ERR("VtkRaster::loadImage(): GeoTiff file format not supported in this "
             "version! Trying to parse as Tiff-file.");
         return loadImageFromFile(fileName);
@@ -114,9 +110,7 @@ vtkImageImport* VtkRaster::loadImageFromArray(double const*const data_array, Geo
 }
 
 #ifdef GEOTIFF_FOUND
-vtkImageAlgorithm* VtkRaster::loadImageFromTIFF(const std::string& fileName,
-                                                double& x0, double& y0,
-                                                double& cellsize)
+vtkImageAlgorithm* VtkRaster::loadImageFromTIFF(const std::string& fileName)
 {
     TIFF* tiff = XTIFFOpen(fileName.c_str(), "r");
 
@@ -126,6 +120,7 @@ vtkImageAlgorithm* VtkRaster::loadImageFromTIFF(const std::string& fileName,
 
         int version[3];
         int count (0);
+        double x0, double y0, cellsize;
         GTIFDirectoryInfo(geoTiff, version, &count);
 
         if (count == 0)

--- a/Applications/DataExplorer/VtkVis/VtkRaster.h
+++ b/Applications/DataExplorer/VtkVis/VtkRaster.h
@@ -44,10 +44,7 @@ public:
      * \param delta The size of each pixel in the image which is needed for correctly displaying the data, the default value is 1.
      * \return The ImageAlgorithm-object.
      */
-    static vtkImageAlgorithm* loadImage(const std::string &fileName,
-                                        double& x0,
-                                        double& y0,
-                                        double& delta);
+    static vtkImageAlgorithm* loadImage(const std::string &fileName);
 private:
 #ifdef GEOTIFF_FOUND
     /**

--- a/Applications/DataExplorer/VtkVis/VtkRaster.h
+++ b/Applications/DataExplorer/VtkVis/VtkRaster.h
@@ -55,9 +55,7 @@ private:
      * \param delta The size of each pixel in the image which is needed for correctly displaying the data.
      * \return A vtkImageImport-object (derived from vtkImageAlgorithm).
      */
-    static vtkImageAlgorithm* loadImageFromTIFF(const std::string& fileName,
-                                                double& x0, double& y0,
-                                                double& cellsize);
+    static vtkImageAlgorithm* loadImageFromTIFF(const std::string& fileName);
 #endif
 
     /**

--- a/Applications/DataExplorer/VtkVis/VtkRaster.h
+++ b/Applications/DataExplorer/VtkVis/VtkRaster.h
@@ -39,9 +39,6 @@ public:
      * Public method for loading all data formats. Internally the method automatically differentiates between
      * images and georeferenced files and then calls the appropriate method for reading the file.
      * \param fileName Filename of the file that should be loaded.
-     * \param x0 X-coordinate of the upper left corner of the data set, the default value is 0.
-     * \param y0 Y-coordinate of the upper left corner of the data set, the default value is 0.
-     * \param delta The size of each pixel in the image which is needed for correctly displaying the data, the default value is 1.
      * \return The ImageAlgorithm-object.
      */
     static vtkImageAlgorithm* loadImage(const std::string &fileName);
@@ -50,9 +47,6 @@ private:
     /**
      * Loads ArcGIS asc-files to a QPixmap object and automatically does a contrast stretching to adjust values to 8 bit greyscale images.
      * \param fileName Filename of the file that should be loaded.
-     * \param x0 X-coordinate of the upper left corner of the data set, the default value is 0.
-     * \param y0 Y-coordinate of the upper left corner of the data set, the default value is 0.
-     * \param delta The size of each pixel in the image which is needed for correctly displaying the data.
      * \return A vtkImageImport-object (derived from vtkImageAlgorithm).
      */
     static vtkImageAlgorithm* loadImageFromTIFF(const std::string& fileName);

--- a/Applications/DataExplorer/VtkVis/VtkTextureOnSurfaceFilter.cpp
+++ b/Applications/DataExplorer/VtkVis/VtkTextureOnSurfaceFilter.cpp
@@ -129,9 +129,7 @@ int VtkTextureOnSurfaceFilter::RequestData( vtkInformation* request,
     return 1;
 }
 
-void VtkTextureOnSurfaceFilter::SetRaster(vtkImageAlgorithm* img,
-                                          double x0, double y0,
-                                          double scalingFactor)
+void VtkTextureOnSurfaceFilter::SetRaster(vtkImageAlgorithm* img)
 {
     double range[2];
     img->Update();
@@ -150,8 +148,9 @@ void VtkTextureOnSurfaceFilter::SetRaster(vtkImageAlgorithm* img,
     texture->SetInputData(scale->GetOutput());
     this->SetTexture(texture);
 
-    _origin = std::pair<float, float>(static_cast<float>(x0), static_cast<float>(y0));
-    _scalingFactor = scalingFactor;
+    double* origin = img->GetOutput()->GetOrigin();
+    _origin = {origin[0], origin[1]};
+    _scalingFactor = img->GetOutput()->GetSpacing()[0];
 }
 
 void VtkTextureOnSurfaceFilter::SetUserProperty( QString name, QVariant value )

--- a/Applications/DataExplorer/VtkVis/VtkTextureOnSurfaceFilter.h
+++ b/Applications/DataExplorer/VtkVis/VtkTextureOnSurfaceFilter.h
@@ -46,7 +46,7 @@ public:
     void PrintSelf(ostream& os, vtkIndent indent) override;
 
     /// Sets the raster/image to be used as a texture map
-    void SetRaster(vtkImageAlgorithm* img, double x0, double y0, double scalingFactor);
+    void SetRaster(vtkImageAlgorithm* img);
 
     void SetUserProperty(QString name, QVariant value) override;
 
@@ -61,6 +61,6 @@ protected:
                     vtkInformationVector* outputVector) override;
 
 private:
-    std::pair<float, float> _origin{0, 0};
+    std::pair<double, double> _origin{0, 0};
     double _scalingFactor{0.};
 };

--- a/Applications/DataExplorer/mainwindow.cpp
+++ b/Applications/DataExplorer/mainwindow.cpp
@@ -30,6 +30,8 @@
 #endif  // NDEBUG
 
 // VTK includes
+#include <vtkImageAlgorithm.h>
+#include <vtkImageData.h>
 #include <vtkOBJExporter.h>
 #include <vtkRenderer.h>
 #include <vtkVRMLExporter.h>
@@ -737,11 +739,10 @@ void MainWindow::loadFile(ImportFileType::type t, const QString &fileName)
     else if (t == ImportFileType::POLYRASTER)
     {
         QImage raster;
-        double origin[2];
-        double cellSize;
-        vtkImageAlgorithm* imageAlgorithm = VtkRaster::loadImage(fileName.toStdString(), origin[0], origin[1], cellSize);
+        vtkImageAlgorithm* img = VtkRaster::loadImage(fileName.toStdString());
         VtkBGImageSource* bg = VtkBGImageSource::New();
-        bg->SetRaster(imageAlgorithm, origin[0], origin[1], cellSize);
+        double* origin = img->GetOutput()->GetOrigin();
+        bg->SetRaster(img, origin[0], origin[1], img->GetOutput()->GetSpacing()[0]);
         bg->SetName(fileName);
         _vtkVisPipeline->addPipelineItem(bg);
         settings.setValue("lastOpenedRasterFileDirectory", dir.absolutePath());

--- a/Tests/FileIO_Qt/TestVtkRaster.cpp
+++ b/Tests/FileIO_Qt/TestVtkRaster.cpp
@@ -28,8 +28,7 @@ TEST(TestVtkRaster, TestPNGReader)
     double x0;
     double y0;
     double delta;
-    vtkSmartPointer<vtkImageAlgorithm> img =
-        VtkRaster::loadImage(name, x0, y0, delta);
+    vtkSmartPointer<vtkImageAlgorithm> img = VtkRaster::loadImage(name);
     img->Update();
     EXPECT_TRUE(img != nullptr);
     EXPECT_TRUE(img->GetOutput() != nullptr);
@@ -57,8 +56,7 @@ TEST(TestVtkRaster, TestASCReader)
     double x0;
     double y0;
     double delta;
-    vtkSmartPointer<vtkImageAlgorithm> img =
-        VtkRaster::loadImage(name, x0, y0, delta);
+    vtkSmartPointer<vtkImageAlgorithm> img = VtkRaster::loadImage(name);
     img->Update();
     EXPECT_TRUE(img != nullptr);
     EXPECT_TRUE(img->GetOutput() != nullptr);

--- a/Tests/MeshLib/TestRasterToMesh.cpp
+++ b/Tests/MeshLib/TestRasterToMesh.cpp
@@ -273,8 +273,7 @@ TEST_F(RasterToMeshTest, vtkImage)
     double x0;
     double y0;
     double spacing;
-    vtkImageAlgorithm* raster =
-        VtkRaster::loadImage(_file_name, x0, y0, spacing);
+    vtkImageAlgorithm* raster = VtkRaster::loadImage(_file_name);
     double origin[3];
     raster->GetOutput()->GetOrigin(origin);
 


### PR DESCRIPTION
Small changes regarding positioning raster data in geographic context.

Previously, position data had been sometimes pulled from image algorithm object and sometimes been given explicitely via parameters. Now it's *always* within the image algorithm, making the interface slimmer and reducing the number of ambiguous cases.

(I cannot currently test this for GeoTIFFs. It *should* work but I'm not 100% sure.)