### PR TITLE
[CL] Interpolate nodal process solutions to int_pt

### DIFF
--- a/Applications/ApplicationsLib/ProjectData.h
+++ b/Applications/ApplicationsLib/ProjectData.h
@@ -139,6 +139,6 @@ private:
              std::unique_ptr<MathLib::PiecewiseLinearInterpolation>>
         _curves;
 
-    std::unique_ptr<ChemistryLib::ChemicalSolverInterface>
+    std::shared_ptr<ChemistryLib::ChemicalSolverInterface>
         _chemical_solver_interface;
 };

--- a/Applications/ApplicationsLib/ProjectData.h
+++ b/Applications/ApplicationsLib/ProjectData.h
@@ -78,6 +78,13 @@ public:
         return _processes;
     }
 
+    std::shared_ptr<ChemistryLib::ChemicalSolverInterface>
+    getChemicalSolverInterface() const
+    {
+        return _chemical_solver_interface ? _chemical_solver_interface
+                                          : nullptr;
+    }
+
     ProcessLib::TimeLoop& getTimeLoop() { return *_time_loop; }
 
 private:

--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -38,6 +38,7 @@
 #include "Applications/ApplicationsLib/ProjectData.h"
 #include "Applications/ApplicationsLib/TestDefinition.h"
 #include "Applications/InSituLib/Adaptor.h"
+#include "ChemistryLib/ChemicalSolverInterface.h"
 #include "InfoLib/CMakeInfo.h"
 #include "InfoLib/GitInfo.h"
 #include "ProcessLib/TimeLoop.h"
@@ -231,6 +232,11 @@ int main(int argc, char* argv[])
 
             auto chemical_solver_interface =
                 project.getChemicalSolverInterface();
+            if (chemical_solver_interface)
+            {
+                chemical_solver_interface->initialize();
+            }
+
             // Check intermediately that config parsing went fine.
             project_config.checkAndInvalidate();
             BaseLib::ConfigTree::assertNoSwallowedErrors();

--- a/Applications/CLI/ogs.cpp
+++ b/Applications/CLI/ogs.cpp
@@ -229,6 +229,8 @@ int main(int argc, char* argv[])
                 p->initialize();
             }
 
+            auto chemical_solver_interface =
+                project.getChemicalSolverInterface();
             // Check intermediately that config parsing went fine.
             project_config.checkAndInvalidate();
             BaseLib::ConfigTree::assertNoSwallowedErrors();

--- a/ChemistryLib/ChemicalSolverInterface.h
+++ b/ChemistryLib/ChemicalSolverInterface.h
@@ -17,6 +17,8 @@ namespace ChemistryLib
 class ChemicalSolverInterface
 {
 public:
+    virtual void initialize() {}
+
     virtual void executeInitialCalculation(
         std::vector<GlobalVector*>& process_solutions) = 0;
 

--- a/ChemistryLib/ChemicalSolverInterface.h
+++ b/ChemistryLib/ChemicalSolverInterface.h
@@ -28,6 +28,14 @@ public:
         return {};
     }
 
+    std::vector<std::vector<GlobalIndexType>>& getChemicalSystemIndexMap()
+    {
+        return _chemical_system_index_map;
+    }
+
     virtual ~ChemicalSolverInterface() = default;
+
+protected:
+    std::vector<std::vector<GlobalIndexType>> _chemical_system_index_map;
 };
 }  // namespace ChemistryLib

