### PR TITLE
Dont skip output of repeated fixed time step

### DIFF
--- a/NumLib/TimeStepping/Algorithms/CreateEvolutionaryPIDcontroller.cpp
+++ b/NumLib/TimeStepping/Algorithms/CreateEvolutionaryPIDcontroller.cpp
@@ -45,12 +45,9 @@ std::unique_ptr<TimeStepAlgorithm> createEvolutionaryPIDcontroller(
     auto fixed_output_times =
         //! \ogs_file_param{prj__time_loop__processes__process__time_stepping__EvolutionaryPIDcontroller__fixed_output_times}
         config.getConfigParameter<std::vector<double>>("fixed_output_times",
-                                                       std::vector<double>{});
-    if (!fixed_output_times.empty())
-    {
-        // Remove possible duplicated elements and sort in descending order.
-        BaseLib::makeVectorUnique(fixed_output_times, std::greater<>());
-    }
+                                                       {});
+    // Remove possible duplicated elements and sort.
+    BaseLib::makeVectorUnique(fixed_output_times);
 
     //! \ogs_file_param{prj__time_loop__processes__process__time_stepping__EvolutionaryPIDcontroller__tol}
     auto const tol = config.getConfigParameter<double>("tol");

--- a/NumLib/TimeStepping/Algorithms/CreateIterationNumberBasedTimeStepping.cpp
+++ b/NumLib/TimeStepping/Algorithms/CreateIterationNumberBasedTimeStepping.cpp
@@ -46,12 +46,9 @@ std::unique_ptr<TimeStepAlgorithm> createIterationNumberBasedTimeStepping(
     auto fixed_output_times =
         //! \ogs_file_param{prj__time_loop__processes__process__time_stepping__IterationNumberBasedTimeStepping__fixed_output_times}
         config.getConfigParameter<std::vector<double>>("fixed_output_times",
-                                                       std::vector<double>{});
-    if (!fixed_output_times.empty())
-    {
-        // Remove possible duplicated elements and sort in descending order.
-        BaseLib::makeVectorUnique(fixed_output_times, std::greater<>());
-    }
+                                                       {});
+    // Remove possible duplicated elements and sort.
+    BaseLib::makeVectorUnique(fixed_output_times);
 
     return std::make_unique<IterationNumberBasedTimeStepping>(
         t_initial, t_end, minimum_dt, maximum_dt, initial_dt,

--- a/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.cpp
+++ b/NumLib/TimeStepping/Algorithms/EvolutionaryPIDcontroller.cpp
@@ -36,8 +36,12 @@ EvolutionaryPIDcontroller::EvolutionaryPIDcontroller(
       _e_n_minus2(0.),
       _is_accepted(true)
 {
-    // Remove possible duplicated elements. Result will be sorted.
-    BaseLib::makeVectorUnique(_fixed_output_times);
+    if (!std::is_sorted(cbegin(_fixed_output_times), cend(_fixed_output_times)))
+    {
+        OGS_FATAL(
+            "Vector of fixed time steps passed to the "
+            "EvolutionaryPIDcontroller constructor must be sorted");
+    }
 }
 
 bool EvolutionaryPIDcontroller::next(double const solution_error,

--- a/NumLib/TimeStepping/Algorithms/IterationNumberBasedTimeStepping.cpp
+++ b/NumLib/TimeStepping/Algorithms/IterationNumberBasedTimeStepping.cpp
@@ -53,8 +53,12 @@ IterationNumberBasedTimeStepping::IterationNumberBasedTimeStepping(
         OGS_FATAL("Vector of iteration numbers must be sorted.");
     }
 
-    // Remove possible duplicated elements. Result will be sorted.
-    BaseLib::makeVectorUnique(_fixed_output_times);
+    if (!std::is_sorted(cbegin(_fixed_output_times), cend(_fixed_output_times)))
+    {
+        OGS_FATAL(
+            "Vector of fixed time steps passed to the "
+            "IterationNumberBasedTimeStepping constructor must be sorted");
+    }
 }
 
 bool IterationNumberBasedTimeStepping::next(double const /*solution_error*/,

--- a/ProcessLib/Output/CreateOutput.cpp
+++ b/ProcessLib/Output/CreateOutput.cpp
@@ -131,17 +131,12 @@ std::unique_ptr<Output> createOutput(
         }
     }
 
-    std::vector<double> fixed_output_times;
-    auto fixed_output_times_ptr =
+    std::vector<double> fixed_output_times =
         //! \ogs_file_param{prj__time_loop__output__fixed_output_times}
-        config.getConfigParameterOptional<std::vector<double>>(
-            "fixed_output_times");
-    if (fixed_output_times_ptr)
-    {
-        fixed_output_times = std::move(*fixed_output_times_ptr);
-        // Remove possible duplicated elements and sort.
-        BaseLib::makeVectorUnique(fixed_output_times);
-    }
+        config.getConfigParameter<std::vector<double>>("fixed_output_times",
+                                                       {});
+    // Remove possible duplicated elements and sort.
+    BaseLib::makeVectorUnique(fixed_output_times);
 
     bool const output_iteration_results =
         //! \ogs_file_param{prj__time_loop__output__output_iteration_results}

--- a/ProcessLib/Output/CreateOutput.cpp
+++ b/ProcessLib/Output/CreateOutput.cpp
@@ -55,8 +55,6 @@ std::unique_ptr<Output> createOutput(
     // Construction of output times
     std::vector<Output::PairRepeatEachSteps> repeats_each_steps;
 
-    std::vector<double> fixed_output_times;
-
     //! \ogs_file_param{prj__time_loop__output__timesteps}
     if (auto const timesteps = config.getConfigSubtreeOptional("timesteps"))
     {
@@ -133,6 +131,7 @@ std::unique_ptr<Output> createOutput(
         }
     }
 
+    std::vector<double> fixed_output_times;
     auto fixed_output_times_ptr =
         //! \ogs_file_param{prj__time_loop__output__fixed_output_times}
         config.getConfigParameterOptional<std::vector<double>>(
@@ -140,8 +139,8 @@ std::unique_ptr<Output> createOutput(
     if (fixed_output_times_ptr)
     {
         fixed_output_times = std::move(*fixed_output_times_ptr);
-        // Remove possible duplicated elements and sort in descending order.
-        BaseLib::makeVectorUnique(fixed_output_times, std::greater<>());
+        // Remove possible duplicated elements and sort.
+        BaseLib::makeVectorUnique(fixed_output_times);
     }
 
     bool const output_iteration_results =

--- a/ProcessLib/Output/Output.cpp
+++ b/ProcessLib/Output/Output.cpp
@@ -78,30 +78,20 @@ bool Output::shallDoOutput(int timestep, double const t)
         }
     }
 
-    bool make_output = timestep % each_steps == 0;
-
-    if (_fixed_output_times.empty())
+    if (timestep % each_steps == 0)
     {
-        return make_output;
+        return true;
     }
 
     auto const fixed_output_time = std::lower_bound(
         cbegin(_fixed_output_times), cend(_fixed_output_times), t);
     if (fixed_output_time == cend(_fixed_output_times))
     {
-        return make_output;
-    }
-    DBUG(
-        "Fixed time output; Found {} in list of output times for current time "
-        "{}.",
-        *fixed_output_time, t);
-    const double zero_threshold = std::numeric_limits<double>::min();
-    if (std::fabs(*fixed_output_time - t) < zero_threshold)
-    {
-        make_output = true;
+        return false;
     }
 
-    return make_output;
+    return std::fabs(*fixed_output_time - t) <
+           std::numeric_limits<double>::min();
 }
 
 Output::Output(std::string output_directory, std::string output_file_prefix,
@@ -125,8 +115,12 @@ Output::Output(std::string output_directory, std::string output_file_prefix,
       _mesh_names_for_output(mesh_names_for_output),
       _meshes(meshes)
 {
-    assert(
-        std::is_sorted(cbegin(_fixed_output_times), cend(_fixed_output_times)));
+    if (!std::is_sorted(cbegin(_fixed_output_times), cend(_fixed_output_times)))
+    {
+        OGS_FATAL(
+            "Vector of fixed output time steps passed to the Output "
+            "constructor must be sorted");
+    }
 }
 
 void Output::addProcess(ProcessLib::Process const& process,

--- a/ProcessLib/Output/Output.h
+++ b/ProcessLib/Output/Output.h
@@ -104,7 +104,7 @@ private:
     std::vector<PairRepeatEachSteps> _repeats_each_steps;
 
     //! Given times that steps have to reach.
-    std::vector<double> _fixed_output_times;
+    std::vector<double> const _fixed_output_times;
 
     std::multimap<Process const*, MeshLib::IO::PVDFile> _process_to_pvd_file;
 


### PR DESCRIPTION
Fixes missed output in case of repeated time step.

- [x] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.1)
