### PR TITLE
Pass xdot to compute secondary

### DIFF
--- a/NumLib/ODESolver/MatrixTranslator.cpp
+++ b/NumLib/ODESolver/MatrixTranslator.cpp
@@ -29,12 +29,13 @@ void MatrixTranslatorGeneral<ODESystemTag::FirstOrderImplicitQuasilinear>::
 
 void MatrixTranslatorGeneral<ODESystemTag::FirstOrderImplicitQuasilinear>::
     computeRhs(const GlobalMatrix& M, const GlobalMatrix& /*K*/,
-               const GlobalVector& b, GlobalVector& rhs) const
+               const GlobalVector& b, const GlobalVector& x_prev,
+               GlobalVector& rhs) const
 {
     namespace LinAlg = MathLib::LinAlg;
 
     auto& tmp = NumLib::GlobalVectorProvider::provider.getVector(_tmp_id);
-    _time_disc.getWeightedOldX(tmp);
+    _time_disc.getWeightedOldX(tmp, x_prev);
 
     // rhs = M * weighted_old_x + b
     LinAlg::matMultAdd(M, tmp, b, rhs);

--- a/NumLib/ODESolver/MatrixTranslator.h
+++ b/NumLib/ODESolver/MatrixTranslator.h
@@ -44,9 +44,10 @@ public:
     virtual void computeA(GlobalMatrix const& M, GlobalMatrix const& K,
                           GlobalMatrix& A) const = 0;
 
-    //! Computes \c rhs from \c M, \c K and \c b.
+    //! Computes \c rhs from \c M, \c K, \c b and \c x_prev.
     virtual void computeRhs(const GlobalMatrix& M, const GlobalMatrix& K,
-                            const GlobalVector& b, GlobalVector& rhs) const = 0;
+                            const GlobalVector& b, const GlobalVector& x_prev,
+                            GlobalVector& rhs) const = 0;
 
     /*! Computes \c res from \c M, \c K, \c b, \f$ \hat x \f$ and \f$ x_N \f$.
      * You might also want read the remarks on
@@ -101,7 +102,8 @@ public:
 
     //! Computes \f$ \mathtt{rhs} = M \cdot x_O + b \f$.
     void computeRhs(const GlobalMatrix& M, const GlobalMatrix& /*K*/,
-                    const GlobalVector& b, GlobalVector& rhs) const override;
+                    const GlobalVector& b, const GlobalVector& x_prev,
+                    GlobalVector& rhs) const override;
 
     //! Computes \f$ r = M \cdot \hat x + K \cdot x_C - b \f$.
     void computeResidual(GlobalMatrix const& M, GlobalMatrix const& K,

--- a/NumLib/ODESolver/NonlinearSolver.h
+++ b/NumLib/ODESolver/NonlinearSolver.h
@@ -36,11 +36,13 @@ class NonlinearSolverBase
 {
 public:
     virtual void calculateNonEquilibriumInitialResiduum(
-        std::vector<GlobalVector*> const& x, int const process_id) = 0;
+        std::vector<GlobalVector*> const& x,
+        std::vector<GlobalVector*> const& x_prev, int const process_id) = 0;
 
     /*! Assemble and solve the equation system.
      *
      * \param x   in: the initial guess, out: the solution.
+     * \param x_prev previous time step solution.
      * \param postIterationCallback called after each iteration if set.
      * \param process_id usually used in staggered schemes.
      *
@@ -49,6 +51,7 @@ public:
      */
     virtual NonlinearSolverStatus solve(
         std::vector<GlobalVector*>& x,
+        std::vector<GlobalVector*> const& x_prev,
         std::function<void(int, std::vector<GlobalVector*> const&)> const&
             postIterationCallback,
         int const process_id) = 0;
@@ -100,10 +103,13 @@ public:
     }
 
     void calculateNonEquilibriumInitialResiduum(
-        std::vector<GlobalVector*> const& x, int const process_id) override;
+        std::vector<GlobalVector*> const& x,
+        std::vector<GlobalVector*> const& x_prev,
+        int const process_id) override;
 
     NonlinearSolverStatus solve(
         std::vector<GlobalVector*>& x,
+        std::vector<GlobalVector*> const& x_prev,
         std::function<void(int, std::vector<GlobalVector*> const&)> const&
             postIterationCallback,
         int const process_id) override;
@@ -175,10 +181,13 @@ public:
     }
 
     void calculateNonEquilibriumInitialResiduum(
-        std::vector<GlobalVector*> const& x, int const process_id) override;
+        std::vector<GlobalVector*> const& x,
+        std::vector<GlobalVector*> const& x_prev,
+        int const process_id) override;
 
     NonlinearSolverStatus solve(
         std::vector<GlobalVector*>& x,
+        std::vector<GlobalVector*> const& x_prev,
         std::function<void(int, std::vector<GlobalVector*> const&)> const&
             postIterationCallback,
         int const process_id) override;

