### PR TITLE
MPL exponenential property additive offset

### DIFF
--- a/Documentation/ProjectFile/properties/property/Exponential/c_Exponential.md
+++ b/Documentation/ProjectFile/properties/property/Exponential/c_Exponential.md
@@ -1,7 +1,1 @@
-Definition of a exponential property:
-\f$y(x) = y_{\textrm{offset}} + y_{\textrm{ref}} \exp(m (x - x_{\textrm{ref}}))\f$
-where
- - \f$y_{\textrm{ref}}\f$ is a reference value, for instance reference viscosity
- - \f$m\f$ is a factor influencing the exponent of the exponential relationship
- - \f$x_{\textrm{ref}}\f$ is a reference condition, for instance reference
-   temperature
+\copydoc MaterialPropertyLib::Exponential

--- a/Documentation/ProjectFile/properties/property/Exponential/c_Exponential.md
+++ b/Documentation/ProjectFile/properties/property/Exponential/c_Exponential.md
@@ -1,5 +1,5 @@
 Definition of a exponential property:
-\f$y(x) = y_{\textrm{ref}} \exp(m (x - x_{\textrm{ref}}))\f$
+\f$y(x) = y_{\textrm{offset}} + y_{\textrm{ref}} \exp(m (x - x_{\textrm{ref}}))\f$
 where
  - \f$y_{\textrm{ref}}\f$ is a reference value, for instance reference viscosity
  - \f$m\f$ is a factor influencing the exponent of the exponential relationship

--- a/Documentation/ProjectFile/properties/property/Exponential/exponent/t_factor.md
+++ b/Documentation/ProjectFile/properties/property/Exponential/exponent/t_factor.md
@@ -1,1 +1,1 @@
-\f$f\f$ is a factor included in the exponent of the exponential relationship.
+\copydoc MaterialPropertyLib::ExponentData::factor

--- a/Documentation/ProjectFile/properties/property/Exponential/exponent/t_reference_condition.md
+++ b/Documentation/ProjectFile/properties/property/Exponential/exponent/t_reference_condition.md
@@ -1,1 +1,1 @@
-A numeric value for the reference condition \f$x_{\textrm{ref}}\f$.
+\copydoc MaterialPropertyLib::ExponentData::reference_condition

--- a/Documentation/ProjectFile/properties/property/Exponential/exponent/t_variable_name.md
+++ b/Documentation/ProjectFile/properties/property/Exponential/exponent/t_variable_name.md
@@ -1,1 +1,1 @@
-The variable type the exponential relationship depends on.
+The independent variable name the exponential relationship depends on.

--- a/Documentation/ProjectFile/properties/property/Exponential/t_offset.md
+++ b/Documentation/ProjectFile/properties/property/Exponential/t_offset.md
@@ -1,0 +1,1 @@
+\copydoc MaterialPropertyLib::Exponential::offset_

