### PR TITLE
[T] RasterToMesh: Const, auto, unused uninit vars.

### DIFF
--- a/Tests/MeshLib/TestRasterToMesh.cpp
+++ b/Tests/MeshLib/TestRasterToMesh.cpp
@@ -49,15 +49,15 @@ protected:
 
 TEST_F(RasterToMeshTest, convertRasterToTriMeshElevation)
 {
-    std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::RasterToMesh::convert(
+    auto const mesh = MeshLib::RasterToMesh::convert(
         *_raster, MeshLib::MeshElemType::TRIANGLE,
-        MeshLib::UseIntensityAs::ELEVATION, "test"));
+        MeshLib::UseIntensityAs::ELEVATION, "test");
     ASSERT_TRUE(mesh != nullptr);
 
     ASSERT_EQ(_n_nodes, mesh->getNodes().size());
     ASSERT_EQ(_n_nodes, mesh->getNumberOfNodes());
 
-    std::vector<std::string> names =
+    std::vector<std::string> const names =
         mesh->getProperties().getPropertyVectorNames();
     ASSERT_TRUE(names.empty());
 
@@ -65,7 +65,7 @@ TEST_F(RasterToMeshTest, convertRasterToTriMeshElevation)
         MeshLib::MeshInformation::getNumberOfElementTypes(*mesh);
     ASSERT_EQ(2 * _n_pix, n_types.at(MeshLib::MeshElemType::TRIANGLE));
 
