### PR TITLE
Add switch to function addLayerToMesh to copy the MaterialID.

### DIFF
--- a/Applications/DataExplorer/DataView/MeshView.cpp
+++ b/Applications/DataExplorer/DataView/MeshView.cpp
@@ -244,9 +244,11 @@ void MeshView::openAddLayerDialog()
         return;
     }
 
-    double const thickness (dlg.getThickness());
-    std::unique_ptr<MeshLib::Mesh> result(MeshLib::addLayerToMesh(
-        *mesh, thickness, dlg.getName(), dlg.isTopLayer()));
+    bool const copy_material_ids = false;
+    double const thickness(dlg.getThickness());
+    std::unique_ptr<MeshLib::Mesh> result(
+        MeshLib::addLayerToMesh(*mesh, thickness, dlg.getName(),
+                                dlg.isTopLayer(), copy_material_ids));
 
     if (result)
     {

--- a/Applications/Utils/MeshEdit/AddTopLayer.cpp
+++ b/Applications/Utils/MeshEdit/AddTopLayer.cpp
@@ -46,6 +46,15 @@ int main (int argc, char* argv[])
         "the thickness of the new layer", false, 10, "floating point value");
     cmd.add(layer_thickness_arg);
 
+    TCLAP::ValueArg<bool> copy_material_ids_arg(
+        "", "copy_material_ids",
+        "copy the existing material distribution of the layer which is to "
+        "be extented ",
+        false, false,
+        "bool value: either true for copying or false for adding new "
+        "material ID");
+    cmd.add(copy_material_ids_arg);
+
     cmd.parse(argc, argv);
 
     INFO("Reading mesh '{:s}' ... ", mesh_arg.getValue());
@@ -58,7 +67,8 @@ int main (int argc, char* argv[])
     INFO("done.");
 
     std::unique_ptr<MeshLib::Mesh> result(MeshLib::addTopLayerToMesh(
-        *subsfc_mesh, layer_thickness_arg.getValue(), mesh_out_arg.getValue()));
+        *subsfc_mesh, layer_thickness_arg.getValue(), mesh_out_arg.getValue(),
+        copy_material_ids_arg.getValue()));
     if (!result) {
         ERR("Failure while adding top layer.");
         return EXIT_FAILURE;

--- a/MeshLib/MeshEditing/AddLayerToMesh.h
+++ b/MeshLib/MeshEditing/AddLayerToMesh.h
@@ -26,14 +26,14 @@ class Element;
 
 /// Adds a layer on top of the mesh
 MeshLib::Mesh* addTopLayerToMesh(MeshLib::Mesh const& mesh,
-    double thickness,
-    std::string const& name);
+                                 double thickness,
+                                 std::string const& name,
+                                 bool copy_material_ids);
 
 /// Adds a layer to the mesh. If on_top is true, the layer is added on top,
 /// if it is false, the layer is added at the bottom.
-MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh,
-    double thickness,
-    std::string const& name,
-    bool on_top);
+MeshLib::Mesh* addLayerToMesh(MeshLib::Mesh const& mesh, double thickness,
+                              std::string const& name, bool on_top,
+                              bool copy_material_ids);
 
 } // end namespace MeshLib

