### PR TITLE
Added bulk moduli computation to CreepBGRa and LinearElasticOrthotropic.

### DIFF
--- a/MaterialLib/SolidModels/CreepBGRa.h
+++ b/MaterialLib/SolidModels/CreepBGRa.h
@@ -51,6 +51,8 @@ public:
 
     using Parameter = ParameterLib::Parameter<double>;
 
+    using LinearElasticIsotropic<DisplacementDim>::getBulkModulus;
+
     std::unique_ptr<
         typename MechanicsBase<DisplacementDim>::MaterialStateVariables>
     createMaterialStateVariables() const override

--- a/MaterialLib/SolidModels/LinearElasticOrthotropic.h
+++ b/MaterialLib/SolidModels/LinearElasticOrthotropic.h
@@ -171,6 +171,21 @@ public:
 
     MaterialProperties getMaterialProperties() const { return _mp; }
 
+    double getBulkModulus(double const t,
+                          ParameterLib::SpatialPosition const& x,
+                          KelvinMatrix const* const /*C*/) const override
+    {
+        auto const& mp = _mp.evaluate(t, x);
+        auto const E = [&mp](int const i) { return mp.E(i); };
+        auto const nu = [&mp](int const i, int const j) { return mp.nu(i, j); };
+        // corresponds to 1/(I:S:I) --> Reuss bound.
+        // Voigt bound would proceed as (I:C:I)/9. Use MFront model if you
+        // prefer that.
+        return E(1) * E(2) * E(3) /
+               (E(1) * E(2) + E(1) * E(3) * (1 - 2 * nu(2, 3)) +
+                E(2) * E(3) * (1 - 2 * nu(1, 2) * nu(1, 3)));
+    }
+
 protected:
     MaterialProperties _mp;
     boost::optional<ParameterLib::CoordinateSystem> const&


### PR DESCRIPTION
So far, these two models did not have expressions to compute bulk moduli of the porous matrix. This PR adds this functionality which is required when using these models with HM or RM processes to compute intrinsic solid compressibility.