-    GeoLib::AABB aabb = MeshLib::MeshInformation::getBoundingBox(*mesh);
+    GeoLib::AABB const aabb = MeshLib::MeshInformation::getBoundingBox(*mesh);
     ASSERT_NEAR(aabb.getMinPoint()[2], 0,
                 std::numeric_limits<double>::epsilon());
     ASSERT_NEAR(aabb.getMaxPoint()[2], 0.07,
@@ -74,20 +74,22 @@ TEST_F(RasterToMeshTest, convertRasterToTriMeshElevation)
 
 TEST_F(RasterToMeshTest, convertRasterToQuadMeshElevation)
 {
-    std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::RasterToMesh::convert(
-        *_raster, MeshLib::MeshElemType::QUAD,  MeshLib::UseIntensityAs::ELEVATION, "test"));
+    auto const mesh = MeshLib::RasterToMesh::convert(
+        *_raster, MeshLib::MeshElemType::QUAD,
+        MeshLib::UseIntensityAs::ELEVATION, "test");
     ASSERT_TRUE(mesh != nullptr);
 
     ASSERT_EQ(_n_nodes, mesh->getNumberOfBaseNodes());
 
-    std::vector<std::string> names = mesh->getProperties().getPropertyVectorNames();
+    std::vector<std::string> const names =
+        mesh->getProperties().getPropertyVectorNames();
     ASSERT_TRUE(names.empty());
 
     auto const& n_types =
         MeshLib::MeshInformation::getNumberOfElementTypes(*mesh);
     ASSERT_EQ(_n_pix, n_types.at(MeshLib::MeshElemType::QUAD));
 
-    GeoLib::AABB aabb = MeshLib::MeshInformation::getBoundingBox(*mesh);
+    GeoLib::AABB const aabb = MeshLib::MeshInformation::getBoundingBox(*mesh);
     ASSERT_NEAR(aabb.getMinPoint()[2], 0,
                 std::numeric_limits<double>::epsilon());
     ASSERT_NEAR(aabb.getMaxPoint()[2], 0.07,
@@ -96,32 +98,33 @@ TEST_F(RasterToMeshTest, convertRasterToQuadMeshElevation)
 
 TEST_F(RasterToMeshTest, convertRasterTo3DMeshElevation)
 {
-    std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::RasterToMesh::convert(
+    auto const mesh = MeshLib::RasterToMesh::convert(
         *_raster, MeshLib::MeshElemType::PRISM,
-        MeshLib::UseIntensityAs::ELEVATION, "test"));
+        MeshLib::UseIntensityAs::ELEVATION, "test");
     ASSERT_TRUE(mesh == nullptr);
 
-    std::unique_ptr<MeshLib::Mesh> mesh2(MeshLib::RasterToMesh::convert(
+    auto const mesh2 = MeshLib::RasterToMesh::convert(
         *_raster, MeshLib::MeshElemType::HEXAHEDRON,
-        MeshLib::UseIntensityAs::ELEVATION, "test"));
+        MeshLib::UseIntensityAs::ELEVATION, "test");
     ASSERT_TRUE(mesh2 == nullptr);
 }
 
 TEST_F(RasterToMeshTest, convertRasterToTriMeshValue)
 {
-    std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::RasterToMesh::convert(
+    auto const mesh = MeshLib::RasterToMesh::convert(
         *_raster, MeshLib::MeshElemType::TRIANGLE,
-        MeshLib::UseIntensityAs::DATAVECTOR, "test"));
+        MeshLib::UseIntensityAs::DATAVECTOR, "test");
     ASSERT_TRUE(mesh != nullptr);
 
     ASSERT_EQ(_n_nodes, mesh->getNumberOfBaseNodes());
 
-    std::vector<std::string> names =
+    std::vector<std::string> const names =
         mesh->getProperties().getPropertyVectorNames();
     ASSERT_EQ(1, names.size());
 
-    MeshLib::PropertyVector<double>* prop =
+    MeshLib::PropertyVector<double>* const prop =
         mesh->getProperties().getPropertyVector<double>("test");
+    ASSERT_TRUE(prop != nullptr);
     ASSERT_EQ(2 * _n_pix, prop->size());
 
     auto const& bounds =
@@ -130,8 +133,7 @@ TEST_F(RasterToMeshTest, convertRasterToTriMeshValue)
     ASSERT_NEAR(0, bounds->first, std::numeric_limits<double>::epsilon());
     ASSERT_NEAR(0.07, bounds->second, std::numeric_limits<double>::epsilon());
 
-    std::vector<MeshLib::Node*> const& nodes = mesh->getNodes();
-    for (MeshLib::Node* n : nodes)
+    for (MeshLib::Node* n : mesh->getNodes())
     {
         ASSERT_NEAR(0, (*n)[2], std::numeric_limits<double>::epsilon());
     }
@@ -143,19 +145,20 @@ TEST_F(RasterToMeshTest, convertRasterToTriMeshValue)
 
 TEST_F(RasterToMeshTest, convertRasterToQuadMeshValue)
 {
-    std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::RasterToMesh::convert(
+    auto const mesh = MeshLib::RasterToMesh::convert(
         *_raster, MeshLib::MeshElemType::QUAD,
-        MeshLib::UseIntensityAs::DATAVECTOR, "test"));
+        MeshLib::UseIntensityAs::DATAVECTOR, "test");
     ASSERT_TRUE(mesh != nullptr);
 
     ASSERT_EQ(_n_nodes, mesh->getNumberOfBaseNodes());
 
-    std::vector<std::string> names =
+    std::vector<std::string> const names =
         mesh->getProperties().getPropertyVectorNames();
     ASSERT_EQ(1, names.size());
 
-    MeshLib::PropertyVector<double>* prop =
+    MeshLib::PropertyVector<double>* const prop =
         mesh->getProperties().getPropertyVector<double>("test");
+    ASSERT_TRUE(prop != nullptr);
     ASSERT_EQ(_n_pix, prop->size());
 
     auto const& bounds =
@@ -164,8 +167,7 @@ TEST_F(RasterToMeshTest, convertRasterToQuadMeshValue)
     ASSERT_NEAR(0, bounds->first, std::numeric_limits<double>::epsilon());
     ASSERT_NEAR(0.07, bounds->second, std::numeric_limits<double>::epsilon());
 
-    std::vector<MeshLib::Node*> const& nodes = mesh->getNodes();
-    for (MeshLib::Node* n : nodes)
+    for (MeshLib::Node* n : mesh->getNodes())
     {
         ASSERT_TRUE((*n)[2] == 0);
     }
@@ -177,19 +179,20 @@ TEST_F(RasterToMeshTest, convertRasterToQuadMeshValue)
 
 TEST_F(RasterToMeshTest, convertRasterToPrismMeshValue)
 {
-    std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::RasterToMesh::convert(
+    auto const mesh = MeshLib::RasterToMesh::convert(
         *_raster, MeshLib::MeshElemType::PRISM,
-        MeshLib::UseIntensityAs::DATAVECTOR, "test"));
+        MeshLib::UseIntensityAs::DATAVECTOR, "test");
     ASSERT_TRUE(mesh != nullptr);
 
     ASSERT_EQ(2 * _n_nodes, mesh->getNumberOfBaseNodes());
 
-    std::vector<std::string> names =
+    std::vector<std::string> const names =
         mesh->getProperties().getPropertyVectorNames();
     ASSERT_EQ(1, names.size());
 
-    MeshLib::PropertyVector<double>* prop =
+    MeshLib::PropertyVector<double>* const prop =
         mesh->getProperties().getPropertyVector<double>("test");
+    ASSERT_TRUE(prop != nullptr);
     ASSERT_EQ(2 * _n_pix, prop->size());
 
     auto const& bounds =
@@ -198,8 +201,7 @@ TEST_F(RasterToMeshTest, convertRasterToPrismMeshValue)
     ASSERT_NEAR(0, bounds->first, std::numeric_limits<double>::epsilon());
     ASSERT_NEAR(0.07, bounds->second, std::numeric_limits<double>::epsilon());
 
-    std::vector<MeshLib::Node*> const& nodes = mesh->getNodes();
-    for (MeshLib::Node* n : nodes)
+    for (MeshLib::Node* n : mesh->getNodes())
     {
         ASSERT_TRUE(((*n)[2] == 0) || ((*n)[2] == _spacing));
     }
@@ -211,19 +213,20 @@ TEST_F(RasterToMeshTest, convertRasterToPrismMeshValue)
 
 TEST_F(RasterToMeshTest, convertRasterToHexMeshValue)
 {
-    std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::RasterToMesh::convert(
+    auto const mesh = MeshLib::RasterToMesh::convert(
         *_raster, MeshLib::MeshElemType::HEXAHEDRON,
-        MeshLib::UseIntensityAs::MATERIALS, "MaterialIDs"));
+        MeshLib::UseIntensityAs::MATERIALS, "MaterialIDs");
     ASSERT_TRUE(mesh != nullptr);
 
     ASSERT_EQ(2 * _n_nodes, mesh->getNumberOfBaseNodes());
 
-    std::vector<std::string> names =
+    std::vector<std::string> const names =
         mesh->getProperties().getPropertyVectorNames();
     ASSERT_EQ(1, names.size());
 
-    MeshLib::PropertyVector<int>* prop =
+    MeshLib::PropertyVector<int>* const prop =
         mesh->getProperties().getPropertyVector<int>("MaterialIDs");
+    ASSERT_TRUE(prop != nullptr);
     ASSERT_EQ(_n_pix, prop->size());
 
     auto const& bounds =
@@ -232,8 +235,7 @@ TEST_F(RasterToMeshTest, convertRasterToHexMeshValue)
     ASSERT_NEAR(0, bounds->first, std::numeric_limits<double>::epsilon());
     ASSERT_NEAR(0, bounds->second, std::numeric_limits<double>::epsilon());
 
-    std::vector<MeshLib::Node*> const& nodes = mesh->getNodes();
-    for (MeshLib::Node* n : nodes)
+    for (MeshLib::Node* n : mesh->getNodes())
     {
         ASSERT_TRUE(((*n)[2] == 0) || ((*n)[2] == _spacing));
     }
@@ -245,19 +247,18 @@ TEST_F(RasterToMeshTest, convertRasterToHexMeshValue)
 
 TEST_F(RasterToMeshTest, convertRasterToQuadMeshNone)
 {
-    std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::RasterToMesh::convert(
-        *_raster, MeshLib::MeshElemType::QUAD,
-        MeshLib::UseIntensityAs::NONE, "test"));
+    auto const mesh =
+        MeshLib::RasterToMesh::convert(*_raster, MeshLib::MeshElemType::QUAD,
+                                       MeshLib::UseIntensityAs::NONE, "test");
     ASSERT_TRUE(mesh != nullptr);
 
     ASSERT_EQ(_n_nodes, mesh->getNumberOfBaseNodes());
 
-    std::vector<std::string> names =
+    std::vector<std::string> const names =
         mesh->getProperties().getPropertyVectorNames();
     ASSERT_TRUE(names.empty());
 
-    std::vector<MeshLib::Node*> const& nodes = mesh->getNodes();
-    for (MeshLib::Node* n : nodes)
+    for (MeshLib::Node* n : mesh->getNodes())
     {
         ASSERT_TRUE((*n)[2] == 0);
     }
@@ -270,26 +271,25 @@ TEST_F(RasterToMeshTest, convertRasterToQuadMeshNone)
 #ifdef OGS_BUILD_GUI
 TEST_F(RasterToMeshTest, vtkImage)
 {
-    double x0;
-    double y0;
-    double spacing;
-    vtkImageAlgorithm* raster = VtkRaster::loadImage(_file_name);
+    double const spacing = std::numeric_limits<double>::quiet_NaN();
+    vtkImageAlgorithm* const raster = VtkRaster::loadImage(_file_name);
     double origin[3];
     raster->GetOutput()->GetOrigin(origin);
 
-    std::unique_ptr<MeshLib::Mesh> mesh(MeshLib::RasterToMesh::convert(
+    auto const mesh = MeshLib::RasterToMesh::convert(
         raster->GetOutput(), origin, spacing, MeshLib::MeshElemType::TRIANGLE,
-        MeshLib::UseIntensityAs::DATAVECTOR, "test"));
+        MeshLib::UseIntensityAs::DATAVECTOR, "test");
     ASSERT_TRUE(mesh != nullptr);
 
     ASSERT_EQ(_n_nodes, mesh->getNumberOfBaseNodes());
 
-    std::vector<std::string> names =
+    std::vector<std::string> const names =
         mesh->getProperties().getPropertyVectorNames();
     ASSERT_EQ(1, names.size());
 
-    MeshLib::PropertyVector<double>* prop =
+    MeshLib::PropertyVector<double>* const prop =
         mesh->getProperties().getPropertyVector<double>("test");
+    ASSERT_TRUE(prop != nullptr);
     ASSERT_EQ(2 * _n_pix, prop->size());
 
     auto const& bounds =
@@ -298,8 +298,7 @@ TEST_F(RasterToMeshTest, vtkImage)
     ASSERT_NEAR(0, bounds->first, std::numeric_limits<double>::epsilon());
     ASSERT_NEAR(0.07, bounds->second, std::numeric_limits<float>::epsilon());
 
-    std::vector<MeshLib::Node*> const& nodes = mesh->getNodes();
-    for (MeshLib::Node* n : nodes)
+    for (MeshLib::Node* const n : mesh->getNodes())
     {
         ASSERT_TRUE((*n)[2] == 0);
     }


### PR DESCRIPTION
Triggered by fixing a warning of uninitialized spacing variable.