--- a/ChemistryLib/CreateChemicalSolverInterface.cpp
+++ b/ChemistryLib/CreateChemicalSolverInterface.cpp
@@ -84,11 +84,8 @@ createChemicalSolverInterface<ChemicalSolver::Phreeqc>(
     auto path_to_database = parseDatabasePath(config);
 
     // chemical system
-    auto chemical_system_map =
-        *mesh.getProperties().template getPropertyVector<std::size_t>(
-            "bulk_node_ids", MeshLib::MeshItemType::Node, 1);
-    auto chemical_system = PhreeqcIOData::createChemicalSystem(
-        config, *meshes[0], chemical_system_map);
+    auto chemical_system =
+        PhreeqcIOData::createChemicalSystem(config, *meshes[0]);
 
     // rates
     auto reaction_rates = createReactionRates<PhreeqcIOData::ReactionRate>(

--- a/ChemistryLib/CreateChemicalSolverInterface.cpp
+++ b/ChemistryLib/CreateChemicalSolverInterface.cpp
@@ -60,7 +60,7 @@ std::string parseDatabasePath(BaseLib::ConfigTree const& config)
 namespace ChemistryLib
 {
 template <>
-std::unique_ptr<ChemicalSolverInterface>
+std::shared_ptr<ChemicalSolverInterface>
 createChemicalSolverInterface<ChemicalSolver::Phreeqc>(
     std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,
     BaseLib::ConfigTree const& config, std::string const& output_directory)
@@ -126,7 +126,7 @@ createChemicalSolverInterface<ChemicalSolver::Phreeqc>(
     auto output = PhreeqcIOData::createOutput(
         *chemical_system, user_punch, use_high_precision, project_file_name);
 
-    return std::make_unique<PhreeqcIOData::PhreeqcIO>(
+    return std::make_shared<PhreeqcIOData::PhreeqcIO>(
         std::move(project_file_name), *meshes[mesh.getID()],
         std::move(path_to_database), std::move(chemical_system),
         std::move(reaction_rates), std::move(surface), std::move(user_punch),
@@ -134,7 +134,7 @@ createChemicalSolverInterface<ChemicalSolver::Phreeqc>(
 }
 
 template <>
-std::unique_ptr<ChemicalSolverInterface>
+std::shared_ptr<ChemicalSolverInterface>
 createChemicalSolverInterface<ChemicalSolver::PhreeqcKernel>(
     std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,
     BaseLib::ConfigTree const& config, std::string const& /*output_directory*/)
@@ -165,7 +165,7 @@ createChemicalSolverInterface<ChemicalSolver::PhreeqcKernel>(
         //! \ogs_file_param{prj__chemical_system__equilibrium_reactants}
         config.getConfigSubtreeOptional("equilibrium_reactants"), mesh);
 
-    return std::make_unique<PhreeqcKernelData::PhreeqcKernel>(
+    return std::make_shared<PhreeqcKernelData::PhreeqcKernel>(
         mesh.getNumberOfBaseNodes(), process_id_to_component_name_map,
         std::move(path_to_database), std::move(aqueous_solution),
         std::move(equilibrium_reactants), std::move(kinetic_reactants),

--- a/ChemistryLib/CreateChemicalSolverInterface.h
+++ b/ChemistryLib/CreateChemicalSolverInterface.h
@@ -31,7 +31,7 @@ namespace ChemistryLib
 class ChemicalSolverInterface;
 
 template <ChemicalSolver chemical_solver>
-std::unique_ptr<ChemicalSolverInterface> createChemicalSolverInterface(
+std::shared_ptr<ChemicalSolverInterface> createChemicalSolverInterface(
     std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,
     BaseLib::ConfigTree const& config, std::string const& output_directory);
 }  // namespace ChemistryLib

--- a/ChemistryLib/PhreeqcIO.cpp
+++ b/ChemistryLib/PhreeqcIO.cpp
@@ -109,6 +109,8 @@ void PhreeqcIO::initialize()
             num_chemical_systems += _chemical_system_index_map[i].size();
         return num_chemical_systems;
     }();
+
+    _chemical_system->initialize(_num_chemical_systems);
 }
 
 void PhreeqcIO::executeInitialCalculation(

--- a/ChemistryLib/PhreeqcIO.cpp
+++ b/ChemistryLib/PhreeqcIO.cpp
@@ -101,6 +101,16 @@ PhreeqcIO::PhreeqcIO(std::string const project_file_name,
     }
 }
 
+void PhreeqcIO::initialize()
+{
+    _num_chemical_systems = [&] {
+        std::size_t num_chemical_systems = 0;
+        for (std::size_t i = 0; i < _chemical_system_index_map.size(); ++i)
+            num_chemical_systems += _chemical_system_index_map[i].size();
+        return num_chemical_systems;
+    }();
+}
+
 void PhreeqcIO::executeInitialCalculation(
     std::vector<GlobalVector*>& process_solutions)
 {

--- a/ChemistryLib/PhreeqcIO.h
+++ b/ChemistryLib/PhreeqcIO.h
@@ -51,6 +51,8 @@ public:
               std::unique_ptr<Dump>&& dump,
               Knobs&& knobs);
 
+    void initialize() override;
+
     void executeInitialCalculation(
         std::vector<GlobalVector*>& process_solutions) override;
 
@@ -97,6 +99,8 @@ private:
     Knobs const _knobs;
     double _dt = std::numeric_limits<double>::quiet_NaN();
     const int phreeqc_instance_id = 0;
+    std::size_t _num_chemical_systems =
+        std::numeric_limits<std::size_t>::quiet_NaN();
 };
 }  // namespace PhreeqcIOData
 }  // namespace ChemistryLib

--- a/ChemistryLib/PhreeqcIOData/AqueousSolution.h
+++ b/ChemistryLib/PhreeqcIOData/AqueousSolution.h
@@ -33,13 +33,7 @@ namespace PhreeqcIOData
 {
 struct Component
 {
-    explicit Component(std::string name_,
-                       std::size_t const num_chemical_systems_)
-        : name(std::move(name_)),
-          amount(MathLib::MatrixVectorTraits<GlobalVector>::newInstance(
-              num_chemical_systems_))
-    {
-    }
+    explicit Component(std::string name_) : name(std::move(name_)) {}
 
     std::string const name;
     std::unique_ptr<GlobalVector> amount;

--- a/ChemistryLib/PhreeqcIOData/AqueousSolution.h
+++ b/ChemistryLib/PhreeqcIOData/AqueousSolution.h
@@ -49,7 +49,7 @@ struct Component
 struct AqueousSolution
 {
     AqueousSolution(double temperature_, double pressure_,
-                    MeshLib::PropertyVector<double>* pe_,
+                    MeshLib::PropertyVector<double>* pe_, double const pe0_,
                     std::vector<Component>&& components_,
                     ChargeBalance charge_balance_,
                     std::size_t const num_chemical_systems_)
@@ -58,6 +58,7 @@ struct AqueousSolution
           pH(MathLib::MatrixVectorTraits<GlobalVector>::newInstance(
               num_chemical_systems_)),
           pe(pe_),
+          pe0(pe0_),
           components(std::move(components_)),
           charge_balance(charge_balance_)
     {
@@ -69,6 +70,7 @@ struct AqueousSolution
     double const pressure;
     std::unique_ptr<GlobalVector> pH;
     MeshLib::PropertyVector<double>* pe;
+    double const pe0;
     std::vector<Component> components;
     ChargeBalance const charge_balance;
 };

--- a/ChemistryLib/PhreeqcIOData/AqueousSolution.h
+++ b/ChemistryLib/PhreeqcIOData/AqueousSolution.h
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include "MathLib/LinAlg/GlobalMatrixVectorTypes.h"
-#include "MathLib/LinAlg/MatrixVectorTraits.h"
 #include "Output.h"
 
 namespace MeshLib
@@ -45,12 +44,9 @@ struct AqueousSolution
     AqueousSolution(double temperature_, double pressure_,
                     MeshLib::PropertyVector<double>* pe_, double const pe0_,
                     std::vector<Component>&& components_,
-                    ChargeBalance charge_balance_,
-                    std::size_t const num_chemical_systems_)
+                    ChargeBalance charge_balance_)
         : temperature(temperature_),
           pressure(pressure_),
-          pH(MathLib::MatrixVectorTraits<GlobalVector>::newInstance(
-              num_chemical_systems_)),
           pe(pe_),
           pe0(pe0_),
           components(std::move(components_)),

--- a/ChemistryLib/PhreeqcIOData/ChemicalSystem.cpp
+++ b/ChemistryLib/PhreeqcIOData/ChemicalSystem.cpp
@@ -1,0 +1,62 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "ChemicalSystem.h"
+#include "AqueousSolution.h"
+
+#include "MathLib/LinAlg/MatrixVectorTraits.h"
+#include "MathLib/LinAlg/UnifiedMatrixSetters.h"
+
+namespace ChemistryLib
+{
+namespace PhreeqcIOData
+{
+void ChemicalSystem::initialize(std::size_t const num_chemical_systems)
+{
+    aqueous_solution->pH =
+        MathLib::MatrixVectorTraits<GlobalVector>::newInstance(
+            num_chemical_systems);
+
+    aqueous_solution->pe->resize(num_chemical_systems);
+    std::fill(aqueous_solution->pe->begin(), aqueous_solution->pe->end(),
+              aqueous_solution->pe0);
+
+    auto& components = aqueous_solution->components;
+    for (auto& component : components)
+    {
+        component.amount =
+            MathLib::MatrixVectorTraits<GlobalVector>::newInstance(
+                num_chemical_systems);
+    }
+
+    if (!kinetic_reactants.empty())
+    {
+        for (auto& kinetic_reactant : kinetic_reactants)
+        {
+            kinetic_reactant.amount->resize(num_chemical_systems);
+            std::fill(kinetic_reactant.amount->begin(),
+                      kinetic_reactant.amount->end(),
+                      kinetic_reactant.initial_amount);
+        }
+    }
+
+    if (!equilibrium_reactants.empty())
+    {
+        for (auto& equilibrium_reactant : equilibrium_reactants)
+        {
+            equilibrium_reactant.amount->resize(num_chemical_systems);
+            std::fill(equilibrium_reactant.amount->begin(),
+                      equilibrium_reactant.amount->end(),
+                      equilibrium_reactant.initial_amount);
+        }
+    }
+}
+}  // namespace PhreeqcIOData
+}  // namespace ChemistryLib

--- a/ChemistryLib/PhreeqcIOData/ChemicalSystem.h
+++ b/ChemistryLib/PhreeqcIOData/ChemicalSystem.h
@@ -32,6 +32,8 @@ struct ChemicalSystem
     {
     }
 
+    void initialize(std::size_t const num_chemical_systems);
+
     std::unique_ptr<AqueousSolution> aqueous_solution;
     std::vector<KineticReactant> kinetic_reactants;
     std::vector<EquilibriumReactant> equilibrium_reactants;

--- a/ChemistryLib/PhreeqcIOData/ChemicalSystem.h
+++ b/ChemistryLib/PhreeqcIOData/ChemicalSystem.h
@@ -17,11 +17,6 @@
 #include "EquilibriumReactant.h"
 #include "KineticReactant.h"
 
-namespace MeshLib
-{
-class Mesh;
-}
-
 namespace ChemistryLib
 {
 namespace PhreeqcIOData

--- a/ChemistryLib/PhreeqcIOData/CreateAqueousSolution.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateAqueousSolution.cpp
@@ -47,6 +47,7 @@ std::unique_ptr<AqueousSolution> createAqueousSolution(
     return std::make_unique<AqueousSolution>(temperature,
                                              pressure,
                                              pe,
+                                             pe0,
                                              std::move(components),
                                              charge_balance,
                                              mesh.getNumberOfBaseNodes());

--- a/ChemistryLib/PhreeqcIOData/CreateAqueousSolution.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateAqueousSolution.cpp
@@ -39,8 +39,7 @@ std::unique_ptr<AqueousSolution> createAqueousSolution(
         MeshLib::MeshItemType::IntegrationPoint,
         1);
 
-    auto components =
-        createSolutionComponents(config, mesh.getNumberOfBaseNodes());
+    auto components = createSolutionComponents(config);
 
     auto charge_balance = createChargeBalance(config);
 

--- a/ChemistryLib/PhreeqcIOData/CreateAqueousSolution.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateAqueousSolution.cpp
@@ -20,9 +20,7 @@ namespace ChemistryLib
 namespace PhreeqcIOData
 {
 std::unique_ptr<AqueousSolution> createAqueousSolution(
-    BaseLib::ConfigTree const& config,
-    MeshLib::Mesh const& mesh,
-    MeshLib::PropertyVector<std::size_t> const& chemical_system_map)
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh)
 {
     //! \ogs_file_param{prj__chemical_system__solution__temperature}
     auto const temperature = config.getConfigParameter<double>("temperature");

--- a/ChemistryLib/PhreeqcIOData/CreateAqueousSolution.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateAqueousSolution.cpp
@@ -34,16 +34,10 @@ std::unique_ptr<AqueousSolution> createAqueousSolution(
     auto const pe0 = config.getConfigParameter<double>("pe");
 
     auto pe = MeshLib::getOrCreateMeshProperty<double>(
-        const_cast<MeshLib::Mesh&>(mesh), "pe", MeshLib::MeshItemType::Node, 1);
-
-    std::fill(std::begin(*pe),
-              std::end(*pe),
-              std::numeric_limits<double>::quiet_NaN());
-
-    std::for_each(
-        chemical_system_map.begin(),
-        chemical_system_map.end(),
-        [&pe, pe0](auto const& global_id) { (*pe)[global_id] = pe0; });
+        const_cast<MeshLib::Mesh&>(mesh),
+        "pe",
+        MeshLib::MeshItemType::IntegrationPoint,
+        1);
 
     auto components =
         createSolutionComponents(config, mesh.getNumberOfBaseNodes());

--- a/ChemistryLib/PhreeqcIOData/CreateAqueousSolution.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateAqueousSolution.cpp
@@ -41,13 +41,8 @@ std::unique_ptr<AqueousSolution> createAqueousSolution(
 
     auto charge_balance = createChargeBalance(config);
 
-    return std::make_unique<AqueousSolution>(temperature,
-                                             pressure,
-                                             pe,
-                                             pe0,
-                                             std::move(components),
-                                             charge_balance,
-                                             mesh.getNumberOfBaseNodes());
+    return std::make_unique<AqueousSolution>(
+        temperature, pressure, pe, pe0, std::move(components), charge_balance);
 }
 }  // namespace PhreeqcIOData
 }  // namespace ChemistryLib

--- a/ChemistryLib/PhreeqcIOData/CreateAqueousSolution.h
+++ b/ChemistryLib/PhreeqcIOData/CreateAqueousSolution.h
@@ -20,9 +20,6 @@ class ConfigTree;
 namespace MeshLib
 {
 class Mesh;
-
-template <typename PROP_VAL_TYPE>
-class PropertyVector;
 }  // namespace MeshLib
 
 namespace ChemistryLib
@@ -32,8 +29,6 @@ namespace PhreeqcIOData
 struct AqueousSolution;
 
 std::unique_ptr<AqueousSolution> createAqueousSolution(
-    BaseLib::ConfigTree const& config,
-    MeshLib::Mesh const& mesh,
-    MeshLib::PropertyVector<std::size_t> const& chemical_system_map);
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh);
 }  // namespace PhreeqcIOData
 }  // namespace ChemistryLib

--- a/ChemistryLib/PhreeqcIOData/CreateChemicalSystem.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateChemicalSystem.cpp
@@ -28,7 +28,7 @@ std::unique_ptr<ChemicalSystem> createChemicalSystem(
     // solution
     auto aqueous_solution = createAqueousSolution(
         //! \ogs_file_param{prj__chemical_system__solution}
-        config.getConfigSubtree("solution"), mesh, chemical_system_map);
+        config.getConfigSubtree("solution"), mesh);
 
     // kinetic reactants
     auto kinetic_reactants = createKineticReactants(

--- a/ChemistryLib/PhreeqcIOData/CreateChemicalSystem.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateChemicalSystem.cpp
@@ -22,8 +22,7 @@ namespace ChemistryLib
 namespace PhreeqcIOData
 {
 std::unique_ptr<ChemicalSystem> createChemicalSystem(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh,
-    MeshLib::PropertyVector<std::size_t> const& chemical_system_map)
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh)
 {
     // solution
     auto aqueous_solution = createAqueousSolution(
@@ -33,14 +32,12 @@ std::unique_ptr<ChemicalSystem> createChemicalSystem(
     // kinetic reactants
     auto kinetic_reactants = createKineticReactants(
         //! \ogs_file_param{prj__chemical_system__kinetic_reactants}
-        config.getConfigSubtreeOptional("kinetic_reactants"), mesh,
-        chemical_system_map);
+        config.getConfigSubtreeOptional("kinetic_reactants"), mesh);
 
     // equilibrium reactants
     auto equilibrium_reactants = createEquilibriumReactants(
         //! \ogs_file_param{prj__chemical_system__equilibrium_reactants}
-        config.getConfigSubtreeOptional("equilibrium_reactants"), mesh,
-        chemical_system_map);
+        config.getConfigSubtreeOptional("equilibrium_reactants"), mesh);
 
     return std::make_unique<ChemicalSystem>(std::move(aqueous_solution),
                                             std::move(kinetic_reactants),

--- a/ChemistryLib/PhreeqcIOData/CreateChemicalSystem.h
+++ b/ChemistryLib/PhreeqcIOData/CreateChemicalSystem.h
@@ -20,9 +20,6 @@ class ConfigTree;
 namespace MeshLib
 {
 class Mesh;
-
-template <typename PROP_VAL_TYPE>
-class PropertyVector;
 }  // namespace MeshLib
 
 namespace ChemistryLib
@@ -32,7 +29,6 @@ namespace PhreeqcIOData
 struct ChemicalSystem;
 
 std::unique_ptr<ChemicalSystem> createChemicalSystem(
-    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh,
-    MeshLib::PropertyVector<std::size_t> const& chemical_system_map);
+    BaseLib::ConfigTree const& config, MeshLib::Mesh const& mesh);
 }  // namespace PhreeqcIOData
 }  // namespace ChemistryLib

--- a/ChemistryLib/PhreeqcIOData/CreateEquilibriumReactants.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateEquilibriumReactants.cpp
@@ -55,16 +55,6 @@ std::vector<EquilibriumReactant> createEquilibriumReactants(
             MeshLib::MeshItemType::IntegrationPoint,
             1);
 
-        std::fill(std::begin(*amount),
-                  std::end(*amount),
-                  std::numeric_limits<double>::quiet_NaN());
-
-        std::for_each(chemical_system_map.begin(),
-                      chemical_system_map.end(),
-                      [&amount, initial_amount](auto const& global_id) {
-                          (*amount)[global_id] = initial_amount;
-                      });
-
         equilibrium_reactants.emplace_back(
             std::move(name), amount, saturation_index);
     }

--- a/ChemistryLib/PhreeqcIOData/CreateEquilibriumReactants.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateEquilibriumReactants.cpp
@@ -21,8 +21,7 @@ namespace PhreeqcIOData
 {
 std::vector<EquilibriumReactant> createEquilibriumReactants(
     boost::optional<BaseLib::ConfigTree> const& config,
-    MeshLib::Mesh const& mesh,
-    MeshLib::PropertyVector<std::size_t> const& chemical_system_map)
+    MeshLib::Mesh const& mesh)
 {
     if (!config)
     {

--- a/ChemistryLib/PhreeqcIOData/CreateEquilibriumReactants.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateEquilibriumReactants.cpp
@@ -55,7 +55,7 @@ std::vector<EquilibriumReactant> createEquilibriumReactants(
             1);
 
         equilibrium_reactants.emplace_back(
-            std::move(name), amount, saturation_index);
+            std::move(name), amount, initial_amount, saturation_index);
     }
 
     return equilibrium_reactants;

--- a/ChemistryLib/PhreeqcIOData/CreateEquilibriumReactants.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateEquilibriumReactants.cpp
@@ -52,7 +52,7 @@ std::vector<EquilibriumReactant> createEquilibriumReactants(
         auto amount = MeshLib::getOrCreateMeshProperty<double>(
             const_cast<MeshLib::Mesh&>(mesh),
             name,
-            MeshLib::MeshItemType::Node,
+            MeshLib::MeshItemType::IntegrationPoint,
             1);
 
         std::fill(std::begin(*amount),

--- a/ChemistryLib/PhreeqcIOData/CreateEquilibriumReactants.h
+++ b/ChemistryLib/PhreeqcIOData/CreateEquilibriumReactants.h
@@ -34,7 +34,6 @@ struct EquilibriumReactant;
 
 std::vector<EquilibriumReactant> createEquilibriumReactants(
     boost::optional<BaseLib::ConfigTree> const& config,
-    MeshLib::Mesh const& mesh,
-    MeshLib::PropertyVector<std::size_t> const& chemical_system_map);
+    MeshLib::Mesh const& mesh);
 }  // namespace PhreeqcIOData
 }  // namespace ChemistryLib

--- a/ChemistryLib/PhreeqcIOData/CreateKineticReactant.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateKineticReactant.cpp
@@ -59,7 +59,7 @@ std::vector<KineticReactant> createKineticReactants(
         auto amount = MeshLib::getOrCreateMeshProperty<double>(
             const_cast<MeshLib::Mesh&>(mesh),
             name,
-            MeshLib::MeshItemType::Node,
+            MeshLib::MeshItemType::IntegrationPoint,
             1);
 
         std::fill(std::begin(*amount),

--- a/ChemistryLib/PhreeqcIOData/CreateKineticReactant.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateKineticReactant.cpp
@@ -71,6 +71,7 @@ std::vector<KineticReactant> createKineticReactants(
         kinetic_reactants.emplace_back(std::move(name),
                                        std::move(chemical_formula),
                                        amount,
+                                       initial_amount,
                                        std::move(parameters),
                                        fix_amount);
     }

--- a/ChemistryLib/PhreeqcIOData/CreateKineticReactant.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateKineticReactant.cpp
@@ -21,8 +21,7 @@ namespace PhreeqcIOData
 {
 std::vector<KineticReactant> createKineticReactants(
     boost::optional<BaseLib::ConfigTree> const& config,
-    MeshLib::Mesh const& mesh,
-    MeshLib::PropertyVector<std::size_t> const& chemical_system_map)
+    MeshLib::Mesh const& mesh)
 {
     if (!config)
     {

--- a/ChemistryLib/PhreeqcIOData/CreateKineticReactant.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateKineticReactant.cpp
@@ -62,16 +62,6 @@ std::vector<KineticReactant> createKineticReactants(
             MeshLib::MeshItemType::IntegrationPoint,
             1);
 
-        std::fill(std::begin(*amount),
-                  std::end(*amount),
-                  std::numeric_limits<double>::quiet_NaN());
-
-        std::for_each(chemical_system_map.begin(),
-                      chemical_system_map.end(),
-                      [&amount, initial_amount](auto const& global_id) {
-                          (*amount)[global_id] = initial_amount;
-                      });
-
         if (chemical_formula.empty() && fix_amount)
         {
             OGS_FATAL(

--- a/ChemistryLib/PhreeqcIOData/CreateKineticReactant.h
+++ b/ChemistryLib/PhreeqcIOData/CreateKineticReactant.h
@@ -34,7 +34,6 @@ struct KineticReactant;
 
 std::vector<KineticReactant> createKineticReactants(
     boost::optional<BaseLib::ConfigTree> const& config,
-    MeshLib::Mesh const& mesh,
-    MeshLib::PropertyVector<std::size_t> const& chemical_system_map);
+    MeshLib::Mesh const& mesh);
 }  // namespace PhreeqcIOData
 }  // namespace ChemistryLib

--- a/ChemistryLib/PhreeqcIOData/CreateSolutionComponent.cpp
+++ b/ChemistryLib/PhreeqcIOData/CreateSolutionComponent.cpp
@@ -17,7 +17,7 @@ namespace ChemistryLib
 namespace PhreeqcIOData
 {
 std::vector<Component> createSolutionComponents(
-    BaseLib::ConfigTree const& config, std::size_t const num_chemical_systems)
+    BaseLib::ConfigTree const& config)
 {
     std::vector<Component> components;
     //! \ogs_file_param{prj__chemical_system__solution__components}
@@ -27,7 +27,7 @@ std::vector<Component> createSolutionComponents(
         //! \ogs_file_param{prj__chemical_system__solution__components__component}
         comp_config.getConfigParameterList<std::string>("component"))
     {
-        components.emplace_back(component_name, num_chemical_systems);
+        components.emplace_back(component_name);
     }
 
     return components;

--- a/ChemistryLib/PhreeqcIOData/CreateSolutionComponent.h
+++ b/ChemistryLib/PhreeqcIOData/CreateSolutionComponent.h
@@ -24,6 +24,6 @@ namespace PhreeqcIOData
 struct Component;
 
 std::vector<Component> createSolutionComponents(
-    BaseLib::ConfigTree const& config, std::size_t const num_chemical_systems);
+    BaseLib::ConfigTree const& config);
 }  // namespace PhreeqcIOData
 }  // namespace ChemistryLib

--- a/ChemistryLib/PhreeqcIOData/EquilibriumReactant.h
+++ b/ChemistryLib/PhreeqcIOData/EquilibriumReactant.h
@@ -30,9 +30,11 @@ struct EquilibriumReactant
 {
     EquilibriumReactant(std::string name_,
                         MeshLib::PropertyVector<double>* amount_,
+                        double const initial_amount_,
                         double saturation_index_)
         : name(std::move(name_)),
           amount(amount_),
+          initial_amount(initial_amount_),
           saturation_index(saturation_index_)
     {
     }
@@ -41,6 +43,7 @@ struct EquilibriumReactant
 
     std::string const name;
     MeshLib::PropertyVector<double>* amount;
+    double const initial_amount;
     double const saturation_index;
     static const ItemType item_type = ItemType::EquilibriumReactant;
 };

--- a/ChemistryLib/PhreeqcIOData/KineticReactant.h
+++ b/ChemistryLib/PhreeqcIOData/KineticReactant.h
@@ -27,11 +27,13 @@ struct KineticReactant
     KineticReactant(std::string name_,
                     std::string chemical_formula_,
                     MeshLib::PropertyVector<double>* amount_,
+                    double const initial_amount_,
                     std::vector<double>&& parameters_,
                     bool const fix_amount_)
         : name(std::move(name_)),
           chemical_formula(std::move(chemical_formula_)),
           amount(amount_),
+          initial_amount(initial_amount_),
           parameters(std::move(parameters_)),
           fix_amount(fix_amount_)
     {
@@ -42,6 +44,7 @@ struct KineticReactant
     std::string const name;
     std::string const chemical_formula;
     MeshLib::PropertyVector<double>* amount;
+    double const initial_amount;
     std::vector<double> const parameters;
     bool const fix_amount;
     static const ItemType item_type = ItemType::KineticReactant;

--- a/ProcessLib/ComponentTransport/ChemicalProcessData.h
+++ b/ProcessLib/ComponentTransport/ChemicalProcessData.h
@@ -1,0 +1,32 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "MathLib/LinAlg/GlobalMatrixVectorTypes.h"
+
+namespace ProcessLib
+{
+namespace ComponentTransport
+{
+struct ChemicalProcessData
+{
+    ChemicalProcessData(
+        std::vector<std::vector<GlobalIndexType>>& chemical_system_index_map_)
+        : chemical_system_index_map(chemical_system_index_map_)
+    {
+    }
+
+    std::vector<std::vector<GlobalIndexType>>& chemical_system_index_map;
+};
+}  // namespace ComponentTransport
+}  // namespace ProcessLib

--- a/ProcessLib/ComponentTransport/ComponentTransportFEM.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportFEM.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include <numeric>
 #include <vector>
 
 #include "ComponentTransportProcessData.h"
@@ -150,6 +151,24 @@ public:
                 _integration_method.getWeightedPoint(ip).getWeight() *
                     shape_matrices[ip].integralMeasure *
                     shape_matrices[ip].detJ);
+        }
+
+        if (_process_data.chemical_process_data)
+        {
+            // chemical system index map
+            auto& chemical_system_index_map =
+                _process_data.chemical_process_data->chemical_system_index_map;
+
+            GlobalIndexType const start_value =
+                chemical_system_index_map.empty()
+                    ? 0
+                    : chemical_system_index_map.back().back() + 1;
+
+            std::vector<GlobalIndexType> indices(
+                _integration_method.getNumberOfPoints());
+            std::iota(indices.begin(), indices.end(), start_value);
+
+            chemical_system_index_map.push_back(std::move(indices));
         }
     }
 