--- a/NumLib/ODESolver/NonlinearSystem.h
+++ b/NumLib/ODESolver/NonlinearSystem.h
@@ -38,6 +38,7 @@ public:
     //! The linearized system is \f$A(x) \cdot x = b(x)\f$. Here the matrix
     //! \f$A(x)\f$ and the vector \f$b(x)\f$ are assembled.
     virtual void assemble(std::vector<GlobalVector*> const& x,
+                          std::vector<GlobalVector*> const& x_prev,
                           int const process_id) = 0;
 
     /*! Writes the residual at point \c x to \c res.
@@ -47,6 +48,7 @@ public:
      * \todo Remove argument \c x.
      */
     virtual void getResidual(GlobalVector const& x,
+                             GlobalVector const& x_prev,
                              GlobalVector& res) const = 0;
 
     /*! Writes the Jacobian of the residual to \c Jac.
@@ -85,6 +87,7 @@ public:
     //! The linearized system is \f$J(x) \cdot \Delta x = (x)\f$. Here the
     //! residual vector \f$r(x)\f$ and its Jacobian \f$J(x)\f$ are assembled.
     virtual void assemble(std::vector<GlobalVector*> const& x,
+                          std::vector<GlobalVector*> const& x_prev,
                           int const process_id) = 0;
 
     //! Writes the linearized equation system matrix to \c A.
@@ -93,7 +96,8 @@ public:
 
     //! Writes the linearized equation system right-hand side to \c rhs.
     //! \pre assemble() must have been called before.
-    virtual void getRhs(GlobalVector& rhs) const = 0;
+    virtual void getRhs(GlobalVector const& x_prev,
+                        GlobalVector& rhs) const = 0;
 
     //! Pre-compute known solutions and possibly store them internally.
     virtual void computeKnownSolutions(GlobalVector const& x,

--- a/NumLib/ODESolver/TimeDiscretization.cpp
+++ b/NumLib/ODESolver/TimeDiscretization.cpp
@@ -54,9 +54,11 @@ double TimeDiscretization::computeRelativeChangeFromPreviousTimestep(
 }
 
 double BackwardEuler::getRelativeChangeFromPreviousTimestep(
-    GlobalVector const& x, MathLib::VecNormType norm_type)
+    GlobalVector const& x,
+    GlobalVector const& x_old,
+    MathLib::VecNormType norm_type)
 {
-    return computeRelativeChangeFromPreviousTimestep(x, _x_old, norm_type);
+    return computeRelativeChangeFromPreviousTimestep(x, x_old, norm_type);
 }
 
 }  // end of namespace NumLib

--- a/NumLib/ODESolver/TimeDiscretization.cpp
+++ b/NumLib/ODESolver/TimeDiscretization.cpp
@@ -52,13 +52,4 @@ double TimeDiscretization::computeRelativeChangeFromPreviousTimestep(
     // Only norm_x is close to zero
     return norm_dx / std::numeric_limits<double>::epsilon();
 }
-
-double BackwardEuler::getRelativeChangeFromPreviousTimestep(
-    GlobalVector const& x,
-    GlobalVector const& x_old,
-    MathLib::VecNormType norm_type)
-{
-    return computeRelativeChangeFromPreviousTimestep(x, x_old, norm_type);
-}
-
 }  // end of namespace NumLib

--- a/NumLib/ODESolver/TimeDiscretization.h
+++ b/NumLib/ODESolver/TimeDiscretization.h
@@ -90,7 +90,7 @@ public:
     TimeDiscretization() = default;
 
     //! Sets the initial condition.
-    virtual void setInitialState(const double t0, GlobalVector const& x0) = 0;
+    virtual void setInitialState(const double t0) = 0;
 
     /*! Get the relative change of solutions between two successive time steps
      *  by \f$ e_n = \|u^{n+1}-u^{n}\|/\|u^{n+1}\| \f$.
@@ -99,30 +99,9 @@ public:
      * \param norm_type The type of global vector norm.
      */
     virtual double getRelativeChangeFromPreviousTimestep(
-        GlobalVector const& x, MathLib::VecNormType norm_type) = 0;
-
-    /*! Indicate that the current timestep is done and that you will proceed to
-     * the next one.
-     *
-     * \warning Do not use this method for setting the initial condition,
-     *          rather use setInitialState()!
-     *
-     * \param t    The current timestep.
-     * \param x    The solution at the current timestep.
-     */
-    virtual void pushState(const double t, GlobalVector const& x) = 0;
-
-    /*!
-     * Restores the given vector x to its old value.
-     * Used only for repeating of the time step with new time step size when
-     * the current time step is rejected. The restored x is only used as
-     * an initial guess for linear solver in the first Picard nonlinear
-     * iteration.
-     *
-     * \param x The solution at the current time step, which is going to be
-     *          reset to its previous value.
-     */
-    virtual void popState(GlobalVector& x) = 0;
+        GlobalVector const& x,
+        GlobalVector const& x_old,
+        MathLib::VecNormType norm_type) = 0;
 
     /*! Indicate that the computation of a new timestep is being started now.
      *
@@ -142,14 +121,16 @@ public:
 
     //! Returns \f$ \hat x \f$, i.e. the discretized approximation of \f$ \dot x
     //! \f$.
-    void getXdot(GlobalVector const& x_at_new_timestep, GlobalVector& xdot) const
+    void getXdot(GlobalVector const& x_at_new_timestep,
+                 GlobalVector const& x_old,
+                 GlobalVector& xdot) const
     {
         namespace LinAlg = MathLib::LinAlg;
 
         auto const dxdot_dx = getNewXWeight();
 
         // xdot = dxdot_dx * x_at_new_timestep - x_old
-        getWeightedOldX(xdot);
+        getWeightedOldX(xdot, x_old);
         LinAlg::axpby(xdot, dxdot_dx, -1.0, x_at_new_timestep);
     }
 
@@ -157,7 +138,8 @@ public:
     virtual double getNewXWeight() const = 0;
 
     //! Returns \f$ x_O \f$.
-    virtual void getWeightedOldX(GlobalVector& y) const = 0;  // = x_old
+    virtual void getWeightedOldX(
+        GlobalVector& y, GlobalVector const& x_old) const = 0;  // = x_old
 
     virtual ~TimeDiscretization() = default;
 
@@ -186,34 +168,12 @@ protected:
 class BackwardEuler final : public TimeDiscretization
 {
 public:
-    BackwardEuler()
-        : _x_old(NumLib::GlobalVectorProvider::provider.getVector())
-    {
-    }
-
-    ~BackwardEuler() override
-    {
-        NumLib::GlobalVectorProvider::provider.releaseVector(_x_old);
-    }
-
-    void setInitialState(const double t0, GlobalVector const& x0) override
-    {
-        _t = t0;
-        MathLib::LinAlg::copy(x0, _x_old);
-    }
+    void setInitialState(const double t0) override { _t = t0; }
 
     double getRelativeChangeFromPreviousTimestep(
-        GlobalVector const& x, MathLib::VecNormType norm_type) override;
-
-    void pushState(const double /*t*/, GlobalVector const& x) override
-    {
-        MathLib::LinAlg::copy(x, _x_old);
-    }
-
-    void popState(GlobalVector& x) override
-    {
-        MathLib::LinAlg::copy(_x_old, x);
-    }
+        GlobalVector const& x,
+        GlobalVector const& x_old,
+        MathLib::VecNormType norm_type) override;
 
     void nextTimestep(const double t, const double delta_t) override
     {
@@ -224,12 +184,13 @@ public:
     double getCurrentTime() const override { return _t; }
     double getCurrentTimeIncrement() const override { return _delta_t; }
     double getNewXWeight() const override { return 1.0 / _delta_t; }
-    void getWeightedOldX(GlobalVector& y) const override
+    void getWeightedOldX(GlobalVector& y,
+                         GlobalVector const& x_old) const override
     {
         namespace LinAlg = MathLib::LinAlg;
 
         // y = x_old / delta_t
-        LinAlg::copy(_x_old, y);
+        LinAlg::copy(x_old, y);
         LinAlg::scale(y, 1.0 / _delta_t);
     }
 
@@ -237,7 +198,6 @@ private:
     double _t = std::numeric_limits<double>::quiet_NaN();  //!< \f$ t_C \f$
     double _delta_t =
         std::numeric_limits<double>::quiet_NaN();  //!< the timestep size
-    GlobalVector& _x_old;   //!< the solution from the preceding timestep
 };
 
 //! @}

