### PR TITLE
Improve error handling in MPL

### DIFF
--- a/MaterialLib/MPL/Component.cpp
+++ b/MaterialLib/MPL/Component.cpp
@@ -39,4 +39,9 @@ bool Component::hasProperty(PropertyType const& p) const
 {
     return properties_[p] != nullptr;
 }
+
+std::string Component::description() const
+{
+    return "component '" + name + "'";
+}
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Component.h
+++ b/MaterialLib/MPL/Component.h
@@ -66,6 +66,9 @@ public:
                                                variable2);
     }
 
+    /// Short description of the component with its name.
+    std::string description() const;
+
 public:
     std::string const name;
 

--- a/MaterialLib/MPL/Medium.cpp
+++ b/MaterialLib/MPL/Medium.cpp
@@ -56,4 +56,9 @@ std::size_t Medium::numberOfPhases() const
 {
     return phases_.size();
 }
+
+std::string Medium::description() const
+{
+    return "medium";
+}
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Medium.h
+++ b/MaterialLib/MPL/Medium.h
@@ -47,6 +47,9 @@ public:
     /// consists of.
     std::size_t numberOfPhases() const;
 
+    /// Short description of the medium.
+    std::string description() const;
+
     template <typename T>
     T value(PropertyType const p) const
     {

--- a/MaterialLib/MPL/Phase.cpp
+++ b/MaterialLib/MPL/Phase.cpp
@@ -54,8 +54,8 @@ Property const& Phase::property(PropertyType const& p) const
     Property const* const property = properties_[p].get();
     if (property == nullptr)
     {
-        OGS_FATAL("Trying to access undefined property '{:s}' of phase {:s}",
-                  property_enum_to_string[p], name);
+        OGS_FATAL("Trying to access undefined property '{:s}' of {:s}",
+                  property_enum_to_string[p], description());
     }
     return *properties_[p];
 }

--- a/MaterialLib/MPL/Phase.cpp
+++ b/MaterialLib/MPL/Phase.cpp
@@ -70,4 +70,8 @@ std::size_t Phase::numberOfComponents() const
     return components_.size();
 }
 
+std::string Phase::description() const
+{
+    return "phase '" + name + "'";
+}
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Phase.h
+++ b/MaterialLib/MPL/Phase.h
@@ -51,6 +51,9 @@ public:
     /// A get-function for retrieving the number of components in this phase.
     std::size_t numberOfComponents() const;
 
+    /// Short description of the phase with its name.
+    std::string description() const;
+
 public:
     std::string const name;
 

--- a/MaterialLib/MPL/Property.cpp
+++ b/MaterialLib/MPL/Property.cpp
@@ -14,6 +14,10 @@
 
 #include <string>
 
