### PR TITLE
fixing command line in case of whitespaces in path

### DIFF
--- a/Applications/FileIO/Legacy/createSurface.cpp
+++ b/Applications/FileIO/Legacy/createSurface.cpp
@@ -89,7 +89,7 @@ bool createSurface(GeoLib::Polyline const& ply,
     // the moment we can't read this new format. This is a switch for gmsh to
     // write the 'old' file format.
     std::string gmsh_command =
-        gmsh_binary + " -2 -algo meshadapt -format msh22 -o "
+        "\"" + gmsh_binary + "\" -2 -algo meshadapt -format msh22 -o "
         + msh_file.string() + " " + geo_file.string();
 
     int const gmsh_return_value = std::system(gmsh_command.c_str());


### PR DESCRIPTION
Fixes an issue with calling GMSH if the path includes whitespaces.

(This was fixed before for creating meshes but apparently not when meshing geometric surfaces.)