--- a/NumLib/ODESolver/TimeDiscretization.h
+++ b/NumLib/ODESolver/TimeDiscretization.h
@@ -92,16 +92,22 @@ public:
     //! Sets the initial condition.
     virtual void setInitialState(const double t0) = 0;
 
-    /*! Get the relative change of solutions between two successive time steps
-     *  by \f$ e_n = \|u^{n+1}-u^{n}\|/\|u^{n+1}\| \f$.
+    /**
+     * Compute and return the relative change of solutions between two
+     * successive time steps by \f$ e_n = \|u^{n+1}-u^{n}\|/\|u^{n+1}\| \f$.
      *
-     * \param x         The solution at the current timestep.
-     * \param norm_type The type of global vector norm.
+     * @param x         The current solution
+     * @param x_old     The previous solution
+     * @param norm_type The norm type of global vector
+     * @return          \f$ e_n = \|u^{n+1}-u^{n}\|/\|u^{n+1}\| \f$.
+     *
+     * @warning the value of x_old is changed to x - x_old after this
+     * computation.
      */
-    virtual double getRelativeChangeFromPreviousTimestep(
+    double computeRelativeChangeFromPreviousTimestep(
         GlobalVector const& x,
         GlobalVector const& x_old,
-        MathLib::VecNormType norm_type) = 0;
+        MathLib::VecNormType norm_type);
 
     /*! Indicate that the computation of a new timestep is being started now.
      *
@@ -145,23 +151,6 @@ public:
 
 protected:
     std::unique_ptr<GlobalVector> _dx;  ///< Used to store \f$ u_{n+1}-u_{n}\f$.
-
-    /**
-     * Compute and return the relative change of solutions between two
-     * successive time steps by \f$ e_n = \|u^{n+1}-u^{n}\|/\|u^{n+1}\| \f$.
-     *
-     * @param x         The current solution
-     * @param x_old     The previous solution
-     * @param norm_type The norm type of global vector
-     * @return          \f$ e_n = \|u^{n+1}-u^{n}\|/\|u^{n+1}\| \f$.
-     *
-     * @warning the value of x_old is changed to x - x_old after this
-     * computation.
-     */
-    double computeRelativeChangeFromPreviousTimestep(
-        GlobalVector const& x,
-        GlobalVector const& x_old,
-        MathLib::VecNormType norm_type);
 };
 
 //! Backward Euler scheme.