--- a/ProcessLib/ComponentTransport/ComponentTransportFEM.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportFEM.h
@@ -910,6 +910,21 @@ public:
         return flux;
     }
 
+    std::vector<double> interpolateNodalValuesToIntegrationPoints(
+        std::vector<double> const& local_x) override
+    {
+        unsigned const n_integration_points =
+            _integration_method.getNumberOfPoints();
+
+        std::vector<double> interpolated_values(n_integration_points);
+        for (unsigned ip(0); ip < n_integration_points; ++ip)
+        {
+            NumLib::shapeFunctionInterpolate(local_x, _ip_data[ip].N,
+                                             interpolated_values[ip]);
+        }
+        return interpolated_values;
+    }
+
 private:
     MeshLib::Element const& _element;
     ComponentTransportProcessData const& _process_data;

--- a/ProcessLib/ComponentTransport/ComponentTransportProcess.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcess.h
@@ -117,6 +117,9 @@ public:
     void setCoupledTermForTheStaggeredSchemeToLocalAssemblers(
         int const process_id) override;
 
+    std::vector<GlobalVector> interpolateProcessSolutions(
+        std::vector<GlobalVector*> const& x) override;
+
     void preTimestepConcreteProcess(std::vector<GlobalVector*> const& x,
                                     const double /*t*/,
                                     const double /*delta_t*/,

--- a/ProcessLib/ComponentTransport/ComponentTransportProcessData.h
+++ b/ProcessLib/ComponentTransport/ComponentTransportProcessData.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 
+#include "ChemicalProcessData.h"
 #include "MaterialLib/MPL/CreateMaterialSpatialDistributionMap.h"
 #include "MathLib/LinAlg/Eigen/EigenMapTools.h"
 
@@ -30,11 +31,13 @@ struct ComponentTransportProcessData
         std::unique_ptr<MaterialPropertyLib::MaterialSpatialDistributionMap>&&
             media_map_,
         Eigen::VectorXd const& specific_body_force_, bool const has_gravity_,
-        bool const non_advective_form_)
+        bool const non_advective_form_,
+        std::unique_ptr<ChemicalProcessData>&& chemical_process_data_)
         : media_map(std::move(media_map_)),
           specific_body_force(specific_body_force_),
           has_gravity(has_gravity_),
