### PR TITLE
[Math/KelvinVector] Added an argument of double factor to kelvinVectorToSymmetricTensor

### DIFF
--- a/MathLib/KelvinVector.cpp
+++ b/MathLib/KelvinVector.cpp
@@ -140,20 +140,21 @@ KelvinVectorType<3> tensorToKelvin<3>(Eigen::Matrix<double, 3, 3> const& m)
 
 template <>
 Eigen::Matrix<double, 4, 1> kelvinVectorToSymmetricTensor(
-    Eigen::Matrix<double, 4, 1, Eigen::ColMajor, 4, 1> const& v)
+    Eigen::Matrix<double, 4, 1, Eigen::ColMajor, 4, 1> const& v,
+    double const factor)
 {
     Eigen::Matrix<double, 4, 1> m;
-    m << v[0], v[1], v[2], v[3] / std::sqrt(2.);
+    m << v[0], v[1], v[2], factor * v[3];
     return m;
 }
 
 template <>
 Eigen::Matrix<double, 6, 1> kelvinVectorToSymmetricTensor(
-    Eigen::Matrix<double, 6, 1, Eigen::ColMajor, 6, 1> const& v)
+    Eigen::Matrix<double, 6, 1, Eigen::ColMajor, 6, 1> const& v,
+    double const factor)
 {
     Eigen::Matrix<double, 6, 1> m;
-    m << v[0], v[1], v[2], v[3] / std::sqrt(2.), v[4] / std::sqrt(2.),
-        v[5] / std::sqrt(2.);
+    m << v[0], v[1], v[2], factor * v[3], factor * v[4], v[5] / std::sqrt(2.);
     return m;
 }
 
@@ -164,15 +165,16 @@ kelvinVectorToSymmetricTensor(Eigen::Matrix<double,
                                             1,
                                             Eigen::ColMajor,
                                             Eigen::Dynamic,
-                                            1> const& v)
+                                            1> const& v,
+                              double const factor)
 {
     if (v.size() == 4)
     {
-        return kelvinVectorToSymmetricTensor<4>(v);
+        return kelvinVectorToSymmetricTensor<4>(v, factor);
     }
     if (v.size() == 6)
     {
-        return kelvinVectorToSymmetricTensor<6>(v);
+        return kelvinVectorToSymmetricTensor<6>(v, factor);
     }
     OGS_FATAL(
         "Kelvin vector to tensor conversion expected an input vector of size 4 "

--- a/MathLib/KelvinVector.h
+++ b/MathLib/KelvinVector.h
@@ -10,6 +10,8 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include <boost/math/constants/constants.hpp>
+
 #include "BaseLib/Error.h"
 
 namespace MathLib
@@ -153,14 +155,14 @@ KelvinVectorType<DisplacementDim> tensorToKelvin(
 ///
 /// Only implementations for KelvinVectorSize 4 and 6, and dynamic size vectors
 /// are provided.
+/// \c factor gives a multiplier for the off diagonal entries. By default,
+/// \c factor is 1/sqrt(2).
 template <int KelvinVectorSize>
 Eigen::Matrix<double, KelvinVectorSize, 1, Eigen::ColMajor, KelvinVectorSize, 1>
-kelvinVectorToSymmetricTensor(Eigen::Matrix<double,
-                                            KelvinVectorSize,
-                                            1,
-                                            Eigen::ColMajor,
-                                            KelvinVectorSize,
-                                            1> const& v);
+kelvinVectorToSymmetricTensor(
+    Eigen::Matrix<double, KelvinVectorSize, 1, Eigen::ColMajor,
+                  KelvinVectorSize, 1> const& v,
+    double const factor = 1.0 / boost::math::constants::root_two<double>());
 
 /// Conversion of a short vector representation of a
 /// symmetric 3x3 matrix to a Kelvin vector.


### PR DESCRIPTION
As titled. The default value for that factor is 1/sqrt(2). I wonder that  the factor in the original implementation is incorrect, which should be sqrt(2) instead of 1/sqrt(2.0). If it is true, this PR  just for an correction of that.  

Function  kelvinVectorToSymmetricTensor is used in
[HydroMechanicsLocalAssembler::getEpsilon](https://github.com/ufz/ogs/blob/master/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h#L788-L792) for strain output. 
and
[HydroMechanicsLocalAssembler::computeSecondaryVariableConcrete](https://github.com/ufz/ogs/blob/master/ProcessLib/HydroMechanics/HydroMechanicsFEM-impl.h#L840-L856) for the principle stress calculation.