@@ -169,11 +158,6 @@ class BackwardEuler final : public TimeDiscretization
 {
 public:
     void setInitialState(const double t0) override { _t = t0; }
-
-    double getRelativeChangeFromPreviousTimestep(
-        GlobalVector const& x,
-        GlobalVector const& x_old,
-        MathLib::VecNormType norm_type) override;
 
     void nextTimestep(const double t, const double delta_t) override
     {

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.cpp
@@ -73,6 +73,7 @@ TimeDiscretizedODESystem<
 void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
                               NonlinearSolverTag::Newton>::
     assemble(std::vector<GlobalVector*> const& x_new_timestep,
+             std::vector<GlobalVector*> const& x_prev,
              int const process_id)
 {
     namespace LinAlg = MathLib::LinAlg;
@@ -86,7 +87,8 @@ void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
     for (auto& v : xdot)
     {
         v = &NumLib::GlobalVectorProvider::provider.getVector();
-        _time_disc.getXdot(*x_new_timestep[process_id], *v);
+        _time_disc.getXdot(*x_new_timestep[process_id], *x_prev[process_id],
+                           *v);
     }
 
     _M->setZero();
@@ -124,13 +126,14 @@ void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
 void TimeDiscretizedODESystem<
     ODESystemTag::FirstOrderImplicitQuasilinear,
     NonlinearSolverTag::Newton>::getResidual(GlobalVector const& x_new_timestep,
+                                             GlobalVector const& x_prev,
                                              GlobalVector& res) const
 {
     // TODO Maybe the duplicate calculation of xdot here and in assembleJacobian
     //      can be optimuized. However, that would make the interface a bit more
     //      fragile.
     auto& xdot = NumLib::GlobalVectorProvider::provider.getVector(_xdot_id);
-    _time_disc.getXdot(x_new_timestep, xdot);
+    _time_disc.getXdot(x_new_timestep, x_prev, xdot);
 
     _mat_trans->computeResidual(*_M, *_K, *_b, x_new_timestep, xdot, res);
 
@@ -210,6 +213,7 @@ TimeDiscretizedODESystem<
 void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
                               NonlinearSolverTag::Picard>::
     assemble(std::vector<GlobalVector*> const& x_new_timestep,
+             std::vector<GlobalVector*> const& x_prev,
              int const process_id)
 {
     namespace LinAlg = MathLib::LinAlg;
@@ -221,7 +225,8 @@ void TimeDiscretizedODESystem<ODESystemTag::FirstOrderImplicitQuasilinear,
     for (auto& v : xdot)
     {
         v = &NumLib::GlobalVectorProvider::provider.getVector();
-        _time_disc.getXdot(*x_new_timestep[process_id], *v);
+        _time_disc.getXdot(*x_new_timestep[process_id], *x_prev[process_id],
+                           *v);
     }
 
     _M->setZero();

--- a/NumLib/ODESolver/TimeDiscretizedODESystem.h
+++ b/NumLib/ODESolver/TimeDiscretizedODESystem.h
@@ -83,9 +83,11 @@ public:
     ~TimeDiscretizedODESystem() override;
 
     void assemble(std::vector<GlobalVector*> const& x_new_timestep,
+                  std::vector<GlobalVector*> const& x_prev,
                   int const process_id) override;
 
     void getResidual(GlobalVector const& x_new_timestep,
+                     GlobalVector const& x_prev,
                      GlobalVector& res) const override;
 
     void getJacobian(GlobalMatrix& Jac) const override;
@@ -173,6 +175,7 @@ public:
     ~TimeDiscretizedODESystem() override;
 
     void assemble(std::vector<GlobalVector*> const& x_new_timestep,
+                  std::vector<GlobalVector*> const& x_prev,
                   int const process_id) override;
 
     void getA(GlobalMatrix& A) const override
@@ -180,9 +183,9 @@ public:
         _mat_trans->computeA(*_M, *_K, A);
     }
 
-    void getRhs(GlobalVector& rhs) const override
+    void getRhs(GlobalVector const& x_prev, GlobalVector& rhs) const override
     {
-        _mat_trans->computeRhs(*_M, *_K, *_b, rhs);
+        _mat_trans->computeRhs(*_M, *_K, *_b, x_prev, rhs);
     }
 
     void computeKnownSolutions(GlobalVector const& x,

--- a/ProcessLib/HeatConduction/HeatConductionFEM.h
+++ b/ProcessLib/HeatConduction/HeatConductionFEM.h
@@ -131,7 +131,8 @@ public:
     }
 
     void computeSecondaryVariableConcrete(
-        const double t, std::vector<double> const& local_x) override
+        double const t, double const /*dt*/, std::vector<double> const& local_x,
+        std::vector<double> const& /*local_x_dot*/) override
     {
         auto const local_matrix_size = local_x.size();
         // This assertion is valid only if all nodal d.o.f. use the same shape

--- a/ProcessLib/HeatConduction/HeatConductionProcess.cpp
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.cpp
@@ -109,16 +109,17 @@ void HeatConductionProcess::assembleWithJacobianConcreteProcess(
 }
 
 void HeatConductionProcess::computeSecondaryVariableConcrete(
-    const double t, GlobalVector const& x, int const process_id)
+    double const t, double const dt, GlobalVector const& x,
+    GlobalVector const& x_dot, int const process_id)
 {
     DBUG("Compute heat flux for HeatConductionProcess.");
 
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     GlobalExecutor::executeSelectedMemberOnDereferenced(
-            &HeatConductionLocalAssemblerInterface::computeSecondaryVariable,
-            _local_assemblers, pv.getActiveElementIDs(),
-             getDOFTable(process_id), t, x, _coupled_solutions);
+        &HeatConductionLocalAssemblerInterface::computeSecondaryVariable,
+        _local_assemblers, pv.getActiveElementIDs(), getDOFTable(process_id), t,
+        dt, x, x_dot, _coupled_solutions);
 }
 
 }  // namespace HeatConduction

--- a/ProcessLib/HeatConduction/HeatConductionProcess.h
+++ b/ProcessLib/HeatConduction/HeatConductionProcess.h
@@ -40,8 +40,10 @@ public:
 
     bool isLinear() const override { return true; }
 
-    void computeSecondaryVariableConcrete(
-        double const t, GlobalVector const& x, int const process_id) override;
+    void computeSecondaryVariableConcrete(double const t, double const dt,
+                                          GlobalVector const& x,
+                                          GlobalVector const& x_dot,
+                                          int const process_id) override;
 
 private:
     void initializeConcreteProcess(

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.cpp
@@ -187,7 +187,8 @@ void HeatTransportBHEProcess::assembleWithJacobianConcreteProcess(
 }
 
 void HeatTransportBHEProcess::computeSecondaryVariableConcrete(
-    const double t, GlobalVector const& x, int const process_id)
+    double const t, double const dt, GlobalVector const& x,
+    GlobalVector const& x_dot, int const process_id)
 {
     DBUG("Compute heat flux for HeatTransportBHE process.");
 
@@ -195,7 +196,7 @@ void HeatTransportBHEProcess::computeSecondaryVariableConcrete(
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &HeatTransportBHELocalAssemblerInterface::computeSecondaryVariable,
         _local_assemblers, pv.getActiveElementIDs(), getDOFTable(process_id), t,
-        x, _coupled_solutions);
+        dt, x, x_dot, _coupled_solutions);
 }
 
 #ifdef OGS_USE_PYTHON

