### PR TITLE
Correction of the calcualtion of dPc/dS when S<S_r in the van Genuchten model.

### DIFF
--- a/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_maximum_capillary_pressure.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureVanGenuchten/t_maximum_capillary_pressure.md
@@ -1,1 +1,1 @@
-\copydoc MaterialPropertyLib::CapillaryPressureVanGenuchten::p_cap_max_
+Maximum capillary pressure. It is an optional input.

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.h
@@ -25,10 +25,12 @@ class Component;
  * The van Genuchten capillary pressure model (\cite Genuchten1980) is:
  * \f[p_c(S)=p_b (S_\text{eff}^{-1/m}-1)^{1-m}\f]
  * with effective saturation defined as
- * \f[S_\text{eff}=\frac{S-S_r}{S_{\text{max}}-S_r}.\f]
+ * \f[S_\text{eff}=\frac{S-S_r}{S_{\text{max}}-S_r},\quad \forall S \in (S_r,
+ * S_{max}].\f]
  * Above, \f$S_r\f$ and \f$S_{\text{max}}\f$ are the residual and the maximum
  * saturations.
- * The exponent \f$m \in (0,1)\f$ and the pressure scaling parameter \f$p_b\f$
+ *
+ *  The exponent \f$m \in (0,1)\f$ and the pressure scaling parameter \f$p_b\f$
  * (it is equal to \f$\rho g/\alpha\f$ in original publication) are given by the
  * user.
  * The scaling parameter \f$p_b\f$ is given in same units as pressure.
@@ -36,8 +38,29 @@ class Component;
  * In the original work another exponent \f$n\f$ is used, but usually set to
  * \f$n = 1 / (1 - m)\f$, and also in this implementation.
  *
- * The the capillary pressure is computed from saturation as above but is cut
- * off at maximum capillary pressure given by user.
+ * Base the about raw van Genuchten capillary pressure model, an extension is
+ * introduced as follows to headle the singularity and the saturation below its
+ * lower bound for the model.
+ *
+ * The \f$p_c(S)\f$ has a singularity at \f$S=S_r\f$. A parameter of the maximum
+ * capillary pressure, \f$p_c^{max}\f$, is introduced. With the restriction of
+ * \f$p_c^{max}\f$, the lower bound or saturation for the model is calculated as
+ * \f[S_m = p_c^{-1}(p_c^{max})\f]
+ * where\f$p_c^{-1}\f$ indicates the inverse function of \f$p_c(S)\f$, and
+ * \f$p_c^{max}\f$ is set as an optional input. If the input data for it is not
+ * given, the lower bound of the saturation is set as
+ * \f[S_m = S_r+10^{-9}\f]
+ *
+ *  In some applications, e.g. the heating deduced vaporization, the saturation
+ * can be smaller than the lower bound of saturation, \f$S_m\f$. For such
+ * saturation,
+ * the values of capillary pressure and its derivative with respect to
+ * saturation are taken as
+ *        \f[p_c(S_m+10^{-9}), \quad \frac{\partial p_c}{\partial S
+ * }|_{S_m+10^{-9}}.\f]
+ * or by setting
+ *        \f[S=max(S_m+10^{-9},S)\f]
+ *
  */
 class CapillaryPressureVanGenuchten : public Property
 {

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.h
@@ -80,5 +80,7 @@ private:
     double const m_;          ///< Exponent.
     double const p_b_;        ///< Pressure scaling factor.
     double const p_cap_max_;  ///< Maximum capillary pressure.
+    /// Saturation for Maximum capillary pressure.
+    double const S_for_p_cap_max_;
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureVanGenuchten.h
@@ -46,7 +46,7 @@ public:
                                   double const residual_gas_saturation,
                                   double const exponent,
                                   double const p_b,
-                                  double const maximum_capillary_pressure);
+                                  double const S_at_pc_max);
 
     void setScale(
         std::variant<Medium*, Phase*, Component*> scale_pointer) override
@@ -79,8 +79,7 @@ private:
     double const S_L_max_;    ///< Maximum saturation of liquid phase.
     double const m_;          ///< Exponent.
     double const p_b_;        ///< Pressure scaling factor.
-    double const p_cap_max_;  ///< Maximum capillary pressure.
-    /// Saturation for Maximum capillary pressure.
-    double const S_for_p_cap_max_;
+    /// Saturation at the maximum capillary pressure.
+    double const S_at_p_cap_max_;
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateCapillaryPressureVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateCapillaryPressureVanGenuchten.cpp
@@ -11,8 +11,11 @@
 
 #include "CreateCapillaryPressureVanGenuchten.h"
 