--- a/MaterialLib/MPL/Properties/CreateExponential.cpp
+++ b/MaterialLib/MPL/Properties/CreateExponential.cpp
@@ -44,6 +44,10 @@ std::unique_ptr<Exponential> createExponential(
         //! \ogs_file_param{properties__property__Exponential__exponent__factor}
         exponent_data_config.getConfigParameter<double>("factor");
 
+    auto const offset =
+        //! \ogs_file_param{properties__property__Exponential__offset}
+        config.getConfigParameter<double>("offset");
+
     MaterialPropertyLib::Variable exp_data_type =
         MaterialPropertyLib::convertStringToVariable(variable_name);
 
@@ -51,6 +55,6 @@ std::unique_ptr<Exponential> createExponential(
         exp_data_type, reference_condition, factor};
 
     return std::make_unique<MaterialPropertyLib::Exponential>(
-        std::move(property_name), reference_value, exp_data);
+        std::move(property_name), offset, reference_value, exp_data);
 }
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/Exponential.cpp
+++ b/MaterialLib/MPL/Properties/Exponential.cpp
@@ -16,9 +16,10 @@
 namespace MaterialPropertyLib
 {
 Exponential::Exponential(std::string name,
+                         double const offset,
                          PropertyDataType const& property_reference_value,
                          ExponentData const& v)
-    : exponent_data_(v)
+    : exponent_data_(v), offset_(offset)
 {
     name_ = std::move(name);
     auto const f = std::get<double>(exponent_data_.factor);
@@ -35,7 +36,7 @@ PropertyDataType Exponential::value(
     auto const v =
         std::get<double>(variable_array[static_cast<int>(exponent_data_.type)]);
 
-    return std::get<double>(value_) * std::exp(f * v);
+    return offset_ + std::get<double>(value_) * std::exp(f * v);
 }
 
 PropertyDataType Exponential::dValue(

--- a/MaterialLib/MPL/Properties/Exponential.h
+++ b/MaterialLib/MPL/Properties/Exponential.h
@@ -17,15 +17,26 @@ namespace MaterialPropertyLib
 struct ExponentData
 {
     Variable type;
-    VariableType reference_condition;
-    VariableType factor;
+    VariableType
+        reference_condition;  ///< a reference condition value of independent
+                              ///< variable, for instance reference temperature.
+    VariableType factor;      ///< a dimensionless exponent.
 };
 
-/// The exponential property class. This property calculates the exponential
-/// relationship \f$ \alpha(\beta) = \alpha_{\mathrm{offset}} +
-/// \alpha_{\mathrm{ref}} \cdot \exp (-s (\beta - \beta_{\mathrm{ref}})\f$.
-/// The current implementation accepts only the double datatype defined in
-/// PropertyDataType.
+/// An exponential property.
+///
+/// This property calculates the exponential relationship \f$ \alpha(\beta) =
+/// \alpha_{\mathrm{offset}} + \alpha_{\mathrm{ref}} \cdot \exp (m (\beta -
+/// \beta_{\mathrm{ref}})\f$, where:
+///  - \f$\alpha_{\mathrm{ref}}\f$ is a reference value, for instance reference
+///    viscosity,
+///  - \f$\alpha_{\mathrm{offset}}\f$ is additive offset in units of the
+///    property,
+///  - \f$m\f$ is a dimensionless exponent,
+///  - \f$\beta_{\mathrm{ref}}\f$ is a reference condition value of independent
+///  variable, for instance reference temperature.
+///
+/// The current implementation accepts only the scalar independent variables.
 class Exponential final : public Property
 {
 public:
@@ -58,6 +69,6 @@ public:
 
 private:
     ExponentData const exponent_data_;
-    double const offset_;  //< additive offset in units of the property.
+    double const offset_;  ///< additive offset in units of the property.
 };
 }  // namespace MaterialPropertyLib

--- a/MaterialLib/MPL/Properties/Exponential.h
+++ b/MaterialLib/MPL/Properties/Exponential.h
@@ -22,7 +22,7 @@ struct ExponentData
 };
 
 /// The exponential property class. This property calculates the exponential
-/// relationship \f$ \alpha(\beta) =
+/// relationship \f$ \alpha(\beta) = \alpha_{\mathrm{offset}} +
 /// \alpha_{\mathrm{ref}} \cdot \exp (-s (\beta - \beta_{\mathrm{ref}})\f$.
 /// The current implementation accepts only the double datatype defined in
 /// PropertyDataType.
@@ -33,6 +33,7 @@ public:
     /// the PropertyDataType definition and sets the protected attribute value_
     /// of the base class Property to that value.
     Exponential(std::string name,
+                double const offset,
                 PropertyDataType const& property_reference_value,
                 ExponentData const& v);
     /// This method computes the value of a property \f$\alpha\f$ depending
@@ -57,5 +58,6 @@ public:
 
 private:
     ExponentData const exponent_data_;
+    double const offset_;  //< additive offset in units of the property.
 };
 }  // namespace MaterialPropertyLib