--- a/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
+++ b/ProcessLib/HeatTransportBHE/HeatTransportBHEProcess.h
@@ -41,8 +41,9 @@ public:
     //! @{
     bool isLinear() const override { return false; }
 
-    void computeSecondaryVariableConcrete(double const t,
+    void computeSecondaryVariableConcrete(double const t, double const dt,
                                           GlobalVector const& x,
+                                          GlobalVector const& x_dot,
                                           int const process_id) override;
 
 private:

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h
@@ -847,8 +847,9 @@ template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
 void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                   ShapeFunctionPressure, IntegrationMethod,
                                   DisplacementDim>::
-    computeSecondaryVariableConcrete(double const t,
-                                     std::vector<double> const& local_x)
+    computeSecondaryVariableConcrete(double const t, double const dt,
+                                     std::vector<double> const& local_x,
+                                     std::vector<double> const& /*local_x_dot*/)
 {
     auto p = Eigen::Map<typename ShapeMatricesTypePressure::template VectorType<
         pressure_size> const>(local_x.data() + pressure_index, pressure_size);
@@ -866,10 +867,6 @@ void HydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
 
     auto const& medium = _process_data.media_map->getMedium(elem_id);
     MPL::VariableArray vars;
-
-    // TODO (naumov) Temporary value not used by current material models. Need
-    // extension of secondary variables interface.
-    double const dt = std::numeric_limits<double>::quiet_NaN();
 
     constexpr int symmetric_tensor_size =
         MathLib::KelvinVector::KelvinVectorDimensions<DisplacementDim>::value;

--- a/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsFEM.h
@@ -191,7 +191,9 @@ public:
     }
 
     void computeSecondaryVariableConcrete(
-        double const t, std::vector<double> const& local_x) override;
+        double const t, double const dt, std::vector<double> const& local_x,
+        std::vector<double> const& local_x_dot) override;
+
     void postNonLinearSolverConcrete(std::vector<double> const& local_x,
                                      double const t, double const dt,
                                      bool const use_monolithic_scheme) override;

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.cpp
@@ -519,13 +519,14 @@ void HydroMechanicsProcess<DisplacementDim>::postNonLinearSolverConcreteProcess(
 
 template <int DisplacementDim>
 void HydroMechanicsProcess<DisplacementDim>::computeSecondaryVariableConcrete(
-    const double t, GlobalVector const& x, const int process_id)
+    double const t, double const dt, GlobalVector const& x,
+    GlobalVector const& x_dot, const int process_id)
 {
     DBUG("Compute the secondary variables for HydroMechanicsProcess.");
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerIF::computeSecondaryVariable, _local_assemblers,
-        pv.getActiveElementIDs(), getDOFTable(process_id), t, x,
+        pv.getActiveElementIDs(), getDOFTable(process_id), t, dt, x, x_dot,
         _coupled_solutions);
 }
 

--- a/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
+++ b/ProcessLib/HydroMechanics/HydroMechanicsProcess.h
@@ -123,7 +123,9 @@ private:
     /// Solutions of the previous time step
     std::array<std::unique_ptr<GlobalVector>, 2> _xs_previous_timestep;
 
-    void computeSecondaryVariableConcrete(const double t, GlobalVector const& x,
+    void computeSecondaryVariableConcrete(double const t, double const dt,
+                                          GlobalVector const& x,
+                                          GlobalVector const& x_dot,
                                           const int process_id) override;
     /**
      * @copydoc ProcessLib::Process::getDOFTableForExtrapolatorData()

--- a/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerInterface.h
+++ b/ProcessLib/LIE/SmallDeformation/LocalAssembler/SmallDeformationLocalAssemblerInterface.h
@@ -88,14 +88,15 @@ public:
     }
 
     void computeSecondaryVariableConcrete(
-        const double t, std::vector<double> const& local_x_) override
+        double const t, double const /*dt*/, std::vector<double> const& local_x,
+        std::vector<double> const& /*local_x_dot*/) override
     {
         if (!_dofIndex_to_localIndex.empty())
         {
             _local_u.setZero();
-            for (std::size_t i = 0; i < local_x_.size(); i++)
+            for (std::size_t i = 0; i < local_x.size(); i++)
             {
-                _local_u[_dofIndex_to_localIndex[i]] = local_x_[i];
+                _local_u[_dofIndex_to_localIndex[i]] = local_x[i];
             }
         }
 

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.cpp
@@ -525,15 +525,16 @@ void SmallDeformationProcess<DisplacementDim>::initializeConcreteProcess(
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::computeSecondaryVariableConcrete(
-    const double t, GlobalVector const& x, int const process_id)
+    double const t, double const dt, GlobalVector const& x,
+    GlobalVector const& x_dot, int const process_id)
 {
     DBUG("Compute the secondary variables for SmallDeformationProcess.");
 
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &SmallDeformationLocalAssemblerInterface::computeSecondaryVariable,
-        _local_assemblers, pv.getActiveElementIDs(),
-        getDOFTable(process_id), t, x, _coupled_solutions);
+        _local_assemblers, pv.getActiveElementIDs(), getDOFTable(process_id), t,
+        dt, x, x_dot, _coupled_solutions);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/LIE/SmallDeformation/SmallDeformationProcess.h
@@ -46,8 +46,9 @@ public:
     bool isLinear() const override;
     //! @}
 
