### PR TITLE
Copy the old implementation regularized van Genuchten to MPL with some improvements

### DIFF
--- a/Documentation/ProjectFile/properties/property/CapillaryPressureRegularizedVanGenuchten/c_CapillaryPressureRegularizedVanGenuchten.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureRegularizedVanGenuchten/c_CapillaryPressureRegularizedVanGenuchten.md
@@ -1,0 +1,1 @@
+\copydoc MaterialPropertyLib::CapillaryPressureRegularizedVanGenuchten

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureRegularizedVanGenuchten/t_exponent.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureRegularizedVanGenuchten/t_exponent.md
@@ -1,0 +1,1 @@
+\copydoc MaterialPropertyLib::CapillaryPressureRegularizedVanGenuchten::m_

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureRegularizedVanGenuchten/t_p_b.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureRegularizedVanGenuchten/t_p_b.md
@@ -1,0 +1,1 @@
+\copydoc MaterialPropertyLib::CapillaryPressureRegularizedVanGenuchten::p_b_

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureRegularizedVanGenuchten/t_residual_gas_saturation.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureRegularizedVanGenuchten/t_residual_gas_saturation.md
@@ -1,0 +1,1 @@
+\copydoc MaterialPropertyLib::CapillaryPressureRegularizedVanGenuchten::Sg_r_

--- a/Documentation/ProjectFile/properties/property/CapillaryPressureRegularizedVanGenuchten/t_residual_liquid_saturation.md
+++ b/Documentation/ProjectFile/properties/property/CapillaryPressureRegularizedVanGenuchten/t_residual_liquid_saturation.md
@@ -1,0 +1,1 @@
+Residual saturation of liquid phase.

--- a/Documentation/bibliography.bib
+++ b/Documentation/bibliography.bib
@@ -284,3 +284,27 @@
   doi = "10.1007/978-3-319-68225-9",
   isbn = "978-3-319-68224-2"
 }