-          non_advective_form(non_advective_form_)
+          non_advective_form(non_advective_form_),
+          chemical_process_data(std::move(chemical_process_data_))
     {
     }
 
@@ -43,6 +46,7 @@ struct ComponentTransportProcessData
     Eigen::VectorXd const specific_body_force;
     bool const has_gravity;
     bool const non_advective_form;
+    std::unique_ptr<ChemicalProcessData> chemical_process_data;
 };
 
 }  // namespace ComponentTransport

--- a/ProcessLib/ComponentTransport/CreateChemicalProcessData.cpp
+++ b/ProcessLib/ComponentTransport/CreateChemicalProcessData.cpp
@@ -1,0 +1,35 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#include "CreateChemicalProcessData.h"
+#include "ChemicalProcessData.h"
+
+#include "ChemistryLib/ChemicalSolverInterface.h"
+
+namespace ProcessLib
+{
+namespace ComponentTransport
+{
+std::unique_ptr<ChemicalProcessData> createChemicalProcessData(
+    std::shared_ptr<ChemistryLib::ChemicalSolverInterface> const&
+        chemical_solver_interface)
+{
+    if (!chemical_solver_interface)
+    {
+        return nullptr;
+    }
+
+    auto& chemical_system_index_map =
+        chemical_solver_interface->getChemicalSystemIndexMap();
+
+    return std::make_unique<ChemicalProcessData>(chemical_system_index_map);
+}
+}  // namespace ComponentTransport
+}  // namespace ProcessLib