-    void computeSecondaryVariableConcrete(double const t,
+    void computeSecondaryVariableConcrete(double const t, double const dt,
                                           GlobalVector const& x,
+                                          GlobalVector const& x_dot,
                                           int const process_id) override;
 
 private:

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.cpp
@@ -101,9 +101,9 @@ void LiquidFlowProcess::assembleWithJacobianConcreteProcess(
         dxdot_dx, dx_dx, process_id, M, K, b, Jac, _coupled_solutions);
 }
 
-void LiquidFlowProcess::computeSecondaryVariableConcrete(const double t,
-                                                         GlobalVector const& x,
-                                                         int const process_id)
+void LiquidFlowProcess::computeSecondaryVariableConcrete(
+    double const t, double const dt, GlobalVector const& x,
+    GlobalVector const& x_dot, int const process_id)
 {
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
@@ -111,7 +111,7 @@ void LiquidFlowProcess::computeSecondaryVariableConcrete(const double t,
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LiquidFlowLocalAssemblerInterface::computeSecondaryVariable,
         _local_assemblers, pv.getActiveElementIDs(), getDOFTable(process_id), t,
-        x, _coupled_solutions);
+        dt, x, x_dot, _coupled_solutions);
 }
 
 Eigen::Vector3d LiquidFlowProcess::getFlux(

--- a/ProcessLib/LiquidFlow/LiquidFlowProcess.h
+++ b/ProcessLib/LiquidFlow/LiquidFlowProcess.h
@@ -68,8 +68,9 @@ public:
         SecondaryVariableCollection&& secondary_variables,
         std::unique_ptr<ProcessLib::SurfaceFluxData>&& surfaceflux);
 