--- a/Tests/Data/Parabolic/HT/FaultedCube/Ra_795_fault_bcgs_jacobi.prj
+++ b/Tests/Data/Parabolic/HT/FaultedCube/Ra_795_fault_bcgs_jacobi.prj
@@ -53,6 +53,7 @@
                         <property>
                             <name>viscosity</name>
                             <type>Exponential</type>
+                            <offset>0</offset>
                             <reference_value>1.0e-3</reference_value>
                             <exponent>
                                 <variable_name>temperature</variable_name>
@@ -139,6 +140,7 @@
                         <property>
                             <name>viscosity</name>
                             <type>Exponential</type>
+                            <offset>0</offset>
                             <reference_value>1.0e-3</reference_value>
                             <exponent>
                                 <variable_name>temperature</variable_name>

--- a/Tests/Data/RichardsMechanics/deformation_dependent_porosity_swelling.prj
+++ b/Tests/Data/RichardsMechanics/deformation_dependent_porosity_swelling.prj
@@ -73,6 +73,7 @@
                         <property>
                             <name>density</name>
                             <type>Exponential</type>
+                            <offset>0</offset>
                             <reference_value>1</reference_value>
                             <exponent>
                                 <variable_name>solid_grain_pressure</variable_name>

--- a/Tests/MaterialLib/TestMPLExponential.cpp
+++ b/Tests/MaterialLib/TestMPLExponential.cpp
@@ -23,11 +23,12 @@ struct MaterialPropertyLibExponentialProperty : public ::testing::Test
 {
     void SetUp() override
     {
+        double const y_offset = 1.;
         double const y_ref = 1.;
         double const T_ref = 1.;
         double const factor = 2.;
         p = std::make_unique<MPL::Exponential>(
-            "exponential", y_ref,
+            "exponential", y_offset, y_ref,
             MPL::ExponentData{MPL::Variable::temperature, T_ref, factor});
     }
     std::unique_ptr<MPL::Property> p;
@@ -90,12 +91,13 @@ TEST_F(MaterialPropertyLibExponentialProperty, TestNumericalDerivatives)
 
 TEST(MaterialPropertyLib, Exponential)
 {
+    double const y_offset = -1e-3;
     double const y_ref = 1e-3;
     double const reference_condition = 20.0;
     double const factor = 1 / 75.0;
     MPL::ExponentData const exp_data{MPL::Variable::temperature,
                                      reference_condition, factor};
-    MPL::Property const& p = MPL::Exponential{"exponential", y_ref, exp_data};
+    MPL::Property const& p = MPL::Exponential{"exponential", y_offset, y_ref, exp_data};
 
     double const T = 20.;
     MPL::VariableArray variable_array;
@@ -103,9 +105,10 @@ TEST(MaterialPropertyLib, Exponential)
     ParameterLib::SpatialPosition const pos;
     double const time = std::numeric_limits<double>::quiet_NaN();
     double const dt = std::numeric_limits<double>::quiet_NaN();
-    ASSERT_NEAR(p.template value<double>(variable_array, pos, time, dt),
-                y_ref * (std::exp(factor * (T - reference_condition))),
-                1.e-10);
+    ASSERT_NEAR(
+        p.template value<double>(variable_array, pos, time, dt),
+        y_offset + y_ref * (std::exp(factor * (T - reference_condition))),
+        1.e-10);
     ASSERT_EQ(p.template dValue<double>(
                   variable_array, MPL::Variable::phase_pressure, pos, time, dt),
               0.0);


### PR DESCRIPTION
A small generalization.

Can be used for exponential saturation-head relation as described by Tracy2006 paper for analytical solutions of Richards equation. [https://doi.org/10.1029/2005WR004638]

1. [ ] Feature description was added to the [changelog](https://github.com/ufz/ogs/wiki/Release-notes-6.3.1)
2. [x] Tests covering your feature were added?
3. [x] Any new feature or behavior change was documented?