--- a/ProcessLib/ComponentTransport/CreateChemicalProcessData.h
+++ b/ProcessLib/ComponentTransport/CreateChemicalProcessData.h
@@ -1,0 +1,30 @@
+/**
+ * \file
+ * \copyright
+ * Copyright (c) 2012-2020, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace ChemistryLib
+{
+class ChemicalSolverInterface;
+}
+
+namespace ProcessLib
+{
+namespace ComponentTransport
+{
+struct ChemicalProcessData;
+
+std::unique_ptr<ChemicalProcessData> createChemicalProcessData(
+    std::shared_ptr<ChemistryLib::ChemicalSolverInterface> const&
+        chemical_solver_interface);
+}  // namespace ComponentTransport
+}  // namespace ProcessLib

--- a/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "CreateComponentTransportProcess.h"
+#include "CreateChemicalProcessData.h"
 
 #include "ChemistryLib/ChemicalSolverInterface.h"
 #include "MaterialLib/MPL/CreateMaterialSpatialDistributionMap.h"
@@ -221,6 +222,9 @@ std::unique_ptr<Process> createComponentTransportProcess(
     DBUG("Check the media properties of ComponentTransport process ...");
     checkMPLProperties(mesh, *media_map);
     DBUG("Media properties verified.");
+
+    auto chemical_process_data =
+        createChemicalProcessData(chemical_solver_interface);
 
     ComponentTransportProcessData process_data{
         std::move(media_map),

--- a/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
@@ -84,7 +84,7 @@ std::unique_ptr<Process> createComponentTransportProcess(
     std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,
     std::string const& output_directory,
     std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media,
-    std::unique_ptr<ChemistryLib::ChemicalSolverInterface> const&
+    std::shared_ptr<ChemistryLib::ChemicalSolverInterface> const&
         chemical_solver_interface)
 {
     //! \ogs_file_param{prj__processes__process__type}

--- a/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
+++ b/ProcessLib/ComponentTransport/CreateComponentTransportProcess.cpp
@@ -227,10 +227,8 @@ std::unique_ptr<Process> createComponentTransportProcess(
         createChemicalProcessData(chemical_solver_interface);
 
     ComponentTransportProcessData process_data{
-        std::move(media_map),
-        specific_body_force,
-        has_gravity,
-        non_advective_form};
+        std::move(media_map), specific_body_force, has_gravity,
+        non_advective_form, std::move(chemical_process_data)};
 
     SecondaryVariableCollection secondary_variables;
 

--- a/ProcessLib/ComponentTransport/CreateComponentTransportProcess.h
+++ b/ProcessLib/ComponentTransport/CreateComponentTransportProcess.h
@@ -38,7 +38,7 @@ std::unique_ptr<Process> createComponentTransportProcess(
     std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,
     std::string const& output_directory,
     std::map<int, std::shared_ptr<MaterialPropertyLib::Medium>> const& media,
-    std::unique_ptr<ChemistryLib::ChemicalSolverInterface> const&
+    std::shared_ptr<ChemistryLib::ChemicalSolverInterface> const&
         chemical_solver_interface);
 }  // namespace ComponentTransport
 }  // namespace ProcessLib

--- a/ProcessLib/ComponentTransport/Tests.cmake
+++ b/ProcessLib/ComponentTransport/Tests.cmake
@@ -1077,11 +1077,6 @@ AddTest(
     1d_isofrac_pcs_3_ts_126_t_12600.000000_expected.vtu 1d_isofrac_ts_126_t_12600.000000.vtu Syntheticb Syntheticb 1e-10 1e-16
     1d_isofrac_pcs_3_ts_168_t_16800.000000_expected.vtu 1d_isofrac_ts_168_t_16800.000000.vtu Syntheticb Syntheticb 1e-10 1e-16
     1d_isofrac_pcs_3_ts_210_t_21000.000000_expected.vtu 1d_isofrac_ts_210_t_21000.000000.vtu Syntheticb Syntheticb 1e-10 1e-16
-    1d_isofrac_pcs_3_ts_42_t_4200.000000_expected.vtu 1d_isofrac_ts_42_t_4200.000000.vtu Productc Productc 1e-10 1e-16
-    1d_isofrac_pcs_3_ts_84_t_8400.000000_expected.vtu 1d_isofrac_ts_84_t_8400.000000.vtu Productc Productc 1e-10 1e-16
-    1d_isofrac_pcs_3_ts_126_t_12600.000000_expected.vtu 1d_isofrac_ts_126_t_12600.000000.vtu Productc Productc 1e-10 1e-16
-    1d_isofrac_pcs_3_ts_168_t_16800.000000_expected.vtu 1d_isofrac_ts_168_t_16800.000000.vtu Productc Productc 1e-10 1e-16
-    1d_isofrac_pcs_3_ts_210_t_21000.000000_expected.vtu 1d_isofrac_ts_210_t_21000.000000.vtu Productc Productc 1e-10 1e-16
     1d_isofrac_pcs_3_ts_42_t_4200.000000_expected.vtu 1d_isofrac_ts_42_t_4200.000000.vtu H H 1e-10 1e-16
     1d_isofrac_pcs_3_ts_84_t_8400.000000_expected.vtu 1d_isofrac_ts_84_t_8400.000000.vtu H H 1e-10 1e-16
     1d_isofrac_pcs_3_ts_126_t_12600.000000_expected.vtu 1d_isofrac_ts_126_t_12600.000000.vtu H H 1e-10 1e-16

--- a/ProcessLib/ComponentTransport/Tests.cmake
+++ b/ProcessLib/ComponentTransport/Tests.cmake
@@ -1054,7 +1054,7 @@ AddTest(
 )
 
 AddTest(
-    NAME 1D_ReactiveMassTransport_IPhreeqc_KineticReactantBlockTest
+    NAME 1D_ReactiveMassTransport_PhreeqcIO_KineticReactantBlockTest
     PATH Parabolic/ComponentTransport/ReactiveTransport/KineticReactant
     EXECUTABLE ogs
     EXECUTABLE_ARGS 1d_isofrac.prj

--- a/ProcessLib/CreateTimeLoop.cpp
+++ b/ProcessLib/CreateTimeLoop.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<TimeLoop> createTimeLoop(
     const std::map<std::string, std::unique_ptr<NumLib::NonlinearSolverBase>>&
         nonlinear_solvers,
     std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,
-    std::unique_ptr<ChemistryLib::ChemicalSolverInterface>&
+    std::shared_ptr<ChemistryLib::ChemicalSolverInterface>&
         chemical_solver_interface)
 {
     auto const& coupling_config
@@ -94,7 +94,7 @@ std::unique_ptr<TimeLoop> createTimeLoop(
 
     return std::make_unique<TimeLoop>(
         std::move(output), std::move(per_process_data), max_coupling_iterations,
-        std::move(global_coupling_conv_criteria),
-        std::move(chemical_solver_interface), start_time, end_time);
+        std::move(global_coupling_conv_criteria), chemical_solver_interface,
+        start_time, end_time);
 }
 }  // namespace ProcessLib

--- a/ProcessLib/CreateTimeLoop.h
+++ b/ProcessLib/CreateTimeLoop.h
@@ -50,7 +50,7 @@ std::unique_ptr<TimeLoop> createTimeLoop(
     std::map<std::string, std::unique_ptr<NumLib::NonlinearSolverBase>> const&
         nonlinear_solvers,
     std::vector<std::unique_ptr<MeshLib::Mesh>> const& meshes,
-    std::unique_ptr<ChemistryLib::ChemicalSolverInterface>&
+    std::shared_ptr<ChemistryLib::ChemicalSolverInterface>&
         chemical_solver_interface);
 
 }  // namespace ProcessLib

--- a/ProcessLib/LocalAssemblerInterface.h
+++ b/ProcessLib/LocalAssemblerInterface.h
@@ -98,6 +98,12 @@ public:
                              GlobalVector const& x, double const t,
                              double const dt, bool const use_monolithic_scheme);
 
+    virtual std::vector<double> interpolateNodalValuesToIntegrationPoints(
+        std::vector<double> const& /*local_x*/)
+    {
+        return {};
+    }
+
     /// Computes the flux in the point \c p_local_coords that is given in local
     /// coordinates using the values from \c local_x.
     /// Fits to monolithic scheme.