--- a/MeshLib/MeshGenerators/MeshGenerator.cpp
+++ b/MeshLib/MeshGenerators/MeshGenerator.cpp
@@ -588,9 +588,11 @@ Mesh* MeshGenerator::generateRegularPrismMesh(
     std::unique_ptr<MeshLib::Mesh> mesh (
         generateRegularTriMesh(n_x_cells, n_y_cells, cell_size_x, cell_size_y, origin, mesh_name));
     std::size_t const n_tris (mesh->getNumberOfElements());
+    bool const copy_material_ids = false;
     for (std::size_t i = 0; i < n_z_cells; ++i)
     {
-        mesh.reset(MeshLib::addTopLayerToMesh(*mesh, cell_size_z, mesh_name));
+        mesh.reset(MeshLib::addTopLayerToMesh(*mesh, cell_size_z, mesh_name,
+                                              copy_material_ids));
     }
     std::vector<std::size_t> elem_ids (n_tris);
     std::iota(elem_ids.begin(), elem_ids.end(), 0);

--- a/Tests/MeshLib/TestAddLayerToMesh.cpp
+++ b/Tests/MeshLib/TestAddLayerToMesh.cpp
@@ -66,7 +66,9 @@ TEST(MeshLib, AddTopLayerToLineMesh)
 {
     std::unique_ptr<MeshLib::Mesh> const mesh (MeshLib::MeshGenerator::generateLineMesh(1.0, 5));
     double const height (1);
-    std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", true));
+    constexpr bool const copy_material_ids = false;
+    std::unique_ptr<MeshLib::Mesh> const result(MeshLib::addLayerToMesh(
+        *mesh, height, "mesh", true, copy_material_ids));
 
     ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
     ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
@@ -84,7 +86,9 @@ TEST(MeshLib, AddBottomLayerToLineMesh)
 {
     std::unique_ptr<MeshLib::Mesh> const mesh (MeshLib::MeshGenerator::generateLineMesh(1.0, 5));
     double const height (1);
-    std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", false));
+    constexpr bool const copy_material_ids = false;
+    std::unique_ptr<MeshLib::Mesh> const result(MeshLib::addLayerToMesh(
+        *mesh, height, "mesh", false, copy_material_ids));
 
     ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
     ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
@@ -116,7 +120,9 @@ TEST(MeshLib, AddTopLayerToTriMesh)
     }
     ASSERT_EQ(2, mesh->getProperties().getPropertyVectorNames().size());
     double const height (1);
-    std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", true));
+    constexpr bool copy_material_ids = false;
+    std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh,
+    height, "mesh", true, copy_material_ids));
 
     ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
     ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
