### PR TITLE
Pass the geometry dimension to functions for creating properties

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.cpp
+++ b/Applications/ApplicationsLib/ProjectData.cpp
@@ -486,7 +486,8 @@ void ProjectData::parseMedia(
             _media[id] =
                 (id == material_ids[0])
                     ? MaterialPropertyLib::createMedium(
-                          medium_config, _parameters,
+                          _mesh_vec[0]->getDimension(), medium_config,
+                          _parameters,
                           _local_coordinate_system ? &*_local_coordinate_system
                                                    : nullptr,
                           _curves)

--- a/MaterialLib/MPL/CreateComponent.cpp
+++ b/MaterialLib/MPL/CreateComponent.cpp
@@ -21,6 +21,7 @@
 namespace
 {
 std::unique_ptr<MaterialPropertyLib::Component> createComponent(
+    int const geometry_dimension,
     BaseLib::ConfigTree const& config,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
     ParameterLib::CoordinateSystem const* const local_coordinate_system,
@@ -43,10 +44,11 @@ std::unique_ptr<MaterialPropertyLib::Component> createComponent(
     // component is predefined in the class implementation, properties
     // become optional. The default values of properties will be overwritten
     // if specified.
-    std::unique_ptr<PropertyArray> properties =
+    std::unique_ptr<PropertyArray> properties = createProperties(
+        geometry_dimension,
         //! \ogs_file_param{prj__media__medium__phases__phase__components__component__properties}
-        createProperties(config.getConfigSubtreeOptional("properties"),
-                         parameters, local_coordinate_system, curves);
+        config.getConfigSubtreeOptional("properties"), parameters,
+        local_coordinate_system, curves);
 
     // If a name is given, it must conform with one of the derived component
     // names in the following list:
@@ -70,6 +72,7 @@ std::unique_ptr<MaterialPropertyLib::Component> createComponent(
 namespace MaterialPropertyLib
 {
 std::vector<std::unique_ptr<Component>> createComponents(
+    int const geometry_dimension,
     boost::optional<BaseLib::ConfigTree> const& config,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
     ParameterLib::CoordinateSystem const* const local_coordinate_system,
@@ -88,8 +91,9 @@ std::vector<std::unique_ptr<Component>> createComponents(
         //! \ogs_file_param{prj__media__medium__phases__phase__components__component}
         config->getConfigSubtreeList("component"))
     {
-        auto component = createComponent(component_config, parameters,
-                                         local_coordinate_system, curves);
+        auto component =
+            createComponent(geometry_dimension, component_config, parameters,
+                            local_coordinate_system, curves);
 
         if (std::find_if(components.begin(),
                          components.end(),

--- a/MaterialLib/MPL/CreateComponent.h
+++ b/MaterialLib/MPL/CreateComponent.h
@@ -44,6 +44,7 @@ namespace MaterialPropertyLib
 /// Assigning a name is optional; If no name is given, a custom component
 /// without predefined properties is created.
 std::vector<std::unique_ptr<Component>> createComponents(
+    int const geometry_dimension,
     boost::optional<BaseLib::ConfigTree> const& config,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
     ParameterLib::CoordinateSystem const* const local_coordinate_system,

--- a/MaterialLib/MPL/CreateMedium.cpp
+++ b/MaterialLib/MPL/CreateMedium.cpp
@@ -25,6 +25,7 @@
 namespace MaterialPropertyLib
 {
 std::unique_ptr<Medium> createMedium(
+    int const geometry_dimension,
     BaseLib::ConfigTree const& config,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
     ParameterLib::CoordinateSystem const* const local_coordinate_system,
@@ -34,15 +35,16 @@ std::unique_ptr<Medium> createMedium(
 {
     // Parsing the phases
     // Properties of phases may be not required in all the cases.
-    auto&& phases =
-        //! \ogs_file_param{prj__media__medium__phases}
-        createPhases(config.getConfigSubtreeOptional("phases"), parameters,
-                     local_coordinate_system, curves);
+    auto&& phases = createPhases(geometry_dimension,
+                                 //! \ogs_file_param{prj__media__medium__phases}
+                                 config.getConfigSubtreeOptional("phases"),
+                                 parameters, local_coordinate_system, curves);
 
     // Parsing medium properties, overwriting the defaults.
     auto&& properties =
-        //! \ogs_file_param{prj__media__medium__properties}
-        createProperties(config.getConfigSubtreeOptional("properties"),
+        createProperties(geometry_dimension,
+                         //! \ogs_file_param{prj__media__medium__properties}
+                         config.getConfigSubtreeOptional("properties"),
                          parameters, local_coordinate_system, curves);
 
     if (phases.empty() && !properties)

--- a/MaterialLib/MPL/CreateMedium.h
+++ b/MaterialLib/MPL/CreateMedium.h
@@ -42,6 +42,7 @@ namespace MaterialPropertyLib
 /// Medium properties are optional. If not defined, default properties are
 /// assigned.
 std::unique_ptr<Medium> createMedium(
+    int const geometry_dimension,
     BaseLib::ConfigTree const& config,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
     ParameterLib::CoordinateSystem const* const local_coordinate_system,

--- a/MaterialLib/MPL/CreatePhase.cpp
+++ b/MaterialLib/MPL/CreatePhase.cpp
@@ -25,6 +25,7 @@
 namespace
 {
 std::unique_ptr<MaterialPropertyLib::Phase> createPhase(
+    int const geometry_dimension,
     BaseLib::ConfigTree const& config,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
     ParameterLib::CoordinateSystem const* const local_coordinate_system,
@@ -60,16 +61,18 @@ std::unique_ptr<MaterialPropertyLib::Phase> createPhase(
     }
 
     // Parsing of optional components.
-    auto components =
+    auto components = createComponents(
+        geometry_dimension,
         //! \ogs_file_param{prj__media__medium__phases__phase__components}
-        createComponents(config.getConfigSubtreeOptional("components"),
-                         parameters, local_coordinate_system, curves);
+        config.getConfigSubtreeOptional("components"), parameters,
+        local_coordinate_system, curves);
 
     // Properties of optional properties.
-    auto properties =
+    auto properties = createProperties(
+        geometry_dimension,
         //! \ogs_file_param{prj__media__medium__phases__phase__properties}
-        createProperties(config.getConfigSubtreeOptional("properties"),
-                         parameters, local_coordinate_system, curves);
+        config.getConfigSubtreeOptional("properties"), parameters,
+        local_coordinate_system, curves);
 
     if (components.empty() && !properties)
     {
@@ -87,6 +90,7 @@ std::unique_ptr<MaterialPropertyLib::Phase> createPhase(
 namespace MaterialPropertyLib
 {
 std::vector<std::unique_ptr<Phase>> createPhases(
+    int const geometry_dimension,
     boost::optional<BaseLib::ConfigTree> const& config,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
     ParameterLib::CoordinateSystem const* const local_coordinate_system,
@@ -105,7 +109,7 @@ std::vector<std::unique_ptr<Phase>> createPhases(
          //! \ogs_file_param{prj__media__medium__phases__phase}
          config->getConfigSubtreeList("phase"))
     {
-        auto phase = createPhase(phase_config, parameters,
+        auto phase = createPhase(geometry_dimension, phase_config, parameters,
                                  local_coordinate_system, curves);
 
         if (std::find_if(phases.begin(),

--- a/MaterialLib/MPL/CreatePhase.h
+++ b/MaterialLib/MPL/CreatePhase.h
@@ -48,6 +48,7 @@ namespace MaterialPropertyLib
 /// assigned. These default properties average the component properties,
 /// weighted by mole fraction.
 std::vector<std::unique_ptr<Phase>> createPhases(
+    int const geometry_dimension,
     boost::optional<BaseLib::ConfigTree> const& config,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
     ParameterLib::CoordinateSystem const* const local_coordinate_system,

--- a/MaterialLib/MPL/CreateProperty.cpp
+++ b/MaterialLib/MPL/CreateProperty.cpp
@@ -27,6 +27,7 @@
 namespace
 {
 std::unique_ptr<MaterialPropertyLib::Property> createProperty(
+    int const /*geometry_dimension*/,
     BaseLib::ConfigTree const& config,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
     ParameterLib::CoordinateSystem const* const local_coordinate_system,
@@ -154,6 +155,7 @@ std::unique_ptr<MaterialPropertyLib::Property> createProperty(
 namespace MaterialPropertyLib
 {
 std::unique_ptr<PropertyArray> createProperties(
+    int const geometry_dimension,
     boost::optional<BaseLib::ConfigTree> const& config,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
     ParameterLib::CoordinateSystem const* const local_coordinate_system,
@@ -182,8 +184,9 @@ std::unique_ptr<PropertyArray> createProperties(
             //! \ogs_file_param{properties__property__name}
             property_config.getConfigParameter<std::string>("name");
         // Create a new property based on the configuration subtree:
-        auto property = createProperty(
-            property_config, parameters, local_coordinate_system, curves);
+        auto property =
+            createProperty(geometry_dimension, property_config, parameters,
+                           local_coordinate_system, curves);
 
         // Insert the new property at the right position into the components
         // private PropertyArray:

--- a/MaterialLib/MPL/CreateProperty.h
+++ b/MaterialLib/MPL/CreateProperty.h
@@ -47,6 +47,7 @@ using PropertyArray =
 /// Then, the property name is evaluated and the property is copied into the
 /// properties array.
 std::unique_ptr<PropertyArray> createProperties(
+    int const geometry_dimension,
     boost::optional<BaseLib::ConfigTree> const& config,
     std::vector<std::unique_ptr<ParameterLib::ParameterBase>> const& parameters,
     ParameterLib::CoordinateSystem const* const local_coordinate_system,

--- a/Tests/MaterialLib/TestMPL.cpp
+++ b/Tests/MaterialLib/TestMPL.cpp
@@ -22,7 +22,8 @@
 
 namespace Tests
 {
-std::unique_ptr<MPL::Medium> createTestMaterial(std::string const& xml)
+std::unique_ptr<MPL::Medium> createTestMaterial(std::string const& xml,
+                                                int const geometry_dimension)
 {
     auto const ptree = Tests::readXml(xml.c_str());
     BaseLib::ConfigTree conf(ptree, "", BaseLib::ConfigTree::onerror,
@@ -33,7 +34,8 @@ std::unique_ptr<MPL::Medium> createTestMaterial(std::string const& xml)
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>>
         curves;
 
-    return MPL::createMedium(config, parameters, nullptr, curves);
+    return MPL::createMedium(geometry_dimension, config, parameters, nullptr,
+                             curves);
 }
 
 std::unique_ptr<MaterialPropertyLib::Property> createTestProperty(

--- a/Tests/MaterialLib/TestMPL.h
+++ b/Tests/MaterialLib/TestMPL.h
@@ -32,7 +32,8 @@ class Property;
 
 namespace Tests
 {
-std::unique_ptr<MPL::Medium> createTestMaterial(std::string const& xml);
+std::unique_ptr<MPL::Medium> createTestMaterial(
+    std::string const& xml, int const geometry_dimension = 1);
 
 std::unique_ptr<MaterialPropertyLib::Property> createTestProperty(
     const char xml[],


### PR DESCRIPTION
As titled,  `ProjectData::_mesh_vec[0]->getDimension()` is passed into the functions for creating properties.

There exists a  property creation function, 
 [CreatePermeabilityOrthotropicPowerLaw.cpp](https://github.com/ufz/ogs/blob/master/MaterialLib/MPL/Properties/CreatePermeabilityOrthotropicPowerLaw.cpp#L64-L82), 
which use the size of the input parameter as the geometry dimension. For properties that such parameter size may not be identical to the the geometry dimension, such consideration is invalid. Besides, the input info should be made as unique as possible. Therefore, the changes in this PR were made.  