-    void computeSecondaryVariableConcrete(double const t,
+    void computeSecondaryVariableConcrete(double const t, double const dt,
                                           GlobalVector const& x,
+                                          GlobalVector const& x_dot,
                                           int const process_id) override;
 
     bool isLinear() const override { return true; }

--- a/ProcessLib/LocalAssemblerInterface.cpp
+++ b/ProcessLib/LocalAssemblerInterface.cpp
@@ -73,7 +73,8 @@ void LocalAssemblerInterface::assembleWithJacobianForStaggeredScheme(
 void LocalAssemblerInterface::computeSecondaryVariable(
     std::size_t const mesh_item_id,
     NumLib::LocalToGlobalIndexMap const& dof_table, double const t,
-    GlobalVector const& x, CoupledSolutionsForStaggeredScheme const* coupled_xs)
+    double const dt, GlobalVector const& x, GlobalVector const& x_dot,
+    CoupledSolutionsForStaggeredScheme const* coupled_xs)
 {
     auto const indices = NumLib::getIndices(mesh_item_id, dof_table);
 
@@ -83,7 +84,8 @@ void LocalAssemblerInterface::computeSecondaryVariable(
     }
 
     auto const local_x = x.get(indices);
-    computeSecondaryVariableConcrete(t, local_x);
+    auto const local_x_dot = x_dot.get(indices);
+    computeSecondaryVariableConcrete(t, dt, local_x, local_x_dot);
 }
 
 void LocalAssemblerInterface::setInitialConditions(

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -78,8 +78,9 @@ public:
 
     virtual void computeSecondaryVariable(
         std::size_t const mesh_item_id,
-        NumLib::LocalToGlobalIndexMap const& dof_table, const double t,
-        GlobalVector const& x,
+        NumLib::LocalToGlobalIndexMap const& dof_table, double const t,
+        double const dt, GlobalVector const& local_x,
+        GlobalVector const& local_x_dot,
         CoupledSolutionsForStaggeredScheme const* coupled_xs);
 
     virtual void preTimestep(std::size_t const mesh_item_id,
@@ -142,7 +143,10 @@ private:
     }
 
     virtual void computeSecondaryVariableConcrete(
-        double const /*t*/, std::vector<double> const& /*local_x*/)
+        double const /*t*/,
+        double const /*dt*/,
+        std::vector<double> const& /*local_x*/,
+        std::vector<double> const& /*local_x_dot*/)
     {
     }
 

--- a/ProcessLib/Process.cpp
+++ b/ProcessLib/Process.cpp
@@ -383,12 +383,16 @@ void Process::postNonLinearSolver(GlobalVector const& x, const double t,
     postNonLinearSolverConcreteProcess(x, t, dt, process_id);
 }
 
-void Process::computeSecondaryVariable(const double t, GlobalVector const& x,
+void Process::computeSecondaryVariable(double const t,
+                                       double const dt,
+                                       GlobalVector const& x,
+                                       GlobalVector const& x_dot,
                                        int const process_id)
 {
     MathLib::LinAlg::setLocalAccessibleVector(x);
+    MathLib::LinAlg::setLocalAccessibleVector(x_dot);
 
-    computeSecondaryVariableConcrete(t, x, process_id);
+    computeSecondaryVariableConcrete(t, dt, x, x_dot, process_id);
 }
 
 void Process::preIteration(const unsigned iter, const GlobalVector& x)

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -71,7 +71,10 @@ public:
     void preIteration(const unsigned iter, GlobalVector const& x) final;
 
     /// compute secondary variables for the coupled equations or for output.
-    void computeSecondaryVariable(const double t, GlobalVector const& x,
+    void computeSecondaryVariable(double const t,
+                                  double const dt,
+                                  GlobalVector const& x,
+                                  GlobalVector const& x_dot,
                                   int const process_id);
 
     NumLib::IterationResult postIteration(GlobalVector const& x) final;
@@ -238,8 +241,10 @@ private:
     {
     }
 
-    virtual void computeSecondaryVariableConcrete(const double /*t*/,
+    virtual void computeSecondaryVariableConcrete(double const /*t*/,
+                                                  double const /*dt*/,
                                                   GlobalVector const& /*x*/,
+                                                  GlobalVector const& /*x_dot*/,
                                                   int const /*process_id*/)
     {
     }

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM-impl.h
@@ -1339,8 +1339,9 @@ template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
 void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                      ShapeFunctionPressure, IntegrationMethod,
                                      DisplacementDim>::
-    computeSecondaryVariableConcrete(double const t,
-                                     std::vector<double> const& local_x)
+    computeSecondaryVariableConcrete(double const t, double const dt,
+                                     std::vector<double> const& local_x,
+                                     std::vector<double> const& /*local_x_dot*/)
 {
     auto p_L =
         Eigen::Map<typename ShapeMatricesTypePressure::template VectorType<
@@ -1392,9 +1393,6 @@ void RichardsMechanicsLocalAssembler<ShapeFunctionDisplacement,
             p_cap_ip;
         variables[static_cast<int>(MPL::Variable::phase_pressure)] = -p_cap_ip;
 
-        // TODO (naumov) Temporary value not used by current material models.
-        // Need extension of secondary variables interface.
-        double const dt = std::numeric_limits<double>::quiet_NaN();
         auto const temperature =
             medium->property(MPL::PropertyType::reference_temperature)
                 .template value<double>(variables, x_position, t, dt);

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsFEM.h
@@ -158,7 +158,8 @@ public:
     }
 
     void computeSecondaryVariableConcrete(
-        double const t, std::vector<double> const& local_x) override;
+        double const t, double const dt, std::vector<double> const& local_x,
+        std::vector<double> const& local_x_dot) override;
 
     void postNonLinearSolverConcrete(std::vector<double> const& local_x,
                                      double const t, double const dt,

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.cpp
@@ -569,17 +569,18 @@ void RichardsMechanicsProcess<
 }
 
 template <int DisplacementDim>
-void RichardsMechanicsProcess<
-    DisplacementDim>::computeSecondaryVariableConcrete(const double t,
-                                                       GlobalVector const& x,
-                                                       int const process_id)
+void RichardsMechanicsProcess<DisplacementDim>::
+    computeSecondaryVariableConcrete(const double t, const double dt,
+                                     GlobalVector const& x,
+                                     GlobalVector const& x_dot,
+                                     int const process_id)
 {
     DBUG("Compute the secondary variables for RichardsMechanicsProcess.");
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
 
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerIF::computeSecondaryVariable, _local_assemblers,
-        pv.getActiveElementIDs(), getDOFTable(process_id), t, x,
+        pv.getActiveElementIDs(), getDOFTable(process_id), t, dt, x, x_dot,
         _coupled_solutions);
 }
 

--- a/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
+++ b/ProcessLib/RichardsMechanics/RichardsMechanicsProcess.h
@@ -121,8 +121,9 @@ private:
     /// Solutions of the previous time step
     std::array<std::unique_ptr<GlobalVector>, 2> _xs_previous_timestep;
 
-    void computeSecondaryVariableConcrete(const double t,
+    void computeSecondaryVariableConcrete(double const t, double const dt,
                                           GlobalVector const& x,
+                                          GlobalVector const& x_dot,
                                           int const process_id) override;
     /**
      * @copydoc ProcessLib::Process::getDOFTableForExtrapolatorData()

--- a/ProcessLib/SmallDeformation/SmallDeformationFEM.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationFEM.h
@@ -494,7 +494,9 @@ public:
     }
 
     void computeSecondaryVariableConcrete(
-        double const /*t*/, std::vector<double> const& /*local_x*/) override
+        double const /*t*/, double const /*dt*/,
+        std::vector<double> const& /*x*/,
+        std::vector<double> const& /*x_dot*/) override
     {
         int const elem_id = _element.getID();
         ParameterLib::SpatialPosition x_position;

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.cpp
@@ -262,13 +262,14 @@ void SmallDeformationProcess<DisplacementDim>::postTimestepConcreteProcess(
 
 template <int DisplacementDim>
 void SmallDeformationProcess<DisplacementDim>::computeSecondaryVariableConcrete(
-    const double t, GlobalVector const& x, const int process_id)
+    double const t, double const dt, GlobalVector const& x,
+    GlobalVector const& x_dot, const int process_id)
 {
     DBUG("Compute the secondary variables for SmallDeformationProcess.");
     ProcessLib::ProcessVariable const& pv = getProcessVariables(process_id)[0];
     GlobalExecutor::executeSelectedMemberOnDereferenced(
         &LocalAssemblerInterface::computeSecondaryVariable, _local_assemblers,
-        pv.getActiveElementIDs(), getDOFTable(process_id), t, x,
+        pv.getActiveElementIDs(), getDOFTable(process_id), t, dt, x, x_dot,
         _coupled_solutions);
 }
 template class SmallDeformationProcess<2>;

--- a/ProcessLib/SmallDeformation/SmallDeformationProcess.h
+++ b/ProcessLib/SmallDeformation/SmallDeformationProcess.h
@@ -65,7 +65,9 @@ private:
                                      const double t, const double dt,
                                      int const process_id) override;
 
-    void computeSecondaryVariableConcrete(const double t, GlobalVector const& x,
+    void computeSecondaryVariableConcrete(double const t, double const dt,
+                                          GlobalVector const& x,
+                                          GlobalVector const& x_dot,
                                           const int process_id) override;
 
 private:

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM-impl.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM-impl.h
@@ -589,8 +589,9 @@ template <typename ShapeFunctionDisplacement, typename ShapeFunctionPressure,
 void ThermoHydroMechanicsLocalAssembler<ShapeFunctionDisplacement,
                                         ShapeFunctionPressure,
                                         IntegrationMethod, DisplacementDim>::
-    computeSecondaryVariableConcrete(double const /*t*/,
-                                     std::vector<double> const& local_x)
+    computeSecondaryVariableConcrete(double const /*t*/, double const /*dt*/,
+                                     std::vector<double> const& local_x,
+                                     std::vector<double> const& /*local_x_dot*/)
 {
     auto p = Eigen::Map<typename ShapeMatricesTypePressure::template VectorType<
         pressure_size> const>(local_x.data() + pressure_index, pressure_size);

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsFEM.h
@@ -121,7 +121,9 @@ public:
     }
 
     void computeSecondaryVariableConcrete(
-        double const t, std::vector<double> const& local_x) override;
+        double const t, double const dt, std::vector<double> const& local_x,
+        std::vector<double> const& local_x_dot) override;
+
     void postNonLinearSolverConcrete(std::vector<double> const& local_x,
                                      double const t, double const dt,
                                      bool const use_monolithic_scheme) override;

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.cpp
@@ -375,15 +375,16 @@ void ThermoHydroMechanicsProcess<
 }
 
 template <int DisplacementDim>