@@ -142,7 +148,9 @@ TEST(MeshLib, AddBottomLayerToTriMesh)
 {
     std::unique_ptr<MeshLib::Mesh> const mesh (MeshLib::MeshGenerator::generateRegularTriMesh(5, 5));
     double const height (1);
-    std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", false));
+    constexpr bool copy_material_ids = false;
+    std::unique_ptr<MeshLib::Mesh> const result(MeshLib::addLayerToMesh(
+        *mesh, height, "mesh", false, copy_material_ids));
 
     ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
     ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
@@ -160,7 +168,9 @@ TEST(MeshLib, AddTopLayerToQuadMesh)
 {
     std::unique_ptr<MeshLib::Mesh> const mesh (MeshLib::MeshGenerator::generateRegularQuadMesh(5, 5));
     double const height (1);
-    std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", true));
+    constexpr bool copy_material_ids = false;
+    std::unique_ptr<MeshLib::Mesh> const result(MeshLib::addLayerToMesh(
+        *mesh, height, "mesh", true, copy_material_ids));
 
     ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
     ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
@@ -178,7 +188,9 @@ TEST(MeshLib, AddBottomLayerToQuadMesh)
 {
     std::unique_ptr<MeshLib::Mesh> const mesh (MeshLib::MeshGenerator::generateRegularQuadMesh(5, 5));
     double const height (1);
-    std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", false));
+    constexpr bool copy_material_ids = false;
+    std::unique_ptr<MeshLib::Mesh> const result(MeshLib::addLayerToMesh(
+        *mesh, height, "mesh", false, copy_material_ids));
 
     ASSERT_EQ(2*mesh->getNumberOfNodes(), result->getNumberOfNodes());
     ASSERT_EQ(2*mesh->getNumberOfElements(), result->getNumberOfElements());
@@ -196,7 +208,9 @@ TEST(MeshLib, AddTopLayerToHexMesh)
 {
     std::unique_ptr<MeshLib::Mesh> const mesh (MeshLib::MeshGenerator::generateRegularHexMesh(5, 5));
     double const height (1);
-    std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", true));
+    constexpr bool copy_material_ids = false;
+    std::unique_ptr<MeshLib::Mesh> const result(MeshLib::addLayerToMesh(
+        *mesh, height, "mesh", true, copy_material_ids));
 
     ASSERT_EQ(mesh->getNumberOfNodes(), result->getNumberOfNodes()-36);
     ASSERT_EQ(mesh->getNumberOfElements(), result->getNumberOfElements()-25);
@@ -218,7 +232,9 @@ TEST(MeshLib, AddBottomLayerToHexMesh)
 {
     std::unique_ptr<MeshLib::Mesh> const mesh (MeshLib::MeshGenerator::generateRegularHexMesh(5, 5));
     double const height (1);
-    std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh, height, "mesh", false));
+    constexpr bool copy_material_ids = false;
+    std::unique_ptr<MeshLib::Mesh> const result(MeshLib::addLayerToMesh(
+        *mesh, height, "mesh", false, copy_material_ids));
 
     ASSERT_EQ(mesh->getNumberOfNodes(), result->getNumberOfNodes()-36);
     ASSERT_EQ(mesh->getNumberOfElements(), result->getNumberOfElements()-25);
@@ -239,9 +255,12 @@ TEST(MeshLib, AddBottomLayerToHexMesh)
 TEST(MeshLib, AddTopLayerToPrismMesh)
 {
     std::unique_ptr<MeshLib::Mesh> const mesh (MeshLib::MeshGenerator::generateRegularTriMesh(5, 5));
-    std::unique_ptr<MeshLib::Mesh> const mesh2 (MeshLib::addLayerToMesh(*mesh, 5, "mesh", true));
+    constexpr bool copy_material_ids = false;
+    std::unique_ptr<MeshLib::Mesh> const mesh2(MeshLib::addLayerToMesh(
+        *mesh, 5, "mesh", true, copy_material_ids));
     double const height (1);
-    std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh2, height, "mesh", true));
+    std::unique_ptr<MeshLib::Mesh> const result(MeshLib::addLayerToMesh(
+        *mesh2, height, "mesh", true, copy_material_ids));
 
     ASSERT_EQ(mesh2->getNumberOfNodes()/2.0 * 3, result->getNumberOfNodes());
     ASSERT_EQ(mesh2->getNumberOfElements()/2.0 * 3, result->getNumberOfElements());
@@ -263,7 +282,9 @@ TEST(MeshLib, AddTopLayerToPrismMesh)
 TEST(MeshLib, AddBottomLayerToPrismMesh)
 {
     std::unique_ptr<MeshLib::Mesh> const mesh (MeshLib::MeshGenerator::generateRegularTriMesh(5, 5));
-    std::unique_ptr<MeshLib::Mesh> const mesh2 (MeshLib::addLayerToMesh(*mesh, 5, "mesh", true));
+    constexpr bool copy_material_ids = false;
+    std::unique_ptr<MeshLib::Mesh> const mesh2(MeshLib::addLayerToMesh(
+        *mesh, 5, "mesh", true, copy_material_ids));
     double const height (1);
     std::string const& mat_name ("MaterialIDs");
     auto* const mats = mesh2->getProperties().createNewPropertyVector<int>(
@@ -273,7 +294,8 @@ TEST(MeshLib, AddBottomLayerToPrismMesh)
         mats->resize(mesh2->getNumberOfElements(), 0);
     }
 
-    std::unique_ptr<MeshLib::Mesh> const result (MeshLib::addLayerToMesh(*mesh2, height, "mesh", false));
+    std::unique_ptr<MeshLib::Mesh> const result(MeshLib::addLayerToMesh(
+        *mesh2, height, "mesh", false, copy_material_ids));
     ASSERT_EQ(mesh2->getNumberOfNodes()/2.0 * 3, result->getNumberOfNodes());
     ASSERT_EQ(mesh2->getNumberOfElements()/2.0 * 3, result->getNumberOfElements());
 


### PR DESCRIPTION
In some applications it is practical to adopt the material ID of the underlying layer.