+#include <limits>
+
 #include "BaseLib/ConfigTree.h"
 #include "CapillaryPressureVanGenuchten.h"
+#include "GetSaturationVanGenuchten.h"
 #include "MaterialLib/MPL/Property.h"
 
 namespace MaterialPropertyLib
@@ -39,10 +42,25 @@ std::unique_ptr<Property> createCapillaryPressureVanGenuchten(
         config.getConfigParameter<double>("p_b");
     auto const maximum_capillary_pressure =
         //! \ogs_file_param{properties__property__CapillaryPressureVanGenuchten__maximum_capillary_pressure}
-        config.getConfigParameter<double>("maximum_capillary_pressure");
+        config.getConfigParameter<double>(
+            "maximum_capillary_pressure",
+            std::numeric_limits<double>::quiet_NaN());
+
+    // If maximum_capillary_pressure, pc_max, is not given,
+    //    S_at_pc_max = S_L_res  + 1.0e-9.
+    // Otherwise
+    //    S_at_pc_max = max(S_L_res  + 1.0e-9, S(pc_max))
+    const double S_at_pc_max =
+        (maximum_capillary_pressure == std::numeric_limits<double>::quiet_NaN())
+            ? residual_liquid_saturation + 1.0e-9
+            : std::max(residual_liquid_saturation + 1.0e-9,
+                       getSaturationVanGenuchten(
+                           maximum_capillary_pressure, p_b,
+                           residual_liquid_saturation,
+                           1.0 - residual_gas_saturation, exponent));
 
     return std::make_unique<CapillaryPressureVanGenuchten>(
         residual_liquid_saturation, residual_gas_saturation, exponent, p_b,
-        maximum_capillary_pressure);
+        S_at_pc_max);
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/GetSaturationVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/GetSaturationVanGenuchten.cpp
@@ -1,0 +1,30 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on May 5, 2020, 10:11 AM
+ */
+
+#include "GetSaturationVanGenuchten.h"
+
+#include <cmath>
+
+namespace MaterialPropertyLib
+{
+double getSaturationVanGenuchten(double const p_c, double const p_b,
+                                 double const S_L_res, double const S_L_max,
+                                 double const m)
+{
+    double const p = p_c / p_b;
+    double const n = 1. / (1. - m);
+    double const p_to_n = std::pow(p, n);
+
+    double const S_eff = std::pow(p_to_n + 1., -m);
+    return S_eff * S_L_max - S_eff * S_L_res + S_L_res;
+}
+
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/GetSaturationVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/GetSaturationVanGenuchten.h
@@ -1,0 +1,29 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on May 5, 2020, 10:11 AM
+ */
+
+#pragma once
+
+namespace MaterialPropertyLib
+{
+/**
+ * \fn getSaturationVanGenuchten(double const p_c, double const p_b,
+                                 double const S_L_res, double const S_L_max,
+                                 double const m)
+ * \brief A common function of class SaturationVanGenuchten and class
+ * CapillaryPressureVanGenuchten.
+ * It is used to compute saturation via capillary pressure.
+ * \sa MaterialPropertyLib::SaturationVanGenuchten
+ */
+double getSaturationVanGenuchten(double const p_c, double const p_b,
+                                 double const S_L_res, double const S_L_max,
+                                 double const m);
+
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/SaturationVanGenuchten.cpp
@@ -15,6 +15,8 @@
 
 #include "MaterialLib/MPL/Medium.h"
 
+#include "GetSaturationVanGenuchten.h"
+
 namespace MaterialPropertyLib
 {
 SaturationVanGenuchten::SaturationVanGenuchten(
@@ -49,12 +51,8 @@ PropertyDataType SaturationVanGenuchten::value(
         return S_L_max_;
     }
 
-    double const p = p_cap / p_b_;
-    double const n = 1. / (1. - m_);
-    double const p_to_n = std::pow(p, n);
-
-    double const S_eff = std::pow(p_to_n + 1., -m_);
-    double const S = S_eff * S_L_max_ - S_eff * S_L_res_ + S_L_res_;
+    double const S =
+        getSaturationVanGenuchten(p_cap, p_b_, S_L_res_, S_L_max_, m_);
     return std::clamp(S, S_L_res_, S_L_max_);
 }
 


### PR DESCRIPTION
In PR. #2919, `dPc/dS` when `S<S_r` is set to zero. It is not correct.

The correction in this PR is that: `dPc/dS` is computed with `S_r + 1.e-9` or `S` for `pc_max` if `S<S_r`. For this correction, a new member of  `_S_for_p_cap_max` is introduced to `CapillaryPressureVanGenuchten`.