--- a/ProcessLib/Process.h
+++ b/ProcessLib/Process.h
@@ -100,6 +100,13 @@ public:
         int const /*process_id*/)
     {
     }
+
+    virtual std::vector<GlobalVector> interpolateProcessSolutions(
+        std::vector<GlobalVector*> const& /*x*/)
+    {
+        return {};
+    }
+
     void preAssemble(const double t, double const dt,
                      GlobalVector const& x) final;
     void assemble(const double t, double const dt,

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -229,7 +229,7 @@ TimeLoop::TimeLoop(std::unique_ptr<Output>&& output,
                    const int global_coupling_max_iterations,
                    std::vector<std::unique_ptr<NumLib::ConvergenceCriterion>>&&
                        global_coupling_conv_crit,
-                   std::unique_ptr<ChemistryLib::ChemicalSolverInterface>&&
+                   std::shared_ptr<ChemistryLib::ChemicalSolverInterface>&
                        chemical_solver_interface,
                    const double start_time, const double end_time)
     : _output(std::move(output)),
@@ -238,7 +238,7 @@ TimeLoop::TimeLoop(std::unique_ptr<Output>&& output,
       _end_time(end_time),
       _global_coupling_max_iterations(global_coupling_max_iterations),
       _global_coupling_conv_crit(std::move(global_coupling_conv_crit)),
-      _chemical_solver_interface(std::move(chemical_solver_interface))
+      _chemical_solver_interface(chemical_solver_interface)
 {
 }
 

--- a/ProcessLib/TimeLoop.cpp
+++ b/ProcessLib/TimeLoop.cpp
@@ -448,6 +448,11 @@ void TimeLoop::initialize()
     {
         BaseLib::RunTime time_phreeqc;
         time_phreeqc.start();
+
+        auto& pcs = _per_process_data[0]->process;
+        auto const interpolated_process_solutions =
+            pcs.interpolateProcessSolutions(_process_solutions);
+
         _chemical_solver_interface->executeInitialCalculation(
             _process_solutions);
         INFO("[time] Phreeqc took {:g} s.", time_phreeqc.elapsed());
@@ -810,6 +815,11 @@ TimeLoop::solveCoupledEquationSystemsByStaggeredScheme(
         // space and localized chemical equilibrium between solutes.
         BaseLib::RunTime time_phreeqc;
         time_phreeqc.start();
+
+        auto& pcs = _per_process_data[0]->process;
+        auto const interpolated_process_solutions =
+            pcs.interpolateProcessSolutions(_process_solutions);
+
         _chemical_solver_interface->doWaterChemistryCalculation(
             _process_solutions, dt);
         INFO("[time] Phreeqc took {:g} s.", time_phreeqc.elapsed());

--- a/ProcessLib/TimeLoop.h
+++ b/ProcessLib/TimeLoop.h
@@ -43,8 +43,8 @@ public:
              const int global_coupling_max_iterations,
              std::vector<std::unique_ptr<NumLib::ConvergenceCriterion>>&&
                  global_coupling_conv_crit,
-             std::unique_ptr<ChemistryLib::ChemicalSolverInterface>&&
-                 chemical_system,
+             std::shared_ptr<ChemistryLib::ChemicalSolverInterface>&
+                 chemical_solver_interface,
              const double start_time, const double end_time);
 
     void initialize();
@@ -125,7 +125,7 @@ private:
     std::vector<std::unique_ptr<NumLib::ConvergenceCriterion>>
         _global_coupling_conv_crit;
 
-    std::unique_ptr<ChemistryLib::ChemicalSolverInterface>
+    std::shared_ptr<ChemistryLib::ChemicalSolverInterface>
         _chemical_solver_interface;
 
     /// Solutions of the previous coupling iteration for the convergence


### PR DESCRIPTION
Pull requests #2998, #3001, and #3003 make changes to the chemical solver interface. Pull request #2998 serves to interpolate nodal process solutions to integration points; pull request #3001 updates the PhreeqcIO interface to loop speciation calculation over all intergration points; pull request #3003 serves to extrapolate post-reaction solutions to nodes. Previously, chemical calculation is carried out by node-wise. With the above pull requests, chemical calculation will be done on the integration points.

1. [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.1)
2. [x] Tests covering your feature were added?
3. [ ] Any new feature or behavior change was documented?