+
+@article{marchand2013fully,
+  title={{F}ully coupled generalized hybrid-mixed finite element approximation
+         of two-phase two-component flow in porous media. {Part I}:
+  formulation and properties of the mathematical model},
+  author={Marchand, E and M{\"u}ller, T and Knabner, P},
+  journal={Computational Geosciences},
+  volume={17},
+  number={2},
+  pages={431--442},
+  year={2013},
+  doi = "10.1007/s10596-013-9341-7",
+  publisher={Springer}
+}
+@article{huang2015extending,
+  title={Extending the persistent primary variable algorithm to simulate non-isothermal two-phase two-component flow with phase change phenomena},
+  author={Huang, Yonghui and Kolditz, Olaf and Shao, Haibing},
+  journal={Geothermal Energy},
+  volume={3},
+  number={1},
+  pages={13},
+  year={2015},
+  publisher={Springer}
+}

--- a/MaterialLib/MPL/CreateProperty.cpp
+++ b/MaterialLib/MPL/CreateProperty.cpp
@@ -118,6 +118,12 @@ std::unique_ptr<MaterialPropertyLib::Property> createProperty(
         return createCapillaryPressureVanGenuchten(config);
     }
 
+    if (boost::iequals(property_type,
+                       "CapillaryPressureRegularizedVanGenuchten"))
+    {
+        return createCapillaryPressureRegularizedVanGenuchten(config);
+    }
+
     if (boost::iequals(property_type, "RelativePermeabilityVanGenuchten"))
     {
         return createRelPermVanGenuchten(config);

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureRegularizedVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureRegularizedVanGenuchten.cpp
@@ -1,0 +1,136 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on April 20, 2020, 9:30 AM
+ */
+
+#include "CapillaryPressureRegularizedVanGenuchten.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "BaseLib/Error.h"
+#include "MaterialLib/MPL/Medium.h"
+#include "MaterialLib/MPL/VariableType.h"
+#include "MaterialLib/MPL/Utils/CheckVanGenuchtenExponentRange.h"
+
+namespace MaterialPropertyLib
+{
+void checkSaturationRange(const double Sl)
+{
+    if (Sl < 0 || Sl > 1)
+    {
+        OGS_FATAL("The saturation of {:e} is out of its range of [0, 1]", Sl);
+    }
+}
+
+CapillaryPressureRegularizedVanGenuchten::
+    CapillaryPressureRegularizedVanGenuchten(
+        double const residual_liquid_saturation,
+        double const maximum_liquid_saturation,
+        double const exponent,
+        double const p_b)
+    : Sg_r_(1.0 - maximum_liquid_saturation),
+      Sg_max_(1.0 - residual_liquid_saturation),
+      m_(exponent),
+      p_b_(p_b),
+      PcBarvGSg_Sg_max_(getPcBarvGSg(Sg_max_)),
+      dPcdSvGBarSg_max_(getdPcdSvGBar(Sg_max_))
+{
+    checkVanGenuchtenExponentRange(m_);
+}
+
+PropertyDataType CapillaryPressureRegularizedVanGenuchten::value(
+    VariableArray const& variable_array,
+    ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
+    double const /*dt*/) const
+{
+    const double Sl = std::get<double>(
+        variable_array[static_cast<int>(Variable::liquid_saturation)]);
+
+    checkSaturationRange(Sl);
+
+    double const Sg = 1 - Sl;
+    if (!(Sg < Sg_r_ || Sg > Sg_max_))
+    {
+        return getPcBarvGSg(Sg);
+    }
+    if (Sg < Sg_r_)
+    {
+        return 0.0;
+    }
+
+    return PcBarvGSg_Sg_max_ + dPcdSvGBarSg_max_ * (Sg - Sg_max_);
+}
+
+PropertyDataType CapillaryPressureRegularizedVanGenuchten::dValue(
+    VariableArray const& variable_array, Variable const primary_variable,
+    ParameterLib::SpatialPosition const& /*pos*/, double const /*t*/,
+    double const /*dt*/) const
+{
+    (void)primary_variable;
+    assert(
+        (primary_variable == Variable::liquid_saturation) &&
+        "CapillaryPressureRegularizedVanGenuchten::dValue is implemented for "
+        "derivatives with respect to liquid saturation only.");
+
+    const double Sl = std::get<double>(
+        variable_array[static_cast<int>(Variable::liquid_saturation)]);
+
+    checkSaturationRange(Sl);
+
+    double const Sg = 1 - Sl;
+    if (!(Sg < Sg_r_ || Sg > Sg_max_))
+    {
+        return -getdPcdSvGBar(Sg);
+    }
+    if (Sg < Sg_r_)
+    {
+        return 0.0;
+    }
+
+    return -dPcdSvGBarSg_max_;
+}
+
+double CapillaryPressureRegularizedVanGenuchten::getPcBarvGSg(
+    double const Sg) const
+{
+    double const S_bar = getSBar(Sg);
+    return getPcvGSg(S_bar) - getPcvGSg(Sg_r_ + (Sg_max_ - Sg_r_) * xi_ / 2);
+}
+
+double CapillaryPressureRegularizedVanGenuchten::getSBar(double const Sg) const
+{
+    return Sg_r_ + (1 - xi_) * (Sg - Sg_r_) + 0.5 * xi_ * (Sg_max_ - Sg_r_);
+}
+
+double CapillaryPressureRegularizedVanGenuchten::getPcvGSg(
+    double const Sg) const
+{
+    double const Se = (Sg_max_ - Sg) / (Sg_max_ - Sg_r_);
+    return p_b_ * std::pow(std::pow(Se, (-1.0 / m_)) - 1.0, 1.0 - m_);
+}
+
+double CapillaryPressureRegularizedVanGenuchten::getdPcdSvGBar(
+    double const Sg) const
+{
+    double S_bar = getSBar(Sg);
+    return getdPcdSvG(S_bar) * (1 - xi_);
+}
+
+double CapillaryPressureRegularizedVanGenuchten::getdPcdSvG(
+    const double Sg) const
+{
+    double const n = 1 / (1 - m_);
+    double const Se = (Sg_max_ - Sg) / (Sg_max_ - Sg_r_);
+    auto const temp = std::pow(Se, (-1 / m_));
+    return p_b_ * (1 / (m_ * n)) * (1 / (Sg_max_ - Sg_r_)) *
+           std::pow(temp - 1, (1 / n) - 1) * temp / Se;
+}
+
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureRegularizedVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureRegularizedVanGenuchten.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on April 20, 2020, 9:30 AM
+ */
+
+#pragma once
+
+#include "MaterialLib/MPL/Property.h"
+
+namespace MaterialPropertyLib
+{
+class Medium;
+
+/**
+ *  \brief This class handles the computation of the capillary pressure,
+ *  \f$ p_c(S_l) \f$, with the
+ * capillary pressure regularization.
+ *
+ *   For the regularized van Genuchten model, please refer to
+ *  \cite huang2015extending.
+ *
+ *   For the van Genuchten capillary pressure mode,
+ *   \sa MaterialPropertyLib::CapillaryPressureVanGenuchten
+ */
+class CapillaryPressureRegularizedVanGenuchten final : public Property
+{
+public:
+    CapillaryPressureRegularizedVanGenuchten(
+        double const residual_liquid_saturation,
+        double const maximum_liquid_saturation,
+        double const exponent,
+        double const p_b);
+
+    void checkScale() const override
+    {
+        if (!std::holds_alternative<Medium*>(scale_))
+        {
+            OGS_FATAL(
+                "The property 'CapillaryPressureRegularizedVanGenuchten' is "
+                "implemented on the 'media' scale only.");
+        }
+    }
+
+    /// \return \f$ p_c(S_l) \f$.
+    PropertyDataType value(VariableArray const& variable_array,
+                           ParameterLib::SpatialPosition const& pos,
+                           double const t,
+                           double const dt) const override;
+
+    /// \return \f$ \frac{\partial p_c(S_l)}{\partial  S_l} \f$
+    PropertyDataType dValue(VariableArray const& variable_array,
+                            Variable const variable,
+                            ParameterLib::SpatialPosition const& pos,
+                            double const t,
+                            double const dt) const override;
+
+private:
+    double const Sg_r_;    ///< Residual saturation of gas phase
+    double const Sg_max_;  ///< Maximum saturation of gas phase
+    double const m_;       ///< Exponent.
+    /// Capillary pressure scaling factor. Sometimes, it is called apparent gas
+    /// entry pressure.
+    double const p_b_;
+    /// parameter in regularized van Genuchten model
+    static constexpr double xi_ = 1e-5;
+
+    double const PcBarvGSg_Sg_max_;
+    double const dPcdSvGBarSg_max_;
+
+    /// Gets regularized capillary pressure via the saturation of the
+    /// non-wetting phase.
+    double getPcBarvGSg(double const Sg) const;
+    /// Gets regularized saturation via the saturation of the non-wetting
+    /// phase.
+    double getSBar(double const Sg) const;
+    /// Gets capillary pressure via the non-wetting phase saturation with the
+    /// original van Genuchten model.
+    double getPcvGSg(double const Sg) const;
+    /// Gets \f$\frac{\partial p_c}{\partial {\bar S}_g }\f$.
+    double getdPcdSvGBar(double const Sg) const;
+    /// Gets \f$\frac{\partial p_c}{\partial {S}_g }\f$.
+    double getdPcdSvG(double const Sg) const;
+};
+
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateCapillaryPressureRegularizedVanGenuchten.cpp
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateCapillaryPressureRegularizedVanGenuchten.cpp
@@ -1,0 +1,46 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on April 21, 2020, 11:06 AM
+ */
+
+#include "CreateCapillaryPressureRegularizedVanGenuchten.h"
+
+#include "BaseLib/ConfigTree.h"
+#include "CapillaryPressureRegularizedVanGenuchten.h"
+#include "MaterialLib/MPL/Property.h"
+
+namespace MaterialPropertyLib
+{
+std::unique_ptr<Property> createCapillaryPressureRegularizedVanGenuchten(
+    BaseLib::ConfigTree const& config)
+{
+    //! \ogs_file_param{properties__property__type}
+    config.checkConfigParameter("type",
+                                "CapillaryPressureRegularizedVanGenuchten");
+
+    DBUG("Create CapillaryPressureRegularizedVanGenuchten medium property");
+
+    auto const residual_liquid_saturation =
+        //! \ogs_file_param{properties__property__CapillaryPressureRegularizedVanGenuchten__residual_liquid_saturation}
+        config.getConfigParameter<double>("residual_liquid_saturation");
+    auto const maximum_liquid_saturation =
+        1.0 -
+        //! \ogs_file_param{properties__property__CapillaryPressureRegularizedVanGenuchten__residual_gas_saturation}
+        config.getConfigParameter<double>("residual_gas_saturation");
+    auto const exponent =
+        //! \ogs_file_param{properties__property__CapillaryPressureRegularizedVanGenuchten__exponent}
+        config.getConfigParameter<double>("exponent");
+    auto const p_b =
+        //! \ogs_file_param{properties__property__CapillaryPressureRegularizedVanGenuchten__p_b}
+        config.getConfigParameter<double>("p_b");
+
+    return std::make_unique<CapillaryPressureRegularizedVanGenuchten>(
+        residual_liquid_saturation, maximum_liquid_saturation, exponent, p_b);
+}
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateCapillaryPressureRegularizedVanGenuchten.h
+++ b/MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateCapillaryPressureRegularizedVanGenuchten.h
@@ -1,0 +1,26 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on April 21, 2020, 11:06 AM
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace BaseLib
+{
+class ConfigTree;
+}
+
+namespace MaterialPropertyLib
+{
+class Property;
+std::unique_ptr<Property> createCapillaryPressureRegularizedVanGenuchten(
+    BaseLib::ConfigTree const& config);
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/CreateProperties.h
+++ b/MaterialLib/MPL/Properties/CreateProperties.h
@@ -15,6 +15,8 @@
 #include "CapillaryPressureSaturation/CreateSaturationBrooksCorey.h"
 #include "CapillaryPressureSaturation/CreateSaturationLiakopoulos.h"
 #include "CapillaryPressureSaturation/CreateSaturationVanGenuchten.h"
+#include "CapillaryPressureSaturation/CreateCapillaryPressureRegularizedVanGenuchten.h"
+
 #include "CreateBishopsPowerLaw.h"
 #include "CreateBishopsSaturationCutoff.h"
 #include "CreateConstant.h"

--- a/MaterialLib/MPL/Utils/CheckVanGenuchtenExponentRange.cpp
+++ b/MaterialLib/MPL/Utils/CheckVanGenuchtenExponentRange.cpp
@@ -1,0 +1,28 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on April 20, 2020, 10:47 AM
+ */
+
+#include "CheckVanGenuchtenExponentRange.h"
+
+#include "BaseLib/Error.h"
+
+namespace MaterialPropertyLib
+{
+void checkVanGenuchtenExponentRange(const double m)
+{
+    if (m <= 0 || m >= 1)
+    {
+        OGS_FATAL(
+            "The exponent value m = {:e} of van Genuchten saturation "
+            "model, is out of its range of(0, 1) ",
+            m);
+    }
+}
+}  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Utils/CheckVanGenuchtenExponentRange.h
+++ b/MaterialLib/MPL/Utils/CheckVanGenuchtenExponentRange.h
@@ -1,0 +1,17 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * Created on April 20, 2020, 10:47 AM
+ */
+
+#pragma once
+
+namespace MaterialPropertyLib
+{
+void checkVanGenuchtenExponentRange(const double m);
+}  // namespace MaterialPropertyLib

--- a/Tests/MaterialLib/TestMPLCapillaryPressureRegularizedVanGenuchten.cpp
+++ b/Tests/MaterialLib/TestMPLCapillaryPressureRegularizedVanGenuchten.cpp
@@ -110,7 +110,6 @@ TEST(MaterialPropertyLib, CapillaryPressureRegularizedVanGenuchten)
                                0.0}};
 
     const int n = 30;
-    const double offset = 1.0e-7;
     for (int i = 0; i <= n; ++i)
     {
         variable_array[static_cast<int>(MPL::Variable::liquid_saturation)] =
@@ -149,6 +148,7 @@ TEST(MaterialPropertyLib, CapillaryPressureRegularizedVanGenuchten)
                 variable_array,
                 MaterialPropertyLib::Variable::liquid_saturation, pos, t, dt);
 
+        const double offset = (S[i] < Sl_r) ? 1.0e-2 : 1.0e-7;
         variable_array[static_cast<int>(MPL::Variable::liquid_saturation)] =
             S[i] - offset;
 

--- a/Tests/MaterialLib/TestMPLCapillaryPressureRegularizedVanGenuchten.cpp
+++ b/Tests/MaterialLib/TestMPLCapillaryPressureRegularizedVanGenuchten.cpp
@@ -1,0 +1,177 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ *  Created on March 27, 2020, 3:01 PM
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+#include <limits>
+
+#include "BaseLib/ConfigTree.h"
+
+#include "MaterialLib/MPL/Medium.h"
+#include "MaterialLib/MPL/Properties/CapillaryPressureSaturation/CreateCapillaryPressureRegularizedVanGenuchten.h"
+#include "MaterialLib/MPL/Properties/CapillaryPressureSaturation/CapillaryPressureRegularizedVanGenuchten.h"
+
+#include "TestMPL.h"
+#include "Tests/TestTools.h"
+
+namespace MPL = MaterialPropertyLib;
+
+std::unique_ptr<MaterialPropertyLib::Property> createTestProperty(
+    const char xml[],
+    std::function<std::unique_ptr<MaterialPropertyLib::Property>(
+        BaseLib::ConfigTree const& config)>
+        createProperty)
+{
+    auto const ptree = readXml(xml);
+    BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
+                             BaseLib::ConfigTree::onwarning);
+    auto const& sub_config = conf.getConfigSubtree("property");
+    // Parsing the property name:
+    auto const property_name =
+        sub_config.getConfigParameter<std::string>("name");
+
+    return createProperty(sub_config);
+}
+
+TEST(MaterialPropertyLib, CapillaryPressureRegularizedVanGenuchten)
+{
+    const char xml_pc_S[] =
+        "<property>"
+        "   <name>capillary_pressure</name>"
+        "   <type>CapillaryPressureRegularizedVanGenuchten</type>"
+        "   <residual_liquid_saturation>0.1</residual_liquid_saturation>"
+        "   <residual_gas_saturation>0.05</residual_gas_saturation>"
+        "   <exponent>0.6</exponent>"
+        "   <p_b>1.e+4</p_b>"
+        "</property>";
+    auto const capillary_pressure_property_ptr = createTestProperty(
+        xml_pc_S, MPL::createCapillaryPressureRegularizedVanGenuchten);
+
+    MPL::Property const& capillary_pressure_property =
+        *capillary_pressure_property_ptr;
+
+    double const Sl_r = 0.1;
+    double const Sl_max = 0.95;
+
+    MPL::VariableArray variable_array;
+    ParameterLib::SpatialPosition const pos;
+    double const t = std::numeric_limits<double>::quiet_NaN();
+    double const dt = std::numeric_limits<double>::quiet_NaN();
+
+    std::array<double, 31> S{
+        {0,        0.0333333, 0.0666667, 0.1,      0.133333, 0.166667, 0.2,
+         0.233333, 0.266667,  0.3,       0.333333, 0.366667, 0.4,      0.433333,
+         0.466667, 0.5,       0.533333,  0.566667, 0.6,      0.633333, 0.666667,
+         0.7,      0.733333,  0.766667,  0.8,      0.833333, 0.866667, 0.9,
+         0.933333, 0.966667,  1}};
+    // Data for S in [0, S_max] calculated by the old implementation.
+    // When S in [Smax, 1], pc=0.
+    std::array<double, 31> pc{{5.3649187738e+11,
+                               3.5767283022e+11,
+                               1.7885324659e+11,
+                               3.4199425947e+07,
+                               8.6378746283e+04,
+                               5.4166427767e+04,
+                               4.1081248712e+04,
+                               3.3651450177e+04,
+                               2.8734971602e+04,
+                               2.5176752591e+04,
+                               2.2443387810e+04,
+                               2.0251583348e+04,
+                               1.8435732700e+04,
+                               1.6891590993e+04,
+                               1.5549880275e+04,
+                               1.4362497435e+04,
+                               1.3294509680e+04,
+                               1.2319676236e+04,
+                               1.1417620350e+04,
+                               1.0571723353e+04,
+                               9.7678323835e+03,
+                               8.9932086994e+03,
+                               8.2353166956e+03,
+                               7.4806165205e+03,
+                               6.7126607840e+03,
+                               5.9081641105e+03,
+                               5.0279021651e+03,
+                               3.9870638390e+03,
+                               2.4795040664e+03,
+                               0.0,
+                               0.0}};
+
+    const int n = 30;
+    const double offset = 1.0e-7;
+    for (int i = 0; i <= n; ++i)
+    {
+        variable_array[static_cast<int>(MPL::Variable::liquid_saturation)] =
+            S[i];
+
+        const double calculated_pc =
+            capillary_pressure_property.template value<double>(variable_array,
+                                                               pos, t, dt);
+
+        if (std::fabs(calculated_pc) < std::numeric_limits<double>::epsilon())
+        {
+            ASSERT_LE(std::fabs(pc[i] - calculated_pc), 1e-16)
+                << "for the reference pc " << pc[i] << " and the calculated pc."
+                << calculated_pc;
+        }
+        else
+        {
+            ASSERT_LE(std::fabs((pc[i] - calculated_pc) / calculated_pc), 1e-10)
+                << "for the reference pc " << pc[i] << " and the calculated pc."
+                << calculated_pc;
+        }
+
+        // The regularized function in not smooth at Sl_r
+        if (S[i] == Sl_r)
+        {
+            continue;
+        }
+
+        if (i == 0 || i == n)
+        {
+            continue;
+        }
+
+        const double dPcdS =
+            capillary_pressure_property.template dValue<double>(
+                variable_array,
+                MaterialPropertyLib::Variable::liquid_saturation, pos, t, dt);
+
+        variable_array[static_cast<int>(MPL::Variable::liquid_saturation)] =
+            S[i] - offset;
+
+        const double pc0 = capillary_pressure_property.template value<double>(
+            variable_array, pos, t, dt);
+        variable_array[static_cast<int>(MPL::Variable::liquid_saturation)] =
+            S[i] + offset;
+        const double pc1 = capillary_pressure_property.template value<double>(
+            variable_array, pos, t, dt);
+
+        const double numerical_dPcdS = 0.5 * (pc1 - pc0) / offset;
+
+        if (std::fabs(numerical_dPcdS) < std::numeric_limits<double>::epsilon())
+        {
+            ASSERT_LE(std::fabs((dPcdS - numerical_dPcdS)), 1e-16)
+                << "for the analytic derivative of dPc/dS " << dPcdS
+                << " and numeric derivative of dPc/dS." << numerical_dPcdS;
+        }
+        else
+        {
+            ASSERT_LE(std::fabs((dPcdS - numerical_dPcdS) / dPcdS), 1e-8)
+                << "for the analytic derivative of dPc/dS " << dPcdS
+                << " and numeric derivative of dPc/dS." << numerical_dPcdS;
+        }
+    }
+}


### PR DESCRIPTION
as titled.
In the old  old implementation, pc of  S  in [Smax, 1] is wrong, which should be zero. 

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.1)
2. [x] Tests covering your feature were added? Yes.
The following figure shows the curve of the regularized pc(S) in the test:
![RegularizedVanGenuchten](https://user-images.githubusercontent.com/1343839/82664181-75171900-9c31-11ea-8c2b-c292bd36694f.png)
 

3. [x] Any new feature or behavior change was documented? Yes