-void ThermoHydroMechanicsProcess<
-    DisplacementDim>::computeSecondaryVariableConcrete(const double t,
-                                                       GlobalVector const& x,
-                                                       const int process_id)
+void ThermoHydroMechanicsProcess<DisplacementDim>::
+    computeSecondaryVariableConcrete(double const t, double const dt,
+                                     GlobalVector const& x,
+                                     GlobalVector const& x_dot,
+                                     const int process_id)
 {
     DBUG("Compute the secondary variables for ThermoHydroMechanicsProcess.");
     GlobalExecutor::executeMemberOnDereferenced(
         &LocalAssemblerInterface::computeSecondaryVariable, _local_assemblers,
-        getDOFTable(process_id), t, x, _coupled_solutions);
+        getDOFTable(process_id), t, dt, x, x_dot, _coupled_solutions);
 }
 
 template <int DisplacementDim>

--- a/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
+++ b/ProcessLib/ThermoHydroMechanics/ThermoHydroMechanicsProcess.h
@@ -123,7 +123,9 @@ private:
     /// Solutions of the previous time step
     std::array<std::unique_ptr<GlobalVector>, 2> _xs_previous_timestep;
 
-    void computeSecondaryVariableConcrete(const double t, GlobalVector const& x,
+    void computeSecondaryVariableConcrete(double const t, double const dt,
+                                          GlobalVector const& x,
+                                          GlobalVector const& x_dot,
                                           const int process_id) override;
     /**
      * @copydoc ProcessLib::Process::getDOFTableForExtrapolatorData()

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -282,7 +282,7 @@ double TimeLoop::computeTimeStepping(const double prev_dt, double& t,
             (timestepper->isSolutionErrorComputationNeeded())
                 ? ((t == timestepper->begin())
                        ? 0.  // Always accepts the zeroth step
-                       : time_disc->getRelativeChangeFromPreviousTimestep(
+                       : time_disc->computeRelativeChangeFromPreviousTimestep(
                              x, x_prev, norm_type))
                 : 0.;
 

--- a/ProcessLib/TimeLoop.h
+++ b/ProcessLib/TimeLoop.h
@@ -110,6 +110,7 @@ private:
 
 private:
     std::vector<GlobalVector*> _process_solutions;
+    std::vector<GlobalVector*> _process_solutions_prev;
     std::unique_ptr<Output> _output;
     std::vector<std::unique_ptr<ProcessData>> _per_process_data;
 


### PR DESCRIPTION
Pass xdot and dt to Process::computeSecondaryVariables().
In this PR the xdot and dt is mostly commented and is needed in RichardsMechanics process (see following PR #2936) to compute rate dependent secondary variables.

Main change is the storage of `x_prev` value in the time loop.
Review commit-wise.

1. [ ] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.1)
2. [x] Tests covering your feature were added? Covered by ctests
3. [x] Any new feature or behavior change was documented? No user changes.
