### PR TITLE
[netcdf] allow explicitly setting no data value

### DIFF
--- a/Applications/Utils/FileConverter/NetCdfConverter.cpp
+++ b/Applications/Utils/FileConverter/NetCdfConverter.cpp
@@ -31,8 +31,8 @@
 
 using namespace netCDF;
 
-const double no_data_output = -9999;
-double no_data_input = -9999;
+static const double no_data_output = -9999;
+static double no_data_input = -9999;
 
 enum class OutputType
 {
@@ -430,6 +430,7 @@ static std::vector<double> getData(NcFile const& dataset, NcVar const& var,
     offset[0] = time_step;
     std::vector<double> data_vec(total_length, 0);
     var.getVar(offset, length, data_vec.data());
+
     std::replace_if(
         data_vec.begin(), data_vec.end(),
         [](double& x) { return x == no_data_input; }, no_data_output);
@@ -624,8 +625,8 @@ int main(int argc, char* argv[])
 
     TCLAP::ValueArg<int> arg_nodata(
         "n", "nodata",
-        "explicitely specifies the no data value used in the dataset (usually it not necessary to set this)",
-        false, -9999, "integer specifying no data value");
+        "explicitly specifies the no data value used in the dataset (usually it is not necessary to set this)",
+        false, no_data_input, "integer specifying no data value");
     cmd.add(arg_nodata);
 
     std::vector<std::string> allowed_elems{"tri", "quad", "prism", "hex"};

--- a/Tests/Data/FileConverter/slim_100897_198.vtu
+++ b/Tests/Data/FileConverter/slim_100897_198.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ceec1ea5ea0967e7111c945e5e41032a8351a60bddd5ecc8675ef40ab46432e
+oid sha256:cbc59239316835e389fec40bf758fe7d6a481a17fad9389f3fa0c24b453d6398
 size 4462866


### PR DESCRIPTION
Allows to manually set the no data value when converting netCDF data.

It's not straightforward to automatically extract this from the file, so this allows to handle the issue in the rare cases when not the default value is used.