+#include "Component.h"
+#include "Medium.h"
+#include "Phase.h"
+
 namespace MaterialPropertyLib
 {
 PropertyDataType fromVector(std::vector<double> const& values)
@@ -98,5 +102,13 @@ PropertyDataType Property::d2Value(VariableArray const& /*variable_array*/,
                                    double const /*dt*/) const
 {
     return 0.0;
+}
+
+std::string Property::description() const
+{
+    return "property '" + name_ + "' defined for " +
+           std::visit(
+               [](auto&& scale) -> std::string { return scale->description(); },
+               scale_);
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Property.h
+++ b/MaterialLib/MPL/Property.h
@@ -90,9 +90,9 @@ public:
         catch (std::bad_variant_access const&)
         {
             OGS_FATAL(
-                "The '{:s}' property's initial value does not hold requested "
-                "type {:s} but a {:s}.",
-                name_,
+                "The initial value of {:s} does not hold requested type '{:s}' "
+                "but a {:s}.",
+                description(),
                 typeid(T).name(),
                 property_data_type_names_[initialValue(pos, t).index()]);
         }
@@ -108,9 +108,9 @@ public:
         catch (std::bad_variant_access const&)
         {
             OGS_FATAL(
-                "The '{:s}' property's value does not hold requested type {:s} "
-                "but a {:s}.",
-                name_,
+                "The value of {:s} does not hold requested type '{:s}' but a "
+                "{:s}.",
+                description(),
                 typeid(T).name(),
                 property_data_type_names_[value().index()]);
         }
@@ -128,9 +128,9 @@ public:
         catch (std::bad_variant_access const&)
         {
             OGS_FATAL(
-                "The '{:s}' property's value is not of the requested type {:s} "
-                "but a {:s}.",
-                name_,
+                "The value of {:s} is not of the requested type '{:s}' but a "
+                "{:s}.",
+                description(),
                 typeid(T).name(),
                 property_data_type_names_[value(variable_array, pos, t, dt)
                                               .index()]);
@@ -149,9 +149,9 @@ public:
         catch (std::bad_variant_access const&)
         {
             OGS_FATAL(
-                "The '{:s}' property's first derivative value is not of the "
-                "requested type {:s} but a {:s}.",
-                name_,
+                "The first derivative value of {:s} is not of the requested "
+                "type '{:s}' but a {:s}.",
+                description(),
                 typeid(T).name(),
                 property_data_type_names_
                     [dValue(variable_array, variable, pos, t, dt).index()]);
@@ -171,9 +171,9 @@ public:
         catch (std::bad_variant_access const&)
         {
             OGS_FATAL(
-                "The '{:s}' property's second derivative value is not of the "
-                "requested type {:s} but a {:s}.",
-                name_,
+                "The second derivative value of {:s} is not of the requested "
+                "type '{:s}' but a {:s}.",
+                description(),
                 typeid(T).name(),
                 property_data_type_names_[d2Value(variable_array, variable1,
                                                   variable2, pos, t, dt)

--- a/MaterialLib/MPL/Property.h
+++ b/MaterialLib/MPL/Property.h
@@ -14,6 +14,7 @@
 #include <Eigen/Dense>
 #include <array>
 #include <string>
+#include <typeinfo>
 #include <variant>
 
 #include "ParameterLib/SpatialPosition.h"
@@ -82,13 +83,37 @@ public:
     T initialValue(ParameterLib::SpatialPosition const& pos,
                    double const t) const
     {
-        return std::get<T>(initialValue(pos, t));
+        try
+        {
+            return std::get<T>(initialValue(pos, t));
+        }
+        catch (std::bad_variant_access const&)
+        {
+            OGS_FATAL(
+                "The '{:s}' property's initial value does not hold requested "
+                "type {:s} but a {:s}.",
+                name_,
+                typeid(T).name(),
+                property_data_type_names_[initialValue(pos, t).index()]);
+        }
     }
 
     template <typename T>
     T value() const
     {
-        return std::get<T>(value());
+        try
+        {
+            return std::get<T>(value());
+        }
+        catch (std::bad_variant_access const&)
+        {
+            OGS_FATAL(
+                "The '{:s}' property's value does not hold requested type {:s} "
+                "but a {:s}.",
+                name_,
+                typeid(T).name(),
+                property_data_type_names_[value().index()]);
+        }
     }
 
     template <typename T>
@@ -96,7 +121,20 @@ public:
             ParameterLib::SpatialPosition const& pos, double const t,
             double const dt) const
     {
-        return std::get<T>(value(variable_array, pos, t, dt));
+        try
+        {
+            return std::get<T>(value(variable_array, pos, t, dt));
+        }
+        catch (std::bad_variant_access const&)
+        {
+            OGS_FATAL(
+                "The '{:s}' property's value is not of the requested type {:s} "
+                "but a {:s}.",
+                name_,
+                typeid(T).name(),
+                property_data_type_names_[value(variable_array, pos, t, dt)
+                                              .index()]);
+        }
     }
 
     template <typename T>
@@ -104,7 +142,20 @@ public:
              ParameterLib::SpatialPosition const& pos, double const t,
              double const dt) const
     {
-        return std::get<T>(dValue(variable_array, variable, pos, t, dt));
+        try
+        {
+            return std::get<T>(dValue(variable_array, variable, pos, t, dt));
+        }
+        catch (std::bad_variant_access const&)
+        {
+            OGS_FATAL(
+                "The '{:s}' property's first derivative value is not of the "
+                "requested type {:s} but a {:s}.",
+                name_,
+                typeid(T).name(),
+                property_data_type_names_
+                    [dValue(variable_array, variable, pos, t, dt).index()]);
+        }
     }
     template <typename T>
     T d2Value(VariableArray const& variable_array, Variable const& variable1,
@@ -112,8 +163,22 @@ public:
               ParameterLib::SpatialPosition const& pos, double const t,
               double const dt) const
     {
-        return std::get<T>(
-            d2Value(variable_array, variable1, variable2, pos, t, dt));
+        try
+        {
+            return std::get<T>(
+                d2Value(variable_array, variable1, variable2, pos, t, dt));
+        }
+        catch (std::bad_variant_access const&)
+        {
+            OGS_FATAL(
+                "The '{:s}' property's second derivative value is not of the "
+                "requested type {:s} but a {:s}.",
+                name_,
+                typeid(T).name(),
+                property_data_type_names_[d2Value(variable_array, variable1,
+                                                  variable2, pos, t, dt)
+                                              .index()]);
+        }
     }
 
 protected:

--- a/MaterialLib/MPL/Property.h
+++ b/MaterialLib/MPL/Property.h
@@ -132,6 +132,16 @@ private:
         // Empty check for properties which can be defined on every scale,
         // medium, phase or component
     }
+
+private:
+    /// Corresponds to the PropertyDataType
+    static constexpr std::array property_data_type_names_ = {
+        "scalar",     "2-vector",         "3-vector",        "2x2-matrix",
+        "3x3-matrix", "2D-Kelvin vector", "3D-Kelvin vector"};
+    static_assert(property_data_type_names_.size() ==
+                      std::variant_size_v<PropertyDataType>,
+                  "The array of property data type names has different size "
+                  "than the PropertyDataType variant type.");
 };
 
 inline void overwriteExistingProperties(

--- a/MaterialLib/MPL/Property.h
+++ b/MaterialLib/MPL/Property.h
@@ -197,6 +197,7 @@ private:
         // Empty check for properties which can be defined on every scale,
         // medium, phase or component
     }
+    std::string description() const;
 
 private:
     /// Corresponds to the PropertyDataType


### PR DESCRIPTION
Improves error handling upon access of wrong type.
For the extra information on the medium/phase/component the definition scale was moved to the property.

Closes #2933 
Review commit-wise.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.1)

TODO:

- [x] Update other properties beside the Constant.